### PR TITLE
feat: add workflow to republish release artifacts under different ref

### DIFF
--- a/.github/workflows/port-release.yml
+++ b/.github/workflows/port-release.yml
@@ -1,0 +1,68 @@
+name: Port Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Source release tag (e.g., v1.2.3-rc.1)"
+        required: true
+        type: string
+      target_ref:
+        description: "Target release tag (e.g., v1.2.3)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (don't actually publish)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: port-release-${{ github.event.inputs.target_ref }}
+  cancel-in-progress: false
+
+jobs:
+  port-release:
+    name: Port Release (${{ github.event.inputs.source_ref }} -> ${{ github.event.inputs.target_ref }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        run: |
+          # Validate source_ref is a valid semver
+          if ! [[ "${{ github.event.inputs.source_ref }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Error: source_ref must be a valid semver tag (e.g., v1.2.3 or v1.2.3-rc.1)"
+            exit 1
+          fi
+          # Validate target_ref is a valid semver
+          if ! [[ "${{ github.event.inputs.target_ref }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Error: target_ref must be a valid semver tag (e.g., v1.2.3)"
+            exit 1
+          fi
+          echo "Porting release from ${{ github.event.inputs.source_ref }} to ${{ github.event.inputs.target_ref }}"
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.inputs.source_ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Port Release
+        env:
+          SOURCE_REF: ${{ github.event.inputs.source_ref }}
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          DRY_RUN: ${{ github.event.inputs.dry_run && '1' || '0' }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          GH_TOKEN: ${{ github.token }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          ./bootstrap.sh port_release "$SOURCE_REF" "$TARGET_REF"

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -48,6 +48,32 @@ function release {
   fi
 }
 
+# Port release: copy S3 artifacts from source version to target version/dist_tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "aztec-up port_release: $source_ref -> $target_ref"
+
+  local source_version=${source_ref#v}
+  local target_version=${target_ref#v}
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  # Copy from source version to target version.
+  echo "Copying S3 files from $source_version to $target_version..."
+  do_or_dryrun aws s3 sync "s3://install.aztec.network/$source_version/" "s3://install.aztec.network/$target_version/"
+
+  if [[ "$target_dist_tag" != "latest" ]]; then
+    # Also copy to dist_tag directory, if not latest.
+    echo "Copying S3 files to $target_dist_tag..."
+    do_or_dryrun aws s3 sync "s3://install.aztec.network/$source_version/" "s3://install.aztec.network/$target_dist_tag/"
+  else
+    # Copy to root for latest.
+    echo "Copying S3 files to root (latest)..."
+    do_or_dryrun aws s3 sync "s3://install.aztec.network/$source_version/" "s3://install.aztec.network/"
+  fi
+}
+
 case "$cmd" in
   "")
     ;;

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -378,6 +378,32 @@ function release {
   do_or_dryrun gh release upload $REF_NAME build-release/* --clobber
 }
 
+# Port release: download artifacts from source release and upload to target release.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "bb cpp port_release: $source_ref -> $target_ref"
+
+  # Create temporary directory for artifacts.
+  local tmpdir=$(mktemp -d)
+  trap "rm -rf $tmpdir" EXIT
+
+  # Download artifacts from source release.
+  echo "Downloading artifacts from $source_ref..."
+  gh release download "$source_ref" --dir "$tmpdir" --pattern "barretenberg-*.tar.gz" || {
+    echo "Warning: Could not download all barretenberg artifacts from $source_ref"
+  }
+
+  # Upload to target release.
+  if [ -n "$(ls -A $tmpdir 2>/dev/null)" ]; then
+    echo "Uploading artifacts to $target_ref..."
+    do_or_dryrun gh release upload "$target_ref" "$tmpdir"/* --clobber
+  else
+    echo "No artifacts found to port."
+  fi
+}
+
 function bench_ivc {
   # Intended only for dev usage. For CI usage, we run yarn-project/end-to-end/bootstrap.sh bench.
   # Sample usage (CI=1 required for bench results to be visible; exclude NO_WASM=1 to run wasm benchmarks):

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -63,6 +63,32 @@ function release {
   retry "deploy_npm $(dist_tag) ${REF_NAME#v}"
 }
 
+# Port release: re-tag NPM package from source version to target dist tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "bb.js port_release: $source_ref -> $target_ref"
+
+  local source_version=${source_ref#v}
+  local target_version=${target_ref#v}
+
+  # Compute target dist tag from target_ref.
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  local package_name=$(jq -r '.name' package.json)
+
+  # Check if source version exists on NPM.
+  if ! npm view "$package_name@$source_version" version >/dev/null 2>&1; then
+    echo "Error: $package_name@$source_version not found on NPM."
+    exit 1
+  fi
+
+  # Tag existing version with target dist tag.
+  echo "Tagging $package_name@$source_version as $target_dist_tag..."
+  do_or_dryrun npm dist-tag add "$package_name@$source_version" "$target_dist_tag"
+}
+
 function cross_copy {
   ./scripts/copy_cross.sh
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -488,6 +488,58 @@ function release_dryrun {
   DRY_RUN=1 release
 }
 
+# Port a release from one REF_NAME to another.
+# This republishes artifacts from a source release under a new target release tag.
+# Usage: ./bootstrap.sh port_release <source_ref> <target_ref>
+# Example: ./bootstrap.sh port_release v1.2.3-rc.1 v1.2.3
+function port_release {
+  local source_ref=${1:-}
+  local target_ref=${2:-}
+
+  if [ -z "$source_ref" ] || [ -z "$target_ref" ]; then
+    echo "Usage: ./bootstrap.sh port_release <source_ref> <target_ref>"
+    echo "Example: ./bootstrap.sh port_release v1.2.3-rc.1 v1.2.3"
+    exit 1
+  fi
+
+  if ! semver check "$source_ref"; then
+    echo "Error: source_ref '$source_ref' is not a valid semver tag."
+    exit 1
+  fi
+
+  if ! semver check "$target_ref"; then
+    echo "Error: target_ref '$target_ref' is not a valid semver tag."
+    exit 1
+  fi
+
+  echo_header "port release: $source_ref -> $target_ref"
+  set -x
+
+  # Export for use in submodules.
+  export SOURCE_REF="$source_ref"
+  export TARGET_REF="$target_ref"
+
+  # Set REF_NAME to target for release_github and dist_tag.
+  export REF_NAME="$target_ref"
+
+  # Ensure we have a github release for our target REF_NAME.
+  release_github
+
+  projects=(
+    barretenberg/cpp
+    barretenberg/ts
+    noir
+    yarn-project
+    aztec-up
+    playground
+    release-image
+  )
+
+  for project in "${projects[@]}"; do
+    $project/bootstrap.sh port_release "$source_ref" "$target_ref"
+  done
+}
+
 case "$cmd" in
   "clean")
     echo "WARNING: This will erase *all* untracked files, including hooks and submodules."

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -124,6 +124,32 @@ function release {
   done
 }
 
+# Port release: re-tag NPM packages from source version to target dist tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "noir port_release: $source_ref -> $target_ref"
+
+  local source_version=${source_ref#v}
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  for package in $js_projects; do
+    # Packages are published as @aztec/noir-* not @noir-lang/*.
+    local npm_package="@aztec/noir-${package#*/}"
+
+    # Check if source version exists on NPM.
+    if ! npm view "$npm_package@$source_version" version >/dev/null 2>&1; then
+      echo "Warning: $npm_package@$source_version not found on NPM, skipping."
+      continue
+    fi
+
+    # Tag existing version with target dist tag.
+    echo "Tagging $npm_package@$source_version as $target_dist_tag..."
+    do_or_dryrun npm dist-tag add "$npm_package@$source_version" "$target_dist_tag"
+  done
+}
+
 case "$cmd" in
   "clean")
     # Double `f` needed to delete the nested git repository.

--- a/playground/bootstrap.sh
+++ b/playground/bootstrap.sh
@@ -37,6 +37,25 @@ function release {
   invalidate_cloudfront
 }
 
+# Port release: copy S3 artifacts from source version to target version/dist_tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "playground port_release: $source_ref -> $target_ref"
+
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  # Copy from source ref to target dist_tag and target ref.
+  echo "Copying S3 files from $source_ref to $target_dist_tag..."
+  do_or_dryrun aws s3 sync "s3://play.aztec.network/$source_ref" "s3://play.aztec.network/$target_dist_tag" --quiet
+
+  echo "Copying S3 files from $source_ref to $target_ref..."
+  do_or_dryrun aws s3 sync "s3://play.aztec.network/$source_ref" "s3://play.aztec.network/$target_ref" --quiet
+
+  invalidate_cloudfront
+}
+
 function invalidate_cloudfront {
   local id=$(cd terraform && terraform init &>/dev/null && terraform output -raw cloudfront_distribution_id)
   do_or_dryrun aws cloudfront create-invalidation --distribution-id $id --paths "/*"

--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -76,6 +76,46 @@ function release {
   fi
 }
 
+# Port release: re-tag Docker images from source version to target version/dist_tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "release-image port_release: $source_ref -> $target_ref"
+
+  if [ -z "${DOCKERHUB_PASSWORD:-}" ]; then
+    echo "Missing DOCKERHUB_PASSWORD."
+    exit 1
+  fi
+  echo $DOCKERHUB_PASSWORD | docker login -u ${DOCKERHUB_USERNAME:-aztecprotocolci} --password-stdin
+
+  local source_tag=${source_ref#v}
+  local target_tag=${target_ref#v}
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  # Check if source manifest exists.
+  if ! docker manifest inspect "aztecprotocol/aztec:$source_tag" &>/dev/null; then
+    echo "Error: aztecprotocol/aztec:$source_tag not found on Docker Hub."
+    exit 1
+  fi
+
+  # Create manifest for target tag using source arch-specific images.
+  echo "Creating manifest for aztecprotocol/aztec:$target_tag..."
+  docker manifest rm "aztecprotocol/aztec:$target_tag" &>/dev/null || true
+  do_or_dryrun docker manifest create "aztecprotocol/aztec:$target_tag" \
+    --amend "aztecprotocol/aztec:$source_tag-amd64" \
+    --amend "aztecprotocol/aztec:$source_tag-arm64"
+  do_or_dryrun docker manifest push "aztecprotocol/aztec:$target_tag"
+
+  # Create manifest for target dist_tag.
+  echo "Creating manifest for aztecprotocol/aztec:$target_dist_tag..."
+  docker manifest rm "aztecprotocol/aztec:$target_dist_tag" &>/dev/null || true
+  do_or_dryrun docker manifest create "aztecprotocol/aztec:$target_dist_tag" \
+    --amend "aztecprotocol/aztec:$source_tag-amd64" \
+    --amend "aztecprotocol/aztec:$source_tag-arm64"
+  do_or_dryrun docker manifest push "aztecprotocol/aztec:$target_dist_tag"
+}
+
 function push {
   echo_header "release-image push"
 

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -234,6 +234,33 @@ function release {
   release_packages "$(dist_tag)" "${REF_NAME#v}"
 }
 
+# Port release: re-tag NPM packages from source version to target dist tag.
+function port_release {
+  local source_ref=${1:-$SOURCE_REF}
+  local target_ref=${2:-$TARGET_REF}
+
+  echo_header "yarn-project port_release: $source_ref -> $target_ref"
+
+  local source_version=${source_ref#v}
+  local target_dist_tag=$(REF_NAME=$target_ref dist_tag)
+
+  echo "Computing packages to port..."
+  local packages=$(get_projects topological)
+  for package in $packages; do
+    local package_name=$(jq -r .name "$package/package.json")
+
+    # Check if source version exists on NPM.
+    if ! npm view "$package_name@$source_version" version >/dev/null 2>&1; then
+      echo "Warning: $package_name@$source_version not found on NPM, skipping."
+      continue
+    fi
+
+    # Tag existing version with target dist tag.
+    echo "Tagging $package_name@$source_version as $target_dist_tag..."
+    do_or_dryrun npm dist-tag add "$package_name@$source_version" "$target_dist_tag"
+  done
+}
+
 case "$cmd" in
   "clean")
     [ -n "${1:-}" ] && cd $1


### PR DESCRIPTION
Add a workflow_dispatch-triggered release workflow that can take an existing release tag and republish its artifacts under a different target ref name. Implement a bootstrap.sh port-release command pattern that handles loading artifacts from the publication target and republishing them. This enables flexible release management and artifact retagging without requiring full rebuilds.