### PR TITLE
chore: Add support for the Noir `msgpack-compact` serialisation format 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -285,7 +285,10 @@ T deserialize_any_format(std::vector<uint8_t>&& buf,
         // Once we remove support for legacy bincode format, we should expect to always
         // have a format marker corresponding to acir::serialization::Format::Msgpack,
         // but until then a match could be pure coincidence.
-        if (buf[0] == 2) {
+        const uint8_t FORMAT_MSGPACK = 2;
+        const uint8_t FORMAT_MSGPACK_COMPACT = 3;
+        uint8_t format = buf[0];
+        if (format == FORMAT_MSGPACK || format == FORMAT_MSGPACK_COMPACT) {
             // Skip the format marker to get the data.
             const char* buffer = &reinterpret_cast<const char*>(buf.data())[1];
             size_t size = buf.size() - 1;
@@ -295,10 +298,9 @@ T deserialize_any_format(std::vector<uint8_t>&& buf,
                 // This has to be on a separate line, see
                 // https://github.com/msgpack/msgpack-c/issues/695#issuecomment-393035172
                 auto o = oh.get();
-                // In experiments bincode data was parsed as 0.
-                // All the top level formats we look for are MAP types.
-                if (o.type == msgpack::type::MAP) {
-                    BB_ASSERT(false, "acir_format::deserialize_any_format: Msgpack is not currently supported.");
+                // In experiments bincode data was parsed as 0, so a successful parse is not a guarnatee that it's
+                // msgpack. All the top level formats we look for are MAP or ARRAY types (depending on the format).
+                if (o.type == msgpack::type::MAP || o.type == msgpack::type::ARRAY) {
                     return decode_msgpack(o);
                 }
             }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -29,6 +29,7 @@ struct Helpers {
         }
         return kvmap;
     }
+
     template <typename T>
     static void conv_fld_from_kvmap(std::map<std::string, msgpack::object const*> const& kvmap,
                                     std::string const& struct_name,
@@ -46,6 +47,25 @@ struct Helpers {
             }
         } else if (!is_optional) {
             throw_or_abort("missing field: " + struct_name + "::" + field_name);
+        }
+    }
+
+    template <typename T>
+    static void conv_fld_from_array(msgpack::object_array const& array,
+                                    std::string const& struct_name,
+                                    std::string const& field_name,
+                                    T& field,
+                                    uint32_t index)
+    {
+        if (index >= array.size) {
+            throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
+        }
+        auto element = array.ptr[index];
+        try {
+            element.convert(field);
+        } catch (const msgpack::type_error&) {
+            std::cerr << element << std::endl;
+            throw_or_abort("error converting into field " + struct_name + "::" + field_name);
         }
     }
 };
@@ -894,10 +914,18 @@ struct HeapArray {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "HeapArray";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+        std::string name = "HeapArray";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
+            Helpers::conv_fld_from_array(array, name, "size", size, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -918,10 +946,18 @@ struct HeapVector {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "HeapVector";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+        std::string name = "HeapVector";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
+            Helpers::conv_fld_from_array(array, name, "size", size, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -948,12 +984,22 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "AES128Encrypt";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "AES128Encrypt";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
+                Helpers::conv_fld_from_array(array, name, "key", key, 2);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -974,10 +1020,18 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Blake2s";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "Blake2s";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "message", message, 0);
+                Helpers::conv_fld_from_array(array, name, "output", output, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -998,10 +1052,18 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Blake3";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "Blake3";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "message", message, 0);
+                Helpers::conv_fld_from_array(array, name, "output", output, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1022,10 +1084,18 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Keccakf1600";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "Keccakf1600";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input", input, 0);
+                Helpers::conv_fld_from_array(array, name, "output", output, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1052,13 +1122,24 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EcdsaSecp256k1";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            std::string name = "EcdsaSecp256k1";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
+                Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
+                Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
+                Helpers::conv_fld_from_array(array, name, "signature", signature, 3);
+                Helpers::conv_fld_from_array(array, name, "result", result, 4);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1085,13 +1166,24 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EcdsaSecp256r1";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            std::string name = "EcdsaSecp256r1";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
+                Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
+                Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
+                Helpers::conv_fld_from_array(array, name, "signature", signature, 3);
+                Helpers::conv_fld_from_array(array, name, "result", result, 4);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1114,11 +1206,20 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "MultiScalarMul";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "MultiScalarMul";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "points", points, 0);
+                Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1149,15 +1250,28 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EmbeddedCurveAdd";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input1_infinite", input1_infinite, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input2_x", input2_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input2_y", input2_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input2_infinite", input2_infinite, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            std::string name = "EmbeddedCurveAdd";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input1_infinite", input1_infinite, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input2_x", input2_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input2_y", input2_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input2_infinite", input2_infinite, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input1_x", input1_x, 0);
+                Helpers::conv_fld_from_array(array, name, "input1_y", input1_y, 1);
+                Helpers::conv_fld_from_array(array, name, "input1_infinite", input1_infinite, 2);
+                Helpers::conv_fld_from_array(array, name, "input2_x", input2_x, 3);
+                Helpers::conv_fld_from_array(array, name, "input2_y", input2_y, 4);
+                Helpers::conv_fld_from_array(array, name, "input2_infinite", input2_infinite, 5);
+                Helpers::conv_fld_from_array(array, name, "result", result, 6);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1178,10 +1292,18 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Poseidon2Permutation";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "Poseidon2Permutation";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "message", message, 0);
+                Helpers::conv_fld_from_array(array, name, "output", output, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1204,11 +1326,20 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Sha256Compression";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "Sha256Compression";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input", input, 0);
+                Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
+                Helpers::conv_fld_from_array(array, name, "output", output, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1235,13 +1366,24 @@ struct BlackBoxOp {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "ToRadix";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output_pointer", output_pointer, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "num_limbs", num_limbs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output_bits", output_bits, false);
+            std::string name = "ToRadix";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output_pointer", output_pointer, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "num_limbs", num_limbs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output_bits", output_bits, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input", input, 0);
+                Helpers::conv_fld_from_array(array, name, "radix", radix, 1);
+                Helpers::conv_fld_from_array(array, name, "output_pointer", output_pointer, 2);
+                Helpers::conv_fld_from_array(array, name, "num_limbs", num_limbs, 3);
+                Helpers::conv_fld_from_array(array, name, "output_bits", output_bits, 4);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1507,10 +1649,18 @@ struct HeapValueType {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Array";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+            std::string name = "Array";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
+                Helpers::conv_fld_from_array(array, name, "size", size, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1529,9 +1679,16 @@ struct HeapValueType {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Vector";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+            std::string name = "Vector";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1816,12 +1973,22 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "BinaryFieldOp";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+            std::string name = "BinaryFieldOp";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "op", op, 1);
+                Helpers::conv_fld_from_array(array, name, "lhs", lhs, 2);
+                Helpers::conv_fld_from_array(array, name, "rhs", rhs, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1848,13 +2015,24 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "BinaryIntOp";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+            std::string name = "BinaryIntOp";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "op", op, 1);
+                Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
+                Helpers::conv_fld_from_array(array, name, "lhs", lhs, 3);
+                Helpers::conv_fld_from_array(array, name, "rhs", rhs, 4);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1877,11 +2055,20 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Not";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+            std::string name = "Not";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "source", source, 1);
+                Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1904,11 +2091,20 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Cast";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+            std::string name = "Cast";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "source", source, 1);
+                Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1929,10 +2125,18 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "JumpIf";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            std::string name = "JumpIf";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "condition", condition, 0);
+                Helpers::conv_fld_from_array(array, name, "location", location, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1951,9 +2155,16 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Jump";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            std::string name = "Jump";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "location", location, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1976,11 +2187,20 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "CalldataCopy";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "offset_address", offset_address, false);
+            std::string name = "CalldataCopy";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "offset_address", offset_address, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination_address", destination_address, 0);
+                Helpers::conv_fld_from_array(array, name, "size_address", size_address, 1);
+                Helpers::conv_fld_from_array(array, name, "offset_address", offset_address, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -1999,9 +2219,16 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Call";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            std::string name = "Call";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "location", location, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2024,11 +2251,20 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Const";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+            std::string name = "Const";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
+                Helpers::conv_fld_from_array(array, name, "value", value, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2051,11 +2287,20 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "IndirectConst";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+            std::string name = "IndirectConst";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
+                Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
+                Helpers::conv_fld_from_array(array, name, "value", value, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2091,13 +2336,24 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "ForeignCall";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination_value_types", destination_value_types, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input_value_types", input_value_types, false);
+            std::string name = "ForeignCall";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination_value_types", destination_value_types, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input_value_types", input_value_types, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "function", function, 0);
+                Helpers::conv_fld_from_array(array, name, "destinations", destinations, 1);
+                Helpers::conv_fld_from_array(array, name, "destination_value_types", destination_value_types, 2);
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 3);
+                Helpers::conv_fld_from_array(array, name, "input_value_types", input_value_types, 4);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2118,10 +2374,18 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Mov";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+            std::string name = "Mov";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "source", source, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2146,12 +2410,22 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "ConditionalMov";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source_b", source_b, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+            std::string name = "ConditionalMov";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source_b", source_b, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "source_a", source_a, 1);
+                Helpers::conv_fld_from_array(array, name, "source_b", source_b, 2);
+                Helpers::conv_fld_from_array(array, name, "condition", condition, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2172,10 +2446,18 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Load";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
+            std::string name = "Load";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
+                Helpers::conv_fld_from_array(array, name, "source_pointer", source_pointer, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2196,10 +2478,18 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Store";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+            std::string name = "Store";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
+                Helpers::conv_fld_from_array(array, name, "source", source, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2238,9 +2528,16 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Trap";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
+            std::string name = "Trap";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "revert_data", revert_data, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2259,9 +2556,16 @@ struct BrilligOpcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Stop";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
+            std::string name = "Stop";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "return_data", return_data, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2768,12 +3072,22 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "AES128Encrypt";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "AES128Encrypt";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
+                Helpers::conv_fld_from_array(array, name, "key", key, 2);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2798,12 +3112,22 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "AND";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "AND";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
+                Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
+                Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
+                Helpers::conv_fld_from_array(array, name, "output", output, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2828,12 +3152,22 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "XOR";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "XOR";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
+                Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
+                Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
+                Helpers::conv_fld_from_array(array, name, "output", output, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2854,10 +3188,18 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "RANGE";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+            std::string name = "RANGE";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input", input, 0);
+                Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2878,10 +3220,18 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Blake2s";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "Blake2s";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2902,10 +3252,18 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Blake3";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "Blake3";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2934,14 +3292,26 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EcdsaSecp256k1";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "EcdsaSecp256k1";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
+                Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
+                Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
+                Helpers::conv_fld_from_array(array, name, "hashed_message", hashed_message, 3);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 4);
+                Helpers::conv_fld_from_array(array, name, "output", output, 5);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -2970,14 +3340,26 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EcdsaSecp256r1";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            std::string name = "EcdsaSecp256r1";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
+                Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
+                Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
+                Helpers::conv_fld_from_array(array, name, "hashed_message", hashed_message, 3);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 4);
+                Helpers::conv_fld_from_array(array, name, "output", output, 5);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3002,12 +3384,22 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "MultiScalarMul";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "MultiScalarMul";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "points", points, 0);
+                Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3032,12 +3424,22 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "EmbeddedCurveAdd";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "EmbeddedCurveAdd";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "input1", input1, 0);
+                Helpers::conv_fld_from_array(array, name, "input2", input2, 1);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3058,10 +3460,18 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Keccakf1600";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "Keccakf1600";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3090,14 +3500,26 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "RecursiveAggregation";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "public_inputs", public_inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "key_hash", key_hash, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "proof_type", proof_type, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+            std::string name = "RecursiveAggregation";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "public_inputs", public_inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "key_hash", key_hash, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "proof_type", proof_type, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "verification_key", verification_key, 0);
+                Helpers::conv_fld_from_array(array, name, "proof", proof, 1);
+                Helpers::conv_fld_from_array(array, name, "public_inputs", public_inputs, 2);
+                Helpers::conv_fld_from_array(array, name, "key_hash", key_hash, 3);
+                Helpers::conv_fld_from_array(array, name, "proof_type", proof_type, 4);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 5);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3118,10 +3540,18 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Poseidon2Permutation";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "Poseidon2Permutation";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3144,11 +3574,20 @@ struct BlackBoxFuncCall {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Sha256Compression";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            std::string name = "Sha256Compression";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
+                Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3581,11 +4020,20 @@ struct Expression {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "Expression";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "q_c", q_c, false);
+        std::string name = "Expression";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "q_c", q_c, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "mul_terms", mul_terms, 0);
+            Helpers::conv_fld_from_array(array, name, "linear_combinations", linear_combinations, 1);
+            Helpers::conv_fld_from_array(array, name, "q_c", q_c, 2);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -3894,11 +4342,20 @@ struct MemOp {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "MemOp";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+        std::string name = "MemOp";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "operation", operation, 0);
+            Helpers::conv_fld_from_array(array, name, "index", index, 1);
+            Helpers::conv_fld_from_array(array, name, "value", value, 2);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -3961,10 +4418,18 @@ struct Opcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "MemoryOp";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+            std::string name = "MemoryOp";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
+                Helpers::conv_fld_from_array(array, name, "op", op, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -3987,11 +4452,20 @@ struct Opcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "MemoryInit";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "block_type", block_type, false);
+            std::string name = "MemoryInit";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "block_type", block_type, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
+                Helpers::conv_fld_from_array(array, name, "init", init, 1);
+                Helpers::conv_fld_from_array(array, name, "block_type", block_type, 2);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -4016,12 +4490,22 @@ struct Opcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "BrilligCall";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+            std::string name = "BrilligCall";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "id", id, 0);
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -4046,12 +4530,22 @@ struct Opcode {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Call";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+            std::string name = "Call";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "id", id, 0);
+                Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
+                Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
+                Helpers::conv_fld_from_array(array, name, "predicate", predicate, 3);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -4338,10 +4832,18 @@ struct AssertionPayload {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "AssertionPayload";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
+        std::string name = "AssertionPayload";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "error_selector", error_selector, 0);
+            Helpers::conv_fld_from_array(array, name, "payload", payload, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -4384,10 +4886,18 @@ struct OpcodeLocation {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Brillig";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
+            std::string name = "Brillig";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "acir_index", acir_index, 0);
+                Helpers::conv_fld_from_array(array, name, "brillig_index", brillig_index, 1);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -4495,10 +5005,6 @@ struct PublicInputs {
     }
 };
 
-/**
- * @brief The intermediate representation of a function when being transformed from a vector of bytes into a series of
- * constraints.
- */
 struct Circuit {
     std::string function_name;
     uint32_t current_witness_index;
@@ -4526,15 +5032,28 @@ struct Circuit {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "Circuit";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "return_values", return_values, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "assert_messages", assert_messages, false);
+        std::string name = "Circuit";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "return_values", return_values, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "assert_messages", assert_messages, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
+            Helpers::conv_fld_from_array(array, name, "current_witness_index", current_witness_index, 1);
+            Helpers::conv_fld_from_array(array, name, "opcodes", opcodes, 2);
+            Helpers::conv_fld_from_array(array, name, "private_parameters", private_parameters, 3);
+            Helpers::conv_fld_from_array(array, name, "public_parameters", public_parameters, 4);
+            Helpers::conv_fld_from_array(array, name, "return_values", return_values, 5);
+            Helpers::conv_fld_from_array(array, name, "assert_messages", assert_messages, 6);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -4555,10 +5074,18 @@ struct BrilligBytecode {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "BrilligBytecode";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "bytecode", bytecode, false);
+        std::string name = "BrilligBytecode";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "bytecode", bytecode, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
+            Helpers::conv_fld_from_array(array, name, "bytecode", bytecode, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -4579,15 +5106,24 @@ struct Program {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "Program";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "unconstrained_functions", unconstrained_functions, false);
+        std::string name = "Program";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "unconstrained_functions", unconstrained_functions, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
+            Helpers::conv_fld_from_array(array, name, "unconstrained_functions", unconstrained_functions, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
 struct ProgramWithoutBrillig {
     std::vector<Acir::Circuit> functions;
+    std::monostate unconstrained_functions;
 
     friend bool operator==(const ProgramWithoutBrillig&, const ProgramWithoutBrillig&);
     std::vector<uint8_t> bincodeSerialize() const;
@@ -4601,9 +5137,16 @@ struct ProgramWithoutBrillig {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "ProgramWithoutBrillig";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+        std::string name = "ProgramWithoutBrillig";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -4633,9 +5176,16 @@ struct ExpressionWidth {
 
         void msgpack_unpack(msgpack::object const& o)
         {
-            auto name = "Bounded";
-            auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "width", width, false);
+            std::string name = "Bounded";
+            if (o.type == msgpack::type::MAP) {
+                auto kvmap = Helpers::make_kvmap(o, name);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "width", width, false);
+            } else if (o.type == msgpack::type::ARRAY) {
+                auto array = o.via.array;
+                Helpers::conv_fld_from_array(array, name, "width", width, 0);
+            } else {
+                throw_or_abort("expected MAP or ARRAY for " + name);
+            }
         }
     };
 
@@ -11004,6 +11554,9 @@ inline bool operator==(const ProgramWithoutBrillig& lhs, const ProgramWithoutBri
     if (!(lhs.functions == rhs.functions)) {
         return false;
     }
+    if (!(lhs.unconstrained_functions == rhs.unconstrained_functions)) {
+        return false;
+    }
     return true;
 }
 
@@ -11033,6 +11586,7 @@ void serde::Serializable<Acir::ProgramWithoutBrillig>::serialize(const Acir::Pro
 {
     serializer.increase_container_depth();
     serde::Serializable<decltype(obj.functions)>::serialize(obj.functions, serializer);
+    serde::Serializable<decltype(obj.unconstrained_functions)>::serialize(obj.unconstrained_functions, serializer);
     serializer.decrease_container_depth();
 }
 
@@ -11043,6 +11597,8 @@ Acir::ProgramWithoutBrillig serde::Deserializable<Acir::ProgramWithoutBrillig>::
     deserializer.increase_container_depth();
     Acir::ProgramWithoutBrillig obj;
     obj.functions = serde::Deserializable<decltype(obj.functions)>::deserialize(deserializer);
+    obj.unconstrained_functions =
+        serde::Deserializable<decltype(obj.unconstrained_functions)>::deserialize(deserializer);
     deserializer.decrease_container_depth();
     return obj;
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include "barretenberg/serialize/msgpack_impl.hpp"
 #include "bincode.hpp"
-#include "msgpack.hpp"
 #include "serde.hpp"
 
 namespace Witnesses {
@@ -29,6 +29,7 @@ struct Helpers {
         }
         return kvmap;
     }
+
     template <typename T>
     static void conv_fld_from_kvmap(std::map<std::string, msgpack::object const*> const& kvmap,
                                     std::string const& struct_name,
@@ -46,6 +47,25 @@ struct Helpers {
             }
         } else if (!is_optional) {
             throw_or_abort("missing field: " + struct_name + "::" + field_name);
+        }
+    }
+
+    template <typename T>
+    static void conv_fld_from_array(msgpack::object_array const& array,
+                                    std::string const& struct_name,
+                                    std::string const& field_name,
+                                    T& field,
+                                    uint32_t index)
+    {
+        if (index >= array.size) {
+            throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
+        }
+        auto element = array.ptr[index];
+        try {
+            element.convert(field);
+        } catch (const msgpack::type_error&) {
+            std::cerr << element << std::endl;
+            throw_or_abort("error converting into field " + struct_name + "::" + field_name);
         }
     }
 };
@@ -111,10 +131,18 @@ struct StackItem {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "StackItem";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
+        std::string name = "StackItem";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "index", index, 0);
+            Helpers::conv_fld_from_array(array, name, "witness", witness, 1);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 
@@ -133,9 +161,16 @@ struct WitnessStack {
 
     void msgpack_unpack(msgpack::object const& o)
     {
-        auto name = "WitnessStack";
-        auto kvmap = Helpers::make_kvmap(o, name);
-        Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
+        std::string name = "WitnessStack";
+        if (o.type == msgpack::type::MAP) {
+            auto kvmap = Helpers::make_kvmap(o, name);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
+        } else if (o.type == msgpack::type::ARRAY) {
+            auto array = o.via.array;
+            Helpers::conv_fld_from_array(array, name, "stack", stack, 0);
+        } else {
+            throw_or_abort("expected MAP or ARRAY for " + name);
+        }
     }
 };
 


### PR DESCRIPTION
Brings the changes in the generated C++ for deserialising programs from https://github.com/noir-lang/noir/pull/10878
adding support for the `msgpack-compact` format. 

Removes the exception if `msgpack` or `msgpack-compact` format is encountered in the format marker.

Tested the same way as https://github.com/AztecProtocol/aztec-packages/pull/12841 but with `export NOIR_SERIALIZATION_FORMAT=msgpack-compact`.
