### PR TITLE
fix: clarify selection of publisher for block invalidation

### DIFF
--- a/yarn-project/node-lib/package.json
+++ b/yarn-project/node-lib/package.json
@@ -79,13 +79,15 @@
   },
   "devDependencies": {
     "@aztec/blob-lib": "workspace:^",
+    "@aztec/node-keystore": "workspace:^",
     "@jest/globals": "^30.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.17",
     "jest": "^30.0.0",
     "jest-mock-extended": "^4.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "viem": "npm:@aztec/viem@2.38.2"
   },
   "files": [
     "dest",

--- a/yarn-project/node-lib/src/factories/l1_tx_utils.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils.ts
@@ -65,7 +65,7 @@ export async function createL1TxUtilsWithBlobsFromViemWallet(
 }
 
 /**
- * Creates L1TxUtils with blobs from multiple EthSigners, sharing store and metrics.
+ * Creates L1TxUtils with blobs from multiple EthSigners, sharing store and metrics. Removes duplicates
  */
 export async function createL1TxUtilsWithBlobsFromEthSigner(
   client: ViemClient,
@@ -79,7 +79,25 @@ export async function createL1TxUtilsWithBlobsFromEthSigner(
 ) {
   const sharedDeps = await createSharedDeps(config, deps);
 
-  return signers.map(signer =>
+  // Deduplicate signers by address to avoid creating multiple L1TxUtils instances
+  // for the same publisher address (e.g., when multiple attesters share the same publisher key)
+  const signersByAddress = new Map<string, EthSigner>();
+  for (const signer of signers) {
+    const addressKey = signer.address.toString().toLowerCase();
+    if (!signersByAddress.has(addressKey)) {
+      signersByAddress.set(addressKey, signer);
+    }
+  }
+
+  const uniqueSigners = Array.from(signersByAddress.values());
+
+  if (uniqueSigners.length < signers.length) {
+    sharedDeps.logger.info(
+      `Deduplicated ${signers.length} signers to ${uniqueSigners.length} unique publisher addresses`,
+    );
+  }
+
+  return uniqueSigners.map(signer =>
     createL1TxUtilsWithBlobsFromEthSignerBase(client, signer, sharedDeps, config, config.debugMaxGasLimit),
   );
 }
@@ -103,7 +121,7 @@ export async function createL1TxUtilsFromViemWalletWithStore(
 }
 
 /**
- * Creates L1TxUtils (without blobs) from multiple EthSigners, sharing store and metrics.
+ * Creates L1TxUtils (without blobs) from multiple EthSigners, sharing store and metrics. Removes duplicates.
  */
 export async function createL1TxUtilsFromEthSignerWithStore(
   client: ViemClient,
@@ -118,5 +136,23 @@ export async function createL1TxUtilsFromEthSignerWithStore(
 ) {
   const sharedDeps = await createSharedDeps(config, deps);
 
-  return signers.map(signer => createL1TxUtilsFromEthSignerBase(client, signer, sharedDeps, config));
+  // Deduplicate signers by address to avoid creating multiple L1TxUtils instances
+  // for the same publisher address (e.g., when multiple attesters share the same publisher key)
+  const signersByAddress = new Map<string, EthSigner>();
+  for (const signer of signers) {
+    const addressKey = signer.address.toString().toLowerCase();
+    if (!signersByAddress.has(addressKey)) {
+      signersByAddress.set(addressKey, signer);
+    }
+  }
+
+  const uniqueSigners = Array.from(signersByAddress.values());
+
+  if (uniqueSigners.length < signers.length) {
+    sharedDeps.logger.info(
+      `Deduplicated ${signers.length} signers to ${uniqueSigners.length} unique publisher addresses`,
+    );
+  }
+
+  return uniqueSigners.map(signer => createL1TxUtilsFromEthSignerBase(client, signer, sharedDeps, config));
 }

--- a/yarn-project/node-lib/src/factories/l1_tx_utils_integration.test.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils_integration.test.ts
@@ -1,0 +1,152 @@
+import type { ViemClient } from '@aztec/ethereum';
+import { getAddressFromPrivateKey } from '@aztec/ethereum';
+import { times } from '@aztec/foundation/collection';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { KeystoreManager } from '@aztec/node-keystore';
+import type { EthPrivateKey, KeyStore } from '@aztec/node-keystore';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { TelemetryClient } from '@aztec/telemetry-client';
+
+import { generatePrivateKey } from 'viem/accounts';
+
+import { createL1TxUtilsWithBlobsFromEthSigner } from './l1_tx_utils.js';
+
+describe('L1TxUtils Integration - Publisher Deduplication', () => {
+  let kvStore: AztecAsyncKVStore;
+  let mockClient: ViemClient;
+  let mockTelemetry: TelemetryClient;
+  let count = 0;
+
+  const mockConfig = {
+    dataDirectory: undefined,
+    dataStoreMapSizeKb: 1024 * 1024,
+  };
+
+  beforeEach(async () => {
+    kvStore = await openTmpStore(`l1-tx-utils-integration-test-${count++}`, true);
+
+    // Mock ViemClient
+    mockClient = {
+      chain: { id: 1 },
+      getBalance: () => Promise.resolve(1000000000000000000n),
+      getTransactionCount: () => Promise.resolve(0),
+      getBlock: () => Promise.resolve({ timestamp: BigInt(Date.now() / 1000) }),
+    } as any;
+
+    // Mock TelemetryClient
+    mockTelemetry = {
+      getMeter: () => ({
+        createCounter: () => ({ add: () => {} }),
+        createHistogram: () => ({ record: () => {} }),
+        createGauge: () => ({ record: () => {} }),
+        createUpDownCounter: () => ({ add: () => {} }),
+      }),
+    } as any;
+  });
+
+  afterEach(async () => {
+    if (kvStore) {
+      await kvStore.close();
+    }
+  });
+
+  it('should deduplicate 500 validators sharing the same publisher key', async () => {
+    // Create a shared publisher private key
+    const sharedPublisherKey = generatePrivateKey() as EthPrivateKey;
+    const expectedPublisherAddress = EthAddress.fromString(getAddressFromPrivateKey(sharedPublisherKey));
+
+    // Create keystore with many validators, all using the same publisher
+    const keystore: KeyStore = {
+      schemaVersion: 1,
+      validators: times(500, _ => {
+        const attesterKey = generatePrivateKey() as EthPrivateKey;
+        const attesterAddress = getAddressFromPrivateKey(attesterKey);
+
+        return {
+          attester: attesterKey,
+          publisher: sharedPublisherKey,
+          coinbase: EthAddress.fromString(attesterAddress),
+          feeRecipient: AztecAddress.ZERO,
+        };
+      }),
+    };
+
+    // Create KeystoreManager and extract publisher signers
+    const manager = new KeystoreManager(keystore);
+    const allPublisherSigners = manager.createAllValidatorPublisherSigners();
+
+    // we should have publishers for each validator
+    expect(allPublisherSigners).toHaveLength(keystore.validators!.length);
+
+    const l1TxUtils = await createL1TxUtilsWithBlobsFromEthSigner(mockClient, allPublisherSigners, mockConfig, {
+      telemetry: mockTelemetry,
+    });
+
+    // all of the publisherSigners should deduplicate to one L1TxUtils instance
+    expect(l1TxUtils).toHaveLength(1);
+    expect(l1TxUtils[0].getSenderAddress().equals(expectedPublisherAddress)).toBe(true);
+  });
+
+  it('should handle validators with 3 unique publishers correctly', async () => {
+    // Create 3 different publisher keys
+    const publisherKey1 = generatePrivateKey() as EthPrivateKey;
+    const publisherKey2 = generatePrivateKey() as EthPrivateKey;
+    const publisherKey3 = generatePrivateKey() as EthPrivateKey;
+
+    const expectedAddresses = [
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey1)),
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey2)),
+      EthAddress.fromString(getAddressFromPrivateKey(publisherKey3)),
+    ];
+
+    const keystore: KeyStore = {
+      schemaVersion: 1,
+      validators: [
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey1,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey2,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+        ...times(200, () => {
+          const addr = EthAddress.random();
+          return {
+            attester: generatePrivateKey() as EthPrivateKey,
+            publisher: publisherKey3,
+            coinbase: addr,
+            feeRecipient: AztecAddress.ZERO,
+          };
+        }),
+      ],
+    };
+
+    const manager = new KeystoreManager(keystore);
+    const allPublisherSigners = manager.createAllValidatorPublisherSigners();
+
+    expect(allPublisherSigners).toHaveLength(keystore.validators!.length);
+
+    const l1TxUtils = await createL1TxUtilsWithBlobsFromEthSigner(mockClient, allPublisherSigners, mockConfig, {
+      telemetry: mockTelemetry,
+    });
+
+    expect(l1TxUtils).toHaveLength(3);
+
+    const actualAddresses = l1TxUtils.map(utils => utils.getSenderAddress().toString().toLowerCase()).sort();
+    const expectedAddressesLower = expectedAddresses.map(addr => addr.toString().toLowerCase()).sort();
+    expect(actualAddresses).toEqual(expectedAddressesLower);
+  });
+});

--- a/yarn-project/node-lib/tsconfig.json
+++ b/yarn-project/node-lib/tsconfig.json
@@ -62,6 +62,9 @@
     },
     {
       "path": "../blob-lib"
+    },
+    {
+      "path": "../node-keystore"
     }
   ],
   "include": ["src"]

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -752,6 +752,157 @@ describe('sequencer', () => {
       expect(publisher.sendRequests).not.toHaveBeenCalled();
     });
   });
+
+  describe('considerInvalidatingBlock', () => {
+    const validator1 = EthAddress.random();
+    const validator2 = EthAddress.random();
+    const validator3 = EthAddress.random();
+
+    let invalidValidationResult: {
+      valid: false;
+      block: {
+        blockNumber: number;
+        timestamp: bigint;
+        archive: Fr;
+        lastArchive: Fr;
+        slotNumber: number;
+        txCount: number;
+      };
+      committee: EthAddress[];
+      epoch: bigint;
+      seed: bigint;
+      attestors: EthAddress[];
+      attestations: any[];
+      reason: 'insufficient-attestations';
+    };
+
+    beforeEach(() => {
+      invalidValidationResult = {
+        valid: false,
+        block: {
+          blockNumber: lastBlockNumber,
+          timestamp: 1000n,
+          archive: Fr.random(),
+          lastArchive: Fr.random(),
+          slotNumber: newSlotNumber,
+          txCount: 0,
+        },
+        committee: [validator2],
+        epoch: 1n,
+        seed: 123n,
+        attestors: [],
+        attestations: [],
+        reason: 'insufficient-attestations',
+      };
+
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue(invalidValidationResult);
+
+      // Mock committee to include validator2
+      epochCache.getCommittee.mockResolvedValue({
+        committee: [validator2],
+        seed: 123n,
+        epoch: 1n,
+      });
+
+      // Setup validator client
+      validatorClient.getValidatorAddresses.mockReturnValue([validator1, validator2, validator3]);
+
+      // Make sure we're NOT the proposer so considerInvalidatingBlock is called
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(EthAddress.random());
+
+      // Setup publisher factory
+      publisherFactory.create.mockImplementation((validatorAddress?: EthAddress) => {
+        return Promise.resolve({
+          attestorAddress: validatorAddress ?? validator1,
+          publisher,
+        });
+      });
+
+      publisher.simulateInvalidateBlock.mockResolvedValue({
+        forcePendingBlockNumber: lastBlockNumber,
+      } as any);
+    });
+
+    it('should use committee member when invalidating as committee member', async () => {
+      // Set time past the committee member threshold
+      const timePastThreshold = 2; // seconds
+      dateProvider.setTime(Number(invalidValidationResult.block.timestamp) * 1000 + timePastThreshold * 1000);
+
+      sequencer.updateConfig({
+        secondsBeforeInvalidatingBlockAsCommitteeMember: 2,
+        secondsBeforeInvalidatingBlockAsNonCommitteeMember: 3,
+      });
+
+      await sequencer.work();
+
+      // Should create publisher with the committee member validator
+      expect(publisherFactory.create).toHaveBeenCalledWith(validator2);
+      expect(publisher.enqueueInvalidateBlock).toHaveBeenCalled();
+      expect(publisher.sendRequests).toHaveBeenCalled();
+    });
+
+    it('should use first validator when invalidating as non-committee member', async () => {
+      // Mock committee without any of our validators
+      epochCache.getCommittee.mockResolvedValue({
+        committee: [EthAddress.random()],
+        seed: 123n,
+        epoch: 1n,
+      });
+
+      // Set time past the non-committee member threshold
+      const timePastThreshold = 5; // seconds
+      dateProvider.setTime(Number(invalidValidationResult.block.timestamp) * 1000 + timePastThreshold * 1000);
+
+      sequencer.updateConfig({
+        secondsBeforeInvalidatingBlockAsCommitteeMember: 2,
+        secondsBeforeInvalidatingBlockAsNonCommitteeMember: 3,
+      });
+
+      await sequencer.work();
+
+      // Should create publisher with the first validator
+      expect(publisherFactory.create).toHaveBeenCalledWith(validator1);
+      expect(publisher.enqueueInvalidateBlock).toHaveBeenCalled();
+      expect(publisher.sendRequests).toHaveBeenCalled();
+    });
+
+    it('should not invalidate when time thresholds not met', async () => {
+      // Set time before any threshold
+      const timePastThreshold = 1;
+      dateProvider.setTime(Number(invalidValidationResult.block.timestamp) * 1000 + timePastThreshold * 1000);
+
+      sequencer.updateConfig({
+        secondsBeforeInvalidatingBlockAsCommitteeMember: 2,
+        secondsBeforeInvalidatingBlockAsNonCommitteeMember: 3,
+      });
+
+      await sequencer.work();
+
+      // Should not create publisher or invalidate
+      expect(publisherFactory.create).not.toHaveBeenCalled();
+      expect(publisher.enqueueInvalidateBlock).not.toHaveBeenCalled();
+    });
+
+    it('should not invalidate when pending chain is valid', async () => {
+      // Mock valid chain
+      l2BlockSource.getPendingChainValidationStatus.mockResolvedValue({ valid: true });
+
+      // Set time past threshold
+      const timePastThreshold = 5; // seconds
+      dateProvider.setTime(Number(invalidValidationResult.block.timestamp) * 1000 + timePastThreshold * 1000);
+
+      sequencer.updateConfig({
+        secondsBeforeInvalidatingBlockAsCommitteeMember: 2,
+        secondsBeforeInvalidatingBlockAsNonCommitteeMember: 3,
+      });
+
+      await sequencer.work();
+
+      // Should not create publisher or invalidate
+      expect(publisherFactory.create).not.toHaveBeenCalled();
+      expect(publisher.enqueueInvalidateBlock).not.toHaveBeenCalled();
+    });
+  });
 });
 
 class TestSubject extends Sequencer {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1162,7 +1162,6 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
 
-    const { publisher } = await this.publisherFactory.create(undefined);
     const invalidBlockNumber = pendingChainValidationStatus.block.blockNumber;
     const invalidBlockTimestamp = pendingChainValidationStatus.block.timestamp;
     const timeSinceChainInvalid = this.dateProvider.nowInSeconds() - Number(invalidBlockTimestamp);
@@ -1201,6 +1200,24 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.log.debug(`Not invalidating pending chain`, logData);
       return;
     }
+
+    let validatorToUse: EthAddress;
+    if (invalidateAsCommitteeMember) {
+      // When invalidating as a committee member, use first validator that's actually in the committee
+      const { committee } = await this.epochCache.getCommittee(currentSlot);
+      if (committee) {
+        const committeeSet = new Set(committee.map(addr => addr.toString()));
+        validatorToUse =
+          ourValidatorAddresses.find(addr => committeeSet.has(addr.toString())) ?? ourValidatorAddresses[0];
+      } else {
+        validatorToUse = ourValidatorAddresses[0];
+      }
+    } else {
+      // When invalidating as a non-committee member, use the first validator
+      validatorToUse = ourValidatorAddresses[0];
+    }
+
+    const { publisher } = await this.publisherFactory.create(validatorToUse);
 
     const invalidateBlock = await publisher.simulateInvalidateBlock(pendingChainValidationStatus);
     if (!invalidateBlock) {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1597,6 +1597,7 @@ __metadata:
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
     "@aztec/merkle-tree": "workspace:^"
+    "@aztec/node-keystore": "workspace:^"
     "@aztec/p2p": "workspace:^"
     "@aztec/protocol-contracts": "workspace:^"
     "@aztec/prover-client": "workspace:^"
@@ -1614,6 +1615,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.3.3"
+    viem: "npm:@aztec/viem@2.38.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR builds on top of #18833 and clarifies the way publishers are selected for block invalidation duties. Optional to go into v2