### PR TITLE
chore: Do not edit files during precommit hook

### DIFF
--- a/yarn-project/precommit.sh
+++ b/yarn-project/precommit.sh
@@ -21,8 +21,7 @@ export -f lint
 
 parallel ::: \
   'yarn prepare:check' \
-  "$staged_files_cmd | grep -E '\.(json|js|mjs|cjs|ts)$' | parallel -N10 ./node_modules/.bin/prettier --log-level error --write"
+  "$staged_files_cmd | grep -E '\.(json|js|mjs|cjs|ts)$' | parallel -N10 ./node_modules/.bin/prettier --log-level warn --check"
   # TODO(ci3) find a way to ensure the yarn-project state is ready for linting
   # "lint"
 
-$staged_files_cmd | xargs -r git add


### PR DESCRIPTION
Precommit hook in yarn project would edit files in place and add them to stage. This meant that any file that was intended to be committed partially (as in only some hunks) would end up having all its changes committed, silently.

This changes the precommit hook so it warns on format errors and aborts the commit, instead of editing files.
