### PR TITLE
refactor: de-boilerplating notes

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -18,7 +18,7 @@ contract BoxReact {
     #[external("private")]
     #[initializer]
     fn constructor(number: Field, owner: AztecAddress) {
-        let new_number = FieldNote::new(number);
+        let new_number = FieldNote { value: number };
 
         self.storage.numbers.at(owner).initialize(new_number).deliver(
             owner,
@@ -28,7 +28,7 @@ contract BoxReact {
 
     #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
-        self.storage.numbers.at(owner).replace(|_old| FieldNote::new(number)).deliver(
+        self.storage.numbers.at(owner).replace(|_old| FieldNote { value: number }).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -18,7 +18,7 @@ contract BoxReact {
     #[external("private")]
     #[initializer]
     fn constructor(number: Field, owner: AztecAddress) {
-        let new_number = FieldNote::new(number);
+        let new_number = FieldNote { value: number };
 
         self.storage.numbers.at(owner).initialize(new_number).deliver(
             owner,
@@ -28,7 +28,7 @@ contract BoxReact {
 
     #[external("private")]
     fn setNumber(number: Field, owner: AztecAddress) {
-        self.storage.numbers.at(owner).replace(|_old| FieldNote::new(number)).deliver(
+        self.storage.numbers.at(owner).replace(|_old| FieldNote { value: number }).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );

--- a/docs/docs/developers/docs/resources/migration_notes.md
+++ b/docs/docs/developers/docs/resources/migration_notes.md
@@ -9,6 +9,39 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### [Aztec.nr] Note fields are now public
+
+All note struct fields are now public, and the `new()` constructor methods and getter methods have been removed. Notes should be instantiated using struct literal syntax, and fields should be accessed directly.
+
+The motivation for this change has been enshrining of randomness which lead to the `new` method being unnecessary boilerplate.
+
+**Affected notes:**
+- `UintNote` - `value` is now public, `new()` and `get_value()` removed
+- `AddressNote` - `address` is now public, `new()` and `get_address()` removed
+- `FieldNote` - `value` is now public, `new()` and `value()` removed
+
+**Migration:**
+
+```diff
+- let note = UintNote::new(100);
++ let note = UintNote { value: 100 };
+
+- let value = note.get_value();
++ let value = note.value;
+
+- let address_note = AddressNote::new(owner);
++ let address_note = AddressNote { address: owner };
+
+- let address = address_note.get_address();
++ let address = address_note.address;
+
+- let field_note = FieldNote::new(42);
++ let field_note = FieldNote { value: 42 };
+
+- let value = field_note.value();
++ let value = field_note.value;
+```
+
 ### [Aztec.nr] `emit` renamed to `deliver`
 
 Private state variable functions that created notes and returned their messages no longer return a `NoteEmission` but instead a `NoteMessage`. These messages are delivered to their recipient via `deliver` instead of `emit`. The verb 'emit' remains for things like emitting events.

--- a/docs/docs/developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs/developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -104,10 +104,6 @@ In this file, you're going to create a **private note** that represents NFT owne
 
 #include_code nft_note_struct /docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr rust
 
-Now add a `new` method to make creating notes easier. For simplicity, set the randomness within the method. This approach is unsafe because it's unconstrained, but in the current case this won't cause problems:
-
-#include_code nft_note_new /docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr rust
-
 You now have a note that represents the owner of a particular NFT. Next, move on to the contract itself.
 
 :::tip Custom Notes

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/main.nr
@@ -50,7 +50,7 @@ pub contract NFTPunk {
         assert(self.storage.minter.read().eq(self.msg_sender().unwrap()), "caller is not the authorized minter");
 
         // we create an NFT note and insert it to the PrivateSet - a collection of notes meant to be read in private
-        let new_nft = NFTNote::new(to, token_id);
+        let new_nft = NFTNote { token_id };
         self.storage.owners.at(to).insert(new_nft).deliver( to, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // calling the internal public function above to indicate that the NFT is taken

--- a/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr
+++ b/docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/src/nft.nr
@@ -11,14 +11,6 @@ use dep::aztec::{
 #[derive(Eq, Packable)]
 #[note]
 pub struct NFTNote {
-    token_id: Field,
+    pub token_id: Field,
 }
 // docs:end:nft_note_struct
-
-// docs:start:nft_note_new
-impl NFTNote {
-    pub fn new(token_id: Field) -> Self {
-        NFTNote { token_id }
-    }
-}
-// docs:end:nft_note_new

--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -6,15 +6,5 @@ use dep::aztec::{
 #[derive(Deserialize, Eq, Packable, Serialize)]
 #[note]
 pub struct AddressNote {
-    address: AztecAddress,
-}
-
-impl AddressNote {
-    pub fn new(address: AztecAddress) -> Self {
-        AddressNote { address }
-    }
-
-    pub fn get_address(self) -> AztecAddress {
-        self.address
-    }
+    pub address: AztecAddress,
 }

--- a/noir-projects/aztec-nr/balance-set/src/balance_set.nr
+++ b/noir-projects/aztec-nr/balance-set/src/balance_set.nr
@@ -37,7 +37,7 @@ impl BalanceSet<UtilityContext> {
         let notes = self.set.view_notes(options.set_offset(offset));
         for i in 0..options.limit {
             if i < notes.len() {
-                balance = balance + notes.get_unchecked(i).get_value();
+                balance = balance + notes.get_unchecked(i).value;
             }
         }
         if (notes.len() == options.limit) {
@@ -53,7 +53,7 @@ impl BalanceSet<&mut PrivateContext> {
         let maybe_new_note = if addend == 0 as u128 {
             Option::none()
         } else {
-            let addend_note = UintNote::new(addend);
+            let addend_note = UintNote { value: addend };
 
             Option::some(self.set.insert(addend_note).get_new_note())
         };
@@ -94,7 +94,7 @@ impl BalanceSet<&mut PrivateContext> {
         for i in 0..options.limit {
             if i < notes.len() {
                 let note = notes.get_unchecked(i);
-                subtracted = subtracted + note.get_value();
+                subtracted = subtracted + note.value;
             }
         }
 
@@ -121,7 +121,7 @@ pub fn preprocess_notes_min_sum(
         if notes[i].is_some() & sum < min_sum {
             let retrieved_note = notes[i].unwrap_unchecked();
             selected[i] = Option::some(retrieved_note);
-            sum = sum.add(retrieved_note.note.get_value());
+            sum = sum.add(retrieved_note.note.value);
         }
     }
     selected

--- a/noir-projects/aztec-nr/field-note/src/field_note.nr
+++ b/noir-projects/aztec-nr/field-note/src/field_note.nr
@@ -3,15 +3,5 @@ use aztec::{macros::notes::note, protocol_types::traits::{Deserialize, Packable,
 #[derive(Deserialize, Eq, Packable, Serialize)]
 #[note]
 pub struct FieldNote {
-    value: Field,
-}
-
-impl FieldNote {
-    pub fn new(value: Field) -> Self {
-        FieldNote { value }
-    }
-
-    pub fn value(self) -> Field {
-        self.value
-    }
+    pub value: Field,
 }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -29,7 +29,7 @@ use dep::aztec::{
 #[custom_note]
 pub struct UintNote {
     /// The number stored in the note.
-    value: u128,
+    pub value: u128,
 }
 // docs:end:uint_note_def
 
@@ -94,14 +94,6 @@ impl NoteHash for UintNote {
 }
 
 impl UintNote {
-    pub fn new(value: u128) -> Self {
-        Self { value }
-    }
-
-    pub fn get_value(self) -> u128 {
-        self.value
-    }
-
     /// Creates a partial note that will hide the owner and storage slot but not the value, since the note will be later
     /// completed in public. This is a powerful technique for scenarios in which the value cannot be known in private
     /// (e.g. because it depends on some public state, such as a DEX).

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -27,7 +27,7 @@ pub contract EcdsaKAccount {
     #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
-        let pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y);
+        let pub_key_note = EcdsaPublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -26,7 +26,7 @@ pub contract EcdsaRAccount {
     #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
-        let pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y);
+        let pub_key_note = EcdsaPublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -41,7 +41,7 @@ pub contract SchnorrAccount {
     #[external("private")]
     #[initializer]
     fn constructor(signing_pub_key_x: Field, signing_pub_key_y: Field) {
-        let pub_key_note = PublicKeyNote::new(signing_pub_key_x, signing_pub_key_y);
+        let pub_key_note = PublicKeyNote { x: signing_pub_key_x, y: signing_pub_key_y };
 
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/public_key_note.nr
@@ -8,9 +8,3 @@ pub struct PublicKeyNote {
     pub x: Field,
     pub y: Field,
 }
-
-impl PublicKeyNote {
-    pub fn new(x: Field, y: Field) -> Self {
-        PublicKeyNote { x, y }
-    }
-}

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -83,7 +83,10 @@ pub contract AppSubscription {
             assert(note.remaining_txs > 0, "you're out of txs");
             *user_expiry_block_number = note.expiry_block_number;
 
-            SubscriptionNote::new(note.expiry_block_number, note.remaining_txs - 1)
+            SubscriptionNote {
+                expiry_block_number: note.expiry_block_number,
+                remaining_txs: note.remaining_txs - 1,
+            }
         });
         message.deliver(user_address, MessageDelivery.CONSTRAINED_ONCHAIN);
 
@@ -153,7 +156,9 @@ pub contract AppSubscription {
             .storage
             .subscriptions
             .at(subscriber)
-            .initialize_or_replace(|_| SubscriptionNote::new(expiry_block_number, tx_count))
+            .initialize_or_replace(|_| {
+                SubscriptionNote { expiry_block_number, remaining_txs: tx_count }
+            })
             .deliver(subscriber, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/subscription_note.nr
@@ -6,9 +6,3 @@ pub struct SubscriptionNote {
     pub expiry_block_number: u32,
     pub remaining_txs: u32,
 }
-
-impl SubscriptionNote {
-    pub fn new(expiry_block_number: u32, remaining_txs: u32) -> Self {
-        Self { expiry_block_number, remaining_txs }
-    }
-}

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -57,11 +57,11 @@ impl CardNote {
     }
 
     pub fn from_card(card: Card) -> CardNote {
-        CardNote { card, note: FieldNote::new(card.to_field()) }
+        CardNote { card, note: FieldNote { value: card.to_field() } }
     }
 
     pub fn from_note(note: FieldNote) -> CardNote {
-        CardNote { card: Card::from_field(note.value()), note }
+        CardNote { card: Card::from_field(note.value), note }
     }
 }
 
@@ -144,7 +144,7 @@ impl Deck<UtilityContext> {
         let mut options = NoteViewerOptions::new();
         let notes = self.owned_set.at(owner).view_notes(options.set_offset(offset));
 
-        notes.map(|note| Card::from_field(note.value()))
+        notes.map(|note| Card::from_field(note.value))
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -68,7 +68,7 @@ pub contract Claim {
         // 4) Finally we mint the reward token to the sender of the transaction
         self.enqueue(Token::at(self.storage.reward_token.read()).mint_to_public(
             recipient,
-            proof_retrieved_note.note.get_value(),
+            proof_retrieved_note.note.value,
         ));
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -60,7 +60,7 @@ pub contract Crowdfunding {
 
         // 3) Create a value note for the donor so that he can later on claim a rewards token in the Claim
         // contract by proving that the hash of this note exists in the note hash tree.
-        let note = UintNote::new(amount);
+        let note = UintNote { value: amount };
 
         // We don't constrain encryption because the donor is sending the note to himself. And hence by performing
         // encryption incorrectly would harm himself only.

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -22,7 +22,7 @@ pub contract Escrow {
     #[external("private")]
     #[initializer]
     fn constructor(owner: AztecAddress) {
-        let note = AddressNote::new(owner);
+        let note = AddressNote { address: owner };
         self.storage.owner.at(owner).initialize(note).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -35,7 +35,7 @@ pub contract Escrow {
         let sender = self.msg_sender().unwrap();
 
         let note = self.storage.owner.at(sender).get_note();
-        assert(note.get_address() == sender);
+        assert(note.address == sender);
         self.call(Token::at(token).transfer(recipient, amount));
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -254,7 +254,7 @@ pub contract NFT {
             .set_limit(1));
         assert(notes.len() == 1, "NFT not found when transferring");
 
-        let new_note = NFTNote::new(token_id);
+        let new_note = NFTNote { token_id };
 
         nfts.at(to).insert(new_note).deliver(to, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
@@ -304,7 +304,7 @@ pub contract NFT {
         let mut owned_nft_ids = [0; MAX_NOTES_PER_PAGE];
         for i in 0..options.limit {
             if i < notes.len() {
-                owned_nft_ids[i] = notes.get_unchecked(i).get_token_id();
+                owned_nft_ids[i] = notes.get_unchecked(i).token_id;
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -27,7 +27,7 @@ use dep::aztec::{
 #[custom_note]
 pub struct NFTNote {
     /// The ID of the token represented by this note.
-    token_id: Field,
+    pub token_id: Field,
 }
 
 impl NoteHash for NFTNote {
@@ -89,14 +89,6 @@ impl NoteHash for NFTNote {
 }
 
 impl NFTNote {
-    pub fn new(token_id: Field) -> Self {
-        Self { token_id }
-    }
-
-    pub fn get_token_id(self) -> Field {
-        self.token_id
-    }
-
     /// Creates a partial note that will hide the owner and storage slot but not the token id, since the note will be
     /// later completed in public. This is a powerful technique for scenarios in which the token id cannot be known in
     /// private (e.g. because it depends on some public state, such as a DEX).

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -114,7 +114,7 @@ pub contract TokenBlacklist {
         let caller_roles = self.storage.roles.at(self.msg_sender().unwrap()).get_current_value();
         assert(caller_roles.is_minter, "caller is not minter");
 
-        let note = TransparentNote::new(amount, secret_hash);
+        let note = TransparentNote { amount, secret_hash };
         let supply = self.storage.total_supply.read().add(amount);
 
         self.storage.total_supply.write(supply);
@@ -139,7 +139,7 @@ pub contract TokenBlacklist {
         assert(!from_roles.is_blacklisted, "Blacklisted: Sender");
 
         let from_balance = self.storage.public_balances.at(from).read().sub(amount);
-        let note = TransparentNote::new(amount, secret_hash);
+        let note = TransparentNote { amount, secret_hash };
 
         self.storage.public_balances.at(from).write(from_balance);
 
@@ -282,7 +282,7 @@ pub contract TokenBlacklist {
         first_nullifier_in_tx: Field,
         recipient: AztecAddress,
     ) {
-        let note = TransparentNote::new(amount, secret_hash);
+        let note = TransparentNote { amount, secret_hash };
         let storage_slot = TokenBlacklist::storage_layout().pending_shields.slot;
         let note_type_id = TransparentNote::get_id();
         let packed_note = BoundedVec::from_array(note.pack());

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
@@ -18,8 +18,8 @@ use dep::std::mem::zeroed;
 #[derive(Eq, Packable)]
 #[custom_note]
 pub struct TransparentNote {
-    amount: u128,
-    secret_hash: Field,
+    pub amount: u128,
+    pub secret_hash: Field,
 }
 
 impl NoteHash for TransparentNote {
@@ -60,12 +60,5 @@ impl NoteHash for TransparentNote {
     ) -> Field {
         // compute_nullifier ignores context so we can reuse it here
         self.compute_nullifier(zeroed(), owner, note_hash_for_nullification)
-    }
-}
-
-impl TransparentNote {
-    // CONSTRUCTORS
-    pub fn new(amount: u128, secret_hash: Field) -> Self {
-        TransparentNote { amount, secret_hash }
     }
 }

--- a/noir-projects/noir-contracts/contracts/libs/ecdsa_public_key_note/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/libs/ecdsa_public_key_note/src/lib.nr
@@ -13,11 +13,6 @@ pub struct EcdsaPublicKeyNote {
     pub y: [u8; 32],
 }
 
-impl EcdsaPublicKeyNote {
-    pub fn new(x: [u8; 32], y: [u8; 32]) -> Self {
-        EcdsaPublicKeyNote { x, y }
-    }
-}
 
 impl Packable for EcdsaPublicKeyNote {
     let N: u32 = 4;

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -25,7 +25,7 @@ pub contract Benchmarking {
     // Creates a new value note for the target owner. Use this method to seed an initial set of notes.
     #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
-        let note = FieldNote::new(value);
+        let note = FieldNote { value };
         self.storage.notes.at(owner).insert(note).deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
     // Deletes a note at a specific index in the set and creates a new one with the same value.

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -49,7 +49,7 @@ pub contract Child {
 
     #[external("private")]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let note = FieldNote::new(new_value);
+        let note = FieldNote { value: new_value };
 
         self.storage.private_values.at(owner).insert(note).deliver(
             owner,
@@ -63,7 +63,7 @@ pub contract Child {
         let mut options = NoteGetterOptions::new();
         options = options.select(FieldNote::properties().value, Comparator.EQ, amount).set_limit(1);
         let retrieved_notes = self.storage.private_values.at(owner).get_notes(options);
-        retrieved_notes.get(0).note.value()
+        retrieved_notes.get(0).note.value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract NoConstructor {
     #[external("private")]
     fn initialize_private_mutable(value: Field) {
         let owner = self.msg_sender().unwrap();
-        let note = FieldNote::new(value);
+        let note = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(note).deliver(
             owner,

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -24,7 +24,7 @@ pub contract NoteGetter {
     #[external("private")]
     fn insert_note(value: Field) {
         let owner = self.msg_sender().unwrap();
-        let note = FieldNote::new(value);
+        let note = FieldNote { value };
 
         self.storage.set.at(owner).insert(note).deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }
@@ -40,6 +40,6 @@ pub contract NoteGetter {
             comparator,
             value,
         ));
-        notes.map(|note| note.value())
+        notes.map(|note| note.value)
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -59,7 +59,7 @@ contract OffchainEffect {
 
     #[external("private")]
     fn emit_note_as_offchain_message(value: u128, owner: AztecAddress) {
-        let note = UintNote::new(value);
+        let note = UintNote { value };
 
         self.storage.balances.at(owner).insert(note).deliver(
             self.msg_sender().unwrap(),
@@ -76,6 +76,6 @@ contract OffchainEffect {
     unconstrained fn get_note_value(owner: AztecAddress) -> u128 {
         let notes = self.storage.balances.at(owner).view_notes(NoteViewerOptions::new());
         assert(notes.len() == 1, "No note found");
-        notes.get(0).get_value()
+        notes.get(0).value
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr
@@ -17,7 +17,7 @@ pub fn filter_notes_min_sum(
         if notes[i].is_some() & full_field_less_than(sum, min_sum) {
             let retrieved_note = notes[i].unwrap_unchecked();
             selected[i] = Option::some(retrieved_note);
-            sum += retrieved_note.note.value();
+            sum += retrieved_note.note.value;
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -43,7 +43,7 @@ pub contract PendingNoteHashes {
     ) -> Field {
         let owner_balance = self.storage.balances.at(owner);
 
-        let note = FieldNote::new(amount);
+        let note = FieldNote { value: amount };
 
         // Insert note
         owner_balance.insert(note).deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
@@ -53,10 +53,10 @@ pub contract PendingNoteHashes {
         let notes = owner_balance.pop_notes(options);
 
         let note0 = notes.get(0);
-        assert(note.value() == note0.value());
+        assert(note.value == note0.value);
         assert(notes.len() == 1);
 
-        note0.value()
+        note0.value
     }
 
     // Confirm cannot access note hashes inserted later in same function
@@ -71,7 +71,7 @@ pub contract PendingNoteHashes {
         assert(notes.len() == 0);
 
         // Insert note
-        let note = FieldNote::new(amount);
+        let note = FieldNote { value: amount };
         // Discard the message
         let _ = owner_balance.insert(note);
 
@@ -87,7 +87,7 @@ pub contract PendingNoteHashes {
     fn insert_note(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = self.storage.balances.at(owner);
 
-        let note = FieldNote::new(amount);
+        let note = FieldNote { value: amount };
 
         // Insert note
         owner_balance.insert(note).deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
@@ -114,7 +114,7 @@ pub contract PendingNoteHashes {
     fn insert_note_extra_emit(amount: Field, owner: AztecAddress, sender: AztecAddress) {
         let owner_balance = self.storage.balances.at(owner);
 
-        let note = FieldNote::new(amount);
+        let note = FieldNote { value: amount };
 
         // Insert note
         let message = owner_balance.insert(note);
@@ -134,7 +134,7 @@ pub contract PendingNoteHashes {
         options = options.set_limit(1);
         let note = owner_balance.pop_notes(options).get(0);
 
-        assert(expected_value == note.value());
+        assert(expected_value == note.value);
         expected_value
     }
 
@@ -328,7 +328,7 @@ pub contract PendingNoteHashes {
         let owner_balance = self.storage.balances.at(owner);
 
         for i in 0..self.internal.max_notes_per_call() {
-            let note = FieldNote::new(i as Field);
+            let note = FieldNote { value: i as Field };
             owner_balance.insert(note).deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
         }
     }

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -98,7 +98,7 @@ pub contract StateVars {
     #[external("private")]
     fn initialize_private_immutable(randomness: Field, value: Field) {
         let owner = self.msg_sender().unwrap();
-        let new_note = FieldNote::new(value);
+        let new_note = FieldNote { value };
 
         self.storage.private_immutable.at(owner).initialize(new_note).deliver(
             owner,
@@ -109,7 +109,7 @@ pub contract StateVars {
     #[external("private")]
     fn initialize_private(randomness: Field, value: Field) {
         let owner = self.msg_sender().unwrap();
-        let private_mutable = FieldNote::new(value);
+        let private_mutable = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(private_mutable).deliver(
             owner,
@@ -120,7 +120,7 @@ pub contract StateVars {
     #[external("private")]
     fn update_private_mutable(randomness: Field, value: Field) {
         let owner = self.msg_sender().unwrap();
-        self.storage.private_mutable.at(owner).replace(|_old_note| FieldNote::new(value)).deliver(
+        self.storage.private_mutable.at(owner).replace(|_old_note| FieldNote { value }).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -135,8 +135,8 @@ pub contract StateVars {
             .private_mutable
             .at(owner)
             .replace(|old_note| {
-                let new_value = old_note.value() + 1;
-                FieldNote::new(new_value)
+                let new_value = old_note.value + 1;
+                FieldNote { value: new_value }
             })
             .deliver(owner, MessageDelivery.CONSTRAINED_ONCHAIN);
     }

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -46,7 +46,7 @@ pub contract StatefulTest {
     #[external("private")]
     fn create_note(owner: AztecAddress, value: Field) {
         if (value != 0) {
-            let note = FieldNote::new(value);
+            let note = FieldNote { value };
             self.storage.notes.at(owner).insert(note).deliver(
                 owner,
                 MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -58,7 +58,7 @@ pub contract StatefulTest {
     #[noinitcheck]
     fn create_note_no_init_check(owner: AztecAddress, value: Field) {
         if (value != 0) {
-            let note = FieldNote::new(value);
+            let note = FieldNote { value };
             self.storage.notes.at(owner).insert(note).deliver(
                 owner,
                 MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -73,7 +73,7 @@ pub contract StatefulTest {
 
         let _ = self.storage.notes.at(sender).pop_notes(NoteGetterOptions::new().set_limit(2));
 
-        self.storage.notes.at(recipient).insert(FieldNote::new(92)).deliver(
+        self.storage.notes.at(recipient).insert(FieldNote { value: 92 }).deliver(
             recipient,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -86,7 +86,7 @@ pub contract StatefulTest {
 
         let _ = self.storage.notes.at(sender).pop_notes(NoteGetterOptions::new().set_limit(2));
 
-        self.storage.notes.at(recipient).insert(FieldNote::new(92)).deliver(
+        self.storage.notes.at(recipient).insert(FieldNote { value: 92 }).deliver(
             recipient,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -121,7 +121,7 @@ pub contract StatefulTest {
         let notes = set.view_notes(options.set_offset(offset));
         for i in 0..options.limit {
             if i < notes.len() {
-                balance += notes.get_unchecked(i).value();
+                balance += notes.get_unchecked(i).value;
             }
         }
 

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -45,7 +45,7 @@ pub contract StaticChild {
     #[external("private")]
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let note = FieldNote::new(new_value);
+        let note = FieldNote { value: new_value };
         self.storage.a_private_value.at(owner).insert(note).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -56,7 +56,7 @@ pub contract StaticChild {
     // Modify a note
     #[external("private")]
     fn private_set_value(new_value: Field, owner: AztecAddress, sender: AztecAddress) -> Field {
-        let note = FieldNote::new(new_value);
+        let note = FieldNote { value: new_value };
 
         self.storage.a_private_value.at(owner).insert(note).deliver(
             owner,
@@ -72,7 +72,7 @@ pub contract StaticChild {
         let mut options = NoteGetterOptions::new();
         options = options.select(FieldNote::properties().value, Comparator.EQ, amount).set_limit(1);
         let retrieved_notes = self.storage.a_private_value.at(owner).get_notes(options);
-        retrieved_notes.get(0).note.value()
+        retrieved_notes.get(0).note.value
     }
 
     // Increments `current_value` by `new_value`

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -139,7 +139,7 @@ pub contract Test {
         storage_slot: Field,
         make_tx_hybrid: bool,
     ) {
-        let note = UintNote::new(value);
+        let note = UintNote { value };
         create_note(self.context, owner, storage_slot, note).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -182,7 +182,7 @@ pub contract Test {
         let (retrieved_notes, _): (BoundedVec<RetrievedNote<UintNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<NoteHashRead, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) =
             get_notes(self.context, owner, storage_slot, options);
 
-        retrieved_notes.get(0).note.get_value()
+        retrieved_notes.get(0).note.value
     }
 
     #[external("private")]
@@ -199,7 +199,7 @@ pub contract Test {
         let (retrieved_notes, _): (BoundedVec<RetrievedNote<UintNote>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>, BoundedVec<NoteHashRead, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>) =
             get_notes(self.context, owner, storage_slot, options);
 
-        [retrieved_notes.get(0).note.get_value(), retrieved_notes.get(1).note.get_value()]
+        [retrieved_notes.get(0).note.value, retrieved_notes.get(1).note.value]
     }
 
     #[external("utility")]
@@ -216,7 +216,7 @@ pub contract Test {
         let notes: BoundedVec<UintNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner, storage_slot, options);
 
-        notes.get(0).get_value()
+        notes.get(0).value
     }
 
     #[external("utility")]
@@ -233,7 +233,7 @@ pub contract Test {
         let notes: BoundedVec<UintNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner, storage_slot, options);
 
-        [notes.get(0).get_value(), notes.get(1).get_value()]
+        [notes.get(0).value, notes.get(1).value]
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
@@ -12,7 +12,7 @@ use dep::aztec::{
 #[derive(Eq, Packable)]
 #[custom_note]
 pub struct TestNote {
-    value: Field,
+    pub value: Field,
 }
 
 impl NoteHash for TestNote {
@@ -47,15 +47,5 @@ impl NoteHash for TestNote {
         // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
         // implementation here.
         0
-    }
-}
-
-impl TestNote {
-    pub fn new(value: Field) -> Self {
-        TestNote { value }
-    }
-
-    pub fn get_value(self) -> Field {
-        self.value
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -25,7 +25,7 @@ contract Updatable {
     #[external("private")]
     fn initialize(initial_value: Field) {
         let owner = self.msg_sender().unwrap();
-        let note = FieldNote::new(initial_value);
+        let note = FieldNote { value: initial_value };
         self.storage.private_value.at(owner).initialize(note).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
@@ -58,7 +58,7 @@ contract Updatable {
 
     #[external("utility")]
     unconstrained fn get_private_value(owner: AztecAddress) -> Field {
-        self.storage.private_value.at(owner).view_note().value()
+        self.storage.private_value.at(owner).view_note().value
     }
 
     #[external("utility")]

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -29,7 +29,7 @@ contract Updated {
     fn set_private_value() {
         let owner = self.msg_sender().unwrap();
 
-        self.storage.private_value.at(owner).replace(|_old| FieldNote::new(27)).deliver(
+        self.storage.private_value.at(owner).replace(|_old| FieldNote { value: 27 }).deliver(
             owner,
             MessageDelivery.CONSTRAINED_ONCHAIN,
         );
@@ -43,7 +43,7 @@ contract Updated {
 
     #[external("utility")]
     unconstrained fn get_private_value(owner: AztecAddress) -> Field {
-        self.storage.private_value.at(owner).view_note().value()
+        self.storage.private_value.at(owner).view_note().value
     }
 
     #[external("utility")]


### PR DESCRIPTION
As discussed [here](https://aztecprotocol.slack.com/archives/C09CN078WQ5/p1765210502463579) the `new` method and the getters on notes are now a pointless boilerplate as now we don't populate randomness in the `new` method. In this PR I drop these.

Decided to go ahead and just do it because AI is able to one-shot changes like this which makes doing them almost free.

Now is also a good time to do this because there were some note-related changes done recently which will force devs to migrate anyway (e.g. `ValueNote` has been renamed as `FieldNote`, partial notes implementation has changed etc.).