### PR TITLE
refactor!: remove `getPrivateLogs` from node

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,13 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+### [Aztec node, archiver] Deprecated `getPrivateLogs`
+
+Aztec node no longer offers a `getPrivateLogs` method. If you need to process the logs of a block, you can instead use `getBlock` and call `getPrivateLogs` on an `L2BlockNew` instance. See the diff below for before/after equivalent code samples.
+
+```diff
+-  const logs = await aztecNode.getPrivateLogs(blockNumber, 1);
++  const logs = (await aztecNode.getBlock(blockNumber))?.toL2Block().getPrivateLogs();
 ### [Aztec.nr] Private event emission API changes
 
 Private events are still emitted via the `emit` function, but this now returns an `EventMessage` type that must have `deliver_to` called on it in order to deliver the event message to the intended recipients. This allows for multiple recipients to receive the same event.

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -384,7 +384,7 @@ describe('Archiver', () => {
       for (const block of checkpoint.blocks) {
         const blockNumber = block.number;
 
-        const privateLogs = await archiver.getPrivateLogs(blockNumber, 1);
+        const privateLogs = (await archiver.getBlock(blockNumber))!.toL2Block().getPrivateLogs();
         const expectedTotalNumPrivateLogs = block.body.txEffects.reduce(
           (acc, txEffect) => acc + txEffect.privateLogs.length,
           0,
@@ -781,7 +781,6 @@ describe('Archiver', () => {
     expect(await archiver.getTxEffect(txHash)).resolves.toBeUndefined;
     expect(await archiver.getCheckpoint(CheckpointNumber(2))).resolves.toBeUndefined;
 
-    expect(await archiver.getPrivateLogs(BlockNumber(2), 1)).toEqual([]);
     expect((await archiver.getPublicLogs({ fromBlock: 2, toBlock: 3 })).logs).toEqual([]);
     expect((await archiver.getContractClassLogs({ fromBlock: 2, toBlock: 3 })).logs).toEqual([]);
   }, 10_000);

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1363,16 +1363,6 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
   }
 
   /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  public getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]> {
-    return this.store.getPrivateLogs(from, limit);
-  }
-
-  /**
    * Gets all logs that match any of the received tags (i.e. logs with their first field equal to a tag).
    * @param tags - The tags to filter the logs by.
    * @returns For each received tag, an array of matching logs is returned. An empty array implies no logs match
@@ -1842,9 +1832,6 @@ export class ArchiverStoreHelper
   }
   getL1ToL2MessageIndex(l1ToL2Message: Fr): Promise<bigint | undefined> {
     return this.store.getL1ToL2MessageIndex(l1ToL2Message);
-  }
-  getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]> {
-    return this.store.getPrivateLogs(from, limit);
   }
   getLogsByTags(tags: Fr[], logsPerTag?: number): Promise<TxScopedL2Log[][]> {
     return this.store.getLogsByTags(tags, logsPerTag);

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -13,7 +13,7 @@ import type {
   UtilityFunctionWithMembershipProof,
 } from '@aztec/stdlib/contract';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
-import type { LogFilter, PrivateLog, TxScopedL2Log } from '@aztec/stdlib/logs';
+import type { LogFilter, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { BlockHeader, type IndexedTxEffect, type TxHash, type TxReceipt } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
 
@@ -150,14 +150,6 @@ export interface ArchiverDataStore {
    * @returns The number of L1 to L2 messages in the store
    */
   getTotalL1ToL2MessageCount(): Promise<bigint>;
-
-  /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]>;
 
   /**
    * Gets all logs that match any of the received tags (i.e. logs with their first field equal to a tag).

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -352,36 +352,19 @@ export function describeArchiverDataStore(
       });
     });
 
-    describe('deleteLogs', () => {
-      it('deletes private & public logs', async () => {
-        const block = blocks[0].block;
-        await store.addBlocks([blocks[0]]);
-        await expect(store.addLogs([block])).resolves.toEqual(true);
+    it('deleteLogs', async () => {
+      const block = blocks[0].block;
+      await store.addBlocks([blocks[0]]);
+      await expect(store.addLogs([block])).resolves.toEqual(true);
 
-        expect((await store.getPrivateLogs(BlockNumber(1), 1)).length).toEqual(
-          block.body.txEffects.map(txEffect => txEffect.privateLogs).flat().length,
-        );
-        expect((await store.getPublicLogs({ fromBlock: BlockNumber(1) })).logs.length).toEqual(
-          block.body.txEffects.map(txEffect => txEffect.publicLogs).flat().length,
-        );
+      expect((await store.getPublicLogs({ fromBlock: BlockNumber(1) })).logs.length).toEqual(
+        block.body.txEffects.map(txEffect => txEffect.publicLogs).flat().length,
+      );
 
-        // This one is a pain for memory as we would never want to just delete memory in the middle.
-        await store.deleteLogs([block]);
+      // This one is a pain for memory as we would never want to just delete memory in the middle.
+      await store.deleteLogs([block]);
 
-        expect((await store.getPrivateLogs(BlockNumber(1), 1)).length).toEqual(0);
-        expect((await store.getPublicLogs({ fromBlock: BlockNumber(1) })).logs.length).toEqual(0);
-      });
-    });
-
-    describe('getPrivateLogs', () => {
-      it('gets added private logs', async () => {
-        const block = blocks[0].block;
-        await store.addBlocks([blocks[0]]);
-        await store.addLogs([block]);
-
-        const privateLogs = await store.getPrivateLogs(BlockNumber(1), 1);
-        expect(privateLogs).toEqual(block.body.txEffects.map(txEffect => txEffect.privateLogs).flat());
-      });
+      expect((await store.getPublicLogs({ fromBlock: BlockNumber(1) })).logs.length).toEqual(0);
     });
 
     describe('getTxEffect', () => {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -16,7 +16,7 @@ import type {
   UtilityFunctionWithMembershipProof,
 } from '@aztec/stdlib/contract';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
-import { type LogFilter, PrivateLog, type TxScopedL2Log } from '@aztec/stdlib/logs';
+import type { LogFilter, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { BlockHeader, TxHash, TxReceipt } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
 
@@ -31,7 +31,7 @@ import { ContractInstanceStore } from './contract_instance_store.js';
 import { LogStore } from './log_store.js';
 import { MessageStore } from './message_store.js';
 
-export const ARCHIVER_DB_VERSION = 3;
+export const ARCHIVER_DB_VERSION = 4;
 export const MAX_FUNCTION_SIGNATURES = 1000;
 export const MAX_FUNCTION_NAME_LEN = 256;
 
@@ -306,16 +306,6 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
    */
   getL1ToL2Messages(checkpointNumber: CheckpointNumber): Promise<Fr[]> {
     return this.#messageStore.getL1ToL2Messages(checkpointNumber);
-  }
-
-  /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]> {
-    return this.#logStore.getPrivateLogs(from, limit);
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -12,7 +12,6 @@ import {
   ExtendedPublicLog,
   type LogFilter,
   LogId,
-  PrivateLog,
   PublicLog,
   TxScopedL2Log,
 } from '@aztec/stdlib/logs';
@@ -25,7 +24,6 @@ import type { BlockStore } from './block_store.js';
 export class LogStore {
   #logsByTag: AztecAsyncMap<string, Buffer[]>;
   #logTagsByBlock: AztecAsyncMap<number, string[]>;
-  #privateLogsByBlock: AztecAsyncMap<number, Buffer>;
   #publicLogsByBlock: AztecAsyncMap<number, Buffer>;
   #contractClassLogsByBlock: AztecAsyncMap<number, Buffer>;
   #logsMaxPageSize: number;
@@ -38,7 +36,6 @@ export class LogStore {
   ) {
     this.#logsByTag = db.openMap('archiver_tagged_logs_by_tag');
     this.#logTagsByBlock = db.openMap('archiver_log_tags_by_block');
-    this.#privateLogsByBlock = db.openMap('archiver_private_logs_by_block');
     this.#publicLogsByBlock = db.openMap('archiver_public_logs_by_block');
     this.#contractClassLogsByBlock = db.openMap('archiver_contract_class_logs_by_block');
 
@@ -112,12 +109,6 @@ export class LogStore {
         }
         await this.#logTagsByBlock.set(block.number, tagsInBlock);
 
-        const privateLogsInBlock = block.body.txEffects
-          .map(txEffect => txEffect.privateLogs)
-          .flat()
-          .map(log => log.toBuffer());
-        await this.#privateLogsByBlock.set(block.number, Buffer.concat(privateLogsInBlock));
-
         const publicLogsInBlock = block.body.txEffects
           .map((txEffect, txIndex) =>
             [
@@ -160,7 +151,6 @@ export class LogStore {
       await Promise.all(
         blocks.map(block =>
           Promise.all([
-            this.#privateLogsByBlock.delete(block.number),
             this.#publicLogsByBlock.delete(block.number),
             this.#logTagsByBlock.delete(block.number),
             this.#contractClassLogsByBlock.delete(block.number),
@@ -171,23 +161,6 @@ export class LogStore {
       await Promise.all(tagsToDelete.map(tag => this.#logsByTag.delete(tag.toString())));
       return true;
     });
-  }
-
-  /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `start`.
-   * @param start - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  async getPrivateLogs(start: number, limit: number): Promise<PrivateLog[]> {
-    const logs = [];
-    for await (const buffer of this.#privateLogsByBlock.valuesAsync({ start, limit })) {
-      const reader = new BufferReader(buffer);
-      while (reader.remainingBytes() > 0) {
-        logs.push(reader.readObject(PrivateLog));
-      }
-    }
-    return logs;
   }
 
   /**

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -82,7 +82,7 @@ import {
   type WorldStateSynchronizer,
   tryStop,
 } from '@aztec/stdlib/interfaces/server';
-import type { LogFilter, PrivateLog, TxScopedL2Log } from '@aztec/stdlib/logs';
+import type { LogFilter, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { InboxLeaf, type L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { P2PClientType } from '@aztec/stdlib/p2p';
 import type { Offense, SlashPayloadRound } from '@aztec/stdlib/slashing';
@@ -655,16 +655,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
   public getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
     return this.contractDataSource.getContract(address);
-  }
-
-  /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  public getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]> {
-    return this.logsSource.getPrivateLogs(from, limit);
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -178,8 +178,10 @@ describe('e2e_deploy_contract contract class registration', () => {
 
         it('stores contract instance in the aztec node', async () => {
           // Contract instance deployed event is emitted via private logs.
-          const block = await aztecNode.getBlockNumber();
-          const logs = await aztecNode.getPrivateLogs(block, 1);
+          const blockNumber = await aztecNode.getBlockNumber();
+
+          const logs = (await aztecNode.getBlock(blockNumber))!.toL2Block().getPrivateLogs();
+
           expect(logs.length).toBe(1);
 
           // To actually trigger this write:

--- a/yarn-project/end-to-end/src/e2e_event_logs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_logs.test.ts
@@ -184,11 +184,11 @@ describe('Logs', () => {
           .send({ from: account1Address })
           .wait();
 
-        const blockNumber = tx.blockNumber!;
-
         // Fetch raw private logs for that block and check tag uniqueness
-        const privateLogs = await aztecNode.getPrivateLogs(blockNumber, 1);
-        const logs = privateLogs.filter(l => !l.isEmpty());
+        const logs = (await aztecNode.getBlock(tx.blockNumber!))!
+          .toL2Block()
+          .getPrivateLogs()
+          .filter(l => !l.isEmpty());
 
         expect(logs.length).toBe(tx1NumLogs);
 
@@ -210,8 +210,10 @@ describe('Logs', () => {
         const blockNumber = tx.blockNumber!;
 
         // Fetch raw private logs for that block and check tag uniqueness
-        const privateLogs = await aztecNode.getPrivateLogs(blockNumber, 1);
-        const logs = privateLogs.filter(l => !l.isEmpty());
+        const logs = (await aztecNode.getBlock(blockNumber))!
+          .toL2Block()
+          .getPrivateLogs()
+          .filter(l => !l.isEmpty());
 
         expect(logs.length).toBe(tx2NumLogs);
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -605,7 +605,6 @@ describe('e2e_synching', () => {
           }
 
           expect(await archiver.getTxEffect(txHash)).not.toBeUndefined;
-          expect(await archiver.getPrivateLogs(blockTip.number, 1)).not.toEqual([]);
           expect(
             await archiver.getPublicLogs({ fromBlock: blockTip.number, toBlock: blockTip.number + 1 }),
           ).not.toEqual([]);
@@ -630,7 +629,6 @@ describe('e2e_synching', () => {
           );
 
           expect(await archiver.getTxEffect(txHash)).toBeUndefined;
-          expect(await archiver.getPrivateLogs(blockTip.number, 1)).toEqual([]);
           expect(await archiver.getPublicLogs({ fromBlock: blockTip.number, toBlock: blockTip.number + 1 })).toEqual(
             [],
           );

--- a/yarn-project/stdlib/src/block/l2_block_new.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.ts
@@ -5,6 +5,7 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { z } from 'zod';
 
+import type { PrivateLog } from '../logs/private_log.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { BlockHeader } from '../tx/block_header.js';
 import { Body } from './body.js';
@@ -176,6 +177,10 @@ export class L2BlockNew {
       blockTimestamp: Number(this.header.globalVariables.timestamp),
       ...logsStats,
     };
+  }
+
+  getPrivateLogs(): PrivateLog[] {
+    return this.body.txEffects.map(txEffect => txEffect.privateLogs).flat();
   }
 
   toBlockInfo(): L2BlockInfo {

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -27,7 +27,6 @@ import { PublicKeys } from '../keys/public_keys.js';
 import { ExtendedContractClassLog } from '../logs/extended_contract_class_log.js';
 import { ExtendedPublicLog } from '../logs/extended_public_log.js';
 import type { LogFilter } from '../logs/log_filter.js';
-import { PrivateLog } from '../logs/private_log.js';
 import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import { getTokenContractArtifact } from '../tests/fixtures.js';
 import { BlockHeader } from '../tx/block_header.js';
@@ -193,11 +192,6 @@ describe('ArchiverApiSchema', () => {
       proven: { number: 1, hash: `0x01` },
       finalized: { number: 1, hash: `0x01` },
     });
-  });
-
-  it('getPrivateLogs', async () => {
-    const result = await context.client.getPrivateLogs(BlockNumber(1), BlockNumber(1));
-    expect(result).toEqual([expect.any(PrivateLog)]);
   });
 
   it('getLogsByTags', async () => {
@@ -433,9 +427,6 @@ class MockArchiver implements ArchiverApi {
   getL2BlockHash(blockNumber: BlockNumber): Promise<string | undefined> {
     expect(blockNumber).toEqual(BlockNumber(1));
     return Promise.resolve(`0x01`);
-  }
-  getPrivateLogs(_from: BlockNumber, _limit: number): Promise<PrivateLog[]> {
-    return Promise.resolve([PrivateLog.random()]);
   }
   async getLogsByTags(tags: Fr[]): Promise<TxScopedL2Log[][]> {
     expect(tags[0]).toBeInstanceOf(Fr);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -17,7 +17,6 @@ import {
 } from '../contract/index.js';
 import { L1RollupConstantsSchema } from '../epoch-helpers/index.js';
 import { LogFilterSchema } from '../logs/log_filter.js';
-import { PrivateLog } from '../logs/private_log.js';
 import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import type { L1ToL2MessageSource } from '../messaging/l1_to_l2_message_source.js';
 import { optional, schemas } from '../schemas/schemas.js';
@@ -112,7 +111,6 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getBlockHeadersForEpoch: z.function().args(EpochNumberSchema).returns(z.array(BlockHeader.schema)),
   isEpochComplete: z.function().args(EpochNumberSchema).returns(z.boolean()),
   getL2Tips: z.function().args().returns(L2TipsSchema),
-  getPrivateLogs: z.function().args(BlockNumberSchema, z.number()).returns(z.array(PrivateLog.schema)),
   getLogsByTags: z
     .function()
     .args(z.array(schemas.Fr))

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -39,7 +39,6 @@ import { PublicKeys } from '../keys/public_keys.js';
 import { ExtendedContractClassLog } from '../logs/extended_contract_class_log.js';
 import { ExtendedPublicLog } from '../logs/extended_public_log.js';
 import type { LogFilter } from '../logs/log_filter.js';
-import { PrivateLog } from '../logs/private_log.js';
 import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import { getTokenContractArtifact } from '../tests/fixtures.js';
 import { MerkleTreeId } from '../trees/merkle_tree_id.js';
@@ -286,11 +285,6 @@ describe('AztecNodeApiSchema', () => {
 
   it('registerContractFunctionSignatures', async () => {
     await context.client.registerContractFunctionSignatures(['test()']);
-  });
-
-  it('getPrivateLogs', async () => {
-    const response = await context.client.getPrivateLogs(BlockNumber(1), BlockNumber(1));
-    expect(response).toEqual([expect.any(PrivateLog)]);
   });
 
   it('getPublicLogs', async () => {
@@ -709,9 +703,6 @@ class MockAztecNode implements AztecNode {
   }
   registerContractFunctionSignatures(_signatures: string[]): Promise<void> {
     return Promise.resolve();
-  }
-  getPrivateLogs(_from: number, _limit: number): Promise<PrivateLog[]> {
-    return Promise.resolve([PrivateLog.random()]);
   }
   async getPublicLogs(filter: LogFilter): Promise<GetPublicLogsResponse> {
     expect(filter.contractAddress).toBeInstanceOf(AztecAddress);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -37,7 +37,6 @@ import {
 } from '../contract/index.js';
 import { GasFees } from '../gas/gas_fees.js';
 import { type LogFilter, LogFilterSchema } from '../logs/log_filter.js';
-import { PrivateLog } from '../logs/private_log.js';
 import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import { type ApiSchemaFor, optional, schemas } from '../schemas/schemas.js';
 import { MerkleTreeId } from '../trees/merkle_tree_id.js';
@@ -325,14 +324,6 @@ export interface AztecNode
   registerContractFunctionSignatures(functionSignatures: string[]): Promise<void>;
 
   /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]>;
-
-  /**
    * Gets public logs based on the provided filter.
    * @param filter - The filter to apply to the logs.
    * @returns The requested logs.
@@ -605,11 +596,6 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     .function()
     .args(z.array(z.string().max(MAX_SIGNATURE_LEN)).max(MAX_SIGNATURES_PER_REGISTER_CALL))
     .returns(z.void()),
-
-  getPrivateLogs: z
-    .function()
-    .args(BlockNumberPositiveSchema, z.number().lte(MAX_RPC_LEN))
-    .returns(z.array(PrivateLog.schema)),
 
   getPublicLogs: z.function().args(LogFilterSchema).returns(GetPublicLogsResponseSchema),
 

--- a/yarn-project/stdlib/src/interfaces/l2_logs_source.ts
+++ b/yarn-project/stdlib/src/interfaces/l2_logs_source.ts
@@ -2,7 +2,6 @@ import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 
 import type { LogFilter } from '../logs/log_filter.js';
-import type { PrivateLog } from '../logs/private_log.js';
 import type { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from './get_logs_response.js';
 
@@ -10,14 +9,6 @@ import type { GetContractClassLogsResponse, GetPublicLogsResponse } from './get_
  * Interface of classes allowing for the retrieval of logs.
  */
 export interface L2LogsSource {
-  /**
-   * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
-   * @param from - The block number from which to begin retrieving logs.
-   * @param limit - The maximum number of blocks to retrieve logs from.
-   * @returns An array of private logs from the specified range of blocks.
-   */
-  getPrivateLogs(from: BlockNumber, limit: number): Promise<PrivateLog[]>;
-
   /**
    * Gets all logs that match any of the received tags (i.e. logs with their first field equal to a tag).
    * @param tags - The tags to filter the logs by.


### PR DESCRIPTION
It was effectively only used in integration tests, where the block is known so it's easier to read them from`getBlock` instead. 

Note that PXE relies on `getLogsByTags` instead.
