### PR TITLE
feat(avm): emit unencrypted log gadget fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -82,6 +82,15 @@ class JsSimulator : public Simulator {
                              const Tx& tx) override;
 };
 
+GlobalVariables create_default_globals();
+
+Tx create_default_tx(const AztecAddress& contract_address,
+                     const AztecAddress& sender_address,
+                     const std::vector<FF>& calldata,
+                     [[maybe_unused]] const FF& transaction_fee,
+                     bool is_static_call,
+                     const Gas& gas_limit);
+
 bool compare_simulator_results(const SimulatorResult& result1, const SimulatorResult& result2);
 
 GlobalVariables create_default_globals();

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
@@ -4,8 +4,10 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/events/update_check.hpp"
+#include "barretenberg/vm2/simulation/gadgets/bytecode_manager.hpp"
 #include "barretenberg/vm2/simulation/gadgets/context_provider.hpp"
 #include "barretenberg/vm2/simulation/gadgets/poseidon2.hpp"
+#include "barretenberg/vm2/simulation/interfaces/context.hpp"
 #include "barretenberg/vm2/simulation/lib/raw_data_dbs.hpp"
 #include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
 #include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
@@ -14,14 +16,12 @@ namespace bb::avm2::fuzzing {
 
 using namespace bb::avm2::simulation;
 
-GadgetFuzzerContextHelper::GadgetFuzzerContextHelper(AztecAddress contract_address,
-                                                     bool is_static,
-                                                     TransactionPhase phase,
-                                                     uint32_t start_clk)
+GadgetFuzzerContextHelper::GadgetFuzzerContextHelper(AztecAddress contract_address, bool is_static, uint32_t start_clk)
     : execution_id_manager(start_clk)
     , range_check(range_check_emitter)
     , field_gt(range_check, field_gt_emitter)
     , greater_than(field_gt, range_check, greater_than_emitter)
+    , memory_provider(range_check, execution_id_manager, memory_emitter)
     , merkle_check(poseidon2, merkle_check_emitter)
     , poseidon2(execution_id_manager, greater_than, hash_event_emitter, perm_event_emitter, perm_mem_event_emitter)
     , written_public_data_slots_tree_check(poseidon2,
@@ -29,19 +29,16 @@ GadgetFuzzerContextHelper::GadgetFuzzerContextHelper(AztecAddress contract_addre
                                            field_gt,
                                            build_public_data_slots_tree(),
                                            written_public_data_slots_tree_check_emitter)
-{
+    , retrieved_bytecodes_tree_check(
+          poseidon2, merkle_check, field_gt, build_retrieved_bytecodes_tree(), retrieved_bytecodes_tree_check_emitter)
 
-    bb::avm2::ExecutionHints hints;
-    hints.global_variables = create_default_globals();
+{
+    global_variables = create_default_globals();
+    hints.global_variables = global_variables;
     hints.tx = create_default_tx(contract_address, contract_address, {}, FF(0), is_static, GAS_LIMIT);
 
-    // DBs: Just for now - TODO(MW) use fuzzing dbs?
     HintedRawContractDB contract_db(hints);
-    HintedRawMerkleDB raw_merkle_db(hints);
-    PureMerkleDB base_merkle_db(
-        hints.tx.non_revertible_accumulated_data.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
-    SideEffectTrackingDB merkle_db(
-        hints.tx.non_revertible_accumulated_data.nullifiers[0], base_merkle_db, side_effect_tracker);
+    auto merkle_db = make_empty_merkle_db();
 
     BytecodeHasher bytecode_hasher(poseidon2, bytecode_hashing_emitter);
     CalldataHashingProvider calldata_hashing_provider(poseidon2, calldata_event_emitter);
@@ -53,35 +50,98 @@ GadgetFuzzerContextHelper::GadgetFuzzerContextHelper(AztecAddress contract_addre
     ContractInstanceManager contract_instance_manager(
         contract_db, merkle_db, update_check, field_gt, hints.protocol_contracts, contract_instance_retrieval_emitter);
     InternalCallStackManagerProvider internal_call_stack_manager_provider(internal_call_stack_emitter);
-    TxBytecodeManager bytecode_manager(contract_db,
-                                       merkle_db,
-                                       bytecode_hasher,
-                                       range_check,
-                                       contract_instance_manager,
-                                       retrieved_bytecodes_tree_check,
-                                       bytecode_retrieval_emitter,
-                                       bytecode_decomposition_emitter,
-                                       instruction_fetching_emitter);
+    tx_bytecode_manager = std::make_unique<TxBytecodeManager>(contract_db,
+                                                              merkle_db,
+                                                              bytecode_hasher,
+                                                              range_check,
+                                                              contract_instance_manager,
+                                                              retrieved_bytecodes_tree_check,
+                                                              bytecode_retrieval_emitter,
+                                                              bytecode_decomposition_emitter,
+                                                              instruction_fetching_emitter);
 
     MemoryProvider mem_provider(range_check, execution_id_manager, memory_emitter);
-    ContextProvider context_provider(bytecode_manager,
-                                     mem_provider,
-                                     calldata_hashing_provider,
-                                     internal_call_stack_manager_provider,
-                                     merkle_db,
-                                     written_public_data_slots_tree_check,
-                                     retrieved_bytecodes_tree_check,
-                                     side_effect_tracker,
-                                     hints.global_variables);
-
-    context = context_provider.make_enqueued_context(contract_address,
-                                                     contract_address,
-                                                     FF(0),
-                                                     {},
-                                                     is_static,
-                                                     hints.tx.gas_settings.gas_limits,
-                                                     hints.tx.gas_used_by_private,
-                                                     phase);
+    context_provider = std::make_unique<ContextProvider>(*tx_bytecode_manager,
+                                                         mem_provider,
+                                                         calldata_hashing_provider,
+                                                         internal_call_stack_manager_provider,
+                                                         merkle_db,
+                                                         written_public_data_slots_tree_check,
+                                                         retrieved_bytecodes_tree_check,
+                                                         side_effect_tracker,
+                                                         hints.global_variables);
 }
 
+// A lighter version of ContextProvider::make_enqueued_context
+std::unique_ptr<ContextInterface> GadgetFuzzerContextHelper::make_enqueued_fuzzing_context(AztecAddress address,
+                                                                                           AztecAddress msg_sender,
+                                                                                           bool is_static,
+                                                                                           FF transaction_fee,
+                                                                                           std::span<const FF> calldata,
+                                                                                           Gas gas_limit,
+                                                                                           Gas gas_used,
+                                                                                           TransactionPhase phase)
+{
+    auto merkle_db = make_empty_merkle_db();
+    // Note: not incremented between contexts
+    uint32_t context_id = context_provider->get_next_context_id();
+    return std::make_unique<EnqueuedCallContext>(
+        context_id,
+        address,
+        msg_sender,
+        transaction_fee,
+        is_static,
+        gas_limit,
+        gas_used,
+        global_variables,
+        std::make_unique<BytecodeManager>(address, *tx_bytecode_manager),
+        memory_provider.make_memory(static_cast<uint16_t>(context_id)),
+        InternalCallStackManagerProvider(internal_call_stack_emitter).make_internal_call_stack_manager(context_id),
+        merkle_db,
+        written_public_data_slots_tree_check,
+        retrieved_bytecodes_tree_check,
+        side_effect_tracker,
+        phase,
+        calldata);
+}
+
+// A lighter version of ContextProvider::make_nested_context
+std::unique_ptr<ContextInterface> GadgetFuzzerContextHelper::make_nested_fuzzing_context(
+    AztecAddress address, AztecAddress msg_sender, ContextInterface& parent_context, Gas gas_limit)
+{
+
+    auto merkle_db = make_empty_merkle_db();
+    // Note: not incremented between contexts
+    uint32_t context_id = context_provider->get_next_context_id();
+    return std::make_unique<NestedContext>(
+        context_id,
+        parent_context.get_address(),
+        msg_sender,
+        parent_context.get_transaction_fee(),
+        parent_context.get_is_static(),
+        gas_limit,
+        parent_context.get_globals(),
+        std::make_unique<BytecodeManager>(address, *tx_bytecode_manager),
+        memory_provider.make_memory(static_cast<uint16_t>(context_id)),
+        InternalCallStackManagerProvider(internal_call_stack_emitter).make_internal_call_stack_manager(context_id),
+        merkle_db,
+        written_public_data_slots_tree_check,
+        retrieved_bytecodes_tree_check,
+        side_effect_tracker,
+        parent_context.get_phase(),
+        parent_context,
+        0,
+        0);
+}
+
+SideEffectTrackingDB GadgetFuzzerContextHelper::make_empty_merkle_db()
+{
+    // DBs: Just for now - TODO(MW) use fuzzing dbs?
+    HintedRawMerkleDB raw_merkle_db(hints);
+    PureMerkleDB base_merkle_db(
+        hints.tx.non_revertible_accumulated_data.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
+    SideEffectTrackingDB merkle_db(
+        hints.tx.non_revertible_accumulated_data.nullifiers[0], base_merkle_db, side_effect_tracker);
+    return merkle_db;
+}
 } // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
@@ -1,0 +1,87 @@
+#include "context_helper.hpp"
+
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/simulation/events/update_check.hpp"
+#include "barretenberg/vm2/simulation/gadgets/context_provider.hpp"
+#include "barretenberg/vm2/simulation/gadgets/poseidon2.hpp"
+#include "barretenberg/vm2/simulation/lib/raw_data_dbs.hpp"
+#include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
+#include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
+
+namespace bb::avm2::fuzzing {
+
+using namespace bb::avm2::simulation;
+
+GadgetFuzzerContextHelper::GadgetFuzzerContextHelper(AztecAddress contract_address,
+                                                     bool is_static,
+                                                     TransactionPhase phase,
+                                                     uint32_t start_clk)
+    : execution_id_manager(start_clk)
+    , range_check(range_check_emitter)
+    , field_gt(range_check, field_gt_emitter)
+    , greater_than(field_gt, range_check, greater_than_emitter)
+    , merkle_check(poseidon2, merkle_check_emitter)
+    , poseidon2(execution_id_manager, greater_than, hash_event_emitter, perm_event_emitter, perm_mem_event_emitter)
+    , written_public_data_slots_tree_check(poseidon2,
+                                           merkle_check,
+                                           field_gt,
+                                           build_public_data_slots_tree(),
+                                           written_public_data_slots_tree_check_emitter)
+{
+
+    bb::avm2::ExecutionHints hints;
+    hints.global_variables = create_default_globals();
+    hints.tx = create_default_tx(contract_address, contract_address, {}, FF(0), is_static, GAS_LIMIT);
+
+    // DBs: Just for now - TODO(MW) use fuzzing dbs?
+    HintedRawContractDB contract_db(hints);
+    HintedRawMerkleDB raw_merkle_db(hints);
+    PureMerkleDB base_merkle_db(
+        hints.tx.non_revertible_accumulated_data.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
+    SideEffectTrackingDB merkle_db(
+        hints.tx.non_revertible_accumulated_data.nullifiers[0], base_merkle_db, side_effect_tracker);
+
+    BytecodeHasher bytecode_hasher(poseidon2, bytecode_hashing_emitter);
+    CalldataHashingProvider calldata_hashing_provider(poseidon2, calldata_event_emitter);
+
+    UpdateCheck update_check(
+        poseidon2, range_check, greater_than, merkle_db, update_check_emitter, hints.global_variables);
+    RetrievedBytecodesTreeCheck retrieved_bytecodes_tree_check(
+        poseidon2, merkle_check, field_gt, build_retrieved_bytecodes_tree(), retrieved_bytecodes_tree_check_emitter);
+    ContractInstanceManager contract_instance_manager(
+        contract_db, merkle_db, update_check, field_gt, hints.protocol_contracts, contract_instance_retrieval_emitter);
+    InternalCallStackManagerProvider internal_call_stack_manager_provider(internal_call_stack_emitter);
+    TxBytecodeManager bytecode_manager(contract_db,
+                                       merkle_db,
+                                       bytecode_hasher,
+                                       range_check,
+                                       contract_instance_manager,
+                                       retrieved_bytecodes_tree_check,
+                                       bytecode_retrieval_emitter,
+                                       bytecode_decomposition_emitter,
+                                       instruction_fetching_emitter);
+
+    MemoryProvider mem_provider(range_check, execution_id_manager, memory_emitter);
+    ContextProvider context_provider(bytecode_manager,
+                                     mem_provider,
+                                     calldata_hashing_provider,
+                                     internal_call_stack_manager_provider,
+                                     merkle_db,
+                                     written_public_data_slots_tree_check,
+                                     retrieved_bytecodes_tree_check,
+                                     side_effect_tracker,
+                                     hints.global_variables);
+
+    context = context_provider.make_enqueued_context(contract_address,
+                                                     contract_address,
+                                                     FF(0),
+                                                     {},
+                                                     is_static,
+                                                     hints.tx.gas_settings.gas_limits,
+                                                     hints.tx.gas_used_by_private,
+                                                     phase);
+}
+
+} // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
+#include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/gadgets/bytecode_hashing.hpp"
 #include "barretenberg/vm2/simulation/gadgets/bytecode_manager.hpp"
 #include "barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp"
+#include "barretenberg/vm2/simulation/gadgets/context_provider.hpp"
 #include "barretenberg/vm2/simulation/gadgets/contract_instance_manager.hpp"
 #include "barretenberg/vm2/simulation/gadgets/field_gt.hpp"
 #include "barretenberg/vm2/simulation/gadgets/gt.hpp"
@@ -16,6 +19,7 @@
 #include "barretenberg/vm2/simulation/interfaces/context.hpp"
 #include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
 #include "barretenberg/vm2/simulation/lib/side_effect_tracker.hpp"
+#include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
 
 namespace bb::avm2::fuzzing {
 
@@ -39,7 +43,6 @@ class GadgetFuzzerContextHelper {
   public:
     GadgetFuzzerContextHelper(AztecAddress contract_address = AztecAddress(0),
                               bool is_static = false,
-                              TransactionPhase phase = TransactionPhase::APP_LOGIC,
                               uint32_t start_clk = 0);
     // Commonly used emitters:
     DeduplicatingEventEmitter<RangeCheckEvent> range_check_emitter;
@@ -53,10 +56,25 @@ class GadgetFuzzerContextHelper {
     GreaterThan greater_than;
     // Side effect tracker:
     SideEffectTracker side_effect_tracker;
-
+    // Memory provider:
+    MemoryProvider memory_provider;
+    // Context provider:
+    std::unique_ptr<simulation::ContextProvider> context_provider;
     // Context:
+    std::unique_ptr<simulation::ContextInterface> make_enqueued_fuzzing_context(
+        AztecAddress address,
+        AztecAddress msg_sender,
+        bool is_static = false,
+        FF transaction_fee = FF(0),
+        std::span<const FF> calldata = {},
+        Gas gas_limit = GAS_LIMIT,
+        Gas gas_used = GAS_USED_BY_PRIVATE,
+        TransactionPhase phase = TransactionPhase::APP_LOGIC);
 
-    std::unique_ptr<simulation::ContextInterface> context;
+    std::unique_ptr<simulation::ContextInterface> make_nested_fuzzing_context(AztecAddress address,
+                                                                              AztecAddress msg_sender,
+                                                                              ContextInterface& parent_context,
+                                                                              Gas gas_limit = GAS_LIMIT);
 
   private:
     // Emitters:
@@ -80,9 +98,13 @@ class GadgetFuzzerContextHelper {
     MerkleCheck merkle_check;
     Poseidon2 poseidon2;
     WrittenPublicDataSlotsTreeCheck written_public_data_slots_tree_check;
-};
+    RetrievedBytecodesTreeCheck retrieved_bytecodes_tree_check;
+    std::unique_ptr<TxBytecodeManager> tx_bytecode_manager;
 
-std::unique_ptr<simulation::ContextInterface> make_fuzzing_context(
-    AztecAddress& contract_address, TransactionPhase phase = TransactionPhase::APP_LOGIC);
+    // Misc:
+    GlobalVariables global_variables;
+    ExecutionHints hints;
+    SideEffectTrackingDB make_empty_merkle_db();
+};
 
 } // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/simulation/gadgets/bytecode_hashing.hpp"
+#include "barretenberg/vm2/simulation/gadgets/bytecode_manager.hpp"
+#include "barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp"
+#include "barretenberg/vm2/simulation/gadgets/contract_instance_manager.hpp"
+#include "barretenberg/vm2/simulation/gadgets/field_gt.hpp"
+#include "barretenberg/vm2/simulation/gadgets/gt.hpp"
+#include "barretenberg/vm2/simulation/gadgets/internal_call_stack_manager.hpp"
+#include "barretenberg/vm2/simulation/gadgets/merkle_check.hpp"
+#include "barretenberg/vm2/simulation/gadgets/poseidon2.hpp"
+#include "barretenberg/vm2/simulation/gadgets/range_check.hpp"
+#include "barretenberg/vm2/simulation/gadgets/update_check.hpp"
+#include "barretenberg/vm2/simulation/gadgets/written_public_data_slots_tree_check.hpp"
+#include "barretenberg/vm2/simulation/interfaces/context.hpp"
+#include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
+#include "barretenberg/vm2/simulation/lib/side_effect_tracker.hpp"
+
+namespace bb::avm2::fuzzing {
+
+using namespace bb::avm2::simulation;
+
+/**
+ * @brief Sets up gadgets and instance managers to provide a
+ * context for fuzzing. NOTE: rudimentary set up for testing, should likely be merged
+ * with TestSimulator in fuzz_lib in future
+ *
+ * TODO(MW): I just set the ones I needed to be accessed as public, with others in private and
+ * gadgets in the constructor - will clean this up
+ *
+ * @param contract_address The address to be configured in the context
+ * @param is_static Whether this call is static (defaults to false)
+ * @param phase The phase (defaults to APP_LOGIC)
+ * @param start_clk The starting clk (defaults to 0)
+ * @return A context interface to be passed to fuzzed gadgets
+ */
+class GadgetFuzzerContextHelper {
+  public:
+    GadgetFuzzerContextHelper(AztecAddress contract_address = AztecAddress(0),
+                              bool is_static = false,
+                              TransactionPhase phase = TransactionPhase::APP_LOGIC,
+                              uint32_t start_clk = 0);
+    // Commonly used emitters:
+    DeduplicatingEventEmitter<RangeCheckEvent> range_check_emitter;
+    DeduplicatingEventEmitter<GreaterThanEvent> greater_than_emitter;
+    DeduplicatingEventEmitter<FieldGreaterThanEvent> field_gt_emitter;
+
+    // Commonly used gadgets:
+    ExecutionIdManager execution_id_manager;
+    RangeCheck range_check;
+    FieldGreaterThan field_gt;
+    GreaterThan greater_than;
+    // Side effect tracker:
+    SideEffectTracker side_effect_tracker;
+
+    // Context:
+
+    std::unique_ptr<simulation::ContextInterface> context;
+
+  private:
+    // Emitters:
+    EventEmitter<MemoryEvent> memory_emitter;
+    EventEmitter<Poseidon2HashEvent> hash_event_emitter;
+    EventEmitter<Poseidon2PermutationEvent> perm_event_emitter;
+    EventEmitter<Poseidon2PermutationMemoryEvent> perm_mem_event_emitter;
+    EventEmitter<UpdateCheckEvent> update_check_emitter;
+    EventEmitter<MerkleCheckEvent> merkle_check_emitter;
+    EventEmitter<ContractInstanceRetrievalEvent> contract_instance_retrieval_emitter;
+    EventEmitter<WrittenPublicDataSlotsTreeCheckEvent> written_public_data_slots_tree_check_emitter;
+    EventEmitter<BytecodeRetrievalEvent> bytecode_retrieval_emitter;
+    EventEmitter<BytecodeHashingEvent> bytecode_hashing_emitter;
+    EventEmitter<BytecodeDecompositionEvent> bytecode_decomposition_emitter;
+    EventEmitter<RetrievedBytecodesTreeCheckEvent> retrieved_bytecodes_tree_check_emitter;
+    EventEmitter<CalldataEvent> calldata_event_emitter;
+    EventEmitter<InternalCallStackEvent> internal_call_stack_emitter;
+    DeduplicatingEventEmitter<InstructionFetchingEvent> instruction_fetching_emitter;
+
+    // Gadgets:
+    MerkleCheck merkle_check;
+    Poseidon2 poseidon2;
+    WrittenPublicDataSlotsTreeCheck written_public_data_slots_tree_check;
+};
+
+std::unique_ptr<simulation::ContextInterface> make_fuzzing_context(
+    AztecAddress& contract_address, TransactionPhase phase = TransactionPhase::APP_LOGIC);
+
+} // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
@@ -28,6 +28,7 @@
 #include "barretenberg/vm2/simulation/lib/raw_data_dbs.hpp"
 #include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
 #include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
+#include "barretenberg/vm2/testing/instruction_builder.hpp"
 #include "barretenberg/vm2/tooling/debugger.hpp"
 #include "barretenberg/vm2/tracegen/execution_trace.hpp"
 #include "barretenberg/vm2/tracegen/field_gt_trace.hpp"
@@ -50,8 +51,9 @@ using bb::avm2::MemoryValue;
 using emit_log_rel = bb::avm2::emit_unencrypted_log<FF>;
 
 const uint8_t default_log_fields = 16;
-// TODO(MW): Set to slightly above the maximum size so we hit error_too_many_log_fields, but can be slow.
-// Could instead set to < 1000 and explicitly set an edge case of > max in the custom mutator?
+// TODO(MW): Set to slightly above the maximum size (FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH) so we hit
+// error_too_many_log_fields, but can be slow. Could instead set to < 1000 and explicitly set an edge case of > max in
+// the custom mutator?
 const uint32_t max_log_fields = 4100;
 
 struct EmitUnencryptedLogFuzzerInput {
@@ -116,7 +118,27 @@ struct EmitUnencryptedLogFuzzerInput {
 
         return input;
     }
+
+    bool is_error() const
+    {
+        uint64_t end_log_address = static_cast<uint64_t>(log_offset) + static_cast<uint64_t>(log_size) - 1;
+        bool error_memory_out_of_bounds = end_log_address > AVM_HIGHEST_MEM_ADDRESS;
+        // TODO(MW): Since this fuzzer only emits one log for now, we just check its size, once it emits multiple
+        // we would need to check prev_emitted_log_fields + total_size:
+        bool error_too_many_log_fields = PUBLIC_LOG_HEADER_LENGTH + log_size > FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH;
+        return error_memory_out_of_bounds || error_too_many_log_fields || tag_mismatch || is_static;
+    }
 };
+
+ContextEvent fill_context_event(std::unique_ptr<ContextInterface>& context)
+{
+    return { .id = context->get_context_id(),
+             .pc = context->get_pc(),
+             .contract_addr = context->get_address(),
+             .is_static = context->get_is_static(),
+             .numUnencryptedLogFields =
+                 context->get_side_effect_tracker().get_side_effects().get_num_unencrypted_log_fields() };
+}
 
 // TODO(MW): multiple events, std::vector<std::vector<FF>>
 std::vector<FF> generate_and_set_log_fields(const EmitUnencryptedLogFuzzerInput& input, MemoryInterface* mem)
@@ -275,7 +297,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     EmitUnencryptedLog emit_unencrypted_log(
         context_helper.execution_id_manager, context_helper.greater_than, emit_log_emitter);
 
-    auto context = std::move(context_helper.context);
+    auto context =
+        context_helper.make_enqueued_fuzzing_context(input.contract_address, input.contract_address, input.is_static);
+
+    // TODO(MW): This is a little janky. Without it, emit_unencrypted_log sets its clk at 0, but execution always starts
+    // at 1:
+    context_helper.execution_id_manager.increment_execution_id();
 
     // TODO(MW): multiple log events
     std::vector<FF> log_fields = generate_and_set_log_fields(input, &context->get_memory());
@@ -294,6 +321,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     RangeCheckTraceBuilder range_check_builder;
     FieldGreaterThanTraceBuilder field_gt_builder;
     GreaterThanTraceBuilder gt_builder;
+    ExecutionTraceBuilder ex_builder;
     EmitUnencryptedLogTraceBuilder builder;
 
     uint32_t pi_row = AVM_PUBLIC_INPUTS_AVM_ACCUMULATED_DATA_PUBLIC_LOGS_ROW_IDX;
@@ -319,6 +347,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     precomputed_builder.process_power_of_2(trace);
     precomputed_builder.process_misc(trace, pi_row + 1); // Need enough for public input columns
 
+    // TODO(MW): Properly set these via calls (lookup changed to perm recently)
+    // TODO(MW): Set before_context_event.prev_num_unencrypted_log_fields in multiple calls
+    ExecutionEvent ex_event = { .wire_instruction =
+                                    bb::avm2::testing::InstructionBuilder(WireOpCode::EMITUNENCRYPTEDLOG).build(),
+                                .after_context_event = fill_context_event(context) };
+    ex_builder.process({ ex_event }, trace);
+    auto exec_log_row = trace.get_column_rows(avm2::Column::execution_sel_exec_dispatch_emit_unencrypted_log);
+    trace.set(avm2::Column::execution_rop_1_, exec_log_row - 1, input.log_offset);
+    trace.set(avm2::Column::execution_register_0_, exec_log_row - 1, input.log_size);
+    trace.set(avm2::Column::execution_sel_opcode_error, exec_log_row - 1, error ? 1 : 0);
+
     range_check_builder.process(context_helper.range_check_emitter.dump_events(), trace);
     field_gt_builder.process(context_helper.field_gt_emitter.dump_events(), trace);
     gt_builder.process(context_helper.greater_than_emitter.dump_events(), trace);
@@ -332,8 +371,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     check_relation<emit_log_rel>(trace);
     check_all_interactions<EmitUnencryptedLogTraceBuilder>(trace);
-    check_interaction<ExecutionTraceBuilder, bb::avm2::lookup_execution_dispatch_to_emit_unencrypted_log_settings>(
-        trace);
+    check_interaction<ExecutionTraceBuilder, bb::avm2::perm_execution_dispatch_to_emit_unencrypted_log_settings>(trace);
 
     return 0;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
@@ -1,0 +1,339 @@
+#include "barretenberg/vm2/simulation/gadgets/emit_unencrypted_log.hpp"
+#include <cassert>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
+#include "barretenberg/avm_fuzzer/harness/context_helper.hpp"
+#include "barretenberg/common/serialize.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/vm2/common/avm_io.hpp"
+#include "barretenberg/vm2/common/aztec_constants.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/common/memory_types.hpp"
+#include "barretenberg/vm2/constraining/testing/check_relation.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
+#include "barretenberg/vm2/generated/relations/emit_unencrypted_log.hpp"
+#include "barretenberg/vm2/generated/relations/lookups_execution.hpp"
+#include "barretenberg/vm2/simulation/events/emit_unencrypted_log_event.hpp"
+#include "barretenberg/vm2/simulation/events/event_emitter.hpp"
+#include "barretenberg/vm2/simulation/events/gt_event.hpp"
+#include "barretenberg/vm2/simulation/events/range_check_event.hpp"
+#include "barretenberg/vm2/simulation/gadgets/context_provider.hpp"
+#include "barretenberg/vm2/simulation/gadgets/gt.hpp"
+#include "barretenberg/vm2/simulation/gadgets/range_check.hpp"
+#include "barretenberg/vm2/simulation/interfaces/memory.hpp"
+#include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
+#include "barretenberg/vm2/simulation/lib/raw_data_dbs.hpp"
+#include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
+#include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
+#include "barretenberg/vm2/tooling/debugger.hpp"
+#include "barretenberg/vm2/tracegen/execution_trace.hpp"
+#include "barretenberg/vm2/tracegen/field_gt_trace.hpp"
+#include "barretenberg/vm2/tracegen/gt_trace.hpp"
+#include "barretenberg/vm2/tracegen/opcodes/emit_unencrypted_log_trace.hpp"
+#include "barretenberg/vm2/tracegen/precomputed_trace.hpp"
+#include "barretenberg/vm2/tracegen/public_inputs_trace.hpp"
+#include "barretenberg/vm2/tracegen/range_check_trace.hpp"
+#include "barretenberg/vm2/tracegen/test_trace_container.hpp"
+
+using namespace bb::avm2::simulation;
+using namespace bb::avm2::tracegen;
+using namespace bb::avm2::constraining;
+using namespace bb::avm2::fuzzing;
+
+using bb::avm2::FF;
+using bb::avm2::MemoryTag;
+using bb::avm2::MemoryValue;
+
+using emit_log_rel = bb::avm2::emit_unencrypted_log<FF>;
+
+const uint8_t default_log_fields = 16;
+// TODO(MW): Set to slightly above the maximum size so we hit error_too_many_log_fields, but can be slow.
+// Could instead set to < 1000 and explicitly set an edge case of > max in the custom mutator?
+const uint32_t max_log_fields = 4100;
+
+struct EmitUnencryptedLogFuzzerInput {
+    AztecAddress contract_address;
+    MemoryAddress log_offset = 1;
+    uint32_t log_size;
+    uint64_t selection_encoding = 0;
+    bool is_static = false;
+    bool tag_mismatch =
+        false; // Since we generate log_size values in the test, we must pass a flag to modify their tag(s)
+
+    std::array<FF, default_log_fields> init_log_values{};
+
+    void print() const
+    {
+        info("contract_address: ", contract_address);
+        info("log_offset: ", log_offset);
+        info("log_size: ", log_size);
+        info("selection_encoding: ", selection_encoding);
+        info("is_static: ", is_static);
+        info("tag_mismatch: ", tag_mismatch);
+        for (size_t i = 0; i < init_log_values.size(); i++) {
+            info("init_log_value ", i, ": ", init_log_values[i]);
+        }
+    }
+
+    void to_buffer(uint8_t* buffer) const
+    {
+        size_t offset = 0;
+        std::memcpy(buffer + offset, &contract_address, sizeof(contract_address));
+        offset += sizeof(contract_address);
+        std::memcpy(buffer + offset, &log_offset, sizeof(log_offset));
+        offset += sizeof(log_offset);
+        std::memcpy(buffer + offset, &log_size, sizeof(log_size));
+        offset += sizeof(log_size);
+        std::memcpy(buffer + offset, &selection_encoding, sizeof(selection_encoding));
+        offset += sizeof(selection_encoding);
+        std::memcpy(buffer + offset, &is_static, sizeof(is_static));
+        offset += sizeof(is_static);
+        std::memcpy(buffer + offset, &tag_mismatch, sizeof(tag_mismatch));
+        offset += sizeof(tag_mismatch);
+        std::memcpy(buffer + offset, &init_log_values[0], sizeof(FF) * init_log_values.size());
+    }
+
+    static EmitUnencryptedLogFuzzerInput from_buffer(const uint8_t* buffer)
+    {
+        EmitUnencryptedLogFuzzerInput input;
+        size_t offset = 0;
+        std::memcpy(&input.contract_address, buffer + offset, sizeof(input.contract_address));
+        offset += sizeof(input.contract_address);
+        std::memcpy(&input.log_offset, buffer + offset, sizeof(input.log_offset));
+        offset += sizeof(input.log_offset);
+        std::memcpy(&input.log_size, buffer + offset, sizeof(input.log_size));
+        offset += sizeof(input.log_size);
+        std::memcpy(&input.selection_encoding, buffer + offset, sizeof(input.selection_encoding));
+        offset += sizeof(input.selection_encoding);
+        std::memcpy(&input.is_static, buffer + offset, sizeof(input.is_static));
+        offset += sizeof(input.is_static);
+        std::memcpy(&input.tag_mismatch, buffer + offset, sizeof(input.tag_mismatch));
+        offset += sizeof(input.tag_mismatch);
+        std::memcpy(&input.init_log_values[0], buffer + offset, sizeof(FF) * input.init_log_values.size());
+
+        return input;
+    }
+};
+
+// TODO(MW): multiple events, std::vector<std::vector<FF>>
+std::vector<FF> generate_and_set_log_fields(const EmitUnencryptedLogFuzzerInput& input, MemoryInterface* mem)
+{
+    std::vector<FF> log_fields;
+    auto total_log_fields_size = input.log_size + PUBLIC_LOG_HEADER_LENGTH;
+    log_fields.reserve(total_log_fields_size);
+    // Assign log length and address
+    log_fields.emplace_back(input.log_size);
+    log_fields.emplace_back(input.contract_address);
+
+    size_t max_index = std::min(static_cast<size_t>(input.log_size), input.init_log_values.size());
+    // Place initial values
+    for (size_t j = 0; j < max_index; j++) {
+        log_fields.emplace_back(input.init_log_values[j]);
+    }
+    // If size > init_log_values, fill gaps
+    for (size_t j = input.init_log_values.size(); j < input.log_size; j++) {
+        // Copied from memory.fuzzer:
+        auto entry_idx = (input.selection_encoding >> j) % log_fields.size();
+        // TODO(MW): make sure to exclude size/address fields?
+        auto entry_value = log_fields[entry_idx];
+        FF modified_value = entry_value + input.init_log_values[j % input.init_log_values.size()];
+        log_fields.emplace_back(modified_value);
+    }
+    // The first two fields are size (IS_WRITE_LOG_LENGTH) and contract address (is_write_contract_address), which are
+    // not read from memory, so we start at j = PUBLIC_LOG_HEADER_LENGTH
+    MemoryAddress addr = input.log_offset;
+    for (size_t j = PUBLIC_LOG_HEADER_LENGTH; j < total_log_fields_size; j++) {
+        mem->set(addr++, MemoryValue::from(log_fields[j]));
+    }
+
+    // Choose an index to set to an incorrect tag if we are testing a mismatch
+    if (input.tag_mismatch) {
+        size_t set_incorrect_tag_at = ((input.selection_encoding >> max_index) % log_fields.size()) + 2;
+        MemoryAddress addr = static_cast<MemoryAddress>(input.log_offset + set_incorrect_tag_at - 2);
+        MemoryTag incorrect_tag = MemoryTag::FF;
+        uint64_t incr = 0;
+        while (incorrect_tag == MemoryTag::FF) {
+            // TODO(MW): use rng here?
+            incorrect_tag =
+                static_cast<MemoryTag>((static_cast<uint64_t>(incorrect_tag) + input.selection_encoding + incr++) %
+                                       static_cast<uint64_t>(MemoryTag::MAX));
+        }
+        mem->set(addr, MemoryValue::from_tag_truncating(incorrect_tag, log_fields[set_incorrect_tag_at]));
+    }
+
+    return log_fields;
+}
+
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max_size, unsigned int seed)
+{
+    if (size < sizeof(EmitUnencryptedLogFuzzerInput)) {
+        // Initialize with default input
+        EmitUnencryptedLogFuzzerInput input;
+        input.to_buffer(data);
+        return sizeof(EmitUnencryptedLogFuzzerInput);
+    }
+
+    std::mt19937_64 rng(seed);
+
+    // Deserialize current input
+    EmitUnencryptedLogFuzzerInput input = EmitUnencryptedLogFuzzerInput::from_buffer(data);
+
+    // Choose mutation case
+    std::uniform_int_distribution<int> dist(0, 5);
+    int choice = dist(rng);
+    switch (choice) {
+    case 0: {
+        // Set contract address
+        std::uniform_int_distribution<uint64_t> addr_dist(0, std::numeric_limits<uint64_t>::max());
+        input.contract_address = FF(addr_dist(rng), addr_dist(rng), addr_dist(rng), addr_dist(rng));
+        break;
+    }
+    case 1: {
+        // Set log address
+        std::uniform_int_distribution<int> addr_change(-4000, 4000);
+        int new_addr = static_cast<int>(input.log_offset) + addr_change(rng);
+        input.log_offset = static_cast<uint32_t>(new_addr);
+        break;
+    }
+    case 2: {
+        // Set log size
+        std::uniform_int_distribution<uint32_t> num_fields_dist(0, max_log_fields);
+        input.log_size = num_fields_dist(rng);
+        break;
+    }
+    case 3: {
+        // Toggle selection encoding for a random entry, as long as this log is not empty
+        if (input.log_size != 0) {
+            std::uniform_int_distribution<size_t> entry_dist(0, input.log_size - 1);
+            size_t entry_idx = entry_dist(rng);
+            input.selection_encoding ^= (1ULL << entry_idx);
+        }
+        break;
+    }
+    case 4: {
+        // Modify a random initial value
+        std::uniform_int_distribution<size_t> index_dist(0, input.init_log_values.size() - 1);
+        size_t value_idx = index_dist(rng);
+        std::uniform_int_distribution<uint64_t> dist(0, std::numeric_limits<uint64_t>::max());
+        FF value = FF(dist(rng), dist(rng), dist(rng), dist(rng));
+        input.init_log_values[value_idx] = value;
+        break;
+    }
+    case 5: {
+        // Toggle error cases
+        // Note that memory out of bounds and too many log fields are already covered by other mutations
+        // TODO(MW): Add more? E.g. set incorrect log_size/log_offset in emit_unencrypted_log call?
+        std::uniform_int_distribution<int> err_dist(0, 1);
+        int choice = err_dist(rng);
+        switch (choice) {
+        case 0: {
+            // Toggle is_static
+            input.is_static = !input.is_static;
+            break;
+        }
+        case 1: {
+            // Toggle tag_mismatch
+            input.tag_mismatch = !input.tag_mismatch;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    default:
+        break;
+    }
+
+    // Serialize mutated input back to buffer
+    input.to_buffer(data);
+
+    if (max_size > sizeof(EmitUnencryptedLogFuzzerInput)) {
+        return sizeof(EmitUnencryptedLogFuzzerInput);
+    }
+
+    return sizeof(EmitUnencryptedLogFuzzerInput);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    using bb::avm2::MemoryValue;
+
+    if (size < sizeof(EmitUnencryptedLogFuzzerInput)) {
+        return 0;
+    }
+
+    EmitUnencryptedLogFuzzerInput input = EmitUnencryptedLogFuzzerInput::from_buffer(data);
+    bool error = false;
+
+    // Set up gadgets and event emitters
+    EventEmitter<EmitUnencryptedLogEvent> emit_log_emitter;
+
+    GadgetFuzzerContextHelper context_helper(input.contract_address, input.is_static);
+    EmitUnencryptedLog emit_unencrypted_log(
+        context_helper.execution_id_manager, context_helper.greater_than, emit_log_emitter);
+
+    auto context = std::move(context_helper.context);
+
+    // TODO(MW): multiple log events
+    std::vector<FF> log_fields = generate_and_set_log_fields(input, &context->get_memory());
+
+    try {
+        emit_unencrypted_log.emit_unencrypted_log(
+            context->get_memory(), *context, input.contract_address, input.log_offset, input.log_size);
+    } catch (const EmitUnencryptedLogException& e) {
+        // TODO(MW): Ensure error is expected
+        error = true;
+    }
+
+    TestTraceContainer trace;
+
+    PrecomputedTraceBuilder precomputed_builder;
+    RangeCheckTraceBuilder range_check_builder;
+    FieldGreaterThanTraceBuilder field_gt_builder;
+    GreaterThanTraceBuilder gt_builder;
+    EmitUnencryptedLogTraceBuilder builder;
+
+    uint32_t pi_row = AVM_PUBLIC_INPUTS_AVM_ACCUMULATED_DATA_PUBLIC_LOGS_ROW_IDX;
+
+    if (!error) {
+        // TODO(MW): use below to check values:
+        // auto public_logs = side_effect_tracker.get_side_effects().public_logs;
+        trace.set(avm2::Column::public_inputs_cols_0_, pi_row, log_fields.size());
+        trace.set(avm2::Column::public_inputs_sel, pi_row, 1);
+
+        // Set public input columns
+        for (FF log_field : log_fields) {
+            pi_row++;
+            trace.set(avm2::Column::public_inputs_sel, pi_row, 1);
+            // Logs only use cols_0
+            trace.set(avm2::Column::public_inputs_cols_0_, pi_row, log_field);
+        }
+    }
+
+    // Precomputed values
+    precomputed_builder.process_tag_parameters(trace);
+    precomputed_builder.process_sel_range_8(trace);
+    precomputed_builder.process_power_of_2(trace);
+    precomputed_builder.process_misc(trace, pi_row + 1); // Need enough for public input columns
+
+    range_check_builder.process(context_helper.range_check_emitter.dump_events(), trace);
+    field_gt_builder.process(context_helper.field_gt_emitter.dump_events(), trace);
+    gt_builder.process(context_helper.greater_than_emitter.dump_events(), trace);
+    builder.process(emit_log_emitter.dump_events(), trace);
+
+    if (getenv("AVM_DEBUG") != nullptr) {
+        info("Debugging trace:");
+        bb::avm2::InteractiveDebugger debugger(trace);
+        debugger.run();
+    }
+
+    check_relation<emit_log_rel>(trace);
+    check_all_interactions<EmitUnencryptedLogTraceBuilder>(trace);
+    check_interaction<ExecutionTraceBuilder, bb::avm2::lookup_execution_dispatch_to_emit_unencrypted_log_settings>(
+        trace);
+
+    return 0;
+}

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
@@ -1,33 +1,18 @@
 #include "barretenberg/vm2/simulation/gadgets/emit_unencrypted_log.hpp"
 #include <cassert>
 #include <cstdint>
-#include <fuzzer/FuzzedDataProvider.h>
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/harness/context_helper.hpp"
-#include "barretenberg/common/serialize.hpp"
-#include "barretenberg/numeric/uint256/uint256.hpp"
-#include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
-#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/constraining/testing/check_relation.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/generated/relations/emit_unencrypted_log.hpp"
-#include "barretenberg/vm2/generated/relations/lookups_execution.hpp"
 #include "barretenberg/vm2/simulation/events/emit_unencrypted_log_event.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
-#include "barretenberg/vm2/simulation/events/gt_event.hpp"
-#include "barretenberg/vm2/simulation/events/range_check_event.hpp"
-#include "barretenberg/vm2/simulation/gadgets/context_provider.hpp"
-#include "barretenberg/vm2/simulation/gadgets/gt.hpp"
-#include "barretenberg/vm2/simulation/gadgets/range_check.hpp"
 #include "barretenberg/vm2/simulation/interfaces/memory.hpp"
-#include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
-#include "barretenberg/vm2/simulation/lib/raw_data_dbs.hpp"
-#include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
-#include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
 #include "barretenberg/vm2/testing/instruction_builder.hpp"
 #include "barretenberg/vm2/tooling/debugger.hpp"
 #include "barretenberg/vm2/tracegen/execution_trace.hpp"
@@ -35,7 +20,6 @@
 #include "barretenberg/vm2/tracegen/gt_trace.hpp"
 #include "barretenberg/vm2/tracegen/opcodes/emit_unencrypted_log_trace.hpp"
 #include "barretenberg/vm2/tracegen/precomputed_trace.hpp"
-#include "barretenberg/vm2/tracegen/public_inputs_trace.hpp"
 #include "barretenberg/vm2/tracegen/range_check_trace.hpp"
 #include "barretenberg/vm2/tracegen/test_trace_container.hpp"
 
@@ -293,16 +277,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     // Set up gadgets and event emitters
     EventEmitter<EmitUnencryptedLogEvent> emit_log_emitter;
 
-    GadgetFuzzerContextHelper context_helper(input.contract_address, input.is_static);
+    GadgetFuzzerContextHelper context_helper(input.contract_address, input.is_static, 1);
     EmitUnencryptedLog emit_unencrypted_log(
         context_helper.execution_id_manager, context_helper.greater_than, emit_log_emitter);
 
     auto context =
         context_helper.make_enqueued_fuzzing_context(input.contract_address, input.contract_address, input.is_static);
-
-    // TODO(MW): This is a little janky. Without it, emit_unencrypted_log sets its clk at 0, but execution always starts
-    // at 1:
-    context_helper.execution_id_manager.increment_execution_id();
 
     // TODO(MW): multiple log events
     std::vector<FF> log_fields = generate_and_set_log_fields(input, &context->get_memory());

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
@@ -36,6 +36,7 @@ if [ "$COMMAND" = "list-targets" ]; then
     echo "  gt - Greater Than fuzzer (harness_gt_fuzzer)"
     echo "  merkle_check - Merkle Check fuzzer (harness_merkle_check_fuzzer)"
     echo "  calldata - Calldata fuzzer (harness_calldata_fuzzer)"
+    echo "  emit_unencrypted_log - Emit Unencrypted Log fuzzer (harness_emit_unencrypted_log_fuzzer)"
     exit 0
 fi
 
@@ -78,9 +79,10 @@ case "$FUZZER_ALIAS" in
     gt) FUZZER_TYPE="harness_gt_fuzzer" ;;
     merkle_check) FUZZER_TYPE="harness_merkle_check_fuzzer" ;;
     calldata) FUZZER_TYPE="harness_calldata_fuzzer" ;;
+    emit_unencrypted_log) FUZZER_TYPE="harness_emit_unencrypted_log_fuzzer" ;;
     *)
         echo "Error: Invalid fuzzer type '$FUZZER_ALIAS'"
-        echo "Valid options: 'avm', 'tx', 'alu', 'bitwise', 'ecc', 'gt', 'merkle_check', or 'calldata'"
+        echo "Valid options: 'avm', 'tx', 'alu', 'bitwise', 'ecc', 'gt', 'merkle_check', 'calldata', or 'emit_unencrypted_log'"
         exit 1
         ;;
 esac

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp
@@ -12,6 +12,7 @@ namespace bb::avm2::simulation {
 
 class CalldataHasher : public CalldataHashingInterface {
   public:
+    // TODO should this be uint16? range check is for 16 bit
     CalldataHasher(uint32_t context_id, Poseidon2Interface& hasher, EventEmitterInterface<CalldataEvent>& events)
         : context_id(context_id)
         , events(events)

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/calldata_hashing.hpp
@@ -12,7 +12,6 @@ namespace bb::avm2::simulation {
 
 class CalldataHasher : public CalldataHashingInterface {
   public:
-    // TODO should this be uint16? range check is for 16 bit
     CalldataHasher(uint32_t context_id, Poseidon2Interface& hasher, EventEmitterInterface<CalldataEvent>& events)
         : context_id(context_id)
         , events(events)


### PR DESCRIPTION
### Emit Unencrypted Log Fuzzer

Closes: [AVM-106](https://linear.app/aztec-labs/issue/AVM-106/fuzz-emit-unencryptedlog)

Currently tests a single event (i.e. one log per run) with all interactions. Coverage is nearly 100% with caveats:

- Trace: it seems like there are no gaps - the coverage tool is a bit confused about branches
- Gadget: only the checkpointing functions (e.g. EmitUnencryptedLog::on_checkpoint_created()) aren't hit

Uses similar logic to the memory and calldata fuzzers to fill a field vector to emit as a log while being able to fuzz its length. Covers log values, size, memory address, contract address, and some specific edge cases (static calls, tag mismatch) to hit all errors.

Discovered a possible underflow, addressed here: #19076 

Unfortunately this needed a lot of surrounding gadget setup so I just threw it into a new file (`context_helper`) for readability - we don't have to use this class, happy to remove it! In future I can integrate it with the existing simulation helpers for fuzzing.
