### PR TITLE
chore: Calldata retrieval metrics and debug tx cleanup

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -864,6 +864,7 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
         searchStartBlock, // TODO(palla/reorg): If the L2 reorg was due to an L1 reorg, we need to start search earlier
         searchEndBlock,
         this.l1Addresses,
+        this.instrumentation,
         this.log,
       );
 

--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -58,7 +58,7 @@ export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
   ethereumAllowNoDebugHosts: {
     env: 'ETHEREUM_ALLOW_NO_DEBUG_HOSTS',
     description: 'Whether to allow starting the archiver without debug/trace method support on Ethereum hosts',
-    ...booleanConfigHelper(false),
+    ...booleanConfigHelper(true),
   },
   ...chainConfigMappings,
   ...l1ReaderConfigMappings,

--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -34,6 +34,8 @@ export class ArchiverInstrumentation {
   private syncDurationPerMessage: Histogram;
   private syncMessageCount: UpDownCounter;
 
+  private blockProposalTxTargetCount: UpDownCounter;
+
   private log = createLogger('archiver:instrumentation');
 
   private constructor(
@@ -114,6 +116,11 @@ export class ArchiverInstrumentation {
       valueType: ValueType.INT,
     });
 
+    this.blockProposalTxTargetCount = meter.createUpDownCounter(Metrics.ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT, {
+      description: 'Number of block proposals by tx target',
+      valueType: ValueType.INT,
+    });
+
     this.dbMetrics = new LmdbMetrics(
       meter,
       {
@@ -183,5 +190,12 @@ export class ArchiverInstrumentation {
 
   public updateL1BlockHeight(blockNumber: bigint) {
     this.l1BlockHeight.record(Number(blockNumber));
+  }
+
+  public recordBlockProposalTxTarget(target: string, usedTrace: boolean) {
+    this.blockProposalTxTargetCount.add(1, {
+      [Attributes.L1_BLOCK_PROPOSAL_TX_TARGET]: target.toLowerCase(),
+      [Attributes.L1_BLOCK_PROPOSAL_USED_TRACE]: usedTrace,
+    });
   }
 }

--- a/yarn-project/archiver/src/archiver/l1/README.md
+++ b/yarn-project/archiver/src/archiver/l1/README.md
@@ -48,7 +48,10 @@ proposer known address, and if so, we try decoding it as either a multicall3 or 
 rollup contract.
 
 Similar as with the multicall3 check, we check that there are no other calls in the Spire proposer, so
-we are absolutely sure that the only call is the successful one to the rollup.
+we are absolutely sure that the only call is the successful one to the rollup. Any extraneous call would
+imply an unexpected path to calling `propose` in the rollup contract, and since we cannot verify if the
+calldata arguments we extracted are the correct ones (see the section below), we cannot know for sure which
+one is the call that succeeded, so we don't know which calldata to process.
 
 Furthermore, since the Spire proposer is upgradeable, we check if the implementation has not changed in
 order to decode. As usual, any validation failure triggers fallback to the next step.

--- a/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
+++ b/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
@@ -100,6 +100,7 @@ async function main() {
       publicClient as unknown as ViemPublicClient,
       publicClient as unknown as ViemPublicDebugClient,
       targetCommitteeSize,
+      undefined,
       logger,
       {
         rollupAddress,

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
@@ -22,6 +22,7 @@ import { ContentCommitment, PartialStateReference, ProposedBlockHeader, StateRef
 import { type MockProxy, mock } from 'jest-mock-extended';
 import { type Hex, type Transaction, encodeFunctionData, multicall3Abi, toFunctionSelector } from 'viem';
 
+import type { ArchiverInstrumentation } from '../instrumentation.js';
 import { CalldataRetriever } from './calldata_retriever.js';
 import {
   EIP1967_IMPLEMENTATION_SLOT,
@@ -58,6 +59,7 @@ describe('CalldataRetriever', () => {
   let logger: Logger;
   let retriever: TestCalldataRetriever;
   let txHash: Hex;
+  let instrumentation: MockProxy<ArchiverInstrumentation>;
 
   const TARGET_COMMITTEE_SIZE = 5;
   const rollupAddress = EthAddress.random();
@@ -71,8 +73,9 @@ describe('CalldataRetriever', () => {
     publicClient = mock<ViemPublicClient>();
     debugClient = mock<ViemPublicDebugClient>();
     logger = createLogger('test:calldata_retriever');
+    instrumentation = mock<ArchiverInstrumentation>();
 
-    retriever = new TestCalldataRetriever(publicClient, debugClient, TARGET_COMMITTEE_SIZE, logger, {
+    retriever = new TestCalldataRetriever(publicClient, debugClient, TARGET_COMMITTEE_SIZE, instrumentation, logger, {
       rollupAddress,
       governanceProposerAddress,
       slashFactoryAddress,
@@ -162,6 +165,7 @@ describe('CalldataRetriever', () => {
       expect(result.archiveRoot).toBeInstanceOf(Fr);
       expect(Array.isArray(result.attestations)).toBe(true);
       expect(result.blockHash).toBe(tx.blockHash);
+      expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(MULTI_CALL_3_ADDRESS, false);
     });
 
     it('should fall back to direct propose when multicall3 decoding fails', async () => {
@@ -181,6 +185,7 @@ describe('CalldataRetriever', () => {
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(result.header).toBeInstanceOf(ProposedBlockHeader);
+      expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(rollupAddress.toString(), false);
     });
 
     it('should fall back to trace when both multicall3 and direct propose fail', async () => {
@@ -222,6 +227,7 @@ describe('CalldataRetriever', () => {
 
       expect(result.l2BlockNumber).toBe(l2BlockNumber);
       expect(debugClient.request).toHaveBeenCalledWith({ method: 'trace_transaction', params: [txHash] });
+      expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(wrongAddress.toString(), true);
     });
 
     it('should throw when tracing fails', async () => {
@@ -1010,6 +1016,9 @@ describe('CalldataRetriever', () => {
       expect(result.stateReference.partial).toBeInstanceOf(PartialStateReference);
       expect(result.header.contentCommitment).toBeInstanceOf(ContentCommitment);
       expect(result.header.gasFees).toBeInstanceOf(GasFees);
+
+      // Verify instrumentation was called
+      expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(MULTI_CALL_3_ADDRESS, false);
     });
 
     it('should complete full flow from tx hash to block header via Spire Proposer', async () => {
@@ -1086,6 +1095,9 @@ describe('CalldataRetriever', () => {
 
       // Verify proxy implementation was checked
       expect(publicClient.getStorageAt).toHaveBeenCalled();
+
+      // Verify instrumentation was called with Spire Proposer address
+      expect(instrumentation.recordBlockProposalTxTarget).toHaveBeenCalledWith(SPIRE_PROPOSER_ADDRESS, false);
     });
   });
 });

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
@@ -20,16 +20,9 @@ import {
 import { CommitteeAttestation } from '@aztec/stdlib/block';
 import { ProposedBlockHeader, StateReference } from '@aztec/stdlib/tx';
 
-import {
-  type Hex,
-  type Transaction,
-  decodeFunctionData,
-  getAddress,
-  hexToBytes,
-  multicall3Abi,
-  toFunctionSelector,
-} from 'viem';
+import { type Hex, type Transaction, decodeFunctionData, hexToBytes, multicall3Abi, toFunctionSelector } from 'viem';
 
+import type { ArchiverInstrumentation } from '../instrumentation.js';
 import type { RetrievedL2Block } from './data_retrieval.js';
 import { getSuccessfulCallsFromDebug } from './debug_tx.js';
 import { getCallFromSpireProposer } from './spire_proposer.js';
@@ -50,6 +43,7 @@ export class CalldataRetriever {
     private readonly publicClient: ViemPublicClient,
     private readonly debugClient: ViemPublicDebugClient,
     private readonly targetCommitteeSize: number,
+    private readonly instrumentation: ArchiverInstrumentation | undefined,
     private readonly logger: Logger,
     contractAddresses: {
       rollupAddress: EthAddress;
@@ -83,10 +77,9 @@ export class CalldataRetriever {
   protected async getProposeCallData(tx: Transaction, l2BlockNumber: number): Promise<Hex> {
     // Try to decode as multicall3 with validation
     const proposeCalldata = this.tryDecodeMulticall3(tx);
-
-    // Successfully decoded via multicall3, proceed with decoding
     if (proposeCalldata) {
       this.logger.trace(`Decoded propose calldata from multicall3 for tx ${tx.hash}`);
+      this.instrumentation?.recordBlockProposalTxTarget(tx.to!, false);
       return proposeCalldata;
     }
 
@@ -94,6 +87,7 @@ export class CalldataRetriever {
     const directProposeCalldata = this.tryDecodeDirectPropose(tx);
     if (directProposeCalldata) {
       this.logger.trace(`Decoded propose calldata from direct call for tx ${tx.hash}`);
+      this.instrumentation?.recordBlockProposalTxTarget(tx.to!, false);
       return directProposeCalldata;
     }
 
@@ -101,13 +95,15 @@ export class CalldataRetriever {
     const spireProposeCalldata = await this.tryDecodeSpireProposer(tx);
     if (spireProposeCalldata) {
       this.logger.trace(`Decoded propose calldata from Spire Proposer for tx ${tx.hash}`);
+      this.instrumentation?.recordBlockProposalTxTarget(tx.to!, false);
       return spireProposeCalldata;
     }
 
     // Fall back to trace-based extraction
     this.logger.warn(
-      `Failed to decode multicall3, direct propose, or Spire Proposer for L1 tx ${tx.hash}, falling back to trace for L2 block ${l2BlockNumber}`,
+      `Failed to decode multicall3, direct propose, or Spire proposer for L1 tx ${tx.hash}, falling back to trace for L2 block ${l2BlockNumber}`,
     );
+    this.instrumentation?.recordBlockProposalTxTarget(tx.to ?? EthAddress.ZERO.toString(), true);
     return await this.extractCalldataViaTrace(tx.hash);
   }
 
@@ -158,8 +154,8 @@ export class CalldataRetriever {
 
     try {
       // Check if transaction is to Multicall3 address
-      if (!tx.to || tx.to.toLowerCase() !== MULTI_CALL_3_ADDRESS.toLowerCase()) {
-        this.logger.warn(`Transaction is not to Multicall3 address (to: ${tx.to})`, { txHash, to: tx.to });
+      if (!tx.to || !EthAddress.areEqual(tx.to, MULTI_CALL_3_ADDRESS)) {
+        this.logger.debug(`Transaction is not to Multicall3 address (to: ${tx.to})`, { txHash, to: tx.to });
         return undefined;
       }
 
@@ -252,8 +248,8 @@ export class CalldataRetriever {
     const txHash = tx.hash;
     try {
       // Check if transaction is to the rollup address
-      if (!tx.to || getAddress(tx.to) !== getAddress(this.rollupAddress.toString())) {
-        this.logger.warn(`Transaction is not to rollup address (to: ${tx.to})`, { txHash });
+      if (!tx.to || !EthAddress.areEqual(tx.to, this.rollupAddress)) {
+        this.logger.debug(`Transaction is not to rollup address (to: ${tx.to})`, { txHash });
         return undefined;
       }
 
@@ -304,7 +300,7 @@ export class CalldataRetriever {
         this.logger.debug(`Successfully traced using debug_traceTransaction, found ${calls.length} calls`);
       } catch (debugErr) {
         const debugError = debugErr instanceof Error ? debugErr : new Error(String(debugErr));
-        this.logger.error(`All tracing methods failed for tx ${txHash}`, {
+        this.logger.warn(`All tracing methods failed for tx ${txHash}`, {
           traceError,
           debugError,
           txHash,

--- a/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
@@ -23,6 +23,7 @@ import {
 } from 'viem';
 
 import { NoBlobBodiesFoundError } from '../errors.js';
+import type { ArchiverInstrumentation } from '../instrumentation.js';
 import type { DataRetrieval } from '../structs/data_retrieval.js';
 import type { InboxMessage } from '../structs/inbox_message.js';
 import type { L1PublishedData } from '../structs/published.js';
@@ -105,6 +106,7 @@ export async function retrieveBlocksFromRollup(
     slashFactoryAddress?: EthAddress;
     slashingProposerAddress: EthAddress;
   },
+  instrumentation: ArchiverInstrumentation,
   logger: Logger = createLogger('archiver'),
 ): Promise<RetrievedL2Block[]> {
   const retrievedBlocks: RetrievedL2Block[] = [];
@@ -155,6 +157,7 @@ export async function retrieveBlocksFromRollup(
       l2BlockProposedLogs,
       rollupConstants,
       contractAddresses,
+      instrumentation,
       logger,
     );
     retrievedBlocks.push(...newBlocks);
@@ -185,13 +188,18 @@ async function processL2BlockProposedLogs(
     slashFactoryAddress?: EthAddress;
     slashingProposerAddress: EthAddress;
   },
+  instrumentation: ArchiverInstrumentation,
   logger: Logger,
 ): Promise<RetrievedL2Block[]> {
   const retrievedBlocks: RetrievedL2Block[] = [];
-  const calldataRetriever = new CalldataRetriever(publicClient, debugClient, targetCommitteeSize, logger, {
-    ...contractAddresses,
-    rollupAddress: EthAddress.fromString(rollup.address),
-  });
+  const calldataRetriever = new CalldataRetriever(
+    publicClient,
+    debugClient,
+    targetCommitteeSize,
+    instrumentation,
+    logger,
+    { ...contractAddresses, rollupAddress: EthAddress.fromString(rollup.address) },
+  );
 
   await asyncPool(10, logs, async log => {
     const l2BlockNumber = Number(log.args.blockNumber!);

--- a/yarn-project/archiver/src/archiver/l1/debug_tx.ts
+++ b/yarn-project/archiver/src/archiver/l1/debug_tx.ts
@@ -17,8 +17,8 @@ export const callTraceSchema: ZodFor<DebugCallTrace> = z.lazy(() =>
     type: z.string(),
     input: schemas.HexStringWith0x.optional(),
     output: schemas.HexStringWith0x.optional(),
-    gas: schemas.HexStringWith0x,
-    gasUsed: schemas.HexStringWith0x,
+    gas: schemas.HexStringWith0x.optional(),
+    gasUsed: schemas.HexStringWith0x.optional(),
     value: schemas.HexStringWith0x.optional(),
     error: z.string().optional(),
     calls: z.array(callTraceSchema).optional(),
@@ -52,6 +52,10 @@ export async function getSuccessfulCallsFromDebug(
     params: [txHash, { tracer: 'callTracer' }],
   });
 
+  if (rawTrace === null || rawTrace === undefined) {
+    throw new Error(`Failed to retrieve debug_traceTransaction for ${txHash}`);
+  }
+
   logger?.trace(`Retrieved debug_traceTransaction for ${txHash}`, { trace: rawTrace });
 
   // Validate the response with zod
@@ -76,7 +80,7 @@ export async function getSuccessfulCallsFromDebug(
     ) {
       results.push({
         from: EthAddress.fromString(callTrace.from),
-        gasUsed: BigInt(callTrace.gasUsed),
+        gasUsed: callTrace.gasUsed === undefined ? undefined : BigInt(callTrace.gasUsed),
         input: callTrace.input,
         value: callTrace.value ? BigInt(callTrace.value) : 0n,
       });

--- a/yarn-project/archiver/src/archiver/l1/spire_proposer.ts
+++ b/yarn-project/archiver/src/archiver/l1/spire_proposer.ts
@@ -1,3 +1,4 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 
 import { type Hex, type Transaction, decodeFunctionData, getAddress, trim } from 'viem';
@@ -85,8 +86,8 @@ export async function verifyProxyImplementation(
 
 /**
  * Attempts to decode transaction as a Spire Proposer Multicall.
- * Spire Proposer is a proxy contract that wraps a single call.
- * Returns the target address and calldata of the wrapped call if validation succeeds.
+ * Spire Proposer is a proxy contract that wraps multiple calls.
+ * Returns the target address and calldata of the wrapped call if validation succeeds and there is a single call.
  * @param tx - The transaction to decode
  * @param publicClient - The viem public client for proxy verification
  * @param logger - Logger instance
@@ -101,8 +102,8 @@ export async function getCallFromSpireProposer(
 
   try {
     // Check if transaction is to the Spire Proposer address
-    if (!tx.to || tx.to.toLowerCase() !== SPIRE_PROPOSER_ADDRESS.toLowerCase()) {
-      logger.trace(`Transaction is not to Spire Proposer address (to: ${tx.to})`, { txHash });
+    if (!tx.to || !EthAddress.areEqual(tx.to, SPIRE_PROPOSER_ADDRESS)) {
+      logger.debug(`Transaction is not to Spire Proposer address (to: ${tx.to})`, { txHash });
       return undefined;
     }
 
@@ -140,7 +141,7 @@ export async function getCallFromSpireProposer(
 
     const [calls] = spireArgs;
 
-    // Validate exactly ONE call
+    // Validate exactly ONE call (see ./README.md for rationale)
     if (calls.length !== 1) {
       logger.warn(`Spire Proposer multicall must contain exactly one call (got ${calls.length})`, { txHash });
       return undefined;

--- a/yarn-project/archiver/src/archiver/l1/trace_tx.ts
+++ b/yarn-project/archiver/src/archiver/l1/trace_tx.ts
@@ -14,14 +14,14 @@ const traceActionSchema = z.object({
   from: schemas.HexStringWith0x,
   to: schemas.HexStringWith0x.optional(),
   callType: z.string(),
-  gas: schemas.HexStringWith0x,
+  gas: schemas.HexStringWith0x.optional(),
   input: schemas.HexStringWith0x.optional(),
   value: schemas.HexStringWith0x.optional(),
 });
 
 /** Zod schema for trace result from trace_transaction */
 const traceResultSchema = z.object({
-  gasUsed: schemas.HexStringWith0x,
+  gasUsed: schemas.HexStringWith0x.optional(),
   output: schemas.HexStringWith0x.optional(),
 });
 
@@ -68,6 +68,10 @@ export async function getSuccessfulCallsFromTrace(
     params: [txHash],
   });
 
+  if (rawTrace === null || rawTrace === undefined) {
+    throw new Error(`Failed to retrieve trace_transaction for ${txHash}`);
+  }
+
   logger?.trace(`Retrieved trace_transaction for ${txHash}`, { trace: rawTrace });
 
   // Validate the response with zod
@@ -113,7 +117,7 @@ export async function getSuccessfulCallsFromTrace(
     ) {
       results.push({
         from: EthAddress.fromString(trace.action.from),
-        gasUsed: BigInt(trace.result.gasUsed),
+        gasUsed: trace.result.gasUsed === undefined ? undefined : BigInt(trace.result.gasUsed),
         input: trace.action.input,
         value: trace.action.value ? BigInt(trace.action.value) : 0n,
       });

--- a/yarn-project/archiver/src/archiver/l1/types.ts
+++ b/yarn-project/archiver/src/archiver/l1/types.ts
@@ -7,7 +7,7 @@ import type { Hex } from 'viem';
  */
 export interface CallInfo {
   from: EthAddress;
-  gasUsed: bigint;
+  gasUsed?: bigint;
   input: Hex;
   value: bigint;
 }

--- a/yarn-project/archiver/src/archiver/l1/validate_trace.ts
+++ b/yarn-project/archiver/src/archiver/l1/validate_trace.ts
@@ -15,7 +15,7 @@ const logger = createLogger('aztec:archiver:validate_trace');
  * @param client - The Viem public debug client
  * @param txHash - Transaction hash to trace
  * @param schema - Zod schema to validate the response
- * @param methodName - Name of the RPC method ('debug_traceTransaction' or 'trace_transaction')
+ * @param method - Name of the RPC method ('debug_traceTransaction' or 'trace_transaction')
  * @param blockType - Type of block being tested ('recent' or 'old')
  * @returns true if the method works and validation passes, false otherwise
  */
@@ -23,30 +23,22 @@ async function testTraceMethod(
   client: ViemPublicDebugClient,
   txHash: Hex,
   schema: ZodSchema,
-  methodName: 'debug_traceTransaction' | 'trace_transaction',
+  method: 'debug_traceTransaction' | 'trace_transaction',
   blockType: string,
 ): Promise<boolean> {
   try {
-    let result: unknown;
-
     // Make request with appropriate params based on method name
-    if (methodName === 'debug_traceTransaction') {
-      result = await client.request({
-        method: 'debug_traceTransaction',
-        params: [txHash, { tracer: 'callTracer' }],
-      });
-    } else {
-      result = await client.request({
-        method: 'trace_transaction',
-        params: [txHash],
-      });
-    }
+    const result = await client.request(
+      method === 'debug_traceTransaction'
+        ? { method, params: [txHash, { tracer: 'callTracer' }] }
+        : { method, params: [txHash] },
+    );
 
     schema.parse(result);
-    logger.debug(`${methodName} works for ${blockType} blocks`);
+    logger.debug(`${method} works for ${blockType} blocks`);
     return true;
   } catch (error) {
-    logger.debug(`${methodName} failed for ${blockType} blocks: ${error}`);
+    logger.warn(`${method} failed for ${blockType} blocks: ${error}`);
     return false;
   }
 }
@@ -80,18 +72,15 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
   try {
     // Get the latest block
     let latestBlock = await client.getBlock({ blockTag: 'latest' });
+    let attempts = 10;
 
     // Loop back to find a block with transactions (handles dev/test scenarios)
-    while (
-      (!latestBlock.transactions || latestBlock.transactions.length === 0) &&
-      latestBlock.number &&
-      latestBlock.number > 0n
-    ) {
+    while (!hasTxs(latestBlock) && latestBlock.number && latestBlock.number > 0n && --attempts > 0) {
       logger.debug(`Block ${latestBlock.number} has no transactions, checking previous block`);
       latestBlock = await client.getBlock({ blockNumber: latestBlock.number - 1n });
     }
 
-    if (!latestBlock.transactions || latestBlock.transactions.length === 0) {
+    if (!hasTxs(latestBlock)) {
       logger.warn('No blocks with transactions found from latest back to genesis, cannot validate trace availability');
       return result;
     }
@@ -125,14 +114,15 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
     }
 
     let oldBlock = await client.getBlock({ blockNumber: oldBlockNumber });
+    attempts = 10;
 
     // Loop back to find a block with transactions (handles dev/test scenarios)
-    while ((!oldBlock.transactions || oldBlock.transactions.length === 0) && oldBlock.number && oldBlock.number > 0n) {
+    while (!hasTxs(oldBlock) && oldBlock.number && oldBlock.number > 0n && --attempts > 0) {
       logger.debug(`Block ${oldBlock.number} has no transactions, checking previous block`);
       oldBlock = await client.getBlock({ blockNumber: oldBlock.number - 1n });
     }
 
-    if (!oldBlock.transactions || oldBlock.transactions.length === 0) {
+    if (!hasTxs(oldBlock)) {
       logger.debug(
         'No blocks with transactions found from old block back to genesis, cannot validate trace availability for old blocks',
       );
@@ -153,10 +143,14 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
       'old',
     );
   } catch (error) {
-    logger.error(`Error during trace availability validation: ${error}`);
+    logger.warn(`Error validating debug_traceTransaction and trace_transaction availability: ${error}`);
   }
 
   return result;
+}
+
+function hasTxs(block: { transactions?: Hex[] }): boolean {
+  return Array.isArray(block.transactions) && block.transactions.length > 0;
 }
 
 /**
@@ -205,15 +199,13 @@ export async function validateAndLogTraceAvailability(
   } else {
     // Error case: no support at all
     const errorMessage =
-      'Ethereum client does not support debug_traceTransaction or trace_transaction methods. Transaction tracing will not be available.';
+      'Ethereum debug client does not support debug_traceTransaction or trace_transaction methods. Transaction tracing will not be available. This may impact archiver syncing.';
 
     if (ethereumAllowNoDebugHosts) {
       logger.warn(`${errorMessage} Continuing because ETHEREUM_ALLOW_NO_DEBUG_HOSTS is set to true.`);
     } else {
       logger.error(errorMessage);
-      throw new Error(
-        `${errorMessage} Set ETHEREUM_ALLOW_NO_DEBUG_HOSTS=true to bypass this check if trace functionality is not required.`,
-      );
+      throw new Error(`${errorMessage} Set ETHEREUM_ALLOW_NO_DEBUG_HOSTS=true to bypass this check.`);
     }
   }
 }

--- a/yarn-project/ethereum/src/forwarder_proxy.ts
+++ b/yarn-project/ethereum/src/forwarder_proxy.ts
@@ -4,7 +4,8 @@ import type { Logger } from '@aztec/foundation/log';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
-import type { Hex } from 'viem';
+import { type Hex, extractChain } from 'viem';
+import { anvil, mainnet, sepolia } from 'viem/chains';
 
 import { L1Deployer } from './deploy_l1_contracts.js';
 import type { ExtendedViemWalletClient } from './types.js';
@@ -78,17 +79,21 @@ export async function deployForwarderProxy(client: ExtendedViemWalletClient, log
  */
 async function main() {
   const args = process.argv.slice(2);
-  if (args.length < 2) {
-    console.error('Usage: node forwarder_proxy.js <private_key> <rpc_url>');
+  if (args.length < 3) {
+    console.error('Usage: node forwarder_proxy.js <private_key> <rpc_url> <chain_id>');
     process.exit(1);
   }
 
-  const [privateKey, rpcUrl] = args;
+  const [privateKey, rpcUrl, chainId] = args;
 
   // Dynamic import to avoid pulling in dependencies at module load time
   const { createExtendedL1Client } = await import('./client.js');
 
-  const client = createExtendedL1Client([rpcUrl], privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`);
+  const client = createExtendedL1Client(
+    [rpcUrl],
+    privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`,
+    extractChain({ chains: [mainnet, sepolia, anvil], id: parseInt(chainId) as any }),
+  );
   const address = await deployForwarderProxy(client);
 
   console.log(`Forwarder proxy deployed at: ${address.toString()}`);

--- a/yarn-project/ethereum/src/types.ts
+++ b/yarn-project/ethereum/src/types.ts
@@ -37,8 +37,8 @@ export type DebugCallTrace = {
   type: string;
   input?: Hex;
   output?: Hex;
-  gas: Hex;
-  gasUsed: Hex;
+  gas?: Hex;
+  gasUsed?: Hex;
   value?: Hex;
   error?: string;
   calls?: DebugCallTrace[];
@@ -49,14 +49,14 @@ export type TraceAction = {
   from: Hex;
   to?: Hex;
   callType: string;
-  gas: Hex;
+  gas?: Hex;
   input?: Hex;
   value?: Hex;
 };
 
 /** Result object for a trace_transaction call */
 export type TraceResult = {
-  gasUsed: Hex;
+  gasUsed?: Hex;
   output?: Hex;
 };
 

--- a/yarn-project/foundation/src/eth-address/index.ts
+++ b/yarn-project/foundation/src/eth-address/index.ts
@@ -242,6 +242,12 @@ export class EthAddress {
   static get schema() {
     return hexSchemaFor(EthAddress, EthAddress.isAddress);
   }
+
+  static areEqual(a: EthAddress | string, b: EthAddress | string) {
+    const addrA = typeof a === 'string' ? EthAddress.fromString(a) : a;
+    const addrB = typeof b === 'string' ? EthAddress.fromString(b) : b;
+    return addrA.equals(addrB);
+  }
 }
 
 // For deserializing JSON.

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -127,3 +127,9 @@ export const L1_TX_SCOPE = 'aztec.l1_tx.scope';
 
 /** Generic error type attribute */
 export const IS_COMMITTEE_MEMBER = 'aztec.is_committee_member';
+
+/** The L1 transaction target for block proposal */
+export const L1_BLOCK_PROPOSAL_TX_TARGET = 'aztec.l1.block_proposal_tx_target';
+
+/** Whether tracing methods were used to extract block proposal data */
+export const L1_BLOCK_PROPOSAL_USED_TRACE = 'aztec.l1.block_proposal_used_trace';

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -60,6 +60,8 @@ export const ARCHIVER_PRUNE_COUNT = 'aztec.archiver.prune_count';
 
 export const ARCHIVER_TOTAL_TXS = 'aztec.archiver.tx_count';
 
+export const ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT = 'aztec.archiver.block_proposal_tx_target_count';
+
 export const NODE_RECEIVE_TX_DURATION = 'aztec.node.receive_tx.duration';
 export const NODE_RECEIVE_TX_COUNT = 'aztec.node.receive_tx.count';
 


### PR DESCRIPTION
- Adds a metric for tracking the target of propose txs (tx.to and whether we had to go through the trace codepath to get the calldata)
- Changes default of ETHEREUM_ALLOW_NO_DEBUG_HOSTS to true to avoid a breaking change.
- Addresses comments from @alexghr in previous PRs
