### PR TITLE
feat!: add block hash to log store

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -28,7 +28,7 @@ import {
   SerializableContractInstance,
   computePublicBytecodeCommitment,
 } from '@aztec/stdlib/contract';
-import { LogId, PrivateLog, PublicLog } from '@aztec/stdlib/logs';
+import { ContractClassLog, LogId, PrivateLog, PublicLog } from '@aztec/stdlib/logs';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import {
   makeContractClassPublic,
@@ -905,6 +905,7 @@ export function describeArchiverDataStore(
           [
             expect.objectContaining({
               blockNumber: 2,
+              blockHash: L2BlockHash.fromField(await blocks[2 - 1].block.hash()),
               log: makePrivateLog(tags[0]),
               isFromPublic: false,
             }),
@@ -912,6 +913,7 @@ export function describeArchiverDataStore(
           [
             expect.objectContaining({
               blockNumber: 1,
+              blockHash: L2BlockHash.fromField(await blocks[1 - 1].block.hash()),
               log: makePrivateLog(tags[1]),
               isFromPublic: false,
             }),
@@ -929,11 +931,13 @@ export function describeArchiverDataStore(
           [
             expect.objectContaining({
               blockNumber: 1,
+              blockHash: L2BlockHash.fromField(await blocks[1 - 1].block.hash()),
               log: makePrivateLog(tags[0]),
               isFromPublic: false,
             }),
             expect.objectContaining({
               blockNumber: 1,
+              blockHash: L2BlockHash.fromField(await blocks[1 - 1].block.hash()),
               log: makePublicLog(tags[0]),
               isFromPublic: true,
             }),
@@ -959,11 +963,13 @@ export function describeArchiverDataStore(
           [
             expect.objectContaining({
               blockNumber: 1,
+              blockHash: L2BlockHash.fromField(await blocks[1 - 1].block.hash()),
               log: makePrivateLog(tags[0]),
               isFromPublic: false,
             }),
             expect.objectContaining({
               blockNumber: newBlockNumber,
+              blockHash: L2BlockHash.fromField(await blocks[newBlockNumber - 1].block.hash()),
               log: newLog,
               isFromPublic: false,
             }),
@@ -983,6 +989,7 @@ export function describeArchiverDataStore(
           [
             expect.objectContaining({
               blockNumber: 1,
+              blockHash: L2BlockHash.fromField(await blocks[1 - 1].block.hash()),
               log: makePrivateLog(tags[1]),
               isFromPublic: false,
             }),
@@ -1050,6 +1057,17 @@ export function describeArchiverDataStore(
         }
       });
 
+      it('returns block hash on public log ids', async () => {
+        const targetBlock = blocks[0].block;
+        const expectedBlockHash = L2BlockHash.fromField(await targetBlock.hash());
+
+        const logs = (await store.getPublicLogs({ fromBlock: targetBlock.number, toBlock: targetBlock.number + 1 }))
+          .logs;
+
+        expect(logs.length).toBeGreaterThan(0);
+        expect(logs.every(log => log.id.blockHash.equals(expectedBlockHash))).toBe(true);
+      });
+
       it('"fromBlock" and "toBlock" filter params are respected', async () => {
         // Set "fromBlock" and "toBlock"
         const fromBlock = 3;
@@ -1092,8 +1110,14 @@ export function describeArchiverDataStore(
         const targetBlockIndex = randomInt(numBlocks);
         const targetTxIndex = randomInt(txsPerBlock);
         const targetLogIndex = randomInt(numPublicLogs);
+        const targetBlockHash = L2BlockHash.fromField(await blocks[targetBlockIndex].block.hash());
 
-        const afterLog = new LogId(BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM), targetTxIndex, targetLogIndex);
+        const afterLog = new LogId(
+          BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
+          targetBlockHash,
+          targetTxIndex,
+          targetLogIndex,
+        );
 
         const response = await store.getPublicLogs({ afterLog });
         const logs = response.logs;
@@ -1115,7 +1139,7 @@ export function describeArchiverDataStore(
       it('"txHash" filter param is ignored when "afterLog" is set', async () => {
         // Get random txHash
         const txHash = TxHash.random();
-        const afterLog = new LogId(BlockNumber(1), 0, 0);
+        const afterLog = new LogId(BlockNumber(1), L2BlockHash.random(), 0, 0);
 
         const response = await store.getPublicLogs({ txHash, afterLog });
         expect(response.logs.length).toBeGreaterThan(1);
@@ -1147,20 +1171,25 @@ export function describeArchiverDataStore(
           await store.getPublicLogs({
             fromBlock: BlockNumber(2),
             toBlock: BlockNumber(5),
-            afterLog: new LogId(BlockNumber(4), 0, 0),
+            afterLog: new LogId(BlockNumber(4), L2BlockHash.random(), 0, 0),
           })
         ).logs;
         blockNumbers = new Set(logs.map(log => log.id.blockNumber));
         expect(blockNumbers).toEqual(new Set([4]));
 
-        logs = (await store.getPublicLogs({ toBlock: BlockNumber(5), afterLog: new LogId(BlockNumber(5), 1, 0) })).logs;
+        logs = (
+          await store.getPublicLogs({
+            toBlock: BlockNumber(5),
+            afterLog: new LogId(BlockNumber(5), L2BlockHash.random(), 1, 0),
+          })
+        ).logs;
         expect(logs.length).toBe(0);
 
         logs = (
           await store.getPublicLogs({
             fromBlock: BlockNumber(2),
             toBlock: BlockNumber(5),
-            afterLog: new LogId(BlockNumber(100), 0, 0),
+            afterLog: new LogId(BlockNumber(100), L2BlockHash.random(), 0, 0),
           })
         ).logs;
         expect(logs.length).toBe(0);
@@ -1171,8 +1200,14 @@ export function describeArchiverDataStore(
         const targetBlockIndex = randomInt(numBlocks);
         const targetTxIndex = randomInt(txsPerBlock);
         const targetLogIndex = randomInt(numPublicLogs);
+        const targetBlockHash = L2BlockHash.fromField(await blocks[targetBlockIndex].block.hash());
 
-        const afterLog = new LogId(BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM), targetTxIndex, targetLogIndex);
+        const afterLog = new LogId(
+          BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
+          targetBlockHash,
+          targetTxIndex,
+          targetLogIndex,
+        );
 
         const response = await store.getPublicLogs({ afterLog, fromBlock: afterLog.blockNumber });
         const logs = response.logs;
@@ -1189,6 +1224,40 @@ export function describeArchiverDataStore(
             }
           }
         }
+      });
+    });
+
+    describe('getContractClassLogs', () => {
+      let targetBlock: L2Block;
+      let expectedContractClassLog: ContractClassLog;
+
+      beforeEach(async () => {
+        await store.addBlocks(blocks);
+
+        targetBlock = blocks[0].block;
+        expectedContractClassLog = await ContractClassLog.random();
+        targetBlock.body.txEffects.forEach((txEffect, index) => {
+          txEffect.contractClassLogs = index === 0 ? [expectedContractClassLog] : [];
+        });
+
+        await store.addLogs([targetBlock]);
+      });
+
+      it('returns block hash on contract class log ids', async () => {
+        const result = await store.getContractClassLogs({
+          fromBlock: targetBlock.number,
+          toBlock: targetBlock.number + 1,
+        });
+
+        expect(result.maxLogsHit).toBeFalsy();
+        expect(result.logs).toHaveLength(1);
+
+        const [{ id, log }] = result.logs;
+        const expectedBlockHash = L2BlockHash.fromField(await targetBlock.hash());
+
+        expect(id.blockHash.equals(expectedBlockHash)).toBe(true);
+        expect(id.blockNumber).toEqual(targetBlock.number);
+        expect(log).toEqual(expectedContractClassLog);
       });
     });
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -31,7 +31,7 @@ import { ContractInstanceStore } from './contract_instance_store.js';
 import { LogStore } from './log_store.js';
 import { MessageStore } from './message_store.js';
 
-export const ARCHIVER_DB_VERSION = 4;
+export const ARCHIVER_DB_VERSION = 5;
 export const MAX_FUNCTION_SIGNATURES = 1000;
 export const MAX_FUNCTION_NAME_LEN = 256;
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -1,10 +1,10 @@
 import { INITIAL_L2_BLOCK_NUM, MAX_NOTE_HASHES_PER_TX } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import type { Fr } from '@aztec/foundation/curves/bn254';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, numToUInt32BE } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
-import type { L2Block } from '@aztec/stdlib/block';
+import { type L2Block, L2BlockHash } from '@aztec/stdlib/block';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import {
   ContractClassLog,
@@ -42,7 +42,8 @@ export class LogStore {
     this.#logsMaxPageSize = logsMaxPageSize;
   }
 
-  #extractTaggedLogs(block: L2Block) {
+  async #extractTaggedLogs(block: L2Block) {
+    const blockHash = L2BlockHash.fromField(await block.hash());
     const taggedLogs = new Map<string, Buffer[]>();
     const dataStartIndexForBlock =
       block.header.state.partial.noteHashTree.nextAvailableLeafIndex -
@@ -56,7 +57,9 @@ export class LogStore {
         this.#log.debug(`Found private log with tag ${tag.toString()} in block ${block.number}`);
 
         const currentLogs = taggedLogs.get(tag.toString()) ?? [];
-        currentLogs.push(new TxScopedL2Log(txHash, dataStartIndexForTx, logIndex, block.number, log).toBuffer());
+        currentLogs.push(
+          new TxScopedL2Log(txHash, dataStartIndexForTx, logIndex, block.number, blockHash, log).toBuffer(),
+        );
         taggedLogs.set(tag.toString(), currentLogs);
       });
 
@@ -65,7 +68,9 @@ export class LogStore {
         this.#log.debug(`Found public log with tag ${tag.toString()} in block ${block.number}`);
 
         const currentLogs = taggedLogs.get(tag.toString()) ?? [];
-        currentLogs.push(new TxScopedL2Log(txHash, dataStartIndexForTx, logIndex, block.number, log).toBuffer());
+        currentLogs.push(
+          new TxScopedL2Log(txHash, dataStartIndexForTx, logIndex, block.number, blockHash, log).toBuffer(),
+        );
         taggedLogs.set(tag.toString(), currentLogs);
       });
     });
@@ -77,16 +82,15 @@ export class LogStore {
    * @param blocks - The blocks for which to add the logs.
    * @returns True if the operation is successful.
    */
-  addLogs(blocks: L2Block[]): Promise<boolean> {
-    const taggedLogsToAdd = blocks
-      .map(block => this.#extractTaggedLogs(block))
-      .reduce((acc, val) => {
-        for (const [tag, logs] of val.entries()) {
-          const currentLogs = acc.get(tag) ?? [];
-          acc.set(tag, currentLogs.concat(logs));
-        }
-        return acc;
-      }, new Map());
+  async addLogs(blocks: L2Block[]): Promise<boolean> {
+    const taggedLogsInBlocks = await Promise.all(blocks.map(block => this.#extractTaggedLogs(block)));
+    const taggedLogsToAdd = taggedLogsInBlocks.reduce((acc, taggedLogs) => {
+      for (const [tag, logs] of taggedLogs.entries()) {
+        const currentLogs = acc.get(tag) ?? [];
+        acc.set(tag, currentLogs.concat(logs));
+      }
+      return acc;
+    }, new Map<string, Buffer[]>());
     const tagsToUpdate = Array.from(taggedLogsToAdd.keys());
 
     return this.db.transactionAsync(async () => {
@@ -102,6 +106,8 @@ export class LogStore {
         }
       });
       for (const block of blocks) {
+        const blockHash = await block.hash();
+
         const tagsInBlock = [];
         for (const [tag, logs] of taggedLogsToAdd.entries()) {
           await this.#logsByTag.set(tag, logs);
@@ -129,12 +135,29 @@ export class LogStore {
           )
           .flat();
 
-        await this.#publicLogsByBlock.set(block.number, Buffer.concat(publicLogsInBlock));
-        await this.#contractClassLogsByBlock.set(block.number, Buffer.concat(contractClassLogsInBlock));
+        await this.#publicLogsByBlock.set(block.number, this.#packWithBlockHash(blockHash, publicLogsInBlock));
+        await this.#contractClassLogsByBlock.set(
+          block.number,
+          this.#packWithBlockHash(blockHash, contractClassLogsInBlock),
+        );
       }
 
       return true;
     });
+  }
+
+  #packWithBlockHash(blockHash: Fr, data: Buffer<ArrayBufferLike>[]): Buffer<ArrayBufferLike> {
+    return Buffer.concat([blockHash.toBuffer(), ...data]);
+  }
+
+  #unpackBlockHash(reader: BufferReader): L2BlockHash {
+    const blockHash = reader.remainingBytes() > 0 ? reader.readObject(Fr) : undefined;
+
+    if (!blockHash) {
+      throw new Error('Failed to read block hash from log entry buffer');
+    }
+
+    return L2BlockHash.fromField(blockHash);
   }
 
   deleteLogs(blocks: L2Block[]): Promise<boolean> {
@@ -207,6 +230,9 @@ export class LogStore {
     const buffer = (await this.#publicLogsByBlock.getAsync(blockNumber)) ?? Buffer.alloc(0);
     const publicLogsInBlock: [PublicLog[]] = [[]];
     const reader = new BufferReader(buffer);
+
+    const blockHash = this.#unpackBlockHash(reader);
+
     while (reader.remainingBytes() > 0) {
       const indexOfTx = reader.readNumber();
       const numLogsInTx = reader.readNumber();
@@ -219,7 +245,7 @@ export class LogStore {
     const txLogs = publicLogsInBlock[txIndex];
 
     const logs: ExtendedPublicLog[] = [];
-    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, txIndex, txLogs, filter);
+    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
 
     return { logs, maxLogsHit };
   }
@@ -242,6 +268,9 @@ export class LogStore {
     loopOverBlocks: for await (const [blockNumber, logBuffer] of this.#publicLogsByBlock.entriesAsync({ start, end })) {
       const publicLogsInBlock: [PublicLog[]] = [[]];
       const reader = new BufferReader(logBuffer);
+
+      const blockHash = this.#unpackBlockHash(reader);
+
       while (reader.remainingBytes() > 0) {
         const indexOfTx = reader.readNumber();
         const numLogsInTx = reader.readNumber();
@@ -252,7 +281,7 @@ export class LogStore {
       }
       for (let txIndex = filter.afterLog?.txIndex ?? 0; txIndex < publicLogsInBlock.length; txIndex++) {
         const txLogs = publicLogsInBlock[txIndex];
-        maxLogsHit = this.#accumulateLogs(logs, blockNumber, txIndex, txLogs, filter);
+        maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
         if (maxLogsHit) {
           this.#log.debug(`Max logs hit at block ${blockNumber}`);
           break loopOverBlocks;
@@ -291,6 +320,8 @@ export class LogStore {
     const contractClassLogsInBlock: [ContractClassLog[]] = [[]];
 
     const reader = new BufferReader(contractClassLogsBuffer);
+    const blockHash = this.#unpackBlockHash(reader);
+
     while (reader.remainingBytes() > 0) {
       const indexOfTx = reader.readNumber();
       const numLogsInTx = reader.readNumber();
@@ -303,7 +334,7 @@ export class LogStore {
     const txLogs = contractClassLogsInBlock[txIndex];
 
     const logs: ExtendedContractClassLog[] = [];
-    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, txIndex, txLogs, filter);
+    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
 
     return { logs, maxLogsHit };
   }
@@ -329,6 +360,7 @@ export class LogStore {
     })) {
       const contractClassLogsInBlock: [ContractClassLog[]] = [[]];
       const reader = new BufferReader(logBuffer);
+      const blockHash = this.#unpackBlockHash(reader);
       while (reader.remainingBytes() > 0) {
         const indexOfTx = reader.readNumber();
         const numLogsInTx = reader.readNumber();
@@ -339,7 +371,7 @@ export class LogStore {
       }
       for (let txIndex = filter.afterLog?.txIndex ?? 0; txIndex < contractClassLogsInBlock.length; txIndex++) {
         const txLogs = contractClassLogsInBlock[txIndex];
-        maxLogsHit = this.#accumulateLogs(logs, blockNumber, txIndex, txLogs, filter);
+        maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
         if (maxLogsHit) {
           this.#log.debug(`Max logs hit at block ${blockNumber}`);
           break loopOverBlocks;
@@ -353,9 +385,10 @@ export class LogStore {
   #accumulateLogs(
     results: (ExtendedContractClassLog | ExtendedPublicLog)[],
     blockNumber: number,
+    blockHash: L2BlockHash,
     txIndex: number,
     txLogs: (ContractClassLog | PublicLog)[],
-    filter: LogFilter,
+    filter: LogFilter = {},
   ): boolean {
     let maxLogsHit = false;
     let logIndex = typeof filter.afterLog?.logIndex === 'number' ? filter.afterLog.logIndex + 1 : 0;
@@ -363,9 +396,13 @@ export class LogStore {
       const log = txLogs[logIndex];
       if (!filter.contractAddress || log.contractAddress.equals(filter.contractAddress)) {
         if (log instanceof ContractClassLog) {
-          results.push(new ExtendedContractClassLog(new LogId(BlockNumber(blockNumber), txIndex, logIndex), log));
+          results.push(
+            new ExtendedContractClassLog(new LogId(BlockNumber(blockNumber), blockHash, txIndex, logIndex), log),
+          );
+        } else if (log instanceof PublicLog) {
+          results.push(new ExtendedPublicLog(new LogId(BlockNumber(blockNumber), blockHash, txIndex, logIndex), log));
         } else {
-          results.push(new ExtendedPublicLog(new LogId(BlockNumber(blockNumber), txIndex, logIndex), log));
+          throw new Error('Unknown log type');
         }
 
         if (results.length >= this.#logsMaxPageSize) {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -126,7 +126,14 @@ describe('PXEOracleInterface', () => {
       // Compute the tag as sender (knowledge of preaddress and ivsk)
       for (const sender of senders) {
         const tag = await computeSiloedTagForIndex(sender, recipient.address, contractAddress, tagIndex);
-        const log = new TxScopedL2Log(TxHash.random(), 0, 0, MIN_BLOCK_NUMBER_OF_A_LOG, PrivateLog.random(tag.value));
+        const log = new TxScopedL2Log(
+          TxHash.random(),
+          0,
+          0,
+          MIN_BLOCK_NUMBER_OF_A_LOG,
+          L2BlockHash.random(),
+          PrivateLog.random(tag.value),
+        );
         logs[tag.toString()] = [log];
       }
       // Accumulated logs intended for recipient: NUM_SENDERS
@@ -135,7 +142,14 @@ describe('PXEOracleInterface', () => {
       // Compute the tag as sender (knowledge of preaddress and ivsk)
       const firstSender = senders[0];
       const tag = await computeSiloedTagForIndex(firstSender, recipient.address, contractAddress, tagIndex);
-      const log = new TxScopedL2Log(TxHash.random(), 1, 0, BlockNumber.ZERO, PrivateLog.random(tag.value));
+      const log = new TxScopedL2Log(
+        TxHash.random(),
+        1,
+        0,
+        BlockNumber.ZERO,
+        L2BlockHash.random(),
+        PrivateLog.random(tag.value),
+      );
       logs[tag.toString()].push(log);
       // Accumulated logs intended for recipient: NUM_SENDERS + 1
 
@@ -145,7 +159,14 @@ describe('PXEOracleInterface', () => {
         const sender = senders[i];
         const tag = await computeSiloedTagForIndex(sender, recipient.address, contractAddress, tagIndex + 1);
         const blockNumber = BlockNumber(2);
-        const log = new TxScopedL2Log(TxHash.random(), 0, 0, blockNumber, PrivateLog.random(tag.value));
+        const log = new TxScopedL2Log(
+          TxHash.random(),
+          0,
+          0,
+          blockNumber,
+          L2BlockHash.random(),
+          PrivateLog.random(tag.value),
+        );
         logs[tag.toString()] = [log];
       }
       // Accumulated logs intended for recipient: NUM_SENDERS + 1 + NUM_SENDERS / 2
@@ -157,7 +178,14 @@ describe('PXEOracleInterface', () => {
         const partialAddress = Fr.random();
         const randomRecipient = await computeAddress(keys.publicKeys, partialAddress);
         const tag = await computeSiloedTagForIndex(sender, randomRecipient, contractAddress, tagIndex);
-        const log = new TxScopedL2Log(TxHash.random(), 0, 0, MAX_BLOCK_NUMBER_OF_A_LOG, PrivateLog.random(tag.value));
+        const log = new TxScopedL2Log(
+          TxHash.random(),
+          0,
+          0,
+          MAX_BLOCK_NUMBER_OF_A_LOG,
+          L2BlockHash.random(),
+          PrivateLog.random(tag.value),
+        );
         logs[tag.toString()] = [log];
       }
       // Accumulated logs intended for recipient: NUM_SENDERS + 1 + NUM_SENDERS / 2
@@ -948,6 +976,7 @@ describe('PXEOracleInterface', () => {
         randomInt(100),
         randomInt(100),
         BlockNumber(randomInt(100)),
+        L2BlockHash.random(),
         log,
       );
 

--- a/yarn-project/stdlib/src/logs/log_id.test.ts
+++ b/yarn-project/stdlib/src/logs/log_id.test.ts
@@ -13,10 +13,16 @@ describe('LogId', () => {
     expect(parsedLogId).toEqual(logId);
   });
 
-  it('toBuffer and fromBuffer works', () => {
-    const buffer = logId.toBuffer();
-    const parsedLogId = LogId.fromBuffer(buffer);
+  it('toString and fromString works', () => {
+    const str = logId.toString();
+    const parsedLogId = LogId.fromString(str);
 
     expect(parsedLogId).toEqual(logId);
+  });
+
+  it('human readable string includes block hash', () => {
+    const human = logId.toHumanReadable();
+
+    expect(human).toContain(logId.blockHash.toString());
   });
 });

--- a/yarn-project/stdlib/src/logs/log_id.ts
+++ b/yarn-project/stdlib/src/logs/log_id.ts
@@ -5,6 +5,7 @@ import { BufferReader } from '@aztec/foundation/serialize';
 
 import { z } from 'zod';
 
+import { L2BlockHash } from '../block/block_hash.js';
 import { schemas } from '../schemas/index.js';
 
 /** A globally unique log id. */
@@ -18,6 +19,8 @@ export class LogId {
   constructor(
     /** The block number the log was emitted in. */
     public readonly blockNumber: BlockNumber,
+    /** The hash of the block the log was emitted in. */
+    public readonly blockHash: L2BlockHash,
     /** The index of a tx in a block the log was emitted in. */
     public readonly txIndex: number,
     /** The index of a log the tx was emitted in. */
@@ -37,6 +40,7 @@ export class LogId {
   static random() {
     return new LogId(
       BlockNumber(Math.floor(Math.random() * 1000) + 1),
+      L2BlockHash.random(),
       Math.floor(Math.random() * 1000),
       Math.floor(Math.random() * 100),
     );
@@ -46,10 +50,13 @@ export class LogId {
     return z
       .object({
         blockNumber: BlockNumberSchema,
+        blockHash: L2BlockHash.schema,
         txIndex: schemas.Integer,
         logIndex: schemas.Integer,
       })
-      .transform(({ blockNumber, txIndex, logIndex }) => new LogId(blockNumber, txIndex, logIndex));
+      .transform(
+        ({ blockNumber, blockHash, txIndex, logIndex }) => new LogId(blockNumber, blockHash, txIndex, logIndex),
+      );
   }
 
   /**
@@ -59,6 +66,7 @@ export class LogId {
   public toBuffer(): Buffer {
     return Buffer.concat([
       toBufferBE(BigInt(this.blockNumber), 4),
+      this.blockHash.toBuffer(),
       toBufferBE(BigInt(this.txIndex), 4),
       toBufferBE(BigInt(this.logIndex), 4),
     ]);
@@ -73,10 +81,11 @@ export class LogId {
     const reader = BufferReader.asReader(buffer);
 
     const blockNumber = BlockNumber(reader.readNumber());
+    const blockHash = reader.readObject(L2BlockHash);
     const txIndex = reader.readNumber();
     const logIndex = reader.readNumber();
 
-    return new LogId(blockNumber, txIndex, logIndex);
+    return new LogId(blockNumber, blockHash, txIndex, logIndex);
   }
 
   /**
@@ -84,7 +93,7 @@ export class LogId {
    * @returns A string representation of the log id.
    */
   public toString(): string {
-    return `${this.blockNumber}-${this.txIndex}-${this.logIndex}`;
+    return `${this.blockNumber}-${this.txIndex}-${this.logIndex}-${this.blockHash.toString()}`;
   }
 
   /**
@@ -93,12 +102,13 @@ export class LogId {
    * @returns A log id.
    */
   static fromString(data: string): LogId {
-    const [rawBlockNumber, rawTxIndex, rawLogIndex] = data.split('-');
+    const [rawBlockNumber, rawTxIndex, rawLogIndex, rawBlockHash] = data.split('-');
     const blockNumber = BlockNumber(Number(rawBlockNumber));
+    const blockHash = L2BlockHash.fromString(rawBlockHash);
     const txIndex = Number(rawTxIndex);
     const logIndex = Number(rawLogIndex);
 
-    return new LogId(blockNumber, txIndex, logIndex);
+    return new LogId(blockNumber, blockHash, txIndex, logIndex);
   }
 
   /**
@@ -106,6 +116,6 @@ export class LogId {
    * @returns A human readable representation of the log id.
    */
   public toHumanReadable(): string {
-    return `logId: (blockNumber: ${this.blockNumber}, txIndex: ${this.txIndex}, logIndex: ${this.logIndex})`;
+    return `logId: (blockNumber: ${this.blockNumber}, blockHash: ${this.blockHash.toString()}, txIndex: ${this.txIndex}, logIndex: ${this.logIndex})`;
   }
 }

--- a/yarn-project/stdlib/src/logs/tx_scoped_l2_log.ts
+++ b/yarn-project/stdlib/src/logs/tx_scoped_l2_log.ts
@@ -3,6 +3,7 @@ import { BufferReader, boolToBuffer, numToUInt32BE } from '@aztec/foundation/ser
 
 import { z } from 'zod';
 
+import { L2BlockHash } from '../block/block_hash.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { PrivateLog } from './private_log.js';
 import { PublicLog } from './public_log.js';
@@ -29,6 +30,10 @@ export class TxScopedL2Log {
      */
     public blockNumber: BlockNumber,
     /*
+     * The block this log is included in
+     */
+    public blockHash: L2BlockHash,
+    /*
      * The log data as either a PrivateLog or PublicLog
      */
     public log: PrivateLog | PublicLog,
@@ -45,22 +50,23 @@ export class TxScopedL2Log {
         dataStartIndexForTx: z.number(),
         logIndexInTx: z.number(),
         blockNumber: BlockNumberSchema,
+        blockHash: L2BlockHash.schema,
         log: z.union([PrivateLog.schema, PublicLog.schema]),
       })
       .transform(
-        ({ txHash, dataStartIndexForTx, logIndexInTx, blockNumber, log }) =>
-          new TxScopedL2Log(txHash, dataStartIndexForTx, logIndexInTx, blockNumber, log),
+        ({ txHash, dataStartIndexForTx, logIndexInTx, blockNumber, blockHash, log }) =>
+          new TxScopedL2Log(txHash, dataStartIndexForTx, logIndexInTx, blockNumber, blockHash, log),
       );
   }
 
   toBuffer() {
-    const isFromPublic = this.log instanceof PublicLog;
     return Buffer.concat([
       this.txHash.toBuffer(),
       numToUInt32BE(this.dataStartIndexForTx),
       numToUInt32BE(this.logIndexInTx),
       numToUInt32BE(this.blockNumber),
-      boolToBuffer(isFromPublic),
+      this.blockHash.toBuffer(),
+      boolToBuffer(this.isFromPublic),
       this.log.toBuffer(),
     ]);
   }
@@ -71,15 +77,16 @@ export class TxScopedL2Log {
     const dataStartIndexForTx = reader.readNumber();
     const logIndexInTx = reader.readNumber();
     const blockNumber = BlockNumber(reader.readNumber());
+    const blockHash = reader.readObject(L2BlockHash);
     const isFromPublic = reader.readBoolean();
     const log = isFromPublic ? PublicLog.fromBuffer(reader) : PrivateLog.fromBuffer(reader);
 
-    return new TxScopedL2Log(txHash, dataStartIndexForTx, logIndexInTx, blockNumber, log);
+    return new TxScopedL2Log(txHash, dataStartIndexForTx, logIndexInTx, blockNumber, blockHash, log);
   }
 
   static async random(isFromPublic = Math.random() < 0.5) {
     const log = isFromPublic ? await PublicLog.random() : PrivateLog.random();
-    return new TxScopedL2Log(TxHash.random(), 1, 1, BlockNumber(1), log);
+    return new TxScopedL2Log(TxHash.random(), 1, 1, BlockNumber(1), L2BlockHash.random(), log);
   }
 
   equals(other: TxScopedL2Log) {
@@ -88,6 +95,7 @@ export class TxScopedL2Log {
       this.dataStartIndexForTx === other.dataStartIndexForTx &&
       this.logIndexInTx === other.logIndexInTx &&
       this.blockNumber === other.blockNumber &&
+      this.blockHash.equals(other.blockHash) &&
       ((this.log instanceof PublicLog && other.log instanceof PublicLog) ||
         (this.log instanceof PrivateLog && other.log instanceof PrivateLog)) &&
       this.log.equals(other.log as any)


### PR DESCRIPTION
We want to expose some event metadata to users of Aztec.js (see: https://github.com/AztecProtocol/aztec-packages/issues/16245).

An important metadata attribute is block hash. Block number is not enough due to the possibliity of reorgs.

Currently, in archiver nodes, logs are stored by block number, and the corresponding block hash is lost. This works at the archiver, because the archiver is designed to prune its stores and start over each time a reorg is detected.

Users who download data from the node, however, have no reasonably efficient way of detecting whether the log data they downloaded is still valid unless they also get a block hash to pin the logs they get to. 

So we can bridge this gap in one of two ways:

1. Whenever the node gets a request for logs, it queries the block store to resolve block hashes from block numbers. This works because archiver provides strong guarantees that the data stored corresponds to only one chain. However, it it introduces more store reads

2. At the time of storing logs, we can also store the block hash corresponding to the block number at the moment of storing. this increments the size needed to store the logs of each indexed block by 1 Fr, but in exchange for that we can just unpack the block hash from the logs we're processing without needing extra reads from block store. It also makes block addition a bit more expensive since now we'll be potentially calculating one hash per block (although since `addBlocks` receives them and `hash()` is cached maybe it's not even the case?) 

This PR implements option 2, but if I'm hitting any no-no's please let me know

Note that this PR bumps the ARCHIVER_DB_VERSION, since it modifies how we index public and contract class logs.   

Closes F-220