### PR TITLE
fix!: avm proof length was wrong

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -15,6 +15,7 @@ AvmFlavor::ProverPolynomials::ProverPolynomials(ProvingKey& proving_key)
     }
 }
 
+// Deserializes the proof from proof_data. Length must match COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS in flavor.hpp.
 void AvmFlavor::Transcript::deserialize_full_transcript()
 {
     size_t num_frs_read = 0;
@@ -44,6 +45,7 @@ void AvmFlavor::Transcript::deserialize_full_transcript()
     kzg_w_comm = deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
 }
 
+// Serializes the proof to proof_data. Length must match COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS in flavor.hpp.
 void AvmFlavor::Transcript::serialize_full_transcript()
 {
     size_t old_proof_length = proof_data.size();

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -100,9 +100,14 @@ class AvmFlavor {
 
     // After any circuit changes, hover `COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS` in your IDE
     // to see its value and then update `AVM_V2_PROOF_LENGTH_IN_FIELDS` in constants.nr.
+    // This formula must match the serialization in Transcript::serialize_full_transcript().
     static constexpr size_t COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS =
-        (NUM_WITNESS_ENTITIES + 1) * NUM_FRS_COM + (NUM_ALL_ENTITIES + 1) * NUM_FRS_FR +
-        MAX_AVM_TRACE_LOG_SIZE * (NUM_FRS_COM + NUM_FRS_FR * (BATCHED_RELATION_PARTIAL_LENGTH + 1));
+        NUM_WITNESS_ENTITIES * NUM_FRS_COM +                                    // witness commitments
+        NUM_ALL_ENTITIES * NUM_FRS_FR +                                         // sumcheck evaluations
+        MAX_AVM_TRACE_LOG_SIZE * NUM_FRS_FR * BATCHED_RELATION_PARTIAL_LENGTH + // sumcheck univariates
+        (MAX_AVM_TRACE_LOG_SIZE - 1) * NUM_FRS_COM +                            // gemini fold comms
+        MAX_AVM_TRACE_LOG_SIZE * NUM_FRS_FR +                                   // gemini fold evals
+        2 * NUM_FRS_COM;                                                        // shplonk + kzg
 
     static_assert(AVM_V2_PROOF_LENGTH_IN_FIELDS_PADDED >= COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS,
                   "\n The constant AVM_V2_PROOF_LENGTH_IN_FIELDS_PADDED is now too short\n"

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.test.cpp
@@ -77,4 +77,18 @@ TEST_F(AvmVerifierTests, NegativeBadPublicInputs)
     const bool verified = verifier.verify_proof(proof, public_inputs_cols);
     ASSERT_TRUE(verified) << "native proof verification failed, but should have succeeded";
 }
+
+// Verify that the actual proof size matches COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS
+TEST_F(AvmVerifierTests, ProofSizeMatchesComputedConstant)
+{
+    NativeProofResult proof_result = create_proof_and_vk();
+
+    const size_t actual_proof_size = proof_result.proof.size();
+    const size_t computed_proof_size = AvmFlavor::COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS;
+
+    EXPECT_EQ(actual_proof_size, computed_proof_size)
+        << "Actual proof size (" << actual_proof_size << ") does not match COMPUTED_AVM_PROOF_LENGTH_IN_FIELDS ("
+        << computed_proof_size << "). The formula in flavor.hpp needs to be updated.";
+}
+
 } // namespace bb::avm2::constraining


### PR DESCRIPTION
It was off by 1, but I just changed it to align more exactly with serialize/deserialize transcript fns