### PR TITLE
refactor(bb): remove unused MSGPACK_FIELDS declarations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -289,31 +289,6 @@ class MegaFlavor {
         {
             return concatenate(WireEntities<DataType>::get_all(), DerivedEntities<DataType>::get_to_be_shifted());
         }
-
-        MSGPACK_FIELDS(this->w_l,
-                       this->w_r,
-                       this->w_o,
-                       this->w_4,
-                       this->z_perm,
-                       this->lookup_inverses,
-                       this->lookup_read_counts,
-                       this->lookup_read_tags,
-                       this->ecc_op_wire_1,
-                       this->ecc_op_wire_2,
-                       this->ecc_op_wire_3,
-                       this->ecc_op_wire_4,
-                       this->calldata,
-                       this->calldata_read_counts,
-                       this->calldata_read_tags,
-                       this->calldata_inverses,
-                       this->secondary_calldata,
-                       this->secondary_calldata_read_counts,
-                       this->secondary_calldata_read_tags,
-                       this->secondary_calldata_inverses,
-                       this->return_data,
-                       this->return_data_read_counts,
-                       this->return_data_read_tags,
-                       this->return_data_inverses);
     };
 
     // Default WitnessEntities alias

--- a/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/multilinear_batching_flavor.hpp
@@ -104,11 +104,6 @@ class MultilinearBatchingFlavor {
                               batched_unshifted_instance,    // column 1: batched unshifted poly for instance
                               eq_accumulator,                // column 2: eq(u, r_acc) - selects accumulator eval point
                               eq_instance);                  // column 3: eq(u, r_inst) - selects instance eval point
-
-        MSGPACK_FIELDS(this->batched_unshifted_accumulator,
-                       this->batched_unshifted_instance,
-                       this->eq_accumulator,
-                       this->eq_instance);
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
@@ -225,8 +225,6 @@ class UltraFlavor {
 
         auto get_wires() { return RefArray{ w_l, w_r, w_o, w_4 }; };
         auto get_to_be_shifted() { return RefArray{ w_l, w_r, w_o, w_4, z_perm }; };
-
-        MSGPACK_FIELDS(w_l, w_r, w_o, w_4, z_perm, lookup_inverses, lookup_read_counts, lookup_read_tags);
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/goblin/translation_evaluations.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/translation_evaluations.hpp
@@ -26,9 +26,6 @@ template <typename BF> struct TranslationEvaluations_ {
     std::array<std::string, NUM_TRANSLATION_EVALUATIONS> labels = {
         "Translation:op", "Translation:Px", "Translation:Py", "Translation:z1", "Translation:z2"
     };
-    ;
-
-    MSGPACK_FIELDS(op, Px, Py, z1, z2);
 };
 
 /**
@@ -39,8 +36,6 @@ template <typename FF> struct TranslatorInputData_ {
     FF evaluation_challenge_x;
     FF batching_challenge_v;
     FF accumulated_result;
-
-    MSGPACK_FIELDS(evaluation_challenge_x, batching_challenge_v, accumulated_result);
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/goblin/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/types.hpp
@@ -51,7 +51,6 @@ struct GoblinStdlibProof {
         , ipa_proof(builder, goblin_proof.ipa_proof)
         , translator_proof(builder, goblin_proof.translator_proof)
     {}
-    MSGPACK_FIELDS(merge_proof, eccvm_proof, ipa_proof, translator_proof);
     bool operator==(const GoblinStdlibProof& other) const = default;
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
@@ -13,13 +13,6 @@ namespace bb {
 
 using PublicInputsVector = std::vector<fr>;
 using HonkProof = std::vector<fr>;
-template <typename Proof> struct PublicInputsAndProof {
-    PublicInputsVector public_inputs;
-    Proof proof;
-
-    MSGPACK_FIELDS(public_inputs, proof);
-    bool operator==(const PublicInputsAndProof&) const = default;
-};
 
 template <typename Builder> using StdlibPublicInputsVector = std::vector<bb::stdlib::field_t<Builder>>;
 

--- a/barretenberg/cpp/src/barretenberg/public_input_component/public_component_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/public_input_component/public_component_key.hpp
@@ -5,8 +5,8 @@
 // =====================
 
 #pragma once
-#include <barretenberg/serialize/msgpack.hpp>
 #include <cstdint>
+#include <limits>
 
 namespace bb {
 
@@ -19,7 +19,5 @@ struct PublicComponentKey {
     bool operator==(const PublicComponentKey&) const = default;
 
     bool is_set() const { return start_idx != DEFAULT_IDX; }
-
-    MSGPACK_FIELDS(start_idx);
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/relation_parameters.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_parameters.hpp
@@ -94,7 +94,5 @@ template <typename T> struct RelationParameters {
 
         return result;
     }
-
-    MSGPACK_FIELDS(eta, eta_two, eta_three, beta, gamma, public_input_delta);
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/verifier_instance.hpp
@@ -109,9 +109,6 @@ template <IsUltraOrMegaHonk Flavor_> class VerifierInstance_ {
         // Hash the tagged elements directly
         return Transcript::HashFunction::hash(instance_elements);
     }
-
-    MSGPACK_FIELDS(
-        vk, relation_parameters, alpha, is_complete, gate_challenges, witness_commitments, gemini_masking_commitment);
 };
 
 } // namespace bb


### PR DESCRIPTION
## Summary

Removes `MSGPACK_FIELDS` macro declarations from types that are never actually serialized via msgpack. These were vestigial declarations that added unnecessary code and could cause confusion about which types are actually part of the serialization API.

### Removed from:
- `RelationParameters` - internal struct for relation computations, never serialized
- `GoblinStdlibProof` - only used for in-circuit recursion, not external serialization
- `PublicInputsAndProof` - completely unused type (removed entirely)
- `VerifierInstance` - internal verification struct, not exposed to APIs
- `UltraFlavor::WitnessEntities` - internal witness polynomial container
- `MegaFlavor::WitnessEntities_` - internal witness polynomial container
- `MultilinearBatchingFlavor::WitnessEntities` - internal batching data
- `TranslationEvaluations_` - internal ECCVM evaluation data
- `TranslatorInputData_` - internal ECCVM-to-Translator verification data
- `PublicComponentKey` - only used internally to pass indices, never serialized

### Kept (actively used):
- `GoblinProof` - serialized as part of `Chonk::Proof`
- All types in `bbapi/`, `dsl/acir_format/`, `nodejs_module/`, `world_state/`, `crypto/merkle_tree/`, `vm2/`, `avm_fuzzer/`

## Test plan
- [ ] Build passes (native, wasm, wasm-threads)
- [ ] Existing tests pass