### PR TITLE
chore: deflake fee e2e test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
@@ -29,7 +29,7 @@ describe('e2e_fees fee settings', () => {
 
     testContract = await TestContract.deploy(wallet).send({ from: aliceAddress }).deployed();
     gasSettings = { ...gasSettings, maxFeesPerGas: undefined };
-  }, 60_000);
+  });
 
   afterAll(async () => {
     await t.teardown();


### PR DESCRIPTION
Setup might take more than 60 seconds on a loaded CI machine. Use the default timeout rather than a lower value.