### PR TITLE
chore: Make fuzzing logs smaller by disabling info in some checks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/assert.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.cpp
@@ -11,7 +11,9 @@ AssertMode& get_assert_mode()
 void assert_failure(std::string const& err)
 {
     if (get_assert_mode() == AssertMode::WARN) {
+#ifndef FUZZING_DISABLE_WARNINGS
         info("NOT FOR PROD - assert as warning: ", err);
+#endif
         return;
     }
     throw_or_abort(err);

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -65,6 +65,18 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...) DONT_EVALUATE((left) < (right))
 #define BB_ASSERT_LTE(left, right, ...) DONT_EVALUATE((left) <= (right))
 #else
+#ifdef FUZZING_DISABLE_WARNINGS
+#define BB_ASSERT(expression, ...)                                                                                     \
+    do {                                                                                                               \
+        BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                      \
+        if (!(BB_LIKELY(expression))) {                                                                                \
+            std::ostringstream oss;                                                                                    \
+            oss << "Assertion failed: (" #expression ")";                                                              \
+            __VA_OPT__(oss << "\nReason   : " << __VA_ARGS__;)                                                         \
+            bb::assert_failure(oss.str());                                                                             \
+        }                                                                                                              \
+    } while (0)
+#else
 #define BB_ASSERT(expression, ...)                                                                                     \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT" #expression);                                                                      \
@@ -76,6 +88,7 @@ struct AssertGuard {
             bb::assert_failure(oss.str());                                                                             \
         }                                                                                                              \
     } while (0)
+#endif
 
 #define BB_ASSERT_EQ(actual, expected, ...)                                                                            \
     do {                                                                                                               \


### PR DESCRIPTION
ACIR logs are huge because we deliberately create weird gates. Disabling some info calls when we use fuzzing to ensure the logs stay small