### PR TITLE
chore(docs): quick fixes to align main <-> ignition in node docs

### DIFF
--- a/docs/docs/the_aztec_network/operation/operator_faq.md
+++ b/docs/docs/the_aztec_network/operation/operator_faq.md
@@ -216,7 +216,7 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 
 #### Version-Specific Updates:
 
-To update to a specific version , update your `docker-compose.yml`:
+To update to a specific version:
 
 ```yaml
 # Change the image tag from:

--- a/docs/docs/the_aztec_network/operation/sequencer_management/running_delegated_stake.md
+++ b/docs/docs/the_aztec_network/operation/sequencer_management/running_delegated_stake.md
@@ -11,10 +11,6 @@ This guide covers running a sequencer with delegated stake on the Aztec network.
 
 **This is a non-custodial system**: Delegators retain full control and ownership of their tokens at all times. You never take custody of the delegated tokens—they remain in the delegator's control while providing economic backing for your sequencer operations.
 
-:::tip Alternative: Self-Staking
-If you prefer to provide your own stake instead of receiving delegated stake, see [Registering a Sequencer](./registering_sequencer.md).
-:::
-
 ## Prerequisites
 
 Before proceeding, ensure you have:

--- a/docs/versioned_docs/version-v2.1.5-ignition/the_aztec_network/operation/operator_faq.md
+++ b/docs/versioned_docs/version-v2.1.5-ignition/the_aztec_network/operation/operator_faq.md
@@ -42,7 +42,11 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
    rm -rf ~/.aztec/v2.1.5/data/archiver
    ```
 
-3. Restart your node with your normal startup command
+3. Restart your node:
+
+   ```bash
+   docker compose up -d
+   ```
 
 :::warning Data Loss and Resync
 This process removes local state and requires full resynchronization. Consider using snapshot sync mode (`SYNC_MODE=snapshot`) to speed up recovery. See the [syncing best practices guide](../setup/syncing_best_practices.md) for more information.
@@ -213,10 +217,6 @@ Sequencers with insufficient funds in their publisher account risk being slashed
 #### Version-Specific Updates:
 
 To update to a specific version:
-
-```bash
-# CLI method
-aztec-up -v 2.1.5
 
 ```yaml
 # Change the image tag from:


### PR DESCRIPTION
keeps `docs` and `ignition-versioned` docs the same