### PR TITLE
fix: nullifier tree check should do LookupGeneric into ff_gt

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/nullifier_tree_check_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/nullifier_tree_check_trace.cpp
@@ -102,8 +102,10 @@ const InteractionDefinition NullifierTreeCheckTraceBuilder::interactions =
         .add<lookup_nullifier_check_low_leaf_poseidon2_settings, InteractionType::LookupSequential>()
         .add<lookup_nullifier_check_updated_low_leaf_poseidon2_settings, InteractionType::LookupSequential>()
         .add<lookup_nullifier_check_low_leaf_merkle_check_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_low_leaf_nullifier_validation_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_low_leaf_next_nullifier_validation_settings, InteractionType::LookupSequential>()
+        .add<lookup_nullifier_check_low_leaf_nullifier_validation_settings,
+             InteractionType::LookupGeneric>() // ff_gt deduplicates
+        .add<lookup_nullifier_check_low_leaf_next_nullifier_validation_settings,
+             InteractionType::LookupGeneric>() // ff_gt deduplicates
         .add<lookup_nullifier_check_new_leaf_poseidon2_settings, InteractionType::LookupSequential>()
         .add<lookup_nullifier_check_new_leaf_merkle_check_settings, InteractionType::LookupSequential>()
         .add<lookup_nullifier_check_write_nullifier_to_public_inputs_settings,


### PR DESCRIPTION
After proving failure for emit-nullifier, this change to LookupGeneric into ff_gt fixes it.

Resolves https://linear.app/aztec-labs/issue/AVM-147/bug-failed-computing-counts-for-lookup-nullifier-check-low-leaf-next