### PR TITLE
chore: refactor diff fuzz

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
@@ -29,7 +29,7 @@ if(AVM AND FUZZING)
         TEST_SOURCE_FILES ${TEST_SOURCE_FILES}
         BENCH_SOURCE_FILES ${BENCH_SOURCE_FILES}
         FUZZERS_SOURCE_FILES ${FUZZERS_SOURCE_FILES}
-        DEPENDENCIES vm2 nlohmann_json::nlohmann_json
+        DEPENDENCIES vm2
     )
 
     # Add the harness subdirectory which will create the alu_fuzzer target

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
-#include <nlohmann/json.hpp>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
@@ -30,49 +29,36 @@ using namespace bb::avm2;
 using namespace bb::avm2::simulation;
 using namespace bb::avm2::fuzzer;
 using namespace bb::world_state;
-using json = nlohmann::json;
 
-// Helper function to serialize tx, globals, and contract data to JSON
+// Helper function to serialize simulation request via
 std::string serialize_simulation_request(const Tx& tx,
                                          const GlobalVariables& globals,
                                          const FuzzerContractDB& contract_db)
 {
-    json j;
-
-    // Pass WorldState database path and configuration for TypeScript to open the same DB
-    // Note: TypeScript expects the parent directory and adds "world_state/" subdirectory itself
-    j["ws_data_dir"] = FuzzerWorldStateManager::get_data_dir();
-    j["ws_map_size_kb"] = FuzzerWorldStateManager::get_map_size_kb();
-
-    // Serialize Tx using msgpack and base64 encode
-    auto [tx_buffer, tx_size] = msgpack_encode_buffer(tx);
-    j["tx"] = base64_encode(tx_buffer, tx_size);
-    delete[] tx_buffer;
-
-    // Serialize GlobalVariables using msgpack and base64 encode
-    auto [globals_buffer, globals_size] = msgpack_encode_buffer(globals);
-    j["globals"] = base64_encode(globals_buffer, globals_size);
-    delete[] globals_buffer;
-
-    // Serialize contract instances as vector of pairs (address, instance) to avoid non-string map keys
-    std::vector<std::pair<AztecAddress, ContractInstance>> instances_vec;
-    for (const auto& [address, instance] : contract_db.get_contract_instances()) {
-        instances_vec.emplace_back(address, instance);
-    }
-    auto [instances_buffer, instances_size] = msgpack_encode_buffer(instances_vec);
-    j["contractInstances"] = base64_encode(instances_buffer, instances_size);
-    delete[] instances_buffer;
-
-    // Serialize contract classes as vector (id is already inside each class)
+    // Build vectors from contract_db
     std::vector<ContractClass> classes_vec;
     for (const auto& [_, contract_class] : contract_db.get_contract_classes()) {
         classes_vec.push_back(contract_class);
     }
-    auto [classes_buffer, classes_size] = msgpack_encode_buffer(classes_vec);
-    j["contractClasses"] = base64_encode(classes_buffer, classes_size);
-    delete[] classes_buffer;
 
-    return j.dump();
+    std::vector<std::pair<AztecAddress, ContractInstance>> instances_vec;
+    for (const auto& [address, instance] : contract_db.get_contract_instances()) {
+        instances_vec.emplace_back(address, instance);
+    }
+
+    FuzzerSimulationRequest request{
+        .ws_data_dir = FuzzerWorldStateManager::get_data_dir(),
+        .ws_map_size_kb = FuzzerWorldStateManager::get_map_size_kb(),
+        .tx = tx,
+        .globals = globals,
+        .contract_classes = std::move(classes_vec),
+        .contract_instances = std::move(instances_vec),
+    };
+
+    auto [buffer, size] = msgpack_encode_buffer(request);
+    std::string result = base64_encode(buffer, size);
+    delete[] buffer;
+    return result;
 }
 
 // Helper function to create default global variables for testing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp
@@ -4,12 +4,29 @@
 
 #include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/common/process.hpp"
+#include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/simulation/interfaces/execution.hpp"
 
 using namespace bb::avm2::simulation;
 using namespace bb::avm2;
+
+/**
+ * Request struct for fuzzer simulation communication between C++ and TypeScript.
+ * Contains all data needed for the TS simulator to execute a transaction.
+ */
+struct FuzzerSimulationRequest {
+    std::string ws_data_dir;
+    uint64_t ws_map_size_kb;
+    Tx tx;
+    GlobalVariables globals;
+    std::vector<ContractClass> contract_classes;
+    // Having addresses here avoids doing re-work in TS.
+    std::vector<std::pair<AztecAddress, ContractInstance>> contract_instances;
+
+    MSGPACK_CAMEL_CASE_FIELDS(ws_data_dir, ws_map_size_kb, tx, globals, contract_classes, contract_instances);
+};
 
 struct SimulatorResult {
     bool reverted;

--- a/yarn-project/simulator/src/public/fuzzing/avm_fuzzer_simulator.ts
+++ b/yarn-project/simulator/src/public/fuzzing/avm_fuzzer_simulator.ts
@@ -1,5 +1,4 @@
 import {
-  CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
   MAX_ENQUEUED_CALLS_PER_TX,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
@@ -8,9 +7,9 @@ import {
 } from '@aztec/constants';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import type { AvmTxHint } from '@aztec/stdlib/avm';
+import { AvmTxHint, type PublicTxResult } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { siloNullifier } from '@aztec/stdlib/hash';
+import { contractClassPublicFromPlainObject, contractInstanceWithAddressFromPlainObject } from '@aztec/stdlib/contract';
 import {
   PartialPrivateTailPublicInputsForPublic,
   PrivateKernelTailCircuitPublicInputs,
@@ -20,29 +19,49 @@ import {
 import { PrivateLog } from '@aztec/stdlib/logs';
 import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { ChonkProof } from '@aztec/stdlib/proofs';
-import { MerkleTreeId, type MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
-import { BlockHeader, HashedValues, Tx, TxConstantData, TxContext, TxHash } from '@aztec/stdlib/tx';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables, HashedValues, Tx, TxConstantData, TxContext, TxHash } from '@aztec/stdlib/tx';
+import type { NativeWorldStateService } from '@aztec/world-state';
 
-// Registers a contract by inserting its address nullifier into the nullifier tree
-export async function registerContract(
-  merkleTrees: MerkleTreeWriteOperations,
-  contractAddress: AztecAddress,
-): Promise<void> {
-  const contractAddressNullifier = await siloNullifier(
-    AztecAddress.fromNumber(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS),
-    contractAddress.toField(),
-  );
-  await merkleTrees.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [contractAddressNullifier.toBuffer()]);
+import { BaseAvmSimulationTester } from '../avm/fixtures/base_avm_simulation_tester.js';
+import { SimpleContractDataSource } from '../fixtures/simple_contract_data_source.js';
+import { PublicContractsDB } from '../public_db_sources.js';
+import { PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
+
+/**
+ * Request structure for fuzzer simulation communication from C++.
+ * Matches the C++ FuzzerSimulationRequest struct
+ */
+export class FuzzerSimulationRequest {
+  constructor(
+    public readonly wsDataDir: string,
+    public readonly wsMapSizeKb: number,
+    public readonly tx: AvmTxHint,
+    public readonly globals: GlobalVariables,
+    public readonly contractClasses: any[], // Raw, processed by addContractClassFromCpp
+    public readonly contractInstances: [any, any][], // Raw pairs [address, instance]
+  ) {}
+
+  static fromPlainObject(obj: any): FuzzerSimulationRequest {
+    if (obj instanceof FuzzerSimulationRequest) {
+      return obj;
+    }
+    return new FuzzerSimulationRequest(
+      obj.wsDataDir,
+      obj.wsMapSizeKb,
+      AvmTxHint.fromPlainObject(obj.tx),
+      GlobalVariables.fromPlainObject(obj.globals),
+      obj.contractClasses,
+      obj.contractInstances,
+    );
+  }
 }
 
 /**
  * Creates a TypeScript Tx object from a deserialized C++ Tx (AvmTxHint-like structure).
  * This allows using PublicTxSimulator.simulate() with fuzzer-generated transactions.
- *
- * @param cppTx - Deserialized C++ Tx from msgpack (matches AvmTxHint structure)
- * @returns A TypeScript Tx suitable for PublicTxSimulator
  */
-export async function createFuzzerTx(cppTx: AvmTxHint): Promise<Tx> {
+async function createTxFromHint(cppTx: AvmTxHint): Promise<Tx> {
   // Create TxHash from the C++ tx hash string
   if (!cppTx.hash) {
     throw new Error(`cppTx.hash is undefined. Keys: ${Object.keys(cppTx || {}).join(', ')}`);
@@ -116,8 +135,6 @@ export async function createFuzzerTx(cppTx: AvmTxHint): Promise<Tx> {
     undefined, // forRollup - not needed for public simulation
   );
 
-  // todo(ilyas): I don't think we need to construct this, but keeping for now - the hashing could get costly with
-  // large number of enqueued calls or large calldata so keep an eye on this!
   // Build publicFunctionCalldata from all enqueued calls
   // Calldata is already Fr[] after AvmTxHint.fromPlainObject
   const publicFunctionCalldata: HashedValues[] = [];
@@ -151,4 +168,66 @@ export async function createFuzzerTx(cppTx: AvmTxHint): Promise<Tx> {
     contractClassLogFields,
     publicFunctionCalldata,
   );
+}
+
+/**
+ * A simulator class for the AVM fuzzer that extends BaseAvmSimulationTester.
+ * It provides methods for registering contracts from C++ msgpack data and simulating transactions.
+ */
+export class AvmFuzzerSimulator extends BaseAvmSimulationTester {
+  private simulator: PublicTxSimulator;
+
+  constructor(
+    merkleTrees: MerkleTreeWriteOperations,
+    contractDataSource: SimpleContractDataSource,
+    globals: GlobalVariables,
+  ) {
+    super(contractDataSource, merkleTrees);
+    const contractsDb = new PublicContractsDB(contractDataSource);
+    this.simulator = new PublicTxSimulator(merkleTrees, contractsDb, globals, {
+      skipFeeEnforcement: true,
+      collectDebugLogs: false,
+      collectHints: false,
+      collectStatistics: false,
+      collectCallMetadata: false,
+    });
+  }
+
+  /**
+   * Static factory method to create an AvmFuzzerSimulator.
+   */
+  public static async create(
+    worldStateService: NativeWorldStateService,
+    globals: GlobalVariables,
+  ): Promise<AvmFuzzerSimulator> {
+    const contractDataSource = new SimpleContractDataSource();
+    const merkleTrees = await worldStateService.fork();
+    return new AvmFuzzerSimulator(merkleTrees, contractDataSource, globals);
+  }
+
+  /**
+   * Simulate a transaction from a C++ AvmTxHint.
+   */
+  public async simulate(txHint: AvmTxHint): Promise<PublicTxResult> {
+    const tx = await createTxFromHint(txHint);
+    return await this.simulator.simulate(tx);
+  }
+
+  /**
+   * Add a contract class from C++ raw msgpack data.
+   */
+  public async addContractClassFromCpp(rawClass: any): Promise<void> {
+    const contractClass = contractClassPublicFromPlainObject(rawClass);
+    await this.contractDataSource.addContractClass(contractClass);
+  }
+
+  /**
+   * Add a contract instance from C++ raw msgpack data.
+   * This also inserts the contract address nullifier into the nullifier tree.
+   */
+  public async addContractInstanceFromCpp(rawAddress: any, rawInstance: any): Promise<void> {
+    const address = AztecAddress.fromPlainObject(rawAddress);
+    const instance = contractInstanceWithAddressFromPlainObject(address, rawInstance);
+    await this.addContractInstance(instance);
+  }
 }

--- a/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
+++ b/yarn-project/simulator/src/public/fuzzing/avm_simulator_bin.ts
@@ -2,27 +2,17 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import {
   AvmCircuitPublicInputs,
-  AvmTxHint,
+  type AvmTxHint,
   deserializeFromMessagePack,
   serializeWithMessagePack,
 } from '@aztec/stdlib/avm';
-import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import {
-  type ContractClassPublic,
-  type ContractInstanceWithAddress,
-  contractClassPublicFromPlainObject,
-  contractInstanceWithAddressFromPlainObject,
-} from '@aztec/stdlib/contract';
 import { GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
 import { writeSync } from 'fs';
 import { createInterface } from 'readline';
 
-import { SimpleContractDataSource } from '../fixtures/simple_contract_data_source.js';
-import { PublicContractsDB } from '../public_db_sources.js';
-import { PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
-import { createFuzzerTx, registerContract } from './helpers.js';
+import { AvmFuzzerSimulator, FuzzerSimulationRequest } from './avm_fuzzer_simulator.js';
 
 // This cache holds opened world states to avoid reopening them for each invocation.
 // It's a map so that in the future we could support multiple world states (if we had multiple fuzzers).
@@ -46,44 +36,33 @@ async function openExistingWorldState(dataDir: string, mapSizeKb: number): Promi
   return ws;
 }
 
-async function simulateWithPublicTxSimulator(
+async function simulateWithFuzzer(
   dataDir: string,
   mapSizeKb: number,
-  cppTx: AvmTxHint,
-  cppGlobals: GlobalVariables,
-  contractClasses: ContractClassPublic[],
-  contractInstances: ContractInstanceWithAddress[],
+  txHint: AvmTxHint,
+  globals: GlobalVariables,
+  rawContractClasses: any[], // Replace these when we are moving contract classes to TS
+  rawContractInstances: [any, any][], // Replace these when we are moving contract instances to TS
 ): Promise<{ reverted: boolean; output: Fr[]; revertReason?: string; publicInputs: AvmCircuitPublicInputs }> {
   const worldStateService = await openExistingWorldState(dataDir, mapSizeKb);
-  const merkleTrees = await worldStateService.fork();
 
-  const contractDataSource = new SimpleContractDataSource();
+  const simulator = await AvmFuzzerSimulator.create(worldStateService, globals);
 
   // Register contract classes from C++
-  for (const contractClass of contractClasses) {
-    await contractDataSource.addContractClass(contractClass);
+  for (const rawClass of rawContractClasses) {
+    await simulator.addContractClassFromCpp(rawClass);
   }
 
   // Register contract instances from C++
-  for (const contractInstance of contractInstances) {
-    await registerContract(merkleTrees, contractInstance.address);
-    await contractDataSource.addContractInstance(contractInstance);
+  for (const [rawAddress, rawInstance] of rawContractInstances) {
+    await simulator.addContractInstanceFromCpp(rawAddress, rawInstance);
   }
 
-  const contractsDb = new PublicContractsDB(contractDataSource);
+  const result = await simulator.simulate(txHint);
 
-  const publicTxSimulator = new PublicTxSimulator(merkleTrees, contractsDb, cppGlobals, {
-    skipFeeEnforcement: true,
-    collectDebugLogs: false,
-    collectHints: false,
-    collectStatistics: false,
-    collectCallMetadata: false,
-  });
-
-  const tx = await createFuzzerTx(cppTx);
-  const result = await publicTxSimulator.simulate(tx);
-
-  const output = result.getAppLogicReturnValues().flatMap(rv => rv?.values?.filter(v => v != null) ?? []);
+  const output = result
+    .getAppLogicReturnValues()
+    .flatMap((rv: { values?: Fr[] } | undefined) => rv?.values?.filter((v: Fr | null | undefined) => v != null) ?? []);
 
   return {
     reverted: !result.revertCode.isOK(),
@@ -93,49 +72,24 @@ async function simulateWithPublicTxSimulator(
   };
 }
 
-async function executeFromJson(jsonLine: string): Promise<void> {
+async function execute(base64Line: string): Promise<void> {
   try {
-    const input = JSON.parse(jsonLine.trim());
-    if (
-      !input.ws_data_dir ||
-      !input.ws_map_size_kb ||
-      !input.tx ||
-      !input.globals ||
-      !input.contractClasses ||
-      !input.contractInstances
-    ) {
-      writeSync(
-        process.stdout.fd,
-        'Error: JSON must contain "ws_data_dir", "ws_map_size_kb", "tx", "globals", "contractClasses", and "contractInstances" fields\n',
-      );
-      return;
-    }
+    // Decode base64 and deserialize the entire request from msgpack
+    const buffer = Buffer.from(base64Line.trim(), 'base64');
+    const rawRequest = deserializeFromMessagePack(buffer);
+    const request = FuzzerSimulationRequest.fromPlainObject(rawRequest);
 
-    const rawTx: object = deserializeFromMessagePack(Buffer.from(input.tx, 'base64'));
-    const tx = AvmTxHint.fromPlainObject(rawTx);
-    const rawGlobals = deserializeFromMessagePack(Buffer.from(input.globals, 'base64'));
-    const globals = GlobalVariables.fromPlainObject(rawGlobals);
-
-    // Parse contract classes from C++ (bytecode is inside packedBytecode field)
-    // C++ sends a vector<ContractClass> - id is already inside each class
-    const rawClassesArray: any[] = deserializeFromMessagePack(Buffer.from(input.contractClasses, 'base64'));
-    const contractClasses: ContractClassPublic[] = rawClassesArray.map(contractClassPublicFromPlainObject);
-
-    // Parse contract instances from C++
-    // C++ sends a vector<pair<AztecAddress, ContractInstance>>
-    const rawInstancesArray: [any, any][] = deserializeFromMessagePack(Buffer.from(input.contractInstances, 'base64'));
-    const contractInstances: ContractInstanceWithAddress[] = rawInstancesArray.map(([rawAddress, rawInstance]) =>
-      contractInstanceWithAddressFromPlainObject(AztecAddress.fromPlainObject(rawAddress), rawInstance),
+    // Run the TS simulation
+    const result = await simulateWithFuzzer(
+      request.wsDataDir,
+      request.wsMapSizeKb,
+      request.tx,
+      request.globals,
+      request.contractClasses,
+      request.contractInstances,
     );
 
-    const result = await simulateWithPublicTxSimulator(
-      input.ws_data_dir,
-      input.ws_map_size_kb,
-      tx,
-      globals,
-      contractClasses,
-      contractInstances,
-    );
+    // Serialize the result to msgpack and encode it in base64 for output
     const resultBuffer = serializeWithMessagePack({
       reverted: result.reverted,
       output: result.output,
@@ -158,7 +112,7 @@ function mainLoop() {
   const rl = createInterface({ input: process.stdin, terminal: false });
   rl.on('line', (line: string) => {
     if (line.trim()) {
-      void executeFromJson(line);
+      void execute(line);
     }
   });
   rl.on('close', () => process.exit(0));


### PR DESCRIPTION
Hopefully last bit of cleanup for the differential fuzzer, remove all json serialization in favor of msgpack and introduce a `FuzzerSimulationRequest` to cleanly wrap the data structure moved between cpp and ts fuzzer