### PR TITLE
feat(bb.js): add field transformation helpers

### DIFF
--- a/barretenberg/docs/examples/basic.test.ts
+++ b/barretenberg/docs/examples/basic.test.ts
@@ -120,8 +120,14 @@ describe('Basic Barretenberg Example', () => {
 
     try {
       // docs:start:verification_keys
-      // Get verification key for recursive verification (default)
+      // Get verification key as bytes (for passing to verifier)
       const vk = await backend.getVerificationKey();
+
+      // Get VK as hex field strings (for recursive verification circuits)
+      const vkFields = await backend.getVerificationKeyAsFields({ verifierTarget: 'noir-recursive' });
+
+      // Get VK hash (for verifying VK matches expected in recursive circuit)
+      const vkHash = await backend.getVerificationKeyHash({ verifierTarget: 'noir-recursive' });
 
       // For a solidity verifier (EVM target):
       const vkEvm = await backend.getVerificationKey({ verifierTarget: 'evm-no-zk' });
@@ -132,6 +138,13 @@ describe('Basic Barretenberg Example', () => {
       expect(vk.length).toBeGreaterThan(0);
       expect(vkEvm).toBeInstanceOf(Uint8Array);
       expect(vkEvm.length).toBeGreaterThan(0);
+
+      // Test VK fields and hash
+      expect(vkFields).to.be.an('array');
+      expect(vkFields.length).to.be.greaterThan(0);
+      expect(vkFields[0]).to.match(/^0x[0-9a-f]+$/i);
+      expect(vkHash).to.be.a('string');
+      expect(vkHash).to.match(/^0x[0-9a-f]+$/i);
 
     } finally {
       // Always clean up

--- a/barretenberg/docs/examples/basic.test.ts
+++ b/barretenberg/docs/examples/basic.test.ts
@@ -1,7 +1,7 @@
 // docs:start:imports
 import { UltraHonkBackend } from '@aztec/bb.js';
 // docs:end:imports
-import { Barretenberg, Fr, ProofData } from '@aztec/bb.js';
+import { Barretenberg, Fr, ProofData, VerifierTarget } from '@aztec/bb.js';
 import { readFileSync } from 'fs';
 import { gunzipSync } from 'zlib';
 import { expect, describe, it } from '@jest/globals';
@@ -120,7 +120,7 @@ describe('Basic Barretenberg Example', () => {
 
     try {
       // docs:start:verification_keys
-      // Get verification key as bytes (for passing to verifier)
+      // Get verification key for recursive verification (default)
       const vk = await backend.getVerificationKey();
 
       // For a solidity verifier (EVM target):

--- a/barretenberg/docs/examples/basic.test.ts
+++ b/barretenberg/docs/examples/basic.test.ts
@@ -1,7 +1,7 @@
 // docs:start:imports
 import { UltraHonkBackend } from '@aztec/bb.js';
 // docs:end:imports
-import { Barretenberg, Fr, ProofData, VerifierTarget } from '@aztec/bb.js';
+import { Barretenberg, Fr, ProofData } from '@aztec/bb.js';
 import { readFileSync } from 'fs';
 import { gunzipSync } from 'zlib';
 import { expect, describe, it } from '@jest/globals';
@@ -123,12 +123,6 @@ describe('Basic Barretenberg Example', () => {
       // Get verification key as bytes (for passing to verifier)
       const vk = await backend.getVerificationKey();
 
-      // Get VK as hex field strings (for recursive verification circuits)
-      const vkFields = await backend.getVerificationKeyAsFields({ verifierTarget: 'noir-recursive' });
-
-      // Get VK hash (for verifying VK matches expected in recursive circuit)
-      const vkHash = await backend.getVerificationKeyHash({ verifierTarget: 'noir-recursive' });
-
       // For a solidity verifier (EVM target):
       const vkEvm = await backend.getVerificationKey({ verifierTarget: 'evm-no-zk' });
       // docs:end:verification_keys
@@ -138,13 +132,6 @@ describe('Basic Barretenberg Example', () => {
       expect(vk.length).toBeGreaterThan(0);
       expect(vkEvm).toBeInstanceOf(Uint8Array);
       expect(vkEvm.length).toBeGreaterThan(0);
-
-      // Test VK fields and hash
-      expect(vkFields).to.be.an('array');
-      expect(vkFields.length).to.be.greaterThan(0);
-      expect(vkFields[0]).to.match(/^0x[0-9a-f]+$/i);
-      expect(vkHash).to.be.a('string');
-      expect(vkHash).to.match(/^0x[0-9a-f]+$/i);
 
     } finally {
       // Always clean up

--- a/barretenberg/ts/src/barretenberg/backend.test.ts
+++ b/barretenberg/ts/src/barretenberg/backend.test.ts
@@ -1,0 +1,92 @@
+import { fieldToDecimalString, fieldsToDecimalStrings } from './backend.js';
+
+describe('field helper functions', () => {
+  describe('fieldToDecimalString', () => {
+    it('converts zero field to "0"', () => {
+      const zeroField = new Uint8Array(32).fill(0);
+      expect(fieldToDecimalString(zeroField)).toBe('0');
+    });
+
+    it('converts field with value 1 to "1"', () => {
+      const oneField = new Uint8Array(32).fill(0);
+      oneField[31] = 1;
+      expect(fieldToDecimalString(oneField)).toBe('1');
+    });
+
+    it('converts field with value 256 to "256"', () => {
+      const field = new Uint8Array(32).fill(0);
+      field[30] = 1;
+      field[31] = 0;
+      expect(fieldToDecimalString(field)).toBe('256');
+    });
+
+    it('converts field with max uint8 in last byte to "255"', () => {
+      const field = new Uint8Array(32).fill(0);
+      field[31] = 255;
+      expect(fieldToDecimalString(field)).toBe('255');
+    });
+
+    it('converts larger values correctly', () => {
+      // 0x0100 = 256 in decimal
+      const field = new Uint8Array(32).fill(0);
+      field[30] = 0x01;
+      field[31] = 0x00;
+      expect(fieldToDecimalString(field)).toBe('256');
+    });
+
+    it('handles multi-byte values', () => {
+      // 0x010203 = 66051 in decimal
+      const field = new Uint8Array(32).fill(0);
+      field[29] = 0x01;
+      field[30] = 0x02;
+      field[31] = 0x03;
+      expect(fieldToDecimalString(field)).toBe('66051');
+    });
+
+    it('handles large field values', () => {
+      // A known value: all bytes set to 1
+      // This is 2^248 - 1 + 2^240 - 1 + ... (geometric series)
+      const field = new Uint8Array(32).fill(1);
+      const result = fieldToDecimalString(field);
+      // Verify it's a valid decimal string
+      expect(result).toMatch(/^\d+$/);
+      // Verify the length is reasonable for a 256-bit number
+      expect(result.length).toBeGreaterThan(70);
+    });
+  });
+
+  describe('fieldsToDecimalStrings', () => {
+    it('converts empty array to empty array', () => {
+      expect(fieldsToDecimalStrings([])).toEqual([]);
+    });
+
+    it('converts single field', () => {
+      const oneField = new Uint8Array(32).fill(0);
+      oneField[31] = 42;
+      expect(fieldsToDecimalStrings([oneField])).toEqual(['42']);
+    });
+
+    it('converts multiple fields', () => {
+      const field1 = new Uint8Array(32).fill(0);
+      field1[31] = 1;
+
+      const field2 = new Uint8Array(32).fill(0);
+      field2[31] = 2;
+
+      const field3 = new Uint8Array(32).fill(0);
+      field3[31] = 3;
+
+      expect(fieldsToDecimalStrings([field1, field2, field3])).toEqual(['1', '2', '3']);
+    });
+
+    it('preserves order of fields', () => {
+      const fields = [10, 20, 30, 40, 50].map(v => {
+        const field = new Uint8Array(32).fill(0);
+        field[31] = v;
+        return field;
+      });
+
+      expect(fieldsToDecimalStrings(fields)).toEqual(['10', '20', '30', '40', '50']);
+    });
+  });
+});

--- a/barretenberg/ts/src/barretenberg/backend.test.ts
+++ b/barretenberg/ts/src/barretenberg/backend.test.ts
@@ -1,29 +1,29 @@
-import { fieldToDecimalString, fieldsToDecimalStrings } from './backend.js';
+import { fieldToString, fieldsToStrings } from './backend.js';
 
 describe('field helper functions', () => {
-  describe('fieldToDecimalString', () => {
+  describe('fieldToString', () => {
     it('converts zero field to "0"', () => {
       const zeroField = new Uint8Array(32).fill(0);
-      expect(fieldToDecimalString(zeroField)).toBe('0');
+      expect(fieldToString(zeroField)).toBe('0');
     });
 
     it('converts field with value 1 to "1"', () => {
       const oneField = new Uint8Array(32).fill(0);
       oneField[31] = 1;
-      expect(fieldToDecimalString(oneField)).toBe('1');
+      expect(fieldToString(oneField)).toBe('1');
     });
 
     it('converts field with value 256 to "256"', () => {
       const field = new Uint8Array(32).fill(0);
       field[30] = 1;
       field[31] = 0;
-      expect(fieldToDecimalString(field)).toBe('256');
+      expect(fieldToString(field)).toBe('256');
     });
 
     it('converts field with max uint8 in last byte to "255"', () => {
       const field = new Uint8Array(32).fill(0);
       field[31] = 255;
-      expect(fieldToDecimalString(field)).toBe('255');
+      expect(fieldToString(field)).toBe('255');
     });
 
     it('converts larger values correctly', () => {
@@ -31,7 +31,7 @@ describe('field helper functions', () => {
       const field = new Uint8Array(32).fill(0);
       field[30] = 0x01;
       field[31] = 0x00;
-      expect(fieldToDecimalString(field)).toBe('256');
+      expect(fieldToString(field)).toBe('256');
     });
 
     it('handles multi-byte values', () => {
@@ -40,30 +40,50 @@ describe('field helper functions', () => {
       field[29] = 0x01;
       field[30] = 0x02;
       field[31] = 0x03;
-      expect(fieldToDecimalString(field)).toBe('66051');
+      expect(fieldToString(field)).toBe('66051');
     });
 
     it('handles large field values', () => {
       // A known value: all bytes set to 1
-      // This is 2^248 - 1 + 2^240 - 1 + ... (geometric series)
       const field = new Uint8Array(32).fill(1);
-      const result = fieldToDecimalString(field);
+      const result = fieldToString(field);
       // Verify it's a valid decimal string
       expect(result).toMatch(/^\d+$/);
       // Verify the length is reasonable for a 256-bit number
       expect(result.length).toBeGreaterThan(70);
     });
+
+    it('converts to hex with radix 16', () => {
+      const field = new Uint8Array(32).fill(0);
+      field[31] = 255;
+      expect(fieldToString(field, 16)).toBe('ff');
+    });
+
+    it('converts to hex for multi-byte values', () => {
+      // 0x010203
+      const field = new Uint8Array(32).fill(0);
+      field[29] = 0x01;
+      field[30] = 0x02;
+      field[31] = 0x03;
+      expect(fieldToString(field, 16)).toBe('10203');
+    });
+
+    it('converts to binary with radix 2', () => {
+      const field = new Uint8Array(32).fill(0);
+      field[31] = 5;
+      expect(fieldToString(field, 2)).toBe('101');
+    });
   });
 
-  describe('fieldsToDecimalStrings', () => {
+  describe('fieldsToStrings', () => {
     it('converts empty array to empty array', () => {
-      expect(fieldsToDecimalStrings([])).toEqual([]);
+      expect(fieldsToStrings([])).toEqual([]);
     });
 
     it('converts single field', () => {
       const oneField = new Uint8Array(32).fill(0);
       oneField[31] = 42;
-      expect(fieldsToDecimalStrings([oneField])).toEqual(['42']);
+      expect(fieldsToStrings([oneField])).toEqual(['42']);
     });
 
     it('converts multiple fields', () => {
@@ -76,7 +96,7 @@ describe('field helper functions', () => {
       const field3 = new Uint8Array(32).fill(0);
       field3[31] = 3;
 
-      expect(fieldsToDecimalStrings([field1, field2, field3])).toEqual(['1', '2', '3']);
+      expect(fieldsToStrings([field1, field2, field3])).toEqual(['1', '2', '3']);
     });
 
     it('preserves order of fields', () => {
@@ -86,7 +106,17 @@ describe('field helper functions', () => {
         return field;
       });
 
-      expect(fieldsToDecimalStrings(fields)).toEqual(['10', '20', '30', '40', '50']);
+      expect(fieldsToStrings(fields)).toEqual(['10', '20', '30', '40', '50']);
+    });
+
+    it('converts to hex with radix 16', () => {
+      const fields = [15, 16, 255].map(v => {
+        const field = new Uint8Array(32).fill(0);
+        field[31] = v;
+        return field;
+      });
+
+      expect(fieldsToStrings(fields, 16)).toEqual(['f', '10', 'ff']);
     });
   });
 });

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -213,7 +213,13 @@ export class UltraHonkBackend {
     return verified;
   }
 
-  async getVerificationKey(options?: UltraHonkBackendOptions): Promise<Uint8Array> {
+  /**
+   * Get the verification key and its hash.
+   * @internal
+   */
+  private async getVerificationKeyData(
+    options?: UltraHonkBackendOptions,
+  ): Promise<{ bytes: Uint8Array; hash: Uint8Array }> {
     const vkResult = await this.api.circuitComputeVk({
       circuit: {
         name: 'circuit',
@@ -221,7 +227,48 @@ export class UltraHonkBackend {
       },
       settings: getProofSettingsFromOptions(options),
     });
-    return vkResult.bytes;
+    return { bytes: vkResult.bytes, hash: vkResult.hash };
+  }
+
+  /**
+   * Get the verification key as raw bytes.
+   */
+  async getVerificationKey(options?: UltraHonkBackendOptions): Promise<Uint8Array> {
+    const { bytes } = await this.getVerificationKeyData(options);
+    return bytes;
+  }
+
+  /**
+   * Get the verification key as an array of hex field strings.
+   * Useful for recursive verification where VK needs to be passed as circuit inputs.
+   *
+   * @example
+   * const vkFields = await backend.getVerificationKeyAsFields({ verifierTarget: 'noir-recursive' });
+   * // vkFields is string[] like ["0x1234...", "0x5678...", ...]
+   */
+  async getVerificationKeyAsFields(options?: UltraHonkBackendOptions): Promise<string[]> {
+    const { bytes } = await this.getVerificationKeyData(options);
+
+    // Convert VK bytes to field elements (32-byte chunks as hex strings)
+    const vkAsFields: string[] = [];
+    for (let i = 0; i < bytes.length; i += 32) {
+      const chunk = bytes.slice(i, i + 32);
+      vkAsFields.push(uint8ArrayToHex(chunk));
+    }
+    return vkAsFields;
+  }
+
+  /**
+   * Get the hash of the verification key.
+   * Useful for verifying that a VK matches what's expected in a recursive verification circuit.
+   *
+   * @example
+   * const vkHash = await backend.getVerificationKeyHash({ verifierTarget: 'noir-recursive' });
+   * // vkHash is a hex string like "0x1234..."
+   */
+  async getVerificationKeyHash(options?: UltraHonkBackendOptions): Promise<string> {
+    const { hash } = await this.getVerificationKeyData(options);
+    return uint8ArrayToHex(hash);
   }
 
   /** @description Returns a solidity verifier */
@@ -234,11 +281,16 @@ export class UltraHonkBackend {
   }
 
   // TODO(https://github.com/noir-lang/noir/issues/5661): Update this to handle Honk recursive aggregation in the browser once it is ready in the backend itself
+  /**
+   * @deprecated Use getVerificationKeyAsFields() and getVerificationKeyHash() instead.
+   * This method is kept for backwards compatibility.
+   */
   async generateRecursiveProofArtifacts(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _proof: Uint8Array,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _numOfPublicInputs: number,
+    options?: UltraHonkBackendOptions,
   ): Promise<{ proofAsFields: string[]; vkAsFields: string[]; vkHash: string }> {
     // TODO(https://github.com/noir-lang/noir/issues/5661): This needs to be updated to handle recursive aggregation.
     // There is still a proofAsFields method but we could consider getting rid of it as the proof itself
@@ -248,31 +300,14 @@ export class UltraHonkBackend {
     // const proof = reconstructProofWithPublicInputs(proofData);
     // const proofAsFields = (await this.api.acirProofAsFieldsUltraHonk(proof)).slice(numOfPublicInputs);
 
-    // TODO: perhaps we should put this in the init function. Need to benchmark
-    // TODO how long it takes.
-    const vkResult = await this.api.circuitComputeVk({
-      circuit: {
-        name: 'circuit',
-        bytecode: this.acirUncompressedBytecode,
-      },
-      settings: getProofSettingsFromOptions({}),
-    });
-
-    // Convert VK bytes to field elements (32-byte chunks)
-    const vkAsFields: string[] = [];
-    for (let i = 0; i < vkResult.bytes.length; i += 32) {
-      const chunk = vkResult.bytes.slice(i, i + 32);
-      vkAsFields.push(uint8ArrayToHex(chunk));
-    }
+    const vkAsFields = await this.getVerificationKeyAsFields(options);
+    const vkHash = await this.getVerificationKeyHash(options);
 
     return {
       // TODO(https://github.com/noir-lang/noir/issues/5661)
       proofAsFields: [],
       vkAsFields,
-      // We use an empty string for the vk hash here as it is unneeded as part of the recursive artifacts
-      // The user can be expected to hash the vk inside their circuit to check whether the vk is the circuit
-      // they expect
-      vkHash: uint8ArrayToHex(vkResult.hash),
+      vkHash,
     };
   }
 }

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -388,37 +388,39 @@ function base64Decode(input: string): Uint8Array {
 }
 
 /**
- * Convert a field element (32-byte Uint8Array) to a decimal string.
+ * Convert a field element (32-byte Uint8Array) to a string.
  *
  * @param field - A 32-byte field element
- * @returns The field value as a decimal string
+ * @param radix - The radix for string conversion (2-36), defaults to 10 (decimal)
+ * @returns The field value as a string in the specified radix
  *
  * @example
- * const value = fieldToDecimalString(field);
- * // value is "12345678"
+ * const decimal = fieldToString(field);        // "12345678"
+ * const hex = fieldToString(field, 16);        // "bc614e"
  */
-export function fieldToDecimalString(field: Uint8Array): string {
+export function fieldToString(field: Uint8Array, radix: number = 10): string {
   let result = 0n;
   for (const byte of field) {
     result <<= 8n;
     result += BigInt(byte);
   }
-  return result.toString();
+  return result.toString(radix);
 }
 
 /**
- * Convert an array of field elements to an array of decimal strings.
+ * Convert an array of field elements to an array of strings.
  * Useful for passing VK fields to Noir circuits.
  *
  * @param fields - Array of 32-byte field elements
- * @returns Array of decimal strings
+ * @param radix - The radix for string conversion (2-36), defaults to 10 (decimal)
+ * @returns Array of strings in the specified radix
  *
  * @example
  * const vkAsFields = await barretenbergAPI.vkAsFields({ verificationKey: vk });
- * const vkFieldStrings = fieldsToDecimalStrings(vkAsFields.fields);
- * // vkFieldStrings is ["12345678", "87654321", ...]
+ * const vkDecimalStrings = fieldsToStrings(vkAsFields.fields);      // ["12345678", "87654321", ...]
+ * const vkHexStrings = fieldsToStrings(vkAsFields.fields, 16);      // ["bc614e", "5397fb1", ...]
  */
-export function fieldsToDecimalStrings(fields: Uint8Array[]): string[] {
-  return fields.map(field => fieldToDecimalString(field));
+export function fieldsToStrings(fields: Uint8Array[], radix: number = 10): string[] {
+  return fields.map(field => fieldToString(field, radix));
 }
 

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -213,13 +213,7 @@ export class UltraHonkBackend {
     return verified;
   }
 
-  /**
-   * Get the verification key and its hash.
-   * @internal
-   */
-  private async getVerificationKeyData(
-    options?: UltraHonkBackendOptions,
-  ): Promise<{ bytes: Uint8Array; hash: Uint8Array }> {
+  async getVerificationKey(options?: UltraHonkBackendOptions): Promise<Uint8Array> {
     const vkResult = await this.api.circuitComputeVk({
       circuit: {
         name: 'circuit',
@@ -227,48 +221,7 @@ export class UltraHonkBackend {
       },
       settings: getProofSettingsFromOptions(options),
     });
-    return { bytes: vkResult.bytes, hash: vkResult.hash };
-  }
-
-  /**
-   * Get the verification key as raw bytes.
-   */
-  async getVerificationKey(options?: UltraHonkBackendOptions): Promise<Uint8Array> {
-    const { bytes } = await this.getVerificationKeyData(options);
-    return bytes;
-  }
-
-  /**
-   * Get the verification key as an array of hex field strings.
-   * Useful for recursive verification where VK needs to be passed as circuit inputs.
-   *
-   * @example
-   * const vkFields = await backend.getVerificationKeyAsFields({ verifierTarget: 'noir-recursive' });
-   * // vkFields is string[] like ["0x1234...", "0x5678...", ...]
-   */
-  async getVerificationKeyAsFields(options?: UltraHonkBackendOptions): Promise<string[]> {
-    const { bytes } = await this.getVerificationKeyData(options);
-
-    // Convert VK bytes to field elements (32-byte chunks as hex strings)
-    const vkAsFields: string[] = [];
-    for (let i = 0; i < bytes.length; i += 32) {
-      const chunk = bytes.slice(i, i + 32);
-      vkAsFields.push(uint8ArrayToHex(chunk));
-    }
-    return vkAsFields;
-  }
-
-  /**
-   * Get the hash of the verification key.
-   * Useful for verifying that a VK matches what's expected in a recursive verification circuit.
-   *
-   * @example
-   * const vkHash = await backend.getVerificationKeyHash({ verifierTarget: 'noir-recursive' });
-   * // vkHash is a hex string like "0x1234..."
-   */
-  async getVerificationKeyHash(options?: UltraHonkBackendOptions): Promise<string> {
-    const { hash } = await this.getVerificationKeyData(options);
-    return uint8ArrayToHex(hash);
+    return vkResult.bytes;
   }
 
   /** @description Returns a solidity verifier */
@@ -281,10 +234,6 @@ export class UltraHonkBackend {
   }
 
   // TODO(https://github.com/noir-lang/noir/issues/5661): Update this to handle Honk recursive aggregation in the browser once it is ready in the backend itself
-  /**
-   * @deprecated Use getVerificationKeyAsFields() and getVerificationKeyHash() instead.
-   * This method is kept for backwards compatibility.
-   */
   async generateRecursiveProofArtifacts(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _proof: Uint8Array,
@@ -300,14 +249,29 @@ export class UltraHonkBackend {
     // const proof = reconstructProofWithPublicInputs(proofData);
     // const proofAsFields = (await this.api.acirProofAsFieldsUltraHonk(proof)).slice(numOfPublicInputs);
 
-    const vkAsFields = await this.getVerificationKeyAsFields(options);
-    const vkHash = await this.getVerificationKeyHash(options);
+    const vkResult = await this.api.circuitComputeVk({
+      circuit: {
+        name: 'circuit',
+        bytecode: this.acirUncompressedBytecode,
+      },
+      settings: getProofSettingsFromOptions(options),
+    });
+
+    // Convert VK bytes to field elements (32-byte chunks)
+    const vkAsFields: string[] = [];
+    for (let i = 0; i < vkResult.bytes.length; i += 32) {
+      const chunk = vkResult.bytes.slice(i, i + 32);
+      vkAsFields.push(uint8ArrayToHex(chunk));
+    }
 
     return {
       // TODO(https://github.com/noir-lang/noir/issues/5661)
       proofAsFields: [],
       vkAsFields,
-      vkHash,
+      // We use an empty string for the vk hash here as it is unneeded as part of the recursive artifacts
+      // The user can be expected to hash the vk inside their circuit to check whether the vk is the circuit
+      // they expect
+      vkHash: uint8ArrayToHex(vkResult.hash),
     };
   }
 }
@@ -372,8 +336,8 @@ export class AztecClientBackend {
     const proofFields = [
       proveResult.proof.megaProof,
       proveResult.proof.goblinProof.mergeProof,
-      proveResult.proof.goblinProof.eccvmProof,
-      proveResult.proof.goblinProof.ipaProof,
+      proveResult.proof.goblinProof.eccvmProof.preIpaProof,
+      proveResult.proof.goblinProof.eccvmProof.ipaProof,
       proveResult.proof.goblinProof.translatorProof,
     ].flat();
 
@@ -422,3 +386,39 @@ function base64Decode(input: string): Uint8Array {
     throw new Error('atob is not available. Node.js 18+ or browser required.');
   }
 }
+
+/**
+ * Convert a field element (32-byte Uint8Array) to a decimal string.
+ *
+ * @param field - A 32-byte field element
+ * @returns The field value as a decimal string
+ *
+ * @example
+ * const value = fieldToDecimalString(field);
+ * // value is "12345678"
+ */
+export function fieldToDecimalString(field: Uint8Array): string {
+  let result = 0n;
+  for (const byte of field) {
+    result <<= 8n;
+    result += BigInt(byte);
+  }
+  return result.toString();
+}
+
+/**
+ * Convert an array of field elements to an array of decimal strings.
+ * Useful for passing VK fields to Noir circuits.
+ *
+ * @param fields - Array of 32-byte field elements
+ * @returns Array of decimal strings
+ *
+ * @example
+ * const vkAsFields = await barretenbergAPI.vkAsFields({ verificationKey: vk });
+ * const vkFieldStrings = fieldsToDecimalStrings(vkAsFields.fields);
+ * // vkFieldStrings is ["12345678", "87654321", ...]
+ */
+export function fieldsToDecimalStrings(fields: Uint8Array[]): string[] {
+  return fields.map(field => fieldToDecimalString(field));
+}
+

--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -9,6 +9,8 @@ export {
   UltraHonkBackend,
   UltraHonkVerifierBackend,
   AztecClientBackend,
+  fieldToDecimalString,
+  fieldsToDecimalStrings,
   type UltraHonkBackendOptions,
   type VerifierTarget,
 } from './backend.js';

--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -9,8 +9,8 @@ export {
   UltraHonkBackend,
   UltraHonkVerifierBackend,
   AztecClientBackend,
-  fieldToDecimalString,
-  fieldsToDecimalStrings,
+  fieldToString,
+  fieldsToStrings,
   type UltraHonkBackendOptions,
   type VerifierTarget,
 } from './backend.js';

--- a/barretenberg/ts/src/index.ts
+++ b/barretenberg/ts/src/index.ts
@@ -7,6 +7,8 @@ export {
   UltraHonkVerifierBackend,
   UltraHonkBackend,
   AztecClientBackend,
+  fieldToDecimalString,
+  fieldsToDecimalStrings,
   type UltraHonkBackendOptions,
   type VerifierTarget,
 } from './barretenberg/index.js';

--- a/barretenberg/ts/src/index.ts
+++ b/barretenberg/ts/src/index.ts
@@ -7,8 +7,8 @@ export {
   UltraHonkVerifierBackend,
   UltraHonkBackend,
   AztecClientBackend,
-  fieldToDecimalString,
-  fieldsToDecimalStrings,
+  fieldToString,
+  fieldsToStrings,
   type UltraHonkBackendOptions,
   type VerifierTarget,
 } from './barretenberg/index.js';


### PR DESCRIPTION
## Summary

Add standalone helper functions for converting field elements (Uint8Array) to strings in any radix, useful for passing VK fields to Noir circuits.

## Changes

- Add `fieldToString(field, radix?)`: Convert single field to string (default radix 10 for decimal)
- Add `fieldsToStrings(fields, radix?)`: Convert array of fields to strings
- Export helpers from `@aztec/bb.js`
- Fix pre-existing type error in `AztecClientBackend.prove()` where `ipaProof` was incorrectly accessed
- Add unit tests for the new helper functions (15 tests)

## Usage

```typescript
import { fieldsToStrings } from '@aztec/bb.js';

const api = await Barretenberg.new({ threads: 1 });
const vkAsFields = await api.vkAsFields({ verificationKey: vk });

// Decimal strings (default) - for Noir circuit inputs
const vkDecimalStrings = fieldsToStrings(vkAsFields.fields);
// ["12345678", "87654321", ...]

// Hex strings
const vkHexStrings = fieldsToStrings(vkAsFields.fields, 16);
// ["bc614e", "5397fb1", ...]
```

## Test plan

- [x] Add unit tests for fieldToString and fieldsToStrings (15 tests pass)
- [ ] Run existing tests to verify backwards compatibility