### PR TITLE
chore: More deflake attempts

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_multiple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_multiple.test.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@aztec/aztec.js/log';
 import { RollupContract } from '@aztec/ethereum/contracts';
-import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 
 import { jest } from '@jest/globals';
 
@@ -28,35 +28,27 @@ describe('e2e_epochs/epochs_multiple', () => {
 
   it('successfully proves multiple epochs', async () => {
     const targetProvenEpochs = process.env.TARGET_PROVEN_EPOCHS ? parseInt(process.env.TARGET_PROVEN_EPOCHS) : 3;
-    const targetProvenCheckpointNumber = CheckpointNumber(targetProvenEpochs * test.epochDuration);
-
-    let provenCheckpointNumber = CheckpointNumber(0);
     let epochNumber = 0;
-    logger.info(`Waiting for ${targetProvenEpochs} epochs to be proven at ${targetProvenCheckpointNumber} checkpoints`);
-    while (provenCheckpointNumber < targetProvenCheckpointNumber) {
+    logger.info(`Testing for ${targetProvenEpochs} epochs to be proven`);
+
+    while (epochNumber < targetProvenEpochs) {
       logger.info(`Waiting for the end of epoch ${epochNumber}`);
       await test.waitUntilEpochStarts(epochNumber + 1);
-      const epochTargetCheckpointNumber = await rollup.getCheckpointNumber();
-      logger.info(`Epoch ${epochNumber} ended with PENDING checkpoint number ${epochTargetCheckpointNumber}`);
-      await test.waitUntilCheckpointNumber(
-        epochTargetCheckpointNumber,
-        test.L2_SLOT_DURATION_IN_S * (epochTargetCheckpointNumber + 4),
-      );
-      provenCheckpointNumber = epochTargetCheckpointNumber;
-      logger.info(
-        `Reached PENDING checkpoint ${epochTargetCheckpointNumber}, proving should now start, waiting for PROVEN checkpoint to reach ${provenCheckpointNumber}`,
-      );
-      await test.waitUntilProvenCheckpointNumber(provenCheckpointNumber, 240);
-      expect(await rollup.getProvenCheckpointNumber()).toBeGreaterThanOrEqual(provenCheckpointNumber);
-      logger.info(`Reached PROVEN checkpoint number ${provenCheckpointNumber}, epoch ${epochNumber} is now proven`);
+      const epochEndCheckpointNumber = (await test.monitor.run()).checkpointNumber;
+      logger.info(`Epoch ${epochNumber} ended with pending checkpoint number ${epochEndCheckpointNumber}`);
+
+      await test.waitUntilProvenCheckpointNumber(epochEndCheckpointNumber, 240);
+      expect(await rollup.getProvenCheckpointNumber()).toBeGreaterThanOrEqual(epochEndCheckpointNumber);
+      logger.info(`Reached proven checkpoint number ${epochEndCheckpointNumber}, epoch ${epochNumber} is now proven`);
       epochNumber++;
 
       // Verify the state syncs
-      await test.waitForNodeToSync(BlockNumber(Number(provenCheckpointNumber)), 'proven');
-      await test.verifyHistoricBlock(BlockNumber(Number(provenCheckpointNumber)), true);
+      await test.waitForNodeToSync(BlockNumber.fromCheckpointNumber(epochEndCheckpointNumber), 'proven');
+      await test.verifyHistoricBlock(BlockNumber.fromCheckpointNumber(epochEndCheckpointNumber), true);
 
-      // right now finalization means a checkpoint is two L2 epochs deep. If this rule changes then we need this test needs to be updated
-      const provenBlockNumber = Number(provenCheckpointNumber);
+      // Check that finalized blocks are purged from world state
+      // Right now finalization means a checkpoint is two L2 epochs deep. If this rule changes then this test needs to be updated.
+      const provenBlockNumber = BlockNumber.fromCheckpointNumber(epochEndCheckpointNumber);
       const finalizedBlockNumber = Math.max(provenBlockNumber - context.config.aztecEpochDuration * 2, 0);
       const expectedOldestHistoricBlock = Math.max(finalizedBlockNumber - WORLD_STATE_BLOCK_HISTORY + 1, 1);
       const expectedBlockRemoved = expectedOldestHistoricBlock - 1;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.parallel.test.ts
@@ -40,6 +40,7 @@ describe('e2e_epochs/epochs_proof_fails', () => {
       maxSpeedUpAttempts: 0, // No speed ups
       startProverNode: false, // Avoid early proving
       ethereumSlotDuration: 8,
+      aztecEpochDuration: 8, // Bump empoch duration so we can land at least one block in epoch 0
       cancelTxOnTimeout: false,
     });
     ({ sequencerDelayer, context, l1Client, rollup, constants, logger, monitor } = test);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -95,7 +95,7 @@ export class EpochsTestContext {
       : DEFAULT_L1_BLOCK_TIME;
     const ethereumSlotDuration = opts.ethereumSlotDuration ?? envEthereumSlotDuration;
     const aztecSlotDuration = opts.aztecSlotDuration ?? ethereumSlotDuration * 2;
-    const aztecEpochDuration = opts.aztecEpochDuration ?? 8;
+    const aztecEpochDuration = opts.aztecEpochDuration ?? 6;
     const aztecProofSubmissionEpochs = opts.aztecProofSubmissionEpochs ?? 1;
     return { ethereumSlotDuration, aztecSlotDuration, aztecEpochDuration, aztecProofSubmissionEpochs };
   }

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_with_consecutive_epochs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_with_consecutive_epochs.test.ts
@@ -2,6 +2,7 @@ import type { EthAddress } from '@aztec/aztec.js/addresses';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { unique } from '@aztec/foundation/collection';
 import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
 import { OffenseType } from '@aztec/slasher';
 
 import { jest } from '@jest/globals';
@@ -66,14 +67,24 @@ describe('e2e_p2p_inactivity_slash_with_consecutive_epochs', () => {
       slashed.push(args.attester);
     });
 
-    // Wait until after the slashing would have executed for inactivity plus a bit for good measure
-    const targetEpoch =
-      initialEpoch +
-      slashInactivityConsecutiveEpochThreshold +
-      (slashingExecutionDelayInRounds + slashingOffsetInRounds) * slashingRoundSizeInEpochs +
-      5;
-    test.logger.warn(`Waiting until slot ${aztecEpochDuration * targetEpoch} (epoch ${targetEpoch}) for slash`);
-    await test.test.monitor.waitUntilL2Slot(SlotNumber(aztecEpochDuration * targetEpoch));
+    // Wait until after the slashing would have executed for inactivity
+    // Note that this may take some time if the offline validator is elected as proposer enough times
+    // that we never get to collect enough votes in a round to trigger the slash
+    const attemptsInRounds = 3;
+    const delayInEpochs =
+      attemptsInRounds * slashingRoundSizeInEpochs + // How many rounds to wait until the slash is voted
+      (slashingExecutionDelayInRounds + slashingOffsetInRounds) * slashingRoundSizeInEpochs + // Wait for execution delay
+      4; // A bit extra
+
+    const timeout = delayInEpochs * aztecEpochDuration * aztecSlotDuration;
+    test.logger.warn(`Waiting ${timeout}s (${delayInEpochs} epochs) until for slash`);
+    await retryUntil(
+      () => slashed.length > 0,
+      'slash executed',
+      delayInEpochs * aztecEpochDuration * aztecSlotDuration * 2,
+    );
+
+    await sleep(1000); // Wait a bit to ensure no more slashes are recorded
     expect(unique(slashed.map(addr => addr.toString()))).toEqual([offlineValidator.toString()]);
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
@@ -134,7 +134,10 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
   });
 
   it('collects attestations for validators in proposer node when block is not published', async () => {
-    // Stop the second node, this means the first block won't be able to propose
+    // Ensure all nodes see each other, especially the sentinel
+    await t.waitForP2PMeshConnectivity([...nodes, sentinel]);
+
+    // Stop the second node, this means the first node won't be able to propose since won't achieve quorum
     await tryStop(nodes[1]);
 
     await t.monitor.run();

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -105,6 +105,7 @@ export class ProverNodePublisher {
 
       const txReceipt = await this.sendSubmitEpochProofTx(args);
       if (!txReceipt) {
+        this.log.error(`Failed to mine submitEpochProof tx`, undefined, ctx);
         return false;
       }
 
@@ -137,7 +138,7 @@ export class ProverNodePublisher {
       }
 
       this.metrics.recordFailedTx();
-      this.log.error(`Rollup.submitEpochProof tx status failed ${txReceipt.transactionHash}`, undefined, ctx);
+      this.log.error(`Rollup submitEpochProof tx reverted ${txReceipt.transactionHash}`, undefined, ctx);
     }
 
     this.log.verbose('Checkpoint data syncing interrupted', ctx);
@@ -229,21 +230,24 @@ export class ProverNodePublisher {
     });
     try {
       const { receipt } = await this.l1TxUtils.sendAndMonitorTransaction({ to: this.rollupContract.address, data });
+      if (receipt.status !== 'success') {
+        const errorMsg = await this.l1TxUtils.tryGetErrorFromRevertedTx(
+          data,
+          {
+            args: [...txArgs],
+            functionName: 'submitEpochRootProof',
+            abi: RollupAbi,
+            address: this.rollupContract.address,
+          },
+          /*blobInputs*/ undefined,
+          /*stateOverride*/ [],
+        );
+        this.log.error(`Rollup submit epoch proof tx reverted with ${errorMsg ?? 'unknown error'}`);
+        return undefined;
+      }
       return receipt;
     } catch (err) {
       this.log.error(`Rollup submit epoch proof failed`, err);
-      const errorMsg = await this.l1TxUtils.tryGetErrorFromRevertedTx(
-        data,
-        {
-          args: [...txArgs],
-          functionName: 'submitEpochRootProof',
-          abi: RollupAbi,
-          address: this.rollupContract.address,
-        },
-        /*blobInputs*/ undefined,
-        /*stateOverride*/ [],
-      );
-      this.log.error(`Rollup submit epoch proof tx reverted. ${errorMsg}`);
       return undefined;
     }
   }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -270,13 +270,13 @@ export class ServerWorldStateSynchronizer
         await this.handleL2Blocks(event.blocks.map(b => b.block.toL2Block()));
         break;
       case 'chain-pruned':
-        await this.handleChainPruned(BlockNumber(event.block.number));
+        await this.handleChainPruned(event.block.number);
         break;
       case 'chain-proven':
-        await this.handleChainProven(BlockNumber(event.block.number));
+        await this.handleChainProven(event.block.number);
         break;
       case 'chain-finalized':
-        await this.handleChainFinalized(BlockNumber(event.block.number));
+        await this.handleChainFinalized(event.block.number);
         break;
     }
   }
@@ -349,12 +349,12 @@ export class ServerWorldStateSynchronizer
     if (this.historyToKeep === undefined) {
       return;
     }
-    const newHistoricBlock = BlockNumber(summary.finalizedBlockNumber - this.historyToKeep + 1);
-    if (newHistoricBlock <= BlockNumber(1)) {
+    const newHistoricBlock = summary.finalizedBlockNumber - this.historyToKeep + 1;
+    if (newHistoricBlock <= 1) {
       return;
     }
     this.log.verbose(`Pruning historic blocks to ${newHistoricBlock}`);
-    const status = await this.merkleTreeDb.removeHistoricalBlocks(newHistoricBlock);
+    const status = await this.merkleTreeDb.removeHistoricalBlocks(BlockNumber(newHistoricBlock));
     this.log.debug(`World state summary `, status.summary);
   }
 


### PR DESCRIPTION
- Rollbacks the default epoch duration from 8 to 6 slots in epochs test, which had been increased in #18912, since it was causing other tests to timeout, such as `epochs_multiple_test`.
- Fixes `epochs_multiple_test` so that it checks for the expected number of epochs. It was testing for more proven epochs if there were epochs without all checkpoints mined (eg epoch 0).
- Makes `epochs_proof_fails` test suite run in parallel to sidestep the 10 minute global timeout.
- Allows additional attempts at slashing in `inactivity_slash_with_consecutive_epochs`, which was failing if the inactive validator was chosen as proposer too often within a round, causing not enough votes to be collected.
- Ensures that the node acting as sentinel in `multiple_validators_sentinel.parallel` is properly connected to p2p, otherwise it was not seeing the proposals and attestations broadcasted via p2p by the online validator.
- Fixes handling L1 tx reverts in epoch proof submission, so we can find out the reason for a tx to fail, which may give us an indication to flakes in `epochs_multi_proof`.
- Fixes handling of negative block numbers in world-state, that caused very annoying errors in logs every time the chain was proven.