### PR TITLE
chore: bump sha256 version to 0.3.0

### DIFF
--- a/noir-projects/aztec-nr/aztec/Nargo.toml
+++ b/noir-projects/aztec-nr/aztec/Nargo.toml
@@ -6,5 +6,5 @@ type = "lib"
 
 [dependencies]
 protocol_types = { path = "../../noir-protocol-circuits/crates/types" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 ecdsa_public_key_note = { path = "../../libs/ecdsa_public_key_note" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 ecdsa_public_key_note = { path = "../../libs/ecdsa_public_key_note" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 field_note = { path = "../../../../aztec-nr/field-note" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/Nargo.toml
@@ -7,5 +7,5 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }

--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
@@ -31,69 +31,69 @@ contract AvmGadgetsTest {
 
     #[external("public")]
     fn sha256_hash_10(data: [u8; 10]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_20(data: [u8; 20]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_30(data: [u8; 30]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_40(data: [u8; 40]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_50(data: [u8; 50]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_60(data: [u8; 60]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_70(data: [u8; 70]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_80(data: [u8; 80]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_90(data: [u8; 90]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_100(data: [u8; 100]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_255(data: [u8; 255]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_256(data: [u8; 256]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_511(data: [u8; 511]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
     #[external("public")]
     fn sha256_hash_512(data: [u8; 512]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
 
     #[external("public")]
     fn sha256_hash_1024(data: [u8; 1024]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
 
     #[external("public")]
     fn sha256_hash_1536(data: [u8; 1536]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/Nargo.toml
@@ -7,7 +7,7 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 compressed_string = { path = "../../../../aztec-nr/compressed-string" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }
 poseidon = { tag= "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
 fee_juice = { path = "../../protocol/fee_juice_contract" }

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -941,7 +941,7 @@ pub contract AvmTest {
         dep::aztec::oracle::debug_log::debug_log("keccak_hash");
         let _ = keccak256::keccak256(args_u8, args_u8.len());
         dep::aztec::oracle::debug_log::debug_log("sha256_hash");
-        let _ = sha256::sha256_var(args_u8, args_u8.len() as u64);
+        let _ = sha256::sha256_var(args_u8, args_u8.len());
         dep::aztec::oracle::debug_log::debug_log("poseidon2_hash");
         let _ = poseidon::poseidon2::Poseidon2::hash(args_field, args_field.len());
         dep::aztec::oracle::debug_log::debug_log("pedersen_hash");

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/Nargo.toml
@@ -7,4 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
 field_note = { path = "../../../../aztec-nr/field-note" }
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -59,6 +59,6 @@ pub contract Benchmarking {
     // Does a bunch of heavy compute
     #[external("public")]
     fn sha256_hash_1024(data: [u8; 1024]) -> [u8; 32] {
-        sha256::sha256_var(data, data.len() as u64)
+        sha256::sha256_var(data, data.len())
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.2.0" }
+sha256 = { tag = "v0.3.0", git = "https://github.com/noir-lang/sha256" }
 poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }


### PR DESCRIPTION
Updates the sha256 lib to remove some false positive warnings and also drop circuit size.
