### PR TITLE
feat: allow timestamp to be equal to the previous timestamp

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/tests/consecutive_block_rollups_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/tests/consecutive_block_rollups_tests.nr
@@ -248,12 +248,13 @@ fn non_consecutive_timestamps() {
     builder.execute_and_fail();
 }
 
-#[test(should_fail_with = "Rollup block timestamps do not follow on from each other")]
-fn non_consecutive_timestamps_duplicates() {
+#[test]
+fn identical_timestamps_are_allowed() {
     let mut builder = TestBuilder::default();
 
     // Change the start_timestamp of the right rollup to be the same as the end_timestamp of the left rollup.
     builder.right_rollup.start_timestamp = builder.left_rollup.end_timestamp;
 
-    builder.execute_and_fail();
+    let pi = builder.execute();
+    builder.assert_expected_public_inputs(pi);
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/validate_consecutive_block_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/validate_consecutive_block_rollups.nr
@@ -36,7 +36,7 @@ fn assert_prev_block_rollups_follow_on_from_each_other(
     );
 
     assert(
-        left.end_timestamp < right.start_timestamp,
+        left.end_timestamp <= right.start_timestamp,
         "Rollup block timestamps do not follow on from each other",
     );
 


### PR DESCRIPTION
A block's timestamp can now be greater than or equal to the previous block's timestamp.
Since the timestamp in the checkpoint header is the timestamp of its last block. This enables using the same timestamp for all blocks in a checkpoint, so that we don't have to decide whether a block will be the last one before building it.