### PR TITLE
fix: make pxe check tx hash on note storage

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -538,10 +538,7 @@ describe('PXEOracleInterface', () => {
        ** - Node knows tx effect
        ** - Node knows siloed event commitment
        */
-      const header = BlockHeader.empty({
-        globalVariables: GlobalVariables.empty({ blockNumber }),
-      });
-      await syncDataProvider.setHeader(header);
+      await setSyncedBlockNumber(blockNumber);
 
       aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
 
@@ -615,9 +612,6 @@ describe('PXEOracleInterface', () => {
   });
 
   describe('deliverNote', () => {
-    let noteHash: Fr;
-    let nullifier: Fr;
-    let txHash: TxHash;
     // Recipient is different from the owner because recipient refers to the
     // recipient of the message containing the note, while owner refers to the
     // owner of the note.
@@ -627,6 +621,20 @@ describe('PXEOracleInterface', () => {
     let noteNonce: Fr;
     let content: Fr[];
 
+    let noteHash: Fr;
+    let uniqueNoteHash: Fr;
+    let nullifier: Fr;
+    let siloedNullifier: Fr;
+
+    let txHash: TxHash;
+    let txEffect: TxEffect;
+    let indexedTxEffect: IndexedTxEffect;
+    let blockNumber: BlockNumber;
+
+    let nullified = false;
+
+    // beforeEach sets up the happy path case, so error modes are tested
+    // by minimally failing happy path conditions
     beforeEach(async () => {
       noteHash = Fr.random();
       nullifier = Fr.random();
@@ -636,18 +644,67 @@ describe('PXEOracleInterface', () => {
       randomness = Fr.random();
       noteNonce = Fr.random();
       content = [Fr.random(), Fr.random()];
+
+      uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
+      siloedNullifier = await siloNullifier(contractAddress, nullifier);
+
+      blockNumber = BlockNumber(42);
+
+      txEffect = TxEffect.from({
+        ...(await TxEffect.random()),
+        noteHashes: [uniqueNoteHash],
+      });
+
+      indexedTxEffect = {
+        l2BlockNumber: blockNumber,
+        l2BlockHash: L2BlockHash.random(),
+        data: txEffect,
+        txIndexInBlock: 0,
+      };
+
+      /* Happy path context conditions:
+       ** - PXE is sync'd to _at least_ block including tx
+       ** - Node knows tx effect
+       ** - Node knows unique note hash (and siloed nullifier if requested)
+       */
+      await setSyncedBlockNumber(blockNumber);
+
+      aztecNode.getTxEffect.mockImplementation(queryTxHash =>
+        Promise.resolve(queryTxHash == txHash ? indexedTxEffect : undefined),
+      );
+
+      aztecNode.findLeavesIndexes.mockImplementation((queryBlockNum, treeId, leaves) => {
+        if (queryBlockNum != blockNumber) {
+          throw new Error(`Got a tree query for block ${queryBlockNum} but synced block is ${blockNumber}`);
+        }
+
+        if (treeId == MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
+          return Promise.resolve([
+            {
+              data: BigInt(0),
+              l2BlockNumber: indexedTxEffect.l2BlockNumber,
+              l2BlockHash: indexedTxEffect.l2BlockHash,
+            },
+          ]);
+        } else if (treeId == MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
+          // Note that returning undefined (i.e. the un-nullified case) covers both scenarios where the note has not
+          // been nullified and where the nullifier is in a block past the synced block.
+          return Promise.resolve([
+            nullified
+              ? {
+                  data: BigInt(0),
+                  l2BlockNumber: indexedTxEffect.l2BlockNumber,
+                  l2BlockHash: indexedTxEffect.l2BlockHash,
+                }
+              : undefined,
+          ]);
+        } else {
+          throw new Error();
+        }
+      });
     });
 
     it('should store note if it exists in note hash tree and is not nullified', async () => {
-      const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-      // Mock note exists in tree
-      aztecNode.findLeavesIndexes.mockImplementation((_blockNum, treeId, leaves) => {
-        if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomDataInBlock(0n)]);
-        }
-        return Promise.resolve([undefined]);
-      });
-
       await pxeOracleInterface.deliverNote(
         contractAddress,
         owner,
@@ -668,9 +725,42 @@ describe('PXEOracleInterface', () => {
       expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
 
-    it('should throw if note does not exist in note hash tree', async () => {
-      // Mock note does not exist in tree
-      aztecNode.findLeavesIndexes.mockImplementation(() => Promise.resolve([undefined]));
+    it('should throw if tx hash does not exist', async () => {
+      await expect(
+        pxeOracleInterface.deliverNote(
+          contractAddress,
+          owner,
+          storageSlot,
+          randomness,
+          noteNonce,
+          content,
+          noteHash,
+          nullifier,
+          TxHash.random(),
+          recipient.address,
+        ),
+      ).rejects.toThrow(/Could not find tx effect/);
+    });
+
+    it('should throw if note was not emitted in the tx', async () => {
+      await expect(
+        pxeOracleInterface.deliverNote(
+          contractAddress,
+          owner,
+          storageSlot,
+          randomness,
+          noteNonce,
+          content,
+          Fr.random(), // note hash
+          nullifier,
+          txHash,
+          recipient.address,
+        ),
+      ).rejects.toThrow(/is not present in tx/);
+    });
+
+    it('should throw if tx was mined after synced block number', async () => {
+      await setSyncedBlockNumber(BlockNumber(blockNumber - 1));
 
       await expect(
         pxeOracleInterface.deliverNote(
@@ -685,23 +775,11 @@ describe('PXEOracleInterface', () => {
           txHash,
           recipient.address,
         ),
-      ).rejects.toThrow(/not present on the tree/);
+      ).rejects.toThrow(/as of block number/);
     });
 
     it('should store and immediately remove note if it is already nullified', async () => {
-      const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-      const siloedNullifier = await siloNullifier(contractAddress, nullifier);
-
-      // Mock note exists and is nullified
-      aztecNode.findLeavesIndexes.mockImplementation((_blockNum, treeId, leaves) => {
-        if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomDataInBlock(0n)]);
-        }
-        if (treeId === MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
-          return Promise.resolve([randomDataInBlock(0n)]);
-        }
-        return Promise.resolve([undefined]);
-      });
+      nullified = true;
 
       await pxeOracleInterface.deliverNote(
         contractAddress,
@@ -719,85 +797,6 @@ describe('PXEOracleInterface', () => {
       // Verify note was removed
       const notes = await noteDataProvider.getNotes({ contractAddress, scopes: [recipient.address] });
       expect(notes).toHaveLength(0);
-    });
-
-    // Verifies that notes are only accepted from blocks that have been synced by PXE. We mock
-    // `AztecNode.findLeavesIndexes` to only return the note hash in blocks beyond our current
-    // sync point, and then we check that the function correctly throws.
-    it('should reject notes that exist only in unsynced future blocks', async () => {
-      const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-      const syncedBlockNumber = 100;
-      await setSyncedBlockNumber(BlockNumber(syncedBlockNumber));
-
-      // Mock note only exists in blocks after synced block
-      aztecNode.findLeavesIndexes.mockImplementation((blockNum, treeId, leaves) => {
-        if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          if (typeof blockNum === 'number' && blockNum > syncedBlockNumber) {
-            return Promise.resolve([randomDataInBlock(0n)]);
-          }
-        }
-        return Promise.resolve([undefined]);
-      });
-
-      await expect(
-        pxeOracleInterface.deliverNote(
-          contractAddress,
-          owner,
-          storageSlot,
-          randomness,
-          noteNonce,
-          content,
-          noteHash,
-          nullifier,
-          txHash,
-          recipient.address,
-        ),
-      ).rejects.toThrow(/not present on the tree/);
-    });
-
-    // Verifies that notes are not marked as nullified when their nullifier only exists in blocks that haven't been
-    // synced yet. We mock the note to exist in a synced block but its nullifier to only exist in future blocks, then
-    // verify the note can still be obtained as active.
-    it('should not remove note if nullifier only exists in unsynced blocks', async () => {
-      const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-      const siloedNullifier = await siloNullifier(contractAddress, nullifier);
-      const syncedBlockNumber = 100;
-      await setSyncedBlockNumber(BlockNumber(syncedBlockNumber));
-
-      // Mock note exists in synced blocks but nullifier only exists after
-      aztecNode.findLeavesIndexes.mockImplementation((blockNum, treeId, leaves) => {
-        if (treeId === MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([randomDataInBlock(0n)]);
-        }
-        if (treeId === MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
-          if (typeof blockNum === 'number' && blockNum > syncedBlockNumber) {
-            return Promise.resolve([randomDataInBlock(0n)]);
-          }
-        }
-        return Promise.resolve([undefined]);
-      });
-
-      await pxeOracleInterface.deliverNote(
-        contractAddress,
-        owner,
-        storageSlot,
-        randomness,
-        noteNonce,
-        content,
-        noteHash,
-        nullifier,
-        txHash,
-        recipient.address,
-      );
-
-      // Verify note was stored and not removed
-      const notes = await noteDataProvider.getNotes({
-        contractAddress,
-        status: NoteStatus.ACTIVE,
-        scopes: [recipient.address],
-      });
-      expect(notes).toHaveLength(1);
-      expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -680,6 +680,20 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
     const siloedNullifier = await siloNullifier(contractAddress, nullifier);
 
+    const txEffect = await this.aztecNode.getTxEffect(txHash);
+    if (!txEffect) {
+      throw new Error(`Could not find tx effect for tx hash ${txHash}`);
+    }
+
+    if (txEffect.l2BlockNumber > syncedBlockNumber) {
+      throw new Error(`Could not find tx effect for tx hash ${txHash} as of block number ${syncedBlockNumber}`);
+    }
+
+    const noteInTx = txEffect.data.noteHashes.some(nh => nh.equals(uniqueNoteHash));
+    if (!noteInTx) {
+      throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
+    }
+
     // We store notes by their index in the global note hash tree, which has the convenient side effect of validating
     // note existence in said tree. We concurrently also check if the note's nullifier exists, performing all node
     // queries in a single round-trip.
@@ -814,7 +828,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       throw new Error(`Could not find tx effect for tx hash ${txHash} as of block number ${syncedBlockNumber}`);
     }
 
-    const eventInTx = txEffect.data.nullifiers.some(nullifier => nullifier.equals(siloedEventCommitment));
+    const eventInTx = txEffect.data.nullifiers.some(n => n.equals(siloedEventCommitment));
     if (!eventInTx) {
       throw new Error(
         `Event commitment ${eventCommitment} (siloed as ${siloedEventCommitment}) is not present in tx ${txHash}`,


### PR DESCRIPTION
Part of a broader set of changes re. to note and event storage. I changed note storage so that it checks that the note hash exists in the effects of the tx that we queried for, and adjusted tests accordingly (mirroring the work done in the `deliverEvent` tests by @mverzilli). I did not remove the rest of the behavior during validation, e.g. checking tree leaves, as that will be done in follow up PRs as part of e.g. F-218.