### PR TITLE
chore: dropping superfluous trait bounds

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/contract_self.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self.nr
@@ -320,13 +320,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// # Arguments
     /// * `call` - The interface representing the public function to enqueue.
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
-    pub fn enqueue<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>)
-    where
-        T: Deserialize,
-    {
+    pub fn enqueue<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>) {
         call.enqueue(self.context)
     }
 
@@ -344,13 +338,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// self.enqueue_view(MyContract::at(address).assert_timestamp_less_than(timestamp));
     /// ```
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
-    pub fn enqueue_view<let M: u32, let N: u32, T>(&mut self, call: PublicStaticCall<M, N, T>)
-    where
-        T: Deserialize,
-    {
+    pub fn enqueue_view<let M: u32, let N: u32, T>(&mut self, call: PublicStaticCall<M, N, T>) {
         call.enqueue_view(self.context)
     }
 
@@ -397,13 +385,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///   aztec-nr will translate NULL_MSG_SENDER_CONTRACT_ADDRESS into
     ///   `Option<AztecAddress>::none` for familiarity to devs.
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
-    pub fn enqueue_incognito<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>)
-    where
-        T: Deserialize,
-    {
+    pub fn enqueue_incognito<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>) {
         call.enqueue_incognito(self.context)
     }
 
@@ -422,16 +404,10 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// self.enqueue_view_incognito(MyContract::at(address).assert_timestamp_less_than(timestamp));
     /// ```
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
     pub fn enqueue_view_incognito<let M: u32, let N: u32, T>(
         &mut self,
         call: PublicStaticCall<M, N, T>,
-    )
-    where
-        T: Deserialize,
-    {
+    ) {
         call.enqueue_view_incognito(self.context)
     }
 
@@ -464,13 +440,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// # Arguments
     /// * `call` - The object representing the public function to designate as teardown.
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
-    pub fn set_as_teardown<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>)
-    where
-        T: Deserialize,
-    {
+    pub fn set_as_teardown<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>) {
         call.set_as_teardown(self.context)
     }
 
@@ -483,16 +453,10 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///
     /// See `enqueue_incognito` for more details relating to hiding msg_sender.
     ///
-    /// TODO(F-131): We should drop T from here because it is strange as there
-    /// is no return value. The PublicCall type seems to be defined
-    /// incorrectly.
     pub fn set_as_teardown_incognito<let M: u32, let N: u32, T>(
         &mut self,
         call: PublicCall<M, N, T>,
-    )
-    where
-        T: Deserialize,
-    {
+    ) {
         call.set_as_teardown_incognito(self.context)
     }
 }


### PR DESCRIPTION
Dropping superfluous trait bounds from call interfaces.