### PR TITLE
test: Increase address hit rate in fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.cpp
@@ -253,7 +253,7 @@ int predict_block_size(ProgramBlock* block)
                 auto set_16_instruction =
                     SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
                                         .result_address =
-                                            ResultAddressRef{ .address = address, .mode = AddressingMode::Direct },
+                                            AddressRef{ .address = address, .mode = AddressingMode::Direct },
                                         .value = 0 };
                 block->process_instruction(set_16_instruction);
                 bytecode_length = static_cast<int>(create_bytecode(block->get_instructions()).size());

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
@@ -49,10 +49,10 @@ FF get_result_of_instruction(FuzzInstruction instruction,
                              bb::avm2::MemoryTag return_value_tag = bb::avm2::MemoryTag::U8)
 {
     auto set_instruction_1 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                                .result_address = VariableRef{ .address = 0 },
+                                                .result_address = AddressRef{ .address = 0 },
                                                 .value = 5 };
     auto set_instruction_2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                                .result_address = VariableRef{ .address = 1 },
+                                                .result_address = AddressRef{ .address = 1 },
                                                 .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, instruction };
     auto return_options =
@@ -76,7 +76,7 @@ TEST(fuzz, ADD8)
                 .mode = AddressingMode::Direct,
             },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(add_instruction);
     EXPECT_EQ(result, 7);
@@ -87,7 +87,7 @@ TEST(fuzz, SUB8)
     auto sub_instruction = SUB_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(sub_instruction);
     EXPECT_EQ(result, 3);
@@ -98,7 +98,7 @@ TEST(fuzz, MUL8)
     auto mul_instruction = MUL_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(mul_instruction);
     EXPECT_EQ(result, 10);
@@ -109,7 +109,7 @@ TEST(fuzz, DIV8)
     auto div_instruction = DIV_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(div_instruction);
     EXPECT_EQ(result, 2);
@@ -120,7 +120,7 @@ TEST(fuzz, EQ8)
     auto eq_instruction = EQ_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(eq_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -131,7 +131,7 @@ TEST(fuzz, LT8)
     auto lt_instruction = LT_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(lt_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -142,7 +142,7 @@ TEST(fuzz, LTE8)
     auto lte_instruction = LTE_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(lte_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -153,7 +153,7 @@ TEST(fuzz, AND8)
     auto and_instruction = AND_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(and_instruction);
     EXPECT_EQ(result, 0);
@@ -164,7 +164,7 @@ TEST(fuzz, OR8)
     auto or_instruction = OR_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(or_instruction);
     EXPECT_EQ(result, 7);
@@ -175,7 +175,7 @@ TEST(fuzz, XOR8)
     auto xor_instruction = XOR_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(xor_instruction);
     EXPECT_EQ(result, 7);
@@ -186,7 +186,7 @@ TEST(fuzz, SHL8)
     auto shl_instruction = SHL_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(shl_instruction);
     EXPECT_EQ(result, 20);
@@ -197,7 +197,7 @@ TEST(fuzz, SHR8)
     auto shr_instruction = SHR_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(shr_instruction);
     EXPECT_EQ(result, 1);
@@ -209,15 +209,15 @@ TEST(fuzz, FDIV8)
     auto fdiv_instruction = FDIV_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 4 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, fdiv_instruction };
 
@@ -237,11 +237,11 @@ TEST(fuzz, NOT8)
 {
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 0 };
     auto not_instruction = NOT_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
@@ -262,11 +262,11 @@ FF get_result_of_instruction_16(FuzzInstruction instruction,
 {
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 5 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, instruction };
 
@@ -291,7 +291,7 @@ TEST(fuzz, ADD16)
                 .mode = AddressingMode::Direct,
             },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(add_instruction);
     EXPECT_EQ(result, 7);
@@ -302,7 +302,7 @@ TEST(fuzz, SUB16)
     auto sub_instruction = SUB_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(sub_instruction);
     EXPECT_EQ(result, 3);
@@ -313,7 +313,7 @@ TEST(fuzz, MUL16)
     auto mul_instruction = MUL_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(mul_instruction);
     EXPECT_EQ(result, 10);
@@ -324,7 +324,7 @@ TEST(fuzz, DIV16)
     auto div_instruction = DIV_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(div_instruction);
     EXPECT_EQ(result, 2);
@@ -335,7 +335,7 @@ TEST(fuzz, EQ16)
     auto eq_instruction = EQ_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(eq_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -346,7 +346,7 @@ TEST(fuzz, LT16)
     auto lt_instruction = LT_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(lt_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -357,7 +357,7 @@ TEST(fuzz, LTE16)
     auto lte_instruction = LTE_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(lte_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -368,7 +368,7 @@ TEST(fuzz, AND16)
     auto and_instruction = AND_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(and_instruction);
     EXPECT_EQ(result, 0);
@@ -379,7 +379,7 @@ TEST(fuzz, OR16)
     auto or_instruction = OR_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(or_instruction);
     EXPECT_EQ(result, 7);
@@ -390,7 +390,7 @@ TEST(fuzz, XOR16)
     auto xor_instruction = XOR_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(xor_instruction);
     EXPECT_EQ(result, 7);
@@ -401,7 +401,7 @@ TEST(fuzz, SHL16)
     auto shl_instruction = SHL_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(shl_instruction);
     EXPECT_EQ(result, 20);
@@ -412,7 +412,7 @@ TEST(fuzz, SHR16)
     auto shr_instruction = SHR_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(shr_instruction);
     EXPECT_EQ(result, 1);
@@ -424,15 +424,15 @@ TEST(fuzz, FDIV16)
     auto fdiv_instruction = FDIV_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 4 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, fdiv_instruction };
 
@@ -452,11 +452,11 @@ TEST(fuzz, NOT16)
 {
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 0 };
     auto not_instruction = NOT_16_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
@@ -478,14 +478,14 @@ namespace type_conversion {
 TEST(fuzz, CAST8)
 {
     auto set_u16 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                                      .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                                      .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
                                       .value = 1 };
     auto set_u8 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                     .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                                     .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                      .value = 2 };
     auto cast_instruction = CAST_8_Instruction{
         .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
         .target_tag = bb::avm2::MemoryTag::U16
     };
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
@@ -506,14 +506,14 @@ TEST(fuzz, CAST8)
 TEST(fuzz, CAST16)
 {
     auto set_u16 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                                      .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                                      .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
                                       .value = 1 };
     auto set_u8 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                     .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                                     .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                      .value = 2 };
     auto cast_instruction = CAST_16_Instruction{
         .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
         .target_tag = bb::avm2::MemoryTag::U16
     };
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
@@ -536,7 +536,7 @@ TEST(fuzz, SET16)
     const uint16_t test_value = 0xABCD;
     auto set_instruction =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -555,7 +555,7 @@ TEST(fuzz, SET32)
     const uint32_t test_value = 0x12345678UL;
     auto set_instruction =
         SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -575,7 +575,7 @@ TEST(fuzz, SET64)
     const uint64_t test_value = 0xABCDEF0123456789ULL;
     auto set_instruction =
         SET_64_Instruction{ .value_tag = bb::avm2::MemoryTag::U64,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -598,7 +598,7 @@ TEST(fuzz, SET128)
         (static_cast<uint128_t>(test_value_high) << 64) | static_cast<uint128_t>(test_value_low);
     auto set_instruction =
         SET_128_Instruction{ .value_tag = bb::avm2::MemoryTag::U128,
-                             .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                             .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                              .value_low = test_value_low,
                              .value_high = test_value_high };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
@@ -620,7 +620,7 @@ TEST(fuzz, SETFF)
     const bb::avm2::FF test_value = bb::avm2::FF(123456789);
     auto set_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -641,14 +641,14 @@ TEST(fuzz, MOV8)
     const uint8_t test_value2 = 0x43;
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = test_value };
     auto set_instruction2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                               .result_address = VariableRef{ .address = 1 },
+                                               .result_address = AddressRef{ .address = 1 },
                                                .value = test_value2 };
     auto mov_instruction = MOV_8_Instruction{
         .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
@@ -669,15 +669,15 @@ TEST(fuzz, MOV16)
     const uint16_t test_value2 = 0xc0fe;
     auto set_instruction =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto set_instruction2 =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                             .value = test_value2 };
     auto mov_instruction = MOV_16_Instruction{
         .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U16, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
@@ -702,11 +702,11 @@ TEST(fuzz, JumpToNewBlockSmoke)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions };
     auto return_options =
@@ -729,15 +729,15 @@ TEST(fuzz, JumpToNewBlockSmoke2)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 12 } };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions, block3_instructions };
@@ -761,7 +761,7 @@ TEST(fuzz, JumpToNewBlockSharesVariables)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
 
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions };
@@ -783,19 +783,19 @@ TEST(fuzz, JumpIfToNewBlockSmoke)
 {
     auto set_true_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
         .value = 1 } };
     auto set_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
         .value = 0 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 12 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         set_true_block, set_false_block, block2_instructions, block3_instructions
@@ -831,18 +831,18 @@ TEST(fuzz, JumpIfToNewBlockSmoke)
 FF simulate_jump_if_depth_2_helper(uint8_t first_boolean_value, uint8_t second_boolean_value)
 {
     auto set_instruction_block_1 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                                      .result_address = VariableRef{ .address = 1 },
+                                                      .result_address = AddressRef{ .address = 1 },
                                                       .value = first_boolean_value };
     auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
     auto set_instruction_block_2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                                      .result_address = VariableRef{ .address = 2 },
+                                                      .result_address = AddressRef{ .address = 2 },
                                                       .value = second_boolean_value };
     auto instruction_block_2 = std::vector<FuzzInstruction>{ set_instruction_block_2 };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instruction_block_1, instruction_block_2 };
     for (uint8_t i = 2; i < 5; i++) {
         auto set_instruction =
             SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                               .result_address = VariableRef{ .address = i, .mode = AddressingMode::Direct },
+                               .result_address = AddressRef{ .address = i, .mode = AddressingMode::Direct },
                                .value = i };
         instruction_blocks.push_back({ set_instruction });
     }
@@ -878,11 +878,11 @@ FF simulate_jump_to_block_helper(uint8_t condition_value)
 {
     auto set_instruction_block_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = condition_value };
     auto set_return_value_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 2 } };
     auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
     auto instruction_blocks =
@@ -918,14 +918,14 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     // Block 0: Set condition (U1)
     auto set_condition_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
         .value = 1 } };
 
     // Block 1: Set FF value
     const bb::avm2::FF ff_value = bb::avm2::FF(123456789);
     auto set_ff_block = std::vector<FuzzInstruction>{ SET_FF_Instruction{
         .value_tag = bb::avm2::MemoryTag::FF,
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = ff_value } };
 
     // Block 2: Set U128 value
@@ -933,7 +933,7 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     const uint64_t u128_value_high = 0x123456789ABCDEF0ULL;
     auto set_u128_block = std::vector<FuzzInstruction>{ SET_128_Instruction{
         .value_tag = bb::avm2::MemoryTag::U128,
-        .result_address = VariableRef{ .address = 20, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 20, .mode = AddressingMode::Direct },
         .value_low = u128_value_low,
         .value_high = u128_value_high } };
 
@@ -982,7 +982,7 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     // Test with condition = false (should return U128 value)
     auto set_condition_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
         .value = 0 } };
     auto instruction_blocks_false =
         std::vector<std::vector<FuzzInstruction>>{ set_condition_false_block, set_ff_block, set_u128_block };
@@ -1015,23 +1015,23 @@ TEST(fuzz, SstoreThenSload)
     // M[10] = 10
     auto set_value_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
                            .value = 10 };
     // S[10] = M[10]
     auto sstore_instruction = SSTORE_Instruction{
         .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .slot = 10
     };
     // M[2] = S[10], FF tag
     auto sload_instruction =
         SLOAD_Instruction{ .slot_index = 0,
-                           .slot_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
-                           .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct } };
+                           .slot_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct } };
     // M[10] = 11
     auto set_value_instruction2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
                            .value = 11 };
 
     auto set_sstore_sload_block = std::vector<FuzzInstruction>{
@@ -1057,7 +1057,7 @@ FF getenvvar_helper(uint8_t type, bb::avm2::MemoryTag return_value_tag = bb::avm
 {
 
     auto getenvvar_instruction =
-        GETENVVAR_Instruction{ .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+        GETENVVAR_Instruction{ .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                .type = type };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { getenvvar_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -1094,15 +1094,15 @@ TEST(fuzz, EmitNullifierThenNullifierExists)
 {
     auto set_field_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto emit_nullifier_instruction = EMITNULLIFIER_Instruction{
         .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
     };
     auto nullifier_exists_instruction = NULLIFIEREXISTS_Instruction{
         .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .contract_address_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 20, .mode = AddressingMode::Direct }
+        .contract_address_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 20, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
@@ -1119,15 +1119,15 @@ TEST(fuzz, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
 {
     auto set_field_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto emit_nullifier_instruction = EMITNULLIFIER_Instruction{
         .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
     };
     auto nullifier_exists_instruction = NULLIFIEREXISTS_Instruction{
         .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .contract_address_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
-        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+        .contract_address_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     }; // GETENVVAR overwrites previous nullifier
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
@@ -1143,13 +1143,13 @@ TEST(fuzz, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
 TEST(fuzz, EmitNoteHashThenNoteHashExists)
 {
     auto emit_note_hash_instruction =
-        EMITNOTEHASH_Instruction{ .note_hash_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+        EMITNOTEHASH_Instruction{ .note_hash_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                   .note_hash = 1 };
     auto note_hash_exists_instruction =
         NOTEHASHEXISTS_Instruction{ .notehash_index = 0,
-                                    .notehash_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
-                                    .leaf_index_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
-                                    .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct } };
+                                    .notehash_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                                    .leaf_index_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                                    .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct } };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { emit_note_hash_instruction, note_hash_exists_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -1170,11 +1170,11 @@ TEST(fuzz, EmitNoteHashThenNoteHashExists)
 namespace calldata_returndata {
 TEST(fuzz, CopyCalldataThenReturnData)
 {
-    auto calldatacopy_instruction = CALLDATACOPY_Instruction{ .dst_address = VariableRef{ .address = 0 },
+    auto calldatacopy_instruction = CALLDATACOPY_Instruction{ .dst_address = AddressRef{ .address = 0 },
                                                               .copy_size = 1,
-                                                              .copy_size_address = VariableRef{ .address = 1 },
+                                                              .copy_size_address = AddressRef{ .address = 1 },
                                                               .cd_start = 0,
-                                                              .cd_start_address = VariableRef{ .address = 2 } };
+                                                              .cd_start_address = AddressRef{ .address = 2 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { calldatacopy_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
@@ -1190,11 +1190,11 @@ TEST(fuzz, InternalCall)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto instruction_blocks =
@@ -1216,11 +1216,11 @@ TEST(fuzz, InternalCalledBlockUsesInternalReturn)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_boolean_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto instruction_blocks =
@@ -1246,15 +1246,15 @@ TEST(fuzz, SeveralInternalCalls)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 31337 };
     auto set_field_instruction3 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
@@ -1292,19 +1292,19 @@ TEST(fuzz, Reentrancy)
 {
     auto set_field_instruction0 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1 };
     auto set_field_instruction1 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 31337 };
     auto set_field_instruction3 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
@@ -1353,9 +1353,10 @@ TEST(fuzz, DirectWithIndirect)
                             .result_address = AddressRef{ .address = 3000, .mode = AddressingMode::Direct },
                             .value = 20 };
     auto add_instruction = ADD_8_Instruction{
-        .a_address =
-            VariableRef{
-                .tag = bb::avm2::MemoryTag::FF, .index = 1, .pointer_address = 100, .mode = AddressingMode::Indirect },
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF,
+                                  .index = 1,
+                                  .pointer_address_seed = 100,
+                                  .mode = AddressingMode::Indirect },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
     };
@@ -1382,8 +1383,8 @@ TEST(fuzz, DirectWithIndirectRelative)
     auto add_instruction = ADD_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF,
                                   .index = 1,
-                                  .pointer_address = 100,
-                                  .base_offset = 100,
+                                  .pointer_address_seed = 100,
+                                  .base_offset_seed = 100,
                                   .mode = AddressingMode::IndirectRelative },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
@@ -1407,7 +1408,7 @@ TEST(fuzz, IndirectResultCanBeUsedInNextInstruction)
     auto add_instruction = ADD_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = AddressRef{ .address = 130, .pointer_address = 100, .mode = AddressingMode::Indirect }
+        .result_address = AddressRef{ .address = 130, .pointer_address_seed = 100, .mode = AddressingMode::Indirect }
     };
     auto mul_instruction = MUL_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
@@ -1430,16 +1431,17 @@ TEST(fuzz, Memoryaddressing32BitWidth)
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
                             .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct },
                             .value = 10 };
-    auto set_field_instruction2 = SET_FF_Instruction{
-        .value_tag = bb::avm2::MemoryTag::FF,
-        .result_address = AddressRef{ .address = 4294967295, .pointer_address = 100, .mode = AddressingMode::Indirect },
-        .value = 20
-    };
+    auto set_field_instruction2 = SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
+                                                      .result_address = AddressRef{ .address = 4294967295,
+                                                                                    .pointer_address_seed = 100,
+                                                                                    .mode = AddressingMode::Indirect },
+                                                      .value = 20 };
     auto add_instruction = MUL_8_Instruction{
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .b_address =
-            VariableRef{
-                .tag = bb::avm2::MemoryTag::FF, .index = 1, .pointer_address = 200, .mode = AddressingMode::Indirect },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF,
+                                  .index = 1,
+                                  .pointer_address_seed = 200,
+                                  .mode = AddressingMode::Indirect },
         .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks =

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
@@ -49,10 +49,10 @@ FF get_result_of_instruction(FuzzInstruction instruction,
                              bb::avm2::MemoryTag return_value_tag = bb::avm2::MemoryTag::U8)
 {
     auto set_instruction_1 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                                .result_address = ResultAddressRef{ .address = 0 },
+                                                .result_address = VariableRef{ .address = 0 },
                                                 .value = 5 };
     auto set_instruction_2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                                .result_address = ResultAddressRef{ .address = 1 },
+                                                .result_address = VariableRef{ .address = 1 },
                                                 .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, instruction };
     auto return_options =
@@ -68,16 +68,16 @@ FF get_result_of_instruction(FuzzInstruction instruction,
 
 TEST(fuzz, ADD8)
 {
-    auto add_instruction =
-        ADD_8_Instruction{ .a_address =
-                               AddressRef{
-                                   .tag = bb::avm2::MemoryTag::U8,
-                                   .index = 0,
-                                   .mode = AddressingMode::Direct,
-                               },
-                           .b_address =
-                               AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-                           .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct } };
+    auto add_instruction = ADD_8_Instruction{
+        .a_address =
+            VariableRef{
+                .tag = bb::avm2::MemoryTag::U8,
+                .index = 0,
+                .mode = AddressingMode::Direct,
+            },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
+    };
     auto result = get_result_of_instruction(add_instruction);
     EXPECT_EQ(result, 7);
 }
@@ -85,9 +85,9 @@ TEST(fuzz, ADD8)
 TEST(fuzz, SUB8)
 {
     auto sub_instruction = SUB_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(sub_instruction);
     EXPECT_EQ(result, 3);
@@ -96,9 +96,9 @@ TEST(fuzz, SUB8)
 TEST(fuzz, MUL8)
 {
     auto mul_instruction = MUL_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(mul_instruction);
     EXPECT_EQ(result, 10);
@@ -107,9 +107,9 @@ TEST(fuzz, MUL8)
 TEST(fuzz, DIV8)
 {
     auto div_instruction = DIV_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(div_instruction);
     EXPECT_EQ(result, 2);
@@ -118,9 +118,9 @@ TEST(fuzz, DIV8)
 TEST(fuzz, EQ8)
 {
     auto eq_instruction = EQ_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(eq_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -129,9 +129,9 @@ TEST(fuzz, EQ8)
 TEST(fuzz, LT8)
 {
     auto lt_instruction = LT_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(lt_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -140,9 +140,9 @@ TEST(fuzz, LT8)
 TEST(fuzz, LTE8)
 {
     auto lte_instruction = LTE_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(lte_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -151,9 +151,9 @@ TEST(fuzz, LTE8)
 TEST(fuzz, AND8)
 {
     auto and_instruction = AND_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(and_instruction);
     EXPECT_EQ(result, 0);
@@ -162,9 +162,9 @@ TEST(fuzz, AND8)
 TEST(fuzz, OR8)
 {
     auto or_instruction = OR_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(or_instruction);
     EXPECT_EQ(result, 7);
@@ -173,9 +173,9 @@ TEST(fuzz, OR8)
 TEST(fuzz, XOR8)
 {
     auto xor_instruction = XOR_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(xor_instruction);
     EXPECT_EQ(result, 7);
@@ -184,9 +184,9 @@ TEST(fuzz, XOR8)
 TEST(fuzz, SHL8)
 {
     auto shl_instruction = SHL_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(shl_instruction);
     EXPECT_EQ(result, 20);
@@ -195,9 +195,9 @@ TEST(fuzz, SHL8)
 TEST(fuzz, SHR8)
 {
     auto shr_instruction = SHR_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction(shr_instruction);
     EXPECT_EQ(result, 1);
@@ -207,17 +207,17 @@ TEST(fuzz, SHR8)
 TEST(fuzz, FDIV8)
 {
     auto fdiv_instruction = FDIV_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 4 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, fdiv_instruction };
 
@@ -237,12 +237,12 @@ TEST(fuzz, NOT8)
 {
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 0 };
-    auto not_instruction =
-        NOT_8_Instruction{ .a_address =
-                               AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct } };
+    auto not_instruction = NOT_8_Instruction{
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+    };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
@@ -262,11 +262,11 @@ FF get_result_of_instruction_16(FuzzInstruction instruction,
 {
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 5 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, instruction };
 
@@ -285,13 +285,13 @@ TEST(fuzz, ADD16)
 {
     auto add_instruction = ADD_16_Instruction{
         .a_address =
-            AddressRef{
+            VariableRef{
                 .tag = bb::avm2::MemoryTag::U8,
                 .index = 0,
                 .mode = AddressingMode::Direct,
             },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(add_instruction);
     EXPECT_EQ(result, 7);
@@ -300,9 +300,9 @@ TEST(fuzz, ADD16)
 TEST(fuzz, SUB16)
 {
     auto sub_instruction = SUB_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(sub_instruction);
     EXPECT_EQ(result, 3);
@@ -311,9 +311,9 @@ TEST(fuzz, SUB16)
 TEST(fuzz, MUL16)
 {
     auto mul_instruction = MUL_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(mul_instruction);
     EXPECT_EQ(result, 10);
@@ -322,9 +322,9 @@ TEST(fuzz, MUL16)
 TEST(fuzz, DIV16)
 {
     auto div_instruction = DIV_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(div_instruction);
     EXPECT_EQ(result, 2);
@@ -333,9 +333,9 @@ TEST(fuzz, DIV16)
 TEST(fuzz, EQ16)
 {
     auto eq_instruction = EQ_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(eq_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -344,9 +344,9 @@ TEST(fuzz, EQ16)
 TEST(fuzz, LT16)
 {
     auto lt_instruction = LT_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(lt_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -355,9 +355,9 @@ TEST(fuzz, LT16)
 TEST(fuzz, LTE16)
 {
     auto lte_instruction = LTE_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(lte_instruction, bb::avm2::MemoryTag::U1);
     EXPECT_EQ(result, 0);
@@ -366,9 +366,9 @@ TEST(fuzz, LTE16)
 TEST(fuzz, AND16)
 {
     auto and_instruction = AND_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(and_instruction);
     EXPECT_EQ(result, 0);
@@ -377,9 +377,9 @@ TEST(fuzz, AND16)
 TEST(fuzz, OR16)
 {
     auto or_instruction = OR_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(or_instruction);
     EXPECT_EQ(result, 7);
@@ -388,9 +388,9 @@ TEST(fuzz, OR16)
 TEST(fuzz, XOR16)
 {
     auto xor_instruction = XOR_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(xor_instruction);
     EXPECT_EQ(result, 7);
@@ -399,9 +399,9 @@ TEST(fuzz, XOR16)
 TEST(fuzz, SHL16)
 {
     auto shl_instruction = SHL_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(shl_instruction);
     EXPECT_EQ(result, 20);
@@ -410,9 +410,9 @@ TEST(fuzz, SHL16)
 TEST(fuzz, SHR16)
 {
     auto shr_instruction = SHR_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto result = get_result_of_instruction_16(shr_instruction);
     EXPECT_EQ(result, 1);
@@ -422,17 +422,17 @@ TEST(fuzz, SHR16)
 TEST(fuzz, FDIV16)
 {
     auto fdiv_instruction = FDIV_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct }
     };
     auto set_instruction_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 4 };
     auto set_instruction_2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 2 };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, fdiv_instruction };
 
@@ -452,11 +452,11 @@ TEST(fuzz, NOT16)
 {
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 0 };
     auto not_instruction = NOT_16_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
@@ -477,16 +477,15 @@ namespace type_conversion {
 // if cast failed, should return 1 (the original U16 value)
 TEST(fuzz, CAST8)
 {
-    auto set_u16 =
-        SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                           .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
-                           .value = 1 };
+    auto set_u16 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
+                                      .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                                      .value = 1 };
     auto set_u8 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                     .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                                     .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                                      .value = 2 };
     auto cast_instruction = CAST_8_Instruction{
-        .src_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+        .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
         .target_tag = bb::avm2::MemoryTag::U16
     };
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
@@ -506,16 +505,15 @@ TEST(fuzz, CAST8)
 // if cast failed, should return 1 (the original U16 value)
 TEST(fuzz, CAST16)
 {
-    auto set_u16 =
-        SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                           .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
-                           .value = 1 };
+    auto set_u16 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
+                                      .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                                      .value = 1 };
     auto set_u8 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                     .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                                     .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                                      .value = 2 };
     auto cast_instruction = CAST_16_Instruction{
-        .src_address = AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+        .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
         .target_tag = bb::avm2::MemoryTag::U16
     };
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
@@ -538,7 +536,7 @@ TEST(fuzz, SET16)
     const uint16_t test_value = 0xABCD;
     auto set_instruction =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -557,7 +555,7 @@ TEST(fuzz, SET32)
     const uint32_t test_value = 0x12345678UL;
     auto set_instruction =
         SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -577,7 +575,7 @@ TEST(fuzz, SET64)
     const uint64_t test_value = 0xABCDEF0123456789ULL;
     auto set_instruction =
         SET_64_Instruction{ .value_tag = bb::avm2::MemoryTag::U64,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -600,7 +598,7 @@ TEST(fuzz, SET128)
         (static_cast<uint128_t>(test_value_high) << 64) | static_cast<uint128_t>(test_value_low);
     auto set_instruction =
         SET_128_Instruction{ .value_tag = bb::avm2::MemoryTag::U128,
-                             .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                             .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                              .value_low = test_value_low,
                              .value_high = test_value_high };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
@@ -622,7 +620,7 @@ TEST(fuzz, SETFF)
     const bb::avm2::FF test_value = bb::avm2::FF(123456789);
     auto set_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
@@ -643,15 +641,15 @@ TEST(fuzz, MOV8)
     const uint8_t test_value2 = 0x43;
     auto set_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = test_value };
     auto set_instruction2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                                               .result_address = ResultAddressRef{ .address = 1 },
+                                               .result_address = VariableRef{ .address = 1 },
                                                .value = test_value2 };
-    auto mov_instruction =
-        MOV_8_Instruction{ .src_address =
-                               AddressRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct } };
+    auto mov_instruction = MOV_8_Instruction{
+        .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U8, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
+    };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
@@ -671,15 +669,15 @@ TEST(fuzz, MOV16)
     const uint16_t test_value2 = 0xc0fe;
     auto set_instruction =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = test_value };
     auto set_instruction2 =
         SET_16_Instruction{ .value_tag = bb::avm2::MemoryTag::U16,
-                            .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                             .value = test_value2 };
     auto mov_instruction = MOV_16_Instruction{
-        .src_address = AddressRef{ .tag = bb::avm2::MemoryTag::U16, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct }
+        .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::U16, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
     };
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
@@ -704,11 +702,11 @@ TEST(fuzz, JumpToNewBlockSmoke)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions };
     auto return_options =
@@ -731,15 +729,15 @@ TEST(fuzz, JumpToNewBlockSmoke2)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 12 } };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions, block3_instructions };
@@ -763,7 +761,7 @@ TEST(fuzz, JumpToNewBlockSharesVariables)
 {
     auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 10 } };
 
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions };
@@ -785,19 +783,19 @@ TEST(fuzz, JumpIfToNewBlockSmoke)
 {
     auto set_true_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
         .value = 1 } };
     auto set_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
         .value = 0 } };
     auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 11 } };
     auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 12 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         set_true_block, set_false_block, block2_instructions, block3_instructions
@@ -833,18 +831,18 @@ TEST(fuzz, JumpIfToNewBlockSmoke)
 FF simulate_jump_if_depth_2_helper(uint8_t first_boolean_value, uint8_t second_boolean_value)
 {
     auto set_instruction_block_1 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                                      .result_address = ResultAddressRef{ .address = 1 },
+                                                      .result_address = VariableRef{ .address = 1 },
                                                       .value = first_boolean_value };
     auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
     auto set_instruction_block_2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                                      .result_address = ResultAddressRef{ .address = 2 },
+                                                      .result_address = VariableRef{ .address = 2 },
                                                       .value = second_boolean_value };
     auto instruction_block_2 = std::vector<FuzzInstruction>{ set_instruction_block_2 };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instruction_block_1, instruction_block_2 };
     for (uint8_t i = 2; i < 5; i++) {
         auto set_instruction =
             SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
-                               .result_address = ResultAddressRef{ .address = i, .mode = AddressingMode::Direct },
+                               .result_address = VariableRef{ .address = i, .mode = AddressingMode::Direct },
                                .value = i };
         instruction_blocks.push_back({ set_instruction });
     }
@@ -880,11 +878,11 @@ FF simulate_jump_to_block_helper(uint8_t condition_value)
 {
     auto set_instruction_block_1 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = condition_value };
     auto set_return_value_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = 2 } };
     auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
     auto instruction_blocks =
@@ -920,14 +918,14 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     // Block 0: Set condition (U1)
     auto set_condition_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
         .value = 1 } };
 
     // Block 1: Set FF value
     const bb::avm2::FF ff_value = bb::avm2::FF(123456789);
     auto set_ff_block = std::vector<FuzzInstruction>{ SET_FF_Instruction{
         .value_tag = bb::avm2::MemoryTag::FF,
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .value = ff_value } };
 
     // Block 2: Set U128 value
@@ -935,7 +933,7 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     const uint64_t u128_value_high = 0x123456789ABCDEF0ULL;
     auto set_u128_block = std::vector<FuzzInstruction>{ SET_128_Instruction{
         .value_tag = bb::avm2::MemoryTag::U128,
-        .result_address = ResultAddressRef{ .address = 20, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 20, .mode = AddressingMode::Direct },
         .value_low = u128_value_low,
         .value_high = u128_value_high } };
 
@@ -984,7 +982,7 @@ TEST(fuzz, JumpIfToNewBlockWithReturn)
     // Test with condition = false (should return U128 value)
     auto set_condition_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
         .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
         .value = 0 } };
     auto instruction_blocks_false =
         std::vector<std::vector<FuzzInstruction>>{ set_condition_false_block, set_ff_block, set_u128_block };
@@ -1017,23 +1015,23 @@ TEST(fuzz, SstoreThenSload)
     // M[10] = 10
     auto set_value_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
                            .value = 10 };
     // S[10] = M[10]
     auto sstore_instruction = SSTORE_Instruction{
-        .src_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+        .src_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
         .slot = 10
     };
     // M[2] = S[10], FF tag
     auto sload_instruction =
         SLOAD_Instruction{ .slot_index = 0,
-                           .slot_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
-                           .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct } };
+                           .slot_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct } };
     // M[10] = 11
     auto set_value_instruction2 =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
                            .value = 11 };
 
     auto set_sstore_sload_block = std::vector<FuzzInstruction>{
@@ -1059,7 +1057,7 @@ FF getenvvar_helper(uint8_t type, bb::avm2::MemoryTag return_value_tag = bb::avm
 {
 
     auto getenvvar_instruction =
-        GETENVVAR_Instruction{ .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+        GETENVVAR_Instruction{ .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                                .type = type };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { getenvvar_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -1096,15 +1094,15 @@ TEST(fuzz, EmitNullifierThenNullifierExists)
 {
     auto set_field_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto emit_nullifier_instruction = EMITNULLIFIER_Instruction{
-        .nullifier_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
+        .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
     };
     auto nullifier_exists_instruction = NULLIFIEREXISTS_Instruction{
-        .nullifier_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .contract_address_address = ResultAddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 20, .mode = AddressingMode::Direct }
+        .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .contract_address_address = VariableRef{ .address = 10, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 20, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
@@ -1121,15 +1119,15 @@ TEST(fuzz, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
 {
     auto set_field_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                           .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto emit_nullifier_instruction = EMITNULLIFIER_Instruction{
-        .nullifier_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
+        .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct }
     };
     auto nullifier_exists_instruction = NULLIFIEREXISTS_Instruction{
-        .nullifier_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .contract_address_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct }
+        .nullifier_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .contract_address_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+        .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct }
     }; // GETENVVAR overwrites previous nullifier
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
         { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
@@ -1145,14 +1143,13 @@ TEST(fuzz, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
 TEST(fuzz, EmitNoteHashThenNoteHashExists)
 {
     auto emit_note_hash_instruction =
-        EMITNOTEHASH_Instruction{ .note_hash_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+        EMITNOTEHASH_Instruction{ .note_hash_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                                   .note_hash = 1 };
-    auto note_hash_exists_instruction = NOTEHASHEXISTS_Instruction{
-        .notehash_index = 0,
-        .notehash_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
-        .leaf_index_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 2, .mode = AddressingMode::Direct }
-    };
+    auto note_hash_exists_instruction =
+        NOTEHASHEXISTS_Instruction{ .notehash_index = 0,
+                                    .notehash_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
+                                    .leaf_index_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
+                                    .result_address = VariableRef{ .address = 2, .mode = AddressingMode::Direct } };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { emit_note_hash_instruction, note_hash_exists_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -1173,11 +1170,11 @@ TEST(fuzz, EmitNoteHashThenNoteHashExists)
 namespace calldata_returndata {
 TEST(fuzz, CopyCalldataThenReturnData)
 {
-    auto calldatacopy_instruction = CALLDATACOPY_Instruction{ .dst_address = ResultAddressRef{ .address = 0 },
+    auto calldatacopy_instruction = CALLDATACOPY_Instruction{ .dst_address = VariableRef{ .address = 0 },
                                                               .copy_size = 1,
-                                                              .copy_size_address = ResultAddressRef{ .address = 1 },
+                                                              .copy_size_address = VariableRef{ .address = 1 },
                                                               .cd_start = 0,
-                                                              .cd_start_address = ResultAddressRef{ .address = 2 } };
+                                                              .cd_start_address = VariableRef{ .address = 2 } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { calldatacopy_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
@@ -1193,11 +1190,11 @@ TEST(fuzz, InternalCall)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto instruction_blocks =
@@ -1219,11 +1216,11 @@ TEST(fuzz, InternalCalledBlockUsesInternalReturn)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_boolean_instruction =
         SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                           .result_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                           .result_address = VariableRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto instruction_blocks =
@@ -1249,15 +1246,15 @@ TEST(fuzz, SeveralInternalCalls)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 31337 };
     auto set_field_instruction3 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
@@ -1295,19 +1292,19 @@ TEST(fuzz, Reentrancy)
 {
     auto set_field_instruction0 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1 };
     auto set_field_instruction1 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 1337 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 31337 };
     auto set_field_instruction3 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .result_address = VariableRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
@@ -1349,18 +1346,18 @@ TEST(fuzz, DirectWithIndirect)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct },
                             .value = 10 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 3000, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 3000, .mode = AddressingMode::Direct },
                             .value = 20 };
     auto add_instruction = ADD_8_Instruction{
         .a_address =
-            AddressRef{
+            VariableRef{
                 .tag = bb::avm2::MemoryTag::FF, .index = 1, .pointer_address = 100, .mode = AddressingMode::Indirect },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 130, .mode = AddressingMode::Direct }
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
@@ -1376,21 +1373,21 @@ TEST(fuzz, DirectWithIndirectRelative)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct },
                             .value = 10 };
     auto set_field_instruction2 =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 3000, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 3000, .mode = AddressingMode::Direct },
                             .value = 20 };
-    auto add_instruction =
-        ADD_8_Instruction{ .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF,
-                                                    .index = 1,
-                                                    .pointer_address = 100,
-                                                    .base_offset = 100,
-                                                    .mode = AddressingMode::IndirectRelative },
-                           .b_address =
-                               AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-                           .result_address = ResultAddressRef{ .address = 130, .mode = AddressingMode::Direct } };
+    auto add_instruction = ADD_8_Instruction{
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF,
+                                  .index = 1,
+                                  .pointer_address = 100,
+                                  .base_offset = 100,
+                                  .mode = AddressingMode::IndirectRelative },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
+    };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -1405,17 +1402,17 @@ TEST(fuzz, IndirectResultCanBeUsedInNextInstruction)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct },
                             .value = 10 };
     auto add_instruction = ADD_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 130, .pointer_address = 100, .mode = AddressingMode::Indirect }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 130, .pointer_address = 100, .mode = AddressingMode::Indirect }
     };
     auto mul_instruction = MUL_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .b_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
-        .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct }
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
+        .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
+        .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, add_instruction, mul_instruction } };
@@ -1431,20 +1428,19 @@ TEST(fuzz, Memoryaddressing32BitWidth)
 {
     auto set_field_instruction =
         SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                            .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct },
+                            .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct },
                             .value = 10 };
     auto set_field_instruction2 = SET_FF_Instruction{
         .value_tag = bb::avm2::MemoryTag::FF,
-        .result_address =
-            ResultAddressRef{ .address = 4294967295, .pointer_address = 100, .mode = AddressingMode::Indirect },
+        .result_address = AddressRef{ .address = 4294967295, .pointer_address = 100, .mode = AddressingMode::Indirect },
         .value = 20
     };
     auto add_instruction = MUL_8_Instruction{
-        .a_address = AddressRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
+        .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .b_address =
-            AddressRef{
+            VariableRef{
                 .tag = bb::avm2::MemoryTag::FF, .index = 1, .pointer_address = 200, .mode = AddressingMode::Indirect },
-        .result_address = ResultAddressRef{ .address = 150, .mode = AddressingMode::Direct }
+        .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct }
     };
     auto instruction_blocks =
         std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
@@ -1461,12 +1457,11 @@ namespace misc {
 // TODO(defkit): get info from world state to be sure that the message will be sent / log emitted
 TEST(fuzz, SendL2ToL1Msg)
 {
-    auto sendl2tol1msg_instruction = SENDL2TOL1MSG_Instruction{
-        .recipient = 100,
-        .recipient_address = ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
-        .content = 200,
-        .content_address = ResultAddressRef{ .address = 1, .mode = AddressingMode::Direct }
-    };
+    auto sendl2tol1msg_instruction =
+        SENDL2TOL1MSG_Instruction{ .recipient = 100,
+                                   .recipient_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                                   .content = 200,
+                                   .content_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct } };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { sendl2tol1msg_instruction } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
@@ -1480,8 +1475,7 @@ TEST(fuzz, EmitUnencryptedLog)
 {
     auto emitunencryptedlog_instruction =
         EMITUNENCRYPTEDLOG_Instruction{ .log_size = 1,
-                                        .log_size_address =
-                                            ResultAddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                                        .log_size_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                         .log_values = { 1 },
                                         .log_values_address_start = 1 };
     auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { emitunencryptedlog_instruction } };

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -88,158 +88,172 @@ struct AddressingModeWrapper {
     }
 };
 
-/// @brief Address reference
-/// Used to resolve actual memory address from memory_manager
+/// @brief Variable reference
+/// Used to resolve a tracked variable address from memory_manager
 /// @example
-/// AddressRef {U8, index: 15, mode: IndirectRelative, pointer_address: 50, pointer_value: 10, base_offset: 3}
+/// VariableRef {U8, index: 15, mode: IndirectRelative, pointer_address: 50, pointer_value: 10, base_offset: 3}
 /// If memory_manager resolved DIRECT address 100 for tag U8,
 /// We set M[50] = 10, M[0] = 3
-/// We want to resolve address 100 in IndirectRealtive values, so we get M[50] + M[0] = 13
+/// We want to resolve address 100 in IndirectRelative values, so we get M[50] + M[0] = 13
 /// So we will try to resolve the address 100 - 13 = 87
-struct AddressRef {
+struct VariableRef {
     MemoryTagWrapper tag;
-    /// @brief Index of the address in the memory_manager.stored_variables map
+    /// @brief Index of the variable in the memory_manager.stored_variables map
     uint32_t index = 0;
 
-    /// @brief Index of the pointer in the memory_manager.stored_variables map
+    /// @brief A seed for the generation of the pointer address
     /// Used for Indirect/IndirectRelative modes only
-    uint16_t pointer_address = 0;
+    uint16_t pointer_address_seed = 0;
 
-    /// @brief Base offset
+    /// @brief A seed for the generation of the base offset
     /// Used for Relative/IndirectRelative modes only
     /// Sets M[0] = base_offset
-    uint32_t base_offset = 0;
+    uint32_t base_offset_seed = 0;
     AddressingModeWrapper mode = AddressingMode::Direct;
 
-    MSGPACK_FIELDS(tag, index, pointer_address, base_offset, mode);
+    MSGPACK_FIELDS(tag, index, pointer_address_seed, base_offset_seed, mode);
 };
 
-struct ResultAddressRef {
+struct AddressRef {
     uint32_t address = 0;
 
-    /// @brief Pointer address used for Indirect/IndirectRelative modes only
-    uint16_t pointer_address = 0;
+    /// @brief A seed for the generation of the pointer address
+    /// Used for Indirect/IndirectRelative modes only
+    uint16_t pointer_address_seed = 0;
 
-    /// @brief Base offset used for Relative/IndirectRelative modes only
-    uint32_t base_offset = 0;
+    /// @brief A seed for the generation of the base offset
+    /// Used for Relative/IndirectRelative modes only
+    /// Sets M[0] = base_offset
+    uint32_t base_offset_seed = 0;
     AddressingModeWrapper mode = AddressingMode::Direct;
-    MSGPACK_FIELDS(address, pointer_address, base_offset, mode);
+    MSGPACK_FIELDS(address, pointer_address_seed, base_offset_seed, mode);
+};
+
+/// @brief Output of resolving an address in the memory manager
+/// In order to resolve a given absolute address with a given addressing mode,
+/// we might have needed to override the base pointer or to
+/// make use of indirection via a pointer address, or both.
+struct ResolvedAddress {
+    uint32_t absolute_address = 0;
+    uint32_t operand_address = 0;
+    std::optional<uint32_t> base_pointer = std::nullopt;
+    std::optional<uint32_t> pointer_address = std::nullopt;
 };
 
 /// @brief mem[result_offset] = mem[a_address] + mem[b_address]
 struct ADD_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] - mem[b_address]
 struct SUB_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] * mem[b_address]
 struct MUL_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] / mem[b_address]
 struct DIV_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 struct FDIV_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] == mem[b_address]
 struct EQ_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] < mem[b_address]
 struct LT_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] <= mem[b_address]
 struct LTE_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] & mem[b_address]
 struct AND_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] | mem[b_address]
 struct OR_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] ^ mem[b_address]
 struct XOR_8_Instruction {
     MemoryTagWrapper argument_tag;
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(argument_tag, a_address, b_address, result_address);
 };
 
 struct NOT_8_Instruction {
-    AddressRef a_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] << mem[b_address]
 struct SHL_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] >> mem[b_address]
 struct SHR_8_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief SET_8 instruction
 struct SET_8_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     uint8_t value;
     MSGPACK_FIELDS(value_tag, result_address, value);
 };
@@ -247,7 +261,7 @@ struct SET_8_Instruction {
 /// @brief SET_16 instruction
 struct SET_16_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     uint16_t value;
     MSGPACK_FIELDS(value_tag, result_address, value);
 };
@@ -255,7 +269,7 @@ struct SET_16_Instruction {
 /// @brief SET_32 instruction
 struct SET_32_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     uint32_t value;
     MSGPACK_FIELDS(value_tag, result_address, value);
 };
@@ -263,7 +277,7 @@ struct SET_32_Instruction {
 /// @brief SET_64 instruction
 struct SET_64_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     uint64_t value;
     MSGPACK_FIELDS(value_tag, result_address, value);
 };
@@ -271,7 +285,7 @@ struct SET_64_Instruction {
 /// @brief SET_128 instruction
 struct SET_128_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     uint64_t value_low;
     uint64_t value_high;
     MSGPACK_FIELDS(value_tag, result_address, value_low, value_high);
@@ -280,7 +294,7 @@ struct SET_128_Instruction {
 /// @brief SET_FF instruction
 struct SET_FF_Instruction {
     MemoryTagWrapper value_tag;
-    ResultAddressRef result_address;
+    AddressRef result_address;
     bb::avm2::FF value;
     MSGPACK_FIELDS(value_tag, result_address, value);
 };
@@ -288,133 +302,133 @@ struct SET_FF_Instruction {
 /// @brief MOV_8 instruction: mem[dst_offset] = mem[src_offset]
 struct MOV_8_Instruction {
     MemoryTagWrapper value_tag;
-    AddressRef src_address;
-    ResultAddressRef result_address;
+    VariableRef src_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(value_tag, src_address, result_address);
 };
 
 /// @brief MOV_16 instruction: mem[dst_offset] = mem[src_offset]
 struct MOV_16_Instruction {
     MemoryTagWrapper value_tag;
-    AddressRef src_address;
-    ResultAddressRef result_address;
+    VariableRef src_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(value_tag, src_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] + mem[b_address] (16-bit)
 struct ADD_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] - mem[b_address] (16-bit)
 struct SUB_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] * mem[b_address] (16-bit)
 struct MUL_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] / mem[b_address] (16-bit)
 struct DIV_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 struct FDIV_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] == mem[b_address] (16-bit)
 struct EQ_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] < mem[b_address] (16-bit)
 struct LT_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] <= mem[b_address] (16-bit)
 struct LTE_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] & mem[b_address] (16-bit)
 struct AND_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] | mem[b_address] (16-bit)
 struct OR_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] ^ mem[b_address] (16-bit)
 struct XOR_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 struct NOT_16_Instruction {
-    AddressRef a_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] << mem[b_address] (16-bit)
 struct SHL_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief mem[result_offset] = mem[a_address] >> mem[b_address] (16-bit)
 struct SHR_16_Instruction {
-    AddressRef a_address;
-    AddressRef b_address;
-    ResultAddressRef result_address;
+    VariableRef a_address;
+    VariableRef b_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(a_address, b_address, result_address);
 };
 
 /// @brief CAST_8: cast mem[src_offset_index] to target_tag and store at dst_offset
 struct CAST_8_Instruction {
     MemoryTagWrapper src_tag;
-    AddressRef src_address;
-    ResultAddressRef result_address;
+    VariableRef src_address;
+    AddressRef result_address;
     MemoryTagWrapper target_tag;
     MSGPACK_FIELDS(src_tag, src_address, result_address, target_tag);
 };
@@ -422,31 +436,31 @@ struct CAST_8_Instruction {
 /// @brief CAST_16: cast mem[src_offset_index] to target_tag and store at dst_offset
 struct CAST_16_Instruction {
     MemoryTagWrapper src_tag;
-    AddressRef src_address;
-    ResultAddressRef result_address;
+    VariableRef src_address;
+    AddressRef result_address;
     MemoryTagWrapper target_tag;
     MSGPACK_FIELDS(src_tag, src_address, result_address, target_tag);
 };
 
 /// @brief SSTORE: M[slot_offset_index] = slot; S[M[slotOffset]] = M[srcOffset]
 struct SSTORE_Instruction {
-    AddressRef src_address;
-    ResultAddressRef result_address;
+    VariableRef src_address;
+    AddressRef result_address;
     bb::avm2::FF slot;
     MSGPACK_FIELDS(src_address, result_address, slot);
 };
 
 /// @brief SLOAD: M[slot_offset] = slot; M[result_offset] = S[M[slotOffset]]
 struct SLOAD_Instruction {
-    uint16_t slot_index;           // index of the slot in memory_manager.storage_addresses
-    ResultAddressRef slot_address; // address where we set slot value
-    ResultAddressRef result_address;
+    uint16_t slot_index;     // index of the slot in memory_manager.storage_addresses
+    AddressRef slot_address; // address where we set slot value
+    AddressRef result_address;
     MSGPACK_FIELDS(slot_index, slot_address, result_address);
 };
 
 /// @brief GETENVVAR: M[result_offset] = getenvvar(type)
 struct GETENVVAR_Instruction {
-    ResultAddressRef result_address;
+    AddressRef result_address;
     // msgpack cannot pack enum classes, so we pack that as a uint8_t
     // 0 -> ADDRESS, 1 -> SENDER, 2 -> TRANSACTIONFEE, 3 -> CHAINID, 4 -> VERSION, 5 -> BLOCKNUMBER, 6 -> TIMESTAMP,
     // 7 -> BASEFEEPERDAGAS, 8 -> BASEFEEPERL2GAS, 9 -> ISSTATICCALL, 10 -> L2GASLEFT, 11 -> DAGASLEFT
@@ -456,7 +470,7 @@ struct GETENVVAR_Instruction {
 
 /// @brief EMITNULIFIER: inserts new nullifier to the nullifier tree
 struct EMITNULLIFIER_Instruction {
-    AddressRef nullifier_address;
+    VariableRef nullifier_address;
     MSGPACK_FIELDS(nullifier_address);
 };
 
@@ -464,15 +478,15 @@ struct EMITNULLIFIER_Instruction {
 /// Gets contract's address by GETENVVAR(0)
 /// M[result_offset] = NULLIFIEREXISTS(M[nullifier_offset_index], GETENVVAR(0))
 struct NULLIFIEREXISTS_Instruction {
-    AddressRef nullifier_address;
-    ResultAddressRef contract_address_address; // absolute address where the contract address will be stored
-    ResultAddressRef result_address;
+    VariableRef nullifier_address;
+    AddressRef contract_address_address; // absolute address where the contract address will be stored
+    AddressRef result_address;
     MSGPACK_FIELDS(nullifier_address, contract_address_address, result_address);
 };
 
 /// @brief EMITNOTEHASH: M[note_hash_offset] = note_hash; emit note hash to the note hash tree
 struct EMITNOTEHASH_Instruction {
-    ResultAddressRef note_hash_address; // absolute address where the note hash will be stored
+    AddressRef note_hash_address; // absolute address where the note hash will be stored
     bb::avm2::FF note_hash;
     MSGPACK_FIELDS(note_hash_address, note_hash);
 };
@@ -486,36 +500,36 @@ struct NOTEHASHEXISTS_Instruction {
     // index of the note hash in the memory_manager.emitted_note_hashes
     uint16_t notehash_index;
     // absolute address where the note hash will be stored
-    ResultAddressRef notehash_address;
+    AddressRef notehash_address;
     // absolute address where the leaf index will be stored
-    ResultAddressRef leaf_index_address;
+    AddressRef leaf_index_address;
     // absolute address where the result will be stored
-    ResultAddressRef result_address;
+    AddressRef result_address;
     MSGPACK_FIELDS(notehash_index, notehash_address, leaf_index_address, result_address);
 };
 
 /// @brief CALLDATACOPY: M[dstOffset:dstOffset+M[copySizeOffset]] =
 /// calldata[M[cdStartOffset]:M[cdStartOffset]+M[copySizeOffset]]
 struct CALLDATACOPY_Instruction {
-    ResultAddressRef dst_address;
+    AddressRef dst_address;
     uint8_t copy_size;
-    ResultAddressRef copy_size_address; // where copy size will be stored
+    AddressRef copy_size_address; // where copy size will be stored
     uint16_t cd_start;
-    ResultAddressRef cd_start_address; // where cd start will be stored
+    AddressRef cd_start_address; // where cd start will be stored
     MSGPACK_FIELDS(dst_address, copy_size, copy_size_address, cd_start, cd_start_address);
 };
 
 struct SENDL2TOL1MSG_Instruction {
     bb::avm2::FF recipient;
-    ResultAddressRef recipient_address;
+    AddressRef recipient_address;
     bb::avm2::FF content;
-    ResultAddressRef content_address;
+    AddressRef content_address;
     MSGPACK_FIELDS(recipient, recipient_address, content, content_address);
 };
 
 struct EMITUNENCRYPTEDLOG_Instruction {
     uint8_t log_size;
-    ResultAddressRef log_size_address;
+    AddressRef log_size_address;
     std::vector<bb::avm2::FF> log_values;
     uint16_t log_values_address_start;
     MSGPACK_FIELDS(log_size, log_size_address, log_values);
@@ -581,16 +595,16 @@ inline std::ostream& operator<<(std::ostream& os, const MemoryTag& tag)
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const AddressRef& address)
+inline std::ostream& operator<<(std::ostream& os, const VariableRef& variable)
 {
-    os << "AddressRef " << address.tag << " " << address.index << " " << address.base_offset << " "
-       << static_cast<int>(static_cast<AddressingMode>(address.mode));
+    os << "VariableRef " << variable.tag << " " << variable.index << " " << variable.base_offset_seed << " "
+       << static_cast<int>(static_cast<AddressingMode>(variable.mode));
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const ResultAddressRef& result_address)
+inline std::ostream& operator<<(std::ostream& os, const AddressRef& result_address)
 {
-    os << "ResultAddressRef " << result_address.address << " "
+    os << "AddressRef " << result_address.address << " "
        << static_cast<int>(static_cast<AddressingMode>(result_address.mode));
     return os;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
@@ -1,7 +1,72 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/vm2/testing/instruction_builder.hpp"
 
 using namespace bb::avm2::testing;
+
+namespace {
+
+/**
+ * @brief Get the nth element from a range that satisfies a predicate (zero-copy).
+ *
+ * @tparam Range The range type (e.g., std::vector<T>&)
+ * @tparam Predicate A callable that takes an element and returns bool
+ * @param range The input range to filter
+ * @param predicate Filter predicate - elements where predicate(elem) is true are included
+ * @param index Index used to select element: actual_index = index % count_of_matching_elements
+ * @return std::optional containing the selected element, or std::nullopt if no elements match
+ */
+template <std::ranges::input_range Range, typename Predicate>
+auto get_nth_filtered(Range&& range, Predicate predicate, size_t index)
+    -> std::optional<std::ranges::range_value_t<Range>>
+{
+    auto filtered = range | std::views::filter(predicate);
+
+    auto count = std::ranges::distance(filtered);
+    if (count == 0) {
+        return std::nullopt;
+    }
+
+    return *std::ranges::next(filtered.begin(), static_cast<long>(index % static_cast<size_t>(count)));
+}
+
+uint32_t get_max_variable_address(AddressingMode mode, uint32_t literal_max_value)
+{
+    if (mode == AddressingMode::Direct) {
+        return literal_max_value;
+    }
+    // In relative addressing, and indirect addressing, we can reach any variable address.
+    return AVM_HIGHEST_MEM_ADDRESS;
+}
+
+uint32_t trimmed_direct_address(uint32_t direct_address_seed, uint32_t max_operand_address)
+{
+    return direct_address_seed % (max_operand_address + 1);
+}
+
+uint32_t trimmed_pointer_address(uint32_t pointer_address_seed, uint32_t max_operand_address)
+{
+    if (pointer_address_seed <= max_operand_address) {
+        return pointer_address_seed;
+    }
+
+    return pointer_address_seed % (max_operand_address + 1);
+}
+
+uint32_t trimmed_relative_operand_address(uint32_t base_offset_seed,
+                                          uint32_t relative_target,
+                                          uint32_t max_operand_address)
+{
+    uint32_t max_operand = std::min(relative_target, max_operand_address);
+    return (base_offset_seed % (max_operand + 1));
+}
+
+uint32_t trimmed_base_pointer(uint32_t base_offset_seed, uint32_t relative_target, uint32_t max_operand_address)
+{
+    return relative_target - trimmed_relative_operand_address(base_offset_seed, relative_target, max_operand_address);
+}
+
+} // namespace
 
 MemoryManager& MemoryManager::operator=(const MemoryManager& other)
 {
@@ -35,48 +100,78 @@ void MemoryManager::set_memory_address(bb::avm2::MemoryTag tag, uint32_t address
     stored_variables[tag].push_back(address);
 }
 
-std::optional<uint32_t> MemoryManager::get_memory_address_to_resolve(AddressRef address)
+ResolvedAddress MemoryManager::resolve_address(VariableRef variable,
+                                               uint32_t absolute_address,
+                                               uint32_t max_operand_address)
 {
-    auto memory_address = get_memory_offset(address.tag, address.index);
-    if (!memory_address.has_value()) {
-        return std::nullopt;
-    }
-    auto absolute_address = memory_address.value();
-    switch (address.mode) {
-    case AddressingMode::Indirect:
-        absolute_address = address.pointer_address;
+    ResolvedAddress resolved_address = {
+        .absolute_address = absolute_address,
+    };
+    switch (variable.mode) {
+    case AddressingMode::Indirect: {
+        uint32_t trimmed_pointer_address_value =
+            trimmed_pointer_address(variable.pointer_address_seed, max_operand_address);
+        resolved_address.pointer_address = trimmed_pointer_address_value;
+        resolved_address.operand_address = trimmed_pointer_address_value;
         break;
+    }
     case AddressingMode::Relative:
-        absolute_address -= address.base_offset;
+        resolved_address.base_pointer =
+            trimmed_base_pointer(variable.base_offset_seed, absolute_address, max_operand_address);
+        resolved_address.operand_address =
+            trimmed_relative_operand_address(variable.base_offset_seed, absolute_address, max_operand_address);
         break;
     case AddressingMode::IndirectRelative:
-        absolute_address = address.pointer_address;
-        absolute_address -= address.base_offset;
+        resolved_address.pointer_address = variable.pointer_address_seed;
+        // Relative addressing target is the pointer
+        resolved_address.base_pointer =
+            trimmed_base_pointer(variable.base_offset_seed, variable.pointer_address_seed, max_operand_address);
+        resolved_address.operand_address = trimmed_relative_operand_address(
+            variable.base_offset_seed, variable.pointer_address_seed, max_operand_address);
         break;
     case AddressingMode::Direct:
+        // We can't change the absolute address, or it won't find anything useful there.
+        resolved_address.operand_address = absolute_address;
         break;
     }
-    return absolute_address;
+    return resolved_address;
 }
 
-std::optional<uint32_t> MemoryManager::get_memory_address_to_resolve(ResultAddressRef address)
+ResolvedAddress MemoryManager::resolve_address(AddressRef address, uint32_t max_operand_address)
 {
-    auto absolute_address = address.address;
+
+    ResolvedAddress resolved_address = {
+        .absolute_address = address.address,
+    };
     switch (address.mode) {
-    case AddressingMode::Indirect:
-        absolute_address = address.pointer_address;
-        break;
-    case AddressingMode::Relative:
-        absolute_address -= address.base_offset;
-        break;
-    case AddressingMode::IndirectRelative:
-        absolute_address = address.pointer_address;
-        absolute_address -= address.base_offset;
-        break;
-    case AddressingMode::Direct:
+    case AddressingMode::Indirect: {
+        // Trim the pointer to 16 bits for it to be writable by SET_32
+        uint32_t trimmed_pointer_address_value =
+            trimmed_pointer_address(address.pointer_address_seed, max_operand_address);
+        resolved_address.pointer_address = trimmed_pointer_address_value;
+        resolved_address.operand_address = trimmed_pointer_address_value;
         break;
     }
-    return absolute_address;
+    case AddressingMode::Relative:
+        resolved_address.base_pointer =
+            trimmed_base_pointer(address.base_offset_seed, resolved_address.absolute_address, max_operand_address);
+        resolved_address.operand_address = trimmed_relative_operand_address(
+            address.base_offset_seed, resolved_address.absolute_address, max_operand_address);
+        break;
+    case AddressingMode::IndirectRelative:
+        resolved_address.pointer_address = address.pointer_address_seed;
+        // Relative addressing target is the pointer
+        resolved_address.base_pointer =
+            trimmed_base_pointer(address.base_offset_seed, address.pointer_address_seed, max_operand_address);
+        resolved_address.operand_address = trimmed_relative_operand_address(
+            address.base_offset_seed, address.pointer_address_seed, max_operand_address);
+        break;
+    case AddressingMode::Direct:
+        resolved_address.absolute_address = trimmed_direct_address(address.address, max_operand_address);
+        resolved_address.operand_address = resolved_address.absolute_address;
+        break;
+    }
+    return resolved_address;
 }
 
 OperandBuilder MemoryManager::get_memory_address_operand(OperandBuilder operand, AddressingMode mode)
@@ -98,88 +193,80 @@ OperandBuilder MemoryManager::get_memory_address_operand(OperandBuilder operand,
     return operand;
 }
 
-std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> MemoryManager::get_memory_address_and_operand_8(
-    AddressRef address)
+std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
+    get_resolved_address_and_operand_8(VariableRef address)
 {
-    auto absolute_address = get_memory_address_to_resolve(address);
-    if (!absolute_address.has_value()) {
+    auto actual_address = get_variable_address(address.tag, address.index, get_max_variable_address(address.mode, 255));
+    if (!actual_address.has_value()) {
         return std::nullopt;
     }
-    if (absolute_address.value() > 255) {
+    auto resolved_address = resolve_address(address, actual_address.value(), 255);
+
+    if (resolved_address.operand_address > 255) {
         return std::nullopt;
     }
-    auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(absolute_address.value()));
 
-    auto actual_address = get_memory_offset(address.tag, address.index);
+    auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(resolved_address.operand_address));
 
-    return std::make_pair(actual_address.value(), get_memory_address_operand(operand, address.mode));
+    return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
 
-std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> MemoryManager::get_memory_address_and_operand_8(
-    ResultAddressRef address)
+std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
+    get_resolved_address_and_operand_8(AddressRef address)
 {
-    auto absolute_address = get_memory_address_to_resolve(address);
-    if (!absolute_address.has_value()) {
-        return std::nullopt;
-    }
-    if (absolute_address.value() > 255) {
-        return std::nullopt;
-    }
-    auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(absolute_address.value()));
-    return std::make_pair(address.address, get_memory_address_operand(operand, address.mode));
+    auto resolved_address = resolve_address(address, 255);
+    auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(resolved_address.operand_address));
+    return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
 
-std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> MemoryManager::get_memory_address_and_operand_16(
-    AddressRef address)
+std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
+    get_resolved_address_and_operand_16(VariableRef address)
 {
-    auto absolute_address = get_memory_address_to_resolve(address);
-    if (!absolute_address.has_value()) {
+    auto actual_address =
+        get_variable_address(address.tag, address.index, get_max_variable_address(address.mode, 65535));
+    if (!actual_address.has_value()) {
         return std::nullopt;
     }
-    if (absolute_address.value() > 65535) {
+
+    auto resolved_address = resolve_address(address, actual_address.value(), 65535);
+
+    if (resolved_address.operand_address > 65535) {
         return std::nullopt;
     }
-    auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(absolute_address.value()));
-    auto actual_address = get_memory_offset(address.tag, address.index);
-    return std::make_pair(actual_address.value(), get_memory_address_operand(operand, address.mode));
+    auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(resolved_address.operand_address));
+    return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
 
-std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> MemoryManager::get_memory_address_and_operand_16(
-    ResultAddressRef address)
+std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
+    get_resolved_address_and_operand_16(AddressRef address)
 {
-    auto absolute_address = get_memory_address_to_resolve(address);
-    if (!absolute_address.has_value()) {
-        return std::nullopt;
-    }
-    if (absolute_address.value() > 65535) {
-        return std::nullopt;
-    }
-    auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(absolute_address.value()));
-    return std::make_pair(address.address, get_memory_address_operand(operand, address.mode));
+    auto resolved_address = resolve_address(address, 65535);
+    auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(resolved_address.operand_address));
+    return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
 
-std::optional<uint32_t> MemoryManager::get_memory_offset(bb::avm2::MemoryTag tag, uint32_t index)
+std::optional<uint32_t> MemoryManager::get_variable_address(bb::avm2::MemoryTag tag, uint32_t index, uint32_t max_value)
 {
-    auto it = this->stored_variables.find(tag);
-    if (it == this->stored_variables.end() || it->second.empty()) {
-        return std::nullopt;
-    }
-    auto& arr = it->second;
-    return arr[index % arr.size()];
+    return get_nth_filtered(this->stored_variables[tag], [max_value](uint32_t val) { return val <= max_value; }, index);
 }
 
-std::optional<uint8_t> MemoryManager::get_memory_offset_8_bit(bb::avm2::MemoryTag tag, uint16_t index)
+std::optional<uint8_t> MemoryManager::get_memory_offset_8(bb::avm2::MemoryTag tag, uint32_t index)
 {
-    auto value = get_memory_offset(tag, index);
+    auto value = get_variable_address(tag, index, 255);
+    if (!value.has_value()) {
+        return std::nullopt;
+    }
+    return static_cast<uint8_t>(value.value());
+}
+
+std::optional<uint16_t> MemoryManager::get_memory_offset_16(bb::avm2::MemoryTag tag, uint32_t index)
+{
+    auto value = get_variable_address(tag, index, 65535);
     if (!value.has_value()) {
         return std::nullopt;
     }
 
-    if (value.value() > 255) {
-        return std::nullopt;
-    }
-
-    return static_cast<uint8_t>(value.value());
+    return static_cast<uint16_t>(value.value());
 }
 
 void MemoryManager::append_slot(bb::avm2::FF slot)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/testing/instruction_builder.hpp"
 
 using namespace bb::avm2::testing;
@@ -17,8 +18,7 @@ namespace {
  * @return std::optional containing the selected element, or std::nullopt if no elements match
  */
 template <std::ranges::input_range Range, typename Predicate>
-auto get_nth_filtered(Range&& range, Predicate predicate, size_t index)
-    -> std::optional<std::ranges::range_value_t<Range>>
+std::optional<std::ranges::range_value_t<Range>> get_nth_filtered(Range&& range, Predicate predicate, size_t index)
 {
     auto filtered = range | std::views::filter(predicate);
 
@@ -46,10 +46,6 @@ uint32_t trimmed_direct_address(uint32_t direct_address_seed, uint32_t max_opera
 
 uint32_t trimmed_pointer_address(uint32_t pointer_address_seed, uint32_t max_operand_address)
 {
-    if (pointer_address_seed <= max_operand_address) {
-        return pointer_address_seed;
-    }
-
     return pointer_address_seed % (max_operand_address + 1);
 }
 
@@ -202,9 +198,7 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
     }
     auto resolved_address = resolve_address(address, actual_address.value(), 255);
 
-    if (resolved_address.operand_address > 255) {
-        return std::nullopt;
-    }
+    BB_ASSERT_LTE(resolved_address.operand_address, uint32_t{ 255 });
 
     auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(resolved_address.operand_address));
 
@@ -230,9 +224,7 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
 
     auto resolved_address = resolve_address(address, actual_address.value(), 65535);
 
-    if (resolved_address.operand_address > 65535) {
-        return std::nullopt;
-    }
+    BB_ASSERT_LTE(resolved_address.operand_address, uint32_t{ 65535 });
     auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(resolved_address.operand_address));
     return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
@@ -256,6 +248,7 @@ std::optional<uint8_t> MemoryManager::get_memory_offset_8(bb::avm2::MemoryTag ta
     if (!value.has_value()) {
         return std::nullopt;
     }
+    BB_ASSERT_LTE(value.value(), uint8_t{ 255 });
     return static_cast<uint8_t>(value.value());
 }
 
@@ -265,7 +258,7 @@ std::optional<uint16_t> MemoryManager::get_memory_offset_16(bb::avm2::MemoryTag 
     if (!value.has_value()) {
         return std::nullopt;
     }
-
+    BB_ASSERT_LTE(value.value(), uint16_t{ 65535 });
     return static_cast<uint16_t>(value.value());
 }
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
@@ -23,8 +23,9 @@ class MemoryManager {
 
     bb::avm2::testing::OperandBuilder get_memory_address_operand(bb::avm2::testing::OperandBuilder operand,
                                                                  AddressingMode mode);
-    std::optional<uint32_t> get_memory_address_to_resolve(AddressRef address);
-    std::optional<uint32_t> get_memory_address_to_resolve(ResultAddressRef address);
+    ResolvedAddress resolve_address(VariableRef address, uint32_t absolute_address, uint32_t max_operand_address);
+    ResolvedAddress resolve_address(AddressRef address, uint32_t max_operand_address);
+    std::optional<uint32_t> get_variable_address(bb::avm2::MemoryTag tag, uint32_t index, uint32_t max_value);
 
   public:
     MemoryManager() = default;
@@ -34,18 +35,18 @@ class MemoryManager {
     MemoryManager& operator=(MemoryManager&& other) = default;
     ~MemoryManager() = default;
     void set_memory_address(bb::avm2::MemoryTag tag, uint32_t address);
-    std::optional<uint32_t> get_memory_offset(bb::avm2::MemoryTag tag, uint32_t address_index);
-    std::optional<uint8_t> get_memory_offset_8_bit(bb::avm2::MemoryTag tag, uint16_t address_index);
+    std::optional<uint16_t> get_memory_offset_16(bb::avm2::MemoryTag tag, uint32_t address_index);
+    std::optional<uint8_t> get_memory_offset_8(bb::avm2::MemoryTag tag, uint32_t address_index);
     bool is_memory_address_set(uint16_t address);
 
-    std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> get_memory_address_and_operand_8(
+    std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> get_resolved_address_and_operand_8(
+        VariableRef address);
+    std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> get_resolved_address_and_operand_8(
         AddressRef address);
-    std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> get_memory_address_and_operand_8(
-        ResultAddressRef address);
-    std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> get_memory_address_and_operand_16(
+    std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> get_resolved_address_and_operand_16(
+        VariableRef address);
+    std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> get_resolved_address_and_operand_16(
         AddressRef address);
-    std::optional<std::pair<uint32_t, bb::avm2::testing::OperandBuilder>> get_memory_address_and_operand_16(
-        ResultAddressRef address);
 
     // Append used slot to storage_addresses
     void append_slot(bb::avm2::FF slot);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
@@ -8,62 +8,53 @@
 #include "barretenberg/vm2/simulation/lib/serialization.hpp"
 #include "barretenberg/vm2/testing/instruction_builder.hpp"
 
-void ProgramBlock::preprocess_memory_addresses(AddressRef address, uint32_t actual_address)
+void ProgramBlock::preprocess_memory_addresses(ResolvedAddress resolved_address)
 {
-    auto set_base_offset_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
-                                           .operand(static_cast<uint16_t>(0))
-                                           .operand(bb::avm2::MemoryTag::U32)
-                                           .operand(address.base_offset)
-                                           .build();
-    auto set_pointer_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
-                                       .operand(address.pointer_address)
-                                       .operand(bb::avm2::MemoryTag::U32)
-                                       .operand(actual_address)
-                                       .build();
-    switch (address.mode) {
-    case AddressingMode::Indirect: {
-        instructions.push_back(set_pointer_instruction);
-        memory_manager.set_memory_address(bb::avm2::ValueTag::U32, address.pointer_address);
-        break;
-    }
-    case AddressingMode::Relative: {
+    if (resolved_address.base_pointer.has_value()) {
+        auto set_base_offset_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
+                                               .operand(static_cast<uint16_t>(0))
+                                               .operand(bb::avm2::MemoryTag::U32)
+                                               .operand(resolved_address.base_pointer.value())
+                                               .build();
         instructions.push_back(set_base_offset_instruction);
         memory_manager.set_memory_address(bb::avm2::ValueTag::U32, 0U);
-        break;
     }
-    case AddressingMode::IndirectRelative: {
-        instructions.push_back(set_pointer_instruction);
-        instructions.push_back(set_base_offset_instruction);
-        memory_manager.set_memory_address(bb::avm2::ValueTag::U32, address.pointer_address);
-        memory_manager.set_memory_address(bb::avm2::ValueTag::U32, 0U);
-        break;
-    }
-    case AddressingMode::Direct:
-        break;
-    }
-}
+    if (resolved_address.pointer_address.has_value()) {
+        if (resolved_address.base_pointer.has_value()) {
+            // Indirect relative: Write the pointer in a relative manner
+            auto set_pointer_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
+                                               .operand(static_cast<uint16_t>(resolved_address.pointer_address.value() -
+                                                                              resolved_address.base_pointer.value()))
+                                               .relative()
+                                               .operand(bb::avm2::MemoryTag::U32)
+                                               .operand(resolved_address.absolute_address)
+                                               .build();
+            instructions.push_back(set_pointer_instruction);
+        } else {
+            // Indirect: Write the pointer directly
+            auto set_pointer_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
+                                               .operand(static_cast<uint16_t>(resolved_address.pointer_address.value()))
+                                               .operand(bb::avm2::MemoryTag::U32)
+                                               .operand(resolved_address.absolute_address)
+                                               .build();
+            instructions.push_back(set_pointer_instruction);
+        }
 
-void ProgramBlock::preprocess_memory_addresses(ResultAddressRef address, uint32_t actual_address)
-{
-    // hack: just converting it to AddressRef and using the same function
-    auto address_ref = AddressRef{ .tag = bb::avm2::ValueTag::U32,
-                                   .pointer_address = address.pointer_address,
-                                   .base_offset = address.base_offset,
-                                   .mode = address.mode };
-    preprocess_memory_addresses(address_ref, actual_address);
+        memory_manager.set_memory_address(bb::avm2::ValueTag::U32, resolved_address.pointer_address.value());
+    }
 }
 
 void ProgramBlock::process_add_8_instruction(ADD_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
 
     auto add_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::ADD_8)
                                  .operand(a.value().second)
@@ -71,664 +62,672 @@ void ProgramBlock::process_add_8_instruction(ADD_8_Instruction instruction)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(add_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_sub_8_instruction(SUB_8_Instruction instruction)
 {
 
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto sub_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SUB_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(sub_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_mul_8_instruction(MUL_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto mul_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::MUL_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(mul_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_div_8_instruction(DIV_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto div_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::DIV_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(div_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_eq_8_instruction(EQ_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto eq_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::EQ_8)
                                 .operand(a.value().second)
                                 .operand(b.value().second)
                                 .operand(result.value().second)
                                 .build();
     instructions.push_back(eq_8_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_lt_8_instruction(LT_8_Instruction instruction)
 {
 
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto lt_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::LT_8)
                                 .operand(a.value().second)
                                 .operand(b.value().second)
                                 .operand(result.value().second)
                                 .build();
     instructions.push_back(lt_8_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_lte_8_instruction(LTE_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto lte_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::LTE_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(lte_8_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_and_8_instruction(AND_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto and_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::AND_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(and_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_or_8_instruction(OR_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto or_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::OR_8)
                                 .operand(a.value().second)
                                 .operand(b.value().second)
                                 .operand(result.value().second)
                                 .build();
     instructions.push_back(or_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_xor_8_instruction(XOR_8_Instruction instruction)
 {
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto xor_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::XOR_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(xor_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_shl_8_instruction(SHL_8_Instruction instruction)
 {
 
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto shl_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SHL_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(shl_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_shr_8_instruction(SHR_8_Instruction instruction)
 {
 
-    auto a = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a.has_value() || !b.has_value() || !result.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a.value().first);
-    preprocess_memory_addresses(instruction.b_address, b.value().first);
-    preprocess_memory_addresses(instruction.result_address, result.value().first);
+    preprocess_memory_addresses(a.value().first);
+    preprocess_memory_addresses(b.value().first);
+    preprocess_memory_addresses(result.value().first);
     auto shr_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SHR_8)
                                  .operand(a.value().second)
                                  .operand(b.value().second)
                                  .operand(result.value().second)
                                  .build();
     instructions.push_back(shr_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_8_instruction(SET_8_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_8)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(instruction.value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_16_instruction(SET_16_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_16)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(instruction.value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_32_instruction(SET_32_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(instruction.value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_64_instruction(SET_64_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_64)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(instruction.value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_128_instruction(SET_128_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
     uint128_t value =
         (static_cast<uint128_t>(instruction.value_high) << 64) | static_cast<uint128_t>(instruction.value_low);
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_128)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_set_ff_instruction(SET_FF_Instruction instruction)
 {
-    auto effective_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto effective_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!effective_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, effective_address_operand.value().first);
+    preprocess_memory_addresses(effective_address_operand.value().first);
     instructions.push_back(bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_FF)
                                .operand(effective_address_operand.value().second)
                                .operand(instruction.value_tag.value)
                                .operand(instruction.value)
                                .build());
-    memory_manager.set_memory_address(instruction.value_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.value_tag.value,
+                                      effective_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_mov_8_instruction(MOV_8_Instruction instruction)
 {
-    auto src_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.src_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto src_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.src_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!src_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.src_address, src_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(src_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto mov_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::MOV_8)
                                  .operand(src_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(mov_8_instruction);
-    memory_manager.set_memory_address(instruction.src_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.src_address.tag,
+                                      result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_mov_16_instruction(MOV_16_Instruction instruction)
 {
-    auto src_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.src_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto src_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.src_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!src_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.src_address, src_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(src_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto mov_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::MOV_16)
                                   .operand(src_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(mov_16_instruction);
-    memory_manager.set_memory_address(instruction.src_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.src_address.tag,
+                                      result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_fdiv_8_instruction(FDIV_8_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto fdiv_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::FDIV_8)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(fdiv_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_not_8_instruction(NOT_8_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.a_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.a_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!a_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto not_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::NOT_8)
                                  .operand(a_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(not_8_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_add_16_instruction(ADD_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto add_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::ADD_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(add_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_sub_16_instruction(SUB_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto sub_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SUB_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(sub_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_mul_16_instruction(MUL_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto mul_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::MUL_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(mul_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_div_16_instruction(DIV_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto div_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::DIV_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(div_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_fdiv_16_instruction(FDIV_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto fdiv_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::FDIV_16)
                                    .operand(a_address_operand.value().second)
                                    .operand(b_address_operand.value().second)
                                    .operand(result_address_operand.value().second)
                                    .build();
     instructions.push_back(fdiv_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_eq_16_instruction(EQ_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto eq_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::EQ_16)
                                  .operand(a_address_operand.value().second)
                                  .operand(b_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(eq_16_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_lt_16_instruction(LT_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto lt_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::LT_16)
                                  .operand(a_address_operand.value().second)
                                  .operand(b_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(lt_16_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_lte_16_instruction(LTE_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto lte_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::LTE_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(lte_16_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_and_16_instruction(AND_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto and_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::AND_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(and_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_or_16_instruction(OR_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto or_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::OR_16)
                                  .operand(a_address_operand.value().second)
                                  .operand(b_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(or_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_xor_16_instruction(XOR_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto xor_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::XOR_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(xor_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_not_16_instruction(NOT_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto not_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::NOT_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(not_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_shl_16_instruction(SHL_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
 
     auto shl_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SHL_16)
                                   .operand(a_address_operand.value().second)
@@ -736,77 +735,79 @@ void ProgramBlock::process_shl_16_instruction(SHL_16_Instruction instruction)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(shl_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_shr_16_instruction(SHR_16_Instruction instruction)
 {
-    auto a_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.a_address);
-    auto b_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.b_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto a_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.a_address);
+    auto b_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.b_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!a_address_operand.has_value() || !b_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.a_address, a_address_operand.value().first);
-    preprocess_memory_addresses(instruction.b_address, b_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(a_address_operand.value().first);
+    preprocess_memory_addresses(b_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto shr_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SHR_16)
                                   .operand(a_address_operand.value().second)
                                   .operand(b_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .build();
     instructions.push_back(shr_16_instruction);
-    memory_manager.set_memory_address(instruction.a_address.tag, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.a_address.tag, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_cast_8_instruction(CAST_8_Instruction instruction)
 {
-    auto src_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.src_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_8(instruction.result_address);
+    auto src_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.src_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_8(instruction.result_address);
     if (!src_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.src_address, src_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(src_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto cast_8_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::CAST_8)
                                   .operand(src_address_operand.value().second)
                                   .operand(result_address_operand.value().second)
                                   .operand(instruction.target_tag.value)
                                   .build();
     instructions.push_back(cast_8_instruction);
-    memory_manager.set_memory_address(instruction.target_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.target_tag.value,
+                                      result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_cast_16_instruction(CAST_16_Instruction instruction)
 {
-    auto src_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.src_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto src_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.src_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!src_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.src_address, src_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(src_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto cast_16_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::CAST_16)
                                    .operand(src_address_operand.value().second)
                                    .operand(result_address_operand.value().second)
                                    .operand(instruction.target_tag.value)
                                    .build();
     instructions.push_back(cast_16_instruction);
-    memory_manager.set_memory_address(instruction.target_tag.value, instruction.result_address.address);
+    memory_manager.set_memory_address(instruction.target_tag.value,
+                                      result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_sstore_instruction(SSTORE_Instruction instruction)
 {
-    auto src_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.src_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto src_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.src_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!src_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.src_address, src_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(src_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto set_slot_instruction = SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
                                                     .result_address = instruction.result_address,
                                                     .value = instruction.slot };
@@ -830,30 +831,30 @@ void ProgramBlock::process_sload_instruction(SLOAD_Instruction instruction)
                                                     .result_address = instruction.slot_address,
                                                     .value = *slot_addr };
     this->process_set_ff_instruction(set_slot_instruction);
-    auto slot_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.slot_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto slot_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.slot_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!slot_address_operand.has_value() || !result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.slot_address, slot_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(slot_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
 
     auto sload_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SLOAD)
                                  .operand(slot_address_operand.value().second)
                                  .operand(result_address_operand.value().second)
                                  .build();
     instructions.push_back(sload_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_getenvvar_instruction(GETENVVAR_Instruction instruction)
 {
     auto instruction_type = static_cast<uint8_t>(instruction.type % 12);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto getenvvar_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::GETENVVAR_16)
                                      .operand(result_address_operand.value().second)
                                      .operand(instruction_type)
@@ -861,19 +862,21 @@ void ProgramBlock::process_getenvvar_instruction(GETENVVAR_Instruction instructi
     instructions.push_back(getenvvar_instruction);
     // special case for timestamp, it returns a 64-bit value
     if (instruction_type == 6) {
-        memory_manager.set_memory_address(bb::avm2::MemoryTag::U64, instruction.result_address.address);
+        memory_manager.set_memory_address(bb::avm2::MemoryTag::U64,
+                                          result_address_operand.value().first.absolute_address);
     } else {
-        memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, instruction.result_address.address);
+        memory_manager.set_memory_address(bb::avm2::MemoryTag::FF,
+                                          result_address_operand.value().first.absolute_address);
     }
 }
 
 void ProgramBlock::process_emitnulifier_instruction(EMITNULLIFIER_Instruction instruction)
 {
-    auto nullifier_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.nullifier_address);
+    auto nullifier_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.nullifier_address);
     if (!nullifier_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.nullifier_address, nullifier_address_operand.value().first);
+    preprocess_memory_addresses(nullifier_address_operand.value().first);
     auto emitnulifier_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::EMITNULLIFIER)
                                         .operand(nullifier_address_operand.value().second)
                                         .build();
@@ -882,18 +885,18 @@ void ProgramBlock::process_emitnulifier_instruction(EMITNULLIFIER_Instruction in
 
 void ProgramBlock::process_nullifierexists_instruction(NULLIFIEREXISTS_Instruction instruction)
 {
-    auto nullifier_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.nullifier_address);
+    auto nullifier_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.nullifier_address);
     auto contract_address_operand =
-        memory_manager.get_memory_address_and_operand_16(instruction.contract_address_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+        memory_manager.get_resolved_address_and_operand_16(instruction.contract_address_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!nullifier_address_operand.has_value() || !contract_address_operand.has_value() ||
         !result_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.nullifier_address, nullifier_address_operand.value().first);
-    preprocess_memory_addresses(instruction.contract_address_address, contract_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(nullifier_address_operand.value().first);
+    preprocess_memory_addresses(contract_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
     auto get_contract_address_instruction =
         GETENVVAR_Instruction{ .result_address = instruction.contract_address_address, .type = 0 };
     this->process_getenvvar_instruction(get_contract_address_instruction);
@@ -904,7 +907,7 @@ void ProgramBlock::process_nullifierexists_instruction(NULLIFIEREXISTS_Instructi
                                            .operand(result_address_operand.value().second)
                                            .build();
     instructions.push_back(nullifierexists_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_emitnotehash_instruction(EMITNOTEHASH_Instruction instruction)
@@ -915,11 +918,11 @@ void ProgramBlock::process_emitnotehash_instruction(EMITNOTEHASH_Instruction ins
     this->process_set_ff_instruction(set_note_hash_instruction);
 
     // EMITNOTEHASH expects UINT16 operand
-    auto note_hash_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.note_hash_address);
+    auto note_hash_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.note_hash_address);
     if (!note_hash_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.note_hash_address, note_hash_address_operand.value().first);
+    preprocess_memory_addresses(note_hash_address_operand.value().first);
 
     auto emitnotehash_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::EMITNOTEHASH)
                                         .operand(note_hash_address_operand.value().second)
@@ -953,16 +956,17 @@ void ProgramBlock::process_notehashexists_instruction(NOTEHASHEXISTS_Instruction
                                                           .value = *leaf_index };
     this->process_set_ff_instruction(set_leaf_index_instruction);
 
-    auto notehash_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.notehash_address);
-    auto leaf_index_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.leaf_index_address);
-    auto result_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.result_address);
+    auto notehash_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.notehash_address);
+    auto leaf_index_address_operand =
+        memory_manager.get_resolved_address_and_operand_16(instruction.leaf_index_address);
+    auto result_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
     if (!notehash_address_operand.has_value() || !leaf_index_address_operand.has_value() ||
         !result_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.notehash_address, notehash_address_operand.value().first);
-    preprocess_memory_addresses(instruction.leaf_index_address, leaf_index_address_operand.value().first);
-    preprocess_memory_addresses(instruction.result_address, result_address_operand.value().first);
+    preprocess_memory_addresses(notehash_address_operand.value().first);
+    preprocess_memory_addresses(leaf_index_address_operand.value().first);
+    preprocess_memory_addresses(result_address_operand.value().first);
 
     auto notehashexists_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::NOTEHASHEXISTS)
                                           .operand(notehash_address_operand.value().second)
@@ -970,7 +974,7 @@ void ProgramBlock::process_notehashexists_instruction(NOTEHASHEXISTS_Instruction
                                           .operand(result_address_operand.value().second)
                                           .build();
     instructions.push_back(notehashexists_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, instruction.result_address.address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_address_operand.value().first.absolute_address);
 }
 
 void ProgramBlock::process_calldatacopy_instruction(CALLDATACOPY_Instruction instruction)
@@ -984,17 +988,17 @@ void ProgramBlock::process_calldatacopy_instruction(CALLDATACOPY_Instruction ins
                                                         .value = instruction.cd_start };
     this->process_set_32_instruction(cd_start_set_instruction);
     // CALLDATACOPY expects UINT16 operands for all three addresses
-    auto copy_size_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.copy_size_address);
-    auto cd_start_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.cd_start_address);
-    auto dst_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.dst_address);
+    auto copy_size_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.copy_size_address);
+    auto cd_start_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.cd_start_address);
+    auto dst_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
     if (!copy_size_address_operand.has_value() || !cd_start_address_operand.has_value() ||
         !dst_address_operand.has_value()) {
         return;
     }
 
-    preprocess_memory_addresses(instruction.copy_size_address, copy_size_address_operand.value().first);
-    preprocess_memory_addresses(instruction.cd_start_address, cd_start_address_operand.value().first);
-    preprocess_memory_addresses(instruction.dst_address, dst_address_operand.value().first);
+    preprocess_memory_addresses(copy_size_address_operand.value().first);
+    preprocess_memory_addresses(cd_start_address_operand.value().first);
+    preprocess_memory_addresses(dst_address_operand.value().first);
     auto calldatacopy_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::CALLDATACOPY)
                                         .operand(copy_size_address_operand.value().second)
                                         .operand(cd_start_address_operand.value().second)
@@ -1003,9 +1007,9 @@ void ProgramBlock::process_calldatacopy_instruction(CALLDATACOPY_Instruction ins
     instructions.push_back(calldatacopy_instruction);
 
     // setting calldata_addr to u32 to avoid overflows
-    auto loop_upper_bound =
-        static_cast<uint32_t>(std::min((instruction.dst_address.address) + instruction.copy_size, 65535U));
-    for (uint32_t calldata_addr = instruction.dst_address.address; calldata_addr < loop_upper_bound; calldata_addr++) {
+    uint32_t calldata_base_offset = dst_address_operand.value().first.absolute_address;
+    auto loop_upper_bound = static_cast<uint32_t>(std::min((calldata_base_offset) + instruction.copy_size, 65535U));
+    for (uint32_t calldata_addr = calldata_base_offset; calldata_addr < loop_upper_bound; calldata_addr++) {
         memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, calldata_addr);
     }
 }
@@ -1021,13 +1025,13 @@ void ProgramBlock::process_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction i
                                                        .value = instruction.content };
     this->process_set_ff_instruction(set_content_instruction);
 
-    auto recipient_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.recipient_address);
-    auto content_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.content_address);
+    auto recipient_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.recipient_address);
+    auto content_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.content_address);
     if (!recipient_address_operand.has_value() || !content_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.recipient_address, recipient_address_operand.value().first);
-    preprocess_memory_addresses(instruction.content_address, content_address_operand.value().first);
+    preprocess_memory_addresses(recipient_address_operand.value().first);
+    preprocess_memory_addresses(content_address_operand.value().first);
     auto sendl2tol1msg_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SENDL2TOL1MSG)
                                          .operand(recipient_address_operand.value().second)
                                          .operand(content_address_operand.value().second)
@@ -1044,19 +1048,19 @@ void ProgramBlock::process_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Ins
     size_t counter = 0;
     for (const auto& value : instruction.log_values) {
         auto log_values_address =
-            ResultAddressRef{ .address = static_cast<uint32_t>(instruction.log_values_address_start + counter),
-                              .mode = AddressingMode::Direct };
+            AddressRef{ .address = static_cast<uint32_t>(instruction.log_values_address_start + counter),
+                        .mode = AddressingMode::Direct };
         auto set_value_instruction = SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
                                                          .result_address = log_values_address,
                                                          .value = value };
         this->process_set_ff_instruction(set_value_instruction);
         counter++;
     }
-    auto log_size_address_operand = memory_manager.get_memory_address_and_operand_16(instruction.log_size_address);
+    auto log_size_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.log_size_address);
     if (!log_size_address_operand.has_value()) {
         return;
     }
-    preprocess_memory_addresses(instruction.log_size_address, log_size_address_operand.value().first);
+    preprocess_memory_addresses(log_size_address_operand.value().first);
     auto emitunencryptedlog_instruction =
         bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::EMITUNENCRYPTEDLOG)
             .operand(log_size_address_operand.value().second)
@@ -1078,7 +1082,7 @@ void ProgramBlock::finalize_with_return(uint8_t return_size,
         return;
     }
 
-    auto return_addr = memory_manager.get_memory_offset(return_value_tag.value, return_value_offset_index);
+    auto return_addr = memory_manager.get_memory_offset_16(return_value_tag.value, return_value_offset_index);
     if (!return_addr.has_value()) {
         return_addr = std::optional<uint32_t>(0);
     }
@@ -1096,7 +1100,7 @@ void ProgramBlock::finalize_with_return(uint8_t return_size,
     // RETURN expects UINT16 operands, ensure we cast to uint16_t explicitly
     auto return_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::RETURN)
                                   .operand(static_cast<uint16_t>(return_size_offset))
-                                  .operand(static_cast<uint16_t>(return_addr.value()))
+                                  .operand(return_addr.value())
                                   .build();
     instructions.push_back(return_instruction);
 }
@@ -1159,7 +1163,7 @@ void ProgramBlock::patch_internal_calls()
 
 std::optional<uint16_t> ProgramBlock::get_terminating_condition_value()
 {
-    auto condition_addr = memory_manager.get_memory_offset(bb::avm2::MemoryTag::U1, condition_offset_index);
+    auto condition_addr = memory_manager.get_memory_offset_16(bb::avm2::MemoryTag::U1, condition_offset_index);
     if (!condition_addr.has_value()) {
         return std::nullopt;
     }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
@@ -50,8 +50,7 @@ class ProgramBlock {
     /// @brief preprocess the memory addresses
     /// Sets M[0] = base_offset for Relative/IndirectRelative modes
     /// Sets M[pointer_address] = pointer_value for Indirect/IndirectRelative modes
-    void preprocess_memory_addresses(AddressRef address, uint32_t actual_address);
-    void preprocess_memory_addresses(ResultAddressRef address, uint32_t actual_address);
+    void preprocess_memory_addresses(ResolvedAddress resolved_address);
 
     void process_add_8_instruction(ADD_8_Instruction instruction);
     void process_sub_8_instruction(SUB_8_Instruction instruction);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -105,25 +105,24 @@ constexpr MemoryTagMutationConfig BASIC_MEMORY_TAG_MUTATION_CONFIGURATION = Memo
     { MemoryTagOptions::FF, 1 },
 });
 
-enum class AddressRefMutationOptions { tag, index, pointer_address, base_offset, mode };
-using AddressRefMutationConfig = WeightedSelectionConfig<AddressRefMutationOptions, 5>;
-constexpr AddressRefMutationConfig BASIC_ADDRESS_REF_MUTATION_CONFIGURATION = AddressRefMutationConfig({
-    { AddressRefMutationOptions::tag, 3 },
-    { AddressRefMutationOptions::index, 4 },
-    { AddressRefMutationOptions::pointer_address, 1 },
-    { AddressRefMutationOptions::base_offset, 1 },
-    { AddressRefMutationOptions::mode, 2 },
+enum class VariableRefMutationOptions { tag, index, pointer_address, base_offset, mode };
+using VariableRefMutationConfig = WeightedSelectionConfig<VariableRefMutationOptions, 5>;
+constexpr VariableRefMutationConfig BASIC_VARIABLE_REF_MUTATION_CONFIGURATION = VariableRefMutationConfig({
+    { VariableRefMutationOptions::tag, 3 },
+    { VariableRefMutationOptions::index, 4 },
+    { VariableRefMutationOptions::pointer_address, 1 },
+    { VariableRefMutationOptions::base_offset, 1 },
+    { VariableRefMutationOptions::mode, 2 },
 });
 
-enum class ResultAddressRefMutationOptions { address, pointer_address, base_offset, mode };
-using ResultAddressRefMutationConfig = WeightedSelectionConfig<ResultAddressRefMutationOptions, 5>;
-constexpr ResultAddressRefMutationConfig BASIC_RESULT_ADDRESS_REF_MUTATION_CONFIGURATION =
-    ResultAddressRefMutationConfig({
-        { ResultAddressRefMutationOptions::address, 1 },
-        { ResultAddressRefMutationOptions::pointer_address, 1 },
-        { ResultAddressRefMutationOptions::base_offset, 1 },
-        { ResultAddressRefMutationOptions::mode, 1 },
-    });
+enum class AddressRefMutationOptions { address, pointer_address, base_offset, mode };
+using AddressRefMutationConfig = WeightedSelectionConfig<AddressRefMutationOptions, 5>;
+constexpr AddressRefMutationConfig BASIC_ADDRESS_REF_MUTATION_CONFIGURATION = AddressRefMutationConfig({
+    { AddressRefMutationOptions::address, 1 },
+    { AddressRefMutationOptions::pointer_address, 1 },
+    { AddressRefMutationOptions::base_offset, 1 },
+    { AddressRefMutationOptions::mode, 1 },
+});
 
 enum class UnaryInstruction8MutationOptions { a_address, result_address };
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
@@ -52,6 +52,7 @@ void add_default_instruction_block_if_empty(FuzzerData& fuzzer_data, std::mt1993
         instruction_block.reserve(num_tags);
         // Add one set per memory tag type
         for (uint32_t i = 0; i < num_tags; i++) {
+            // TODO: Randomize address, value. Keep address < 255 so it can be used anywhere.
             auto tag = static_cast<ValueTag>(i);
             instruction_block.push_back(SET_8_Instruction{
                 .value_tag = tag,

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
@@ -8,6 +8,9 @@
 #include "barretenberg/avm_fuzzer/mutations/control_flow/control_flow_vec.hpp"
 #include "barretenberg/avm_fuzzer/mutations/control_flow/return_options.hpp"
 #include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
+#include "barretenberg/vm2/common/tagged_value.hpp"
+
+using ValueTag = bb::avm2::ValueTag;
 
 void mutate_fuzzer_data(FuzzerData& fuzzer_data, std::mt19937_64& rng)
 {
@@ -39,4 +42,36 @@ void mutate_fuzzer_data(FuzzerData& fuzzer_data, std::mt19937_64& rng)
             break;
         }
     }
+}
+
+void add_default_instruction_block_if_empty(FuzzerData& fuzzer_data, std::mt19937_64& rng)
+{
+    if (fuzzer_data.instruction_blocks.empty()) {
+        std::vector<FuzzInstruction> instruction_block;
+        uint32_t num_tags = static_cast<uint32_t>(ValueTag::MAX);
+        instruction_block.reserve(num_tags);
+        // Add one set per memory tag type
+        for (uint32_t i = 0; i < num_tags; i++) {
+            auto tag = static_cast<ValueTag>(i);
+            instruction_block.push_back(SET_8_Instruction{
+                .value_tag = tag,
+                .result_address =
+                    AddressRef{
+                        .address = i + 1, // Skip address 0
+                    },
+                .value = 1,
+            });
+        }
+        auto preamble = generate_instruction_block(rng);
+        instruction_block.insert(instruction_block.end(), preamble.begin(), preamble.end());
+        fuzzer_data.instruction_blocks.push_back(instruction_block);
+        fuzzer_data.cfg_instructions.push_back(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
+    }
+}
+
+FuzzerData generate_fuzzer_data(std::mt19937_64& rng)
+{
+    FuzzerData fuzzer_data = FuzzerData();
+    add_default_instruction_block_if_empty(fuzzer_data, rng);
+    return fuzzer_data;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.hpp
@@ -5,3 +5,5 @@
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
 
 void mutate_fuzzer_data(FuzzerData& fuzzer_data, std::mt19937_64& rng);
+FuzzerData generate_fuzzer_data(std::mt19937_64& rng);
+void add_default_instruction_block_if_empty(FuzzerData& fuzzer_data, std::mt19937_64& rng);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -14,26 +14,28 @@ AddressingMode generate_addressing_mode(std::mt19937_64& rng)
     return static_cast<AddressingMode>(generate_random_uint8(rng) % 4);
 }
 
-AddressRef generate_address_ref(std::mt19937_64& rng)
+VariableRef generate_variable_ref(std::mt19937_64& rng)
 {
     auto tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION);
     auto index = generate_random_uint32(rng);
     auto pointer_address = generate_random_uint16(rng);
     auto base_offset = generate_random_uint32(rng);
     auto mode = generate_addressing_mode(rng);
-    return AddressRef{
-        .tag = tag, .index = index, .pointer_address = pointer_address, .base_offset = base_offset, .mode = mode
-    };
+    return VariableRef{ .tag = tag,
+                        .index = index,
+                        .pointer_address_seed = pointer_address,
+                        .base_offset_seed = base_offset,
+                        .mode = mode };
 }
 
-ResultAddressRef generate_result_address_ref(std::mt19937_64& rng)
+AddressRef generate_address_ref(std::mt19937_64& rng)
 {
     auto address = generate_random_uint32(rng);
     auto pointer_address = generate_random_uint16(rng);
     auto base_offset = generate_random_uint32(rng);
     auto mode = generate_addressing_mode(rng);
-    return ResultAddressRef{
-        .address = address, .pointer_address = pointer_address, .base_offset = base_offset, .mode = mode
+    return AddressRef{
+        .address = address, .pointer_address_seed = pointer_address, .base_offset_seed = base_offset, .mode = mode
     };
 }
 
@@ -43,226 +45,225 @@ FuzzInstruction generate_instruction(std::mt19937_64& rng)
     // forgive me
     switch (option) {
     case InstructionGenerationOptions::ADD_8:
-        return ADD_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return ADD_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SUB_8:
-        return SUB_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return SUB_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::MUL_8:
-        return MUL_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return MUL_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::DIV_8:
-        return DIV_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return DIV_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::EQ_8:
-        return EQ_8_Instruction{ .a_address = generate_address_ref(rng),
-                                 .b_address = generate_address_ref(rng),
-                                 .result_address = generate_result_address_ref(rng) };
+        return EQ_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                 .b_address = generate_variable_ref(rng),
+                                 .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::LT_8:
-        return LT_8_Instruction{ .a_address = generate_address_ref(rng),
-                                 .b_address = generate_address_ref(rng),
-                                 .result_address = generate_result_address_ref(rng) };
+        return LT_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                 .b_address = generate_variable_ref(rng),
+                                 .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::LTE_8:
-        return LTE_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return LTE_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::AND_8:
-        return AND_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return AND_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::OR_8:
-        return OR_8_Instruction{ .a_address = generate_address_ref(rng),
-                                 .b_address = generate_address_ref(rng),
-                                 .result_address = generate_result_address_ref(rng) };
+        return OR_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                 .b_address = generate_variable_ref(rng),
+                                 .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::XOR_8:
-        return XOR_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return XOR_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SHL_8:
-        return SHL_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return SHL_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
 
     case InstructionGenerationOptions::SHR_8:
-        return SHR_8_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return SHR_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SET_8:
         return SET_8_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                  .result_address = generate_result_address_ref(rng),
+                                  .result_address = generate_address_ref(rng),
                                   .value = generate_random_uint8(rng) };
     case InstructionGenerationOptions::SET_16:
         return SET_16_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                   .result_address = generate_result_address_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .value = generate_random_uint16(rng) };
     case InstructionGenerationOptions::SET_32:
         return SET_32_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                   .result_address = generate_result_address_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .value = generate_random_uint32(rng) };
     case InstructionGenerationOptions::SET_64:
         return SET_64_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                   .result_address = generate_result_address_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .value = generate_random_uint64(rng) };
     case InstructionGenerationOptions::SET_128:
         return SET_128_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                    .result_address = generate_result_address_ref(rng),
+                                    .result_address = generate_address_ref(rng),
                                     .value_low = generate_random_uint64(rng),
                                     .value_high = generate_random_uint64(rng) };
     case InstructionGenerationOptions::SET_FF:
         return SET_FF_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
-                                   .result_address = generate_result_address_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .value = generate_random_field(rng) };
     case InstructionGenerationOptions::ADD_16:
-        return ADD_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return ADD_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SUB_16:
-        return SUB_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return SUB_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::MUL_16:
-        return MUL_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return MUL_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::DIV_16:
-        return DIV_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return DIV_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::FDIV_16:
-        return FDIV_16_Instruction{ .a_address = generate_address_ref(rng),
-                                    .b_address = generate_address_ref(rng),
-                                    .result_address = generate_result_address_ref(rng) };
+        return FDIV_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                    .b_address = generate_variable_ref(rng),
+                                    .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::EQ_16:
-        return EQ_16_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return EQ_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::LT_16:
-        return LT_16_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return LT_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::LTE_16:
-        return LTE_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return LTE_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::AND_16:
-        return AND_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return AND_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::OR_16:
-        return OR_16_Instruction{ .a_address = generate_address_ref(rng),
-                                  .b_address = generate_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+        return OR_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::XOR_16:
-        return XOR_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return XOR_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::NOT_16:
-        return NOT_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return NOT_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SHL_16:
-        return SHL_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return SHL_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SHR_16:
-        return SHR_16_Instruction{ .a_address = generate_address_ref(rng),
-                                   .b_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng) };
+        return SHR_16_Instruction{ .a_address = generate_variable_ref(rng),
+                                   .b_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::CAST_8:
-        return CAST_8_Instruction{ .src_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng),
+        return CAST_8_Instruction{ .src_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .target_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION) };
     case InstructionGenerationOptions::CAST_16:
-        return CAST_16_Instruction{ .src_address = generate_address_ref(rng),
-                                    .result_address = generate_result_address_ref(rng),
+        return CAST_16_Instruction{ .src_address = generate_variable_ref(rng),
+                                    .result_address = generate_address_ref(rng),
                                     .target_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION) };
     case InstructionGenerationOptions::SSTORE:
-        return SSTORE_Instruction{ .src_address = generate_address_ref(rng),
-                                   .result_address = generate_result_address_ref(rng),
+        return SSTORE_Instruction{ .src_address = generate_variable_ref(rng),
+                                   .result_address = generate_address_ref(rng),
                                    .slot = generate_random_field(rng) };
     case InstructionGenerationOptions::SLOAD:
         return SLOAD_Instruction{ .slot_index = generate_random_uint16(rng),
-                                  .slot_address = generate_result_address_ref(rng),
-                                  .result_address = generate_result_address_ref(rng) };
+                                  .slot_address = generate_address_ref(rng),
+                                  .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::GETENVVAR:
-        return GETENVVAR_Instruction{ .result_address = generate_result_address_ref(rng),
-                                      .type = generate_random_uint8(rng) };
+        return GETENVVAR_Instruction{ .result_address = generate_address_ref(rng), .type = generate_random_uint8(rng) };
     case InstructionGenerationOptions::EMITNULLIFIER:
-        return EMITNULLIFIER_Instruction{ .nullifier_address = generate_address_ref(rng) };
+        return EMITNULLIFIER_Instruction{ .nullifier_address = generate_variable_ref(rng) };
     case InstructionGenerationOptions::NULLIFIEREXISTS:
-        return NULLIFIEREXISTS_Instruction{ .nullifier_address = generate_address_ref(rng),
-                                            .contract_address_address = generate_result_address_ref(rng),
-                                            .result_address = generate_result_address_ref(rng) };
+        return NULLIFIEREXISTS_Instruction{ .nullifier_address = generate_variable_ref(rng),
+                                            .contract_address_address = generate_address_ref(rng),
+                                            .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::EMITNOTEHASH:
-        return EMITNOTEHASH_Instruction{ .note_hash_address = generate_result_address_ref(rng),
+        return EMITNOTEHASH_Instruction{ .note_hash_address = generate_address_ref(rng),
                                          .note_hash = generate_random_field(rng) };
     case InstructionGenerationOptions::NOTEHASHEXISTS:
         return NOTEHASHEXISTS_Instruction{ .notehash_index = generate_random_uint16(rng),
-                                           .notehash_address = generate_result_address_ref(rng),
-                                           .leaf_index_address = generate_result_address_ref(rng),
-                                           .result_address = generate_result_address_ref(rng) };
+                                           .notehash_address = generate_address_ref(rng),
+                                           .leaf_index_address = generate_address_ref(rng),
+                                           .result_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::CALLDATACOPY:
-        return CALLDATACOPY_Instruction{ .dst_address = generate_result_address_ref(rng),
+        return CALLDATACOPY_Instruction{ .dst_address = generate_address_ref(rng),
                                          .copy_size = generate_random_uint8(rng),
-                                         .copy_size_address = generate_result_address_ref(rng),
+                                         .copy_size_address = generate_address_ref(rng),
                                          .cd_start = generate_random_uint16(rng),
-                                         .cd_start_address = generate_result_address_ref(rng) };
+                                         .cd_start_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::SENDL2TOL1MSG:
         return SENDL2TOL1MSG_Instruction{ .recipient = generate_random_field(rng),
-                                          .recipient_address = generate_result_address_ref(rng),
+                                          .recipient_address = generate_address_ref(rng),
                                           .content = generate_random_field(rng),
-                                          .content_address = generate_result_address_ref(rng) };
+                                          .content_address = generate_address_ref(rng) };
     case InstructionGenerationOptions::EMITUNENCRYPTEDLOG:
         return EMITUNENCRYPTEDLOG_Instruction{ .log_size = generate_random_uint8(rng),
-                                               .log_size_address = generate_result_address_ref(rng),
+                                               .log_size_address = generate_address_ref(rng),
                                                .log_values = { generate_random_field(rng) },
                                                .log_values_address_start = generate_random_uint16(rng) };
     }
 }
 /// Most of the tags will be equal to the default tag
-void mutate_address_ref(AddressRef& address, std::mt19937_64& rng, std::optional<MemoryTag> default_tag)
+void mutate_variable_ref(VariableRef& variable, std::mt19937_64& rng, std::optional<MemoryTag> default_tag)
 {
-    AddressRefMutationOptions option = BASIC_ADDRESS_REF_MUTATION_CONFIGURATION.select(rng);
+    VariableRefMutationOptions option = BASIC_VARIABLE_REF_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
-    case AddressRefMutationOptions::tag:
+    case VariableRefMutationOptions::tag:
         if (default_tag.has_value()) {
-            mutate_or_default_tag(address.tag.value, rng, default_tag.value());
+            mutate_or_default_tag(variable.tag.value, rng, default_tag.value());
         } else {
-            mutate_memory_tag(address.tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
+            mutate_memory_tag(variable.tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         }
         break;
-    case AddressRefMutationOptions::index:
-        mutate_uint32_t(address.index, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
+    case VariableRefMutationOptions::index:
+        mutate_uint32_t(variable.index, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
         break;
-    case AddressRefMutationOptions::pointer_address:
-        mutate_uint16_t(address.pointer_address, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+    case VariableRefMutationOptions::pointer_address:
+        mutate_uint16_t(variable.pointer_address_seed, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
-    case AddressRefMutationOptions::base_offset:
-        mutate_uint32_t(address.base_offset, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
+    case VariableRefMutationOptions::base_offset:
+        mutate_uint32_t(variable.base_offset_seed, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
         break;
-    case AddressRefMutationOptions::mode:
-        address.mode = generate_addressing_mode(rng);
+    case VariableRefMutationOptions::mode:
+        variable.mode = generate_addressing_mode(rng);
         break;
     }
 }
 
-void mutate_result_address_ref(ResultAddressRef& address, std::mt19937_64& rng)
+void mutate_address_ref(AddressRef& address, std::mt19937_64& rng)
 {
-    ResultAddressRefMutationOptions option = BASIC_RESULT_ADDRESS_REF_MUTATION_CONFIGURATION.select(rng);
+    AddressRefMutationOptions option = BASIC_ADDRESS_REF_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
-    case ResultAddressRefMutationOptions::address:
+    case AddressRefMutationOptions::address:
         mutate_uint32_t(address.address, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
         break;
-    case ResultAddressRefMutationOptions::pointer_address:
-        mutate_uint16_t(address.pointer_address, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+    case AddressRefMutationOptions::pointer_address:
+        mutate_uint16_t(address.pointer_address_seed, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
-    case ResultAddressRefMutationOptions::base_offset:
-        mutate_uint32_t(address.base_offset, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
+    case AddressRefMutationOptions::base_offset:
+        mutate_uint32_t(address.base_offset_seed, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
         break;
-    case ResultAddressRefMutationOptions::mode:
+    case AddressRefMutationOptions::mode:
         address.mode = generate_addressing_mode(rng);
         break;
     }
@@ -274,13 +275,13 @@ void mutate_binary_instruction_8(BinaryInstructionType& instruction, std::mt1993
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case BinaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.a_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.a_address, rng, std::nullopt);
         break;
     case BinaryInstruction8MutationOptions::b_address:
-        mutate_address_ref(instruction.b_address, rng, instruction.a_address.tag);
+        mutate_variable_ref(instruction.b_address, rng, instruction.a_address.tag);
         break;
     case BinaryInstruction8MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -291,13 +292,13 @@ void mutate_binary_instruction_16(BinaryInstructionType& instruction, std::mt199
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case BinaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.a_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.a_address, rng, std::nullopt);
         break;
     case BinaryInstruction8MutationOptions::b_address:
-        mutate_address_ref(instruction.b_address, rng, instruction.a_address.tag);
+        mutate_variable_ref(instruction.b_address, rng, instruction.a_address.tag);
         break;
     case BinaryInstruction8MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -308,10 +309,10 @@ void mutate_not_8_instruction(NOT_8_Instruction& instruction, std::mt19937_64& r
     UnaryInstruction8MutationOptions option = BASIC_UNARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case UnaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.a_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.a_address, rng, std::nullopt);
         break;
     case UnaryInstruction8MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -325,7 +326,7 @@ void mutate_set_8_instruction(SET_8_Instruction& instruction, std::mt19937_64& r
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case Set8MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case Set8MutationOptions::value:
         mutate_uint8_t(instruction.value, rng, BASIC_UINT8_T_MUTATION_CONFIGURATION);
@@ -342,7 +343,7 @@ void mutate_set_16_instruction(SET_16_Instruction& instruction, std::mt19937_64&
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case Set16MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case Set16MutationOptions::value:
         mutate_uint16_t(instruction.value, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
@@ -359,7 +360,7 @@ void mutate_set_32_instruction(SET_32_Instruction& instruction, std::mt19937_64&
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case Set32MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case Set32MutationOptions::value:
         mutate_uint32_t(instruction.value, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
@@ -376,7 +377,7 @@ void mutate_set_64_instruction(SET_64_Instruction& instruction, std::mt19937_64&
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case Set64MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case Set64MutationOptions::value:
         mutate_uint64_t(instruction.value, rng, BASIC_UINT64_T_MUTATION_CONFIGURATION);
@@ -393,7 +394,7 @@ void mutate_set_128_instruction(SET_128_Instruction& instruction, std::mt19937_6
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case Set128MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case Set128MutationOptions::value_low:
         mutate_uint64_t(instruction.value_low, rng, BASIC_UINT64_T_MUTATION_CONFIGURATION);
@@ -413,7 +414,7 @@ void mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64&
         mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
         break;
     case SetFFMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case SetFFMutationOptions::value:
         mutate_field(instruction.value, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
@@ -427,10 +428,10 @@ void mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64&
     UnaryInstruction8MutationOptions option = BASIC_UNARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case UnaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.a_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.a_address, rng, std::nullopt);
         break;
     case UnaryInstruction8MutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -441,10 +442,10 @@ void mutate_cast_8_instruction(CAST_8_Instruction& instruction, std::mt19937_64&
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case BinaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.src_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.src_address, rng, std::nullopt);
         break;
     case BinaryInstruction8MutationOptions::b_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case BinaryInstruction8MutationOptions::result_address:
         mutate_memory_tag(instruction.target_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
@@ -458,10 +459,10 @@ void mutate_cast_16_instruction(CAST_16_Instruction& instruction, std::mt19937_6
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case BinaryInstruction8MutationOptions::a_address:
-        mutate_address_ref(instruction.src_address, rng, std::nullopt);
+        mutate_variable_ref(instruction.src_address, rng, std::nullopt);
         break;
     case BinaryInstruction8MutationOptions::b_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case BinaryInstruction8MutationOptions::result_address:
         mutate_memory_tag(instruction.target_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
@@ -475,10 +476,10 @@ void mutate_sstore_instruction(SSTORE_Instruction& instruction, std::mt19937_64&
     SStoreMutationOptions option = BASIC_SSTORE_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case SStoreMutationOptions::src_address:
-        mutate_address_ref(instruction.src_address, rng, MemoryTag::FF);
+        mutate_variable_ref(instruction.src_address, rng, MemoryTag::FF);
         break;
     case SStoreMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case SStoreMutationOptions::slot:
         mutate_field(instruction.slot, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
@@ -495,10 +496,10 @@ void mutate_sload_instruction(SLOAD_Instruction& instruction, std::mt19937_64& r
         mutate_uint16_t(instruction.slot_index, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
     case SLoadMutationOptions::slot_address:
-        mutate_result_address_ref(instruction.slot_address, rng);
+        mutate_address_ref(instruction.slot_address, rng);
         break;
     case SLoadMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -509,7 +510,7 @@ void mutate_getenvvar_instruction(GETENVVAR_Instruction& instruction, std::mt199
     GetEnvVarMutationOptions option = BASIC_GETENVVAR_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case GetEnvVarMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     case GetEnvVarMutationOptions::type:
         mutate_uint8_t(instruction.type, rng, BASIC_UINT8_T_MUTATION_CONFIGURATION);
@@ -521,7 +522,7 @@ void mutate_emit_nullifier_instruction(EMITNULLIFIER_Instruction& instruction, s
 {
     // emitnulifier only has one field
 
-    mutate_address_ref(instruction.nullifier_address, rng, MemoryTag::FF);
+    mutate_variable_ref(instruction.nullifier_address, rng, MemoryTag::FF);
 }
 
 void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instruction, std::mt19937_64& rng)
@@ -530,13 +531,13 @@ void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instructio
     NullifierExistsMutationOptions option = BASIC_NULLIFIER_EXISTS_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case NullifierExistsMutationOptions::nullifier_address:
-        mutate_address_ref(instruction.nullifier_address, rng, MemoryTag::FF);
+        mutate_variable_ref(instruction.nullifier_address, rng, MemoryTag::FF);
         break;
     case NullifierExistsMutationOptions::contract_address_address:
-        mutate_result_address_ref(instruction.contract_address_address, rng);
+        mutate_address_ref(instruction.contract_address_address, rng);
         break;
     case NullifierExistsMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -547,7 +548,7 @@ void mutate_emit_note_hash_instruction(EMITNOTEHASH_Instruction& instruction, st
     EmitNoteHashMutationOptions option = BASIC_EMITNOTEHASH_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case EmitNoteHashMutationOptions::note_hash_address:
-        mutate_result_address_ref(instruction.note_hash_address, rng);
+        mutate_address_ref(instruction.note_hash_address, rng);
         break;
     case EmitNoteHashMutationOptions::note_hash:
         mutate_field(instruction.note_hash, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
@@ -563,13 +564,13 @@ void mutate_note_hash_exists_instruction(NOTEHASHEXISTS_Instruction& instruction
         mutate_uint16_t(instruction.notehash_index, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
     case NoteHashExistsMutationOptions::notehash_address:
-        mutate_result_address_ref(instruction.notehash_address, rng);
+        mutate_address_ref(instruction.notehash_address, rng);
         break;
     case NoteHashExistsMutationOptions::leaf_index_address:
-        mutate_result_address_ref(instruction.leaf_index_address, rng);
+        mutate_address_ref(instruction.leaf_index_address, rng);
         break;
     case NoteHashExistsMutationOptions::result_address:
-        mutate_result_address_ref(instruction.result_address, rng);
+        mutate_address_ref(instruction.result_address, rng);
         break;
     }
 }
@@ -580,19 +581,19 @@ void mutate_calldatacopy_instruction(CALLDATACOPY_Instruction& instruction, std:
     CalldataCopyMutationOptions option = BASIC_CALLDATACOPY_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
     case CalldataCopyMutationOptions::dst_address:
-        mutate_result_address_ref(instruction.dst_address, rng);
+        mutate_address_ref(instruction.dst_address, rng);
         break;
     case CalldataCopyMutationOptions::copy_size:
         mutate_uint8_t(instruction.copy_size, rng, BASIC_UINT8_T_MUTATION_CONFIGURATION);
         break;
     case CalldataCopyMutationOptions::copy_size_address:
-        mutate_result_address_ref(instruction.copy_size_address, rng);
+        mutate_address_ref(instruction.copy_size_address, rng);
         break;
     case CalldataCopyMutationOptions::cd_start:
         mutate_uint16_t(instruction.cd_start, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
     case CalldataCopyMutationOptions::cd_start_address:
-        mutate_result_address_ref(instruction.cd_start_address, rng);
+        mutate_address_ref(instruction.cd_start_address, rng);
         break;
     }
 }
@@ -605,13 +606,13 @@ void mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, st
         mutate_field(instruction.recipient, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
         break;
     case SendL2ToL1MsgMutationOptions::recipient_address:
-        mutate_result_address_ref(instruction.recipient_address, rng);
+        mutate_address_ref(instruction.recipient_address, rng);
         break;
     case SendL2ToL1MsgMutationOptions::content:
         mutate_field(instruction.content, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
         break;
     case SendL2ToL1MsgMutationOptions::content_address:
-        mutate_result_address_ref(instruction.content_address, rng);
+        mutate_address_ref(instruction.content_address, rng);
         break;
     }
 }
@@ -624,7 +625,7 @@ void mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instr
         mutate_uint8_t(instruction.log_size, rng, BASIC_UINT8_T_MUTATION_CONFIGURATION);
         break;
     case EmitUnencryptedLogMutationOptions::log_size_address:
-        mutate_result_address_ref(instruction.log_size_address, rng);
+        mutate_address_ref(instruction.log_size_address, rng);
         break;
     case EmitUnencryptedLogMutationOptions::log_values:
         mutate_vec<bb::avm2::FF>(

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
@@ -6,6 +6,7 @@
 #include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/common/tagged_value.hpp"
 
 #include <random>
 
@@ -248,12 +249,7 @@ void mutate_fuzzer_data_vec(std::vector<FuzzerData>& enqueued_calls, std::mt1993
         fuzz_info("Adding a new enqueued call");
         // Add a new enqueued call
         if (enqueued_calls.size() < max_size) {
-            FuzzerData new_enqueued_call = FuzzerData();
-            mutate_fuzzer_data(new_enqueued_call, rng);
-            // Ensure at least 1 instruction block exists for bytecode generation
-            if (new_enqueued_call.instruction_blocks.empty()) {
-                new_enqueued_call.instruction_blocks.push_back(generate_instruction_block(rng));
-            }
+            FuzzerData new_enqueued_call = generate_fuzzer_data(rng);
             enqueued_calls.push_back(new_enqueued_call);
         }
         break;
@@ -265,10 +261,7 @@ void mutate_fuzzer_data_vec(std::vector<FuzzerData>& enqueued_calls, std::mt1993
             size_t idx = std::uniform_int_distribution<size_t>(0, enqueued_calls.size() - 1)(rng);
             fuzz_info("Mutating enqueued call at index: ", idx);
             mutate_fuzzer_data(enqueued_calls[idx], rng);
-            // Ensure at least 1 instruction block exists for bytecode generation
-            if (enqueued_calls[idx].instruction_blocks.empty()) {
-                enqueued_calls[idx].instruction_blocks.push_back(generate_instruction_block(rng));
-            }
+            add_default_instruction_block_if_empty(enqueued_calls[idx], rng);
         }
         break;
     }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/tx_fuzzer_lib.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/tx_fuzzer_lib.cpp
@@ -81,10 +81,11 @@ SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
 }
 
 // Initialize FuzzerTxData with sensible defaults
-FuzzerTxData create_default_tx_data()
+FuzzerTxData create_default_tx_data(std::mt19937_64& rng)
 {
+    FuzzerData fuzzer_data = generate_fuzzer_data(rng);
     FuzzerTxData tx_data = {
-        .input_programs = { FuzzerData{} },
+        .input_programs = { fuzzer_data },
         .tx = create_default_tx(MSG_SENDER, MSG_SENDER, {}, TRANSACTION_FEE, IS_STATIC_CALL, GAS_LIMIT),
         .global_variables = { .chain_id = CHAIN_ID,
                               .version = VERSION,
@@ -139,7 +140,7 @@ size_t mutate_tx_data(uint8_t* serialized_fuzzer_data,
             .convert(tx_data);
     } catch (const std::exception&) {
         fuzz_info("Failed to deserialize input in CustomMutator, creating default FuzzerTxData");
-        tx_data = create_default_tx_data();
+        tx_data = create_default_tx_data(rng);
     }
 
     // Mutate the fuzzer data multiple times for better bytecode variety


### PR DESCRIPTION
Renames AddressRef to VariableRef and ResultAddressRef to AddressRef
Uses the random values inside variable ref and address ref as sort of seeds, avoiding failures when we are unable to generate an opcode because the operand doesn't fit.
Preseeds FuzzerData with some sets, one per tag, to have some initial variables to work with
