### PR TITLE
fix: remove 'if: always()' from ci3.yml

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -69,7 +69,6 @@ jobs:
         run: ./.github/ci3.sh "${{ join(github.event.pull_request.labels.*.name, ',') }}"
 
       - name: Post-Actions
-        if: always()
         env:
           CI_INTERNAL: "1"
           # For updating success cache.


### PR DESCRIPTION
This was unnecessary. I missed that this didn't play nicely with ci3-post.sh while reviewing generated code and it slipped by testing. 

Notes: I did testing for all supported labels, but didn't do a "failed test with a squash-and-merge" scenario, that would have caught it.