### PR TITLE
chore: Update TXE for new blocks

### DIFF
--- a/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2BlockNew } from '@aztec/stdlib/block';
 import { computePublicDataTreeLeafSlot, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import {
   MerkleTreeId,
@@ -124,7 +124,7 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
     return value;
   }
 
-  async close(): Promise<L2Block> {
+  async close(): Promise<L2BlockNew> {
     this.logger.debug('Exiting Public Context, building block with collected side effects', {
       blockNumber: this.globalVariables.blockNumber,
     });

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -141,7 +141,8 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
   }
 
   async txeGetLastTxEffects() {
-    const block = await this.stateMachine.archiver.getL2Block('latest');
+    const latestBlockNumber = await this.stateMachine.archiver.getBlockNumber();
+    const block = await this.stateMachine.archiver.getL2BlockNew(latestBlockNumber);
 
     if (block!.body.txEffects.length != 1) {
       // Note that calls like env.mine() will result in blocks with no transactions, hitting this

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -3,18 +3,18 @@ import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { isDefined } from '@aztec/foundation/types';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
-  CommitteeAttestation,
-  L2Block,
+  type CheckpointedL2Block,
+  type L2Block,
+  type L2BlockNew,
   type L2BlockSource,
   type L2Tips,
-  PublishedL2Block,
+  type PublishedL2Block,
   type ValidateBlockResult,
 } from '@aztec/stdlib/block';
-import { Checkpoint, type PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import type { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -28,20 +28,29 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     super(new KVArchiverDataStore(db, 9999));
   }
 
-  public async getBlock(number: BlockNumber): Promise<L2Block | undefined> {
+  /**
+   * Gets an L2 block by block number.
+   * @param number - The block number to return.
+   * @returns The requested L2 block (or undefined if not found).
+   */
+  public async getL2BlockNew(number: BlockNumber): Promise<L2BlockNew | undefined> {
+    if (number < 0) {
+      number = await this.store.getLatestBlockNumber();
+    }
     if (number === 0) {
       return undefined;
     }
-    const publishedBlocks = await this.getPublishedBlocks(number, 1);
-    if (publishedBlocks.length === 0) {
-      return undefined;
-    }
-    return publishedBlocks[0].block;
+    return this.store.getBlock(number);
   }
 
-  public async getBlocks(from: BlockNumber, limit: number, proven?: boolean): Promise<L2Block[]> {
-    const publishedBlocks = await this.getPublishedBlocks(from, limit, proven);
-    return publishedBlocks.map(x => x.block);
+  /**
+   * Gets a checkpointed L2 block by block number.
+   * Returns undefined if the block doesn't exist or hasn't been checkpointed yet.
+   * @param number - The block number to retrieve.
+   * @returns The requested checkpointed L2 block (or undefined if not found or not checkpointed).
+   */
+  public override getCheckpointedBlock(number: BlockNumber): Promise<CheckpointedL2Block | undefined> {
+    return this.store.getCheckpointedBlock(number);
   }
 
   public override async addCheckpoints(
@@ -71,71 +80,6 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
   }
 
   /**
-   * Gets a published l2 block. If a negative number is passed, the block returned is the most recent.
-   * @param number - The block number to return (inclusive).
-   * @returns The requested L2 block.
-   */
-  public async getPublishedBlock(number: number): Promise<PublishedL2Block | undefined> {
-    // If the number provided is -ve, then return the latest block.
-    if (number < 0) {
-      number = await this.store.getLatestBlockNumber();
-    }
-    if (number == 0) {
-      return undefined;
-    }
-    const publishedBlocks = await this.retrievePublishedBlocks(BlockNumber(number), 1);
-    return publishedBlocks.length === 0 ? undefined : publishedBlocks[0];
-  }
-
-  getPublishedBlocks(from: BlockNumber, limit: number, proven?: boolean): Promise<PublishedL2Block[]> {
-    return this.retrievePublishedBlocks(from, limit, proven);
-  }
-
-  private async retrievePublishedBlocks(
-    from: BlockNumber,
-    limit: number,
-    proven?: boolean,
-  ): Promise<PublishedL2Block[]> {
-    const checkpoints = await this.store.getRangeOfCheckpoints(CheckpointNumber(from), limit);
-    const provenCheckpointNumber = await this.store.getProvenCheckpointNumber();
-    const blocks = (
-      await Promise.all(checkpoints.map(ch => this.store.getBlocksForCheckpoint(ch.checkpointNumber)))
-    ).filter(isDefined);
-
-    const olbBlocks: PublishedL2Block[] = [];
-    for (let i = 0; i < checkpoints.length; i++) {
-      const blockForCheckpoint = blocks[i][0];
-      const checkpoint = checkpoints[i];
-      if (proven === true && checkpoint.checkpointNumber > provenCheckpointNumber) {
-        continue;
-      }
-      const oldCheckpoint = new Checkpoint(
-        blockForCheckpoint.archive,
-        checkpoint.header,
-        [blockForCheckpoint],
-        checkpoint.checkpointNumber,
-      );
-      const oldBlock = L2Block.fromCheckpoint(oldCheckpoint);
-      const publishedBlock = new PublishedL2Block(
-        oldBlock,
-        checkpoint.l1,
-        checkpoint.attestations.map(x => CommitteeAttestation.fromBuffer(x)),
-      );
-      olbBlocks.push(publishedBlock);
-    }
-    return olbBlocks;
-  }
-
-  /**
-   * Gets an l2 block. If a negative number is passed, the block returned is the most recent.
-   * @param number - The block number to return (inclusive).
-   * @returns The requested L2 block.
-   */
-  public getL2Block(number: BlockNumber | 'latest'): Promise<L2Block | undefined> {
-    return this.getPublishedBlock(number != 'latest' ? number : -1).then(b => b?.block);
-  }
-
-  /**
    * Gets an l2 block header.
    * @param number - The block number to return or 'latest' for the most recent one.
    * @returns The requested L2 block header.
@@ -149,10 +93,6 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     }
     const headers = await this.store.getBlockHeaders(BlockNumber(number), 1);
     return headers.length === 0 ? undefined : headers[0];
-  }
-
-  public getBlockRange(from: number, limit: number, _proven?: boolean): Promise<L2Block[]> {
-    return this.getPublishedBlocks(BlockNumber(from), limit).then(blocks => blocks.map(b => b.block));
   }
 
   public getPublishedCheckpoints(_from: CheckpointNumber, _limit: number): Promise<PublishedCheckpoint[]> {
@@ -175,10 +115,6 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     throw new Error('TXE Archiver does not implement "getCheckpointsForEpoch"');
   }
 
-  public getBlocksForEpoch(_epochNumber: EpochNumber): Promise<L2Block[]> {
-    throw new Error('TXE Archiver does not implement "getBlocksForEpoch"');
-  }
-
   public getBlockHeadersForEpoch(_epochNumber: EpochNumber): Promise<BlockHeader[]> {
     throw new Error('TXE Archiver does not implement "getBlockHeadersForEpoch"');
   }
@@ -192,7 +128,7 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
   }
 
   public getL1Constants(): Promise<L1RollupConstants> {
-    throw new Error('TXE Archiver does not implement "getL2Constants"');
+    throw new Error('TXE Archiver does not implement "getL1Constants"');
   }
 
   public getGenesisValues(): Promise<{ genesisArchiveRoot: Fr }> {
@@ -227,10 +163,29 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
     return Promise.resolve({ valid: true });
   }
 
-  getPublishedBlockByHash(_blockHash: Fr): Promise<PublishedL2Block | undefined> {
-    throw new Error('Method not implemented.');
+  /* Legacy APIs - These return L2Block/PublishedL2Block types which are deprecated */
+
+  public getBlock(_number: BlockNumber): Promise<L2Block | undefined> {
+    throw new Error('TXE Archiver does not implement legacy "getBlock" - use getL2BlockNew instead');
   }
-  getPublishedBlockByArchive(_archive: Fr): Promise<PublishedL2Block | undefined> {
-    throw new Error('Method not implemented.');
+
+  public getBlocks(_from: BlockNumber, _limit: number, _proven?: boolean): Promise<L2Block[]> {
+    throw new Error('TXE Archiver does not implement legacy "getBlocks" - use getCheckpointedBlock instead');
+  }
+
+  public getPublishedBlocks(_from: BlockNumber, _limit: number, _proven?: boolean): Promise<PublishedL2Block[]> {
+    throw new Error('TXE Archiver does not implement legacy "getPublishedBlocks" - use getCheckpointedBlock instead');
+  }
+
+  public getBlocksForEpoch(_epochNumber: EpochNumber): Promise<L2Block[]> {
+    throw new Error('TXE Archiver does not implement "getBlocksForEpoch"');
+  }
+
+  public getPublishedBlockByHash(_blockHash: Fr): Promise<PublishedL2Block | undefined> {
+    throw new Error('TXE Archiver does not implement "getPublishedBlockByHash"');
+  }
+
+  public getPublishedBlockByArchive(_archive: Fr): Promise<PublishedL2Block | undefined> {
+    throw new Error('TXE Archiver does not implement "getPublishedBlockByArchive"');
   }
 }

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -5,14 +5,14 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import {
-  type CheckpointedL2Block,
-  type L2Block,
-  type L2BlockNew,
-  type L2BlockSource,
-  type L2Tips,
-  type PublishedL2Block,
-  type ValidateBlockResult,
+import type {
+  CheckpointedL2Block,
+  L2Block,
+  L2BlockNew,
+  L2BlockSource,
+  L2Tips,
+  PublishedL2Block,
+  ValidateBlockResult,
 } from '@aztec/stdlib/block';
 import type { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -1,11 +1,14 @@
 import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { AnchorBlockDataProvider } from '@aztec/pxe/server';
-import { L2Block } from '@aztec/stdlib/block';
-import { L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import type { L2BlockNew } from '@aztec/stdlib/block';
+import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { ContentCommitment } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 
 import { TXEArchiver } from './archiver.js';
@@ -58,21 +61,39 @@ export class TXEStateMachine {
     return new this(node, synchronizer, archiver, anchorBlockDataProvider);
   }
 
-  public async handleL2Block(block: L2Block) {
-    const checkpoint = block.toCheckpoint();
+  public async handleL2Block(block: L2BlockNew) {
+    const { header, archive, checkpointNumber } = block;
+    const { globalVariables, totalManaUsed, lastArchive } = header;
+
+    // Create a CheckpointHeader from the block's header
+    const checkpointHeader = new CheckpointHeader(
+      lastArchive.root,
+      Fr.ZERO, // blockHeadersHash - not used in TXE
+      ContentCommitment.empty(), // contentCommitment - not used in TXE
+      globalVariables.slotNumber,
+      globalVariables.timestamp,
+      globalVariables.coinbase,
+      globalVariables.feeRecipient,
+      globalVariables.gasFees,
+      totalManaUsed,
+    );
+
+    const checkpoint = new Checkpoint(archive, checkpointHeader, [block], checkpointNumber);
+
     const publishedCheckpoint = new PublishedCheckpoint(
       checkpoint,
       new L1PublishedData(
-        BigInt(block.header.globalVariables.blockNumber),
-        block.header.globalVariables.timestamp,
-        block.header.globalVariables.blockNumber.toString(),
+        BigInt(globalVariables.blockNumber),
+        globalVariables.timestamp,
+        globalVariables.blockNumber.toString(),
       ),
       [],
     );
+
     await Promise.all([
-      this.synchronizer.handleL2Block(block.toL2Block()),
+      this.synchronizer.handleL2Block(block),
       this.archiver.addCheckpoints([publishedCheckpoint], undefined),
-      this.anchorBlockDataProvider.setHeader(block.getBlockHeader()),
+      this.anchorBlockDataProvider.setHeader(header),
     ]);
   }
 }

--- a/yarn-project/txe/src/utils/block_creation.ts
+++ b/yarn-project/txe/src/utils/block_creation.ts
@@ -4,13 +4,12 @@ import {
   NULLIFIER_SUBTREE_HEIGHT,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
 } from '@aztec/constants';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Body, L2Block, L2BlockHeader } from '@aztec/stdlib/block';
-import { makeContentCommitment } from '@aztec/stdlib/testing';
+import { Body, L2BlockNew } from '@aztec/stdlib/block';
 import { AppendOnlyTreeSnapshot, MerkleTreeId, type MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
-import { GlobalVariables, TxEffect } from '@aztec/stdlib/tx';
+import { BlockHeader, GlobalVariables, TxEffect } from '@aztec/stdlib/tx';
 
 /**
  * Returns a transaction request hash that is valid for transactions that are the only ones in a block.
@@ -47,24 +46,23 @@ export async function insertTxEffectIntoWorldTrees(
 export async function makeTXEBlockHeader(
   worldTrees: MerkleTreeWriteOperations,
   globalVariables: GlobalVariables,
-): Promise<L2BlockHeader> {
+): Promise<BlockHeader> {
   const stateReference = await worldTrees.getStateReference();
   const archiveInfo = await worldTrees.getTreeInfo(MerkleTreeId.ARCHIVE);
+  const lastArchive = new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size));
 
-  return new L2BlockHeader(
-    new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size)),
-    makeContentCommitment(),
+  return new BlockHeader(
+    lastArchive,
     stateReference,
+    Fr.ZERO, // spongeBlobHash
     globalVariables,
-    Fr.ZERO,
-    Fr.ZERO,
-    Fr.ZERO,
-    Fr.ZERO,
+    Fr.ZERO, // totalFees
+    Fr.ZERO, // totalManaUsed
   );
 }
 
 /**
- * Creates an L2Block with proper archive chaining.
+ * Creates an L2BlockNew with proper archive chaining.
  * This function:
  * 1. Gets the current archive state as lastArchive for the header
  * 2. Creates the block header
@@ -74,21 +72,24 @@ export async function makeTXEBlockHeader(
  * @param worldTrees - The world trees to read/write from
  * @param globalVariables - Global variables for the block
  * @param txEffects - Transaction effects to include in the block
- * @returns The created L2Block with proper archive chaining
+ * @returns The created L2BlockNew with proper archive chaining
  */
 export async function makeTXEBlock(
   worldTrees: MerkleTreeWriteOperations,
   globalVariables: GlobalVariables,
   txEffects: TxEffect[],
-): Promise<L2Block> {
+): Promise<L2BlockNew> {
   const header = await makeTXEBlockHeader(worldTrees, globalVariables);
 
   // Update the archive tree with this block's header hash
-  await worldTrees.updateArchive(header.toBlockHeader());
+  await worldTrees.updateArchive(header);
 
   // Get the new archive state after updating
   const newArchiveInfo = await worldTrees.getTreeInfo(MerkleTreeId.ARCHIVE);
   const newArchive = new AppendOnlyTreeSnapshot(new Fr(newArchiveInfo.root), Number(newArchiveInfo.size));
 
-  return new L2Block(newArchive, header, new Body(txEffects));
+  const blockNumber = globalVariables.blockNumber;
+  const checkpointNumber = CheckpointNumber.fromBlockNumber(blockNumber);
+
+  return new L2BlockNew(newArchive, header, new Body(txEffects), checkpointNumber, 0);
 }


### PR DESCRIPTION
This PR modifies the TXE to use the new L2 blocks types and APIs.
