### PR TITLE
fix: unique foundry folders per test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_circuit_recorder.test.ts
+++ b/yarn-project/end-to-end/src/e2e_circuit_recorder.test.ts
@@ -65,5 +65,5 @@ describe('Circuit Recorder', () => {
     await fs.rm(RECORD_DIR, { recursive: true, force: true });
     delete process.env.CIRCUIT_RECORD_DIR;
     await teardown();
-  }, 20_000);
+  }, 60_000);
 });

--- a/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
@@ -10,7 +10,9 @@ import { fileURLToPath } from '@aztec/foundation/url';
 import { bn254 } from '@noble/curves/bn254';
 import type { Abi, Narrow } from 'abitype';
 import { spawn } from 'child_process';
-import { dirname, resolve } from 'path';
+import { cp, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
 import readline from 'readline';
 import type { Hex } from 'viem';
 import { foundry, mainnet } from 'viem/chains';
@@ -73,6 +75,17 @@ function runProcess<T>(
   });
 
   return promise;
+}
+
+/**
+ * Copies the foundry cache folder to a temporary location to avoid conflicts when running forge in parallel.
+ * The cache folder is small metadata that links to the out folder, so this is a fast operation.
+ */
+async function copyFoundryCacheToTemp(l1ContractsPath: string): Promise<string> {
+  const cacheFolder = join(l1ContractsPath, 'cache');
+  const tempCacheFolder = await mkdtemp(join(tmpdir(), 'foundry-cache-'));
+  await cp(cacheFolder, tempCacheFolder, { recursive: true });
+  return tempCacheFolder;
 }
 
 // Covers an edge where where we may have a cached BlobLib that is not meant for production.
@@ -247,93 +260,101 @@ export async function deployAztecL1Contracts(
   const FORGE_SCRIPT = 'script/deploy/DeployAztecL1Contracts.s.sol';
   await maybeForgeForceProductionBuild(l1ContractsPath, FORGE_SCRIPT, chainId);
 
-  // From heuristic testing. More caused issues with anvil.
-  const MAGIC_ANVIL_BATCH_SIZE = 12;
-  // Anvil seems to stall with unbounded batch size. Otherwise no max batch size is desirable.
-  // On sepolia and mainnet, we verify on etherscan (if etherscan API key is in env)
-  const forgeArgs = [
-    'script',
-    FORGE_SCRIPT,
-    '--sig',
-    'run()',
-    '--private-key',
-    privateKey,
-    '--rpc-url',
-    rpcUrl,
-    '--broadcast',
-    ...(chainId === foundry.id ? ['--batch-size', MAGIC_ANVIL_BATCH_SIZE.toString()] : []),
-    ...(verifyContracts ? ['--verify'] : []),
-  ];
-  const forgeEnv = {
-    // Protect against root leaving deployment files in docker that cannot be used later.
-    FOUNDRY_BROADCAST: process.getuid?.() === 0 ? 'broadcast-root' : undefined,
-    // Env vars required by l1-contracts/script/deploy/DeploymentConfiguration.sol.
-    NETWORK: getActiveNetworkName(),
-    FOUNDRY_PROFILE: chainId === mainnet.id ? 'production' : undefined,
-    ...getDeployAztecL1ContractsEnvVars(args),
-  };
-  const result = await runProcess<ForgeL1ContractsDeployResult>('forge', forgeArgs, forgeEnv, l1ContractsPath);
-  if (!result) {
-    throw new Error('Forge script did not output deployment result');
-  }
-  logger.info(`Deployed L1 contracts with L1 addresses: ${jsonStringify(result)}`);
+  // Copy cache to temp location to avoid conflicts when running forge in parallel
+  const tempCachePath = await copyFoundryCacheToTemp(l1ContractsPath);
 
-  const rollup = new RollupContract(l1Client, result.rollupAddress);
+  try {
+    // From heuristic testing. More caused issues with anvil.
+    const MAGIC_ANVIL_BATCH_SIZE = 12;
+    // Anvil seems to stall with unbounded batch size. Otherwise no max batch size is desirable.
+    // On sepolia and mainnet, we verify on etherscan (if etherscan API key is in env)
+    const forgeArgs = [
+      'script',
+      FORGE_SCRIPT,
+      '--sig',
+      'run()',
+      '--private-key',
+      privateKey,
+      '--rpc-url',
+      rpcUrl,
+      '--broadcast',
+      ...(chainId === foundry.id ? ['--batch-size', MAGIC_ANVIL_BATCH_SIZE.toString()] : []),
+      ...(verifyContracts ? ['--verify'] : []),
+    ];
+    const forgeEnv = {
+      // Protect against root leaving deployment files in docker that cannot be used later.
+      FOUNDRY_BROADCAST: process.getuid?.() === 0 ? 'broadcast-root' : tempCachePath,
+      // Env vars required by l1-contracts/script/deploy/DeploymentConfiguration.sol.
+      NETWORK: getActiveNetworkName(),
+      FOUNDRY_PROFILE: chainId === mainnet.id ? 'production' : undefined,
+      FOUNDRY_CACHE_PATH: tempCachePath,
+      ...getDeployAztecL1ContractsEnvVars(args),
+    };
+    const result = await runProcess<ForgeL1ContractsDeployResult>('forge', forgeArgs, forgeEnv, l1ContractsPath);
+    if (!result) {
+      throw new Error('Forge script did not output deployment result');
+    }
+    logger.info(`Deployed L1 contracts with L1 addresses: ${jsonStringify(result)}`);
 
-  if (isAnvilTestChain(chainId)) {
-    // @note  We make a time jump PAST the very first slot to not have to deal with the edge case of the first slot.
-    //        The edge case being that the genesis block is already occupying slot 0, so we cannot have another block.
-    try {
-      // Need to get the time
-      const currentSlot = await rollup.getSlotNumber();
+    const rollup = new RollupContract(l1Client, result.rollupAddress);
 
-      if (currentSlot === 0) {
-        const ts = Number(await rollup.getTimestampForSlot(SlotNumber(1)));
-        await rpcCall('evm_setNextBlockTimestamp', [ts]);
-        await rpcCall('hardhat_mine', [1]);
+    if (isAnvilTestChain(chainId)) {
+      // @note  We make a time jump PAST the very first slot to not have to deal with the edge case of the first slot.
+      //        The edge case being that the genesis block is already occupying slot 0, so we cannot have another block.
+      try {
+        // Need to get the time
         const currentSlot = await rollup.getSlotNumber();
 
-        if (currentSlot !== 1) {
-          throw new Error(`Error jumping time: current slot is ${currentSlot}`);
-        }
-        logger.info(`Jumped to slot 1`);
-      }
-    } catch (e) {
-      throw new Error(`Error jumping time: ${e}`);
-    }
-  }
+        if (currentSlot === 0) {
+          const ts = Number(await rollup.getTimestampForSlot(SlotNumber(1)));
+          await rpcCall('evm_setNextBlockTimestamp', [ts]);
+          await rpcCall('hardhat_mine', [1]);
+          const currentSlot = await rollup.getSlotNumber();
 
-  return {
-    l1Client,
-    rollupVersion: result.rollupVersion,
-    l1ContractAddresses: {
-      rollupAddress: EthAddress.fromString(result.rollupAddress),
-      registryAddress: EthAddress.fromString(result.registryAddress),
-      inboxAddress: EthAddress.fromString(result.inboxAddress),
-      outboxAddress: EthAddress.fromString(result.outboxAddress),
-      feeJuiceAddress: EthAddress.fromString(result.feeAssetAddress),
-      feeJuicePortalAddress: EthAddress.fromString(result.feeJuicePortalAddress),
-      coinIssuerAddress: EthAddress.fromString(result.coinIssuerAddress),
-      rewardDistributorAddress: EthAddress.fromString(result.rewardDistributorAddress),
-      governanceProposerAddress: EthAddress.fromString(result.governanceProposerAddress),
-      governanceAddress: EthAddress.fromString(result.governanceAddress),
-      stakingAssetAddress: EthAddress.fromString(result.stakingAssetAddress),
-      slashFactoryAddress: result.slashFactoryAddress ? EthAddress.fromString(result.slashFactoryAddress) : undefined,
-      feeAssetHandlerAddress: result.feeAssetHandlerAddress
-        ? EthAddress.fromString(result.feeAssetHandlerAddress)
-        : undefined,
-      stakingAssetHandlerAddress: result.stakingAssetHandlerAddress
-        ? EthAddress.fromString(result.stakingAssetHandlerAddress)
-        : undefined,
-      zkPassportVerifierAddress: result.zkPassportVerifierAddress
-        ? EthAddress.fromString(result.zkPassportVerifierAddress)
-        : undefined,
-      gseAddress: result.gseAddress ? EthAddress.fromString(result.gseAddress) : undefined,
-      dateGatedRelayerAddress: result.dateGatedRelayerAddress
-        ? EthAddress.fromString(result.dateGatedRelayerAddress)
-        : undefined,
-    },
-  };
+          if (currentSlot !== 1) {
+            throw new Error(`Error jumping time: current slot is ${currentSlot}`);
+          }
+          logger.info(`Jumped to slot 1`);
+        }
+      } catch (e) {
+        throw new Error(`Error jumping time: ${e}`);
+      }
+    }
+
+    return {
+      l1Client,
+      rollupVersion: result.rollupVersion,
+      l1ContractAddresses: {
+        rollupAddress: EthAddress.fromString(result.rollupAddress),
+        registryAddress: EthAddress.fromString(result.registryAddress),
+        inboxAddress: EthAddress.fromString(result.inboxAddress),
+        outboxAddress: EthAddress.fromString(result.outboxAddress),
+        feeJuiceAddress: EthAddress.fromString(result.feeAssetAddress),
+        feeJuicePortalAddress: EthAddress.fromString(result.feeJuicePortalAddress),
+        coinIssuerAddress: EthAddress.fromString(result.coinIssuerAddress),
+        rewardDistributorAddress: EthAddress.fromString(result.rewardDistributorAddress),
+        governanceProposerAddress: EthAddress.fromString(result.governanceProposerAddress),
+        governanceAddress: EthAddress.fromString(result.governanceAddress),
+        stakingAssetAddress: EthAddress.fromString(result.stakingAssetAddress),
+        slashFactoryAddress: result.slashFactoryAddress ? EthAddress.fromString(result.slashFactoryAddress) : undefined,
+        feeAssetHandlerAddress: result.feeAssetHandlerAddress
+          ? EthAddress.fromString(result.feeAssetHandlerAddress)
+          : undefined,
+        stakingAssetHandlerAddress: result.stakingAssetHandlerAddress
+          ? EthAddress.fromString(result.stakingAssetHandlerAddress)
+          : undefined,
+        zkPassportVerifierAddress: result.zkPassportVerifierAddress
+          ? EthAddress.fromString(result.zkPassportVerifierAddress)
+          : undefined,
+        gseAddress: result.gseAddress ? EthAddress.fromString(result.gseAddress) : undefined,
+        dateGatedRelayerAddress: result.dateGatedRelayerAddress
+          ? EthAddress.fromString(result.dateGatedRelayerAddress)
+          : undefined,
+      },
+    };
+  } finally {
+    await rm(tempCachePath, { recursive: true, force: true });
+  }
 }
 
 export const DEPLOYER_ADDRESS: Hex = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
@@ -513,39 +534,46 @@ export const deployRollupForUpgrade = async (
   const FORGE_SCRIPT = 'script/deploy/DeployRollupForUpgrade.s.sol';
   await maybeForgeForceProductionBuild(l1ContractsPath, FORGE_SCRIPT, chainId);
 
-  const forgeArgs = [
-    'script',
-    FORGE_SCRIPT,
-    '--sig',
-    'run()',
-    '--private-key',
-    privateKey,
-    '--rpc-url',
-    rpcUrl,
-    '--broadcast',
-  ];
-  const forgeEnv = {
-    // Protect against root leaving deployment files in docker that cannot be used later.
-    FOUNDRY_BROADCAST: process.getuid?.() === 0 ? 'broadcast-root' : undefined,
-    FOUNDRY_PROFILE: chainId === mainnet.id ? 'production' : undefined,
-    // Env vars required by l1-contracts/script/deploy/RollupConfiguration.sol.
-    REGISTRY_ADDRESS: registryAddress.toString(),
-    NETWORK: getActiveNetworkName(),
-    ...getDeployRollupForUpgradeEnvVars(args),
-  };
+  // Copy cache to temp location to avoid conflicts when running forge in parallel
+  const tempCachePath = await copyFoundryCacheToTemp(l1ContractsPath);
 
-  const result = await runProcess<ForgeRollupUpgradeResult>('forge', forgeArgs, forgeEnv, l1ContractsPath);
-  if (!result) {
-    throw new Error('Forge script did not output deployment result');
+  try {
+    const forgeArgs = [
+      'script',
+      FORGE_SCRIPT,
+      '--sig',
+      'run()',
+      '--private-key',
+      privateKey,
+      '--rpc-url',
+      rpcUrl,
+      '--broadcast',
+    ];
+    const forgeEnv = {
+      FOUNDRY_PROFILE: chainId === mainnet.id ? 'production' : undefined,
+      // Env vars required by l1-contracts/script/deploy/RollupConfiguration.sol.
+      REGISTRY_ADDRESS: registryAddress.toString(),
+      NETWORK: getActiveNetworkName(),
+      FOUNDRY_CACHE_PATH: tempCachePath,
+      FOUNDRY_BROADCAST: tempCachePath,
+      ...getDeployRollupForUpgradeEnvVars(args),
+    };
+
+    const result = await runProcess<ForgeRollupUpgradeResult>('forge', forgeArgs, forgeEnv, l1ContractsPath);
+    if (!result) {
+      throw new Error('Forge script did not output deployment result');
+    }
+
+    const extendedClient = createExtendedL1Client([rpcUrl], privateKey);
+
+    // Create RollupContract wrapper for the deployed rollup
+    const rollup = new RollupContract(extendedClient, result.rollupAddress);
+
+    return {
+      rollup,
+      slashFactoryAddress: result.slashFactoryAddress,
+    };
+  } finally {
+    await rm(tempCachePath, { recursive: true, force: true });
   }
-
-  const extendedClient = createExtendedL1Client([rpcUrl], privateKey);
-
-  // Create RollupContract wrapper for the deployed rollup
-  const rollup = new RollupContract(extendedClient, result.rollupAddress);
-
-  return {
-    rollup,
-    slashFactoryAddress: result.slashFactoryAddress,
-  };
 };


### PR DESCRIPTION
Copy the foundry cache and deployments folder to a temporary location before running forge scripts to avoid conflicts when multiple deployments run in parallel. The cache folder is small metadata that links to the out folder, so copying this is a fast operation.