### PR TITLE
fix: Fix silent exit for fuzzing

### DIFF
--- a/container-builds/fuzzing-container/src/entrypoint.sh
+++ b/container-builds/fuzzing-container/src/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 IFS=$'\n\t'
 
 umask 000


### PR DESCRIPTION
All the extra logging was skipped because of this flag