### PR TITLE
chore: setup foundry

### DIFF
--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -79,6 +79,9 @@ jobs:
           terraform_version: "1.7.5"
           terraform_wrapper: false
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Setup spartan
         run: |
           ./spartan/scripts/install_deps.sh


### PR DESCRIPTION
Adds `setup-foundry` as a step before bootstrapping spartan. In the next PR I'll move cast installation to `install_deps`.