### PR TITLE
chore: add BLAKE2s and BLAKE3 constraint tests in DSL

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
@@ -1,0 +1,68 @@
+#include "blake2s_constraint.hpp"
+#include "acir_format.hpp"
+#include "acir_format_mocks.hpp"
+
+#include "barretenberg/crypto/blake2s/blake2s.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace acir_format::tests {
+
+class Blake2sTests : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+TEST_F(Blake2sTests, TestBlake2sConstraint)
+{
+    // Input
+    std::vector<uint8_t> message(64);
+
+    // Expected native Blake2s hash output
+    std::array<uint8_t, 32> hash_output = bb::crypto::blake2s(message);
+
+    // Witness vector
+    WitnessVector witness;
+    witness.reserve(96);
+    for (auto msg : message) {
+        witness.emplace_back(bb::fr(static_cast<uint64_t>(msg)));
+    }
+    for (auto output : hash_output) {
+        witness.emplace_back(bb::fr(static_cast<uint64_t>(output)));
+    }
+
+    // Blake2s constraint
+    Blake2sConstraint constraint;
+
+    constraint.inputs.reserve(message.size());
+    for (size_t i = 0; i < message.size(); ++i) {
+        Blake2sInput input{
+            .blackbox_input = WitnessOrConstant<bb::fr>::from_index(static_cast<uint32_t>(i)),
+            .num_bits = 8,
+        };
+        constraint.inputs.push_back(input);
+    }
+
+    for (size_t i = 0; i < 32; ++i) {
+        constraint.result[i] = static_cast<uint32_t>(64 + i);
+    }
+
+    // ACIR format
+    AcirFormat constraint_system{
+        .max_witness_index = static_cast<uint32_t>(witness.size()) - 1,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .blake2s_constraints = { constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    AcirProgram program{ constraint_system, witness };
+    auto builder = create_circuit<bb::UltraCircuitBuilder>(program);
+    EXPECT_TRUE(CircuitChecker::check(builder));
+    EXPECT_FALSE(builder.failed());
+}
+
+} // namespace acir_format::tests

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
@@ -1,68 +1,107 @@
 #include "blake2s_constraint.hpp"
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
-
 #include "barretenberg/crypto/blake2s/blake2s.hpp"
-#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/dsl/acir_format/test_class.hpp"
+#include "barretenberg/dsl/acir_format/utils.hpp"
+#include "barretenberg/dsl/acir_format/witness_constant.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>
 
-namespace acir_format::tests {
+using namespace bb;
+using namespace acir_format;
 
-class Blake2sTests : public ::testing::Test {
-  protected:
-    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+template <class BuilderType> class Blake2sTestingFunctions {
+  public:
+    using Builder = BuilderType;
+    using AcirConstraint = Blake2sConstraint;
+
+    struct InvalidWitness {
+      public:
+        enum class Target : uint8_t {
+            None,
+            Input,  // Tamper with an input value
+            Output, // Tamper with an output value
+        };
+
+        static std::vector<Target> get_all() { return { Target::None, Target::Input, Target::Output }; }
+
+        static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
+    };
+
+    void invalidate_witness(Blake2sConstraint& constraint,
+                            WitnessVector& witness_values,
+                            const InvalidWitness::Target& invalid_witness_target)
+    {
+        switch (invalid_witness_target) {
+        case InvalidWitness::Target::Input: {
+            // Tamper with the first input element
+            witness_values[constraint.inputs[0].blackbox_input.index] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::Output: {
+            // Tamper with the first output element
+            witness_values[constraint.result[0]] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::None:
+            break;
+        }
+    }
+
+    /**
+     * @brief Generate a valid Blake2sConstraint with correct witness values
+     */
+    void generate_constraints(Blake2sConstraint& blake2s_constraint, WitnessVector& witness_values)
+    {
+        // Start with the zero variable at index 0
+        witness_values.emplace_back(bb::fr(0));
+
+        // Input: 64-byte message
+        std::vector<uint8_t> input_state(64);
+
+        // Expected Blake2s hash output
+        std::array<uint8_t, 32> output_state = crypto::blake2s(input_state);
+
+        // Add input and output state to witness
+        auto input_indices = add_to_witness_and_track_indices<std::vector<uint8_t>, 64>(witness_values, input_state);
+        auto output_indices =
+            add_to_witness_and_track_indices<std::array<uint8_t, 32>, 32>(witness_values, output_state);
+
+        // Create the constraint
+        blake2s_constraint.inputs.reserve(input_state.size());
+        for (size_t i = 0; i < input_state.size(); ++i) {
+            Blake2sInput input{
+                .blackbox_input = WitnessOrConstant<fr>::from_index(static_cast<uint32_t>(input_indices[i])),
+                .num_bits = 8,
+            };
+            blake2s_constraint.inputs.push_back(input);
+        }
+        for (size_t i = 0; i < 32; ++i) {
+            blake2s_constraint.result[i] = static_cast<uint32_t>(output_indices[i]);
+        }
+    }
 };
 
-TEST_F(Blake2sTests, TestBlake2sConstraint)
+template <class Builder>
+class Blake2sConstraintsTest : public ::testing::Test, public TestClass<Blake2sTestingFunctions<Builder>> {
+  protected:
+    static void SetUpTestSuite() { srs::init_file_crs_factory(srs::bb_crs_path()); }
+};
+
+using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
+
+TYPED_TEST_SUITE(Blake2sConstraintsTest, BuilderTypes);
+
+TYPED_TEST(Blake2sConstraintsTest, GenerateVKFromConstraints)
 {
-    // Input
-    std::vector<uint8_t> message(64);
-
-    // Expected native Blake2s hash output
-    std::array<uint8_t, 32> hash_output = bb::crypto::blake2s(message);
-
-    // Witness vector
-    WitnessVector witness;
-    witness.reserve(96);
-    for (auto msg : message) {
-        witness.emplace_back(bb::fr(static_cast<uint64_t>(msg)));
-    }
-    for (auto output : hash_output) {
-        witness.emplace_back(bb::fr(static_cast<uint64_t>(output)));
-    }
-
-    // Blake2s constraint
-    Blake2sConstraint constraint;
-
-    constraint.inputs.reserve(message.size());
-    for (size_t i = 0; i < message.size(); ++i) {
-        Blake2sInput input{
-            .blackbox_input = WitnessOrConstant<bb::fr>::from_index(static_cast<uint32_t>(i)),
-            .num_bits = 8,
-        };
-        constraint.inputs.push_back(input);
-    }
-
-    for (size_t i = 0; i < 32; ++i) {
-        constraint.result[i] = static_cast<uint32_t>(64 + i);
-    }
-
-    // ACIR format
-    AcirFormat constraint_system{
-        .max_witness_index = static_cast<uint32_t>(witness.size()) - 1,
-        .num_acir_opcodes = 1,
-        .public_inputs = {},
-        .blake2s_constraints = { constraint },
-        .original_opcode_indices = create_empty_original_opcode_indices(),
-    };
-    mock_opcode_indices(constraint_system);
-
-    AcirProgram program{ constraint_system, witness };
-    auto builder = create_circuit<bb::UltraCircuitBuilder>(program);
-    EXPECT_TRUE(CircuitChecker::check(builder));
-    EXPECT_FALSE(builder.failed());
+    using Flavor = std::conditional_t<std::is_same_v<TypeParam, UltraCircuitBuilder>, UltraFlavor, MegaFlavor>;
+    TestFixture::template test_vk_independence<Flavor>();
 }
 
-} // namespace acir_format::tests
+TYPED_TEST(Blake2sConstraintsTest, Tampering)
+{
+    BB_DISABLE_ASSERTS();
+    [[maybe_unused]] std::vector<std::string> _ = TestFixture::test_tampering();
+}

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
@@ -1,68 +1,106 @@
 #include "blake3_constraint.hpp"
 #include "acir_format.hpp"
 #include "acir_format_mocks.hpp"
-
 #include "barretenberg/crypto/blake3s/blake3s.hpp"
-#include "barretenberg/ultra_honk/ultra_prover.hpp"
+#include "barretenberg/dsl/acir_format/test_class.hpp"
+#include "barretenberg/dsl/acir_format/utils.hpp"
+#include "barretenberg/dsl/acir_format/witness_constant.hpp"
 
 #include <gtest/gtest.h>
 #include <vector>
 
-namespace acir_format::tests {
+using namespace bb;
+using namespace acir_format;
 
-class Blake3Tests : public ::testing::Test {
-  protected:
-    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+template <class BuilderType> class Blake3TestingFunctions {
+  public:
+    using Builder = BuilderType;
+    using AcirConstraint = Blake3Constraint;
+
+    struct InvalidWitness {
+      public:
+        enum class Target : uint8_t {
+            None,
+            Input,  // Tamper with an input value
+            Output, // Tamper with an output value
+        };
+
+        static std::vector<Target> get_all() { return { Target::None, Target::Input, Target::Output }; }
+
+        static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
+    };
+
+    void invalidate_witness(Blake3Constraint& constraint,
+                            WitnessVector& witness_values,
+                            const InvalidWitness::Target& invalid_witness_target)
+    {
+        switch (invalid_witness_target) {
+        case InvalidWitness::Target::Input: {
+            // Tamper with the first input element
+            witness_values[constraint.inputs[0].blackbox_input.index] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::Output: {
+            // Tamper with the first output element
+            witness_values[constraint.result[0]] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::None:
+            break;
+        }
+    }
+
+    /**
+     * @brief Generate a valid Blake3Constraint with correct witness values
+     */
+    void generate_constraints(Blake3Constraint& blake3_constraint, WitnessVector& witness_values)
+    {
+        // Start with the zero variable at index 0
+        witness_values.emplace_back(bb::fr(0));
+
+        // Input: 64-byte message
+        std::vector<uint8_t> input_state(64);
+
+        // Expected Blake3s hash output
+        std::vector<uint8_t> output_state = blake3::blake3s(input_state);
+
+        // Add input and output state to witness
+        auto input_indices = add_to_witness_and_track_indices<std::vector<uint8_t>, 64>(witness_values, input_state);
+        auto output_indices = add_to_witness_and_track_indices<std::vector<uint8_t>, 32>(witness_values, output_state);
+
+        // Create the constraint
+        blake3_constraint.inputs.reserve(input_state.size());
+        for (size_t i = 0; i < input_state.size(); ++i) {
+            Blake3Input input{
+                .blackbox_input = WitnessOrConstant<fr>::from_index(static_cast<uint32_t>(input_indices[i])),
+                .num_bits = 8,
+            };
+            blake3_constraint.inputs.push_back(input);
+        }
+        for (size_t i = 0; i < 32; ++i) {
+            blake3_constraint.result[i] = static_cast<uint32_t>(output_indices[i]);
+        }
+    }
 };
 
-TEST_F(Blake3Tests, TestBlake3Constraint)
+template <class Builder>
+class Blake3ConstraintsTest : public ::testing::Test, public TestClass<Blake3TestingFunctions<Builder>> {
+  protected:
+    static void SetUpTestSuite() { srs::init_file_crs_factory(srs::bb_crs_path()); }
+};
+
+using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
+
+TYPED_TEST_SUITE(Blake3ConstraintsTest, BuilderTypes);
+
+TYPED_TEST(Blake3ConstraintsTest, GenerateVKFromConstraints)
 {
-    // Input
-    std::vector<uint8_t> message(64);
-
-    // Expected native Blake3 hash output
-    std::vector<uint8_t> hash_output = blake3::blake3s(message);
-
-    // Witness vector
-    WitnessVector witness;
-    witness.reserve(96);
-    for (auto msg : message) {
-        witness.emplace_back(bb::fr(static_cast<uint64_t>(msg)));
-    }
-    for (auto output : hash_output) {
-        witness.emplace_back(bb::fr(static_cast<uint64_t>(output)));
-    }
-
-    // Blake3 constraint
-    Blake3Constraint constraint;
-
-    constraint.inputs.reserve(message.size());
-    for (size_t i = 0; i < message.size(); ++i) {
-        Blake3Input input{
-            .blackbox_input = WitnessOrConstant<bb::fr>::from_index(static_cast<uint32_t>(i)),
-            .num_bits = 8,
-        };
-        constraint.inputs.push_back(input);
-    }
-
-    for (size_t i = 0; i < 32; ++i) {
-        constraint.result[i] = static_cast<uint32_t>(64 + i);
-    }
-
-    // ACIR format
-    AcirFormat constraint_system{
-        .max_witness_index = static_cast<uint32_t>(witness.size()) - 1,
-        .num_acir_opcodes = 1,
-        .public_inputs = {},
-        .blake3_constraints = { constraint },
-        .original_opcode_indices = create_empty_original_opcode_indices(),
-    };
-    mock_opcode_indices(constraint_system);
-
-    AcirProgram program{ constraint_system, witness };
-    auto builder = create_circuit<bb::UltraCircuitBuilder>(program);
-    EXPECT_TRUE(CircuitChecker::check(builder));
-    EXPECT_FALSE(builder.failed());
+    using Flavor = std::conditional_t<std::is_same_v<TypeParam, UltraCircuitBuilder>, UltraFlavor, MegaFlavor>;
+    TestFixture::template test_vk_independence<Flavor>();
 }
 
-} // namespace acir_format::tests
+TYPED_TEST(Blake3ConstraintsTest, Tampering)
+{
+    BB_DISABLE_ASSERTS();
+    [[maybe_unused]] std::vector<std::string> _ = TestFixture::test_tampering();
+}

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
@@ -1,0 +1,68 @@
+#include "blake3_constraint.hpp"
+#include "acir_format.hpp"
+#include "acir_format_mocks.hpp"
+
+#include "barretenberg/crypto/blake3s/blake3s.hpp"
+#include "barretenberg/ultra_honk/ultra_prover.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace acir_format::tests {
+
+class Blake3Tests : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+TEST_F(Blake3Tests, TestBlake3Constraint)
+{
+    // Input
+    std::vector<uint8_t> message(64);
+
+    // Expected native Blake3 hash output
+    std::vector<uint8_t> hash_output = blake3::blake3s(message);
+
+    // Witness vector
+    WitnessVector witness;
+    witness.reserve(96);
+    for (auto msg : message) {
+        witness.emplace_back(bb::fr(static_cast<uint64_t>(msg)));
+    }
+    for (auto output : hash_output) {
+        witness.emplace_back(bb::fr(static_cast<uint64_t>(output)));
+    }
+
+    // Blake3 constraint
+    Blake3Constraint constraint;
+
+    constraint.inputs.reserve(message.size());
+    for (size_t i = 0; i < message.size(); ++i) {
+        Blake3Input input{
+            .blackbox_input = WitnessOrConstant<bb::fr>::from_index(static_cast<uint32_t>(i)),
+            .num_bits = 8,
+        };
+        constraint.inputs.push_back(input);
+    }
+
+    for (size_t i = 0; i < 32; ++i) {
+        constraint.result[i] = static_cast<uint32_t>(64 + i);
+    }
+
+    // ACIR format
+    AcirFormat constraint_system{
+        .max_witness_index = static_cast<uint32_t>(witness.size()) - 1,
+        .num_acir_opcodes = 1,
+        .public_inputs = {},
+        .blake3_constraints = { constraint },
+        .original_opcode_indices = create_empty_original_opcode_indices(),
+    };
+    mock_opcode_indices(constraint_system);
+
+    AcirProgram program{ constraint_system, witness };
+    auto builder = create_circuit<bb::UltraCircuitBuilder>(program);
+    EXPECT_TRUE(CircuitChecker::check(builder));
+    EXPECT_FALSE(builder.failed());
+}
+
+} // namespace acir_format::tests


### PR DESCRIPTION
Add the missing `blake2s_constraint.test.cpp` and `blake3_constraint.test.cpp` following the format of `poseidon2_constraint.test.cpp` in ```barretenberg/dsl/acir_format```.