### PR TITLE
feat: note deduplication

### DIFF
--- a/yarn-project/pxe/src/storage/note_data_provider/note_dao.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_dao.test.ts
@@ -1,9 +1,0 @@
-import { NoteDao } from '@aztec/stdlib/note';
-
-describe('Note DAO', () => {
-  it('convert to and from buffer', async () => {
-    const note = await NoteDao.random();
-    const buf = note.toBuffer();
-    expect(NoteDao.fromBuffer(buf)).toEqual(note);
-  });
-});

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -181,6 +181,20 @@ describe('NoteDataProvider', () => {
       expect(new Set(getIndexes(res))).toEqual(new Set([1n, 2n, 4n])); // note1, note2, and note4
     });
 
+    it('deduplicates notes that appear in multiple scopes', async () => {
+      // note 1 has been added to scope 1 in setup so we add it to scope 2 to then be able to test deduplication
+      await provider.addNotes([note1], SCOPE_2);
+
+      const res = await provider.getNotes({
+        contractAddress: CONTRACT_A,
+        scopes: [SCOPE_1, SCOPE_2],
+      });
+
+      // Note 1 should be present exactly once in the result
+      const note1Matches = res.filter(n => n.equals(note1));
+      expect(note1Matches.length).toBe(1);
+    });
+
     it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
       const nullifiers = [mkNullifier(note2)];
       await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -225,7 +225,8 @@ export class NoteDataProvider {
    *
    * @param filter - Filter criteria including contractAddress (required), and optional
    *                 owner, storageSlot, status, scopes, and siloedNullifier.
-   * @returns Promise resolving to array of NoteDao objects matching the filter
+   * @returns Filtered and deduplicated notes (a note might be present in multiple scopes - we ensure it is only
+   * returned once if this is the case)
    * @throws If filtering by an empty scopes array. Scopes have to be set to undefined or to a non-empty array.
    */
   async getNotes(filter: NotesFilter): Promise<NoteDao[]> {
@@ -323,7 +324,15 @@ export class NoteDataProvider {
       }
     }
 
-    return result;
+    // A note might be present in multiple scopes - we ensure it is only returned once
+    const deduplicated: NoteDao[] = [];
+    for (const note of result) {
+      if (!deduplicated.some(existing => existing.equals(note))) {
+        deduplicated.push(note);
+      }
+    }
+
+    return deduplicated;
   }
 
   /**

--- a/yarn-project/stdlib/src/note/note.test.ts
+++ b/yarn-project/stdlib/src/note/note.test.ts
@@ -19,4 +19,12 @@ describe('note', () => {
   it('converts to and from json', () => {
     expect(jsonParseWithSchema(jsonStringify(note), Note.schema)).toEqual(note);
   });
+
+  it('equals returns false when number of items is different', () => {
+    const note1 = new Note([Fr.random(), Fr.random(), Fr.random()]);
+    const note2 = new Note([...note1.items, Fr.random(), Fr.random()]);
+
+    expect(note1.equals(note2)).toBe(false);
+    expect(note2.equals(note1)).toBe(false);
+  });
 });

--- a/yarn-project/stdlib/src/note/note.ts
+++ b/yarn-project/stdlib/src/note/note.ts
@@ -67,6 +67,9 @@ export class Note extends Vector<Fr> {
   }
 
   equals(other: Note) {
+    if (this.items.length !== other.items.length) {
+      return false;
+    }
     return this.items.every((item, index) => item.equals(other.items[index]));
   }
 }

--- a/yarn-project/stdlib/src/note/note_dao.test.ts
+++ b/yarn-project/stdlib/src/note/note_dao.test.ts
@@ -1,0 +1,26 @@
+import { NoteDao } from './note_dao.js';
+
+describe('NoteDao', () => {
+  it('convert to and from buffer', async () => {
+    const note = await NoteDao.random();
+    const buf = note.toBuffer();
+    expect(NoteDao.fromBuffer(buf)).toEqual(note);
+  });
+
+  describe('equals', () => {
+    it('returns true for identical NoteDao instances', async () => {
+      const note1 = await NoteDao.random();
+      const note2 = NoteDao.fromBuffer(note1.toBuffer());
+
+      expect(note1.equals(note2)).toBe(true);
+      expect(note2.equals(note1)).toBe(true);
+    });
+
+    it('returns false when note differs', async () => {
+      const note1 = await NoteDao.random();
+      const note2 = await NoteDao.random();
+
+      expect(note1.equals(note2)).toBe(false);
+    });
+  });
+});

--- a/yarn-project/stdlib/src/note/note_dao.ts
+++ b/yarn-project/stdlib/src/note/note_dao.ts
@@ -119,6 +119,26 @@ export class NoteDao {
   }
 
   /**
+   * Returns true if this note is equal to the `other` one.
+   */
+  equals(other: NoteDao): boolean {
+    return (
+      this.note.equals(other.note) &&
+      this.contractAddress.equals(other.contractAddress) &&
+      this.owner.equals(other.owner) &&
+      this.storageSlot.equals(other.storageSlot) &&
+      this.randomness.equals(other.randomness) &&
+      this.noteNonce.equals(other.noteNonce) &&
+      this.noteHash.equals(other.noteHash) &&
+      this.siloedNullifier.equals(other.siloedNullifier) &&
+      this.txHash.equals(other.txHash) &&
+      this.l2BlockNumber === other.l2BlockNumber &&
+      this.l2BlockHash === other.l2BlockHash &&
+      this.index === other.index
+    );
+  }
+
+  /**
    * Returns the size in bytes of the Note Dao.
    * @returns - Its size in bytes.
    */


### PR DESCRIPTION
Fixes F-93

Before this PR a note might have been returned multiple times from the `note_data_provider` because a note might have been present in multiple scopes and we didn't handle that. In this PR I fix this.