### PR TITLE
fix(ci): restore SSH access for external CI workflows

### DIFF
--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -36,8 +36,9 @@ function setup_environment {
     echo "INSTANCE_POSTFIX=$INSTANCE_POSTFIX" >> $GITHUB_ENV
     echo "Instance postfix set to: $INSTANCE_POSTFIX"
   fi
-  # Setup SSH key (internal only)
-  if [ "${CI_INTERNAL:-0}" -eq 1 ] && [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
+  # Setup SSH key for connecting to EC2 instances
+  # Note: The key is used to SSH into instances but is only copied INTO instances when CI_ENABLE_DISK_LOGS=1 (internal CI only)
+  if [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
     mkdir -p ~/.ssh
     echo "${BUILD_INSTANCE_SSH_KEY}" | base64 --decode > ~/.ssh/build_instance_key
     chmod 600 ~/.ssh/build_instance_key


### PR DESCRIPTION
Fixes SSH access for external contributors that was broken in #17978.

## Problem
External CI workflows cannot SSH into EC2 instances because SSH key setup became conditional on `CI_INTERNAL=1`, which external workflows don't set.

## Solution
Remove the `CI_INTERNAL` check from SSH key setup in `.github/ci3.sh`. The SSH key is needed by the GitHub Actions runner to connect to EC2 instances.

Security is maintained because the SSH key is still only copied INTO instances when `CI_ENABLE_DISK_LOGS=1` (internal CI only, see `ci3/bootstrap_ec2:210-220`).