### PR TITLE
chore: Add proof test to test for vk changes

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="a3f7862c"
+pinned_short_hash="69e26033"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function compress_and_upload {
@@ -38,9 +38,22 @@ function compress_and_upload {
     echo "Update the pinned_chonk_inputs_url in this script to point to the new location."
 }
 
+function run_proof_test_on_inputs {
+    local inputs_path=$1
+    echo "Running proof test on inputs at: $inputs_path"
+    prove_exit_code=0
+    $bb prove --scheme chonk --ivc_inputs_path "$inputs_path" > /dev/null 2>&1 || prove_exit_code=$?
+
+    if [[ $prove_exit_code -ne 0 ]]; then
+      echo "Proof test failed. Please re-run the script with flag --update_inputs."
+      exit 1
+    fi
+}
+
 # For easily rerunning the inputs generation
 if [[ "${1:-}" == "--update_inputs" ]]; then
     set -eu
+    trap 'rm -f bb-chonk-inputs.tar.gz' EXIT SIGINT
     echo "Updating pinned IVC inputs..."
 
     # Generate new inputs
@@ -116,9 +129,13 @@ if [[ "${1:-}" == "--update_fast" ]]; then
     echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
   elif [[ $exit_code -eq 1 ]]; then
     # All flows that changed returned the same exit code (1)
+    # Test the new inputs before uploading
+    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
     compress_and_upload $inputs_tmp_dir
   else
     # Mixed results (some 0, some 1) OR real errors (exit code >= 2)
+    # Test the new inputs before uploading
+    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
     # Optimistically upload - real errors will persist on next run
     echo "Mixed results detected (exit code: $exit_code). Uploading updated inputs..."
     compress_and_upload $inputs_tmp_dir
@@ -128,6 +145,7 @@ else
   parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || exit_code=$?
 
   if [[ $exit_code -eq 0 ]]; then
+    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
     echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
   elif [[ $exit_code -eq 1 ]]; then
     # All flows had VK changes
@@ -137,7 +155,7 @@ else
     # Mixed results (some 0, some 1) OR real errors (exit code >= 2)
     echo_stderr "Error: Mixed results or errors detected (exit code: $exit_code)."
     echo_stderr "Some flows may have VK changes while others had errors."
-    echo_stderr "Please re-run with --update_fast to update inputs, or investigate errors above."
+    echo_stderr "Please re-run with --update_inputs to update inputs, or investigate errors above."
     exit $exit_code
   fi
 fi


### PR DESCRIPTION
The flag `update_fast` in the test that tests for vk changes uploads the new vks but doesn't generate new inputs. This allowed the possibility of the vks being updated but the flows being wrong. This PR adds a call to `bb prove` for one of the flows. If that call fails, then the script exits and prompts the user to use the flag `--update_inputs` for regenerating the inputs