### PR TITLE
chore: Try deflake inactivity slash again

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -24,7 +24,7 @@ const SLASHING_UNIT = BigInt(1e18);
 const SLASHING_AMOUNT = SLASHING_UNIT * 3n;
 
 // How many epochs it may take to set everything up, so we dont slash during this period
-const SETUP_EPOCH_DURATION = 5;
+const SETUP_EPOCH_DURATION = 8;
 
 export class P2PInactivityTest {
   public nodes!: AztecNodeService[];
@@ -151,13 +151,8 @@ export class P2PInactivityTest {
     // This prevents race conditions where validators propose blocks before the network is ready
     await this.test.waitForP2PMeshConnectivity(this.nodes, NUM_NODES);
 
-    const ethereumSlotDuration = this.test.ctx.aztecNodeConfig.ethereumSlotDuration!;
-    this.test.logger.warn(
-      `Advancing to epoch ${SETUP_EPOCH_DURATION} (slashing will start after this epoch is complete)`,
-    );
-    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(EpochNumber(SETUP_EPOCH_DURATION), {
-      offset: -ethereumSlotDuration,
-    });
+    this.test.logger.warn(`Advancing to epoch ${SETUP_EPOCH_DURATION - 1} (slashing will start after it is completed)`);
+    await this.test.ctx.cheatCodes.rollup.advanceToEpoch(EpochNumber(SETUP_EPOCH_DURATION - 1));
 
     return this;
   }


### PR DESCRIPTION
Turns out we were missing a `-1` to go to before the first slashable epoch. And setup was taking 4 epochs already, so I bumped that number for good measure.