### PR TITLE
chore: keccak native implementation audit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/README.md
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/README.md
@@ -1,0 +1,43 @@
+# Keccak
+This module implements **Keccak-256** based on the **Keccak-f[1600]** permutation.
+It uses **capacity = 512 bits**, **rate = 1088 bits** (1600=rate+capacity) and the **Keccak domain suffix `0x01`** (not the SHA-3 `0x06`).
+This module includes:
+- Keccak-f[1600] permutation (`ethash_keccakf1600`) over a 1600-bit state (25 lanes of 64-bits each).
+- A Keccak-256 hash function (`ethash_keccak256`).
+
+
+## Specification
+- NIST FIPS 202: defines Keccak-f[1600] (as KECCAK-p[1600,24]) and the sponge construction.
+  - https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf
+
+
+## Overview
+
+**Keccak-f[1600] Permutation** (24 Rounds)
+
+Operates on a 1600-bit state (which is 25 lanes of 64 bits each). The state is represented as a 5×5 matrix of 64-bit lanes `A[x,y]` for `x,y ∈ {0,1,2,3,4}`, where `state[5*y + x]` corresponds to lane `A[x,y]`.
+
+Each round applies the following five steps. All indices are taken modulo 5.
+
+1. **θ (Theta):** compute column parities `C[x] = A[x,0] ⊕ A[x,1] ⊕ A[x,2] ⊕ A[x,3] ⊕ A[x,4]`, then `D[x] = C[x−1] ⊕ ROT(C[x+1], 1)`, and update every lane: `A[x,y] = A[x,y] ⊕ D[x]`.
+2. **ρ (Rho):** rotate each lane by a fixed offset, i.e., `A[x,y] = ROT(A[x,y], r[x,y])`.
+3. **π (Pi):** permute lane positions by moving lane at position `[x,y]` to `[y, (2x + 3y)]`.
+4. **χ (Chi):** apply non-linear operations in each row, i.e., `A[x,y] = B[x,y] ⊕ ((¬B[x+1,y]) ∧ B[x+2,y])`. Here `B` is the output after applying π.
+5. **ι (Iota):** XOR the round constant into lane (0,0), i.e., `A[0,0] = A[0,0] ⊕ RC[round]`.
+
+**Keccak-256**
+
+1. Initialize a 1600-bit state to zero.
+2. Absorb the input message in 136-byte blocks (136 bytes = 1088-bit rate), XORing each block into the state and applying Keccak-f[1600] after every full block.
+3. Apply padding using Keccak pad10*1 with suffix `0x01`. That is, append byte `0x01` after the final message byte, pad with zeros to the last bit of the 136-byte block, set the final bit to `1`. All lanes are 64-bit little-endian words.
+4. Apply a final Keccak-f[1600] permutation.
+5. Output the first 32 bytes of state.
+
+
+## Test Vectors
+Test vectors generated using the keccak reference implementation (https://github.com/XKCP/XKCP) for testing the Keccak-f[1600] (`ethash_keccakf1600`) permutation.
+- Input state: all zero
+- Input state: all zero except `state[7] = 0x01`
+- Input state: random
+
+For testing Keccak-256, we use commonly used test vectors for ASCII messages "" and "abc".

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/hash_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/hash_types.hpp
@@ -17,8 +17,14 @@
 extern "C" {
 #endif
 
+enum {
+    KECCAKF1600_LANES = 25,
+    KECCAKF1600_ROUNDS = 24,
+    KECCAK256_OUTPUT_BYTES = 32,
+    KECCAK256_OUTPUT_WORDS = 4 // 4 * 64 = 256 bits
+};
 struct keccak256 {
-    uint64_t word64s[4];
+    uint64_t word64s[KECCAK256_OUTPUT_WORDS];
 };
 
 #ifdef __cplusplus

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.cpp
@@ -65,7 +65,7 @@ static inline void keccak(uint64_t* out, size_t bits, const uint8_t* data, size_
     uint64_t last_word = 0;
     uint8_t* last_word_iter = (uint8_t*)&last_word;
 
-    uint64_t state[25] = { 0 };
+    uint64_t state[KECCAKF1600_LANES] = { 0 };
 
     while (size >= block_size) {
         for (i = 0; i < (block_size / word_size); ++i) {
@@ -113,11 +113,11 @@ struct keccak256 ethash_keccak256(const uint8_t* data, size_t size) NOEXCEPT
 
 struct keccak256 hash_field_elements(const uint64_t* limbs, size_t num_elements)
 {
-    uint8_t input_buffer[num_elements * 32];
+    uint8_t input_buffer[num_elements * KECCAK256_OUTPUT_BYTES];
 
     for (size_t i = 0; i < num_elements; ++i) {
-        for (size_t j = 0; j < 4; ++j) {
-            uint64_t word = (limbs[i * 4 + j]);
+        for (size_t j = 0; j < KECCAK256_OUTPUT_WORDS; ++j) {
+            uint64_t word = (limbs[i * KECCAK256_OUTPUT_WORDS + j]);
             size_t idx = i * 32 + j * 8;
             input_buffer[idx] = (uint8_t)((word >> 56) & 0xff);
             input_buffer[idx + 1] = (uint8_t)((word >> 48) & 0xff);
@@ -130,7 +130,7 @@ struct keccak256 hash_field_elements(const uint64_t* limbs, size_t num_elements)
         }
     }
 
-    return ethash_keccak256(input_buffer, num_elements * 32);
+    return ethash_keccak256(input_buffer, num_elements * KECCAK256_OUTPUT_BYTES);
 }
 
 struct keccak256 hash_field_element(const uint64_t* limb)

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.hpp
@@ -29,14 +29,14 @@ extern "C" {
 #endif
 
 /**
- * The Keccak-f[1600] function.
+ * The Keccak-f[1600] function (FIPS 202 Section 3: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf)).
  *
  * The implementation of the Keccak-f function with 1600-bit width of the permutation (b).
  * The size of the state is also 1600 bit what gives 25 64-bit words.
  *
  * @param state  The state of 25 64-bit words on which the permutation is to be performed.
  */
-void ethash_keccakf1600(uint64_t state[25]) NOEXCEPT;
+void ethash_keccakf1600(uint64_t state[KECCAKF1600_LANES]) NOEXCEPT;
 
 struct keccak256 ethash_keccak256(const uint8_t* data, size_t size) NOEXCEPT;
 
@@ -63,9 +63,9 @@ class Keccak {
                 word = __builtin_bswap64(word);
             }
         }
-        std::array<uint8_t, 32> result;
+        std::array<uint8_t, KECCAK256_OUTPUT_BYTES> result;
 
-        for (size_t i = 0; i < 4; ++i) {
+        for (size_t i = 0; i < KECCAK256_OUTPUT_WORDS; ++i) {
             for (size_t j = 0; j < 8; ++j) {
                 uint8_t byte = static_cast<uint8_t>(hash_result.word64s[i] >> (56 - (j * 8)));
                 result[i * 8 + j] = byte;

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.test.cpp
@@ -1,0 +1,134 @@
+#include "keccak.hpp"
+#include <algorithm>
+#include <array>
+#include <gtest/gtest.h>
+#include <vector>
+
+struct KeccakF1600TestVector {
+    std::array<uint64_t, KECCAKF1600_LANES> input;
+    std::array<uint64_t, KECCAKF1600_LANES> expected;
+};
+
+struct Keccak256TestVector {
+    std::string input;
+    std::array<uint8_t, KECCAK256_OUTPUT_BYTES> output;
+};
+
+const std::vector<KeccakF1600TestVector> keccak_f1600_test_vectors = {
+    {
+        // Test vector 0: input state all zeros
+        // input
+        {
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+            0x0000000000000000ULL,
+        },
+        // expected
+        {
+            0xf1258f7940e1dde7ULL, 0x84d5ccf933c0478aULL, 0xd598261ea65aa9eeULL, 0xbd1547306f80494dULL,
+            0x8b284e056253d057ULL, 0xff97a42d7f8e6fd4ULL, 0x90fee5a0a44647c4ULL, 0x8c5bda0cd6192e76ULL,
+            0xad30a6f71b19059cULL, 0x30935ab7d08ffc64ULL, 0xeb5aa93f2317d635ULL, 0xa9a6e6260d712103ULL,
+            0x81a57c16dbcf555fULL, 0x43b831cd0347c826ULL, 0x01f22f1a11a5569fULL, 0x05e5635a21d9ae61ULL,
+            0x64befef28cc970f2ULL, 0x613670957bc46611ULL, 0xb87c5a554fd00ecbULL, 0x8c3ee88a1ccf32c8ULL,
+            0x940c7922ae3a2614ULL, 0x1841f924a2c509e4ULL, 0x16f53526e70465c2ULL, 0x75f644e97f30a13bULL,
+            0xeaf1ff7b5ceca249ULL,
+        },
+    },
+    { // Test vector 1: input state all zeros except state[7] = 0x01
+      // input
+      {
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000001ULL,
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+          0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+          0x0000000000000000ULL,
+      },
+      // expected
+      {
+          0xf89fa1b0580a15baULL, 0xd09a0e1fda1679c7ULL, 0x35c3440aa6048cf2ULL, 0x115ec7b0307f2c7eULL,
+          0xe93033174ca2f73eULL, 0xfd7ed47fd5d55ec7ULL, 0xe2ebf004ed0a6afeULL, 0x5a202cba857c67ceULL,
+          0x7d450ddf1f7fce46ULL, 0x21df2dba060c98c9ULL, 0x563f49c5d4bba6a6ULL, 0xe5aa838dfa9578c3ULL,
+          0xdab8f71a22c0aa76ULL, 0x562d3489202a07f5ULL, 0xd07fe4ba0ab87adbULL, 0xece257bfaa08ed0aULL,
+          0xe5b2e12fd47b1f72ULL, 0x9b57fac2e804d61dULL, 0xf348aaa3db7cb967ULL, 0xe4c6816eb6efdb4fULL,
+          0x07e0b2874d9145faULL, 0xfc862e157895914aULL, 0x46f97e688195e6d6ULL, 0xb14d54e0e18737e1ULL,
+          0x6c917bce823be510ULL,
+      } },
+    { // Test vector 2: input state random
+      {
+          0xb927c455c848e162ULL, 0x99aab6305b0c67d2ULL, 0x86c82d9206ff9d10ULL, 0xc62e1591b3acb97cULL,
+          0xd71eb61789837849ULL, 0x1fcae52e1d26b374ULL, 0x5f73f05bbb082416ULL, 0x1106dcfa15d4b341ULL,
+          0xbd1858ca046cca90ULL, 0x3f8b5d62c30ded2dULL, 0x08c41b1679d0e830ULL, 0xa0be02df11a1ea1aULL,
+          0xdcf2f941dacba0eaULL, 0x08dc689cf04dadafULL, 0x9de4c75553d27c26ULL, 0xfba269f116eb1fa9ULL,
+          0x10a26a79d4dda06eULL, 0xdaa0c44ecce5d0aaULL, 0x01845349df0d7282ULL, 0xeaac21cc0f520303ULL,
+          0x040bd46202ffbbcdULL, 0xbebbf2bad6e9c728ULL, 0xadc7181f4d10a5d8ULL, 0x74cc9d08ae6e48daULL,
+          0x56f23161f5de8aa9ULL,
+      },
+      // expected
+      { 0x89ecaa6d735e24ffULL, 0x15851a3b6a301aeeULL, 0xe1bc8595b9acf21eULL, 0x319e186ff7ee8bf4ULL,
+        0x067037274566661dULL, 0x1982160201e28fcfULL, 0xca244e5297f9467dULL, 0xde2ca967a1fd94f9ULL,
+        0x79805a6aa693d2a8ULL, 0x378a7b61abcd5da6ULL, 0xf13f9d48362d6f44ULL, 0x7fd8ca2daeb5ec04ULL,
+        0x7ce2588f4928cab2ULL, 0xb0c80460f1abda2bULL, 0x5f7d9e14b9f92a4eULL, 0x8a2c71fb0603a8b3ULL,
+        0xe69ac90deb369296ULL, 0x4379ca48a4f4ab70ULL, 0xfe25c7dcc34ad624ULL, 0x9451f94dc25ecd1fULL,
+        0x100b88567c225f0aULL, 0xca3baa05c1ab1617ULL, 0x10770385dfd6e43aULL, 0x95a9348911968c9bULL,
+        0x748483f6e42a8fecULL } }
+};
+
+const std::vector<Keccak256TestVector> keccak256_test_vectors = {
+    { "", { 0xC5ULL, 0xD2ULL, 0x46ULL, 0x01ULL, 0x86ULL, 0xF7ULL, 0x23ULL, 0x3CULL, 0x92ULL, 0x7EULL, 0x7DULL,
+            0xB2ULL, 0xDCULL, 0xC7ULL, 0x03ULL, 0xC0ULL, 0xE5ULL, 0x00ULL, 0xB6ULL, 0x53ULL, 0xCAULL, 0x82ULL,
+            0x27ULL, 0x3BULL, 0x7BULL, 0xFAULL, 0xD8ULL, 0x04ULL, 0x5DULL, 0x85ULL, 0xA4ULL, 0x70ULL } },
+    { "abc", { 0x4EULL, 0x03ULL, 0x65ULL, 0x7AULL, 0xEAULL, 0x45ULL, 0xA9ULL, 0x4FULL, 0xC7ULL, 0xD4ULL, 0x7BULL,
+               0xA8ULL, 0x26ULL, 0xC8ULL, 0xD6ULL, 0x67ULL, 0xC0ULL, 0xD1ULL, 0xE6ULL, 0xE3ULL, 0x3AULL, 0x64ULL,
+               0xA0ULL, 0x36ULL, 0xECULL, 0x44ULL, 0xF5ULL, 0x8FULL, 0xA1ULL, 0x2DULL, 0x6CULL, 0x45ULL } },
+};
+
+TEST(misc_keccak, permutation_test)
+{
+    for (size_t i = 0; i < keccak_f1600_test_vectors.size(); ++i) {
+        const auto& test_vec = keccak_f1600_test_vectors[i];
+
+        // Copy input into state array
+        std::array<uint64_t, KECCAKF1600_LANES> state;
+        std::copy(test_vec.input.begin(), test_vec.input.end(), state.begin());
+
+        // Run the permutation
+        ethash_keccakf1600(state.data());
+
+        // Check the output against expected
+        for (size_t j = 0; j < KECCAKF1600_LANES; ++j) {
+            EXPECT_EQ(state[j], test_vec.expected[j]) << "Mismatch in test vector " << i << " at lane " << j;
+        }
+    }
+}
+
+TEST(misc_keccak, keccak256_test)
+{
+    for (const auto& v : keccak256_test_vectors) {
+        std::vector<uint8_t> input(v.input.begin(), v.input.end());
+
+        keccak256 hash_result = ethash_keccak256(input.data(), input.size());
+
+        for (auto& word : hash_result.word64s) {
+            if (is_little_endian()) {
+                word = __builtin_bswap64(word);
+            }
+        }
+
+        std::array<uint8_t, KECCAK256_OUTPUT_BYTES> result;
+
+        for (size_t i = 0; i < KECCAK256_OUTPUT_WORDS; ++i) {
+            for (size_t j = 0; j < 8; ++j) {
+                uint8_t byte = static_cast<uint8_t>(hash_result.word64s[i] >> (56 - (j * 8)));
+                result[i * 8 + j] = byte;
+            }
+        }
+
+        EXPECT_EQ(result, v.output);
+    }
+}

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccak.test.cpp
@@ -14,6 +14,8 @@ struct Keccak256TestVector {
     std::array<uint8_t, KECCAK256_OUTPUT_BYTES> output;
 };
 
+// Test vectors generated using the keccak reference implementation (https://github.com/XKCP/XKCP) for testing the
+// Keccak-f[1600] permutation.
 const std::vector<KeccakF1600TestVector> keccak_f1600_test_vectors = {
     {
         // Test vector 0: input state all zeros

--- a/barretenberg/cpp/src/barretenberg/crypto/keccak/keccakf1600.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/keccak/keccakf1600.cpp
@@ -14,10 +14,10 @@
 
 static uint64_t rol(uint64_t x, unsigned s)
 {
-    return (x << s) | (x >> (64 - s));
+    return (s == 0) ? x : ((x << s) | (x >> (64 - s)));
 }
 
-static const uint64_t round_constants[24] = {
+static const uint64_t round_constants[KECCAKF1600_ROUNDS] = {
     0x0000000000000001, 0x0000000000008082, 0x800000000000808a, 0x8000000080008000, 0x000000000000808b,
     0x0000000080000001, 0x8000000080008081, 0x8000000000008009, 0x000000000000008a, 0x0000000000000088,
     0x0000000080008009, 0x000000008000000a, 0x000000008000808b, 0x800000000000008b, 0x8000000000008089,
@@ -25,12 +25,23 @@ static const uint64_t round_constants[24] = {
     0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
 };
 
-void ethash_keccakf1600(uint64_t state[25]) NOEXCEPT
+// Keccak-f[1600] permutation (24 rounds), i.e. KECCAK-p[1600,24] in FIPS 202. State is 25 lanes of 64 bits, indexed as
+// state[x + 5*y]. Lane byte order is little-endian (per Keccak conventions).
+// The following are the Rho rotation offsets for each lane:
+// {0,  1, 62, 28, 27,
+// 36, 44,  6, 55, 20,
+//  3, 10, 43, 25, 39,
+// 41, 45, 15, 21,  8,
+// 18,  2, 61, 56, 14}
+void ethash_keccakf1600(uint64_t state[KECCAKF1600_LANES]) NOEXCEPT
 {
     /* The implementation based on the "simple" implementation by Ronny Van Keer. */
 
     int round;
 
+    // A[x,y] = state[x + 5*y].
+    // Lane naming convention: Matrix A. Rows are {b,g,k,m,s} (i.e., y in {0,1,2,3,4}) and columns are {a,e,i,o,u}
+    // (i.e., x in {0,1,2,3,4}). For example, Aba = A[x=0,y=0], Abe = A[x=1,y=0].
     uint64_t Aba, Abe, Abi, Abo, Abu;
     uint64_t Aga, Age, Agi, Ago, Agu;
     uint64_t Aka, Ake, Aki, Ako, Aku;
@@ -73,7 +84,7 @@ void ethash_keccakf1600(uint64_t state[25]) NOEXCEPT
     Aso = state[23];
     Asu = state[24];
 
-    for (round = 0; round < 24; round += 2) {
+    for (round = 0; round < KECCAKF1600_ROUNDS; round += 2) {
         /* Round (round + 0): Axx -> Exx */
 
         Ba = Aba ^ Aga ^ Aka ^ Ama ^ Asa;


### PR DESCRIPTION
-add tests for `ethash_keccakf1600()` and `ethash_keccak256()`
-include README.md with spec details and overview of the algorithm
-include inline comments for clarity
-update numbers with appropriate named constants 
