### PR TITLE
chore: Do not signal for the same payload twice or for empty payloads

### DIFF
--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -749,7 +749,7 @@ describe('L1Publisher integration', () => {
 
       await publisher.enqueueProposeL2Block(block, CommitteeAttestationsAndSigners.empty(), Signature.empty());
       await publisher.enqueueGovernanceCastSignal(
-        EthAddress.random(),
+        l1ContractAddresses.rollupAddress,
         block.slot,
         block.timestamp,
         EthAddress.random(),

--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -12,7 +12,7 @@ export interface IEmpireBase {
   getRoundInfo(
     rollupAddress: Hex,
     round: bigint,
-  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; executed: boolean }>;
+  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; quorumReached: boolean; executed: boolean }>;
   computeRound(slot: SlotNumber): Promise<bigint>;
   createSignalRequest(payload: Hex): L1TxRequest;
   createSignalRequestWithSignature(

--- a/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
@@ -79,11 +79,16 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
   public async getRoundInfo(
     rollupAddress: Hex,
     round: bigint,
-  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; executed: boolean }> {
+  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; quorumReached: boolean; executed: boolean }> {
     const result = await this.proposer.read.getRoundData([rollupAddress, round]);
+    const [signalCount, quorum] = await Promise.all([
+      this.proposer.read.signalCount([rollupAddress, round, result.payloadWithMostSignals]),
+      this.getQuorumSize(),
+    ]);
     return {
       lastSignalSlot: SlotNumber.fromBigInt(result.lastSignalSlot),
       payloadWithMostSignals: result.payloadWithMostSignals,
+      quorumReached: signalCount >= quorum,
       executed: result.executed,
     };
   }

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -62,11 +62,16 @@ export class GovernanceProposerContract implements IEmpireBase {
   public async getRoundInfo(
     rollupAddress: Hex,
     round: bigint,
-  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; executed: boolean }> {
+  ): Promise<{ lastSignalSlot: SlotNumber; payloadWithMostSignals: Hex; quorumReached: boolean; executed: boolean }> {
     const result = await this.proposer.read.getRoundData([rollupAddress, round]);
+    const [signalCount, quorum] = await Promise.all([
+      this.proposer.read.signalCount([rollupAddress, round, result.payloadWithMostSignals]),
+      this.getQuorumSize(),
+    ]);
     return {
       lastSignalSlot: SlotNumber.fromBigInt(result.lastSignalSlot),
       payloadWithMostSignals: result.payloadWithMostSignals,
+      quorumReached: signalCount >= quorum,
       executed: result.executed,
     };
   }

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -1,4 +1,5 @@
 import { getKeys, merge, pick, times } from '@aztec/foundation/collection';
+import type { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { DateProvider } from '@aztec/foundation/timer';
@@ -11,6 +12,7 @@ import {
   type BaseError,
   type BlockOverrides,
   type ContractFunctionExecutionError,
+  type GetCodeReturnType,
   type Hex,
   MethodNotFoundRpcError,
   MethodNotSupportedRpcError,
@@ -65,6 +67,10 @@ export class ReadOnlyL1TxUtils {
 
   public getBlockNumber() {
     return this.client.getBlockNumber();
+  }
+
+  public getCode(address: EthAddress): Promise<GetCodeReturnType> {
+    return this.client.getCode({ address: address.toString() });
   }
 
   /**

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -26,6 +26,7 @@ import express, { json } from 'express';
 import type { Server } from 'http';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import {
+  type GetCodeReturnType,
   type GetTransactionReceiptReturnType,
   type PrivateKeyAccount,
   type TransactionReceipt,
@@ -109,6 +110,7 @@ describe('SequencerPublisher', () => {
     l1TxUtils.getBlock.mockResolvedValue({ timestamp: 12n } as any);
     l1TxUtils.getBlockNumber.mockResolvedValue(1n);
     l1TxUtils.getSenderAddress.mockReturnValue(EthAddress.fromString(testHarnessAttesterAccount.address));
+    l1TxUtils.getCode.mockReturnValue(Promise.resolve(`0x1` as GetCodeReturnType));
     const config = {
       blobSinkUrl: BLOB_SINK_URL,
       l1RpcUrls: [`http://127.0.0.1:8545`],
@@ -224,6 +226,7 @@ describe('SequencerPublisher', () => {
     governanceProposerContract.getRoundInfo.mockResolvedValue({
       lastSignalSlot: SlotNumber(1),
       payloadWithMostSignals: govPayload.toString(),
+      quorumReached: false,
       executed: false,
     });
     governanceProposerContract.createSignalRequestWithSignature.mockResolvedValue({
@@ -418,5 +421,41 @@ describe('SequencerPublisher', () => {
     expect(result).toEqual(undefined);
     expect(forwardSpy).not.toHaveBeenCalled();
     expect((publisher as any).requests.length).toEqual(0);
+  });
+
+  it('does not signal for payload when quorum is reached', async () => {
+    const { govPayload } = mockGovernancePayload();
+
+    governanceProposerContract.getRoundInfo.mockResolvedValue({
+      lastSignalSlot: SlotNumber(1),
+      payloadWithMostSignals: govPayload.toString(),
+      quorumReached: true,
+      executed: false,
+    });
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(false);
+  });
+
+  it.each<GetCodeReturnType>([undefined])('does not signal for payload with empty code', async code => {
+    const { govPayload } = mockGovernancePayload();
+    l1TxUtils.getCode.mockReturnValue(Promise.resolve(code));
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(false);
   });
 });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -109,6 +109,8 @@ export class SequencerPublisher {
 
   protected lastActions: Partial<Record<Action, SlotNumber>> = {};
 
+  private isPayloadEmptyCache: Map<string, boolean> = new Map<string, boolean>();
+
   protected log: Logger;
   protected ethereumSlotDuration: bigint;
 
@@ -661,7 +663,16 @@ export class SequencerPublisher {
     const round = await base.computeRound(slotNumber);
     const roundInfo = await base.getRoundInfo(this.rollupContract.address, round);
 
+    if (roundInfo.quorumReached) {
+      return false;
+    }
+
     if (roundInfo.lastSignalSlot >= slotNumber) {
+      return false;
+    }
+
+    if (await this.isPayloadEmpty(payload)) {
+      this.log.warn(`Skipping vote cast for payload with empty code`);
       return false;
     }
 
@@ -722,6 +733,17 @@ export class SequencerPublisher {
       },
     });
     return true;
+  }
+
+  private async isPayloadEmpty(payload: EthAddress): Promise<boolean> {
+    const key = payload.toString();
+    const cached = this.isPayloadEmptyCache.get(key);
+    if (cached) {
+      return cached;
+    }
+    const isEmpty = !(await this.l1TxUtils.getCode(payload));
+    this.isPayloadEmptyCache.set(key, isEmpty);
+    return isEmpty;
   }
 
   /**


### PR DESCRIPTION
Changes:
1. Keep track of signaled payloads and reject if they are signaled twice
2. Before submitting a transaction, check ifthe  payload has code

Ref: A-164