### PR TITLE
feat(avm): fuzzer passes contract classes and instances

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
@@ -1,9 +1,11 @@
 #include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 
+#include <cstdint>
 #include <vector>
 
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/crypto/merkle_tree/indexed_tree/indexed_leaf.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 
 using namespace bb::avm2::simulation;
 using namespace bb::crypto::merkle_tree;
@@ -186,40 +188,31 @@ void FuzzerLowLevelDB::insert_contract_address(const AztecAddress& contract_addr
 ////////////////////////////////
 /// ContractDBInterface methods
 ////////////////////////////////
-std::optional<ContractInstance> FuzzerContractDB::get_contract_instance(
-    [[maybe_unused]] const AztecAddress& address) const
+std::optional<ContractInstance> FuzzerContractDB::get_contract_instance(const AztecAddress& address) const
 {
-    ContractInstance instance = {
-        .salt = FF(0),
-        .deployer = AztecAddress(0),
-        .current_contract_class_id = ContractClassId(0),
-        .original_contract_class_id = ContractClassId(0),
-        .initialization_hash = FF(0),
-        .public_keys = {
-            .nullifier_key = { FF(0), FF(0) },
-            .incoming_viewing_key = { FF(0), FF(0) },
-            .outgoing_viewing_key = { FF(0), FF(0) },
-            .tagging_key = { FF(0), FF(0) },
-        },
-    };
-
-    return instance;
-}
-std::optional<ContractClass> FuzzerContractDB::get_contract_class(
-    [[maybe_unused]] const ContractClassId& class_id) const
-{
-
-    ContractClass klass = {
-        .artifact_hash = FF(0),
-        .private_functions_root = FF(0),
-        .packed_bytecode = bytecode,
-    };
-    return klass;
+    if (!contract_instances.contains(address)) {
+        return std::nullopt;
+    }
+    return contract_instances.at(address);
 }
 
-std::optional<FF> FuzzerContractDB::get_bytecode_commitment([[maybe_unused]] const ContractClassId& class_id) const
+std::optional<ContractClass> FuzzerContractDB::get_contract_class(const ContractClassId& class_id) const
 {
-    return FF(0);
+    if (!contract_classes.contains(class_id)) {
+        return std::nullopt;
+    }
+    return contract_classes.at(class_id);
+}
+
+std::optional<FF> FuzzerContractDB::get_bytecode_commitment(const ContractClassId& class_id) const
+{
+    // Return 0 might be an issue, in the pure bytecode manager we cache based on this value
+    // This might cause different classes to be treated as the same if they return 0 here.
+    // For now we just return the class_id as it should be as unique as the bytecode commitment
+    if (!contract_classes.contains(class_id)) {
+        return std::nullopt;
+    }
+    return class_id;
 }
 std::optional<std::string> FuzzerContractDB::get_debug_function_name(
     [[maybe_unused]] const AztecAddress& address, [[maybe_unused]] const FunctionSelector& selector) const
@@ -227,15 +220,111 @@ std::optional<std::string> FuzzerContractDB::get_debug_function_name(
     return std::nullopt;
 }
 
-void FuzzerContractDB::add_contracts([[maybe_unused]] const ContractDeploymentData& contract_deployment_data)
+void FuzzerContractDB::add_contracts(const ContractDeploymentData& contract_deployment_data)
 {
-    // This probably needs to store the input contract deployment data for later retrieval.
-    {};
+    // Extract ContractClasses
+    for (const auto& log : contract_deployment_data.contract_class_logs) {
+        ContractClass klass = from_logs(log);
+        contract_classes[klass.id] = klass;
+    }
+
+    // Extract ContractInstances
+    for (const auto& log : contract_deployment_data.private_logs) {
+        ContractInstance instance = from_logs(log);
+        AztecAddress contract_address = log.fields[2];
+        contract_instances[contract_address] = instance;
+    }
 }
 
-void FuzzerContractDB::create_checkpoint() {}
-void FuzzerContractDB::commit_checkpoint() {}
-void FuzzerContractDB::revert_checkpoint() {}
+void FuzzerContractDB::add_contract_class(const ContractClassId& class_id, const ContractClass& contract_class)
+{
+    contract_classes[class_id] = contract_class;
+}
+
+void FuzzerContractDB::add_contract_instance(const AztecAddress& address, const ContractInstance& contract_instance)
+{
+    contract_instances[address] = contract_instance;
+}
+
+// Based on fromLogs in yarn-project/protocol-contracts/src/class-registry/contract_class_published_event.ts
+ContractClass FuzzerContractDB::from_logs(const ContractClassLog& log) const
+{
+    // todo(ilyas): difference between log.emitted_length and log.fields.fields.length?
+    size_t offset = 1; // Tag field is at index 0 and we skip it
+    auto class_id = log.fields.fields[offset++];
+    [[maybe_unused]] auto version = static_cast<uint32_t>(log.fields.fields[offset++]);
+    auto artifact_hash = log.fields.fields[offset++];
+    auto private_functions_root = log.fields.fields[offset++];
+    // The remainder is packed_bytecode, the first element is the length
+    auto packed_bytecode_len = static_cast<uint32_t>(log.fields.fields[offset++]);
+    std::vector<uint8_t> packed_bytecode;
+    packed_bytecode.reserve(packed_bytecode_len);
+    for (size_t i = 0; i < packed_bytecode_len; ++i) {
+        // todo(ilyas): check that the bufferFromFields function in TS skips the first byte of each field's buffer
+        // (since it expects it to be zero?)
+        std::vector<uint8_t> f = to_buffer(log.fields.fields[offset + i]);
+        packed_bytecode.insert(packed_bytecode.end(), f.begin() + 1, f.end());
+    }
+
+    return ContractClass{
+        .id = class_id,
+        .artifact_hash = artifact_hash,
+        .private_functions_root = private_functions_root,
+        .packed_bytecode = packed_bytecode,
+    };
+}
+
+// Base on fromLogs in yarn-project/protocol-contracts/src/instance-registry/contract_instance_published_event.ts
+ContractInstance FuzzerContractDB::from_logs(const PrivateLog& log) const
+{
+    // We skip the following fields:
+    // - tag (index 0)
+    // - version (index 1)
+    // - contract address (index 2)
+    size_t offset = 3;
+    FF salt = log.fields[offset++];
+    FF contract_class_id = log.fields[offset++];
+    FF initialization_hash = log.fields[offset++];
+    PublicKeys public_keys = {
+        .nullifier_key = { log.fields[offset++], log.fields[offset++] },
+        .incoming_viewing_key = { log.fields[offset++], log.fields[offset++] },
+        .outgoing_viewing_key = { log.fields[offset++], log.fields[offset++] },
+        .tagging_key = { log.fields[offset++], log.fields[offset++] },
+    };
+    auto deployer = AztecAddress(log.fields[offset++]);
+    return ContractInstance{
+        .salt = salt,
+        .deployer = deployer,
+        .current_contract_class_id = contract_class_id,
+        .original_contract_class_id = contract_class_id,
+        .initialization_hash = initialization_hash,
+        .public_keys = public_keys,
+    };
+}
+
+void FuzzerContractDB::create_checkpoint()
+{
+    checkpoints.push(Checkpoint{
+        .contract_classes = contract_classes,
+        .contract_instances = contract_instances,
+    });
+}
+
+void FuzzerContractDB::commit_checkpoint()
+{
+    if (!checkpoints.empty()) {
+        checkpoints.pop();
+    }
+}
+
+void FuzzerContractDB::revert_checkpoint()
+{
+    if (!checkpoints.empty()) {
+        contract_classes = std::move(checkpoints.top().contract_classes);
+        contract_instances = std::move(checkpoints.top().contract_instances);
+        checkpoints.pop();
+    }
+}
 
 ////////////////////////////////////
 /// FuzzerWorldStateManager methods

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stack>
+
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/lib/merkle.hpp"
@@ -63,9 +65,7 @@ class FuzzerLowLevelDB : public bb::avm2::simulation::LowLevelMerkleDBInterface 
 
 class FuzzerContractDB : public simulation::ContractDBInterface {
   public:
-    FuzzerContractDB(const std::vector<uint8_t>& bytecode)
-        : bytecode(bytecode)
-    {}
+    FuzzerContractDB() = default;
 
     std::optional<ContractInstance> get_contract_instance(const AztecAddress& address) const override;
     std::optional<ContractClass> get_contract_class(const ContractClassId& class_id) const override;
@@ -75,12 +75,33 @@ class FuzzerContractDB : public simulation::ContractDBInterface {
 
     void add_contracts(const ContractDeploymentData& contract_deployment_data) override;
 
+    // Direct methods to add contract class and instance
+    void add_contract_class(const ContractClassId& class_id, const ContractClass& contract_class);
+    void add_contract_instance(const AztecAddress& address, const ContractInstance& contract_instance);
+
     void create_checkpoint() override;
     void commit_checkpoint() override;
     void revert_checkpoint() override;
 
+    // Getters for serialization
+    const std::unordered_map<ContractClassId, ContractClass>& get_contract_classes() const { return contract_classes; }
+    const std::unordered_map<AztecAddress, ContractInstance>& get_contract_instances() const
+    {
+        return contract_instances;
+    }
+
   private:
-    std::vector<uint8_t> bytecode;
+    ContractClass from_logs(const ContractClassLog& log) const;
+    ContractInstance from_logs(const PrivateLog& log) const;
+
+    std::unordered_map<ContractClassId, ContractClass> contract_classes;
+    std::unordered_map<AztecAddress, ContractInstance> contract_instances;
+
+    struct Checkpoint {
+        std::unordered_map<ContractClassId, ContractClass> contract_classes;
+        std::unordered_map<AztecAddress, ContractInstance> contract_instances;
+    };
+    std::stack<Checkpoint> checkpoints;
 };
 
 // Set up and manage a world state for the fuzzer, the plan is to use this to set up different world states

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.cpp
@@ -1,11 +1,95 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
 
+#include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 using namespace bb::avm2::fuzzer;
+
+// Temp Helper function to create a default contract class from bytecode
+ContractClass create_default_class(const std::vector<uint8_t>& bytecode)
+{
+    // This isn't strictly needed for pure simulation, but if we want to re-use inputs in proving we need valid
+    // commitment
+    auto bytecode_commitment = simulation::compute_public_bytecode_commitment(bytecode);
+    auto class_id =
+        simulation::compute_contract_class_id(/*artifact_hash=*/0, /*private_fn_root=*/0, bytecode_commitment);
+    return ContractClass{
+        .id = class_id,
+        .artifact_hash = 0,
+        .private_functions_root = 0,
+        .packed_bytecode = bytecode,
+    };
+}
+
+// Temp Helper function to create a default contract instance from a class ID
+ContractInstance create_default_instance(const ContractClassId& class_id)
+{
+    return ContractInstance{
+        .salt = 0,
+        .deployer = MSG_SENDER,
+        .current_contract_class_id = class_id,
+        .original_contract_class_id = class_id,
+        .initialization_hash = 0,
+        .public_keys = PublicKeys{},
+    };
+}
+
+// Temp Helper function to compute contract address from instance
+AztecAddress compute_contract_address(const ContractInstance& instance)
+{
+    // This isn't strictly needed for pure simulation, but if we want to re-use inputs in proving we need valid
+    // addresses
+    return simulation::compute_contract_address(instance);
+}
+
+// Creates a default transaction that the single app logic enqueued call can be inserted into
+Tx create_default_tx(const AztecAddress& contract_address,
+                     const AztecAddress& sender_address,
+                     const std::vector<FF>& calldata,
+                     [[maybe_unused]] const FF& transaction_fee,
+                     bool is_static_call,
+                     const Gas& gas_limit)
+{
+    return Tx{
+        .hash = TRANSACTION_HASH,
+        .gas_settings = GasSettings{
+            .gas_limits = gas_limit,
+            .max_fees_per_gas = GasFees{ .fee_per_da_gas = FEE_PER_DA_GAS, .fee_per_l2_gas = FEE_PER_L2_GAS },
+        },
+        .effective_gas_fees = EFFECTIVE_GAS_FEES,
+        .non_revertible_accumulated_data = AccumulatedData{
+            .note_hashes = NON_REVERTIBLE_ACCUMULATED_DATA_NOTE_HASHES,
+            // This nullifier is needed to make the nonces for note hashes and expected by simulation_helper
+            .nullifiers = NON_REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS,
+            .l2_to_l1_messages = NON_REVERTIBLE_ACCUMULATED_DATA_L2_TO_L1_MESSAGES,
+        },
+        .revertible_accumulated_data = AccumulatedData{
+            .note_hashes = REVERTIBLE_ACCUMULATED_DATA_NOTE_HASHES,
+            .nullifiers = REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS,
+            .l2_to_l1_messages = REVERTIBLE_ACCUMULATED_DATA_L2_TO_L1_MESSAGES,
+        },
+        .setup_enqueued_calls = SETUP_ENQUEUED_CALLS,
+        .app_logic_enqueued_calls = {
+            PublicCallRequestWithCalldata{
+                .request = PublicCallRequest{
+                    .msg_sender = MSG_SENDER,
+                    .contract_address = contract_address,
+                    .is_static_call = is_static_call,
+                    .calldata_hash = 0,
+                },
+                .calldata = calldata,
+            },
+        },
+        .teardown_enqueued_call = TEARDOWN_ENQUEUED_CALLS,
+        .gas_used_by_private = GAS_USED_BY_PRIVATE,
+        .fee_payer = sender_address,
+    };
+}
 
 SimulatorResult fuzz(FuzzerData& fuzzer_data)
 {
@@ -23,18 +107,32 @@ SimulatorResult fuzz(FuzzerData& fuzzer_data)
     SimulatorResult cpp_result;
 
     FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
-    ws_mgr->register_contract_address(CONTRACT_ADDRESS);
+
+    // Create contract DB and populate with default class and instance
+    // todo(ilyas): extend to support multiple contracts via FuzzerData
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = simulation::compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+
+    ws_mgr->register_contract_address(contract_address);
+
+    // Create the transaction
+    auto tx = create_default_tx(
+        contract_address, MSG_SENDER, fuzzer_data.calldata, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
 
     try {
         ws_mgr->checkpoint();
-        cpp_result = cpp_simulator.simulate(*ws_mgr, bytecode, fuzzer_data.calldata);
+        cpp_result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
         ws_mgr->revert();
     } catch (const std::exception& e) {
         throw std::runtime_error(std::string("CppSimulator threw an exception: ") + e.what());
     }
 
     ws_mgr->checkpoint();
-    auto js_result = js_simulator->simulate(*ws_mgr, bytecode, fuzzer_data.calldata);
+    auto js_result = js_simulator->simulate(*ws_mgr, contract_db, tx);
 
     // If the results does not match
     if (!compare_simulator_results(cpp_result, js_result)) {

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp
@@ -8,3 +8,14 @@
 /// @returns the simulator result if the results are the same
 /// @throws an exception if the simulator results are different
 SimulatorResult fuzz(FuzzerData& fuzzer_data);
+
+// Helper functions to create default contract class, instance, and tx
+ContractClass create_default_class(const std::vector<uint8_t>& bytecode);
+ContractInstance create_default_instance(const ContractClassId& class_id);
+AztecAddress compute_contract_address(const ContractInstance& instance);
+Tx create_default_tx(const AztecAddress& contract_address,
+                     const AztecAddress& sender_address,
+                     const std::vector<FF>& calldata,
+                     const FF& transaction_fee,
+                     bool is_static_call,
+                     const Gas& gas_limit);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
@@ -1,11 +1,16 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
+#include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
 #include "barretenberg/vm2/common/field.hpp"
+
+using namespace bb::avm2::fuzzer;
 
 namespace arithmetic {
 
@@ -26,8 +31,20 @@ FF get_result_of_instruction(FuzzInstruction instruction,
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     return result.output.at(0);
 }
 
@@ -192,8 +209,20 @@ TEST(fuzz, FDIV8)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 2);
 }
 
@@ -215,8 +244,20 @@ TEST(fuzz, NOT8)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 255);
 }
 
@@ -241,8 +282,20 @@ FF get_result_of_instruction_16(FuzzInstruction instruction,
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     return result.output.at(0);
 }
 
@@ -407,8 +460,20 @@ TEST(fuzz, FDIV16)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 2);
 }
 
@@ -430,8 +495,20 @@ TEST(fuzz, NOT16)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 255);
 }
 } // namespace arithmetic
@@ -461,8 +538,20 @@ TEST(fuzz, CAST8)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 2);
 }
 
@@ -490,8 +579,20 @@ TEST(fuzz, CAST16)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 2);
 }
 } // namespace type_conversion
@@ -512,8 +613,20 @@ TEST(fuzz, SET16)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 // set(0, 0x12345678, U32) return(0)
@@ -531,8 +644,20 @@ TEST(fuzz, SET32)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -551,8 +676,20 @@ TEST(fuzz, SET64)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -576,8 +713,20 @@ TEST(fuzz, SET128)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -596,8 +745,20 @@ TEST(fuzz, SETFF)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -624,8 +785,20 @@ TEST(fuzz, MOV8)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -653,8 +826,20 @@ TEST(fuzz, MOV16)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), test_value);
 }
 
@@ -682,8 +867,20 @@ TEST(fuzz, JumpToNewBlockSmoke)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     control_flow.process_cfg_instruction(JumpToNewBlock{ .target_program_block_instruction_block_idx = 1 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 11);
 }
 
@@ -715,8 +912,20 @@ TEST(fuzz, JumpToNewBlockSmoke2)
     control_flow.process_cfg_instruction(JumpToNewBlock{ .target_program_block_instruction_block_idx = 1 });
     control_flow.process_cfg_instruction(JumpToNewBlock{ .target_program_block_instruction_block_idx = 2 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 12);
 }
 
@@ -738,8 +947,20 @@ TEST(fuzz, JumpToNewBlockSharesVariables)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     control_flow.process_cfg_instruction(JumpToNewBlock{ .target_program_block_instruction_block_idx = 1 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 10);
 }
 
@@ -783,10 +1004,32 @@ TEST(fuzz, JumpIfToNewBlockSmoke)
                                                             .else_program_block_instruction_block_idx = 3,
                                                             .condition_offset_index = 1 });
     auto bytecode_2 = control_flow2.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+
+    FuzzerContractDB contract_db_1;
+    auto default_class_1 = create_default_class(bytecode_1);
+    auto default_instance_1 = create_default_instance(default_class_1.id);
+    auto contract_address_1 = compute_contract_address(default_instance_1);
+    contract_db_1.add_contract_class(default_class_1.id, default_class_1);
+    contract_db_1.add_contract_instance(contract_address_1, default_instance_1);
+    ws_mgr->register_contract_address(contract_address_1);
+
+    FuzzerContractDB contract_db_2;
+    auto default_class_2 = create_default_class(bytecode_2);
+    auto default_instance_2 = create_default_instance(default_class_2.id);
+    auto contract_address_2 = compute_contract_address(default_instance_2);
+    contract_db_2.add_contract_class(default_class_2.id, default_class_2);
+    contract_db_2.add_contract_instance(contract_address_2, default_instance_2);
+    ws_mgr->register_contract_address(contract_address_2);
+
+    auto tx_1 = create_default_tx(contract_address_1, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result_1 = cpp_simulator.simulate(bytecode_1, {});
+    auto result_1 = cpp_simulator.simulate(*ws_mgr, contract_db_1, tx_1);
+    auto tx_2 = create_default_tx(contract_address_2, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator2 = CppSimulator();
-    auto result_2 = cpp_simulator2.simulate(bytecode_2, {});
+    auto result_2 = cpp_simulator2.simulate(*ws_mgr, contract_db_2, tx_2);
     EXPECT_EQ(result_1.output.at(0), 11);
     EXPECT_EQ(result_2.output.at(0), 12);
 }
@@ -826,8 +1069,20 @@ FF simulate_jump_if_depth_2_helper(uint8_t first_boolean_value, uint8_t second_b
                                                            .else_program_block_instruction_block_idx = 3, // set 3
                                                            .condition_offset_index = 1 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     return result.output.at(0);
 }
 
@@ -865,8 +1120,20 @@ FF simulate_jump_to_block_helper(uint8_t condition_value)
                           .condition_offset_index = 0 });
     control_flow.process_cfg_instruction(JumpToBlock{ .target_block_idx = 2 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     return result.output.at(0);
 }
 
@@ -943,8 +1210,20 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
 
     auto bytecode_true = control_flow_true.build_bytecode(ReturnOptions{
         .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 10 });
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db_true;
+    auto default_class_true = create_default_class(bytecode_true);
+    auto default_instance_true = create_default_instance(default_class_true.id);
+    auto contract_address_true = compute_contract_address(default_instance_true);
+    contract_db_true.add_contract_class(default_class_true.id, default_class_true);
+    contract_db_true.add_contract_instance(contract_address_true, default_instance_true);
+    ws_mgr->register_contract_address(contract_address_true);
+
+    auto tx_true = create_default_tx(contract_address_true, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator_true = CppSimulator();
-    auto result_true = cpp_simulator_true.simulate(bytecode_true, {});
+    auto result_true = cpp_simulator_true.simulate(*ws_mgr, contract_db_true, tx_true);
     EXPECT_EQ(result_true.output.at(0), ff_value);
 
     // Test with condition = false (should return U128 value)
@@ -971,8 +1250,19 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
         (static_cast<uint128_t>(u128_value_high) << 64) | static_cast<uint128_t>(u128_value_low);
     auto bytecode_false = control_flow_false.build_bytecode(ReturnOptions{
         .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U128, .return_value_offset_index = 20 });
+
+    FuzzerContractDB contract_db_false;
+    auto default_class_false = create_default_class(bytecode_false);
+    auto default_instance_false = create_default_instance(default_class_false.id);
+    auto contract_address_false = compute_contract_address(default_instance_false);
+    contract_db_false.add_contract_class(default_class_false.id, default_class_false);
+    contract_db_false.add_contract_instance(contract_address_false, default_instance_false);
+    ws_mgr->register_contract_address(contract_address_false);
+
+    auto tx_false =
+        create_default_tx(contract_address_false, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator_false = CppSimulator();
-    auto result_false = cpp_simulator_false.simulate(bytecode_false, {});
+    auto result_false = cpp_simulator_false.simulate(*ws_mgr, contract_db_false, tx_false);
     EXPECT_EQ(result_false.output.at(0), expected_u128_value);
 }
 } // namespace control_flow
@@ -1014,8 +1304,20 @@ TEST(fuzz, SstoreThenSload)
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 10);
 }
 } // namespace public_storage
@@ -1032,8 +1334,20 @@ FF getenvvar_helper(uint8_t type, bb::avm2::MemoryTag return_value_tag = bb::avm
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = return_value_tag, .return_value_offset_index = 0 };
     auto bytecode = control_flow.build_bytecode(return_options);
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     return result.output.at(0);
 }
 
@@ -1076,8 +1390,19 @@ TEST(fuzz, EmitNullifierThenNullifierExists)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(ReturnOptions{
         .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U1, .return_value_offset_index = 20 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 1);
 }
 
@@ -1102,8 +1427,19 @@ TEST(fuzz, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U1, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 0);
 }
 
@@ -1124,8 +1460,19 @@ TEST(fuzz, EmitNoteHashThenNoteHashExists)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U1, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_FALSE(result.reverted);
     EXPECT_EQ(result.output.at(0), 1);
 }
@@ -1144,8 +1491,20 @@ TEST(fuzz, CopyCalldataThenReturnData)
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 });
+
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, { FF(1337) }, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, { FF(1337) });
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 1337);
 }
 
@@ -1168,8 +1527,19 @@ TEST(fuzz, InternalCall)
     control_flow.process_cfg_instruction(internal_call_instruction);
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 313373);
 }
 } // namespace calldata_returndata
@@ -1200,8 +1570,19 @@ TEST(fuzz, InternalCalledBlockUsesInternalReturn)
             .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U1, .return_value_offset_index = 0 } });
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 1337);
 }
 
@@ -1233,8 +1614,19 @@ TEST(fuzz, SeveralInternalCalls)
     control_flow.process_cfg_instruction(internal_call_instruction2);
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 313373);
 }
 
@@ -1303,8 +1695,19 @@ TEST(fuzz, Reentrancy)
             .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 } });
     auto bytecode = control_flow.build_bytecode(
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 });
+    FuzzerWorldStateManager::initialize();
+    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
+    FuzzerContractDB contract_db;
+    auto default_class = create_default_class(bytecode);
+    auto default_instance = create_default_instance(default_class.id);
+    auto contract_address = compute_contract_address(default_instance);
+    contract_db.add_contract_class(default_class.id, default_class);
+    contract_db.add_contract_instance(contract_address, default_instance);
+    ws_mgr->register_contract_address(contract_address);
+
+    auto tx = create_default_tx(contract_address, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
     auto cpp_simulator = CppSimulator();
-    auto result = cpp_simulator.simulate(bytecode, {});
+    auto result = cpp_simulator.simulate(*ws_mgr, contract_db, tx);
     EXPECT_EQ(result.output.at(0), 313373);
 }
 } // namespace internal_calls

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -32,22 +32,12 @@ using namespace bb::avm2::fuzzer;
 using namespace bb::world_state;
 using json = nlohmann::json;
 
-// Helper function to serialize bytecode, calldata, tx, and globals to JSON
-std::string serialize_simulation_request(const std::vector<uint8_t>& bytecode,
-                                         const std::vector<FF>& calldata,
-                                         const Tx& tx,
-                                         const GlobalVariables& globals)
+// Helper function to serialize tx, globals, and contract data to JSON
+std::string serialize_simulation_request(const Tx& tx,
+                                         const GlobalVariables& globals,
+                                         const FuzzerContractDB& contract_db)
 {
     json j;
-    j["bytecode"] = base64_encode(bytecode.data(), bytecode.size());
-
-    // Convert FF values to strings for JSON serialization
-    std::vector<std::string> calldata_strings;
-    calldata_strings.reserve(calldata.size());
-    for (const auto& field : calldata) {
-        calldata_strings.push_back(field_to_string(field));
-    }
-    j["inputs"] = calldata_strings;
 
     // Pass WorldState database path and configuration for TypeScript to open the same DB
     // Note: TypeScript expects the parent directory and adds "world_state/" subdirectory itself
@@ -63,6 +53,24 @@ std::string serialize_simulation_request(const std::vector<uint8_t>& bytecode,
     auto [globals_buffer, globals_size] = msgpack_encode_buffer(globals);
     j["globals"] = base64_encode(globals_buffer, globals_size);
     delete[] globals_buffer;
+
+    // Serialize contract instances as vector of pairs (address, instance) to avoid non-string map keys
+    std::vector<std::pair<AztecAddress, ContractInstance>> instances_vec;
+    for (const auto& [address, instance] : contract_db.get_contract_instances()) {
+        instances_vec.emplace_back(address, instance);
+    }
+    auto [instances_buffer, instances_size] = msgpack_encode_buffer(instances_vec);
+    j["contractInstances"] = base64_encode(instances_buffer, instances_size);
+    delete[] instances_buffer;
+
+    // Serialize contract classes as vector (id is already inside each class)
+    std::vector<ContractClass> classes_vec;
+    for (const auto& [_, contract_class] : contract_db.get_contract_classes()) {
+        classes_vec.push_back(contract_class);
+    }
+    auto [classes_buffer, classes_size] = msgpack_encode_buffer(classes_vec);
+    j["contractClasses"] = base64_encode(classes_buffer, classes_size);
+    delete[] classes_buffer;
 
     return j.dump();
 }
@@ -82,71 +90,22 @@ GlobalVariables create_default_globals()
     };
 }
 
-// Creates a default transaction that the single app logic enqueued call can be inserted into
-Tx create_default_tx(const AztecAddress& contract_address,
-                     const AztecAddress& sender_address,
-                     const std::vector<FF>& calldata,
-                     [[maybe_unused]] const FF& transaction_fee,
-                     bool is_static_call,
-                     const Gas& gas_limit)
-{
-    return Tx
-    {
-        .hash = TRANSACTION_HASH,
-        .gas_settings = GasSettings{
-            .gas_limits = gas_limit,
-            .max_fees_per_gas = GasFees{ .fee_per_da_gas = FEE_PER_DA_GAS, .fee_per_l2_gas = FEE_PER_L2_GAS },
-        },
-        .effective_gas_fees = EFFECTIVE_GAS_FEES,
-        .non_revertible_accumulated_data = AccumulatedData{
-            .note_hashes = NON_REVERTIBLE_ACCUMULATED_DATA_NOTE_HASHES,
-            // This nullifier is needed to make the nonces for note hashes and expected by simulation_helper
-            .nullifiers = NON_REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS,
-            .l2_to_l1_messages = NON_REVERTIBLE_ACCUMULATED_DATA_L2_TO_L1_MESSAGES,
-        },
-        .revertible_accumulated_data = AccumulatedData{
-            .note_hashes = REVERTIBLE_ACCUMULATED_DATA_NOTE_HASHES,
-            .nullifiers = REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS,
-            .l2_to_l1_messages = REVERTIBLE_ACCUMULATED_DATA_L2_TO_L1_MESSAGES,
-        },
-        .setup_enqueued_calls = SETUP_ENQUEUED_CALLS,
-        .app_logic_enqueued_calls = {
-            PublicCallRequestWithCalldata{
-                .request = PublicCallRequest{
-                    .msg_sender = MSG_SENDER,
-                    .contract_address = contract_address,
-                    .is_static_call = is_static_call,
-                    .calldata_hash = 0,
-                },
-                .calldata = calldata,
-            },
-        },
-        .teardown_enqueued_call = TEARDOWN_ENQUEUED_CALLS,
-        .gas_used_by_private = GAS_USED_BY_PRIVATE,
-        .fee_payer = sender_address,
-    };
-}
-
 SimulatorResult CppSimulator::simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
-                                       const std::vector<uint8_t>& bytecode,
-                                       const std::vector<FF>& calldata)
+                                       fuzzer::FuzzerContractDB& contract_db,
+                                       const Tx& tx)
 {
-    FuzzerContractDB minimal_contract_db(bytecode);
-
     const PublicSimulatorConfig config{ .collect_call_metadata = true, .collect_public_inputs = true };
 
     ProtocolContracts protocol_contracts{};
 
     auto globals = create_default_globals();
 
-    Tx tx = create_default_tx(CONTRACT_ADDRESS, MSG_SENDER, calldata, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
-
     WorldState& ws = ws_mgr.get_world_state();
     WorldStateRevision ws_rev = ws_mgr.get_current_revision();
 
     AvmSimulationHelper helper;
     TxSimulationResult result =
-        helper.simulate_fast_with_existing_ws(minimal_contract_db, ws_rev, ws, config, tx, globals, protocol_contracts);
+        helper.simulate_fast_with_existing_ws(contract_db, ws_rev, ws, config, tx, globals, protocol_contracts);
     bool reverted = result.revert_code != RevertCode::OK;
     // Just process the top level call's output
     vinfo(
@@ -190,14 +149,12 @@ void JsSimulator::initialize(std::string& simulator_path)
 }
 
 SimulatorResult JsSimulator::simulate([[maybe_unused]] fuzzer::FuzzerWorldStateManager& ws_mgr,
-                                      const std::vector<uint8_t>& bytecode,
-                                      const std::vector<FF>& calldata)
+                                      fuzzer::FuzzerContractDB& contract_db,
+                                      const Tx& tx)
 {
-    // Create tx and globals to match C++ simulator
     auto globals = create_default_globals();
-    Tx tx = create_default_tx(CONTRACT_ADDRESS, MSG_SENDER, calldata, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT);
 
-    std::string serialized = serialize_simulation_request(bytecode, calldata, tx, globals);
+    std::string serialized = serialize_simulation_request(tx, globals, contract_db);
     fuzz_info("Sending request to simulator: ", serialized);
 
     // Send the request

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -29,16 +29,16 @@ class Simulator {
     Simulator& operator=(Simulator&&) = delete;
     Simulator() = default;
     virtual SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
-                                     const std::vector<uint8_t>& bytecode,
-                                     const std::vector<FF>& calldata) = 0;
+                                     fuzzer::FuzzerContractDB& contract_db,
+                                     const Tx& tx) = 0;
 };
 
 /// @brief uses barretenberg/vm2 to simulate the bytecode
 class CppSimulator : public Simulator {
   public:
     SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
-                             const std::vector<uint8_t>& bytecode,
-                             const std::vector<FF>& calldata) override;
+                             fuzzer::FuzzerContractDB& contract_db,
+                             const Tx& tx) override;
 };
 
 /// @brief uses the yarn-project/simulator to simulate the bytecode
@@ -61,8 +61,8 @@ class JsSimulator : public Simulator {
     static void initialize(std::string& simulator_path);
 
     SimulatorResult simulate(fuzzer::FuzzerWorldStateManager& ws_mgr,
-                             const std::vector<uint8_t>& bytecode,
-                             const std::vector<FF>& calldata) override;
+                             fuzzer::FuzzerContractDB& contract_db,
+                             const Tx& tx) override;
 };
 
 bool compare_simulator_results(const SimulatorResult& result1, const SimulatorResult& result2);

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -21,7 +21,7 @@
     "build:dev": "../scripts/tsc.sh --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
-    "build:fuzzer": "tsgo src/public/fuzzing/avm_simulator_bin.ts --outDir dest --rootDir src --module nodenext --moduleResolution nodenext --skipLibCheck --ignoreConfig"
+    "build:fuzzer": "yarn clean && ../scripts/tsc.sh"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
@@ -120,42 +120,4 @@ export class SimpleContractDataSource implements ContractDataSource {
     this.contractInstances.set(contractInstance.address.toString(), contractInstance);
     return Promise.resolve();
   }
-
-  /**
-   * FIXME: This is temporary
-   * Helper method for fuzzer: registers a contract with raw bytecode at a given address.
-   * Creates a minimal ContractClassPublic and ContractInstanceWithAddress.
-   * @param address - The contract address
-   * @param bytecode - The raw AVM bytecode
-   */
-  async addContractWithBytecode(address: AztecAddress, bytecode: Buffer): Promise<void> {
-    // Generate a deterministic class ID from the bytecode
-    const classId = Fr.fromBufferReduce(bytecode.subarray(0, 32));
-
-    // Create minimal ContractClassPublic
-    const contractClass: ContractClassPublic = {
-      id: classId,
-      version: 1 as const,
-      artifactHash: Fr.ZERO,
-      privateFunctionsRoot: Fr.ZERO,
-      privateFunctions: [],
-      utilityFunctions: [],
-      packedBytecode: bytecode,
-    };
-
-    // Create minimal ContractInstanceWithAddress
-    const contractInstance: ContractInstanceWithAddress = {
-      address,
-      version: 1 as const,
-      salt: Fr.ZERO,
-      deployer: address, // Use the contract address as deployer
-      currentContractClassId: classId,
-      originalContractClassId: classId,
-      initializationHash: Fr.ZERO,
-      publicKeys: PublicKeys.default(),
-    };
-
-    await this.addContractClass(contractClass);
-    await this.addContractInstance(contractInstance);
-  }
 }

--- a/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
@@ -4,7 +4,6 @@ import { createLogger } from '@aztec/foundation/log';
 import type { ContractArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import { PublicKeys } from '@aztec/stdlib/keys';
 
 import { getFunctionSelector } from '../avm/fixtures/utils.js';
 

--- a/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
+++ b/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
@@ -6,6 +6,9 @@ import {
   deserializeFromMessagePack,
   serializeWithMessagePack,
 } from '@aztec/stdlib/avm';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractClassPublic, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import { PublicKeys } from '@aztec/stdlib/keys';
 import { GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
@@ -16,6 +19,43 @@ import { SimpleContractDataSource } from '../fixtures/simple_contract_data_sourc
 import { PublicContractsDB } from '../public_db_sources.js';
 import { PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
 import { createFuzzerTx, registerContract } from './helpers.js';
+
+/**
+ * Converts a raw C++ ContractClass (deserialized from msgpack) to ContractClassPublic.
+ * C++ sends: { id, artifactHash, privateFunctionsRoot, packedBytecode }
+ * TS needs: { id, version, artifactHash, privateFunctionsRoot, privateFunctions, utilityFunctions, packedBytecode }
+ */
+function contractClassFromCpp(rawClass: any): ContractClassPublic {
+  return {
+    id: Fr.fromPlainObject(rawClass.id),
+    version: 1 as const,
+    artifactHash: Fr.fromPlainObject(rawClass.artifactHash),
+    privateFunctionsRoot: Fr.fromPlainObject(rawClass.privateFunctionsRoot),
+    privateFunctions: [],
+    utilityFunctions: [],
+    packedBytecode:
+      rawClass.packedBytecode instanceof Buffer ? rawClass.packedBytecode : Buffer.from(rawClass.packedBytecode),
+  };
+}
+
+/**
+ * Converts a raw C++ ContractInstance (deserialized from msgpack) to ContractInstanceWithAddress.
+ * C++ sends: { salt, deployer, currentContractClassId, originalContractClassId, initializationHash, publicKeys }
+ * TS needs: { address, version, salt, deployer, currentContractClassId, originalContractClassId, initializationHash, publicKeys }
+ * The address comes from the map key.
+ */
+function contractInstanceFromCpp(address: AztecAddress, rawInstance: any): ContractInstanceWithAddress {
+  return {
+    address,
+    version: 1 as const,
+    salt: Fr.fromPlainObject(rawInstance.salt),
+    deployer: AztecAddress.fromPlainObject(rawInstance.deployer),
+    currentContractClassId: Fr.fromPlainObject(rawInstance.currentContractClassId),
+    originalContractClassId: Fr.fromPlainObject(rawInstance.originalContractClassId),
+    initializationHash: Fr.fromPlainObject(rawInstance.initializationHash),
+    publicKeys: PublicKeys.fromPlainObject(rawInstance.publicKeys),
+  };
+}
 
 // This cache holds opened world states to avoid reopening them for each invocation.
 // It's a map so that in the future we could support multiple world states (if we had multiple fuzzers).
@@ -42,28 +82,26 @@ async function openExistingWorldState(dataDir: string, mapSizeKb: number): Promi
 async function simulateWithPublicTxSimulator(
   dataDir: string,
   mapSizeKb: number,
-  bytecode: Buffer,
   cppTx: AvmTxHint,
   cppGlobals: GlobalVariables,
+  contractClasses: ContractClassPublic[],
+  contractInstances: ContractInstanceWithAddress[],
 ): Promise<{ reverted: boolean; output: Fr[]; revertReason?: string; publicInputs: AvmCircuitPublicInputs }> {
   const worldStateService = await openExistingWorldState(dataDir, mapSizeKb);
   const merkleTrees = await worldStateService.fork();
 
-  // todo(ilyas): enable this once we can handle multiple bytecodes across multiple enqueued calls
-  // Concat all the enqueued calls, extract the de-duplicated contract addresses so we can register them
-  //const teardownCalls = cppTx.teardownEnqueuedCall ? [cppTx.teardownEnqueuedCall] : [];
-  //const contractAddresses = new Set([...cppTx.setupEnqueuedCalls, ...cppTx.appLogicEnqueuedCalls, ...teardownCalls].map(
-  //    call => call.request.contractAddress,
-  //));
-  //await Promise.all([...contractAddresses].map(addr => registerContract(merkleTrees, addr)));
-  //await Promise.all(
-  //    [...contractAddresses].map(addr => contractDataSource.addContractWithBytecode(addr, bytecode)),
-  //);
-
-  const contractAddress = cppTx.appLogicEnqueuedCalls[0].request.contractAddress;
-  await registerContract(merkleTrees, contractAddress);
   const contractDataSource = new SimpleContractDataSource();
-  await contractDataSource.addContractWithBytecode(contractAddress, bytecode);
+
+  // Register contract classes from C++
+  for (const contractClass of contractClasses) {
+    await contractDataSource.addContractClass(contractClass);
+  }
+
+  // Register contract instances from C++
+  for (const contractInstance of contractInstances) {
+    await registerContract(merkleTrees, contractInstance.address);
+    await contractDataSource.addContractInstance(contractInstance);
+  }
 
   const contractsDb = new PublicContractsDB(contractDataSource);
 
@@ -91,21 +129,51 @@ async function simulateWithPublicTxSimulator(
 async function executeFromJson(jsonLine: string): Promise<void> {
   try {
     const input = JSON.parse(jsonLine.trim());
-    if (!input.bytecode || !input.ws_data_dir || !input.ws_map_size_kb || !input.tx || !input.globals) {
+    if (
+      !input.ws_data_dir ||
+      !input.ws_map_size_kb ||
+      !input.tx ||
+      !input.globals ||
+      !input.contractClasses ||
+      !input.contractInstances
+    ) {
       writeSync(
         process.stdout.fd,
-        'Error: JSON must contain "bytecode", "ws_data_dir", "ws_map_size_kb", "tx", and "globals" fields\n',
+        'Error: JSON must contain "ws_data_dir", "ws_map_size_kb", "tx", "globals", "contractClasses", and "contractInstances" fields\n',
       );
       return;
     }
 
-    const bytecode = Buffer.from(input.bytecode, 'base64');
     const rawTx: object = deserializeFromMessagePack(Buffer.from(input.tx, 'base64'));
     const tx = AvmTxHint.fromPlainObject(rawTx);
     const rawGlobals = deserializeFromMessagePack(Buffer.from(input.globals, 'base64'));
     const globals = GlobalVariables.fromPlainObject(rawGlobals);
 
-    const result = await simulateWithPublicTxSimulator(input.ws_data_dir, input.ws_map_size_kb, bytecode, tx, globals);
+    // Parse contract classes from C++ (bytecode is inside packedBytecode field)
+    // C++ sends a vector<ContractClass> - id is already inside each class
+    const rawClassesArray: any[] = deserializeFromMessagePack(Buffer.from(input.contractClasses, 'base64'));
+    const contractClasses: ContractClassPublic[] = [];
+    for (const rawClass of rawClassesArray) {
+      contractClasses.push(contractClassFromCpp(rawClass));
+    }
+
+    // Parse contract instances from C++
+    // C++ sends a vector<pair<AztecAddress, ContractInstance>>
+    const rawInstancesArray: [any, any][] = deserializeFromMessagePack(Buffer.from(input.contractInstances, 'base64'));
+    const contractInstances: ContractInstanceWithAddress[] = [];
+    for (const [rawAddress, rawInstance] of rawInstancesArray) {
+      const address = AztecAddress.fromPlainObject(rawAddress);
+      contractInstances.push(contractInstanceFromCpp(address, rawInstance));
+    }
+
+    const result = await simulateWithPublicTxSimulator(
+      input.ws_data_dir,
+      input.ws_map_size_kb,
+      tx,
+      globals,
+      contractClasses,
+      contractInstances,
+    );
     const resultBuffer = serializeWithMessagePack({
       reverted: result.reverted,
       output: result.output,

--- a/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
+++ b/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
@@ -7,8 +7,12 @@ import {
   serializeWithMessagePack,
 } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { ContractClassPublic, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import { PublicKeys } from '@aztec/stdlib/keys';
+import {
+  type ContractClassPublic,
+  type ContractInstanceWithAddress,
+  contractClassPublicFromPlainObject,
+  contractInstanceWithAddressFromPlainObject,
+} from '@aztec/stdlib/contract';
 import { GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
@@ -19,43 +23,6 @@ import { SimpleContractDataSource } from '../fixtures/simple_contract_data_sourc
 import { PublicContractsDB } from '../public_db_sources.js';
 import { PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
 import { createFuzzerTx, registerContract } from './helpers.js';
-
-/**
- * Converts a raw C++ ContractClass (deserialized from msgpack) to ContractClassPublic.
- * C++ sends: { id, artifactHash, privateFunctionsRoot, packedBytecode }
- * TS needs: { id, version, artifactHash, privateFunctionsRoot, privateFunctions, utilityFunctions, packedBytecode }
- */
-function contractClassFromCpp(rawClass: any): ContractClassPublic {
-  return {
-    id: Fr.fromPlainObject(rawClass.id),
-    version: 1 as const,
-    artifactHash: Fr.fromPlainObject(rawClass.artifactHash),
-    privateFunctionsRoot: Fr.fromPlainObject(rawClass.privateFunctionsRoot),
-    privateFunctions: [],
-    utilityFunctions: [],
-    packedBytecode:
-      rawClass.packedBytecode instanceof Buffer ? rawClass.packedBytecode : Buffer.from(rawClass.packedBytecode),
-  };
-}
-
-/**
- * Converts a raw C++ ContractInstance (deserialized from msgpack) to ContractInstanceWithAddress.
- * C++ sends: { salt, deployer, currentContractClassId, originalContractClassId, initializationHash, publicKeys }
- * TS needs: { address, version, salt, deployer, currentContractClassId, originalContractClassId, initializationHash, publicKeys }
- * The address comes from the map key.
- */
-function contractInstanceFromCpp(address: AztecAddress, rawInstance: any): ContractInstanceWithAddress {
-  return {
-    address,
-    version: 1 as const,
-    salt: Fr.fromPlainObject(rawInstance.salt),
-    deployer: AztecAddress.fromPlainObject(rawInstance.deployer),
-    currentContractClassId: Fr.fromPlainObject(rawInstance.currentContractClassId),
-    originalContractClassId: Fr.fromPlainObject(rawInstance.originalContractClassId),
-    initializationHash: Fr.fromPlainObject(rawInstance.initializationHash),
-    publicKeys: PublicKeys.fromPlainObject(rawInstance.publicKeys),
-  };
-}
 
 // This cache holds opened world states to avoid reopening them for each invocation.
 // It's a map so that in the future we could support multiple world states (if we had multiple fuzzers).
@@ -152,19 +119,14 @@ async function executeFromJson(jsonLine: string): Promise<void> {
     // Parse contract classes from C++ (bytecode is inside packedBytecode field)
     // C++ sends a vector<ContractClass> - id is already inside each class
     const rawClassesArray: any[] = deserializeFromMessagePack(Buffer.from(input.contractClasses, 'base64'));
-    const contractClasses: ContractClassPublic[] = [];
-    for (const rawClass of rawClassesArray) {
-      contractClasses.push(contractClassFromCpp(rawClass));
-    }
+    const contractClasses: ContractClassPublic[] = rawClassesArray.map(contractClassPublicFromPlainObject);
 
     // Parse contract instances from C++
     // C++ sends a vector<pair<AztecAddress, ContractInstance>>
     const rawInstancesArray: [any, any][] = deserializeFromMessagePack(Buffer.from(input.contractInstances, 'base64'));
-    const contractInstances: ContractInstanceWithAddress[] = [];
-    for (const [rawAddress, rawInstance] of rawInstancesArray) {
-      const address = AztecAddress.fromPlainObject(rawAddress);
-      contractInstances.push(contractInstanceFromCpp(address, rawInstance));
-    }
+    const contractInstances: ContractInstanceWithAddress[] = rawInstancesArray.map(([rawAddress, rawInstance]) =>
+      contractInstanceWithAddressFromPlainObject(AztecAddress.fromPlainObject(rawAddress), rawInstance),
+    );
 
     const result = await simulateWithPublicTxSimulator(
       input.ws_data_dir,

--- a/yarn-project/stdlib/src/contract/interfaces/contract_class.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_class.ts
@@ -1,4 +1,4 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { type ZodFor, schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
@@ -153,3 +153,21 @@ export const ContractClassPublicSchema = z
 
 /** The contract class with the block it was initially deployed at */
 export type ContractClassPublicWithBlockNumber = { l2BlockNumber: number } & ContractClassPublic;
+
+/**
+ * Creates a ContractClassPublic from a plain object without Zod validation.
+ * Suitable for deserializing trusted data (e.g., from C++ via MessagePack).
+ * Note: privateFunctions and utilityFunctions are set to empty arrays since
+ * C++ does not provide them.
+ */
+export function contractClassPublicFromPlainObject(obj: any): ContractClassPublic {
+  return {
+    id: Fr.fromPlainObject(obj.id),
+    version: 1,
+    artifactHash: Fr.fromPlainObject(obj.artifactHash),
+    privateFunctionsRoot: Fr.fromPlainObject(obj.privateFunctionsRoot),
+    privateFunctions: [],
+    utilityFunctions: [],
+    packedBytecode: obj.packedBytecode instanceof Buffer ? obj.packedBytecode : Buffer.from(obj.packedBytecode),
+  };
+}

--- a/yarn-project/stdlib/src/contract/interfaces/contract_instance.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_instance.ts
@@ -1,8 +1,8 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
+import { Fr } from '@aztec/foundation/curves/bn254';
 
 import { z } from 'zod';
 
-import type { AztecAddress } from '../../aztec-address/index.js';
+import { AztecAddress } from '../../aztec-address/index.js';
 import { PublicKeys } from '../../keys/public_keys.js';
 import { type ZodFor, schemas } from '../../schemas/index.js';
 
@@ -45,3 +45,33 @@ export const ContractInstanceSchema = z.object({
 export const ContractInstanceWithAddressSchema = ContractInstanceSchema.and(
   z.object({ address: schemas.AztecAddress }),
 ) satisfies ZodFor<ContractInstanceWithAddress>;
+
+/**
+ * Creates a ContractInstance from a plain object without Zod validation.
+ * Suitable for deserializing trusted data (e.g., from C++ via MessagePack).
+ */
+export function contractInstanceFromPlainObject(obj: any): ContractInstance {
+  return {
+    version: 1,
+    salt: Fr.fromPlainObject(obj.salt),
+    deployer: AztecAddress.fromPlainObject(obj.deployer),
+    currentContractClassId: Fr.fromPlainObject(obj.currentContractClassId),
+    originalContractClassId: Fr.fromPlainObject(obj.originalContractClassId),
+    initializationHash: Fr.fromPlainObject(obj.initializationHash),
+    publicKeys: PublicKeys.fromPlainObject(obj.publicKeys),
+  };
+}
+
+/**
+ * Creates a ContractInstanceWithAddress from a plain object without Zod validation.
+ * Suitable for deserializing trusted data (e.g., from C++ via MessagePack).
+ */
+export function contractInstanceWithAddressFromPlainObject(
+  address: AztecAddress,
+  obj: any,
+): ContractInstanceWithAddress {
+  return {
+    ...contractInstanceFromPlainObject(obj),
+    address,
+  };
+}


### PR DESCRIPTION
Get contract classes and instances from `ContractClassLogs` and `PrivateLogs` and use them as part of fuzzing