### PR TITLE
fix: use attester address for duplicates check

### DIFF
--- a/yarn-project/node-keystore/src/loader.ts
+++ b/yarn-project/node-keystore/src/loader.ts
@@ -3,10 +3,13 @@
  *
  * Handles loading and parsing keystore configuration files.
  */
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import type { Hex } from '@aztec/foundation/string';
 
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { extname, join } from 'path';
+import { privateKeyToAddress } from 'viem/accounts';
 
 import { keystoreSchema } from './schemas.js';
 import type { EthAccounts, KeyStore } from './types.js';
@@ -220,8 +223,9 @@ export function mergeKeystores(keystores: KeyStore[]): KeyStore {
     if (keystore.validators) {
       for (const validator of keystore.validators) {
         // Check for duplicate attester addresses
-        const attesterKeys = extractAttesterKeys(validator.attester);
-        for (const key of attesterKeys) {
+        const attesterKeys = extractAttesterAddresses(validator.attester);
+        for (let key of attesterKeys) {
+          key = key.toLowerCase();
           if (attesterAddresses.has(key)) {
             throw new KeyStoreLoadError(
               `Duplicate attester address ${key} found across keystore files`,
@@ -284,38 +288,43 @@ export function mergeKeystores(keystores: KeyStore[]): KeyStore {
  * @param attester The attester configuration in any supported shape.
  * @returns Array of string keys used to detect duplicates.
  */
-function extractAttesterKeys(attester: unknown): string[] {
+function extractAttesterAddresses(attester: unknown): string[] {
   // String forms (private key or other) - return as-is for coarse uniqueness
   if (typeof attester === 'string') {
-    return [attester];
+    if (attester.length === 66) {
+      return [privateKeyToAddress(attester as Hex<32>)];
+    } else {
+      return [attester];
+    }
   }
 
   // Arrays of attester items
   if (Array.isArray(attester)) {
     const keys: string[] = [];
     for (const item of attester) {
-      keys.push(...extractAttesterKeys(item));
+      keys.push(...extractAttesterAddresses(item));
     }
     return keys;
   }
 
   if (attester && typeof attester === 'object') {
+    if (attester instanceof EthAddress) {
+      return [attester.toString()];
+    }
+
     const obj = attester as Record<string, unknown>;
 
     // New shape: { eth: EthAccount, bls?: BLSAccount }
     if ('eth' in obj) {
-      return extractAttesterKeys(obj.eth);
+      return extractAttesterAddresses(obj.eth);
     }
 
     // Remote signer account object shape: { address, remoteSignerUrl?, ... }
     if ('address' in obj) {
       return [String((obj as any).address)];
     }
-
-    // Mnemonic or other object shapes: stringify
-    return [JSON.stringify(attester)];
   }
 
-  // Fallback stringify for anything else (null/undefined)
-  return [JSON.stringify(attester)];
+  // mnemonic, encrypted file just disable early duplicates checking
+  return [];
 }

--- a/yarn-project/node-keystore/src/validation.test.ts
+++ b/yarn-project/node-keystore/src/validation.test.ts
@@ -8,10 +8,12 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { describe, expect, it } from '@jest/globals';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { generatePrivateKey, privateKeyToAddress } from 'viem/accounts';
 
 import { KeystoreError, KeystoreManager } from '../src/keystore_manager.js';
 import { KeyStoreLoadError, loadKeystoreFile, mergeKeystores } from '../src/loader.js';
 import type { KeyStore, ProverKeyStoreWithId } from '../src/types.js';
+import { keystoreSchema } from './schemas.js';
 
 // Enable logger output in tests by setting LOG_LEVEL
 const logger = createLogger('node-keystore:validation-test');
@@ -20,28 +22,33 @@ describe('Keystore Duplication Validation', () => {
   it('should reject duplicate attester addresses across keystores', () => {
     logger.info('Testing duplicate attester validation');
 
-    const keystore1: KeyStore = {
-      schemaVersion: 1,
-      validators: [
-        {
-          attester: '0x1234567890123456789012345678901234567890' as any,
-          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as any,
-        },
-      ],
-    };
+    const privateKey = generatePrivateKey();
+    const address = privateKeyToAddress(privateKey).toString();
 
-    const keystore2: KeyStore = {
+    const keystore1 = keystoreSchema.parse({
       schemaVersion: 1,
       validators: [
         {
-          attester: '0x1234567890123456789012345678901234567890' as any, // Duplicate!
-          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as any,
+          attester: privateKey,
+          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
         },
       ],
-    };
+    });
+
+    const keystore2 = keystoreSchema.parse({
+      schemaVersion: 1,
+      validators: [
+        {
+          attester: address,
+          feeRecipient: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        },
+      ],
+    });
 
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(KeyStoreLoadError);
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(/Duplicate attester address/);
+    expect(() => mergeKeystores([keystore1, keystore2])).toThrow(address.toLowerCase());
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(privateKey);
   });
 
   it('should reject multiple prover configurations across keystores', () => {
@@ -59,6 +66,8 @@ describe('Keystore Duplication Validation', () => {
 
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(KeyStoreLoadError);
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(/Multiple prover configurations found/);
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(keystore1.prover!);
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(keystore2.prover!);
   });
 
   it('should reject duplicate ETH attester across keystores even if BLS differs', () => {
@@ -88,6 +97,9 @@ describe('Keystore Duplication Validation', () => {
 
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(KeyStoreLoadError);
     expect(() => mergeKeystores([keystore1, keystore2])).toThrow(/Duplicate attester address/);
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(eth);
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(bls1);
+    expect(() => mergeKeystores([keystore1, keystore2])).not.toThrow(bls2);
   });
 
   it('should allow unique attester addresses across keystores', () => {
@@ -185,6 +197,7 @@ describe('Keystore Duplication Validation', () => {
     const manager = new KeystoreManager(keystore);
     expect(() => manager.validateResolvedUniqueAttesterAddresses()).toThrow(KeystoreError);
     expect(() => manager.validateResolvedUniqueAttesterAddresses()).toThrow(/Duplicate attester address/);
+    expect(() => manager.validateResolvedUniqueAttesterAddresses()).not.toThrow(privateKey);
   });
 
   // Integration tests moved from examples.integration.test.ts


### PR DESCRIPTION
Correctly parse attester addresses when checking for duplicates. 

Fix A-360