### PR TITLE
chore(docs): update Aztec image version to 2.1.9 in documentation and scripts

### DIFF
--- a/docs/docs-network/operation/monitoring_example_troubleshooting.md
+++ b/docs/docs-network/operation/monitoring_example_troubleshooting.md
@@ -12,7 +12,7 @@ Here's a complete example with all monitoring components integrated with your Az
 services:
   # Your Aztec node (example for full node)
   aztec-node:
-    image: "aztecprotocol/aztec:2.0.4"
+    image: "aztecprotocol/aztec:2.1.9"
     container_name: "aztec-node"
     ports:
       - ${AZTEC_PORT}:${AZTEC_PORT}

--- a/docs/docs-network/operation/operator_faq.md
+++ b/docs/docs-network/operation/operator_faq.md
@@ -39,7 +39,7 @@ ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: bl
 2. Remove the archiver data directory:
 
    ```bash
-   rm -rf ~/.aztec/v2.0.4/data/archiver
+   rm -rf ~/.aztec/v2.1.9/data/archiver
    ```
 
 3. Restart your node:
@@ -222,7 +222,7 @@ To update to a specific version:
 # Change the image tag from:
 image: "aztecprotocol/aztec:latest"
 # To:
-image: "aztecprotocol/aztec:2.0.4"
+image: "aztecprotocol/aztec:2.1.9"
 ```
 
 Then run:

--- a/docs/docs-network/setup/sequencer_management.md
+++ b/docs/docs-network/setup/sequencer_management.md
@@ -303,7 +303,7 @@ Create a `docker-compose.yml` file in your `aztec-sequencer` directory:
 ```yaml
 services:
   aztec-sequencer:
-    image: "aztecprotocol/aztec:2.1.5"
+    image: "aztecprotocol/aztec:2.1.9"
     container_name: "aztec-sequencer"
     ports:
       - ${AZTEC_PORT}:${AZTEC_PORT}

--- a/docs/network_versioned_docs/version-v2.1.9-ignition/setup/sequencer_management.md
+++ b/docs/network_versioned_docs/version-v2.1.9-ignition/setup/sequencer_management.md
@@ -303,7 +303,7 @@ Create a `docker-compose.yml` file in your `aztec-sequencer` directory:
 ```yaml
 services:
   aztec-sequencer:
-    image: "aztecprotocol/aztec:2.0.4"
+    image: "aztecprotocol/aztec:2.1.9"
     container_name: "aztec-sequencer"
     ports:
       - ${AZTEC_PORT}:${AZTEC_PORT}

--- a/docs/src/preprocess/include_version.js
+++ b/docs/src/preprocess/include_version.js
@@ -1,7 +1,7 @@
 async function preprocessIncludeVersion(markdownContent) {
   const originalContent = markdownContent;
   const commitTag = process.env.COMMIT_TAG || "next";
-  const testnetTag = process.env.TESTNET_TAG || "2.1.4";
+  const testnetTag = process.env.TESTNET_TAG || "2.1.9";
   const devnetTag = process.env.DEVNET_TAG || "3.0.0-devnet.5";
 
   markdownContent = markdownContent.replaceAll(


### PR DESCRIPTION
updates some of the sequencer version references