### PR TITLE
chore: fix syntax in migration notes example

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -16,6 +16,8 @@ Aztec node no longer offers a `getPrivateLogs` method. If you need to process th
 ```diff
 -  const logs = await aztecNode.getPrivateLogs(blockNumber, 1);
 +  const logs = (await aztecNode.getBlock(blockNumber))?.toL2Block().getPrivateLogs();
+```
+
 ### [Aztec.nr] Private event emission API changes
 
 Private events are still emitted via the `emit` function, but this now returns an `EventMessage` type that must have `deliver_to` called on it in order to deliver the event message to the intended recipients. This allows for multiple recipients to receive the same event.


### PR DESCRIPTION
Fixes an unclosed code section in migration notes I introduced while solving a merge conflict in #18985