### PR TITLE
feat: use /logs-disk for live logs, not just final publishes

### DIFF
--- a/ci3/cache_log
+++ b/ci3/cache_log
@@ -36,6 +36,7 @@ function live_publish_log {
   while [ -f $outfile ]; do
     if [ $(( $(date +%s) - $(stat -c %Y "$outfile") )) -le 5 ]; then
       publish_log
+      gzip < $outfile | cache_disk_transfer $key &
     fi
     for i in {1..5}; do
       [ ! -f $outfile ] && break

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -79,6 +79,7 @@ function live_publish_log {
   while [ -f $outfile ]; do
     if [ $(( $(date +%s) - $(stat -c %Y "$outfile") )) -le 5 ]; then
       publish_log
+      format_log_output | gzip | cache_disk_transfer $key &
     fi
     sleep 5
   done

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -107,6 +107,10 @@ function publish_log_final {
   cat $tmp_file 2>/dev/null | cache_persistent $log_key $expire
 }
 
+function publish_disk_live {
+  gzip < $tmp_file 2>/dev/null | cache_disk_transfer $log_key &
+}
+
 function live_publish_log {
   # Not replacing previous trap as we run this function in the background.
   trap 'kill $sleep_pid &>/dev/null; exit' SIGTERM SIGINT
@@ -115,11 +119,13 @@ function live_publish_log {
   local sleep_pid=$!
   wait $sleep_pid
   publish_log
+  publish_disk_live
   echo -e "${blue}RUNNING${reset}${log_info:-}: $test_cmd"
   while [ -f $tmp_file ]; do
     local stat=$(stat -c %Y "$tmp_file" || echo 0)
     if [ $(( $(date +%s) - "$stat" )) -le 5 ]; then
       publish_log
+      publish_disk_live
     fi
     sleep 5 &
     sleep_pid=$!

--- a/ci3/source_cache
+++ b/ci3/source_cache
@@ -4,7 +4,9 @@
 
 # Transfer log to bastion via SSH (accepts gzipped data on stdin)
 # Usage: cat file.gz | cache_disk_transfer <key>
+# Runs in background if called directly for live logging
 function cache_disk_transfer {
+  [ "${CI_ENABLE_DISK_LOGS:-0}" -eq 1 ] || return 0
   local key="$1"
   local prefix="${key:0:4}"
 
@@ -41,15 +43,11 @@ function cache_persistent {
   # Write to Redis (synchronous - must complete before returning)
   cat "$tmpfile" | redis_cli -x SETEX "$key" "$expire" &>/dev/null
 
-  # Transfer to bastion disk in background (only if disk logging enabled)
-  if [ "${CI_ENABLE_DISK_LOGS:-0}" -eq 1 ]; then
-    {
-      cat "$tmpfile" | cache_disk_transfer "$key"
-      rm -f "$tmpfile"
-    } &
-  else
+  # Transfer to bastion disk in background (cache_disk_transfer checks CI_ENABLE_DISK_LOGS)
+  {
+    cat "$tmpfile" | cache_disk_transfer "$key"
     rm -f "$tmpfile"
-  fi
+  } &
 }
 
 # Export functions


### PR DESCRIPTION
Update log handling to write live logs to /logs-disk in addition to final publishes. This ensures logs are persisted incrementally as they're generated, preventing potential data loss if the process terminates unexpectedly. Logs will be appended to the file continuously throughout execution.