### PR TITLE
chore: Try deflake inactivity slash test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -152,8 +152,10 @@ export class P2PInactivityTest {
     await this.test.waitForP2PMeshConnectivity(this.nodes, NUM_NODES);
 
     const ethereumSlotDuration = this.test.ctx.aztecNodeConfig.ethereumSlotDuration!;
-    this.test.logger.warn(`Advancing to the L1 slot before epoch ${SETUP_EPOCH_DURATION + 1} to start slashing`);
-    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(EpochNumber(SETUP_EPOCH_DURATION + 1), {
+    this.test.logger.warn(
+      `Advancing to epoch ${SETUP_EPOCH_DURATION} (slashing will start after this epoch is complete)`,
+    );
+    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(EpochNumber(SETUP_EPOCH_DURATION), {
       offset: -ethereumSlotDuration,
     });
 

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -127,7 +127,7 @@ export class RollupCheatCodes {
     const timestamp = (await this.rollup.read.getTimestampForSlot([BigInt(slotNumber)])) + BigInt(opts.offset ?? 0);
     try {
       await this.ethCheatCodes.warp(Number(timestamp), { ...opts, silent: true, resetBlockInterval: true });
-      this.logger.warn(`Warped to epoch ${epoch}`);
+      this.logger.warn(`Warped to epoch ${epoch}`, { offset: opts.offset, timestamp });
     } catch (err) {
       this.logger.warn(`Warp to epoch ${epoch} failed: ${err}`);
     }


### PR DESCRIPTION
An active validator was getting slashed since it failed to produce an initial block due to time warps. This tries to avoid it by warping first to an epoch where slashing is disabled, giving time to block production to stabilize, and only then start the slashing period.
