### PR TITLE
fix: only create publishers for unique keys

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/interfaces.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/interfaces.ts
@@ -46,7 +46,7 @@ export interface IL1TxStore {
    * @param account - The sender account address
    * @param stateId - The state ID to delete
    */
-  deleteState(account: string, stateId: number): Promise<void>;
+  deleteState(account: string, ...stateId: number[]): Promise<void>;
 
   /**
    * Clears all transaction states for a specific account.

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -130,12 +130,32 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       return;
     }
 
-    // Convert loaded states (which have id) to the txs format
-    this.txs = loadedStates;
-    this.logger.info(`Rehydrated ${loadedStates.length} tx states for account ${account}`);
+    // Clean up excess states if we have more than MAX_L1_TX_STATES
+    if (loadedStates.length > MAX_L1_TX_STATES) {
+      this.logger.warn(
+        `Found ${loadedStates.length} tx states for account ${account}, pruning to most recent ${MAX_L1_TX_STATES}`,
+      );
+
+      // Keep only the most recent MAX_L1_TX_STATES
+      const statesToKeep = loadedStates.slice(-MAX_L1_TX_STATES);
+      const statesToDelete = loadedStates.slice(0, -MAX_L1_TX_STATES);
+
+      // Batch delete old states in a transaction for efficiency
+      const idsToDelete = statesToDelete.map(s => s.id);
+      await this.store.deleteState(account, ...idsToDelete);
+
+      this.txs = statesToKeep;
+      this.logger.info(
+        `Cleaned up ${statesToDelete.length} old tx states, kept ${statesToKeep.length} for account ${account}`,
+      );
+    } else {
+      // Convert loaded states (which have id) to the txs format
+      this.txs = loadedStates;
+      this.logger.info(`Rehydrated ${loadedStates.length} tx states for account ${account}`);
+    }
 
     // Find all pending states and resume monitoring
-    const pendingStates = loadedStates.filter(state => !TerminalTxUtilsState.includes(state.status));
+    const pendingStates = this.txs.filter(state => !TerminalTxUtilsState.includes(state.status));
     if (pendingStates.length === 0) {
       return;
     }

--- a/yarn-project/node-lib/package.json
+++ b/yarn-project/node-lib/package.json
@@ -79,13 +79,15 @@
   },
   "devDependencies": {
     "@aztec/blob-lib": "workspace:^",
+    "@aztec/node-keystore": "workspace:^",
     "@jest/globals": "^30.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "jest": "^30.0.0",
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "viem": "npm:@aztec/viem@2.38.2"
   },
   "files": [
     "dest",

--- a/yarn-project/node-lib/src/factories/l1_tx_utils.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils.ts
@@ -65,7 +65,7 @@ export async function createL1TxUtilsWithBlobsFromViemWallet(
 }
 
 /**
- * Creates L1TxUtils with blobs from multiple EthSigners, sharing store and metrics.
+ * Creates L1TxUtils with blobs from multiple EthSigners, sharing store and metrics. Removes duplicates
  */
 export async function createL1TxUtilsWithBlobsFromEthSigner(
   client: ViemClient,
@@ -79,7 +79,25 @@ export async function createL1TxUtilsWithBlobsFromEthSigner(
 ) {
   const sharedDeps = await createSharedDeps(config, deps);
 
-  return signers.map(signer =>
+  // Deduplicate signers by address to avoid creating multiple L1TxUtils instances
+  // for the same publisher address (e.g., when multiple attesters share the same publisher key)
+  const signersByAddress = new Map<string, EthSigner>();
+  for (const signer of signers) {
+    const addressKey = signer.address.toString().toLowerCase();
+    if (!signersByAddress.has(addressKey)) {
+      signersByAddress.set(addressKey, signer);
+    }
+  }
+
+  const uniqueSigners = Array.from(signersByAddress.values());
+
+  if (uniqueSigners.length < signers.length) {
+    sharedDeps.logger.info(
+      `Deduplicated ${signers.length} signers to ${uniqueSigners.length} unique publisher addresses`,
+    );
+  }
+
+  return uniqueSigners.map(signer =>
     createL1TxUtilsWithBlobsFromEthSignerBase(client, signer, sharedDeps, config, config.debugMaxGasLimit),
   );
 }
@@ -103,7 +121,7 @@ export async function createL1TxUtilsFromViemWalletWithStore(
 }
 
 /**
- * Creates L1TxUtils (without blobs) from multiple EthSigners, sharing store and metrics.
+ * Creates L1TxUtils (without blobs) from multiple EthSigners, sharing store and metrics. Removes duplicates.
  */
 export async function createL1TxUtilsFromEthSignerWithStore(
   client: ViemClient,
@@ -118,5 +136,23 @@ export async function createL1TxUtilsFromEthSignerWithStore(
 ) {
   const sharedDeps = await createSharedDeps(config, deps);
 
-  return signers.map(signer => createL1TxUtilsFromEthSignerBase(client, signer, sharedDeps, config));
+  // Deduplicate signers by address to avoid creating multiple L1TxUtils instances
+  // for the same publisher address (e.g., when multiple attesters share the same publisher key)
+  const signersByAddress = new Map<string, EthSigner>();
+  for (const signer of signers) {
+    const addressKey = signer.address.toString().toLowerCase();
+    if (!signersByAddress.has(addressKey)) {
+      signersByAddress.set(addressKey, signer);
+    }
+  }
+
+  const uniqueSigners = Array.from(signersByAddress.values());
+
+  if (uniqueSigners.length < signers.length) {
+    sharedDeps.logger.info(
+      `Deduplicated ${signers.length} signers to ${uniqueSigners.length} unique publisher addresses`,
+    );
+  }
+
+  return uniqueSigners.map(signer => createL1TxUtilsFromEthSignerBase(client, signer, sharedDeps, config));
 }

--- a/yarn-project/node-lib/src/factories/l1_tx_utils_integration.test.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils_integration.test.ts
@@ -1,0 +1,152 @@
+import type { ViemClient } from '@aztec/ethereum';
+import { getAddressFromPrivateKey } from '@aztec/ethereum';
+import { times } from '@aztec/foundation/collection';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { KeystoreManager } from '@aztec/node-keystore';
+import type { EthPrivateKey, KeyStore } from '@aztec/node-keystore';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { TelemetryClient } from '@aztec/telemetry-client';
+
+import { generatePrivateKey } from 'viem/accounts';
+
+import { createL1TxUtilsWithBlobsFromEthSigner } from './l1_tx_utils.js';
+
+describe('L1TxUtils Integration - Publisher Deduplication', () => {
+  let kvStore: AztecAsyncKVStore;
+  let mockClient: ViemClient;
+  let mockTelemetry: TelemetryClient;
+  let count = 0;
+
+  const mockConfig = {
+    dataDirectory: undefined,
+    dataStoreMapSizeKb: 1024 * 1024,
+  };
+
+  beforeEach(async () => {
+    kvStore = await openTmpStore(`l1-tx-utils-integration-test-${count++}`, true);
+
+    // Mock ViemClient
+    mockClient = {
+      chain: { id: 1 },
+      getBalance: () => Promise.resolve(1000000000000000000n),
+      getTransactionCount: () => Promise.resolve(0),
+      getBlock: () => Promise.resolve({ timestamp: BigInt(Date.now() / 1000) }),
+    } as any;
+
+    // Mock TelemetryClient
+    mockTelemetry = {
+      getMeter: () => ({
+        createCounter: () => ({ add: () => {} }),
+        createHistogram: () => ({ record: () => {} }),
+        createGauge: () => ({ record: () => {} }),
+        createUpDownCounter: () => ({ add: () => {} }),
+      }),
+    } as any;
+  });
+
+  afterEach(async () => {
+    if (kvStore) {
+      await kvStore.close();
+    }
+  });
+
+  it('should deduplicate 500 validators sharing the same publisher key', async () => {
+    // Create a shared publisher private key
+    const sharedPublisherKey = generatePrivateKey() as EthPrivateKey;
+    const expectedPublisherAddress = EthAddress.fromString(getAddressFromPrivateKey(sharedPublisherKey));
+
+    // Create keystore with many validators, all using the same publisher
+    const keystore: KeyStore = {
+      schemaVersion: 1,
+      validators: times(500, _ => {
+        const attesterKey = generatePrivateKey() as EthPrivateKey;
+        const attesterAddress = getAddressFromPrivateKey(attesterKey);
+
+        return {
+          attester: attesterKey,
+          publisher: sharedPublisherKey,
+          coinbase: EthAddress.fromString(attesterAddress),
+          feeRecipient: AztecAddress.ZERO,
+        };
+      }),
+    };
+
+    // Create KeystoreManager and extract publisher signers
+    const manager = new KeystoreManager(keystore);
+    const allPublisherSigners = manager.createAllValidatorPublisherSigners();
+
+    // we should have publishers for each validator
+    expect(allPublisherSigners).toHaveLength(keystore.validators!.length);
+
+    const l1TxUtils = await createL1TxUtilsWithBlobsFromEthSigner(mockClient, allPublisherSigners, mockConfig, {
+      telemetry: mockTelemetry,
+    });
+
+    // all of the publisherSigners should deduplicate to one L1TxUtils instance
+    expect(l1TxUtils).toHaveLength(1);
+    expect(l1TxUtils[0].getSenderAddress().equals(expectedPublisherAddress)).toBe(true);
+  });
+
+  it('should handle validators with 3 unique publishers correctly', async () => {
+    // Create 3 different publisher keys
+    const publisherKey1 = generatePrivateKey() as EthPrivateKey;
+    const publisherKey2 = generatePrivateKey() as EthPrivateKey;
+    const publisherKey3 = generatePrivateKey() as EthPrivateKey;
+
+    const expectedAddresses = [
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey1)),
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey2)),
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey3)),
+    ];
+
+    const keystore: KeyStore = {
+      schemaVersion: 1,
+      validators: [
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey1,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey2,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey3,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+      ],
+    };
+
+    const manager = new KeystoreManager(keystore);
+    const allPublisherSigners = manager.createAllValidatorPublisherSigners();
+
+    expect(allPublisherSigners).toHaveLength(keystore.validators!.length);
+
+    const l1TxUtils = await createL1TxUtilsWithBlobsFromEthSigner(mockClient, allPublisherSigners, mockConfig, {
+      telemetry: mockTelemetry,
+    });
+
+    expect(l1TxUtils).toHaveLength(3);
+
+    const actualAddresses = l1TxUtils.map(utils => utils.getSenderAddress().toString().toLowerCase()).sort();
+    const expectedAddressesLower = expectedAddresses.map(addr => addr.toString().toLowerCase()).sort();
+    expect(actualAddresses).toEqual(expectedAddressesLower);
+  });
+});

--- a/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.test.ts
@@ -285,6 +285,36 @@ describe('L1TxStore', () => {
       const loaded = await store.loadState(account, saved.id);
       expect(loaded).toBeUndefined();
     });
+
+    it('should batch delete multiple states efficiently', async () => {
+      const account = '0xabc123';
+
+      // Create 10 states
+      const savedStates: L1TxState[] = [];
+      for (let i = 1; i <= 10; i++) {
+        savedStates.push(await store.saveState(account, createMockState(i)));
+      }
+
+      // Delete states 1, 3, 5, 7, 9 (every other one)
+      const idsToDelete = [1, 3, 5, 7, 9].map(i => savedStates[i - 1].id);
+      await store.deleteState(account, ...idsToDelete);
+
+      // Should have 5 states remaining (2, 4, 6, 8, 10)
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(5);
+      expect(loaded.map(s => s.nonce)).toEqual([2, 4, 6, 8, 10]);
+    });
+
+    it('should handle empty array gracefully', async () => {
+      const account = '0xabc123';
+      await store.saveState(account, createMockState(1));
+
+      // Should not throw and should not delete anything
+      await expect(store.deleteState(account)).resolves.not.toThrow();
+
+      const loaded = await store.loadStates(account);
+      expect(loaded).toHaveLength(1);
+    });
   });
 
   describe('clearStates', () => {

--- a/yarn-project/node-lib/src/stores/l1_tx_store.ts
+++ b/yarn-project/node-lib/src/stores/l1_tx_store.ts
@@ -231,11 +231,18 @@ export class L1TxStore implements IL1TxStore {
    * @param account - The sender account address
    * @param stateId - The state ID to delete
    */
-  public async deleteState(account: string, stateId: number): Promise<void> {
-    const key = this.makeKey(account, stateId);
-    await this.states.delete(key);
-    await this.blobs.delete(key);
-    this.log.debug(`Deleted state ${stateId} for account ${account}`);
+  public async deleteState(account: string, ...stateIds: number[]): Promise<void> {
+    if (stateIds.length === 0) {
+      return;
+    }
+
+    await this.store.transactionAsync(async () => {
+      for (const stateId of stateIds) {
+        const key = this.makeKey(account, stateId);
+        await this.states.delete(key);
+        await this.blobs.delete(key);
+      }
+    });
   }
 
   /**
@@ -243,14 +250,16 @@ export class L1TxStore implements IL1TxStore {
    * @param account - The sender account address
    */
   public async clearStates(account: string): Promise<void> {
-    const states = await this.loadStates(account);
+    await this.store.transactionAsync(async () => {
+      const states = await this.loadStates(account);
 
-    for (const state of states) {
-      await this.deleteState(account, state.id);
-    }
+      for (const state of states) {
+        await this.deleteState(account, state.id);
+      }
 
-    await this.stateIdCounter.delete(account);
-    this.log.info(`Cleared all tx states for account ${account}`);
+      await this.stateIdCounter.delete(account);
+      this.log.info(`Cleared all tx states for account ${account}`);
+    });
   }
 
   /**

--- a/yarn-project/node-lib/tsconfig.json
+++ b/yarn-project/node-lib/tsconfig.json
@@ -62,6 +62,9 @@
     },
     {
       "path": "../blob-lib"
+    },
+    {
+      "path": "../node-keystore"
     }
   ],
   "include": ["src"]

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1597,6 +1597,7 @@ __metadata:
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
     "@aztec/merkle-tree": "workspace:^"
+    "@aztec/node-keystore": "workspace:^"
     "@aztec/p2p": "workspace:^"
     "@aztec/protocol-contracts": "workspace:^"
     "@aztec/prover-client": "workspace:^"
@@ -1614,6 +1615,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@aztec/viem@2.38.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR deduplicates publishers when parsing the keystore. This fixes a memory issue where multiple attesters sharing a single publisher would end up tracking more tx states than intended potentially leading to an OOM.