### PR TITLE
feat: Add corpus archives and update coverage accumulation 

### DIFF
--- a/container-builds/fuzzing-container/run.sh
+++ b/container-builds/fuzzing-container/run.sh
@@ -108,9 +108,9 @@ if [[ "$mode" == "show-fuzzers" ]]; then
 	entrypoint_args+=(--asm "$asm")
 	entrypoint_args+=(--avm "$avm")
 
-	docker run -it --rm                \
+	docker run -it --rm \
 		--entrypoint "./entrypoint.sh" \
-		"$image_name"                  \
+		"$image_name" \
 		"${entrypoint_args[@]}"
 	exit 0
 fi
@@ -122,7 +122,7 @@ if [ -z "${fuzzer}" ]; then
 	exit 1
 fi
 
-mkdir -p crash-reports/unsorted output corpus coverage
+mkdir -p crash-reports/unsorted output corpus coverage artifacts
 
 docker_args=(
 	-it --rm
@@ -131,6 +131,7 @@ docker_args=(
 	-v "$(pwd)/output:/home/fuzzer/output:rw"
 	-v "$(pwd)/corpus:/home/fuzzer/corpus:rw"
 	-v "$(pwd)/coverage:/home/fuzzer/coverage:rw"
+	-v "$(pwd)/artifacts:/home/fuzzer/artifacts:rw"
 	--cpus="$cpus"
 	-m "$mem"
 	--entrypoint "./entrypoint.sh"

--- a/container-builds/fuzzing-container/src/entrypoint.sh
+++ b/container-builds/fuzzing-container/src/entrypoint.sh
@@ -144,7 +144,8 @@ CORPUS="$workdir/corpus"
 OUTPUT="$workdir/output"
 COVERAGE="$workdir/coverage"
 RAWCOV="$COVERAGE/raw"
-mkdir -p "$CRASHES" "$UNSORTED_CRASHES" "$CORPUS" "$OUTPUT" "$COVERAGE" "$RAWCOV"
+ARTIFACTS="$workdir/artifacts"
+mkdir -p "$CRASHES" "$UNSORTED_CRASHES" "$CORPUS" "$OUTPUT" "$COVERAGE" "$RAWCOV" "$ARTIFACTS"
 
 if [ -z "${fuzzer}" ]; then
 	log "No fuzzer was provided"
@@ -263,6 +264,17 @@ fuzz() {
 
 	mv "$TMPOUT/"* "$OUTPUT"
 	rmdir "$TMPOUT"
+
+	ARCHIVE_NAME="${fuzzer}.tar.gz"
+	if compgen -G "$CORPUS/*" >/dev/null || compgen -G "$CRASHES/*" >/dev/null; then
+		log "Packing corpus & crashes into $ARTIFACTS/$ARCHIVE_NAME"
+		tar -czf "$ARTIFACTS/$ARCHIVE_NAME" \
+			-C "$CORPUS" . \
+			-C "$CRASHES" .
+	else
+		log "Corpus & crashes are empty, skipping packing"
+	fi
+
 	exit "$exit_code"
 }
 
@@ -271,14 +283,26 @@ cov() {
 		log "Corpus is empty, nothing to collect coverage from."
 		return 0
 	fi
+
+	log "Cleaning previous coverage data in $RAWCOV and $COVERAGE..."
+	rm -f "$RAWCOV"/*.profraw 2>/dev/null || true
+	rm -f "$COVERAGE/fuzz.profdata" 2>/dev/null || true
+	rm -rf "$COVERAGE/cov-html" 2>/dev/null || true
+
 	TMPOUT="$(mktemp -d)"
 	trap 'rm -rf "$TMPOUT" 2>/dev/null' EXIT
 
 	TS=$(date +%Y%m%dT%H%M%S)
-	LLVM_PROFILE_FILE="$RAWCOV/${TS}-%p.profraw" "$cov_fuzzer" -merge=1 "$TMPOUT" "$CORPUS/"
 
-	llvm-profdata-18 merge -sparse "$RAWCOV/"*.profraw -o "$COVERAGE/fuzz.profdata"
+	log "Collecting coverage data on corpus..."
+	LLVM_PROFILE_FILE="$RAWCOV/${TS}-%p.profraw" \
+		"$cov_fuzzer" -merge=1 "$TMPOUT" "$CORPUS/"
 
+	log "Merging coverage data..."
+	llvm-profdata-18 merge -sparse "$RAWCOV/"*.profraw \
+		-o "$COVERAGE/fuzz.profdata"
+
+	log "Assembling HTML report..."
 	llvm-cov-18 show "$cov_fuzzer" \
 		-instr-profile="$COVERAGE/fuzz.profdata" \
 		-format=html \
@@ -286,6 +310,8 @@ cov() {
 		-show-line-counts-or-regions \
 		--show-branches=percent \
 		--show-directory-coverage
+
+	log "Coverage HTML written to $COVERAGE/cov-html"
 }
 
 case "$mode" in


### PR DESCRIPTION
This PR adds the following functionality to the fuzzing container:
- corpus and crash-reports are now automatically compressed at the end of fuzzing process
- coverage data is no longer merged with past coverage data due to conflicts and constant changes in library