### PR TITLE
fix(avm): cache tree roots

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
@@ -699,12 +699,16 @@ uint32_t HintedRawMerkleDB::get_checkpoint_id() const
 // PureRawMerkleDB starts.
 TreeSnapshots PureRawMerkleDB::get_tree_roots() const
 {
+    if (cached_tree_snapshots.has_value()) {
+        return cached_tree_snapshots.value();
+    }
+
     auto l1_to_l2_info = ws_instance.get_tree_info(ws_revision, MerkleTreeId::L1_TO_L2_MESSAGE_TREE);
     auto note_hash_info = ws_instance.get_tree_info(ws_revision, MerkleTreeId::NOTE_HASH_TREE);
     auto nullifier_info = ws_instance.get_tree_info(ws_revision, MerkleTreeId::NULLIFIER_TREE);
     auto public_data_info = ws_instance.get_tree_info(ws_revision, MerkleTreeId::PUBLIC_DATA_TREE);
 
-    return TreeSnapshots{
+    TreeSnapshots tree_snapshots = {
         .l1_to_l2_message_tree = AppendOnlyTreeSnapshot{ .root = l1_to_l2_info.meta.root,
                                                          .next_available_leaf_index = l1_to_l2_info.meta.size },
         .note_hash_tree = AppendOnlyTreeSnapshot{ .root = note_hash_info.meta.root,
@@ -714,6 +718,12 @@ TreeSnapshots PureRawMerkleDB::get_tree_roots() const
         .public_data_tree = AppendOnlyTreeSnapshot{ .root = public_data_info.meta.root,
                                                     .next_available_leaf_index = public_data_info.meta.size },
     };
+
+    if (cache_tree_roots) {
+        cached_tree_snapshots = tree_snapshots;
+    }
+
+    return tree_snapshots;
 }
 
 SiblingPath PureRawMerkleDB::get_sibling_path(MerkleTreeId tree_id, index_t leaf_index) const
@@ -763,6 +773,9 @@ IndexedLeaf<NullifierLeafValue> PureRawMerkleDB::get_leaf_preimage_nullifier_tre
 SequentialInsertionResult<PublicDataLeafValue> PureRawMerkleDB::insert_indexed_leaves_public_data_tree(
     const PublicDataLeafValue& leaf_value)
 {
+    // Invalidate the cached tree roots.
+    cached_tree_snapshots = std::nullopt;
+
     auto result = ws_instance.insert_indexed_leaves<PublicDataLeafValue>(
         MerkleTreeId::PUBLIC_DATA_TREE, { leaf_value }, ws_revision.forkId);
     return result;
@@ -771,6 +784,9 @@ SequentialInsertionResult<PublicDataLeafValue> PureRawMerkleDB::insert_indexed_l
 SequentialInsertionResult<NullifierLeafValue> PureRawMerkleDB::insert_indexed_leaves_nullifier_tree(
     const NullifierLeafValue& leaf_value)
 {
+    // Invalidate the cached tree roots.
+    cached_tree_snapshots = std::nullopt;
+
     auto result = ws_instance.insert_indexed_leaves<NullifierLeafValue>(
         MerkleTreeId::NULLIFIER_TREE, { leaf_value }, ws_revision.forkId);
     return result;
@@ -781,6 +797,9 @@ SequentialInsertionResult<NullifierLeafValue> PureRawMerkleDB::insert_indexed_le
 // todo(ilyas): Given this function says append, perhaps we just want to restrict to NoteHash?
 std::vector<AppendLeafResult> PureRawMerkleDB::append_leaves(MerkleTreeId tree_id, std::span<const FF> leaves)
 {
+    // Invalidate the cached tree roots.
+    cached_tree_snapshots = std::nullopt;
+
     std::vector<FF> leaves_vec(leaves.begin(), leaves.end());
 
     // If we wanted intermediate roots and paths, we would need to call append_leaves one by one
@@ -793,6 +812,9 @@ std::vector<AppendLeafResult> PureRawMerkleDB::append_leaves(MerkleTreeId tree_i
 
 void PureRawMerkleDB::pad_tree(MerkleTreeId tree_id, size_t num_leaves)
 {
+    // Invalidate the cached tree roots.
+    cached_tree_snapshots = std::nullopt;
+
     // The only trees that should be padded are NULLIFIER_TREE and NOTE_HASH_TREE
     switch (tree_id) {
     case MerkleTreeId::NULLIFIER_TREE: {
@@ -827,6 +849,9 @@ void PureRawMerkleDB::commit_checkpoint()
 
 void PureRawMerkleDB::revert_checkpoint()
 {
+    // Invalidate the cached tree roots.
+    cached_tree_snapshots = std::nullopt;
+
     ws_instance.revert_checkpoint(ws_revision.forkId);
     checkpoint_stack.pop();
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
@@ -114,9 +114,21 @@ class HintedRawMerkleDB final : public LowLevelMerkleDBInterface {
 // insertions (since we won't be tied to SequentialInsertionResult).
 class PureRawMerkleDB final : public LowLevelMerkleDBInterface {
   public:
-    PureRawMerkleDB(world_state::WorldStateRevision ws_revision, world_state::WorldState& ws_instance)
+    /**
+     * @brief Constructor for PureRawMerkleDB.
+     * @param ws_revision The world state revision.
+     * @param ws_instance The world state instance.
+     * @param cache_tree_roots Whether to cache the tree roots.
+     *  If true, the tree roots will be cached and returned by get_tree_roots().
+     *  If false, the tree roots will be fetched from the world state on each call to get_tree_roots().
+     *  It is important to note that if caching is ON, you are assuming nobody else could concurrently modify the trees.
+     */
+    PureRawMerkleDB(world_state::WorldStateRevision ws_revision,
+                    world_state::WorldState& ws_instance,
+                    bool cache_tree_roots = true)
         : ws_revision(ws_revision)
         , ws_instance(ws_instance)
+        , cache_tree_roots(cache_tree_roots)
     {}
 
     TreeSnapshots get_tree_roots() const override;
@@ -145,6 +157,8 @@ class PureRawMerkleDB final : public LowLevelMerkleDBInterface {
     world_state::WorldStateRevision ws_revision;
     world_state::WorldState& ws_instance;
     std::stack<uint32_t> checkpoint_stack{ { 0 } };
+    bool cache_tree_roots;
+    mutable std::optional<TreeSnapshots> cached_tree_snapshots;
 };
 
 } // namespace bb::avm2::simulation

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -222,6 +222,7 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     txLabel: string = 'unlabeledTx',
     disableRevertCheck: boolean = false,
   ): Promise<PublicTxResult> {
+    const simTimer = new Timer();
     const simRes = await this.simulateTx(
       sender,
       setupCalls,
@@ -231,6 +232,8 @@ export class AvmProvingTester extends PublicTxSimulationTester {
       privateInsertions,
       txLabel,
     );
+    const simDuration = simTimer.ms();
+    this.logger.info(`Simulation took ${simDuration} ms for tx ${txLabel}`);
 
     if (!disableRevertCheck) {
       expect(simRes.revertCode.isOK()).toBe(expectRevert ? false : true);


### PR DESCRIPTION
The witgen flow asks for roots on every execution step. This was making hint generation 100x slower.
