### PR TITLE
feat(avm)!: public exec returns PublicTxEffect

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/avm_io.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/avm_io.hpp
@@ -445,6 +445,7 @@ struct PublicSimulatorConfig {
     bool skip_fee_enforcement = false;
     bool collect_call_metadata = false;
     bool collect_hints = false;
+    bool collect_public_inputs = false;
     bool collect_debug_logs = false;
     bool collect_statistics = false;
     CollectionLimitsConfig collection_limits;
@@ -455,6 +456,7 @@ struct PublicSimulatorConfig {
                               skip_fee_enforcement,
                               collect_call_metadata,
                               collect_hints,
+                              collect_public_inputs,
                               collect_debug_logs,
                               collect_statistics,
                               collection_limits);
@@ -530,20 +532,34 @@ struct CallStackMetadata {
                               num_nested_calls);
 };
 
+struct PublicTxEffect {
+    FF transaction_fee;
+    std::vector<FF> note_hashes;
+    std::vector<FF> nullifiers;
+    std::vector<ScopedL2ToL1Message> l2_to_l1_msgs;
+    std::vector<PublicLog> public_logs;
+    std::vector<PublicDataWrite> public_data_writes;
+
+    bool operator==(const PublicTxEffect& other) const = default;
+
+    MSGPACK_CAMEL_CASE_FIELDS(transaction_fee, note_hashes, nullifiers, l2_to_l1_msgs, public_logs, public_data_writes);
+};
+
 struct TxSimulationResult {
     // Simulation.
     GasUsed gas_used;
     RevertCode revert_code;
+    PublicTxEffect public_tx_effect;
     // The following fields are only guaranteed to be present if the simulator is configured to collect them.
     std::vector<CallStackMetadata> call_stack_metadata; // One per enqueued call. All phases.
     std::optional<std::vector<DebugLog>> logs;
     // Proving request data.
-    PublicInputs public_inputs;
+    std::optional<PublicInputs> public_inputs;
     std::optional<ExecutionHints> hints;
 
     bool operator==(const TxSimulationResult& other) const = default;
 
-    MSGPACK_CAMEL_CASE_FIELDS(gas_used, revert_code, call_stack_metadata, logs, public_inputs, hints);
+    MSGPACK_CAMEL_CASE_FIELDS(gas_used, revert_code, public_tx_effect, call_stack_metadata, logs, public_inputs, hints);
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
@@ -273,6 +273,22 @@ struct PublicLogs {
         return public_logs;
     }
 
+    std::vector<PublicLog> to_logs() const
+    {
+        std::vector<PublicLog> logs;
+        for (uint32_t i = 0; i < length;) {
+            uint32_t log_length = static_cast<uint32_t>(payload[i]);
+            AztecAddress contract_address = payload[i + 1];
+            std::vector<FF> fields;
+            for (uint32_t j = 0; j < log_length; ++j) {
+                fields.push_back(payload[i + 2 + j]);
+            }
+            logs.push_back(PublicLog{ .fields = fields, .contract_address = contract_address });
+            i += log_length + PUBLIC_LOG_HEADER_LENGTH;
+        }
+        return logs;
+    }
+
     MSGPACK_FIELDS(length, payload);
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.test.cpp
@@ -1,0 +1,350 @@
+#include "barretenberg/vm2/common/aztec_types.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace bb::avm2 {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::Eq;
+
+TEST(PublicLogsTest, DefaultConstructor)
+{
+    PublicLogs public_logs;
+    EXPECT_EQ(public_logs.length, 0);
+    EXPECT_EQ(public_logs.payload.size(), FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH);
+    // All payload elements should be zero-initialized
+    for (size_t i = 0; i < FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH; ++i) {
+        EXPECT_EQ(public_logs.payload[i], FF(0));
+    }
+}
+
+TEST(PublicLogsTest, ConstructorWithLengthAndPayload)
+{
+    std::array<FF, FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH> payload{};
+    payload[0] = FF(3);      // log length
+    payload[1] = FF(0x1234); // contract address
+    payload[2] = FF(100);
+    payload[3] = FF(200);
+    payload[4] = FF(300);
+
+    uint32_t length = 5; // 2 (header) + 3 (fields)
+    PublicLogs public_logs(length, payload);
+
+    EXPECT_EQ(public_logs.length, length);
+    EXPECT_EQ(public_logs.payload[0], FF(3));
+    EXPECT_EQ(public_logs.payload[1], FF(0x1234));
+    EXPECT_EQ(public_logs.payload[2], FF(100));
+    EXPECT_EQ(public_logs.payload[3], FF(200));
+    EXPECT_EQ(public_logs.payload[4], FF(300));
+}
+
+TEST(PublicLogsTest, ConstructorFromEmptyVector)
+{
+    std::vector<PublicLog> logs;
+    PublicLogs public_logs(logs);
+
+    EXPECT_EQ(public_logs.length, 0);
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+    EXPECT_TRUE(recovered_logs.empty());
+}
+
+TEST(PublicLogsTest, ConstructorFromSingleLog)
+{
+    AztecAddress contract_address = FF(0xdeadbeef);
+    std::vector<FF> fields = { FF(1), FF(2), FF(3) };
+    PublicLog log{ fields, contract_address };
+
+    std::vector<PublicLog> logs = { log };
+    PublicLogs public_logs(logs);
+
+    EXPECT_EQ(public_logs.length, fields.size() + PUBLIC_LOG_HEADER_LENGTH);
+    EXPECT_EQ(public_logs.payload[0], FF(fields.size()));
+    EXPECT_EQ(public_logs.payload[1], contract_address);
+    EXPECT_EQ(public_logs.payload[2], FF(1));
+    EXPECT_EQ(public_logs.payload[3], FF(2));
+    EXPECT_EQ(public_logs.payload[4], FF(3));
+}
+
+TEST(PublicLogsTest, ConstructorFromMultipleLogs)
+{
+    AztecAddress addr1 = FF(0x1111);
+    AztecAddress addr2 = FF(0x2222);
+    AztecAddress addr3 = FF(0x3333);
+
+    std::vector<PublicLog> logs = {
+        PublicLog{ { FF(1), FF(2), FF(3) }, addr1 },
+        PublicLog{ { FF(4), FF(5) }, addr2 },
+        PublicLog{ { FF(6) }, addr3 },
+    };
+
+    PublicLogs public_logs(logs);
+
+    // First log: length=3, addr=0x1111, fields=[1,2,3] -> total 5
+    // Second log: length=2, addr=0x2222, fields=[4,5] -> total 4
+    // Third log: length=1, addr=0x3333, fields=[6] -> total 3
+    // Total: 5 + 4 + 3 = 12
+    EXPECT_EQ(public_logs.length, 12);
+
+    // Verify first log
+    EXPECT_EQ(public_logs.payload[0], FF(3));
+    EXPECT_EQ(public_logs.payload[1], addr1);
+    EXPECT_EQ(public_logs.payload[2], FF(1));
+    EXPECT_EQ(public_logs.payload[3], FF(2));
+    EXPECT_EQ(public_logs.payload[4], FF(3));
+
+    // Verify second log
+    EXPECT_EQ(public_logs.payload[5], FF(2));
+    EXPECT_EQ(public_logs.payload[6], addr2);
+    EXPECT_EQ(public_logs.payload[7], FF(4));
+    EXPECT_EQ(public_logs.payload[8], FF(5));
+
+    // Verify third log
+    EXPECT_EQ(public_logs.payload[9], FF(1));
+    EXPECT_EQ(public_logs.payload[10], addr3);
+    EXPECT_EQ(public_logs.payload[11], FF(6));
+}
+
+TEST(PublicLogsTest, AddLogToEmpty)
+{
+    PublicLogs public_logs;
+    AztecAddress contract_address = FF(0xabcd);
+    std::vector<FF> fields = { FF(10), FF(20) };
+    PublicLog log{ fields, contract_address };
+
+    public_logs.add_log(log);
+
+    EXPECT_EQ(public_logs.length, fields.size() + PUBLIC_LOG_HEADER_LENGTH);
+    EXPECT_EQ(public_logs.payload[0], FF(fields.size()));
+    EXPECT_EQ(public_logs.payload[1], contract_address);
+    EXPECT_EQ(public_logs.payload[2], FF(10));
+    EXPECT_EQ(public_logs.payload[3], FF(20));
+}
+
+TEST(PublicLogsTest, AddMultipleLogs)
+{
+    PublicLogs public_logs;
+
+    AztecAddress addr1 = FF(0xaaaa);
+    PublicLog log1{ { FF(1), FF(2) }, addr1 };
+    public_logs.add_log(log1);
+
+    AztecAddress addr2 = FF(0xbbbb);
+    PublicLog log2{ { FF(3), FF(4), FF(5) }, addr2 };
+    public_logs.add_log(log2);
+
+    EXPECT_EQ(public_logs.length, 2 + 2 + 2 + 3); // 2 logs with headers: (2+2) + (2+3) = 9
+
+    // Verify first log
+    EXPECT_EQ(public_logs.payload[0], FF(2));
+    EXPECT_EQ(public_logs.payload[1], addr1);
+    EXPECT_EQ(public_logs.payload[2], FF(1));
+    EXPECT_EQ(public_logs.payload[3], FF(2));
+
+    // Verify second log
+    EXPECT_EQ(public_logs.payload[4], FF(3));
+    EXPECT_EQ(public_logs.payload[5], addr2);
+    EXPECT_EQ(public_logs.payload[6], FF(3));
+    EXPECT_EQ(public_logs.payload[7], FF(4));
+    EXPECT_EQ(public_logs.payload[8], FF(5));
+}
+
+TEST(PublicLogsTest, AddLogWithEmptyFields)
+{
+    PublicLogs public_logs;
+    AztecAddress contract_address = FF(0x1234);
+    PublicLog log{ {}, contract_address };
+
+    public_logs.add_log(log);
+
+    EXPECT_EQ(public_logs.length, PUBLIC_LOG_HEADER_LENGTH);
+    EXPECT_EQ(public_logs.payload[0], FF(0));
+    EXPECT_EQ(public_logs.payload[1], contract_address);
+}
+
+TEST(PublicLogsTest, FromLogsStaticMethod)
+{
+    std::vector<PublicLog> logs = {
+        PublicLog{ { FF(1) }, FF(0x1111) },
+        PublicLog{ { FF(2), FF(3) }, FF(0x2222) },
+    };
+
+    PublicLogs public_logs = PublicLogs::from_logs(logs);
+
+    EXPECT_EQ(public_logs.length, 1 + 2 + 2 + 2); // (1+2) + (2+2) = 7
+    EXPECT_EQ(public_logs.payload[0], FF(1));
+    EXPECT_EQ(public_logs.payload[1], FF(0x1111));
+    EXPECT_EQ(public_logs.payload[2], FF(1));
+    EXPECT_EQ(public_logs.payload[3], FF(2));
+    EXPECT_EQ(public_logs.payload[4], FF(0x2222));
+    EXPECT_EQ(public_logs.payload[5], FF(2));
+    EXPECT_EQ(public_logs.payload[6], FF(3));
+}
+
+TEST(PublicLogsTest, ToLogsEmpty)
+{
+    PublicLogs public_logs;
+    std::vector<PublicLog> logs = public_logs.to_logs();
+    EXPECT_TRUE(logs.empty());
+}
+
+TEST(PublicLogsTest, ToLogsSingle)
+{
+    PublicLogs public_logs;
+    AztecAddress contract_address = FF(0xbeef);
+    std::vector<FF> fields = { FF(42), FF(43) };
+    PublicLog original_log{ fields, contract_address };
+    public_logs.add_log(original_log);
+
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+
+    ASSERT_EQ(recovered_logs.size(), 1);
+    EXPECT_EQ(recovered_logs[0].contract_address, contract_address);
+    EXPECT_THAT(recovered_logs[0].fields, ElementsAre(FF(42), FF(43)));
+}
+
+TEST(PublicLogsTest, ToLogsMultiple)
+{
+    std::vector<PublicLog> original_logs = {
+        PublicLog{ { FF(1), FF(2), FF(3) }, FF(0x1111) },
+        PublicLog{ { FF(4), FF(5) }, FF(0x2222) },
+        PublicLog{ { FF(6) }, FF(0x3333) },
+    };
+
+    PublicLogs public_logs(original_logs);
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+
+    ASSERT_EQ(recovered_logs.size(), 3);
+
+    EXPECT_EQ(recovered_logs[0].contract_address, FF(0x1111));
+    EXPECT_THAT(recovered_logs[0].fields, ElementsAre(FF(1), FF(2), FF(3)));
+
+    EXPECT_EQ(recovered_logs[1].contract_address, FF(0x2222));
+    EXPECT_THAT(recovered_logs[1].fields, ElementsAre(FF(4), FF(5)));
+
+    EXPECT_EQ(recovered_logs[2].contract_address, FF(0x3333));
+    EXPECT_THAT(recovered_logs[2].fields, ElementsAre(FF(6)));
+}
+
+TEST(PublicLogsTest, RoundTripConversion)
+{
+    std::vector<PublicLog> original_logs = {
+        PublicLog{ { FF(10), FF(20), FF(30) }, FF(0xaaaa) },
+        PublicLog{ { FF(40), FF(50) }, FF(0xbbbb) },
+        PublicLog{ { FF(60) }, FF(0xcccc) },
+        PublicLog{ {}, FF(0xdddd) }, // Empty fields
+    };
+
+    PublicLogs public_logs(original_logs);
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+
+    ASSERT_EQ(recovered_logs.size(), original_logs.size());
+
+    for (size_t i = 0; i < original_logs.size(); ++i) {
+        EXPECT_EQ(recovered_logs[i].contract_address, original_logs[i].contract_address);
+        EXPECT_EQ(recovered_logs[i].fields.size(), original_logs[i].fields.size());
+        for (size_t j = 0; j < original_logs[i].fields.size(); ++j) {
+            EXPECT_EQ(recovered_logs[i].fields[j], original_logs[i].fields[j]);
+        }
+    }
+}
+
+TEST(PublicLogsTest, EqualityOperator)
+{
+    std::vector<PublicLog> logs = {
+        PublicLog{ { FF(1), FF(2) }, FF(0x1111) },
+        PublicLog{ { FF(3) }, FF(0x2222) },
+    };
+
+    PublicLogs public_logs1(logs);
+    PublicLogs public_logs2(logs);
+
+    EXPECT_EQ(public_logs1, public_logs2);
+}
+
+TEST(PublicLogsTest, EqualityOperatorDifferentLength)
+{
+    PublicLogs public_logs1;
+    public_logs1.add_log(PublicLog{ { FF(1) }, FF(0x1111) });
+
+    PublicLogs public_logs2;
+    public_logs2.add_log(PublicLog{ { FF(1) }, FF(0x1111) });
+    public_logs2.add_log(PublicLog{ { FF(2) }, FF(0x2222) });
+
+    EXPECT_NE(public_logs1, public_logs2);
+}
+
+TEST(PublicLogsTest, EqualityOperatorDifferentPayload)
+{
+    PublicLogs public_logs1;
+    public_logs1.add_log(PublicLog{ { FF(1) }, FF(0x1111) });
+
+    PublicLogs public_logs2;
+    public_logs2.add_log(PublicLog{ { FF(2) }, FF(0x1111) });
+
+    EXPECT_NE(public_logs1, public_logs2);
+}
+
+TEST(PublicLogsTest, EqualityOperatorDifferentContractAddress)
+{
+    PublicLogs public_logs1;
+    public_logs1.add_log(PublicLog{ { FF(1) }, FF(0x1111) });
+
+    PublicLogs public_logs2;
+    public_logs2.add_log(PublicLog{ { FF(1) }, FF(0x2222) });
+
+    EXPECT_NE(public_logs1, public_logs2);
+}
+
+TEST(PublicLogsTest, LargeLog)
+{
+    std::vector<FF> large_fields;
+    for (uint32_t i = 0; i < 100; ++i) {
+        large_fields.push_back(FF(i));
+    }
+
+    AztecAddress contract_address = FF(0xffff);
+    PublicLog large_log{ large_fields, contract_address };
+
+    PublicLogs public_logs;
+    public_logs.add_log(large_log);
+
+    EXPECT_EQ(public_logs.length, large_fields.size() + PUBLIC_LOG_HEADER_LENGTH);
+    EXPECT_EQ(public_logs.payload[0], FF(large_fields.size()));
+    EXPECT_EQ(public_logs.payload[1], contract_address);
+
+    for (size_t i = 0; i < large_fields.size(); ++i) {
+        EXPECT_EQ(public_logs.payload[PUBLIC_LOG_HEADER_LENGTH + i], FF(i));
+    }
+
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+    ASSERT_EQ(recovered_logs.size(), 1);
+    EXPECT_EQ(recovered_logs[0].fields.size(), large_fields.size());
+    for (size_t i = 0; i < large_fields.size(); ++i) {
+        EXPECT_EQ(recovered_logs[0].fields[i], FF(i));
+    }
+}
+
+TEST(PublicLogsTest, ManySmallLogs)
+{
+    PublicLogs public_logs;
+    const uint32_t num_logs = 50;
+
+    for (uint32_t i = 0; i < num_logs; ++i) {
+        AztecAddress contract_address = FF(i);
+        PublicLog log{ { FF(i * 10), FF(i * 10 + 1) }, contract_address };
+        public_logs.add_log(log);
+    }
+
+    std::vector<PublicLog> recovered_logs = public_logs.to_logs();
+    ASSERT_EQ(recovered_logs.size(), num_logs);
+
+    for (uint32_t i = 0; i < num_logs; ++i) {
+        EXPECT_EQ(recovered_logs[i].contract_address, FF(i));
+        EXPECT_THAT(recovered_logs[i].fields, ElementsAre(FF(i * 10), FF(i * 10 + 1)));
+    }
+}
+
+} // namespace
+} // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -482,14 +482,30 @@ TxSimulationResult AvmSimulationHelper::simulate_fast(ContractDBInterface& raw_c
                                           tx_execution_result.revert_code != RevertCode::OK,
                                           side_effect_tracker.get_side_effects());
 
+    PublicTxEffect public_tx_effect;
+    const auto& side_effects = side_effect_tracker.get_side_effects();
+    public_tx_effect.transaction_fee = tx_execution_result.transaction_fee;
+    public_tx_effect.note_hashes = side_effects.note_hashes;
+    public_tx_effect.nullifiers = side_effects.nullifiers;
+    public_tx_effect.l2_to_l1_msgs = side_effects.l2_to_l1_messages;
+    public_tx_effect.public_logs = side_effects.public_logs.to_logs();
+    // We need to copy the storage writes slot to value in the order of the slots by insertion.
+    for (uint32_t i = 0; i < side_effects.storage_writes_slots_by_insertion.size(); i++) {
+        const auto& slot = side_effects.storage_writes_slots_by_insertion.at(i);
+        const auto& value = side_effects.storage_writes_slot_to_value.at(slot);
+        public_tx_effect.public_data_writes.push_back(PublicDataWrite{ .leaf_slot = slot, .value = value });
+    }
+
     return {
         // Simulation.
         .gas_used = tx_execution_result.gas_used,
         .revert_code = tx_execution_result.revert_code,
+        .public_tx_effect = public_tx_effect,
         .call_stack_metadata = call_stack_metadata_collector->dump_call_stack_metadata(),
         .logs = debug_log_component->dump_logs(),
         // Proving request data.
-        .public_inputs = public_inputs_builder.build(),
+        .public_inputs =
+            config.collect_public_inputs ? std::make_optional(public_inputs_builder.build()) : std::nullopt,
         .hints = std::nullopt, // NOTE: hints are injected by the caller.
     };
 }

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -94,6 +94,7 @@ const provingConfig: PublicSimulatorConfig = PublicSimulatorConfig.from({
   collectCallMetadata: true,
   collectDebugLogs: false,
   collectHints: true, // Required for proving!
+  collectPublicInputs: true,
   collectStatistics: false,
 });
 
@@ -237,7 +238,7 @@ export class AvmProvingTester extends PublicTxSimulationTester {
 
     const opString = this.checkCircuitOnly ? 'Check circuit' : 'Proving and verification';
 
-    const avmCircuitInputs = new AvmCircuitInputs(simRes.hints!, simRes.publicInputs);
+    const avmCircuitInputs = new AvmCircuitInputs(simRes.hints!, simRes.publicInputs!);
     const timer = new Timer();
     await this.proveVerify(avmCircuitInputs, txLabel);
     this.logger.info(`${opString} took ${timer.ms()} ms for tx ${txLabel}`);

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -122,7 +122,7 @@ describe('AVM Integration', () => {
   it('Should generate and verify an ultra honk proof from an AVM verification of the bulk test', async () => {
     const avmSimulationResult = await bulkTest(simTester, logger, AvmTestContractArtifact);
     expect(avmSimulationResult.revertCode.isOK()).toBe(true);
-    const avmCircuitInputs = new AvmCircuitInputs(avmSimulationResult.hints!, avmSimulationResult.publicInputs);
+    const avmCircuitInputs = new AvmCircuitInputs(avmSimulationResult.hints!, avmSimulationResult.publicInputs!);
 
     await proveMockPublicBaseRollup(avmCircuitInputs, bbWorkingDirectory, bbBinaryPath, chonkPublicInputs, chonkProof);
   }, 240_000);
@@ -132,7 +132,7 @@ describe('AVM Integration', () => {
     expect(result.revertCode.isOK()).toBe(true);
 
     await proveMockPublicBaseRollup(
-      new AvmCircuitInputs(result.hints!, result.publicInputs),
+      new AvmCircuitInputs(result.hints!, result.publicInputs!),
       bbWorkingDirectory,
       bbBinaryPath,
       chonkPublicInputs,

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -83,7 +83,7 @@ describe('Rollup IVC Integration', () => {
     await worldStateService.close();
     expect(avmSimulationResult.revertCode.isOK()).toBe(true);
 
-    const avmCircuitInputs = new AvmCircuitInputs(avmSimulationResult.hints!, avmSimulationResult.publicInputs);
+    const avmCircuitInputs = new AvmCircuitInputs(avmSimulationResult.hints!, avmSimulationResult.publicInputs!);
     ({
       vk: avmVK,
       proof: avmProof,

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -147,6 +147,7 @@ describe('epoch-proving-job', () => {
         PublicSimulatorConfig.from({
           proverId: proverId.toField(),
           collectHints: true,
+          collectPublicInputs: true,
         }),
       ),
     );

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -213,6 +213,7 @@ export class EpochProvingJob implements Traceable {
             skipFeeEnforcement: false,
             collectDebugLogs: false,
             collectHints: true,
+            collectPublicInputs: true,
             collectStatistics: false,
           });
           const publicProcessor = this.publicProcessorFactory.create(db, globalVariables, config);

--- a/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
+++ b/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
@@ -21,7 +21,7 @@ export async function executeAvmMinimalPublicTx(tester: PublicTxSimulationTester
 
   // Modify the protocol contracts to be all zeros
   result.hints!.protocolContracts = ProtocolContracts.empty();
-  result.publicInputs.protocolContracts = ProtocolContracts.empty();
+  result.publicInputs!.protocolContracts = ProtocolContracts.empty();
 
   return result;
 }

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -42,6 +42,7 @@ const defaultConfig: PublicSimulatorConfig = PublicSimulatorConfig.from({
   collectCallMetadata: true,
   collectDebugLogs: true,
   collectHints: false,
+  collectPublicInputs: false,
   collectStatistics: false,
 });
 

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -523,7 +523,7 @@ export class PublicProcessor implements Traceable {
 
     const result = await this.publicTxSimulator.simulate(tx);
     // TODO: use the callStackMetadata here to extract more data about public execution
-    const { hints, publicInputs, gasUsed, revertCode /*callStackMetadata*/ } = result;
+    const { hints, publicInputs, publicTxEffect, gasUsed, revertCode /*callStackMetadata*/ } = result;
 
     const contractClassLogs = revertCode.isOK()
       ? tx.getContractClassLogs()
@@ -542,10 +542,15 @@ export class PublicProcessor implements Traceable {
     const appLogicReturnValues: NestedProcessReturnValues[] = result.getAppLogicReturnValues();
     // Extract the revert reason from the call stack metadata.
     const revertReason = result.findRevertReason();
+    // Create proving request if we have hints and public inputs.
+    const avmProvingRequest =
+      hints && publicInputs ? PublicProcessor.generateProvingRequest(publicInputs, hints) : undefined;
 
     const processedTx = makeProcessedTxFromTxWithPublicCalls(
       tx,
-      PublicProcessor.generateProvingRequest(publicInputs, hints),
+      this.globalVariables,
+      avmProvingRequest,
+      publicTxEffect,
       gasUsed,
       revertCode,
       revertReason,

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
@@ -21,6 +21,7 @@ describe.each([
     collectCallMetadata: true,
     collectDebugLogs: false,
     collectHints: true,
+    collectPublicInputs: true,
     collectStatistics: false,
   });
 
@@ -42,7 +43,7 @@ describe.each([
   it('Minimal Tx avm inputs snapshot stored in Json file', async () => {
     const result = await executeAvmMinimalPublicTx(tester);
     expect(result.revertCode.isOK()).toBe(true);
-    const inputs = new AvmCircuitInputs(result.hints!, result.publicInputs);
+    const inputs = new AvmCircuitInputs(result.hints!, result.publicInputs!);
     const json = jsonStringify(inputs);
 
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update test data
@@ -58,7 +59,7 @@ describe.each([
     // If the test data needs to be updated, run the above ^ test case
     // with AZTEC_GENERATE_TEST_DATA=1, and _then_ rerun this test and it should pass.
     const result = await executeAvmMinimalPublicTx(tester);
-    const inputs = new AvmCircuitInputs(result.hints!, result.publicInputs);
+    const inputs = new AvmCircuitInputs(result.hints!, result.publicInputs!);
     const avmInputsFromFile = readAvmMinimalPublicTxInputsFromFile();
     expect(inputs).toStrictEqual(avmInputsFromFile);
   });
@@ -67,7 +68,7 @@ describe.each([
   // which is used by the C++ tests.
   it('Minimal TX avm inputs serialized for cpp tests', async () => {
     const result = await executeAvmMinimalPublicTx(tester);
-    const buffer = new AvmCircuitInputs(result.hints!, result.publicInputs).serializeWithMessagePack();
+    const buffer = new AvmCircuitInputs(result.hints!, result.publicInputs!).serializeWithMessagePack();
 
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update test data
     const path = 'barretenberg/cpp/src/barretenberg/vm2/testing/minimal_tx.testdata.bin';

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator_with_hinted_dbs.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator_with_hinted_dbs.ts
@@ -64,7 +64,7 @@ export class CppPublicTxSimulatorHintedDbs extends PublicTxSimulator implements 
     this.log.debug(`TS simulation succeeded for tx ${txHash}`);
 
     // Extract the full AvmCircuitInputs from the TS result
-    const avmCircuitInputs = new AvmCircuitInputs(tsResult.hints!, tsResult.publicInputs);
+    const avmCircuitInputs = new AvmCircuitInputs(tsResult.hints!, tsResult.publicInputs!);
 
     // Second, run C++ simulation with hinted DBs
     this.log.debug(`Running C++ simulation with hinted DBs for tx ${txHash}`);

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_vs_ts_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_vs_ts_public_tx_simulator.ts
@@ -140,7 +140,10 @@ export class CppVsTsPublicTxSimulator extends PublicTxSimulator implements Publi
     assert(cppResult.gasUsed.publicGas.equals(tsResult.gasUsed.publicGas));
     assert(cppResult.gasUsed.teardownGas.equals(tsResult.gasUsed.teardownGas));
     assert(cppResult.gasUsed.billedGas.equals(tsResult.gasUsed.billedGas));
-    assert(cppResult.publicInputs.toBuffer().equals(tsResult.publicInputs.toBuffer()));
+    assert(cppResult.publicTxEffect.equals(tsResult.publicTxEffect));
+    if (cppResult.publicInputs !== undefined) {
+      assert(cppResult.publicInputs!.toBuffer().equals(tsResult.publicInputs!.toBuffer()));
+    }
 
     // TODO(fcarreiro): complete this.
     // Check that C++ hints are a strict subset of TS hints.

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -179,7 +179,7 @@ describe('public_tx_simulator', () => {
   };
 
   const checkNullifierRoot = async (txResult: PublicTxResult) => {
-    const siloedNullifiers = txResult.publicInputs.accumulatedData.nullifiers;
+    const siloedNullifiers = txResult.publicInputs!.accumulatedData.nullifiers;
     // Loop helpful for debugging so you can see root progression
     //for (const nullifier of siloedNullifiers) {
     //  await db.batchInsert(
@@ -197,7 +197,7 @@ describe('public_tx_simulator', () => {
     );
     const expectedRoot = new Fr((await merkleTrees.getTreeInfo(MerkleTreeId.NULLIFIER_TREE)).root);
     const gotRoot = new Fr((await merkleTrees.getTreeInfo(MerkleTreeId.NULLIFIER_TREE)).root);
-    const gotRootPublicInputs = txResult.publicInputs.endTreeSnapshots.nullifierTree.root;
+    const gotRootPublicInputs = txResult.publicInputs!.endTreeSnapshots.nullifierTree.root;
     expect(gotRoot).toEqual(expectedRoot);
     expect(gotRootPublicInputs).toEqual(expectedRoot);
   };
@@ -329,11 +329,11 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas;
     const expectedTxFee = expectedTotalGas.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep all data.
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
   });
 
   it('runs a tx with enqueued public calls in app logic phase only', async () => {
@@ -363,11 +363,11 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas;
     const expectedTxFee = expectedTotalGas.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep all data.
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
   });
 
   it('runs a tx with enqueued public calls in teardown phase only', async () => {
@@ -396,11 +396,11 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep all data.
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
   });
 
   it('runs a tx with all phases', async () => {
@@ -442,11 +442,11 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep all data.
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
   });
 
   it('deduplicates public data writes', async function () {
@@ -493,8 +493,8 @@ describe('public_tx_simulator', () => {
     const output = txResult.publicInputs;
 
     const numPublicDataWrites = 3;
-    expect(countAccumulatedItems(output.accumulatedData.publicDataWrites)).toBe(numPublicDataWrites);
-    expect(output.accumulatedData.publicDataWrites.slice(0, numPublicDataWrites)).toEqual([
+    expect(countAccumulatedItems(output!.accumulatedData.publicDataWrites)).toBe(numPublicDataWrites);
+    expect(output!.accumulatedData.publicDataWrites.slice(0, numPublicDataWrites)).toEqual([
       new PublicDataWrite(await computePublicDataTreeLeafSlot(contractAddress, contractSlotA), fr(0x103)), // 0x101 replaced with 0x103
       new PublicDataWrite(await computePublicDataTreeLeafSlot(contractAddress, contractSlotB), fr(0x151)),
       new PublicDataWrite(await computePublicDataTreeLeafSlot(contractAddress, contractSlotC), fr(0x152)), // 0x201 replaced with 0x102 and then 0x152
@@ -619,13 +619,13 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep all side effects
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(8);
-    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(8);
-    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(8);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(8);
+    expect(countAccumulatedItems(output!.accumulatedData.noteHashes)).toBe(8);
+    expect(countAccumulatedItems(output!.accumulatedData.l2ToL1Msgs)).toBe(8);
 
     // Verify that the actual side effects are as expected and in the right order.
     const includedSiloedNullifiers = [
@@ -636,14 +636,14 @@ describe('public_tx_simulator', () => {
       // teardown
       siloedNullifiers[4],
     ];
-    expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+    expect(output!.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
 
     const includedNoteHashes = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
       noteHashes[0],
       // Cannot use actual revertible note hashes because the AVM will silo them and make them unique.
       // So we'd have to do so here to actually compare. For now, we just check that the correct number
-      // of nonzero revertible notes end up in the output.
+      // of nonzero revertible notes end up in the output!.
       //...tx.data.forPublic!.revertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
       ...Array.from(
         { length: tx.data.forPublic!.revertibleAccumulatedData.noteHashes.filter(n => !n.isZero()).length },
@@ -653,7 +653,7 @@ describe('public_tx_simulator', () => {
       // Teardown
       noteHashes[4],
     ];
-    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+    expect(output!.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
 
     const includedL2ToL1Messages = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
@@ -663,7 +663,7 @@ describe('public_tx_simulator', () => {
       // Teardown
       l2ToL1Messages[4],
     ];
-    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
+    expect(output!.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
 
     await checkNullifierRoot(txResult);
   });
@@ -750,13 +750,13 @@ describe('public_tx_simulator', () => {
 
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep only the non-revertible data and setup
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(4);
-    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(4);
-    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(4);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(4);
+    expect(countAccumulatedItems(output!.accumulatedData.noteHashes)).toBe(4);
+    expect(countAccumulatedItems(output!.accumulatedData.l2ToL1Msgs)).toBe(4);
 
     // Verify that the actual side effects are as expected and in the right order.
     const includedSiloedNullifiers = [
@@ -768,7 +768,7 @@ describe('public_tx_simulator', () => {
       // teardown
       siloedNullifiers[4],
     ];
-    expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+    expect(output!.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
 
     const includedNoteHashes = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
@@ -776,7 +776,7 @@ describe('public_tx_simulator', () => {
       // Teardown
       noteHashes[4],
     ];
-    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+    expect(output!.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
 
     const includedL2ToL1Messages = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
@@ -784,7 +784,7 @@ describe('public_tx_simulator', () => {
       // Teardown
       l2ToL1Messages[4],
     ];
-    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
+    expect(output!.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
 
     await checkNullifierRoot(txResult);
   });
@@ -871,13 +871,13 @@ describe('public_tx_simulator', () => {
     // Should still charge the full teardownGasLimits for fee even though teardown reverted.
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep only the non-revertible data and setup
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
-    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(3);
-    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.noteHashes)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.l2ToL1Msgs)).toBe(3);
 
     // Verify that the actual side effects are as expected and in the right order.
     const includedSiloedNullifiers = [
@@ -887,19 +887,19 @@ describe('public_tx_simulator', () => {
       //...tx.data.forPublic!.revertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
       //..siloedNullifiers[1...4]
     ];
-    expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+    expect(output!.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
 
     const includedNoteHashes = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
       noteHashes[0],
     ];
-    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+    expect(output!.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
 
     const includedL2ToL1Messages = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
       l2ToL1Messages[0],
     ];
-    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
+    expect(output!.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
     await checkNullifierRoot(txResult);
   });
 
@@ -981,13 +981,13 @@ describe('public_tx_simulator', () => {
     // Should still charge the full teardownGasLimits for fee even though teardown reverted.
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
     const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
 
     // We keep only the non-revertible data and setup
-    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
-    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(3);
-    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.noteHashes)).toBe(3);
+    expect(countAccumulatedItems(output!.accumulatedData.l2ToL1Msgs)).toBe(3);
 
     const includedSiloedNullifiers = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
@@ -996,7 +996,7 @@ describe('public_tx_simulator', () => {
       //...tx.data.forPublic!.revertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
       //..siloedNullifiers[1...4]
     ];
-    expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+    expect(output!.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
     await checkNullifierRoot(txResult);
   });
 
@@ -1063,11 +1063,11 @@ describe('public_tx_simulator', () => {
     const output = txResult.publicInputs;
 
     const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
-    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output!.endGasUsed).toEqual(expectedGasUsedForFee);
 
     const totalFees = new GasFees(2 + 5, 3 + 7);
     const expectedTxFee = expectedGasUsedForFee.computeFee(totalFees);
-    expect(output.transactionFee).toEqual(expectedTxFee);
+    expect(output!.transactionFee).toEqual(expectedTxFee);
   });
 
   describe('fees', () => {
@@ -1153,7 +1153,7 @@ describe('public_tx_simulator', () => {
 
       const txResult = await simulator.simulate(tx);
 
-      expect(txResult.publicInputs.proverId).toEqual(Fr.ZERO);
+      expect(txResult.publicInputs?.proverId).toEqual(Fr.ZERO);
     });
 
     it('exposes the prover id in public inputs', async () => {
@@ -1167,7 +1167,7 @@ describe('public_tx_simulator', () => {
 
       const txResult = await simulator.simulate(tx);
 
-      expect(txResult.publicInputs.proverId).toEqual(proverId);
+      expect(txResult.publicInputs?.proverId).toEqual(proverId);
     });
   });
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress, ProtocolContractsList } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
-import { AvmExecutionHints, AvmTxHint, PublicSimulatorConfig, PublicTxResult } from '@aztec/stdlib/avm';
+import { AvmExecutionHints, AvmTxHint, PublicSimulatorConfig, PublicTxEffect, PublicTxResult } from '@aztec/stdlib/avm';
 import { SimulationError } from '@aztec/stdlib/errors';
 import { Gas } from '@aztec/stdlib/gas';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
@@ -209,6 +209,16 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
       (appLogicReturnValues as any).revertReason = context.revertReason;
     }
 
+    // Create PublicTxEffect from PublicInputs.
+    const publicTxEffect = new PublicTxEffect(
+      publicInputs.transactionFee,
+      publicInputs.accumulatedData.noteHashes.filter(h => !h.isEmpty()),
+      publicInputs.accumulatedData.nullifiers.filter(n => !n.isEmpty()),
+      publicInputs.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
+      publicInputs.accumulatedData.publicLogs.toLogs(),
+      publicInputs.accumulatedData.publicDataWrites.filter(w => !w.isEmpty()),
+    );
+
     return new PublicTxResult(
       /*gasUsed=*/ {
         totalGas: context.getActualGasUsed(),
@@ -217,6 +227,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
         billedGas: context.getTotalGasUsed(),
       },
       /*revertCode=*/ revertCode,
+      /*publicTxEffect=*/ publicTxEffect,
       /*callStackMetadata=*/ appLogicReturnValues,
       /*logs=*/ context.state.getActiveStateManager().getLogs(),
       /*hints=*/ hints,

--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -15,6 +15,7 @@ import { GasSettings } from '../gas/gas_settings.js';
 import { GasUsed } from '../gas/gas_used.js';
 import { PublicKeys } from '../keys/public_keys.js';
 import { DebugLog } from '../logs/debug_log.js';
+import { PublicLog } from '../logs/public_log.js';
 import { ScopedL2ToL1Message } from '../messaging/l2_to_l1_message.js';
 import { NullishToUndefined, type ZodFor, schemas } from '../schemas/schemas.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
@@ -33,6 +34,7 @@ import { TxExecutionPhase } from '../tx/processed_tx.js';
 import { WorldStateRevision } from '../world-state/world_state_revision.js';
 import { AvmCircuitPublicInputs } from './avm_circuit_public_inputs.js';
 import { serializeWithMessagePack } from './message_pack.js';
+import { PublicDataWrite } from './public_data_write.js';
 import { RevertCode } from './revert_code.js';
 
 ////////////////////////////////////////////////////////////////////////////
@@ -1174,11 +1176,78 @@ export class CallStackMetadata {
   }
 }
 
+export class PublicTxEffect {
+  constructor(
+    public transactionFee: Fr,
+    public noteHashes: Fr[],
+    public nullifiers: Fr[],
+    public l2ToL1Msgs: ScopedL2ToL1Message[],
+    public publicLogs: PublicLog[],
+    public publicDataWrites: PublicDataWrite[],
+  ) {}
+
+  static empty() {
+    return new PublicTxEffect(Fr.ZERO, [], [], [], [], []);
+  }
+
+  static get schema(): ZodFor<PublicTxEffect> {
+    return z
+      .object({
+        transactionFee: Fr.schema,
+        noteHashes: Fr.schema.array(),
+        nullifiers: Fr.schema.array(),
+        l2ToL1Msgs: ScopedL2ToL1Message.schema.array(),
+        publicLogs: PublicLog.schema.array(),
+        publicDataWrites: PublicDataWrite.schema.array(),
+      })
+      .transform(PublicTxEffect.from);
+  }
+
+  static from(obj: any): PublicTxEffect {
+    return new PublicTxEffect(
+      obj.transactionFee,
+      obj.noteHashes,
+      obj.nullifiers,
+      obj.l2ToL1Msgs,
+      obj.publicLogs,
+      obj.publicDataWrites,
+    );
+  }
+
+  static fromPlainObject(obj: any): PublicTxEffect {
+    return new PublicTxEffect(
+      Fr.fromPlainObject(obj.transactionFee),
+      obj.noteHashes.map((h: any) => Fr.fromPlainObject(h)),
+      obj.nullifiers.map((n: any) => Fr.fromPlainObject(n)),
+      obj.l2ToL1Msgs.map((m: any) => ScopedL2ToL1Message.fromPlainObject(m)),
+      obj.publicLogs.map((l: any) => PublicLog.fromPlainObject(l)),
+      obj.publicDataWrites.map((w: any) => PublicDataWrite.fromPlainObject(w)),
+    );
+  }
+
+  equals(other: PublicTxEffect): boolean {
+    return (
+      this.transactionFee.equals(other.transactionFee) &&
+      this.noteHashes.length === other.noteHashes.length &&
+      this.noteHashes.every((h, i) => h.equals(other.noteHashes[i])) &&
+      this.nullifiers.length === other.nullifiers.length &&
+      this.nullifiers.every((h, i) => h.equals(other.nullifiers[i])) &&
+      this.l2ToL1Msgs.length === other.l2ToL1Msgs.length &&
+      this.l2ToL1Msgs.every((m, i) => m.equals(other.l2ToL1Msgs[i])) &&
+      this.publicLogs.length === other.publicLogs.length &&
+      this.publicLogs.every((l, i) => l.equals(other.publicLogs[i])) &&
+      this.publicDataWrites.length === other.publicDataWrites.length &&
+      this.publicDataWrites.every((w, i) => w.equals(other.publicDataWrites[i]))
+    );
+  }
+}
+
 export class PublicTxResult {
   constructor(
     // Simulation result.
     public gasUsed: GasUsed,
     public revertCode: RevertCode,
+    public publicTxEffect: PublicTxEffect,
     // These are only guaranteed to be present if the simulator is configured to collect them.
     // TODO(fcarreiro): Remove NestedProcessReturnValues[] once we migrate to the C++ simulator.
     public callStackMetadata:
@@ -1187,7 +1256,7 @@ export class PublicTxResult {
     public logs: DebugLog[] | undefined,
     // For the proving request.
     public hints: AvmExecutionHints | undefined,
-    public publicInputs: AvmCircuitPublicInputs,
+    public publicInputs: AvmCircuitPublicInputs | undefined,
   ) {}
 
   static empty() {
@@ -1199,6 +1268,7 @@ export class PublicTxResult {
         billedGas: Gas.empty(),
       },
       RevertCode.OK,
+      PublicTxEffect.empty(),
       /*callStackMetadata=*/ [] as CallStackMetadata[],
       /*logs=*/ [],
       /*hints=*/ AvmExecutionHints.empty(),
@@ -1212,15 +1282,24 @@ export class PublicTxResult {
         gasUsed: schemas.GasUsed,
         revertCode: RevertCode.schema,
         revertReason: NullishToUndefined(SimulationError.schema),
+        publicTxEffect: PublicTxEffect.schema,
         callStackMetadata: z.union([CallStackMetadata.schema.array(), NestedProcessReturnValues.schema.array()]),
         logs: NullishToUndefined(DebugLog.schema.array()),
         // For the proving request.
-        publicInputs: AvmCircuitPublicInputs.schema,
+        publicInputs: NullishToUndefined(AvmCircuitPublicInputs.schema),
         hints: NullishToUndefined(AvmExecutionHints.schema),
       })
       .transform(
-        ({ gasUsed, revertCode, callStackMetadata, logs, hints, publicInputs }) =>
-          new PublicTxResult(gasUsed, revertCode as RevertCode, callStackMetadata, logs, hints, publicInputs),
+        ({ gasUsed, revertCode, publicTxEffect, callStackMetadata, logs, hints, publicInputs }) =>
+          new PublicTxResult(
+            gasUsed,
+            revertCode as RevertCode,
+            publicTxEffect,
+            callStackMetadata,
+            logs,
+            hints,
+            publicInputs,
+          ),
       );
   }
 
@@ -1235,10 +1314,11 @@ export class PublicTxResult {
     return new PublicTxResult(
       GasUsed.fromPlainObject(obj.gasUsed),
       RevertCode.fromPlainObject(obj.revertCode),
+      PublicTxEffect.fromPlainObject(obj.publicTxEffect),
       obj.callStackMetadata.map(CallStackMetadata.fromPlainObject), // Always CallStackMetadata[] from MessagePack.
       obj.logs?.map(DebugLog.fromPlainObject),
       obj.hints ? AvmExecutionHints.fromPlainObject(obj.hints) : undefined,
-      AvmCircuitPublicInputs.fromPlainObject(obj.publicInputs),
+      obj.publicInputs ? AvmCircuitPublicInputs.fromPlainObject(obj.publicInputs) : undefined,
     );
   }
 
@@ -1336,6 +1416,7 @@ export class PublicSimulatorConfig {
     public readonly skipFeeEnforcement: boolean,
     public readonly collectCallMetadata: boolean, // appLogicReturnValues.
     public readonly collectHints: boolean, // hints.
+    public readonly collectPublicInputs: boolean, // public inputs.
     public readonly collectDebugLogs: boolean, // logs.
     public readonly collectStatistics: boolean, // timings etc.
     public readonly collectionLimits: CollectionLimitsConfig,
@@ -1347,6 +1428,7 @@ export class PublicSimulatorConfig {
       obj.skipFeeEnforcement ?? false,
       obj.collectCallMetadata ?? false,
       obj.collectHints ?? false,
+      obj.collectPublicInputs ?? false,
       obj.collectDebugLogs ?? false,
       obj.collectStatistics ?? false,
       obj.collectionLimits ?? CollectionLimitsConfig.empty(),
@@ -1364,6 +1446,7 @@ export class PublicSimulatorConfig {
         skipFeeEnforcement: z.boolean(),
         collectCallMetadata: z.boolean(),
         collectHints: z.boolean(),
+        collectPublicInputs: z.boolean(),
         collectDebugLogs: z.boolean(),
         collectStatistics: z.boolean(),
         collectionLimits: CollectionLimitsConfig.schema,

--- a/yarn-project/stdlib/src/logs/public_log.ts
+++ b/yarn-project/stdlib/src/logs/public_log.ts
@@ -172,6 +172,13 @@ export class PublicLog {
     return new PublicLog(reader.readObject(AztecAddress), reader.readArray(fieldsLength, Fr));
   }
 
+  static fromPlainObject(obj: any): PublicLog {
+    return new PublicLog(
+      AztecAddress.fromPlainObject(obj.contractAddress),
+      obj.fields.map((f: any) => Fr.fromPlainObject(f)),
+    );
+  }
+
   static async random() {
     return new PublicLog(
       await AztecAddress.random(),

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_message.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_message.ts
@@ -160,6 +160,10 @@ export class ScopedL2ToL1Message {
     return new ScopedL2ToL1Message(L2ToL1Message.empty(), AztecAddress.ZERO);
   }
 
+  equals(other: ScopedL2ToL1Message): boolean {
+    return this.message.equals(other.message) && this.contractAddress.equals(other.contractAddress);
+  }
+
   /**
    * Creates a ScopedL2ToL1Message instance from a plain object without Zod validation.
    * This method is optimized for performance and skips validation, making it suitable

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -14,6 +14,7 @@ import { Secp256k1Signer, randomBytes } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 
 import type { ContractArtifact } from '../abi/abi.js';
+import { PublicTxEffect } from '../avm/avm.js';
 import { AvmCircuitPublicInputs } from '../avm/avm_circuit_public_inputs.js';
 import { PublicDataWrite } from '../avm/public_data_write.js';
 import { RevertCode } from '../avm/revert_code.js';
@@ -320,12 +321,24 @@ export async function mockProcessedTx({
     } satisfies GasUsed;
 
     await tx.recomputeHash();
+
+    const publicTxEffect = new PublicTxEffect(
+      avmOutput.transactionFee,
+      avmOutput.accumulatedData.noteHashes.filter(h => !h.isZero()),
+      avmOutput.accumulatedData.nullifiers.filter(h => !h.isZero()),
+      avmOutput.accumulatedData.l2ToL1Msgs.filter(h => !h.isEmpty()),
+      avmOutput.accumulatedData.publicLogs.toLogs(),
+      avmOutput.accumulatedData.publicDataWrites.filter(h => !h.isEmpty()),
+    );
+
     return makeProcessedTxFromTxWithPublicCalls(
       tx,
+      globalVariables,
       {
         type: ProvingRequestType.PUBLIC_VM,
         inputs: avmCircuitInputs,
       },
+      publicTxEffect,
       gasUsed,
       RevertCode.OK,
       undefined /* revertReason */,

--- a/yarn-project/stdlib/src/tx/processed_tx.ts
+++ b/yarn-project/stdlib/src/tx/processed_tx.ts
@@ -1,5 +1,6 @@
 import { Fr } from '@aztec/foundation/fields';
 
+import type { PublicTxEffect } from '../avm/avm.js';
 import type { AvmProvingRequest } from '../avm/avm_proving_request.js';
 import type { PublicDataWrite } from '../avm/public_data_write.js';
 import { RevertCode } from '../avm/revert_code.js';
@@ -130,17 +131,13 @@ export function makeProcessedTxFromPrivateOnlyTx(
 
 export function makeProcessedTxFromTxWithPublicCalls(
   tx: Tx,
-  avmProvingRequest: AvmProvingRequest,
+  globalVariables: GlobalVariables,
+  avmProvingRequest: AvmProvingRequest | undefined,
+  publicTxEffect: PublicTxEffect,
   gasUsed: GasUsed,
   revertCode: RevertCode,
   revertReason: SimulationError | undefined,
 ): ProcessedTx {
-  const avmPublicInputs = avmProvingRequest.inputs.publicInputs;
-
-  const globalVariables = avmPublicInputs.globalVariables;
-
-  const publicDataWrites = avmPublicInputs.accumulatedData.publicDataWrites.filter(w => !w.isEmpty());
-
   const privateLogs = [
     ...tx.data.forPublic!.nonRevertibleAccumulatedData.privateLogs,
     ...(revertCode.isOK() ? tx.data.forPublic!.revertibleAccumulatedData.privateLogs : []),
@@ -153,10 +150,10 @@ export function makeProcessedTxFromTxWithPublicCalls(
   const txEffect = new TxEffect(
     revertCode,
     tx.getTxHash(),
-    avmPublicInputs.transactionFee,
-    avmPublicInputs.accumulatedData.noteHashes.filter(h => !h.isZero()),
-    avmPublicInputs.accumulatedData.nullifiers.filter(h => !h.isZero()),
-    avmPublicInputs.accumulatedData.l2ToL1Msgs
+    publicTxEffect.transactionFee,
+    publicTxEffect.noteHashes,
+    publicTxEffect.nullifiers,
+    publicTxEffect.l2ToL1Msgs // convert messages to hashes.
       .filter(msg => !msg.contractAddress.isZero())
       .map(msg =>
         computeL2ToL1MessageHash({
@@ -167,9 +164,9 @@ export function makeProcessedTxFromTxWithPublicCalls(
           chainId: globalVariables.chainId,
         }),
       ),
-    publicDataWrites,
+    publicTxEffect.publicDataWrites,
     privateLogs,
-    avmPublicInputs.accumulatedData.publicLogs.toLogs(),
+    publicTxEffect.publicLogs,
     contractClassLogs,
   );
 


### PR DESCRIPTION
Make public simulation return a more concise `PublicTxEffect` and optionally return the complete public inputs. This makes serialization way faster. Below are some some timings from `src/public` tests.

### MessagePack Deserialization Performance

| TX Hash (Prefix) | MessagePack Before (ms) | MessagePack After (ms) | Difference % |
| :--- | :--- | :--- | :--- |
| `0x0948...` | 0.8330 | 0.0588 | -92.94% |
| `0x236c...` | 0.9578 | 0.0875 | -90.87% |
| `0x1c5a...` | 0.8919 | 0.0811 | -90.90% |
| `0x03fc...` | 0.8131 | 0.0654 | -91.95% |
| `0x2f4b...` | 0.8429 | 0.0493 | -94.15% |
| `0x20e7...` | 1.0285 | 0.1454 | -85.86% |
| `0x1a94...` | 0.9125 | 0.0982 | -89.24% |
| `0x2ed3...` | 0.9019 | 0.0923 | -89.76% |
| `0x2071...` | 1.3162 | 0.0976 | -92.59% |
| `0x1a80...` | 0.8363 | 0.0654 | -92.18% |
| `0x1792...` | 0.8876 | 0.0496 | -94.41% |
| `0x2b54...` | 0.9479 | 0.0520 | -94.51% |
| `0x256a...` | 0.9801 | 0.1352 | -86.21% |
| `0x2747...` | 0.9177 | 0.0494 | -94.62% |
| `0x04f5...` | 0.9183 | 0.0559 | -93.91% |
| `0x24ab...` | 1.8012 | 0.0463 | -97.43% |

### Plain Object Deserialization Performance

| TX Hash (Prefix) | PlainObject Before (ms) | PlainObject After (ms) | Difference % |
| :--- | :--- | :--- | :--- |
| `0x0948...` | 2.9778 | 0.1470 | -95.06% |
| `0x236c...` | 4.9916 | 0.0891 | -98.22% |
| `0x1c5a...` | 2.7384 | 0.1050 | -96.17% |
| `0x03fc...` | 2.6937 | 0.0409 | -98.48% |
| `0x2f4b...` | 2.7186 | 0.0288 | -98.94% |
| `0x20e7...` | 2.8324 | 0.1164 | -95.89% |
| `0x1a94...` | 2.5619 | 0.0730 | -97.15% |
| `0x2ed3...` | 6.8532 | 0.0723 | -98.95% |
| `0x2071...` | 2.5855 | 0.0523 | -97.98% |
| `0x1a80...` | 2.4254 | 0.0405 | -98.33% |
| `0x1792...` | 2.5787 | 0.0325 | -98.74% |
| `0x2b54...` | 2.5903 | 0.0329 | -98.73% |
| `0x256a...` | 2.8467 | 0.0754 | -97.35% |
| `0x2747...` | 2.5951 | 0.0305 | -98.82% |
| `0x04f5...` | 5.1246 | 0.0347 | -99.32% |
| `0x24ab...` | 4.0177 | 0.0294 | -99.27% |

### Inputs serialization

As an extra bit of information (thought not changed in this PR), these are the INPUT serialization times (with MP). We could consider doing some work here to make it faster, but it's less conceptually correct.

| TX | inputs MP (ms) |
|---|---|
| 0x1718aad139200f59 | 0.3967 |
| 0x16162cdb491c1523 | 0.1931 |
| 0x2e7d351ed2ece901 | 0.2285 |
| 0x10963babb7cf922c | 0.1921 |
| 0x09481f96e362b43e | 0.3784 |
| 0x236cb08d005b0f84 | 0.4016 |
| 0x1c5a05f5164c818a | 0.3985 |
| 0x03fcef92e41a993e | 0.1797 |
| 0x2f4bd1d7e99a66f8 | 0.1756 |
| 0x20e7cb14e74bf09d | 0.2717 |
| 0x1a94c8a29861c94e | 0.1956 |
| 0x2ed393dbd25219dc | 0.2089 |
| 0x192d0b0057568125 | 2.0982 |
| 0x1630fe61c207a145 | 0.9757 |
| 0x17324dc2cef0d26c | 1.0219 |
| 0x2939bee14d5b49d0 | 0.2572 |
| 0x0fb3b75969b491a1 | 0.3141 |
| 0x2ce967d9ea7efe3e | 0.2627 |
| 0x2dc922eb22316955 | 0.2705 |
| 0x2ae7c77b5c1f419f | 0.3722 |
| 0x0ef7884b1527a46d | 0.3304 |
| 0x2f91ef211cda95f3 | 0.3407 |
| 0x0c26e1fbc692a7ee | 0.4065 |
| 0x10215bb38a18bfc5 | 0.3898 |
| 0x2f8745e0ae26251b | 0.4459 |
| 0x0259c04d8465d311 | 0.8044 |
| 0x1fa4218a5037e711 | 0.8106 |
| 0x12203255059189ea | 1.4311 |
| 0x2c5f9ec5ff444272 | 1.4256 |
| 0x0bfa21d44f8dccab | 2.7433 |
| 0x030745a466fbfacb | 3.9942 |
| 0x1c88acc5ca9827f6 | 0.2224 |
| 0x051500c07c27ec7a | 3.5910 |
| 0x10bfeba1f8a87da1 | 0.2679 |
| 0x028efc1af3d412d1 | 0.1964 |
| 0x27259b932c562b65 | 3.3334 |
| 0x25082db5d68743f3 | 0.2030 |
| 0x012e3cfc9585cc20 | 0.2431 |