### PR TITLE
fix(docs): update test config to use ESM loader

### DIFF
--- a/barretenberg/docs/.mocharc.json
+++ b/barretenberg/docs/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "require": ["ts-node/register"],
+  "import": "tsx",
   "extensions": ["ts"],
   "spec": ["examples/**/*.test.ts"],
   "timeout": 60000

--- a/barretenberg/docs/package.json
+++ b/barretenberg/docs/package.json
@@ -12,7 +12,7 @@
     "clear": "./scripts/clean.sh",
     "serve": "docusaurus serve",
     "typecheck": "yarn tsgo",
-    "test": "TS_NODE_PROJECT=./tsconfig.test.json mocha",
+    "test": "mocha",
     "preprocess": "node src/preprocess/index.js",
     "preprocess:clean": "node src/preprocess/index.js clean"
   },

--- a/barretenberg/docs/tsconfig.test.json
+++ b/barretenberg/docs/tsconfig.test.json
@@ -1,18 +1,21 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ESNext",
     "lib": ["ES2020"],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "types": ["mocha", "node"],
     "baseUrl": ".",
     "outDir": "./dist"
+  },
+  "ts-node": {
+    "esm": true
   },
   "include": ["examples/**/*.test.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Fix test runner configuration to support ESM modules.

The `@aztec/bb.js` package is ESM (`"type": "module"`), so the test runner needs to use the ESM loader for ts-node.

## Changes

- Update `.mocharc.json` to use `"loader": "ts-node/esm"` instead of `"require": ["ts-node/register"]`
- Update `tsconfig.test.json` to use `"module": "ESNext"` with `"moduleResolution": "bundler"`
- Add `ts-node.esm: true` option to tsconfig.test.json

## Test plan

- [x] Verify `yarn test` passes in barretenberg/docs