### PR TITLE
feat!: split private event emission from delivery

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,15 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### [Aztec.nr] Private event emission API changes
+
+Private events are still emitted via the `emit` function, but this now returns an `EventMessage` type that must have `deliver_to` called on it in order to deliver the event message to the intended recipients. This allows for multiple recipients to receive the same event.
+
+```diff
+- self.emit(event, recipient, delivery_method)
++ self.emit(event).delivery(recipient, delivery_method)
+```
+
 ### [Aztec.nr] History proof functions no longer require `storage_slot` parameter
 
 The `RetrievedNote` struct now includes a `storage_slot` field, making it self-contained for proving note inclusion and validity. As a result, the history proof functions in the `aztec::history` module no longer require a separate `storage_slot` parameter.

--- a/noir-projects/aztec-nr/aztec/src/contract_self.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self.nr
@@ -3,10 +3,14 @@ use crate::{
         calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall},
         private_context::PrivateContext,
         public_context::PublicContext,
+        utility_context::UtilityContext,
     },
-    event::{event_emission::emit_event_in_private, event_interface::EventInterface},
+    event::{
+        event_emission::{emit_event_in_private, emit_event_in_public},
+        event_interface::EventInterface,
+        event_message::EventMessage,
+    },
 };
-use super::{context::utility_context::UtilityContext, event::event_emission::emit_event_in_public};
 use protocol_types::{
     address::AztecAddress,
     constants::NULL_MSG_SENDER_CONTRACT_ADDRESS,
@@ -23,7 +27,7 @@ use protocol_types::{
 /// Once injected, you can use `self` to:
 /// - Access storage: `self.storage.balances.at(owner).read()`
 /// - Call contracts: `self.call(Token::at(address).transfer(recipient, amount))`
-/// - Emit events: `self.emit(event, recipient, delivery_mode)` (private) or `self.emit(event)` (public)
+/// - Emit events: `self.emit(event).deliver_to(recipient, delivery_mode)` (private) or `self.emit(event)` (public)
 /// - Get the contract address: `self.address`
 /// - Get the caller: `self.msg_sender()`
 /// - Access low-level Aztec.nr APIs through the context: `self.context`
@@ -175,34 +179,44 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
         }
     }
 
-    /// Emits an event from a private function. Private events can be delivered either via private logs or offchain
-    /// messages, with configurable encryption and tagging constraints.
+    /// Emits an event privately.
     ///
-    /// Events in private functions are encrypted and sent to a specific recipient. This ensures that only the intended
-    /// recipient can read the event data.
-    ///
-    /// # Parameters
-    /// - `event`: The event to emit (must implement `EventInterface` and `Serialize`)
-    /// - `recipient`: The address that should be able to decrypt and read this event
-    /// - `delivery_mode`: The delivery mode for the event (e.g., `MessageDelivery.CONSTRAINED_ONCHAIN`)
+    /// Unlike public events, private events do not reveal their contents publicly. They instead create an
+    /// [EventMessage] containing the private event information, which **MUST** be delivered to a recipient via
+    /// [EventMessage::deliver_to] in order for them to learn about the event. Multiple recipients can have the same
+    /// message be delivered to them.
     ///
     /// # Example
     /// ```noir
+    /// #[event]
+    /// struct Transfer { from: AztecAddress, to: AztecAddress, amount: u128 }
+    ///
     /// #[external("private")]
-    /// fn transfer(amount: u128, to: AztecAddress) {
-    ///     // ... transfer logic ...
-    ///     self.emit(
-    ///         TransferEvent { from: sender, to, amount },
-    ///         to,
-    ///         MessageDelivery.CONSTRAINED_ONCHAIN
-    ///     );
+    /// fn transfer(to: AztecAddress, amount: u128) {
+    ///     let from = self.msg_sender().unwrap();
+    ///
+    ///     let message: EventMessage = self.emit(Transfer { from, to, amount });
+    ///     message.deliver_to(from, MessageDelivery.UNCONSTRAINED_OFFCHAIN);
+    ///     message.deliver_to(to, MessageDelivery.CONSTRAINED_ONCHAIN);
     /// }
     /// ```
-    pub fn emit<Event>(&mut self, event: Event, recipient: AztecAddress, delivery_mode: u8)
+    ///
+    /// # Cost
+    ///
+    /// Private event emission always results in the creation of a nullifer, which acts as a commitment to the event and
+    /// is used by third parties to verify its authenticity. See [EventMessage::deliver_to] for the costs associated to
+    /// delivery.
+    ///
+    /// # Privacy
+    ///
+    /// The nullifier created when emitting a private event leaks nothing about the content of the event - it's a
+    /// commitment that includes a random value, so even with full knowledge of the event preimage determining if an
+    /// event was emitted or not requires brute-forcing the entire `Field` space.
+    pub fn emit<Event>(&mut self, event: Event) -> EventMessage<Event>
     where
         Event: EventInterface + Serialize,
     {
-        emit_event_in_private(event, self.context, recipient, delivery_mode);
+        emit_event_in_private(self.context, event)
     }
 
     /// Makes a call to the private function defined by the `call` parameter.
@@ -552,27 +566,33 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
         }
     }
 
-    /// Emits an event from a public function.
+    /// Emits an event publicly.
     ///
-    /// Events in public functions are emitted in plaintext and are visible to everyone.
-    /// Unlike private events, they don't require a recipient parameter.
+    /// Public events are emitted as plaintext and are therefore visible to everyone. This is is the same as Solidity
+    /// events on EVM chains.
     ///
-    /// # Parameters
-    /// - `event`: The event to emit (must implement `EventInterface` and `Serialize`)
+    /// Unlike private events, they don't require delivery of an event message.
     ///
     /// # Example
     /// ```noir
+    /// #[event]
+    /// struct Update { value: Field }
+    ///
     /// #[external("public")]
     /// fn publish_update(value: Field) {
-    ///     // ... update logic ...
-    ///     self.emit(UpdateEvent { value });
+    ///     self.emit(Update { value });
     /// }
     /// ```
+    ///
+    /// # Cost
+    ///
+    /// Public event emission is achieved by emitting public transaction logs. A total of `N+1` fields are emitted,
+    /// where `N` is the serialization length of the event.
     pub fn emit<Event>(&mut self, event: Event)
     where
         Event: EventInterface + Serialize,
     {
-        emit_event_in_public(event, self.context);
+        emit_event_in_public(self.context, event);
     }
 
     /// Makes the call to the public function defined by the `call` parameter.

--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -1,77 +1,48 @@
 use crate::{
     context::{PrivateContext, PublicContext},
-    event::event_interface::EventInterface,
-    messages::{
-        logs::{event::to_encrypted_private_event_message, utils::prefix_with_tag},
-        message_delivery::MessageDelivery,
-        offchain_messages::deliver_offchain_message,
+    event::{
+        event_interface::{compute_private_event_commitment, EventInterface},
+        event_message::EventMessage,
     },
-    utils::remove_constraints::remove_constraints_if,
+    oracle::random::random,
 };
-use protocol_types::{
-    address::AztecAddress,
-    constants::GENERATOR_INDEX__EVENT_COMMITMENT,
-    hash::poseidon2_hash_with_separator,
-    traits::{Serialize, ToField},
-};
+use protocol_types::traits::{Serialize, ToField};
 
-/// Emits an event that can be delivered either via private logs or offchain messages, with configurable encryption and
-/// tagging constraints.
-///
-/// # Arguments
-/// * `event` - The event to emit
-/// * `context` - The private context to emit the event in
-/// * `recipient` - The address that should receive this event
-/// * `delivery_mode` - Controls encryption, tagging, and delivery constraints. Must be a compile-time constant.
-///   See `MessageDeliveryEnum` for details on the available modes.
+/// An event that was emitted in the current contract call.
+pub struct NewEvent<Event> {
+    pub(crate) event: Event,
+    pub(crate) randomness: Field,
+    pub(crate) commitment: Field,
+}
+
+/// Equivalent to `self.emit(event)`: see [crate::contract_self::ContractSelf::emit].
 pub fn emit_event_in_private<Event>(
-    event: Event,
     context: &mut PrivateContext,
-    recipient: AztecAddress,
-    delivery_mode: u8,
-)
+    event: Event,
+) -> EventMessage<Event>
 where
     Event: EventInterface + Serialize,
 {
-    // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when unconstrained
-    // usage is requested. If `delivery_mode` were a runtime value then performance would suffer.
-    assert_constant(delivery_mode);
+    // In private events, we automatically inject randomness to prevent event commitment preimage attacks and event
+    // commitment collisions (the commitments are included in the nullifier tree and duplicate nullifiers are by
+    // definition not allowed).
 
-    // The following maps out the 3 dimensions across which we configure message delivery.
-    let constrained_encryption = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
-    let emit_as_offchain_message = delivery_mode == MessageDelivery.UNCONSTRAINED_OFFCHAIN;
-    // TODO(#14565): Add constrained tagging
-    let _constrained_tagging = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
+    // Safety: We use the randomness to preserve the privacy of the event recipient by preventing brute-forcing,
+    // so a malicious sender could use non-random values to make the event less private. But they already know
+    // the full event pre-image anyway, and so the recipient already trusts them to not disclose this information.
+    // We can therefore assume that the sender will cooperate in the random value generation.
+    let randomness = unsafe { random() };
 
-    let (ciphertext, randomness) = remove_constraints_if(
-        !constrained_encryption,
-        || to_encrypted_private_event_message(event, recipient),
-    );
+    // The event commitment is emitted as a nullifier instead of as a note because these are simpler: nullifiers cannot
+    // be squashed, making kernel processing simpler, and they have no nonce that recipients need to discover.
+    let commitment = compute_private_event_commitment(event, randomness);
+    context.push_nullifier(commitment);
 
-    // We generate a cryptographic commitment to the event to ensure its authenticity during offchain delivery.
-    // The nullifier tree is chosen over the note hash tree for this purpose since it provides a simpler mechanism
-    // - nullifiers require no nonce, and events, being non-spendable, don't need the guarantee that a "spending"
-    // nullifier can be computed.
-    // TODO(#11571): with decryption happening in Noir we can now use the Packable trait instead.
-    let serialized_event_with_randomness = [randomness].concat(event.serialize());
-    let event_commitment = poseidon2_hash_with_separator(
-        serialized_event_with_randomness,
-        GENERATOR_INDEX__EVENT_COMMITMENT,
-    );
-    context.push_nullifier(event_commitment);
-
-    if emit_as_offchain_message {
-        deliver_offchain_message(ciphertext, recipient);
-    } else {
-        // Safety: Currently unsafe. See description of CONSTRAINED_ONCHAIN in MessageDeliveryEnum.
-        // TODO(#14565): Implement proper constrained tag prefixing to make this truly CONSTRAINED_ONCHAIN
-        let log_content = prefix_with_tag(ciphertext, recipient);
-
-        context.emit_private_log(log_content, log_content.len());
-    }
+    EventMessage::new(NewEvent { event, randomness, commitment }, context)
 }
 
-pub fn emit_event_in_public<Event>(event: Event, context: PublicContext)
+/// Equivalent to `self.emit(event)`: see [crate::contract_self::ContractSelf::emit].
+pub fn emit_event_in_public<Event>(context: PublicContext, event: Event)
 where
     Event: EventInterface + Serialize,
 {
@@ -83,6 +54,7 @@ where
     }
 
     // We put the selector in the "last" place, to avoid reading or assigning to an expression in an index
+    // TODO(F-224): change this order.
     log_content[serialized_event.len()] = Event::get_event_type_id().to_field();
 
     context.emit_public_log(log_content);

--- a/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
@@ -1,5 +1,25 @@
 use crate::event::event_selector::EventSelector;
+use protocol_types::{
+    constants::GENERATOR_INDEX__EVENT_COMMITMENT, hash::poseidon2_hash_with_separator,
+    traits::Serialize,
+};
 
 pub trait EventInterface {
     fn get_event_type_id() -> EventSelector;
+}
+
+/// A private event's commitment is used to validate that an event was indeed emitted.
+///
+/// It requires a `randomness` value that must be produced alongside the event in order to perform said validation. This
+/// random value prevents attacks in which someone guesses plausible events (e.g. 'Alice transfers to Bob an amount of
+/// 10'), since they will not be able to test for existence of their guessed events without brute-forcing the entire
+/// `Field` space by guessing `randomness` values.
+pub fn compute_private_event_commitment<Event>(event: Event, randomness: Field) -> Field
+where
+    Event: EventInterface + Serialize,
+{
+    poseidon2_hash_with_separator(
+        [randomness].concat(event.serialize()),
+        GENERATOR_INDEX__EVENT_COMMITMENT,
+    )
 }

--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -1,0 +1,90 @@
+use crate::{
+    context::PrivateContext,
+    event::{event_emission::NewEvent, event_interface::EventInterface},
+    messages::{
+        encryption::{aes128::AES128, message_encryption::MessageEncryption},
+        logs::{event::private_event_to_message_plaintext, utils::prefix_with_tag},
+        message_delivery::MessageDelivery,
+        offchain_messages::deliver_offchain_message,
+    },
+    utils::remove_constraints::remove_constraints_if,
+};
+use protocol_types::{address::AztecAddress, traits::Serialize};
+
+/// A message with information about an event that was emitted in the current contract call. This message **MUST** be
+/// delivered to a recipient in order to not lose the private event information.
+///
+/// Use [EventMessage::deliver_to] to select a delivery mechanism.
+#[must_use = "Unused EventMessage result - use the `deliver_to` function to prevent the event information from being lost forever"]
+pub struct EventMessage<Event> {
+    new_event: NewEvent<Event>,
+
+    // EventMessage is constructed when an event is emitted, which means that the `context` object will be in scope. By
+    // storing a reference to it inside this object we remove the need for its methods to receive it, resulting in a
+    // cleaner end-user API.
+    context: &mut PrivateContext,
+}
+
+impl<Event> EventMessage<Event>
+where
+    Event: EventInterface + Serialize,
+{
+    pub(crate) fn new(new_event: NewEvent<Event>, context: &mut PrivateContext) -> Self {
+        Self { new_event, context }
+    }
+
+    /// Delivers the event message to a `recipient`, providing them access to the private event information.
+    ///
+    /// The same message can be delivered to multiple recipients, resulting in all of them learning about the event. Any
+    /// recipient that receives the private event information will be able to prove its emission - events have no owner,
+    /// and as such all recipients are treated equally.
+    ///
+    /// The message is first encrypted to the recipient's public key, ensuring no other actor can read it.
+    ///
+    /// The `delivery_mode` must be one of [crate::messages::message_delivery::MessageDeliveryEnum], and will inform
+    /// costs (both proving time and TX fees) as well as delivery guarantees. This value must be a compile-time
+    /// constant.
+    ///
+    /// # Invalid Recipients
+    ///
+    /// If `recipient` is an invalid address, then a random public key is selected and message delivery continues as
+    /// normal. This prevents both 'king of the hill' attacks (where a sender would otherwise fail to deliver a message
+    /// to an invalid recipient) and forced privacy leaks (where an invalid recipient results in a unique transaction
+    /// fingerprint, e.g. one lacking the private logs that would correspond to message delivery).
+    pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
+        // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when
+        // unconstrained usage is requested. If `delivery_mode` were a runtime value the compiler would be unable to
+        // perform dead-code elimination.
+        assert_constant(delivery_mode);
+
+        // The following maps out the 3 dimensions across which we configure message delivery.
+        let constrained_encryption = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
+        let deliver_as_offchain_message = delivery_mode == MessageDelivery.UNCONSTRAINED_OFFCHAIN;
+        // TODO(#14565): Add constrained tagging
+        let _constrained_tagging = delivery_mode == MessageDelivery.CONSTRAINED_ONCHAIN;
+
+        // Technical note: we're about to call a closure that needs access to `new_event`, but we can't pass `self` to
+        // it because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
+        // `context` this would cause for a mutable reference to cross the constrained-unconstrained barrier, which is
+        // not allowed. As a workaround, we create a variable without the context and capture that instead.
+        let new_event = self.new_event;
+
+        let ciphertext = remove_constraints_if(
+            !constrained_encryption,
+            || AES128::encrypt(
+                private_event_to_message_plaintext(new_event.event, new_event.randomness),
+                recipient,
+            ),
+        );
+
+        if deliver_as_offchain_message {
+            deliver_offchain_message(ciphertext, recipient);
+        } else {
+            // Safety: Currently unsafe. See description of CONSTRAINED_ONCHAIN in MessageDeliveryEnum.
+            // TODO(#14565): Implement proper constrained tag prefixing to make this truly CONSTRAINED_ONCHAIN
+            let log_content = prefix_with_tag(ciphertext, recipient);
+
+            self.context.emit_private_log(log_content, log_content.len());
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/event/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/mod.nr
@@ -1,3 +1,4 @@
 pub mod event_emission;
 pub mod event_interface;
+pub mod event_message;
 pub mod event_selector;

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -1,13 +1,16 @@
 use crate::{
     event::event_interface::EventInterface,
     messages::{
-        encoding::{encode_message, MESSAGE_CIPHERTEXT_LEN},
+        encoding::{encode_message, MESSAGE_CIPHERTEXT_LEN, MESSAGE_EXPANDED_METADATA_LEN},
         encryption::{aes128::AES128, message_encryption::MessageEncryption},
         msg_type::PRIVATE_EVENT_MSG_TYPE_ID,
     },
     oracle::random::random,
 };
 use protocol_types::{address::AztecAddress, traits::{Serialize, ToField}};
+
+global PRIVATE_EVENT_RESERVED_FIELDS: u32 = 1;
+global PRIVATE_EVENT_RANDOMNESS_INDEX: u32 = 0;
 
 /// Creates an encrypted private event message (i.e. one of type `PRIVATE_EVENT_MSG_TYPE_ID`) by encoding the contents
 /// of the event and then encrypting them for `recipient`.
@@ -27,15 +30,31 @@ where
     // We can therefore assume that the sender will cooperate in the random value generation.
     let randomness = unsafe { random() };
 
-    // TODO(#11571): with decryption happening in Noir we can now use the Packable trait instead.
-    let serialized_event_with_randomness = [randomness].concat(event.serialize());
-
-    // Private events are encoded by placing the event type id (which is expected to fit in 32 bits) in the metadata.
-    let plaintext = encode_message(
-        PRIVATE_EVENT_MSG_TYPE_ID,
-        Event::get_event_type_id().to_field() as u64,
-        serialized_event_with_randomness,
-    );
+    let plaintext = private_event_to_message_plaintext(event, randomness);
 
     (AES128::encrypt(plaintext, recipient), randomness)
+}
+
+pub fn private_event_to_message_plaintext<Event>(
+    event: Event,
+    randomness: Field,
+    ) -> [Field; PRIVATE_EVENT_RESERVED_FIELDS + <Event as Serialize>::N + MESSAGE_EXPANDED_METADATA_LEN]
+where
+    Event: EventInterface + Serialize,
+{
+    let serialized_event = event.serialize();
+
+    let mut msg_content = [0; PRIVATE_EVENT_RESERVED_FIELDS + <Event as Serialize>::N];
+    msg_content[PRIVATE_EVENT_RANDOMNESS_INDEX] = randomness;
+
+    for i in 0..serialized_event.len() {
+        msg_content[PRIVATE_EVENT_RESERVED_FIELDS + i] = serialized_event[i];
+    }
+
+    // Private events use the event type id for metadata
+    encode_message(
+        PRIVATE_EVENT_MSG_TYPE_ID,
+        Event::get_event_type_id().to_field() as u64,
+        msg_content,
+    )
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -45,7 +45,7 @@ pub fn private_note_to_message_plaintext<Note>(
     owner: AztecAddress,
     storage_slot: Field,
     randomness: Field,
-) -> [Field; <Note as Packable>::N + PRIVATE_NOTE_RESERVED_FIELDS + MESSAGE_EXPANDED_METADATA_LEN]
+) -> [Field; PRIVATE_NOTE_RESERVED_FIELDS + <Note as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
     Note: NoteType + Packable,
 {
@@ -68,14 +68,12 @@ pub fn partial_note_private_content_to_message_plaintext<PartialNotePrivateConte
     owner: AztecAddress,
     storage_slot: Field,
     randomness: Field,
-    ) -> [Field; <PartialNotePrivateContent as Packable>::N + PRIVATE_NOTE_RESERVED_FIELDS + MESSAGE_EXPANDED_METADATA_LEN]
+    ) -> [Field; PRIVATE_NOTE_RESERVED_FIELDS + <PartialNotePrivateContent as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
     PartialNotePrivateContent: NoteType + Packable,
 {
     let packed_private_content = partial_note_private_content.pack();
 
-    // A partial note message's content is the storage slot, followed by the randomness,
-    // followed by the packed private content representation
     let mut msg_content =
         [0; PRIVATE_NOTE_RESERVED_FIELDS + <PartialNotePrivateContent as Packable>::N];
     msg_content[PRIVATE_NOTE_OWNER_INDEX] = owner.to_field();

--- a/noir-projects/aztec-nr/aztec/src/note/note_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_message.nr
@@ -11,8 +11,8 @@ use crate::{
 };
 use protocol_types::{address::AztecAddress, traits::Packable};
 
-/// A message with information about a note that has just been created. This message **MUST** be delivered to a
-/// recipient in order to not lose the private note information.
+/// A message with information about a note that was created in the current contract call. This message **MUST** be
+/// delivered to a recipient in order to not lose the private note information.
 ///
 /// Use [NoteMessage::deliver] to select a delivery mechanism. The same message can be delivered to multiple
 /// recipients.

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -136,7 +136,10 @@ pub contract SimpleToken {
         self.storage.balances.at(from).add(change).deliver(MessageDelivery.UNCONSTRAINED_ONCHAIN);
         self.storage.balances.at(to).add(amount).deliver(MessageDelivery.UNCONSTRAINED_ONCHAIN);
 
-        self.emit(Transfer { from, to, amount }, to, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        self.emit(Transfer { from, to, amount }).deliver_to(
+            to,
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
     }
 
     #[authorize_once("from", "authwit_nonce")]

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -243,7 +243,10 @@ pub contract Token {
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
-        self.emit(Transfer { from, to, amount }, to, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        self.emit(Transfer { from, to, amount }).deliver_to(
+            to,
+            MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        );
     }
 
     #[internal("private")]

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -17,6 +17,6 @@ contract EventOnly {
     #[external("private")]
     fn emit_event_for_msg_sender(value: Field) {
         let sender = self.msg_sender().unwrap();
-        self.emit(TestEvent { value }, sender, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        self.emit(TestEvent { value }).deliver_to(sender, MessageDelivery.UNCONSTRAINED_ONCHAIN);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -50,8 +50,7 @@ contract OffchainEffect {
 
     #[external("private")]
     fn emit_event_as_offchain_message_for_msg_sender(a: u64, b: u64, c: u64) {
-        self.emit(
-            TestEvent { a, b, c },
+        self.emit(TestEvent { a, b, c }).deliver_to(
             self.msg_sender().unwrap(),
             MessageDelivery.UNCONSTRAINED_OFFCHAIN,
         );

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -326,7 +326,7 @@ pub contract Test {
             value4: fields[4],
         };
 
-        self.emit(event, owner, MessageDelivery.UNCONSTRAINED_ONCHAIN);
+        self.emit(event).deliver_to(owner, MessageDelivery.UNCONSTRAINED_ONCHAIN);
 
         // this contract has reached max number of functions, so using this one fn
         // to test nested and non nested encrypted logs

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -32,17 +32,17 @@ pub contract TestLog {
     fn emit_encrypted_events(other: AztecAddress, preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
-        self.emit(event0, self.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
+        self.emit(event0).deliver_to(self.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
 
         // We duplicate the emission, but swapping the sender and recipient:
-        self.emit(event0, other, MessageDelivery.CONSTRAINED_ONCHAIN);
+        self.emit(event0).deliver_to(other, MessageDelivery.CONSTRAINED_ONCHAIN);
 
         let event1 = ExampleEvent1 {
             value2: AztecAddress::from_field(preimages[2]),
             value3: preimages[3] as u8,
         };
 
-        self.emit(event1, self.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
+        self.emit(event1).deliver_to(self.msg_sender().unwrap(), MessageDelivery.CONSTRAINED_ONCHAIN);
     }
 
     #[external("public")]
@@ -68,14 +68,12 @@ pub contract TestLog {
         // Safety: We use the following just as an arbitrary test value
         let random_value_3 = unsafe { random() };
 
-        self.emit(
-            ExampleEvent0 { value0: random_value_0, value1: random_value_1 },
+        self.emit(ExampleEvent0 { value0: random_value_0, value1: random_value_1 }).deliver_to(
             other,
             MessageDelivery.UNCONSTRAINED_ONCHAIN,
         );
 
-        self.emit(
-            ExampleEvent0 { value0: random_value_2, value1: random_value_3 },
+        self.emit(ExampleEvent0 { value0: random_value_2, value1: random_value_3 }).deliver_to(
             other,
             MessageDelivery.UNCONSTRAINED_ONCHAIN,
         );


### PR DESCRIPTION
The meat of this change is the following:

```diff
- self.emit(event, recipient, delivery_method)
+ self.emit(event).delivery(recipient, delivery_method)
```

This clears lots of things internally, exposing concepts that were hidden inside functions. For end users, it most notably provides a way for the same event to be delivered to multiple recipients, which was impossible before. It also nicely mirrors how notes are handled, which should help these concepts land better.

There's multiple things that are wrong about events right now, both in terms of the code structure and in terms of behavior (e.g. we don't commit to the event type atm), but I wanted to first get this changeset out so that we can include it in the next release and get it in the hands of users.