### PR TITLE
fix: atomic test cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ define build
 endef
 
 # Collects the test commands from the given project
-# Writes them line-by-line (important to prevent line splitting, lines must be < 4k) to /tmp/test_cmds.
+# Writes the full output to /tmp/test_cmds atomically.
 # The test engine is expected to be running and it will read commands from this file.
 define test
 	$(call run_command,$(1),$(ROOT)/$(2),\
-	  ./bootstrap.sh test_cmds $(3) | $(ROOT)/ci3/filter_test_cmds | tee -a /tmp/test_cmds >/dev/null)
+	  ./bootstrap.sh test_cmds $(3) | $(ROOT)/ci3/filter_test_cmds | $(ROOT)/ci3/atomic_append /tmp/test_cmds)
 endef
 
 #==============================================================================

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,16 +19,19 @@ export MAKEFLAGS="-j${MAKE_JOBS:-$(get_num_cpus)}"
 function cleanup {
   set +e
   if [ -n "${test_engine_pid:-}" ]; then
+    echo "Sending SIGTERM to test engine process group..."
     kill -SIGTERM -- -$test_engine_pgid &>/dev/null
     wait $test_engine_pid
     test_engine_pid=
   fi
   if [ -n "${make_pid:-}" ]; then
+    echo "Sending SIGTERM to make process..."
     kill -SIGTERM $make_pid &>/dev/null
     wait $make_pid
     make_pid=
   fi
   if [ -n "${txe_pids:-}" ]; then
+    echo "Sending SIGTERM to TXE processes..."
     kill -SIGTERM $txe_pids &>/dev/null
     wait $txe_pids
     txe_pids=
@@ -230,7 +233,7 @@ function test_engine_start {
   # parallel will only process the result of job N when it receives a new job *after* job N has completed.
   # This can prevent a "fail fast" situation, or prevent the results from the first batch of commands from showing up.
   # Empty commands fed to run_test_cmd are no-ops, so we keep parallel processing results in timely fashion with this.
-  while ! grep -E '^STOP$' $test_cmds_file; do sleep 5; echo >> $test_cmds_file; done &
+  while ! grep -E '^STOP$' $test_cmds_file; do sleep 5; echo | atomic_append $test_cmds_file; done &
   # Continuously stream the test cmds into parallelize.
   DENOISE=0 parallelize < <(tail -n+0 -f $test_cmds_file)
 }

--- a/ci3/atomic_append
+++ b/ci3/atomic_append
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Atomically appends stdin to a file using flock.
+# Usage: echo "data" | atomic_append /path/to/file
+set -euo pipefail
+
+file="$1"
+
+# Read all of stdin first, then acquire lock and write
+data=$(cat)
+
+(
+  flock -x 200
+  printf '%s\n' "$data" >&200
+) 200>>"$file"

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -118,16 +118,18 @@ time="${SECONDS}s"
 [ -n "${publish_pid:-}" ] && kill $publish_pid &>/dev/null || true
 publish_log_final
 
-# Don't print any further status info on SIGINT or SIGTERM.
-[ "$status" -eq 143 ] || [ "$status" -eq 130 ] && exit $status
-
 # Handle non-zero exit status
 if [ "$status" -ne 0 ]; then
-  if [ -t 1 ]; then
-    echo -e "\nCommand exited with status $status. Dumping output:"
-    cat $outfile
+  # Print "interrupted" on SIGINT or SIGTERM.
+  if [ "$status" -eq 143 ] || [ "$status" -eq 130 ]; then
+    echo -e ". ${yellow}interrupted${reset} ($time)"
+  else
+    if [ -t 1 ]; then
+      echo -e "\nCommand exited with status $status. Dumping output:"
+      cat $outfile
+    fi
+    echo -e ". ${red}failed${reset} ($time) ${log_info:-}"
   fi
-  echo -e ". ${red}failed${reset} ($time) ${log_info:-}"
 else
   echo -e ". ${green}done${reset} ($time)"
 fi

--- a/ci3/redact
+++ b/ci3/redact
@@ -25,4 +25,5 @@ BEGIN { n = split(ENVIRON["__REDACT_PATTERNS"], p, "\n") }
     if (p[i] != "") while ((j = index($0, p[i])) > 0)
       $0 = substr($0, 1, j-1) "***" substr($0, j + length(p[i]))
   print
+  fflush()
 }'


### PR DESCRIPTION
* `redact` modifications are block-buffering and thus swallowing log lines. ensure we `fflush`.
* Make an interrupted denoise print it explicitly was interrupted.
* Ensure all writes to the test_cmds file are atomic to prevent line splitting.