### PR TITLE
chore: Remove old blocks from p2p

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -470,12 +470,15 @@ describe('P2P Client', () => {
     it('triggers tx collection for missing txs from mined blocks', async () => {
       await client.start();
       const block = await L2Block.random(BlockNumber(101), 3);
+      const newBlock = block.toL2Block();
+      // Compute the block hash since it gets cached when the p2p client logs it
+      await newBlock.hash();
 
       txPool.hasTxs.mockResolvedValue([true, false, true]);
       blockSource.addBlocks([block]);
       await client.sync();
 
-      expect(txCollection.startCollecting).toHaveBeenCalledWith(block, [block.body.txEffects[1].txHash]);
+      expect(txCollection.startCollecting).toHaveBeenCalledWith(newBlock, [block.body.txEffects[1].txHash]);
     });
   });
 });

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -5,13 +5,12 @@ import { DateProvider } from '@aztec/foundation/timer';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton } from '@aztec/kv-store';
 import type {
   EthAddress,
-  L2Block,
   L2BlockId,
+  L2BlockNew,
   L2BlockSource,
   L2BlockStream,
   L2BlockStreamEvent,
   L2Tips,
-  PublishedL2Block,
 } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
@@ -217,7 +216,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     this.log.debug(`Handling block stream event ${event.type}`);
     switch (event.type) {
       case 'blocks-added':
-        await this.handleLatestL2Blocks(event.blocks);
+        await this.handleLatestL2Blocks(event.blocks.map(b => b.block.toL2Block()));
         break;
       case 'chain-finalized': {
         // TODO (alexg): I think we can prune the block hashes map here
@@ -225,7 +224,8 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
         const from = BlockNumber((await this.getSyncedFinalizedBlockNum()) + 1);
         const limit = event.block.number - from + 1;
         if (limit > 0) {
-          await this.handleFinalizedL2Blocks(await this.l2BlockSource.getBlocks(from, limit));
+          const oldBlocks = await this.l2BlockSource.getBlocks(from, limit);
+          await this.handleFinalizedL2Blocks(oldBlocks.map(b => b.toL2Block()));
         }
         break;
       }
@@ -697,10 +697,10 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param blocks - A list of existing blocks with txs that the P2P client needs to ensure the tx pool is reconciled with.
    * @returns Empty promise.
    */
-  private async markTxsAsMinedFromBlocks(blocks: L2Block[]): Promise<void> {
+  private async markTxsAsMinedFromBlocks(blocks: L2BlockNew[]): Promise<void> {
     for (const block of blocks) {
       const txHashes = block.body.txEffects.map(txEffect => txEffect.txHash);
-      await this.txPool.markAsMined(txHashes, block.getBlockHeader());
+      await this.txPool.markAsMined(txHashes, block.header);
     }
   }
 
@@ -709,21 +709,21 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param blocks - A list of existing blocks with txs that the P2P client needs to ensure the tx pool is reconciled with.
    * @returns Empty promise.
    */
-  private async handleLatestL2Blocks(blocks: PublishedL2Block[]): Promise<void> {
+  private async handleLatestL2Blocks(blocks: L2BlockNew[]): Promise<void> {
     if (!blocks.length) {
       return Promise.resolve();
     }
 
-    await this.markTxsAsMinedFromBlocks(blocks.map(b => b.block));
-    await this.startCollectingMissingTxs(blocks.map(b => b.block));
+    await this.markTxsAsMinedFromBlocks(blocks);
+    await this.startCollectingMissingTxs(blocks);
 
-    const lastBlock = blocks.at(-1)!.block;
+    const lastBlock = blocks.at(-1)!;
 
     await Promise.all(
       blocks.map(async block =>
         this.setBlockHash({
-          number: block.block.number,
-          hash: await block.block.hash().then(h => h.toString()),
+          number: block.number,
+          hash: await block.hash().then(h => h.toString()),
         }),
       ),
     );
@@ -735,7 +735,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   }
 
   /** Request txs for unproven blocks so the prover node has more chances to get them. */
-  private async startCollectingMissingTxs(blocks: L2Block[]): Promise<void> {
+  private async startCollectingMissingTxs(blocks: L2BlockNew[]): Promise<void> {
     try {
       // TODO(#15435): If the archiver has lagged behind L1, the reported proven block number may
       // be much lower than the actual one, and it does not update until the pending chain is
@@ -768,7 +768,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param blocks - A list of finalized L2 blocks.
    * @returns Empty promise.
    */
-  private async handleFinalizedL2Blocks(blocks: L2Block[]): Promise<void> {
+  private async handleFinalizedL2Blocks(blocks: L2BlockNew[]): Promise<void> {
     if (!blocks.length) {
       return Promise.resolve();
     }

--- a/yarn-project/p2p/src/services/tx_collection/slow_tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/slow_tx_collection.ts
@@ -4,7 +4,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { boundInclusive } from '@aztec/foundation/number';
 import { RunningPromise } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import { type L1RollupConstants, getEpochAtSlot, getTimestampRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
 import { type Tx, TxHash } from '@aztec/stdlib/tx';
 
@@ -76,7 +76,7 @@ export class SlowTxCollection {
   }
 
   /** Starts collecting the given tx hashes for the given L2Block in the slow loop */
-  public startCollecting(block: L2Block, txHashes: TxHash[]) {
+  public startCollecting(block: L2BlockNew, txHashes: TxHash[]) {
     const slot = block.header.getSlot();
     const deadline = this.getDeadlineForSlot(slot);
     if (+deadline < this.dateProvider.now()) {

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
@@ -1,10 +1,10 @@
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times } from '@aztec/foundation/collection';
 import { getDefaultConfig } from '@aztec/foundation/config';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
-import { L2Block } from '@aztec/stdlib/block';
+import { L2BlockNew } from '@aztec/stdlib/block';
 import { EmptyL1RollupConstants, type L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxArray, TxHash } from '@aztec/stdlib/tx';
@@ -36,7 +36,7 @@ describe('TxCollection', () => {
   let deadline: Date;
   let txs: Tx[];
   let txHashes: TxHash[];
-  let block: L2Block;
+  let block: L2BlockNew;
 
   const makeNode = (name: string) => {
     const node = mock<TxSource>();
@@ -52,7 +52,14 @@ describe('TxCollection', () => {
   };
 
   const makeL2Block = (blockNumber = 1, slotNumber?: number) =>
-    L2Block.random(BlockNumber(blockNumber), 0, 0, 0, undefined, slotNumber ?? blockNumber);
+    L2BlockNew.random(BlockNumber(blockNumber), {
+      txsPerBlock: 4,
+      txOptions: {
+        numPublicCallsPerTx: 3,
+        numPublicLogsPerCall: 1,
+      },
+      ...(slotNumber !== undefined ? { slotNumber: SlotNumber(slotNumber) } : {}),
+    });
 
   const setNodeTxs = (node: MockProxy<TxSource>, txs: Tx[]) => {
     node.getTxsByHash.mockImplementation(async hashes => {

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.ts
@@ -3,7 +3,7 @@ import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise } from '@aztec/foundation/promise';
 import { DateProvider } from '@aztec/foundation/timer';
-import type { L2Block, L2BlockInfo, L2BlockNew } from '@aztec/stdlib/block';
+import type { L2BlockInfo, L2BlockNew } from '@aztec/stdlib/block';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -146,7 +146,7 @@ export class TxCollection {
   }
 
   /** Starts collecting the given tx hashes for the given L2Block in the slow loop */
-  public startCollecting(block: L2Block, txHashes: TxHash[]) {
+  public startCollecting(block: L2BlockNew, txHashes: TxHash[]) {
     return this.slowCollection.startCollecting(block, txHashes);
   }
 
@@ -162,11 +162,11 @@ export class TxCollection {
 
   /** Collects the set of txs for the given mined block as fast as possible */
   public collectFastForBlock(
-    block: L2Block,
+    block: L2BlockNew,
     txHashes: TxHash[] | string[],
     opts: { deadline: Date; pinnedPeer?: PeerId },
   ) {
-    return this.collectFastFor({ type: 'block', block: block.toL2Block() }, txHashes, opts);
+    return this.collectFastFor({ type: 'block', block }, txHashes, opts);
   }
 
   /** Collects the set of txs for the given proposal or block as fast as possible */


### PR DESCRIPTION
This PR updates the P2P subsystem to use the new `L2BlockNew` struct. The `L2Block` struct is received over the block stream and then immediately converted, meaning it will be simple to later change the block stream to work with the new block type.
