### PR TITLE
feat: validate attestationsHash and payloadDigest when synching checkpoints.

### DIFF
--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -101,7 +101,13 @@ struct RollupStore {
 }
 
 interface IRollupCore {
-  event CheckpointProposed(uint256 indexed checkpointNumber, bytes32 indexed archive, bytes32[] versionedBlobHashes);
+  event CheckpointProposed(
+    uint256 indexed checkpointNumber,
+    bytes32 indexed archive,
+    bytes32[] versionedBlobHashes,
+    bytes32 payloadDigest,
+    bytes32 attestationsHash
+  );
   event L2ProofVerified(uint256 indexed checkpointNumber, address indexed proverId);
   event CheckpointInvalidated(uint256 indexed checkpointNumber);
   event RewardConfigUpdated(RewardConfig rewardConfig);

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -302,7 +302,9 @@ library ProposeLib {
     }
 
     // Emit event for external listeners. Nodes rely on this event to update their state.
-    emit IRollupCore.CheckpointProposed(checkpointNumber, _args.archive, v.blobHashes);
+    emit IRollupCore.CheckpointProposed(
+      checkpointNumber, _args.archive, v.blobHashes, v.payloadDigest, v.attestationsHash
+    );
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
+++ b/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
@@ -141,8 +141,8 @@ async function main() {
     logger.info('Retrieving block header from rollup transaction...');
     logger.info('');
 
-    // For this script, we don't have blob hashes, so pass empty array
-    const result = await retriever.getCheckpointFromRollupTx(txHash, [], CheckpointNumber(l2BlockNumber));
+    // For this script, we don't have blob hashes or expected hashes, so pass empty arrays/objects
+    const result = await retriever.getCheckpointFromRollupTx(txHash, [], CheckpointNumber(l2BlockNumber), {});
 
     logger.info(' Successfully retrieved block header!');
     logger.info('');

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.test.ts
@@ -11,11 +11,20 @@ import { withHexPrefix } from '@aztec/foundation/string';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { Signature } from '@aztec/stdlib/block';
 import { GasFees } from '@aztec/stdlib/gas';
+import { ConsensusPayload, SignatureDomainSeparator } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { ContentCommitment } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
-import { type Hex, type Transaction, encodeFunctionData, multicall3Abi, toFunctionSelector } from 'viem';
+import {
+  type Hex,
+  type Transaction,
+  encodeAbiParameters,
+  encodeFunctionData,
+  keccak256,
+  multicall3Abi,
+  toFunctionSelector,
+} from 'viem';
 
 import type { ArchiverInstrumentation } from '../instrumentation.js';
 import { CalldataRetriever } from './calldata_retriever.js';
@@ -43,8 +52,13 @@ class TestCalldataRetriever extends CalldataRetriever {
     return await super.extractCalldataViaTrace(txHash);
   }
 
-  public override decodeAndBuildCheckpoint(proposeCalldata: Hex, blockHash: Hex, checkpointNumber: CheckpointNumber) {
-    return super.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber);
+  public override decodeAndBuildCheckpoint(
+    proposeCalldata: Hex,
+    blockHash: Hex,
+    checkpointNumber: CheckpointNumber,
+    expectedHashes: { attestationsHash?: Hex; payloadDigest?: Hex },
+  ) {
+    return super.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber, expectedHashes);
   }
 }
 
@@ -145,7 +159,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber);
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
       expect(result.header).toBeInstanceOf(CheckpointHeader);
@@ -168,7 +182,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber);
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
       expect(result.header).toBeInstanceOf(CheckpointHeader);
@@ -210,7 +224,7 @@ describe('CalldataRetriever', () => {
         },
       ]);
 
-      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber);
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
       expect(debugClient.request).toHaveBeenCalledWith({ method: 'trace_transaction', params: [txHash] });
@@ -234,7 +248,7 @@ describe('CalldataRetriever', () => {
       // Mock both trace methods to fail
       debugClient.request.mockRejectedValue(new Error(`Method not available`));
 
-      await expect(retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber)).rejects.toThrow(
+      await expect(retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {})).rejects.toThrow(
         'Failed to trace transaction',
       );
     });
@@ -242,9 +256,133 @@ describe('CalldataRetriever', () => {
     it('should throw when transaction retrieval fails', async () => {
       publicClient.getTransaction.mockRejectedValue(new Error('Transaction not found'));
 
-      await expect(retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber)).rejects.toThrow(
+      await expect(retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {})).rejects.toThrow(
         'Transaction not found',
       );
+    });
+
+    it('should validate attestationsHash when provided', async () => {
+      const attestations = makeViemCommitteeAttestations();
+      const proposeCalldata = makeProposeCalldata(undefined, attestations);
+      const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
+
+      publicClient.getTransaction.mockResolvedValue(tx);
+
+      // Compute the expected attestationsHash
+      const expectedAttestationsHash = keccak256(
+        encodeAbiParameters(
+          [
+            {
+              type: 'tuple',
+              components: [
+                { name: 'signatureIndices', type: 'bytes' },
+                { name: 'signaturesOrAddresses', type: 'bytes' },
+              ],
+            },
+          ],
+          [
+            {
+              signatureIndices: attestations.signatureIndices,
+              signaturesOrAddresses: attestations.signaturesOrAddresses,
+            },
+          ],
+        ),
+      );
+
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {
+        attestationsHash: expectedAttestationsHash,
+      });
+
+      expect(result.checkpointNumber).toBe(checkpointNumber);
+      expect(result.header).toBeInstanceOf(CheckpointHeader);
+    });
+
+    it('should throw when attestationsHash does not match', async () => {
+      const attestations = makeViemCommitteeAttestations();
+      const proposeCalldata = makeProposeCalldata(undefined, attestations);
+      const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
+
+      publicClient.getTransaction.mockResolvedValue(tx);
+
+      // Use a different (wrong) attestationsHash
+      const wrongAttestationsHash = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex;
+
+      await expect(
+        retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {
+          attestationsHash: wrongAttestationsHash,
+        }),
+      ).rejects.toThrow('Attestations hash mismatch');
+    });
+
+    it('should work with empty expectedHashes for backwards compatibility', async () => {
+      const proposeCalldata = makeProposeCalldata();
+      const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
+
+      publicClient.getTransaction.mockResolvedValue(tx);
+
+      // Call with empty expectedHashes (simulating old event format without hash fields)
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
+
+      expect(result.checkpointNumber).toBe(checkpointNumber);
+      expect(result.header).toBeInstanceOf(CheckpointHeader);
+      // Should succeed without validation when hashes are not provided
+    });
+
+    it('should validate payloadDigest when provided', async () => {
+      const header = makeViemHeader();
+      const attestations = makeViemCommitteeAttestations();
+      const archiveRoot = Fr.random();
+      const archive = archiveRoot.toString() as Hex;
+      const feeAssetPriceModifier = BigInt(0);
+
+      // Create propose calldata with known values
+      const proposeCalldata = encodeFunctionData({
+        abi: RollupAbi,
+        functionName: 'propose',
+        args: [
+          {
+            archive,
+            oracleInput: { feeAssetPriceModifier },
+            header,
+          },
+          attestations,
+          [], // signers
+          Signature.random().toViemSignature(),
+          '0x' as Hex, // blobInput
+        ],
+      });
+
+      const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
+      publicClient.getTransaction.mockResolvedValue(tx);
+
+      // Compute the expected payloadDigest using ConsensusPayload (same logic as the validator)
+      const checkpointHeader = CheckpointHeader.fromViem(header);
+      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot);
+      const payloadToSign = consensusPayload.getPayloadToSign(SignatureDomainSeparator.blockAttestation);
+      const expectedPayloadDigest = keccak256(payloadToSign);
+
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {
+        payloadDigest: expectedPayloadDigest,
+      });
+
+      expect(result.checkpointNumber).toBe(checkpointNumber);
+      expect(result.header).toBeInstanceOf(CheckpointHeader);
+    });
+
+    it('should throw when payloadDigest does not match', async () => {
+      const proposeCalldata = makeProposeCalldata();
+      const tx = makeMulticall3Transaction([{ target: rollupAddress.toString(), callData: proposeCalldata }]);
+
+      publicClient.getTransaction.mockResolvedValue(tx);
+
+      // Use a different (wrong) payloadDigest
+      const wrongPayloadDigest = '0x0000000000000000000000000000000000000000000000000000000000000002' as Hex;
+
+      await expect(
+        retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {
+          payloadDigest: wrongPayloadDigest,
+        }),
+      ).rejects.toThrow('Payload digest mismatch');
     });
   });
   describe('tryDecodeMulticall3', () => {
@@ -944,7 +1082,7 @@ describe('CalldataRetriever', () => {
     it('should correctly decode propose calldata and build checkpoint', () => {
       const proposeCalldata = makeProposeCalldata();
 
-      const result = retriever.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber);
+      const result = retriever.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber, {});
 
       expect(result.checkpointNumber).toBe(checkpointNumber);
       expect(result.header).toBeInstanceOf(CheckpointHeader);
@@ -957,7 +1095,7 @@ describe('CalldataRetriever', () => {
       const attestations = makeViemCommitteeAttestations();
       const proposeCalldata = makeProposeCalldata(undefined, attestations);
 
-      const result = retriever.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber);
+      const result = retriever.decodeAndBuildCheckpoint(proposeCalldata, blockHash, checkpointNumber, {});
 
       expect(result.attestations).toHaveLength(TARGET_COMMITTEE_SIZE);
     });
@@ -968,13 +1106,13 @@ describe('CalldataRetriever', () => {
       );
       const invalidCalldata = (invalidateBadSelector + '0'.repeat(120)) as Hex;
 
-      expect(() => retriever.decodeAndBuildCheckpoint(invalidCalldata, blockHash, checkpointNumber)).toThrow();
+      expect(() => retriever.decodeAndBuildCheckpoint(invalidCalldata, blockHash, checkpointNumber, {})).toThrow();
     });
 
     it('should throw when calldata is malformed', () => {
       const malformedCalldata = '0xinvalid' as Hex;
 
-      expect(() => retriever.decodeAndBuildCheckpoint(malformedCalldata, blockHash, checkpointNumber)).toThrow();
+      expect(() => retriever.decodeAndBuildCheckpoint(malformedCalldata, blockHash, checkpointNumber, {})).toThrow();
     });
   });
 
@@ -987,7 +1125,7 @@ describe('CalldataRetriever', () => {
 
       publicClient.getTransaction.mockResolvedValue(tx);
 
-      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber);
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
 
       expect(result).toBeDefined();
       expect(result.checkpointNumber).toBe(checkpointNumber);
@@ -1060,7 +1198,7 @@ describe('CalldataRetriever', () => {
         ('0x000000000000000000000000' + SPIRE_PROPOSER_EXPECTED_IMPLEMENTATION.slice(2)) as Hex,
       );
 
-      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber);
+      const result = await retriever.getCheckpointFromRollupTx(txHash, [], checkpointNumber, {});
 
       expect(result).toBeDefined();
       expect(result.checkpointNumber).toBe(checkpointNumber);

--- a/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
+++ b/yarn-project/archiver/src/archiver/l1/calldata_retriever.ts
@@ -13,9 +13,20 @@ import {
   TallySlashingProposerAbi,
 } from '@aztec/l1-artifacts';
 import { CommitteeAttestation } from '@aztec/stdlib/block';
+import { ConsensusPayload, SignatureDomainSeparator } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 
-import { type Hex, type Transaction, decodeFunctionData, hexToBytes, multicall3Abi, toFunctionSelector } from 'viem';
+import {
+  type AbiParameter,
+  type Hex,
+  type Transaction,
+  decodeFunctionData,
+  encodeAbiParameters,
+  hexToBytes,
+  keccak256,
+  multicall3Abi,
+  toFunctionSelector,
+} from 'viem';
 
 import type { ArchiverInstrumentation } from '../instrumentation.js';
 import { getSuccessfulCallsFromDebug } from './debug_tx.js';
@@ -56,12 +67,17 @@ export class CalldataRetriever {
    * @param txHash - Hash of the tx that published it.
    * @param blobHashes - Blob hashes for the checkpoint.
    * @param checkpointNumber - Checkpoint number.
+   * @param expectedHashes - Optional expected hashes from the CheckpointProposed event for validation
    * @returns Checkpoint header and metadata from the calldata, deserialized
    */
   async getCheckpointFromRollupTx(
     txHash: `0x${string}`,
     blobHashes: Buffer[],
     checkpointNumber: CheckpointNumber,
+    expectedHashes: {
+      attestationsHash?: Hex;
+      payloadDigest?: Hex;
+    },
   ): Promise<{
     checkpointNumber: CheckpointNumber;
     archiveRoot: Fr;
@@ -69,10 +85,14 @@ export class CalldataRetriever {
     attestations: CommitteeAttestation[];
     blockHash: string;
   }> {
-    this.logger.trace(`Fetching checkpoint ${checkpointNumber} from rollup tx ${txHash}`);
+    this.logger.trace(`Fetching checkpoint ${checkpointNumber} from rollup tx ${txHash}`, {
+      willValidateHashes: !!expectedHashes.attestationsHash || !!expectedHashes.payloadDigest,
+      hasAttestationsHash: !!expectedHashes.attestationsHash,
+      hasPayloadDigest: !!expectedHashes.payloadDigest,
+    });
     const tx = await this.publicClient.getTransaction({ hash: txHash });
     const proposeCalldata = await this.getProposeCallData(tx, checkpointNumber);
-    return this.decodeAndBuildCheckpoint(proposeCalldata, tx.blockHash!, checkpointNumber);
+    return this.decodeAndBuildCheckpoint(proposeCalldata, tx.blockHash!, checkpointNumber, expectedHashes);
   }
 
   /** Gets rollup propose calldata from a transaction */
@@ -325,16 +345,58 @@ export class CalldataRetriever {
   }
 
   /**
+   * Extracts the CommitteeAttestations struct definition from RollupAbi.
+   * Finds the _attestations parameter by name in the propose function.
+   * Lazy-loaded to avoid issues during module initialization.
+   */
+  private getCommitteeAttestationsStructDef(): AbiParameter {
+    const proposeFunction = RollupAbi.find(item => item.type === 'function' && item.name === 'propose') as
+      | { type: 'function'; name: string; inputs: readonly AbiParameter[] }
+      | undefined;
+
+    if (!proposeFunction) {
+      throw new Error('propose function not found in RollupAbi');
+    }
+
+    // Find the _attestations parameter by name, not by index
+    const attestationsParam = proposeFunction.inputs.find(param => param.name === '_attestations');
+
+    if (!attestationsParam) {
+      throw new Error('_attestations parameter not found in propose function');
+    }
+
+    if (attestationsParam.type !== 'tuple') {
+      throw new Error(`Expected _attestations parameter to be a tuple, got ${attestationsParam.type}`);
+    }
+
+    // Extract the tuple components (struct fields)
+    const tupleParam = attestationsParam as unknown as {
+      type: 'tuple';
+      components?: readonly AbiParameter[];
+    };
+
+    return {
+      type: 'tuple',
+      components: tupleParam.components || [],
+    } as AbiParameter;
+  }
+
+  /**
    * Decodes propose calldata and builds the checkpoint header structure.
    * @param proposeCalldata - The propose function calldata
    * @param blockHash - The L1 block hash containing this transaction
    * @param checkpointNumber - The checkpoint number
+   * @param expectedHashes - Optional expected hashes from the CheckpointProposed event for validation
    * @returns The decoded checkpoint header and metadata
    */
   protected decodeAndBuildCheckpoint(
     proposeCalldata: Hex,
     blockHash: Hex,
     checkpointNumber: CheckpointNumber,
+    expectedHashes: {
+      attestationsHash?: Hex;
+      payloadDigest?: Hex;
+    },
   ): {
     checkpointNumber: CheckpointNumber;
     archiveRoot: Fr;
@@ -365,6 +427,57 @@ export class CalldataRetriever {
       ];
 
     const attestations = CommitteeAttestation.fromPacked(packedAttestations, this.targetCommitteeSize);
+    const header = CheckpointHeader.fromViem(decodedArgs.header);
+    const archiveRoot = new Fr(Buffer.from(hexToBytes(decodedArgs.archive)));
+
+    // Validate attestationsHash if provided (skip for backwards compatibility with older events)
+    if (expectedHashes.attestationsHash) {
+      // Compute attestationsHash: keccak256(abi.encode(CommitteeAttestations))
+      const computedAttestationsHash = keccak256(
+        encodeAbiParameters([this.getCommitteeAttestationsStructDef()], [packedAttestations]),
+      );
+
+      // Compare as buffers to avoid case-sensitivity and string comparison issues
+      const computedBuffer = Buffer.from(hexToBytes(computedAttestationsHash));
+      const expectedBuffer = Buffer.from(hexToBytes(expectedHashes.attestationsHash));
+
+      if (!computedBuffer.equals(expectedBuffer)) {
+        throw new Error(
+          `Attestations hash mismatch for checkpoint ${checkpointNumber}: ` +
+            `computed=${computedAttestationsHash}, expected=${expectedHashes.attestationsHash}`,
+        );
+      }
+
+      this.logger.trace(`Validated attestationsHash for checkpoint ${checkpointNumber}`, {
+        computedAttestationsHash,
+        expectedAttestationsHash: expectedHashes.attestationsHash,
+      });
+    }
+
+    // Validate payloadDigest if provided (skip for backwards compatibility with older events)
+    if (expectedHashes.payloadDigest) {
+      // Use ConsensusPayload to compute the digest - this ensures we match the exact logic
+      // used by the network for signing and verification
+      const consensusPayload = new ConsensusPayload(header, archiveRoot);
+      const payloadToSign = consensusPayload.getPayloadToSign(SignatureDomainSeparator.blockAttestation);
+      const computedPayloadDigest = keccak256(payloadToSign);
+
+      // Compare as buffers to avoid case-sensitivity and string comparison issues
+      const computedBuffer = Buffer.from(hexToBytes(computedPayloadDigest));
+      const expectedBuffer = Buffer.from(hexToBytes(expectedHashes.payloadDigest));
+
+      if (!computedBuffer.equals(expectedBuffer)) {
+        throw new Error(
+          `Payload digest mismatch for checkpoint ${checkpointNumber}: ` +
+            `computed=${computedPayloadDigest}, expected=${expectedHashes.payloadDigest}`,
+        );
+      }
+
+      this.logger.trace(`Validated payloadDigest for checkpoint ${checkpointNumber}`, {
+        computedPayloadDigest,
+        expectedPayloadDigest: expectedHashes.payloadDigest,
+      });
+    }
 
     this.logger.trace(`Decoded propose calldata`, {
       checkpointNumber,
@@ -375,9 +488,6 @@ export class CalldataRetriever {
       packedAttestations,
       targetCommitteeSize: this.targetCommitteeSize,
     });
-
-    const header = CheckpointHeader.fromViem(decodedArgs.header);
-    const archiveRoot = new Fr(Buffer.from(hexToBytes(decodedArgs.archive)));
 
     return {
       checkpointNumber,

--- a/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/l1/data_retrieval.ts
@@ -261,10 +261,17 @@ async function processCheckpointProposedLogs(
 
     // The value from the event and contract will match only if the checkpoint is in the chain.
     if (archive === archiveFromChain) {
+      // Build expected hashes object (fields may be undefined for backwards compatibility with older events)
+      const expectedHashes = {
+        attestationsHash: log.args.attestationsHash,
+        payloadDigest: log.args.payloadDigest,
+      };
+
       const checkpoint = await calldataRetriever.getCheckpointFromRollupTx(
         log.transactionHash!,
         blobHashes,
         checkpointNumber,
+        expectedHashes,
       );
       const checkpointBlobData = await getCheckpointBlobDataFromBlobs(
         blobSinkClient,


### PR DESCRIPTION
Initial work to validate `attestationsHash` and `payloadDigest` when synching. Extends the event on L1, so needs a rollup upgrade to make a diff. Currently throwing if not matching, will need additional work to validate properly