### PR TITLE
refactor(PXE): clean up block sync

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -9,21 +9,21 @@ import { randomPublishedL2Block } from '@aztec/stdlib/testing';
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
+import { AnchorBlockDataProvider } from '../storage/anchor_block_data_provider/anchor_block_data_provider.js';
 import { NoteDataProvider } from '../storage/note_data_provider/note_data_provider.js';
-import { SyncDataProvider } from '../storage/sync_data_provider/sync_data_provider.js';
 import { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
-import { Synchronizer } from './synchronizer.js';
+import { BlockSynchronizer } from './block_synchronizer.js';
 
-describe('Synchronizer', () => {
-  let synchronizer: Synchronizer;
+describe('BlockSynchronizer', () => {
+  let synchronizer: BlockSynchronizer;
   let tipsStore: L2TipsKVStore;
-  let syncDataProvider: SyncDataProvider;
+  let anchorBlockDataProvider: AnchorBlockDataProvider;
   let noteDataProvider: NoteDataProvider;
   let taggingDataProvider: TaggingDataProvider;
   let aztecNode: MockProxy<AztecNode>;
   let blockStream: MockProxy<L2BlockStream>;
 
-  const TestSynchronizer = class extends Synchronizer {
+  const TestSynchronizer = class extends BlockSynchronizer {
     protected override createBlockStream(): L2BlockStream {
       return blockStream;
     }
@@ -34,17 +34,23 @@ describe('Synchronizer', () => {
     blockStream = mock<L2BlockStream>();
     aztecNode = mock<AztecNode>();
     tipsStore = new L2TipsKVStore(store, 'pxe');
-    syncDataProvider = new SyncDataProvider(store);
+    anchorBlockDataProvider = new AnchorBlockDataProvider(store);
     noteDataProvider = await NoteDataProvider.create(store);
     taggingDataProvider = new TaggingDataProvider(store);
-    synchronizer = new TestSynchronizer(aztecNode, syncDataProvider, noteDataProvider, taggingDataProvider, tipsStore);
+    synchronizer = new TestSynchronizer(
+      aztecNode,
+      anchorBlockDataProvider,
+      noteDataProvider,
+      taggingDataProvider,
+      tipsStore,
+    );
   });
 
   it('sets header from latest block', async () => {
     const block = await randomPublishedL2Block(1);
     await synchronizer.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
 
-    const obtainedHeader = await syncDataProvider.getBlockHeader();
+    const obtainedHeader = await anchorBlockDataProvider.getBlockHeader();
     expect(obtainedHeader).toEqual(block.block.getBlockHeader());
   });
 

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -5,23 +5,23 @@ import { L2BlockStream, type L2BlockStreamEvent, type L2BlockStreamEventHandler 
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
 import type { PXEConfig } from '../config/index.js';
+import type { AnchorBlockDataProvider } from '../storage/anchor_block_data_provider/anchor_block_data_provider.js';
 import type { NoteDataProvider } from '../storage/note_data_provider/note_data_provider.js';
-import type { SyncDataProvider } from '../storage/sync_data_provider/sync_data_provider.js';
 import type { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
 
 /**
- * The Synchronizer class orchestrates synchronization between the PXE and Aztec node, maintaining an up-to-date
+ * The BlockSynchronizer class orchestrates synchronization between PXE and Aztec node, maintaining an up-to-date
  * view of the L2 chain state. It handles block header retrieval, chain reorganizations, and provides an interface
  * for querying sync status.
  */
-export class Synchronizer implements L2BlockStreamEventHandler {
+export class BlockSynchronizer implements L2BlockStreamEventHandler {
   private log: Logger;
   private isSyncing: Promise<void> | undefined;
   protected readonly blockStream: L2BlockStream;
 
   constructor(
     private node: AztecNode,
-    private syncDataProvider: SyncDataProvider,
+    private anchorBlockDataProvider: AnchorBlockDataProvider,
     private noteDataProvider: NoteDataProvider,
     private taggingDataProvider: TaggingDataProvider,
     private l2TipsStore: L2TipsKVStore,
@@ -30,7 +30,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
   ) {
     this.log =
       !loggerOrSuffix || typeof loggerOrSuffix === 'string'
-        ? createLogger(loggerOrSuffix ? `pxe:synchronizer:${loggerOrSuffix}` : `pxe:synchronizer`)
+        ? createLogger(loggerOrSuffix ? `pxe:block_synchronizer:${loggerOrSuffix}` : `pxe:block_synchronizer`)
         : loggerOrSuffix;
     this.blockStream = this.createBlockStream(config);
   }
@@ -56,13 +56,13 @@ export class Synchronizer implements L2BlockStreamEventHandler {
           archive: lastBlock.archive.root.toString(),
           header: lastBlock.header.toInspect(),
         });
-        await this.syncDataProvider.setHeader(lastBlock.getBlockHeader());
+        await this.anchorBlockDataProvider.setHeader(lastBlock.getBlockHeader());
         break;
       }
       case 'chain-pruned': {
         this.log.warn(`Pruning data after block ${event.block.number} due to reorg`);
         // We first unnullify and then remove so that unnullified notes that were created after the block number end up deleted.
-        const lastSynchedBlockNumber = await this.syncDataProvider.getBlockNumber();
+        const lastSynchedBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
         await this.noteDataProvider.rollbackNotesAndNullifiers(event.block.number, lastSynchedBlockNumber);
         // Remove all note tagging indexes to force a full resync. This is suboptimal, but unless we track the
         // block number in which each index is used it's all we can do.
@@ -72,7 +72,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
         if (!newHeader) {
           this.log.error(`Block header not found for block number ${event.block.number} during chain prune`);
         } else {
-          await this.syncDataProvider.setHeader(newHeader);
+          await this.anchorBlockDataProvider.setHeader(newHeader);
         }
         break;
       }
@@ -82,6 +82,11 @@ export class Synchronizer implements L2BlockStreamEventHandler {
   /**
    * Syncs PXE and the node by downloading the metadata of the latest blocks, allowing simulations to use
    * recent data (e.g. notes), and handling any reorgs that might have occurred.
+   *
+   * Note this BlockSynchronizer is designed to let its users control when a synchronization is run,
+   * so this component doesn't proactively stay up to date with the blockchain.
+   *
+   * We do this so PXE can ensure data consistency.
    */
   public async sync() {
     if (this.isSyncing !== undefined) {
@@ -104,18 +109,14 @@ export class Synchronizer implements L2BlockStreamEventHandler {
     let currentHeader;
 
     try {
-      currentHeader = await this.syncDataProvider.getBlockHeader();
+      currentHeader = await this.anchorBlockDataProvider.getBlockHeader();
     } catch {
       this.log.debug('Header is not set, requesting from the node');
     }
     if (!currentHeader) {
       // REFACTOR: We should know the header of the genesis block without having to request it from the node.
-      await this.syncDataProvider.setHeader((await this.node.getBlockHeader(BlockNumber.ZERO))!);
+      await this.anchorBlockDataProvider.setHeader((await this.node.getBlockHeader(BlockNumber.ZERO))!);
     }
     await this.blockStream.sync();
-  }
-
-  public getSynchedBlockNumber() {
-    return this.syncDataProvider.getBlockNumber();
   }
 }

--- a/yarn-project/pxe/src/block_synchronizer/index.ts
+++ b/yarn-project/pxe/src/block_synchronizer/index.ts
@@ -1,0 +1,1 @@
+export * from './block_synchronizer.js';

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -19,14 +19,14 @@ export interface KernelProverConfig {
 }
 
 /**
- * Configuration settings for the synchronizer.
+ * Configuration settings for the block synchronizer.
  */
-export interface SynchronizerConfig {
+export interface BlockSynchronizerConfig {
   /** Maximum amount of blocks to pull from the stream in one request when synchronizing */
   l2BlockBatchSize: number;
 }
 
-export type PXEConfig = KernelProverConfig & DataStoreConfig & ChainConfig & SynchronizerConfig;
+export type PXEConfig = KernelProverConfig & DataStoreConfig & ChainConfig & BlockSynchronizerConfig;
 
 export type CliPXEOptions = {
   /** Custom Aztec Node URL to connect to  */

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -59,6 +59,7 @@ import { PrivateLog } from '@aztec/stdlib/logs';
 import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { ChonkProof } from '@aztec/stdlib/proofs';
 import {
+  BlockHeader,
   CallContext,
   HashedValues,
   PrivateExecutionResult,
@@ -98,6 +99,7 @@ export class ContractFunctionSimulator {
    * @param contractAddress - The address of the contract (should match request.origin)
    * @param msgSender - The address calling the function. This can be replaced to simulate a call from another contract
    * or a specific account.
+   * @param anchorBlockHeader - The block header to use as base state for this run.
    * @param senderForTags - The address that is used as a tagging sender when emitting private logs. Returned from
    * the `privateGetSenderForTags` oracle.
    * @param scopes - The accounts whose notes we can access in this call. Currently optional and will default to all.
@@ -108,13 +110,13 @@ export class ContractFunctionSimulator {
     contractAddress: AztecAddress,
     selector: FunctionSelector,
     msgSender = AztecAddress.fromField(Fr.MAX_FIELD_VALUE),
+    anchorBlockHeader: BlockHeader,
     senderForTags?: AztecAddress,
     scopes?: AztecAddress[],
   ): Promise<PrivateExecutionResult> {
     const simulatorSetupTimer = new Timer();
-    const anchorBlockHeader = await this.executionDataProvider.getAnchorBlockHeader();
 
-    await verifyCurrentClassId(contractAddress, this.executionDataProvider);
+    await verifyCurrentClassId(contractAddress, this.executionDataProvider, anchorBlockHeader);
 
     const entryPointArtifact = await this.executionDataProvider.getFunctionArtifact(contractAddress, selector);
 
@@ -213,12 +215,18 @@ export class ContractFunctionSimulator {
    * Runs a utility function.
    * @param call - The function call to execute.
    * @param authwits - Authentication witnesses required for the function call.
+   * @param anchorBlockHeader - The block header to use as base state for this run.
    * @param scopes - Optional array of account addresses whose notes can be accessed in this call. Defaults to all
    * accounts if not specified.
    * @returns A return value of the utility function in a form as returned by the simulator (Noir fields)
    */
-  public async runUtility(call: FunctionCall, authwits: AuthWitness[], scopes?: AztecAddress[]): Promise<Fr[]> {
-    await verifyCurrentClassId(call.to, this.executionDataProvider);
+  public async runUtility(
+    call: FunctionCall,
+    authwits: AuthWitness[],
+    anchorBlockHeader: BlockHeader,
+    scopes?: AztecAddress[],
+  ): Promise<Fr[]> {
+    await verifyCurrentClassId(call.to, this.executionDataProvider, anchorBlockHeader);
 
     const entryPointArtifact = await this.executionDataProvider.getFunctionArtifact(call.to, call.selector);
 
@@ -226,7 +234,15 @@ export class ContractFunctionSimulator {
       throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);
     }
 
-    const oracle = new UtilityExecutionOracle(call.to, authwits, [], this.executionDataProvider, undefined, scopes);
+    const oracle = new UtilityExecutionOracle(
+      call.to,
+      authwits,
+      [],
+      anchorBlockHeader,
+      this.executionDataProvider,
+      undefined,
+      scopes,
+    );
 
     try {
       this.log.verbose(`Executing utility function ${entryPointArtifact.name}`, {

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -10,7 +10,7 @@ import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import type { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
-import type { BlockHeader, NodeStats } from '@aztec/stdlib/tx';
+import type { NodeStats } from '@aztec/stdlib/tx';
 
 import type { NoteData } from './oracle/interfaces.js';
 import type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
@@ -137,14 +137,6 @@ export interface ExecutionDataProvider {
     messageHash: Fr,
     secret: Fr,
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
-
-  /**
-   * Retrieve the latest block header synchronized by the execution data provider. This block header is referred
-   * to as the anchor block header in Aztec terminology and it defines the state that is used during private function
-   * execution.
-   * @returns The anchor block header.
-   */
-  getAnchorBlockHeader(): Promise<BlockHeader>;
 
   /**
    * Fetches the index and sibling path of a leaf at a given block from a given tree.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -63,7 +63,7 @@ export interface IMiscOracle {
 export interface IUtilityExecutionOracle {
   isUtility: true;
 
-  utilityGetUtilityContext(): Promise<UtilityContext>;
+  utilityGetUtilityContext(): UtilityContext;
   utilityGetKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest>;
   utilityGetContractInstance(address: AztecAddress): Promise<ContractInstance>;
   utilityGetMembershipWitness(blockNumber: BlockNumber, treeId: MerkleTreeId, leafValue: Fr): Promise<Fr[] | undefined>;

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -112,9 +112,9 @@ export class Oracle {
     return [values.map(toACVMField)];
   }
 
-  async utilityGetUtilityContext(): Promise<(ACVMField | ACVMField[])[]> {
-    const context = await this.handlerAsUtility().utilityGetUtilityContext();
-    return context.toNoirRepresentation();
+  utilityGetUtilityContext(): Promise<(ACVMField | ACVMField[])[]> {
+    const context = this.handlerAsUtility().utilityGetUtilityContext();
+    return Promise.resolve(context.toNoirRepresentation());
   }
 
   async utilityGetKeyValidationRequest([pkMHash]: ACVMField[]): Promise<ACVMField[]> {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -25,7 +25,6 @@ describe('Oracle Version Check test suite', () => {
     // Mock basic oracle responses
     executionDataProvider.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
     executionDataProvider.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
-    executionDataProvider.getAnchorBlockHeader.mockResolvedValue(BlockHeader.empty());
     executionDataProvider.getContractInstance.mockResolvedValue({
       currentContractClassId: new Fr(42),
       originalContractClassId: new Fr(42),
@@ -68,7 +67,7 @@ describe('Oracle Version Check test suite', () => {
       // Call the private function with arbitrary message sender and sender for tags
       const msgSender = await AztecAddress.random();
       const senderForTags = await AztecAddress.random();
-      await acirSimulator.run(txRequest, contractAddress, selector, msgSender, senderForTags);
+      await acirSimulator.run(txRequest, contractAddress, selector, msgSender, BlockHeader.random(), senderForTags);
 
       expect(executionDataProvider.assertCompatibleOracleVersion).toHaveBeenCalledTimes(1);
     }, 30_000);
@@ -97,7 +96,7 @@ describe('Oracle Version Check test suite', () => {
       };
 
       // Call the utility function
-      await acirSimulator.runUtility(execRequest, [], []);
+      await acirSimulator.runUtility(execRequest, [], BlockHeader.random(), []);
 
       expect(executionDataProvider.assertCompatibleOracleVersion).toHaveBeenCalledTimes(1);
     }, 30_000);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -152,6 +152,7 @@ describe('Private Execution test suite', () => {
   const runSimulator = async ({
     artifact,
     functionName,
+    anchorBlockHeader,
     args = [],
     /** Notice that we're defaulting to the "null" msg_sender, which many public functions will fail to unwrap, and will revert. */
     msgSender = AztecAddress.fromBigInt(NULL_MSG_SENDER_CONTRACT_ADDRESS),
@@ -160,6 +161,7 @@ describe('Private Execution test suite', () => {
   }: {
     artifact: ContractArtifact;
     functionName: string;
+    anchorBlockHeader: BlockHeader;
     msgSender?: AztecAddress;
     contractAddress?: AztecAddress;
     args?: any[];
@@ -185,7 +187,7 @@ describe('Private Execution test suite', () => {
     // We don't care about the `senderForTags` in this test. We just need it to be populated in order for the private
     // log emission to not revert.
     const senderForTags = await AztecAddress.random();
-    return acirSimulator.run(txRequest, contractAddress, selector, msgSender, senderForTags);
+    return acirSimulator.run(txRequest, contractAddress, selector, msgSender, anchorBlockHeader, senderForTags);
   };
 
   const insertLeaves = async (leaves: Fr[], name = 'noteHash') => {
@@ -290,7 +292,6 @@ describe('Private Execution test suite', () => {
     // We call insertLeaves here with no leaves to populate empty public data tree root --> this is necessary to be
     // able to get ivpk_m during execution
     await insertLeaves([], 'publicData');
-    executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
     executionDataProvider.getCompleteAddress.mockImplementation((address: AztecAddress) => {
       if (address.equals(owner)) {
@@ -342,6 +343,7 @@ describe('Private Execution test suite', () => {
       const result = await runSimulator({
         artifact: TestContractArtifact,
         functionName: 'emit_array_as_encrypted_log',
+        anchorBlockHeader,
         msgSender: owner,
         args,
       });
@@ -400,6 +402,7 @@ describe('Private Execution test suite', () => {
       const executionResult = await runSimulator({
         args: initArgs,
         artifact: StatefulTestContractArtifact,
+        anchorBlockHeader,
         functionName: 'constructor',
         contractAddress: instance.address,
         msgSender: AztecAddress.fromNumber(1234),
@@ -424,6 +427,7 @@ describe('Private Execution test suite', () => {
       const { entrypoint: result } = await runSimulator({
         args: [owner, owner, 140],
         artifact: StatefulTestContractArtifact,
+        anchorBlockHeader,
         functionName: 'create_note_no_init_check',
       });
 
@@ -464,6 +468,7 @@ describe('Private Execution test suite', () => {
       const { entrypoint: result } = await runSimulator({
         args,
         artifact: StatefulTestContractArtifact,
+        anchorBlockHeader,
         functionName: 'destroy_and_create_no_init_check',
         msgSender: owner,
         contractAddress,
@@ -511,6 +516,7 @@ describe('Private Execution test suite', () => {
       const { entrypoint: result } = await runSimulator({
         args,
         artifact: StatefulTestContractArtifact,
+        anchorBlockHeader,
         functionName: 'destroy_and_create_no_init_check',
         msgSender: owner,
         contractAddress,
@@ -536,6 +542,7 @@ describe('Private Execution test suite', () => {
       const { entrypoint: result } = await runSimulator({
         args: [initialValue],
         artifact: ChildContractArtifact,
+        anchorBlockHeader,
         functionName: 'value',
       });
 
@@ -556,6 +563,7 @@ describe('Private Execution test suite', () => {
       const { entrypoint: result } = await runSimulator({
         args,
         artifact: ParentContractArtifact,
+        anchorBlockHeader,
         functionName: 'entry_point',
       });
 
@@ -614,14 +622,11 @@ describe('Private Execution test suite', () => {
         l1ToL2MessageIndex,
       ];
 
-      const mockOracles = async (updateHeader = true) => {
+      const mockOracles = async () => {
         const tree = await insertLeaves([preimage.hash()], 'l1ToL2Messages');
         executionDataProvider.getL1ToL2MembershipWitness.mockImplementation(async () => {
           return Promise.resolve(new MessageLoadOracleInputs(0n, await tree.getSiblingPath(0n, true)));
         });
-        if (updateHeader) {
-          executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
-        }
       };
 
       it('Should be able to consume a dummy cross chain message', async () => {
@@ -632,6 +637,7 @@ describe('Private Execution test suite', () => {
         const result = await runSimulator({
           contractAddress,
           artifact: TestContractArtifact,
+          anchorBlockHeader,
           functionName: 'consume_mint_to_private_message',
           args,
           txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -647,13 +653,16 @@ describe('Private Execution test suite', () => {
 
         args = computeArgs();
 
-        // Don't update the header so the message is not in state
-        await mockOracles(false);
+        // mockOracles advances the current block, but in this case we want to simulate
+        // the state where PXE hasn't learned about the new block yet
+        const previousAnchorBlock = anchorBlockHeader;
+        await mockOracles();
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader: previousAnchorBlock,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -669,13 +678,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -690,13 +698,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -710,13 +717,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(2n) },
@@ -730,13 +736,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(2n), chainId: new Fr(1n) },
@@ -751,13 +756,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -772,13 +776,12 @@ describe('Private Execution test suite', () => {
         args = computeArgs();
 
         await mockOracles();
-        // Update state
-        executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
 
         await expect(
           runSimulator({
             contractAddress,
             artifact: TestContractArtifact,
+            anchorBlockHeader,
             functionName: 'consume_mint_to_private_message',
             args,
             txContext: { version: new Fr(1n), chainId: new Fr(1n) },
@@ -804,6 +807,7 @@ describe('Private Execution test suite', () => {
       const result = await runSimulator({
         msgSender: parentAddress,
         contractAddress: parentAddress,
+        anchorBlockHeader,
         artifact: ParentContractArtifact,
         functionName: 'enqueue_call_to_child',
         args,
@@ -828,6 +832,7 @@ describe('Private Execution test suite', () => {
       await runSimulator({
         msgSender: parentAddress,
         contractAddress: parentAddress,
+        anchorBlockHeader,
         artifact: ParentContractArtifact,
         functionName: 'enqueue_call_to_child_with_many_args_and_recurse',
         args,
@@ -850,6 +855,7 @@ describe('Private Execution test suite', () => {
         runSimulator({
           msgSender: parentAddress,
           contractAddress: parentAddress,
+          anchorBlockHeader,
           artifact: ParentContractArtifact,
           functionName: 'enqueue_call_to_child_with_many_args_and_recurse',
           args,
@@ -862,6 +868,7 @@ describe('Private Execution test suite', () => {
     it('should be able to set a teardown function', async () => {
       const { entrypoint: result, publicFunctionCalldata } = await runSimulator({
         artifact: TestContractArtifact,
+        anchorBlockHeader,
         functionName: 'test_setting_teardown',
       });
       expect(result.publicInputs.publicTeardownCallRequest.isEmpty()).toBe(false);
@@ -878,6 +885,7 @@ describe('Private Execution test suite', () => {
       const contractAddress = await AztecAddress.random();
       const { entrypoint: result } = await runSimulator({
         artifact: TestContractArtifact,
+        anchorBlockHeader,
         functionName: 'get_this_address',
         contractAddress,
       });
@@ -888,6 +896,7 @@ describe('Private Execution test suite', () => {
       const contractAddress = await AztecAddress.random();
       const { entrypoint: result } = await runSimulator({
         artifact: TestContractArtifact,
+        anchorBlockHeader,
         functionName: 'test_setting_fee_payer',
         contractAddress,
       });
@@ -901,6 +910,7 @@ describe('Private Execution test suite', () => {
       const contractAddress = await AztecAddress.random();
       const { entrypoint: result } = await runSimulator({
         artifact: TestContractArtifact,
+        anchorBlockHeader,
         functionName: 'end_setup_checking_phases',
         contractAddress,
       });
@@ -935,6 +945,7 @@ describe('Private Execution test suite', () => {
         artifact: PendingNoteHashesContractArtifact,
         functionName: 'test_insert_then_get_then_nullify_flat',
         contractAddress,
+        anchorBlockHeader,
       });
 
       expect(result.newNotes).toHaveLength(1);
@@ -1000,6 +1011,7 @@ describe('Private Execution test suite', () => {
         artifact: PendingNoteHashesContractArtifact,
         functionName: 'test_insert_then_get_then_nullify_all_in_nested_calls',
         contractAddress: contractAddress,
+        anchorBlockHeader,
       });
 
       const execInsert = result.nestedExecutionResults[0];
@@ -1051,6 +1063,7 @@ describe('Private Execution test suite', () => {
         artifact: PendingNoteHashesContractArtifact,
         functionName: 'test_bad_get_then_insert_flat',
         contractAddress,
+        anchorBlockHeader,
       });
     });
   });
@@ -1067,6 +1080,7 @@ describe('Private Execution test suite', () => {
         artifact: TestContractArtifact,
         functionName: 'get_master_incoming_viewing_public_key',
         args,
+        anchorBlockHeader,
       });
       expect(result.returnValues).toEqual([pubKey.x, pubKey.y]);
     });
@@ -1080,7 +1094,7 @@ describe('Private Execution test suite', () => {
       executionDataProvider.getNotes.mockResolvedValue([]);
 
       await expect(() =>
-        runSimulator({ artifact: TestContractArtifact, functionName: 'call_get_notes', args }),
+        runSimulator({ artifact: TestContractArtifact, functionName: 'call_get_notes', args, anchorBlockHeader }),
       ).rejects.toThrow(`Assertion failed: Attempted to read past end of BoundedVec`);
     });
   });
@@ -1094,6 +1108,7 @@ describe('Private Execution test suite', () => {
         functionName: 'get_this_address',
         args: [],
         contractAddress,
+        anchorBlockHeader,
       });
       expect(result.returnValues).toEqual([contractAddress.toField()]);
     });
@@ -1118,6 +1133,7 @@ describe('Private Execution test suite', () => {
         msgSender: owner,
         args,
         txContext: { chainId, version },
+        anchorBlockHeader,
       });
     });
 
@@ -1131,6 +1147,7 @@ describe('Private Execution test suite', () => {
           msgSender: owner,
           args,
           txContext: { chainId: unexpectedChainId, version },
+          anchorBlockHeader,
         }),
       ).rejects.toThrow('Invalid chain id');
     });
@@ -1145,17 +1162,15 @@ describe('Private Execution test suite', () => {
           msgSender: owner,
           args,
           txContext: { chainId, version: unexpectedVersion },
+          anchorBlockHeader,
         }),
       ).rejects.toThrow('Invalid version');
     });
   });
 
-  describe('Historical header in private context', () => {
+  describe('Anchor header in private context', () => {
     beforeEach(() => {
       anchorBlockHeader = makeBlockHeader();
-
-      executionDataProvider.getAnchorBlockHeader.mockClear();
-      executionDataProvider.getAnchorBlockHeader.mockResolvedValue(anchorBlockHeader);
     });
 
     it('Header is correctly set', async () => {
@@ -1166,6 +1181,7 @@ describe('Private Execution test suite', () => {
         functionName: 'assert_header_private',
         msgSender: owner,
         args,
+        anchorBlockHeader,
       });
     });
 
@@ -1174,7 +1190,13 @@ describe('Private Execution test suite', () => {
       const args = [unexpectedHeaderHash];
 
       await expect(() =>
-        runSimulator({ artifact: TestContractArtifact, functionName: 'assert_header_private', msgSender: owner, args }),
+        runSimulator({
+          artifact: TestContractArtifact,
+          functionName: 'assert_header_private',
+          msgSender: owner,
+          args,
+          anchorBlockHeader,
+        }),
       ).rejects.toThrow('Invalid header hash');
     });
   });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -188,10 +188,8 @@ export async function readCurrentClassId(
 export async function verifyCurrentClassId(
   contractAddress: AztecAddress,
   executionDataProvider: ExecutionDataProvider,
-  header?: BlockHeader,
+  header: BlockHeader,
 ) {
-  header = header ?? (await executionDataProvider.getAnchorBlockHeader());
-
   const instance = await executionDataProvider.getContractInstance(contractAddress);
   const currentClassId = await readCurrentClassId(
     contractAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -71,7 +71,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     private readonly txContext: TxContext,
     private readonly callContext: CallContext,
     /** Header of a block whose state is used during private execution (not the block the transaction is included in). */
-    protected readonly anchorBlockHeader: BlockHeader,
+    protected override readonly anchorBlockHeader: BlockHeader,
     /** List of transient auth witnesses to be used during this simulation */
     authWitnesses: AuthWitness[],
     capsules: Capsule[],
@@ -86,7 +86,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     private senderForTags?: AztecAddress,
     private simulator?: CircuitSimulator,
   ) {
-    super(callContext.contractAddress, authWitnesses, capsules, executionDataProvider, log, scopes);
+    super(callContext.contractAddress, authWitnesses, capsules, anchorBlockHeader, executionDataProvider, log, scopes);
   }
 
   public getPrivateContextInputs(): PrivateContextInputs {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -70,7 +70,6 @@ describe('Utility Execution test suite', () => {
     );
 
     executionDataProvider.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
-    executionDataProvider.getAnchorBlockHeader.mockResolvedValue(BlockHeader.empty());
 
     const execRequest: FunctionCall = {
       name: artifact.name,
@@ -83,7 +82,7 @@ describe('Utility Execution test suite', () => {
       returnTypes: artifact.returnTypes,
     };
 
-    const result = await acirSimulator.runUtility(execRequest, [], []);
+    const result = await acirSimulator.runUtility(execRequest, [], BlockHeader.random(), []);
 
     expect(result).toEqual([new Fr(9)]);
   }, 30_000);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -31,6 +31,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     /** List of transient auth witnesses to be used during this simulation */
     protected readonly authWitnesses: AuthWitness[],
     protected readonly capsules: Capsule[], // TODO(#12425): Rename to transientCapsules
+    protected readonly anchorBlockHeader: BlockHeader,
     protected readonly executionDataProvider: ExecutionDataProvider,
     protected log = createLogger('simulator:client_view_context'),
     protected readonly scopes?: AztecAddress[],
@@ -44,14 +45,13 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return Fr.random();
   }
 
-  public async utilityGetUtilityContext(): Promise<UtilityContext> {
-    const blockHeader = await this.executionDataProvider.getAnchorBlockHeader();
+  public utilityGetUtilityContext(): UtilityContext {
     return UtilityContext.from({
-      blockNumber: blockHeader.globalVariables.blockNumber,
-      timestamp: blockHeader.globalVariables.timestamp,
+      blockNumber: this.anchorBlockHeader.globalVariables.blockNumber,
+      timestamp: this.anchorBlockHeader.globalVariables.timestamp,
       contractAddress: this.contractAddress,
-      version: blockHeader.globalVariables.version,
-      chainId: blockHeader.globalVariables.chainId,
+      version: this.anchorBlockHeader.globalVariables.version,
+      chainId: this.anchorBlockHeader.globalVariables.chainId,
     });
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -27,11 +27,11 @@ import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { AddressDataProvider } from '../storage/address_data_provider/address_data_provider.js';
+import { AnchorBlockDataProvider } from '../storage/anchor_block_data_provider/anchor_block_data_provider.js';
 import { CapsuleDataProvider } from '../storage/capsule_data_provider/capsule_data_provider.js';
 import { ContractDataProvider } from '../storage/contract_data_provider/contract_data_provider.js';
 import { NoteDataProvider } from '../storage/note_data_provider/note_data_provider.js';
 import { PrivateEventDataProvider } from '../storage/private_event_data_provider/private_event_data_provider.js';
-import { SyncDataProvider } from '../storage/sync_data_provider/sync_data_provider.js';
 import { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
 import { WINDOW_HALF_SIZE } from '../tagging/constants.js';
 import { SiloedTag } from '../tagging/siloed_tag.js';
@@ -65,7 +65,7 @@ describe('PXEOracleInterface', () => {
   let privateEventDataProvider: PrivateEventDataProvider;
   let contractDataProvider: ContractDataProvider;
   let noteDataProvider: NoteDataProvider;
-  let syncDataProvider: SyncDataProvider;
+  let anchorBlockDataProvider: AnchorBlockDataProvider;
   let taggingDataProvider: TaggingDataProvider;
   let capsuleDataProvider: CapsuleDataProvider;
   let keyStore: KeyStore;
@@ -89,7 +89,7 @@ describe('PXEOracleInterface', () => {
     addressDataProvider = new AddressDataProvider(store);
     privateEventDataProvider = new PrivateEventDataProvider(store);
     noteDataProvider = await NoteDataProvider.create(store);
-    syncDataProvider = new SyncDataProvider(store);
+    anchorBlockDataProvider = new AnchorBlockDataProvider(store);
     taggingDataProvider = new TaggingDataProvider(store);
     capsuleDataProvider = new CapsuleDataProvider(store);
     keyStore = new KeyStore(store);
@@ -99,7 +99,7 @@ describe('PXEOracleInterface', () => {
       contractDataProvider,
       noteDataProvider,
       capsuleDataProvider,
-      syncDataProvider,
+      anchorBlockDataProvider,
       taggingDataProvider,
       addressDataProvider,
       privateEventDataProvider,
@@ -1193,21 +1193,8 @@ describe('PXEOracleInterface', () => {
     });
   });
 
-  describe('getAnchorBlockHeader', () => {
-    it('returns the anchor block header and not a header from aztec node', async () => {
-      const blockNumber = BlockNumber(42);
-      const header = BlockHeader.empty({
-        globalVariables: GlobalVariables.empty({ blockNumber }),
-      });
-      await syncDataProvider.setHeader(header);
-
-      const result = await pxeOracleInterface.getAnchorBlockHeader();
-      expect(result).toEqual(header);
-    });
-  });
-
   const setSyncedBlockNumber = (blockNumber: BlockNumber) => {
-    return syncDataProvider.setHeader(
+    return anchorBlockDataProvider.setHeader(
       BlockHeader.empty({
         globalVariables: GlobalVariables.empty({ blockNumber }),
       }),

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -24,18 +24,17 @@ import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import { Note, type NoteStatus } from '@aztec/stdlib/note';
 import { NoteDao } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
-import type { BlockHeader } from '@aztec/stdlib/tx';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import type { ExecutionDataProvider, ExecutionStats } from '../contract_function_simulator/execution_data_provider.js';
 import { MessageLoadOracleInputs } from '../contract_function_simulator/oracle/message_load_oracle_inputs.js';
 import { ORACLE_VERSION } from '../oracle_version.js';
 import type { AddressDataProvider } from '../storage/address_data_provider/address_data_provider.js';
+import type { AnchorBlockDataProvider } from '../storage/anchor_block_data_provider/anchor_block_data_provider.js';
 import type { CapsuleDataProvider } from '../storage/capsule_data_provider/capsule_data_provider.js';
 import type { ContractDataProvider } from '../storage/contract_data_provider/contract_data_provider.js';
 import type { NoteDataProvider } from '../storage/note_data_provider/note_data_provider.js';
 import type { PrivateEventDataProvider } from '../storage/private_event_data_provider/private_event_data_provider.js';
-import type { SyncDataProvider } from '../storage/sync_data_provider/sync_data_provider.js';
 import type { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
 import {
   DirectionalAppTaggingSecret,
@@ -61,7 +60,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     private contractDataProvider: ContractDataProvider,
     private noteDataProvider: NoteDataProvider,
     private capsuleDataProvider: CapsuleDataProvider,
-    private syncDataProvider: SyncDataProvider,
+    private anchorBlockDataProvider: AnchorBlockDataProvider,
     private taggingDataProvider: TaggingDataProvider,
     private addressDataProvider: AddressDataProvider,
     private privateEventDataProvider: PrivateEventDataProvider,
@@ -197,7 +196,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   public async getNullifierMembershipWitnessAtLatestBlock(nullifier: Fr) {
-    const blockNumber = (await this.getAnchorBlockHeader()).globalVariables.blockNumber;
+    const blockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
     return this.getNullifierMembershipWitness(blockNumber, nullifier);
   }
 
@@ -212,39 +211,35 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     blockNumber: BlockParameter,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
-    const header = await this.getAnchorBlockHeader();
-    if (blockNumber !== 'latest' && blockNumber > header.globalVariables.blockNumber) {
-      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    const anchorBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
+    if (blockNumber !== 'latest' && blockNumber > anchorBlockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
     }
     return this.aztecNode.getLowNullifierMembershipWitness(blockNumber, nullifier);
   }
 
   public async getBlock(blockNumber: BlockParameter): Promise<L2Block | undefined> {
-    const header = await this.getAnchorBlockHeader();
-    if (blockNumber !== 'latest' && blockNumber > header.globalVariables.blockNumber) {
-      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    const anchorBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
+    if (blockNumber !== 'latest' && blockNumber > anchorBlockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
     }
     return await this.aztecNode.getBlock(blockNumber);
   }
 
   public async getPublicDataWitness(blockNumber: BlockParameter, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
-    const header = await this.getAnchorBlockHeader();
-    if (blockNumber !== 'latest' && blockNumber > header.globalVariables.blockNumber) {
-      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    const anchorBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
+    if (blockNumber !== 'latest' && blockNumber > anchorBlockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
     }
     return await this.aztecNode.getPublicDataWitness(blockNumber, leafSlot);
   }
 
   public async getPublicStorageAt(blockNumber: BlockParameter, contract: AztecAddress, slot: Fr): Promise<Fr> {
-    const header = await this.getAnchorBlockHeader();
-    if (blockNumber !== 'latest' && blockNumber > header.globalVariables.blockNumber) {
-      throw new Error(`Block number ${blockNumber} is higher than current block ${header.globalVariables.blockNumber}`);
+    const anchorBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
+    if (blockNumber !== 'latest' && blockNumber > anchorBlockNumber) {
+      throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
     }
     return await this.aztecNode.getPublicStorageAt(blockNumber, contract, slot);
-  }
-
-  getAnchorBlockHeader(): Promise<BlockHeader> {
-    return this.syncDataProvider.getBlockHeader();
   }
 
   public assertCompatibleOracleVersion(version: number): void {
@@ -416,7 +411,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   ) {
     this.log.verbose('Searching for tagged logs', { contract: contractAddress });
 
-    const maxBlockNumber = await this.syncDataProvider.getBlockNumber();
+    const maxBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
 
     // Ideally this algorithm would be implemented in noir, exposing its building blocks as oracles.
     // However it is impossible at the moment due to the language not supporting nested slices.
@@ -673,7 +668,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // number which *should* be recent enough to be available, even for non-archive nodes.
     // Also note that the note should never be ahead of the synced block here since `fetchTaggedLogs` only processes
     // logs up to the synced block making this only an additional safety check.
-    const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
+    const syncedBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.
@@ -814,11 +809,13 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // (and thus we're less concerned about being ahead of the synced block), we use the synced block number to
     // maintain consistent behavior in the PXE. Additionally, events should never be ahead of the synced block here
     // since `fetchTaggedLogs` only processes logs up to the synced block.
-    const [syncedBlockNumber, siloedEventCommitment, txEffect] = await Promise.all([
-      this.syncDataProvider.getBlockNumber(),
+    const [syncedBlockHeader, siloedEventCommitment, txEffect] = await Promise.all([
+      this.anchorBlockDataProvider.getBlockHeader(),
       siloNullifier(contractAddress, eventCommitment),
       this.aztecNode.getTxEffect(txHash),
     ]);
+
+    const syncedBlockNumber = syncedBlockHeader.getBlockNumber();
 
     if (!txEffect) {
       throw new Error(`Could not find tx effect for tx hash ${txHash}`);
@@ -942,7 +939,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   public async syncNoteNullifiers(contractAddress: AztecAddress) {
     this.log.verbose('Searching for nullifiers of known notes', { contract: contractAddress });
 
-    const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
+    const syncedBlockNumber = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
 
     const contractNotes = await this.noteDataProvider.getNotes({ contractAddress });
 

--- a/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
@@ -1,28 +1,31 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { TxHash } from '@aztec/stdlib/tx';
+import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
 import { mock } from 'jest-mock-extended';
 import type { MockProxy } from 'jest-mock-extended/lib/Mock.js';
 
-import { SyncDataProvider } from '../storage/index.js';
+import { AnchorBlockDataProvider } from '../storage/index.js';
 import { PrivateEventFilterValidator } from './private_event_filter_validator.js';
 
 describe('PrivateEventFilterValidator', () => {
   let contractAddress: AztecAddress;
+  let lastKnownBlock: BlockHeader;
   let lastKnownBlockNumber: BlockNumber;
   let scope: AztecAddress;
-  let syncDataProvider: MockProxy<SyncDataProvider>;
+  let anchorBlockDataProvider: MockProxy<AnchorBlockDataProvider>;
   let validator: PrivateEventFilterValidator;
 
   beforeEach(async () => {
-    lastKnownBlockNumber = BlockNumber(42);
+    lastKnownBlock = BlockHeader.random();
+    lastKnownBlockNumber = lastKnownBlock.getBlockNumber();
     contractAddress = await AztecAddress.random();
     scope = await AztecAddress.random();
-    syncDataProvider = mock<SyncDataProvider>();
-    syncDataProvider.getBlockNumber.mockResolvedValue(lastKnownBlockNumber);
-    validator = new PrivateEventFilterValidator(syncDataProvider);
+    anchorBlockDataProvider = mock<AnchorBlockDataProvider>();
+
+    anchorBlockDataProvider.getBlockHeader.mockResolvedValue(lastKnownBlock);
+    validator = new PrivateEventFilterValidator(anchorBlockDataProvider);
   });
 
   it('rejects empty scope', async () => {

--- a/yarn-project/pxe/src/events/private_event_filter_validator.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.ts
@@ -2,10 +2,10 @@ import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 
-import type { PrivateEventDataProviderFilter, SyncDataProvider } from '../storage/index.js';
+import type { AnchorBlockDataProvider, PrivateEventDataProviderFilter } from '../storage/index.js';
 
 export class PrivateEventFilterValidator {
-  constructor(private syncDataProvider: SyncDataProvider) {}
+  constructor(private anchorBlockDataProvider: AnchorBlockDataProvider) {}
 
   async validate(filter: PrivateEventFilter): Promise<PrivateEventDataProviderFilter> {
     let { fromBlock, toBlock } = filter;
@@ -15,7 +15,7 @@ export class PrivateEventFilterValidator {
     // We then default to [INITIAL_L2_BLOCK_NUM, latestKnownBlock + 1), ie: by default return events from
     // the first block to the latest known block.
     if (!fromBlock || !toBlock) {
-      const lastKnownBlock = await this.syncDataProvider.getBlockNumber();
+      const lastKnownBlock = (await this.anchorBlockDataProvider.getBlockHeader()).getBlockNumber();
       fromBlock = fromBlock ?? BlockNumber(INITIAL_L2_BLOCK_NUM);
       toBlock = toBlock ?? BlockNumber(lastKnownBlock + 1);
     }

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -56,6 +56,7 @@ import {
 
 import { inspect } from 'util';
 
+import { BlockSynchronizer } from './block_synchronizer/index.js';
 import type { PXEConfig } from './config/index.js';
 import {
   ContractFunctionSimulator,
@@ -73,13 +74,12 @@ import {
 } from './private_kernel/private_kernel_execution_prover.js';
 import { PrivateKernelOracleImpl } from './private_kernel/private_kernel_oracle_impl.js';
 import { AddressDataProvider } from './storage/address_data_provider/address_data_provider.js';
+import { AnchorBlockDataProvider } from './storage/anchor_block_data_provider/anchor_block_data_provider.js';
 import { CapsuleDataProvider } from './storage/capsule_data_provider/capsule_data_provider.js';
 import { ContractDataProvider } from './storage/contract_data_provider/contract_data_provider.js';
 import { NoteDataProvider } from './storage/note_data_provider/note_data_provider.js';
 import { PrivateEventDataProvider } from './storage/private_event_data_provider/private_event_data_provider.js';
-import { SyncDataProvider } from './storage/sync_data_provider/sync_data_provider.js';
 import { TaggingDataProvider } from './storage/tagging_data_provider/tagging_data_provider.js';
-import { Synchronizer } from './synchronizer/index.js';
 
 export type PackedPrivateEvent = InTx & {
   packedEvent: Fr[];
@@ -93,12 +93,12 @@ export type PackedPrivateEvent = InTx & {
 export class PXE {
   private constructor(
     private node: AztecNode,
-    private synchronizer: Synchronizer,
+    private blockStateSynchronizer: BlockSynchronizer,
     private keyStore: KeyStore,
     private contractDataProvider: ContractDataProvider,
     private noteDataProvider: NoteDataProvider,
     private capsuleDataProvider: CapsuleDataProvider,
-    private syncDataProvider: SyncDataProvider,
+    private anchorBlockDataProvider: AnchorBlockDataProvider,
     private taggingDataProvider: TaggingDataProvider,
     private addressDataProvider: AddressDataProvider,
     private privateEventDataProvider: PrivateEventDataProvider,
@@ -136,14 +136,14 @@ export class PXE {
     const privateEventDataProvider = new PrivateEventDataProvider(store);
     const contractDataProvider = new ContractDataProvider(store);
     const noteDataProvider = await NoteDataProvider.create(store);
-    const syncDataProvider = new SyncDataProvider(store);
+    const anchorBlockDataProvider = new AnchorBlockDataProvider(store);
     const taggingDataProvider = new TaggingDataProvider(store);
     const capsuleDataProvider = new CapsuleDataProvider(store);
     const keyStore = new KeyStore(store);
     const tipsStore = new L2TipsKVStore(store, 'pxe');
-    const synchronizer = new Synchronizer(
+    const synchronizer = new BlockSynchronizer(
       node,
-      syncDataProvider,
+      anchorBlockDataProvider,
       noteDataProvider,
       taggingDataProvider,
       tipsStore,
@@ -160,7 +160,7 @@ export class PXE {
       contractDataProvider,
       noteDataProvider,
       capsuleDataProvider,
-      syncDataProvider,
+      anchorBlockDataProvider,
       taggingDataProvider,
       addressDataProvider,
       privateEventDataProvider,
@@ -189,7 +189,7 @@ export class PXE {
       ProxiedContractDataProviderFactory.create(this.contractDataProvider, overrides?.contracts),
       this.noteDataProvider,
       this.capsuleDataProvider,
-      this.syncDataProvider,
+      this.anchorBlockDataProvider,
       this.taggingDataProvider,
       this.addressDataProvider,
       this.privateEventDataProvider,
@@ -289,11 +289,14 @@ export class PXE {
     const { origin: contractAddress, functionSelector } = txRequest;
 
     try {
+      const anchorBlockHeader = await this.anchorBlockDataProvider.getBlockHeader();
+
       const result = await contractFunctionSimulator.run(
         txRequest,
         contractAddress,
         functionSelector,
         undefined,
+        anchorBlockHeader,
         // The sender for tags is set by contracts, typically by an account
         // contract entrypoint
         undefined, // senderForTags
@@ -325,7 +328,8 @@ export class PXE {
     scopes?: AztecAddress[],
   ) {
     try {
-      return contractFunctionSimulator.runUtility(call, authWitnesses ?? [], scopes);
+      const anchorBlockHeader = await this.anchorBlockDataProvider.getBlockHeader();
+      return contractFunctionSimulator.runUtility(call, authWitnesses ?? [], anchorBlockHeader, scopes);
     } catch (err) {
       if (err instanceof SimulationError) {
         await enrichSimulationError(err, this.contractDataProvider, this.log);
@@ -623,9 +627,9 @@ export class PXE {
         throw new Error(`Instance not found when updating a contract. Contract address: ${contractAddress}.`);
       }
       const contractClass = await getContractClassFromArtifact(artifact);
-      await this.synchronizer.sync();
+      await this.blockStateSynchronizer.sync();
 
-      const header = await this.syncDataProvider.getBlockHeader();
+      const header = await this.anchorBlockDataProvider.getBlockHeader();
 
       const currentClassId = await readCurrentClassId(
         contractAddress,
@@ -695,7 +699,7 @@ export class PXE {
       const totalTimer = new Timer();
       try {
         const syncTimer = new Timer();
-        await this.synchronizer.sync();
+        await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
         const contractFunctionSimulator = this.#getSimulatorForTx();
         privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest);
@@ -783,7 +787,7 @@ export class PXE {
           txInfo,
         );
         const syncTimer = new Timer();
-        await this.synchronizer.sync();
+        await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
 
         const contractFunctionSimulator = this.#getSimulatorForTx();
@@ -883,7 +887,7 @@ export class PXE {
           txInfo,
         );
         const syncTimer = new Timer();
-        await this.synchronizer.sync();
+        await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
 
         const contractFunctionSimulator = this.#getSimulatorForTx(overrides);
@@ -1012,7 +1016,7 @@ export class PXE {
       try {
         const totalTimer = new Timer();
         const syncTimer = new Timer();
-        await this.synchronizer.sync();
+        await this.blockStateSynchronizer.sync();
         const syncTime = syncTimer.ms();
         const functionTimer = new Timer();
         const contractFunctionSimulator = this.#getSimulatorForTx();
@@ -1065,7 +1069,7 @@ export class PXE {
     const call = await this.#getFunctionCall('sync_private_state', [], filter.contractAddress);
     await this.simulateUtility(call);
 
-    const sanitizedFilter = await new PrivateEventFilterValidator(this.syncDataProvider).validate(filter);
+    const sanitizedFilter = await new PrivateEventFilterValidator(this.anchorBlockDataProvider).validate(filter);
 
     this.log.error(
       `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,

--- a/yarn-project/pxe/src/storage/anchor_block_data_provider/anchor_block_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_data_provider/anchor_block_data_provider.test.ts
@@ -4,24 +4,24 @@ import { randomInt } from '@aztec/foundation/crypto/random';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { makeBlockHeader } from '@aztec/stdlib/testing';
 
-import { SyncDataProvider } from './sync_data_provider.js';
+import { AnchorBlockDataProvider } from './anchor_block_data_provider.js';
 
 describe('block header', () => {
-  let syncDataProvider: SyncDataProvider;
+  let anchorBlockDataProvider: AnchorBlockDataProvider;
 
   beforeEach(async () => {
     const store = await openTmpStore('sync_data_provider_test');
-    syncDataProvider = new SyncDataProvider(store);
+    anchorBlockDataProvider = new AnchorBlockDataProvider(store);
   });
 
   it('stores and retrieves the block header', async () => {
     const header = makeBlockHeader(randomInt(1000), { blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
 
-    await syncDataProvider.setHeader(header);
-    await expect(syncDataProvider.getBlockHeader()).resolves.toEqual(header);
+    await anchorBlockDataProvider.setHeader(header);
+    await expect(anchorBlockDataProvider.getBlockHeader()).resolves.toEqual(header);
   });
 
   it('rejects getting header if no block set', async () => {
-    await expect(() => syncDataProvider.getBlockHeader()).rejects.toThrow();
+    await expect(() => anchorBlockDataProvider.getBlockHeader()).rejects.toThrow();
   });
 });

--- a/yarn-project/pxe/src/storage/anchor_block_data_provider/anchor_block_data_provider.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_data_provider/anchor_block_data_provider.ts
@@ -1,8 +1,7 @@
-import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAsyncKVStore, AztecAsyncSingleton } from '@aztec/kv-store';
 import { BlockHeader } from '@aztec/stdlib/tx';
 
-export class SyncDataProvider {
+export class AnchorBlockDataProvider {
   #store: AztecAsyncKVStore;
   #synchronizedHeader: AztecAsyncSingleton<Buffer>;
 
@@ -15,19 +14,10 @@ export class SyncDataProvider {
     await this.#synchronizedHeader.set(header.toBuffer());
   }
 
-  async getBlockNumber(): Promise<BlockNumber> {
-    const headerBuffer = await this.#synchronizedHeader.getAsync();
-    if (!headerBuffer) {
-      throw new Error(`Trying to get block number with a not-yet-synchronized PXE - this should never happen`);
-    }
-
-    return BlockHeader.fromBuffer(headerBuffer).globalVariables.blockNumber;
-  }
-
   async getBlockHeader(): Promise<BlockHeader> {
     const headerBuffer = await this.#synchronizedHeader.getAsync();
     if (!headerBuffer) {
-      throw new Error(`Header not set`);
+      throw new Error(`Trying to get block header with a not-yet-synchronized PXE - this should never happen`);
     }
 
     return BlockHeader.fromBuffer(headerBuffer);

--- a/yarn-project/pxe/src/storage/anchor_block_data_provider/index.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_data_provider/index.ts
@@ -1,0 +1,1 @@
+export { AnchorBlockDataProvider } from './anchor_block_data_provider.js';

--- a/yarn-project/pxe/src/storage/index.ts
+++ b/yarn-project/pxe/src/storage/index.ts
@@ -2,7 +2,7 @@ export * from './address_data_provider/index.js';
 export * from './capsule_data_provider/index.js';
 export * from './contract_data_provider/index.js';
 export * from './note_data_provider/index.js';
-export * from './sync_data_provider/index.js';
+export * from './anchor_block_data_provider/index.js';
 export * from './tagging_data_provider/index.js';
 export * from './metadata.js';
 export * from './private_event_data_provider/private_event_data_provider.js';

--- a/yarn-project/pxe/src/storage/sync_data_provider/index.ts
+++ b/yarn-project/pxe/src/storage/sync_data_provider/index.ts
@@ -1,1 +1,0 @@
-export { SyncDataProvider } from './sync_data_provider.js';

--- a/yarn-project/pxe/src/synchronizer/index.ts
+++ b/yarn-project/pxe/src/synchronizer/index.ts
@@ -1,1 +1,0 @@
-export * from './synchronizer.js';

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
@@ -26,6 +26,10 @@ export class L2BlockStream {
       skipFinalized?: boolean;
     } = {},
   ) {
+    // Note that RunningPromise is in stopped state by default. This promise won't run until someone invokes `start`,
+    // which makes it run periodically, or `sync`, which triggers it once.
+    // Users of L2BlockStream decide what mode to run it in (_periodically_ vs _manually triggered_).
+    // The default is _manually triggered_.
     this.runningPromise = new RunningPromise(() => this.work(), log, this.opts.pollIntervalMS ?? 1000);
   }
 
@@ -42,6 +46,11 @@ export class L2BlockStream {
     return this.runningPromise.isRunning();
   }
 
+  /**
+   * Runs the synchronization process once.
+   *
+   * If you want to run this process continuously use `start` and `stop` instead.
+   */
   public async sync() {
     this.isSyncing = true;
     await this.runningPromise.trigger();

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -280,7 +280,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const txContext = new TxContext(this.chainId, this.version, gasSettings);
 
-    const blockHeader = await this.pxeOracleInterface.getAnchorBlockHeader();
+    const blockHeader = await this.stateMachine.anchorBlockDataProvider.getBlockHeader();
 
     const protocolNullifier = await computeProtocolNullifier(getSingleTxBlockRequestHash(blockNumber));
     const noteCache = new ExecutionNoteCache(protocolNullifier);
@@ -459,7 +459,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const txContext = new TxContext(this.chainId, this.version, gasSettings);
 
-    const anchorBlockHeader = await this.pxeOracleInterface.getAnchorBlockHeader();
+    const anchorBlockHeader = await this.stateMachine.anchorBlockDataProvider.getBlockHeader();
 
     const calldataHash = await computeCalldataHash(calldata);
     const calldataHashedValues = new HashedValues(calldata, calldataHash);
@@ -609,7 +609,8 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     });
 
     try {
-      const oracle = new UtilityExecutionOracle(call.to, [], [], this.pxeOracleInterface);
+      const anchorBlockHeader = await this.stateMachine.anchorBlockDataProvider.getBlockHeader();
+      const oracle = new UtilityExecutionOracle(call.to, [], [], anchorBlockHeader, this.pxeOracleInterface);
       const acirExecutionResult = await new WASMSimulator()
         .executeUserCircuit(toACVMWitness(0, args), entryPointArtifact, new Oracle(oracle).toACIRCallback())
         .catch((err: Error) => {

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -580,8 +580,8 @@ export class RPCTranslator {
     return toForeignCallResult([toSingle(new Fr(isRevertible))]);
   }
 
-  async utilityGetUtilityContext() {
-    const context = await this.handlerAsUtility().utilityGetUtilityContext();
+  utilityGetUtilityContext() {
+    const context = this.handlerAsUtility().utilityGetUtilityContext();
 
     return toForeignCallResult(context.toNoirRepresentation());
   }

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -2,7 +2,7 @@ import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
-import { SyncDataProvider } from '@aztec/pxe/server';
+import { AnchorBlockDataProvider } from '@aztec/pxe/server';
 import { L2Block } from '@aztec/stdlib/block';
 import { L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -22,13 +22,13 @@ export class TXEStateMachine {
     public node: AztecNode,
     public synchronizer: TXESynchronizer,
     public archiver: TXEArchiver,
-    public syncDataProvider: SyncDataProvider,
+    public anchorBlockDataProvider: AnchorBlockDataProvider,
   ) {}
 
   public static async create(db: AztecAsyncKVStore) {
     const archiver = new TXEArchiver(db);
     const synchronizer = await TXESynchronizer.create();
-    const syncDataProvider = new SyncDataProvider(db);
+    const anchorBlockDataProvider = new AnchorBlockDataProvider(db);
 
     const aztecNodeConfig = {} as AztecNodeConfig;
 
@@ -55,7 +55,7 @@ export class TXEStateMachine {
       log,
     );
 
-    return new this(node, synchronizer, archiver, syncDataProvider);
+    return new this(node, synchronizer, archiver, anchorBlockDataProvider);
   }
 
   public async handleL2Block(block: L2Block) {
@@ -72,7 +72,7 @@ export class TXEStateMachine {
     await Promise.all([
       this.synchronizer.handleL2Block(block.toL2Block()),
       this.archiver.addCheckpoints([publishedCheckpoint], undefined),
-      this.syncDataProvider.setHeader(block.header.toBlockHeader()),
+      this.anchorBlockDataProvider.setHeader(block.getBlockHeader()),
     ]);
   }
 }

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -159,7 +159,7 @@ export class TXESession implements TXESessionStateHandler {
       contractDataProvider,
       noteDataProvider,
       capsuleDataProvider,
-      stateMachine.syncDataProvider,
+      stateMachine.anchorBlockDataProvider,
       taggingDataProvider,
       addressDataProvider,
       privateEventDataProvider,
@@ -353,7 +353,15 @@ export class TXESession implements TXESessionStateHandler {
     // TODO(#12553): make the synchronizer sync here instead and remove this
     await this.pxeOracleInterface.syncNoteNullifiers(contractAddress);
 
-    this.oracleHandler = new UtilityExecutionOracle(contractAddress, [], [], this.pxeOracleInterface);
+    const anchorBlockHeader = await this.stateMachine.anchorBlockDataProvider.getBlockHeader();
+
+    this.oracleHandler = new UtilityExecutionOracle(
+      contractAddress,
+      [],
+      [],
+      anchorBlockHeader,
+      this.pxeOracleInterface,
+    );
 
     this.state = { name: 'UTILITY' };
     this.logger.debug(`Entered state ${this.state.name}`);


### PR DESCRIPTION
Block sync is currently handled through collaboration of `Synchronizer`, `SyncDataProvider`, and even `PXEOracleInterface#getAnchorBlock`. 

## Current problems
- The names aren't very intuitive (`Synchronizer` and `SyncDataProvider` only handle chain state data at the end of the day).
- Any code running inside `ContractFunctionSimulator` can call `getAnchorBlock` whenever it pleases. This works currently because calls to `Synchronizer` are carefully orchestrated from PXE. But it seems error prone, obscure, and it gives the false impression that function simulation happens on live block data when it actually depends on a static anchor.
- There are multiple ways throughout the app to get the anchor block: `Synchronizer#getSynchedBlock` (unused), `PXEOracleInterface#getAnchorBlock` (unnecessary, inappropriate), `SyncDataProvider#getBlockNumber` (redundant), and `SyncDataProvider#getBlockHeader` (the one that should be the source of truth)
- Many checks are relying on block number when they should rely on block hash. 

## Refactor 

(note: adjusted naming after discussing with @benesjan) 

- Rename `Synchronizer` => `BlockSynchronizer`
- Rename `SyncDataProvider` => `AnchorBlockDataProvider`
- Remove `AnchorBlockDataProvider#getBlockNumber`. `AnchorBlockDataProvider#getBlockHeader` remains the only way to consume current block information for the rest of the app. To get the block number, there's a simple `getBlockNumber` accessor in `BlockHeader`.
- Remove `ExecutionDataProvider#getAnchorBlock`. Instead, explicitly pass anchor block headers as params to functions in "the realm" of `ContractFunctionSimulator` (`run`, `runUtility`, `varifyCurrentClassId`, etc).   

## Out of scope of PR

> - Many checks are relying on block number when they should rely on block hash. 

This should be tackled on a per use case/feature basis in future PRs, though relying on `getBlockHeader` solely seems aligned in the right direction. 

Closes F-225