### PR TITLE
chore: lazy otel init

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -51,7 +51,7 @@ export async function startArchiver(
   const store = await createStore('archiver', KVArchiverDataStore.SCHEMA_VERSION, archiverConfig, storeLog);
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 
-  const telemetry = initTelemetryClient(getTelemetryClientConfig());
+  const telemetry = await initTelemetryClient(getTelemetryClientConfig());
   const blobSinkClient = createBlobSinkClient(archiverConfig, { logger: createLogger('archiver:blob-sink:client') });
   const archiver = await Archiver.createAndSync(archiverConfig, archiverStore, { telemetry, blobSinkClient }, true);
   services.archiver = [archiver, ArchiverApiSchema];

--- a/yarn-project/aztec/src/cli/cmds/start_blob_sink.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_blob_sink.ts
@@ -35,7 +35,7 @@ export async function startBlobSink(options: any, signalHandlers: (() => Promise
     throw new Error('L1_CHAIN_ID');
   }
 
-  const telemetry = initTelemetryClient(getTelemetryClientConfig());
+  const telemetry = await initTelemetryClient(getTelemetryClientConfig());
 
   const { config: chainConfig, addresses } = await getL1Config(
     blobSinkConfig.l1Contracts.registryAddress,

--- a/yarn-project/aztec/src/cli/cmds/start_bot.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_bot.ts
@@ -40,7 +40,7 @@ export async function startBot(
   const pxeConfig = extractRelevantOptions<PXEConfig & CliPXEOptions>(options, allPxeConfigMappings, 'pxe');
   const wallet = await TestWallet.create(aztecNode, pxeConfig);
 
-  const telemetry = initTelemetryClient(getTelemetryClientConfig());
+  const telemetry = await initTelemetryClient(getTelemetryClientConfig());
   await addBot(options, signalHandlers, services, wallet, aztecNode, telemetry, undefined);
 }
 

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -117,7 +117,7 @@ export async function startNode(
   }
 
   const telemetryConfig = extractRelevantOptions<TelemetryClientConfig>(options, telemetryClientConfigMappings, 'tel');
-  const telemetry = initTelemetryClient(telemetryConfig);
+  const telemetry = await initTelemetryClient(telemetryConfig);
 
   // Create and start Aztec Node
   const node = await createAztecNode(nodeConfig, { telemetry }, { prefilledPublicData });

--- a/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
@@ -25,7 +25,7 @@ export async function startP2PBootstrap(
   userLog(`Starting P2P bootstrap node with config: ${jsonStringify(safeConfig)}`);
 
   const telemetryConfig = extractRelevantOptions<TelemetryClientConfig>(options, telemetryClientConfigMappings, 'tel');
-  const telemetryClient = initTelemetryClient(telemetryConfig);
+  const telemetryClient = await initTelemetryClient(telemetryConfig);
 
   const store = await createStore('p2p-bootstrap', 1, config, createLogger('p2p:bootstrap:store'));
   const node = new BootstrapNode(store, telemetryClient);

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -53,7 +53,7 @@ export async function startProverAgent(
   );
   const broker = createProvingJobBrokerClient(config.proverBrokerUrl, getVersions(), fetch);
 
-  const telemetry = initTelemetryClient(extractRelevantOptions(options, telemetryClientConfigMappings, 'tel'));
+  const telemetry = await initTelemetryClient(extractRelevantOptions(options, telemetryClientConfigMappings, 'tel'));
   const prover = await buildServerCircuitProver(config, telemetry);
   const proofStore = new InlineProofStore();
   const agents = times(

--- a/yarn-project/aztec/src/cli/cmds/start_prover_broker.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_broker.ts
@@ -45,7 +45,7 @@ export async function startProverBroker(
   config.l1Contracts = addresses;
   config.rollupVersion = rollupConfig.rollupVersion;
 
-  const client = initTelemetryClient(getTelemetryClientConfig());
+  const client = await initTelemetryClient(getTelemetryClientConfig());
   const broker = await createAndStartProvingBroker(config, client);
 
   if (options.autoUpdate !== 'disabled' && options.autoUpdateUrl) {

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -67,7 +67,7 @@ export async function startProverNode(
     );
   }
 
-  const telemetry = initTelemetryClient(extractRelevantOptions(options, telemetryClientConfigMappings, 'tel'));
+  const telemetry = await initTelemetryClient(extractRelevantOptions(options, telemetryClientConfigMappings, 'tel'));
 
   let broker: ProvingJobBroker;
   if (proverConfig.proverBrokerUrl) {

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -7,8 +7,7 @@ import type { ConfigMappingsType } from '@aztec/foundation/config';
 import { type LogFn, createLogger } from '@aztec/foundation/log';
 import type { SharedNodeConfig } from '@aztec/node-lib/config';
 import type { ProverConfig } from '@aztec/stdlib/interfaces/server';
-import { UpdateChecker } from '@aztec/stdlib/update-checker';
-import { getTelemetryClient } from '@aztec/telemetry-client';
+import { getTelemetryClient } from '@aztec/telemetry-client/start';
 import type { TestWallet } from '@aztec/test-wallet/server';
 
 import chalk from 'chalk';
@@ -312,6 +311,7 @@ export async function setupUpdateMonitor(
   updateNodeConfig?: (config: object) => Promise<void>,
 ) {
   const logger = createLogger('update-check');
+  const { UpdateChecker } = await import('@aztec/stdlib/update-checker');
   const checker = await UpdateChecker.new({
     baseURL: updatesLocation,
     publicClient,

--- a/yarn-project/aztec/src/local-network/local-network.ts
+++ b/yarn-project/aztec/src/local-network/local-network.ts
@@ -181,7 +181,7 @@ export async function createLocalNetwork(config: Partial<LocalNetworkConfig> = {
     await watcher.start();
   }
 
-  const telemetry = initTelemetryClient(getTelemetryClientConfig());
+  const telemetry = await initTelemetryClient(getTelemetryClientConfig());
   // Create a local blob sink client inside the local network, no http connectivity
   const blobSinkClient = createBlobSinkClient();
   const node = await createAztecNode(

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -200,7 +200,7 @@ export class P2PNetworkTest {
 
   async addBootstrapNode() {
     await this.snapshotManager.snapshot('add-bootstrap-node', async ({ aztecNodeConfig }) => {
-      const telemetry = getEndToEndTestTelemetryClient(this.metricsPort);
+      const telemetry = await getEndToEndTestTelemetryClient(this.metricsPort);
       this.bootstrapNode = await createBootstrapNodeFromPrivateKey(
         BOOTSTRAP_NODE_PRIVATE_KEY,
         this.bootNodePort,

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -99,7 +99,7 @@ export async function createNode(
 ) {
   const createNode = async () => {
     const validatorConfig = await createValidatorConfig(config, bootstrapNode, tcpPort, addressIndex, dataDirectory);
-    const telemetry = getEndToEndTestTelemetryClient(metricsPort);
+    const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
     return await AztecNodeService.createAndSync(
       validatorConfig,
       { telemetry, dateProvider },
@@ -128,7 +128,7 @@ export async function createNonValidatorNode(
       validatorPrivateKeys: undefined,
       publisherPrivateKeys: [],
     };
-    const telemetry = getEndToEndTestTelemetryClient(metricsPort);
+    const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
     return await AztecNodeService.createAndSync(config, { telemetry, dateProvider }, { prefilledPublicData });
   };
   return loggerIdStorage ? await loggerIdStorage.run(tcpPort.toString(), createNode) : createNode();
@@ -147,7 +147,7 @@ export async function createProverNode(
 ) {
   const createProverNode = async () => {
     const proverNodePrivateKey = getPrivateKeyFromIndex(ATTESTER_PRIVATE_KEYS_START_INDEX + addressIndex)!;
-    const telemetry = getEndToEndTestTelemetryClient(metricsPort);
+    const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
 
     const proverConfig: Partial<ProverNodeConfig> = await createP2PConfig(
       config,

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -393,7 +393,7 @@ async function setupFromFresh(
     aztecNodeConfig.bbWorkingDirectory = bbConfig.bbWorkingDirectory;
   }
 
-  const telemetry = getEndToEndTestTelemetryClient(opts.metricsPort);
+  const telemetry = await getEndToEndTestTelemetryClient(opts.metricsPort);
 
   // Setup blob sink service
   const blobSink = await createBlobSinkServer(
@@ -523,7 +523,7 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
   );
   await watcher.start();
 
-  const telemetry = initTelemetryClient(getTelemetryConfig());
+  const telemetry = await initTelemetryClient(getTelemetryConfig());
   const blobSink = await createBlobSinkServer(
     {
       l1ChainId: aztecNodeConfig.l1ChainId,

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -91,10 +91,10 @@ const { AZTEC_NODE_URL = '' } = process.env;
 const getAztecUrl = () => AZTEC_NODE_URL;
 
 let telemetry: TelemetryClient | undefined = undefined;
-function getTelemetryClient(partialConfig: Partial<TelemetryClientConfig> & { benchmark?: boolean } = {}) {
+async function getTelemetryClient(partialConfig: Partial<TelemetryClientConfig> & { benchmark?: boolean } = {}) {
   if (!telemetry) {
     const config = { ...getTelemetryConfig(), ...partialConfig };
-    telemetry = config.benchmark ? new BenchmarkTelemetryClient() : initTelemetryClient(config);
+    telemetry = config.benchmark ? new BenchmarkTelemetryClient() : await initTelemetryClient(config);
   }
   return telemetry;
 }
@@ -540,7 +540,7 @@ export async function setup(
       await watcher.start();
     }
 
-    const telemetry = getTelemetryClient(opts.telemetryConfig);
+    const telemetry = await getTelemetryClient(opts.telemetryConfig);
 
     // Blob sink service - blobs get posted here and served from here
     const blobSinkPort = await getPort();

--- a/yarn-project/end-to-end/src/fixtures/with_telemetry_utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/with_telemetry_utils.ts
@@ -7,12 +7,12 @@ import {
 } from '@aztec/telemetry-client';
 import { OTelPinoStream } from '@aztec/telemetry-client/otel-pino-stream';
 
-export function getEndToEndTestTelemetryClient(metricsPort?: number): TelemetryClient {
+export async function getEndToEndTestTelemetryClient(metricsPort?: number): Promise<TelemetryClient> {
   if (metricsPort) {
     const otelStream = new OTelPinoStream({ levels });
     registerLoggingStream(otelStream);
   }
-  return initTelemetryClient(getEndToEndTestTelemetryConfig(metricsPort));
+  return await initTelemetryClient(getEndToEndTestTelemetryConfig(metricsPort));
 }
 
 /**

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./dest/index.js",
     "./bench": "./dest/bench.js",
+    "./start": "./dest/start.js",
     "./otel-pino-stream": "./dest/vendor/otel-pino-stream.js"
   },
   "scripts": {

--- a/yarn-project/telemetry-client/src/start.ts
+++ b/yarn-project/telemetry-client/src/start.ts
@@ -2,7 +2,6 @@ import { createLogger } from '@aztec/foundation/log';
 
 import type { TelemetryClientConfig } from './config.js';
 import { NoopTelemetryClient } from './noop.js';
-import { OpenTelemetryClient } from './otel.js';
 import type { TelemetryClient } from './telemetry.js';
 
 export * from './config.js';
@@ -10,7 +9,7 @@ export * from './config.js';
 let initialized = false;
 let telemetry: TelemetryClient = new NoopTelemetryClient();
 
-export function initTelemetryClient(config: TelemetryClientConfig): TelemetryClient {
+export async function initTelemetryClient(config: TelemetryClientConfig): Promise<TelemetryClient> {
   const log = createLogger('telemetry:client');
   if (initialized) {
     log.warn('Telemetry client has already been initialized once');
@@ -19,6 +18,8 @@ export function initTelemetryClient(config: TelemetryClientConfig): TelemetryCli
 
   if (config.metricsCollectorUrl || config.publicMetricsCollectorUrl) {
     log.info(`Using OpenTelemetry client with custom collector`);
+    // Lazy load OpenTelemetry to avoid loading heavy deps at startup
+    const { OpenTelemetryClient } = await import('./otel.js');
     telemetry = OpenTelemetryClient.createAndStart(config, log);
   } else {
     log.info('Using NoopTelemetryClient');


### PR DESCRIPTION
As title. A push to fix cli startup times. This is one of several import granularization efforts. At the end of it all we can at least print the cli help in 0.5s.

I propose the following:
* We **remove barrel imports**. So no more `index.ts` that's just a list of `export * from 'foo'`.
* In any project, there are files that are deemed part of the public api (they were exported directly or indirectly via the barrel import), and there are files that are not deemed part of the public api.
* Any file that is deemed part of the public api is exported directly through the `package.json` `export` api. If it's good enough to be exported through a barrel, it's good enough to have it's own export on the package.
* This will make it *explicit and clear* what we're presenting as the packages public api.
* It makes it easier to trivially time the importation of each entrypoint for debugging slow stuff.
* It makes it easier to see messy apis and take action to clean them up.