### PR TITLE
fix(avm): the "deepest" error for C++ simulations is the LAST one at the deepest level

### DIFF
--- a/yarn-project/stdlib/src/avm/avm.ts
+++ b/yarn-project/stdlib/src/avm/avm.ts
@@ -1162,17 +1162,37 @@ export class CallStackMetadata {
     );
   }
 
+  /**
+   * Finds the "rightmost deepest" revert in the call tree.
+   *
+   * At each level, we select the LAST (rightmost) reverted call, then recurse into its
+   * nested calls to find the deepest reverted leaf along that path. The chain stops
+   * when we encounter a non-reverted call (since you can choose not to rethrow).
+   *
+   * Examples (X = reverted, O = passed):
+   *
+   * 1. [X, X, X] at depth 1 -> returns the last X (rightmost)
+   *
+   * 2. [X(depth2), X, X] where first X has a nested revert -> returns the last X at depth 1,
+   *    NOT the deeper revert in the first X (rightmost takes priority over depth)
+   *
+   * 3. X -> X -> X -> O -> O -> X (nested chain)
+   *    Returns the 3rd X, because the O's break the reverted chain (they didn't rethrow)
+   *
+   * @param calls - Array of call metadata at the current level
+   * @param parentStack - Accumulated stack of parent calls (for building the result)
+   * @returns The deepest reverted call along the rightmost reverted path, or undefined if none
+   */
   private findDeepestRevert(
     calls: CallStackMetadata[],
     parentStack: CallStackMetadata[] = [],
   ): { stack: CallStackMetadata[]; leaf: CallStackMetadata } | undefined {
-    for (const call of calls) {
-      if (call.reverted) {
-        const nested = this.findDeepestRevert(call.nested, [...parentStack, call]);
-        return nested || { stack: [...parentStack, call], leaf: call };
-      }
+    const lastReverted = calls.findLast(call => call.reverted);
+    if (!lastReverted) {
+      return undefined;
     }
-    return undefined;
+    const currentStack = [...parentStack, lastReverted];
+    return this.findDeepestRevert(lastReverted.nested, currentStack) || { stack: currentStack, leaf: lastReverted };
   }
 }
 


### PR DESCRIPTION
Prior to this, if there are multiple errors at the same level, `findDeepestRevert` would return the FIRST (earliest) one. This was different from TS, and intuitively I think it should be the LAST (most recent).

This was encountered when running opcode spam tests. Example:
1. Make nested call
2. run EMITNOTEHASH up until limit (but not past limit)
3. explicit REVERT opcode
4. Make nested call again

This REVERT happens like 1000 times until eventually the nested call actually halts due to "out of gas". That is the last error at that deepest level.

- TS reported "out of gas"
- C++ reported "Assertion failed" (aka REVERT opcode reached)