### PR TITLE
fix: makeGas and makeAppendOnlyTreeSnapshot should respect that members are u32

### DIFF
--- a/yarn-project/stdlib/src/tests/factories.ts
+++ b/yarn-project/stdlib/src/tests/factories.ts
@@ -439,7 +439,10 @@ function makeAvmAccumulatedDataArrayLengths(seed = 1) {
 }
 
 export function makeGas(seed = 1) {
-  return new Gas(seed, seed + 1);
+  // Constrain gas values to u32 range
+  const daGas = seed % 2 ** 32;
+  const l2Gas = (seed + 1) % 2 ** 32;
+  return new Gas(daGas, l2Gas);
 }
 
 /**
@@ -722,7 +725,9 @@ function makeFeeRecipient(seed = 1) {
  * @returns An append only tree snapshot.
  */
 export function makeAppendOnlyTreeSnapshot(seed = 1): AppendOnlyTreeSnapshot {
-  return new AppendOnlyTreeSnapshot(fr(seed), seed);
+  // Constrain nextAvailableLeafIndex to u32 range
+  const nextAvailableLeafIndex = seed % 2 ** 32;
+  return new AppendOnlyTreeSnapshot(fr(seed), nextAvailableLeafIndex);
 }
 
 /**

--- a/yarn-project/stdlib/src/tx/__snapshots__/block_header.test.ts.snap
+++ b/yarn-project/stdlib/src/tx/__snapshots__/block_header.test.ts.snap
@@ -2,4 +2,4 @@
 
 exports[`BlockHeader computes empty hash 1`] = `Fr<0x2c920b5fcfe68d413eab3e0022eb918d64d62ca44d195d5c32b8b9c68bff2dfe>`;
 
-exports[`BlockHeader computes hash 1`] = `Fr<0x2f59a996be11cced6d0452cd02455cb55d1e1944463e02d36a3c3919e71e7478>`;
+exports[`BlockHeader computes hash 1`] = `Fr<0x270685169636054e0491cba0834e8f7b809114c4f35542cb1094febfd8389519>`;


### PR DESCRIPTION
These factories were generating numbers out of range of u32 in prover-client tests, but errors were being caught during AVM fallback error-catching. These became real errors in upstack PR to remove fallback.

I had to update block header snapshot.