### PR TITLE
chore(avm): remove unused constant from GenericPermutationSettingIndices enum

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/generic_permutation/generic_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/generic_permutation/generic_permutation_relation.hpp
@@ -26,8 +26,7 @@ namespace bb {
  *
  */
 enum GenericPermutationSettingIndices {
-    INVERSE_POLYNOMIAL_INDEX,                          /* The index of the inverse polynomial*/
-    ENABLE_INVERSE_CORRECTNESS_CHECK_POLYNOMIAL_INDEX, /* The index of the polynomial enabling first subrelation*/
+    INVERSE_POLYNOMIAL_INDEX,                       /* The index of the inverse polynomial*/
     FIRST_PERMUTATION_SET_ENABLE_POLYNOMIAL_INDEX,  /* The index of the polynomial that adds an element from the first
                                                        set to the sum*/
     SECOND_PERMUTATION_SET_ENABLE_POLYNOMIAL_INDEX, /* The index of the polynomial that adds an element from the second

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/interactions_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/interactions_base.hpp
@@ -105,13 +105,11 @@ template <typename Settings_> struct permutation_settings : public Settings_ {
         return []<size_t... ISource, size_t... IDest>(
                    AllEntities&& in, std::index_sequence<ISource...>, std::index_sequence<IDest...>) {
             // 0.                       The polynomial containing the inverse products -> taken from the attributes
-            // 1.                       The polynomial enabling the relation (the selector)
-            // 2.                       lhs selector
-            // 3.                       rhs selector
-            // 4.. + columns per set.   lhs cols
-            // 4 + columns per set      rhs cols
+            // 1.                       lhs selector
+            // 2.                       rhs selector
+            // 3.. + columns per set.   lhs cols
+            // 3 + columns per set      rhs cols
             return flat_tuple::forward_as_tuple(in.get(static_cast<ColumnAndShifts>(Settings_::INVERSES)),
-                                                in.get(static_cast<ColumnAndShifts>(Settings_::SRC_SELECTOR)),
                                                 in.get(static_cast<ColumnAndShifts>(Settings_::SRC_SELECTOR)),
                                                 in.get(static_cast<ColumnAndShifts>(Settings_::DST_SELECTOR)),
                                                 in.get(Settings_::SRC_COLUMNS[ISource])...,


### PR DESCRIPTION
Linear issue: [AVM-133](https://linear.app/aztec-labs/issue/AVM-133/check-permutation-selectors-usage)