### PR TITLE
chore: Stricter zodFor check for schemas

### DIFF
--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -20,7 +20,7 @@ import {
   type ContractMetadata,
 } from '@aztec/stdlib/contract';
 import { Gas } from '@aztec/stdlib/gas';
-import { AbiDecodedSchema, type ApiSchemaFor, type ZodFor, optional, schemas } from '@aztec/stdlib/schemas';
+import { AbiDecodedSchema, type ApiSchemaFor, optional, schemas, zodFor } from '@aztec/stdlib/schemas';
 import {
   Capsule,
   HashedValues,
@@ -281,17 +281,21 @@ export const BatchedMethodSchema = z.union([
   }),
 ]);
 
-export const ContractMetadataSchema = z.object({
-  contractInstance: z.union([ContractInstanceWithAddressSchema, z.undefined()]),
-  isContractInitialized: z.boolean(),
-  isContractPublished: z.boolean(),
-}) satisfies ZodFor<ContractMetadata>;
+export const ContractMetadataSchema = zodFor<ContractMetadata>()(
+  z.object({
+    contractInstance: z.union([ContractInstanceWithAddressSchema, z.undefined()]),
+    isContractInitialized: z.boolean(),
+    isContractPublished: z.boolean(),
+  }),
+);
 
-export const ContractClassMetadataSchema = z.object({
-  contractClass: z.union([ContractClassWithIdSchema, z.undefined()]),
-  isContractClassPubliclyRegistered: z.boolean(),
-  artifact: z.union([ContractArtifactSchema, z.undefined()]),
-}) satisfies ZodFor<ContractClassMetadata>;
+export const ContractClassMetadataSchema = zodFor<ContractClassMetadata>()(
+  z.object({
+    contractClass: z.union([ContractClassWithIdSchema, z.undefined()]),
+    isContractClassPubliclyRegistered: z.boolean(),
+    artifact: z.union([ContractArtifactSchema, z.undefined()]),
+  }),
+);
 
 export const EventMetadataDefinitionSchema = z.object({
   eventSelector: schemas.EventSelector,
@@ -299,10 +303,12 @@ export const EventMetadataDefinitionSchema = z.object({
   fieldNames: z.array(z.string()),
 });
 
-export const PrivateEventSchema: ZodFor<PrivateEvent<AbiDecoded>> = z.object({
-  event: AbiDecodedSchema,
-  metadata: inTxSchema(),
-});
+export const PrivateEventSchema: z.ZodType<any> = zodFor<PrivateEvent<AbiDecoded>>()(
+  z.object({
+    event: AbiDecodedSchema,
+    metadata: inTxSchema(),
+  }),
+);
 
 export const PrivateEventFilterSchema = z.object({
   contractAddress: schemas.AztecAddress,

--- a/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
+++ b/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
@@ -1,7 +1,7 @@
 import type { BlobJson } from '@aztec/blob-lib/types';
 import { createLogger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import { z } from 'zod';
@@ -9,38 +9,40 @@ import { z } from 'zod';
 import { BlobArchiveClientInstrumentation } from './instrumentation.js';
 import type { BlobArchiveClient } from './interface.js';
 
-export const BlobscanBlockResponseSchema = z
-  .object({
-    hash: z.string(),
-    slot: z.number().int(),
-    number: z.number().int(),
-    transactions: z.array(
-      z.object({
-        hash: z.string(),
-        blobs: z.array(
-          z.object({
-            versionedHash: z.string(),
-            data: z.string(),
-            commitment: z.string(),
-            proof: z.string(),
-            size: z.number().int(),
-            index: z.number().int().optional(), // This is the index within the tx, not within the block!
-          }),
-        ),
-      }),
+export const BlobscanBlockResponseSchema = zodFor<BlobJson[]>()(
+  z
+    .object({
+      hash: z.string(),
+      slot: z.number().int(),
+      number: z.number().int(),
+      transactions: z.array(
+        z.object({
+          hash: z.string(),
+          blobs: z.array(
+            z.object({
+              versionedHash: z.string(),
+              data: z.string(),
+              commitment: z.string(),
+              proof: z.string(),
+              size: z.number().int(),
+              index: z.number().int().optional(), // This is the index within the tx, not within the block!
+            }),
+          ),
+        }),
+      ),
+    })
+    .transform(data =>
+      data.transactions
+        .flatMap(tx =>
+          tx.blobs.map(blob => ({
+            blob: blob.data,
+            // eslint-disable-next-line camelcase
+            kzg_commitment: blob.commitment,
+          })),
+        )
+        .map((blob, index) => ({ ...blob, index: index.toString() })),
     ),
-  })
-  .transform(data =>
-    data.transactions
-      .flatMap(tx =>
-        tx.blobs.map(blob => ({
-          blob: blob.data,
-          // eslint-disable-next-line camelcase
-          kzg_commitment: blob.commitment,
-        })),
-      )
-      .map((blob, index) => ({ ...blob, index: index.toString() })),
-  ) satisfies ZodFor<BlobJson[]>;
+);
 
 // Response from https://api.blobscan.com/blocks?sort=desc&type=canonical
 export const BlobscanBlocksResponseSchema = z.object({

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -14,7 +14,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractsHash } from '@aztec/protocol-contracts';
-import { type ZodFor, schemas } from '@aztec/stdlib/schemas';
+import { schemas, zodFor } from '@aztec/stdlib/schemas';
 import type { ComponentsVersions } from '@aztec/stdlib/versioning';
 
 import { z } from 'zod';
@@ -80,50 +80,52 @@ export type BotConfig = {
   ammTxs: boolean;
 } & Pick<DataStoreConfig, 'dataDirectory' | 'dataStoreMapSizeKb'>;
 
-export const BotConfigSchema = z
-  .object({
-    nodeUrl: z.string().optional(),
-    nodeAdminUrl: z.string().optional(),
-    l1RpcUrls: z.array(z.string()).optional(),
-    l1Mnemonic: schemas.SecretValue(z.string()).optional(),
-    l1PrivateKey: schemas.SecretValue(z.string()).optional(),
-    l1ToL2MessageTimeoutSeconds: z.number(),
-    senderPrivateKey: schemas.SecretValue(schemas.Fr).optional(),
-    senderSalt: schemas.Fr.optional(),
-    tokenSalt: schemas.Fr,
-    txIntervalSeconds: z.number(),
-    privateTransfersPerTx: z.number().int().nonnegative(),
-    publicTransfersPerTx: z.number().int().nonnegative(),
-    feePaymentMethod: z.literal('fee_juice'),
-    baseFeePadding: z.number().int().nonnegative(),
-    noStart: z.boolean(),
-    txMinedWaitSeconds: z.number(),
-    followChain: z.enum(BotFollowChain),
-    maxPendingTxs: z.number().int().nonnegative(),
-    flushSetupTransactions: z.boolean(),
-    l2GasLimit: z.number().int().nonnegative().optional(),
-    daGasLimit: z.number().int().nonnegative().optional(),
-    contract: z.nativeEnum(SupportedTokenContracts),
-    maxConsecutiveErrors: z.number().int().nonnegative(),
-    stopWhenUnhealthy: z.boolean(),
-    ammTxs: z.boolean().default(false),
-    dataDirectory: z.string().optional(),
-    dataStoreMapSizeKb: z.number().optional(),
-  })
-  .transform(config => ({
-    nodeUrl: undefined,
-    nodeAdminUrl: undefined,
-    l1RpcUrls: undefined,
-    senderSalt: undefined,
-    l2GasLimit: undefined,
-    daGasLimit: undefined,
-    l1Mnemonic: undefined,
-    l1PrivateKey: undefined,
-    senderPrivateKey: undefined,
-    dataDirectory: undefined,
-    dataStoreMapSizeKb: 1_024 * 1_024,
-    ...config,
-  })) satisfies ZodFor<BotConfig>;
+export const BotConfigSchema = zodFor<BotConfig>()(
+  z
+    .object({
+      nodeUrl: z.string().optional(),
+      nodeAdminUrl: z.string().optional(),
+      l1RpcUrls: z.array(z.string()).optional(),
+      l1Mnemonic: schemas.SecretValue(z.string()).optional(),
+      l1PrivateKey: schemas.SecretValue(z.string()).optional(),
+      l1ToL2MessageTimeoutSeconds: z.number(),
+      senderPrivateKey: schemas.SecretValue(schemas.Fr).optional(),
+      senderSalt: schemas.Fr.optional(),
+      tokenSalt: schemas.Fr,
+      txIntervalSeconds: z.number(),
+      privateTransfersPerTx: z.number().int().nonnegative(),
+      publicTransfersPerTx: z.number().int().nonnegative(),
+      feePaymentMethod: z.literal('fee_juice'),
+      baseFeePadding: z.number().int().nonnegative(),
+      noStart: z.boolean(),
+      txMinedWaitSeconds: z.number(),
+      followChain: z.enum(BotFollowChain),
+      maxPendingTxs: z.number().int().nonnegative(),
+      flushSetupTransactions: z.boolean(),
+      l2GasLimit: z.number().int().nonnegative().optional(),
+      daGasLimit: z.number().int().nonnegative().optional(),
+      contract: z.nativeEnum(SupportedTokenContracts),
+      maxConsecutiveErrors: z.number().int().nonnegative(),
+      stopWhenUnhealthy: z.boolean(),
+      ammTxs: z.boolean().default(false),
+      dataDirectory: z.string().optional(),
+      dataStoreMapSizeKb: z.number().optional(),
+    })
+    .transform(config => ({
+      nodeUrl: undefined,
+      nodeAdminUrl: undefined,
+      l1RpcUrls: undefined,
+      senderSalt: undefined,
+      l2GasLimit: undefined,
+      daGasLimit: undefined,
+      l1Mnemonic: undefined,
+      l1PrivateKey: undefined,
+      senderPrivateKey: undefined,
+      dataDirectory: undefined,
+      dataStoreMapSizeKb: 1_024 * 1_024,
+      ...config,
+    })),
+);
 
 export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   nodeUrl: {

--- a/yarn-project/ethereum/src/l1_contract_addresses.ts
+++ b/yarn-project/ethereum/src/l1_contract_addresses.ts
@@ -1,6 +1,6 @@
 import type { ConfigMappingsType } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
@@ -35,25 +35,27 @@ export type L1ContractAddresses = {
   dateGatedRelayerAddress?: EthAddress | undefined;
 };
 
-export const L1ContractAddressesSchema = z.object({
-  rollupAddress: schemas.EthAddress,
-  registryAddress: schemas.EthAddress,
-  inboxAddress: schemas.EthAddress,
-  outboxAddress: schemas.EthAddress,
-  feeJuiceAddress: schemas.EthAddress,
-  stakingAssetAddress: schemas.EthAddress,
-  feeJuicePortalAddress: schemas.EthAddress,
-  coinIssuerAddress: schemas.EthAddress,
-  rewardDistributorAddress: schemas.EthAddress,
-  governanceProposerAddress: schemas.EthAddress,
-  governanceAddress: schemas.EthAddress,
-  slashFactoryAddress: schemas.EthAddress.optional(),
-  feeAssetHandlerAddress: schemas.EthAddress.optional(),
-  stakingAssetHandlerAddress: schemas.EthAddress.optional(),
-  zkPassportVerifierAddress: schemas.EthAddress.optional(),
-  gseAddress: schemas.EthAddress.optional(),
-  dateGatedRelayerAddress: schemas.EthAddress.optional(),
-}) satisfies ZodFor<L1ContractAddresses>;
+export const L1ContractAddressesSchema = zodFor<L1ContractAddresses>()(
+  z.object({
+    rollupAddress: schemas.EthAddress,
+    registryAddress: schemas.EthAddress,
+    inboxAddress: schemas.EthAddress,
+    outboxAddress: schemas.EthAddress,
+    feeJuiceAddress: schemas.EthAddress,
+    stakingAssetAddress: schemas.EthAddress,
+    feeJuicePortalAddress: schemas.EthAddress,
+    coinIssuerAddress: schemas.EthAddress,
+    rewardDistributorAddress: schemas.EthAddress,
+    governanceProposerAddress: schemas.EthAddress,
+    governanceAddress: schemas.EthAddress,
+    slashFactoryAddress: schemas.EthAddress.optional(),
+    feeAssetHandlerAddress: schemas.EthAddress.optional(),
+    stakingAssetHandlerAddress: schemas.EthAddress.optional(),
+    zkPassportVerifierAddress: schemas.EthAddress.optional(),
+    gseAddress: schemas.EthAddress.optional(),
+    dateGatedRelayerAddress: schemas.EthAddress.optional(),
+  }),
+);
 
 const parseEnv = (val: string) => EthAddress.fromString(val);
 

--- a/yarn-project/foundation/src/schemas/types.ts
+++ b/yarn-project/foundation/src/schemas/types.ts
@@ -1,3 +1,36 @@
 import type { ZodType } from 'zod';
 
 export type ZodFor<T> = ZodType<T, any, any>;
+
+/**
+ * Creates a schema validator that enforces all properties of type T are present in the schema.
+ * This provides compile-time safety to ensure schemas don't miss optional properties.
+ *
+ * @example
+ * ```ts
+ * interface MyConfig {
+ *   foo: string;
+ *   bar?: number;
+ * }
+ *
+ * // ✅ This will work - all keys present
+ * const schema1 = zodFor<MyConfig>()(z.object({
+ *   foo: z.string(),
+ *   bar: z.number().optional(),
+ * }));
+ *
+ * // ❌ This will error - 'bar' is missing
+ * const schema2 = zodFor<MyConfig>()(z.object({
+ *   foo: z.string(),
+ * }));
+ * ```
+ */
+export function zodFor<T>() {
+  return (schema => schema) as <S extends ZodType<any, any, any>>(
+    schema: keyof T extends keyof S['_output']
+      ? keyof S['_output'] extends keyof T
+        ? S
+        : S & { __error__: 'Schema has extra keys not in type'; __extra__: Exclude<keyof S['_output'], keyof T> }
+      : S & { __error__: 'Schema is missing keys from type'; __missing__: Exclude<keyof T, keyof S['_output']> },
+  ) => S;
+}

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { inflate } from 'pako';
 import { z } from 'zod';
@@ -154,11 +154,13 @@ export type AbiErrorType =
   | { error_kind: 'fmtstring'; length: number; item_types: AbiType[] }
   | ({ error_kind: 'custom' } & AbiType);
 
-const AbiErrorTypeSchema = z.union([
-  z.object({ error_kind: z.literal('string'), string: z.string() }),
-  z.object({ error_kind: z.literal('fmtstring'), length: z.number(), item_types: z.array(AbiTypeSchema) }),
-  z.object({ error_kind: z.literal('custom') }).and(AbiTypeSchema),
-]) satisfies ZodFor<AbiErrorType>;
+const AbiErrorTypeSchema = zodFor<AbiErrorType>()(
+  z.union([
+    z.object({ error_kind: z.literal('string'), string: z.string() }),
+    z.object({ error_kind: z.literal('fmtstring'), length: z.number(), item_types: z.array(AbiTypeSchema) }),
+    z.object({ error_kind: z.literal('custom') }).and(AbiTypeSchema),
+  ]),
+);
 
 /** Aztec.nr function types. */
 export enum FunctionType {
@@ -242,14 +244,16 @@ export interface FunctionArtifactWithContractName extends FunctionArtifact {
   contractName: string;
 }
 
-export const FunctionArtifactSchema = FunctionAbiSchema.and(
-  z.object({
-    bytecode: schemas.Buffer,
-    verificationKey: z.string().optional(),
-    debugSymbols: z.string(),
-    debug: FunctionDebugMetadataSchema.optional(),
-  }),
-) satisfies ZodFor<FunctionArtifact>;
+export const FunctionArtifactSchema = zodFor<FunctionArtifact>()(
+  FunctionAbiSchema.and(
+    z.object({
+      bytecode: schemas.Buffer,
+      verificationKey: z.string().optional(),
+      debugSymbols: z.string(),
+      debug: FunctionDebugMetadataSchema.optional(),
+    }),
+  ),
+);
 
 /** A file ID. It's assigned during compilation. */
 type FileId = number;
@@ -342,28 +346,30 @@ export interface ContractArtifact {
   fileMap: DebugFileMap;
 }
 
-export const ContractArtifactSchema: ZodFor<ContractArtifact> = z.object({
-  name: z.string(),
-  functions: z.array(FunctionArtifactSchema),
-  nonDispatchPublicFunctions: z.array(FunctionAbiSchema),
-  outputs: z.object({
-    structs: z.record(z.array(AbiTypeSchema)).transform(structs => {
-      for (const [key, value] of Object.entries(structs)) {
-        // We are manually ordering events and functions in the abi by path.
-        // The path ordering is arbitrary, and only needed to ensure deterministic order.
-        // These are the only arrays in the artifact with arbitrary order, and hence the only ones
-        // we need to sort.
-        if (key === 'events' || key === 'functions') {
-          structs[key] = (value as StructType[]).sort((a, b) => (a.path > b.path ? -1 : 1));
+export const ContractArtifactSchema = zodFor<ContractArtifact>()(
+  z.object({
+    name: z.string(),
+    functions: z.array(FunctionArtifactSchema),
+    nonDispatchPublicFunctions: z.array(FunctionAbiSchema),
+    outputs: z.object({
+      structs: z.record(z.array(AbiTypeSchema)).transform(structs => {
+        for (const [key, value] of Object.entries(structs)) {
+          // We are manually ordering events and functions in the abi by path.
+          // The path ordering is arbitrary, and only needed to ensure deterministic order.
+          // These are the only arrays in the artifact with arbitrary order, and hence the only ones
+          // we need to sort.
+          if (key === 'events' || key === 'functions') {
+            structs[key] = (value as StructType[]).sort((a, b) => (a.path > b.path ? -1 : 1));
+          }
         }
-      }
-      return structs;
+        return structs;
+      }),
+      globals: z.record(z.array(AbiValueSchema)),
     }),
-    globals: z.record(z.array(AbiValueSchema)),
+    storageLayout: z.record(z.object({ slot: schemas.Fr })),
+    fileMap: z.record(z.coerce.number(), z.object({ source: z.string(), path: z.string() })),
   }),
-  storageLayout: z.record(z.object({ slot: schemas.Fr })),
-  fileMap: z.record(z.coerce.number(), z.object({ source: z.string(), path: z.string() })),
-});
+);
 
 export function getFunctionArtifactByName(artifact: ContractArtifact, functionName: string): FunctionArtifact {
   const functionArtifact = artifact.functions.find(f => f.name === functionName);

--- a/yarn-project/stdlib/src/contract/interfaces/contract_class.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_class.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
@@ -35,10 +35,12 @@ export interface PrivateFunction {
   vkHash: Fr;
 }
 
-const PrivateFunctionSchema = z.object({
-  selector: FunctionSelector.schema,
-  vkHash: schemas.Fr,
-}) satisfies ZodFor<PrivateFunction>;
+const PrivateFunctionSchema = zodFor<PrivateFunction>()(
+  z.object({
+    selector: FunctionSelector.schema,
+    vkHash: schemas.Fr,
+  }),
+);
 
 /** Private function definition with executable bytecode. */
 export interface ExecutablePrivateFunction extends PrivateFunction {
@@ -46,9 +48,9 @@ export interface ExecutablePrivateFunction extends PrivateFunction {
   bytecode: Buffer;
 }
 
-const ExecutablePrivateFunctionSchema = PrivateFunctionSchema.and(
-  z.object({ bytecode: schemas.Buffer }),
-) satisfies ZodFor<ExecutablePrivateFunction>;
+const ExecutablePrivateFunctionSchema = zodFor<ExecutablePrivateFunction>()(
+  PrivateFunctionSchema.and(z.object({ bytecode: schemas.Buffer })),
+);
 
 /** Utility function definition. */
 export interface UtilityFunction {
@@ -58,11 +60,12 @@ export interface UtilityFunction {
   bytecode: Buffer;
 }
 
-const UtilityFunctionSchema = z.object({
-  /** lala */
-  selector: FunctionSelector.schema,
-  bytecode: schemas.Buffer,
-}) satisfies ZodFor<UtilityFunction>;
+const UtilityFunctionSchema = zodFor<UtilityFunction>()(
+  z.object({
+    selector: FunctionSelector.schema,
+    bytecode: schemas.Buffer,
+  }),
+);
 
 /** Sibling paths and sibling commitments for proving membership of a private function within a contract class. */
 export type PrivateFunctionMembershipProof = {
@@ -75,15 +78,17 @@ export type PrivateFunctionMembershipProof = {
   artifactTreeLeafIndex: number;
 };
 
-const PrivateFunctionMembershipProofSchema = z.object({
-  artifactMetadataHash: schemas.Fr,
-  functionMetadataHash: schemas.Fr,
-  utilityFunctionsTreeRoot: schemas.Fr,
-  privateFunctionTreeSiblingPath: z.array(schemas.Fr),
-  privateFunctionTreeLeafIndex: schemas.Integer,
-  artifactTreeSiblingPath: z.array(schemas.Fr),
-  artifactTreeLeafIndex: schemas.Integer,
-}) satisfies ZodFor<PrivateFunctionMembershipProof>;
+const PrivateFunctionMembershipProofSchema = zodFor<PrivateFunctionMembershipProof>()(
+  z.object({
+    artifactMetadataHash: schemas.Fr,
+    functionMetadataHash: schemas.Fr,
+    utilityFunctionsTreeRoot: schemas.Fr,
+    privateFunctionTreeSiblingPath: z.array(schemas.Fr),
+    privateFunctionTreeLeafIndex: schemas.Integer,
+    artifactTreeSiblingPath: z.array(schemas.Fr),
+    artifactTreeLeafIndex: schemas.Integer,
+  }),
+);
 
 /** A private function with a membership proof. */
 export type ExecutablePrivateFunctionWithMembershipProof = ExecutablePrivateFunction & PrivateFunctionMembershipProof;
@@ -97,23 +102,27 @@ export type UtilityFunctionMembershipProof = {
   artifactTreeLeafIndex: number;
 };
 
-const UtilityFunctionMembershipProofSchema = z.object({
-  artifactMetadataHash: schemas.Fr,
-  functionMetadataHash: schemas.Fr,
-  privateFunctionsArtifactTreeRoot: schemas.Fr,
-  artifactTreeSiblingPath: z.array(schemas.Fr),
-  artifactTreeLeafIndex: schemas.Integer,
-}) satisfies ZodFor<UtilityFunctionMembershipProof>;
+const UtilityFunctionMembershipProofSchema = zodFor<UtilityFunctionMembershipProof>()(
+  z.object({
+    artifactMetadataHash: schemas.Fr,
+    functionMetadataHash: schemas.Fr,
+    privateFunctionsArtifactTreeRoot: schemas.Fr,
+    artifactTreeSiblingPath: z.array(schemas.Fr),
+    artifactTreeLeafIndex: schemas.Integer,
+  }),
+);
 
 /** A utility function with a membership proof. */
 export type UtilityFunctionWithMembershipProof = UtilityFunction & UtilityFunctionMembershipProof;
 
-export const ContractClassSchema = z.object({
-  version: z.literal(VERSION),
-  artifactHash: schemas.Fr,
-  privateFunctions: z.array(PrivateFunctionSchema),
-  packedBytecode: schemas.Buffer,
-}) satisfies ZodFor<ContractClass>;
+export const ContractClassSchema = zodFor<ContractClass>()(
+  z.object({
+    version: z.literal(VERSION),
+    artifactHash: schemas.Fr,
+    privateFunctions: z.array(PrivateFunctionSchema),
+    packedBytecode: schemas.Buffer,
+  }),
+);
 
 /** Commitments to fields of a contract class. */
 interface ContractClassCommitments {
@@ -128,9 +137,11 @@ interface ContractClassCommitments {
 /** A contract class with its precomputed id. */
 export type ContractClassWithId = ContractClass & Pick<ContractClassCommitments, 'id'>;
 
-export const ContractClassWithIdSchema = ContractClassSchema.extend({
-  id: schemas.Fr,
-}) satisfies ZodFor<ContractClassWithId>;
+export const ContractClassWithIdSchema = zodFor<ContractClassWithId>()(
+  ContractClassSchema.extend({
+    id: schemas.Fr,
+  }),
+);
 
 /** A contract class with public bytecode information, and optional private and utility functions. */
 export type ContractClassPublic = {
@@ -142,14 +153,16 @@ export type ContractClassPublic = {
 export type ContractClassPublicWithCommitment = ContractClassPublic &
   Pick<ContractClassCommitments, 'publicBytecodeCommitment'>;
 
-export const ContractClassPublicSchema = z
-  .object({
-    id: schemas.Fr,
-    privateFunctionsRoot: schemas.Fr,
-    privateFunctions: z.array(ExecutablePrivateFunctionSchema.and(PrivateFunctionMembershipProofSchema)),
-    utilityFunctions: z.array(UtilityFunctionSchema.and(UtilityFunctionMembershipProofSchema)),
-  })
-  .and(ContractClassSchema.omit({ privateFunctions: true })) satisfies ZodFor<ContractClassPublic>;
+export const ContractClassPublicSchema = zodFor<ContractClassPublic>()(
+  z
+    .object({
+      id: schemas.Fr,
+      privateFunctionsRoot: schemas.Fr,
+      privateFunctions: z.array(ExecutablePrivateFunctionSchema.and(PrivateFunctionMembershipProofSchema)),
+      utilityFunctions: z.array(UtilityFunctionSchema.and(UtilityFunctionMembershipProofSchema)),
+    })
+    .and(ContractClassSchema.omit({ privateFunctions: true })),
+);
 
 /** The contract class with the block it was initially deployed at */
 export type ContractClassPublicWithBlockNumber = { l2BlockNumber: number } & ContractClassPublic;

--- a/yarn-project/stdlib/src/contract/interfaces/contract_instance.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_instance.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import { AztecAddress } from '../../aztec-address/index.js';
 import { PublicKeys } from '../../keys/public_keys.js';
-import { type ZodFor, schemas } from '../../schemas/index.js';
+import { schemas, zodFor } from '../../schemas/index.js';
 
 const VERSION = 1 as const;
 
@@ -32,19 +32,21 @@ export interface ContractInstance {
 
 export type ContractInstanceWithAddress = ContractInstance & { address: AztecAddress };
 
-export const ContractInstanceSchema = z.object({
-  version: z.literal(VERSION),
-  salt: schemas.Fr,
-  deployer: schemas.AztecAddress,
-  currentContractClassId: schemas.Fr,
-  originalContractClassId: schemas.Fr,
-  initializationHash: schemas.Fr,
-  publicKeys: PublicKeys.schema,
-}) satisfies ZodFor<ContractInstance>;
+export const ContractInstanceSchema = zodFor<ContractInstance>()(
+  z.object({
+    version: z.literal(VERSION),
+    salt: schemas.Fr,
+    deployer: schemas.AztecAddress,
+    currentContractClassId: schemas.Fr,
+    originalContractClassId: schemas.Fr,
+    initializationHash: schemas.Fr,
+    publicKeys: PublicKeys.schema,
+  }),
+);
 
-export const ContractInstanceWithAddressSchema = ContractInstanceSchema.and(
-  z.object({ address: schemas.AztecAddress }),
-) satisfies ZodFor<ContractInstanceWithAddress>;
+export const ContractInstanceWithAddressSchema = zodFor<ContractInstanceWithAddress>()(
+  ContractInstanceSchema.and(z.object({ address: schemas.AztecAddress })),
+);
 
 /**
  * Creates a ContractInstance from a plain object without Zod validation.

--- a/yarn-project/stdlib/src/contract/interfaces/contract_instance_update.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_instance_update.ts
@@ -3,7 +3,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { z } from 'zod';
 
 import type { AztecAddress } from '../../aztec-address/index.js';
-import { type ZodFor, schemas } from '../../schemas/index.js';
+import { schemas, zodFor } from '../../schemas/index.js';
 import type { UInt64 } from '../../types/shared.js';
 
 /**
@@ -20,12 +20,14 @@ export interface ContractInstanceUpdate {
 
 export type ContractInstanceUpdateWithAddress = ContractInstanceUpdate & { address: AztecAddress };
 
-export const ContractInstanceUpdateSchema = z.object({
-  prevContractClassId: schemas.Fr,
-  newContractClassId: schemas.Fr,
-  timestampOfChange: schemas.BigInt,
-}) satisfies ZodFor<ContractInstanceUpdate>;
+export const ContractInstanceUpdateSchema = zodFor<ContractInstanceUpdate>()(
+  z.object({
+    prevContractClassId: schemas.Fr,
+    newContractClassId: schemas.Fr,
+    timestampOfChange: schemas.BigInt,
+  }),
+);
 
-export const ContractInstanceUpdateWithAddressSchema = ContractInstanceUpdateSchema.and(
-  z.object({ address: schemas.AztecAddress }),
-) satisfies ZodFor<ContractInstanceUpdateWithAddress>;
+export const ContractInstanceUpdateWithAddressSchema = zodFor<ContractInstanceUpdateWithAddress>()(
+  ContractInstanceUpdateSchema.and(z.object({ address: schemas.AztecAddress })),
+);

--- a/yarn-project/stdlib/src/epoch-helpers/index.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.ts
@@ -2,7 +2,7 @@ import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 
 import { z } from 'zod';
 
-import { type ZodFor, schemas } from '../schemas/index.js';
+import { schemas, zodFor } from '../schemas/index.js';
 
 export type L1RollupConstants = {
   l1StartBlock: bigint;
@@ -22,14 +22,16 @@ export const EmptyL1RollupConstants: L1RollupConstants = {
   proofSubmissionEpochs: 1,
 };
 
-export const L1RollupConstantsSchema = z.object({
-  l1StartBlock: schemas.BigInt,
-  l1GenesisTime: schemas.BigInt,
-  slotDuration: z.number(),
-  epochDuration: z.number(),
-  ethereumSlotDuration: z.number(),
-  proofSubmissionEpochs: z.number(),
-}) satisfies ZodFor<L1RollupConstants>;
+export const L1RollupConstantsSchema = zodFor<L1RollupConstants>()(
+  z.object({
+    l1StartBlock: schemas.BigInt,
+    l1GenesisTime: schemas.BigInt,
+    slotDuration: z.number(),
+    epochDuration: z.number(),
+    ethereumSlotDuration: z.number(),
+    proofSubmissionEpochs: z.number(),
+  }),
+);
 
 /** Returns the timestamp for a given L2 slot. */
 export function getTimestampForSlot(

--- a/yarn-project/stdlib/src/interfaces/allowed_element.ts
+++ b/yarn-project/stdlib/src/interfaces/allowed_element.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import type { FunctionSelector } from '../abi/function_selector.js';
 import type { AztecAddress } from '../aztec-address/index.js';
-import { type ZodFor, schemas } from '../schemas/index.js';
+import { schemas, zodFor } from '../schemas/index.js';
 
 type AllowedInstance = { address: AztecAddress };
 type AllowedInstanceFunction = { address: AztecAddress; selector: FunctionSelector };
@@ -13,9 +13,11 @@ type AllowedClassFunction = { classId: Fr; selector: FunctionSelector };
 
 export type AllowedElement = AllowedInstance | AllowedInstanceFunction | AllowedClass | AllowedClassFunction;
 
-export const AllowedElementSchema = z.union([
-  z.object({ address: schemas.AztecAddress, selector: schemas.FunctionSelector }),
-  z.object({ address: schemas.AztecAddress }),
-  z.object({ classId: schemas.Fr, selector: schemas.FunctionSelector }),
-  z.object({ classId: schemas.Fr }),
-]) satisfies ZodFor<AllowedElement>;
+export const AllowedElementSchema = zodFor<AllowedElement>()(
+  z.union([
+    z.object({ address: schemas.AztecAddress, selector: schemas.FunctionSelector }),
+    z.object({ address: schemas.AztecAddress }),
+    z.object({ classId: schemas.Fr, selector: schemas.FunctionSelector }),
+    z.object({ classId: schemas.Fr }),
+  ]),
+);

--- a/yarn-project/stdlib/src/interfaces/configs.ts
+++ b/yarn-project/stdlib/src/interfaces/configs.ts
@@ -3,7 +3,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
-import { type ZodFor, schemas } from '../schemas/index.js';
+import { schemas, zodFor } from '../schemas/index.js';
 import { type AllowedElement, AllowedElementSchema } from './allowed_element.js';
 
 /**
@@ -62,29 +62,32 @@ export interface SequencerConfig {
   shuffleAttestationOrdering?: boolean;
 }
 
-export const SequencerConfigSchema = z.object({
-  transactionPollingIntervalMS: z.number().optional(),
-  maxTxsPerBlock: z.number().optional(),
-  minTxsPerBlock: z.number().optional(),
-  maxL2BlockGas: z.number().optional(),
-  publishTxsWithProposals: z.boolean().optional(),
-  maxDABlockGas: z.number().optional(),
-  coinbase: schemas.EthAddress.optional(),
-  feeRecipient: schemas.AztecAddress.optional(),
-  acvmWorkingDirectory: z.string().optional(),
-  acvmBinaryPath: z.string().optional(),
-  txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
-  maxBlockSizeInBytes: z.number().optional(),
-  governanceProposerPayload: schemas.EthAddress.optional(),
-  maxL1TxInclusionTimeIntoSlot: z.number().optional(),
-  enforceTimeTable: z.boolean().optional(),
-  fakeProcessingDelayPerTxMs: z.number().optional(),
-  attestationPropagationTime: z.number().optional(),
-  skipCollectingAttestations: z.boolean().optional(),
-  secondsBeforeInvalidatingBlockAsCommitteeMember: z.number(),
-  secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
-  broadcastInvalidBlockProposal: z.boolean().optional(),
-  injectFakeAttestation: z.boolean().optional(),
-  fishermanMode: z.boolean().optional(),
-  shuffleAttestationOrdering: z.boolean().optional(),
-}) satisfies ZodFor<SequencerConfig>;
+export const SequencerConfigSchema = zodFor<SequencerConfig>()(
+  z.object({
+    transactionPollingIntervalMS: z.number().optional(),
+    maxTxsPerBlock: z.number().optional(),
+    minTxsPerBlock: z.number().optional(),
+    maxL2BlockGas: z.number().optional(),
+    publishTxsWithProposals: z.boolean().optional(),
+    maxDABlockGas: z.number().optional(),
+    coinbase: schemas.EthAddress.optional(),
+    feeRecipient: schemas.AztecAddress.optional(),
+    acvmWorkingDirectory: z.string().optional(),
+    acvmBinaryPath: z.string().optional(),
+    txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
+    maxBlockSizeInBytes: z.number().optional(),
+    governanceProposerPayload: schemas.EthAddress.optional(),
+    maxL1TxInclusionTimeIntoSlot: z.number().optional(),
+    enforceTimeTable: z.boolean().optional(),
+    fakeProcessingDelayPerTxMs: z.number().optional(),
+    attestationPropagationTime: z.number().optional(),
+    skipCollectingAttestations: z.boolean().optional(),
+    skipInvalidateBlockAsProposer: z.boolean().optional(),
+    secondsBeforeInvalidatingBlockAsCommitteeMember: z.number(),
+    secondsBeforeInvalidatingBlockAsNonCommitteeMember: z.number(),
+    broadcastInvalidBlockProposal: z.boolean().optional(),
+    injectFakeAttestation: z.boolean().optional(),
+    fishermanMode: z.boolean().optional(),
+    shuffleAttestationOrdering: z.boolean().optional(),
+  }),
+);

--- a/yarn-project/stdlib/src/interfaces/get_logs_response.ts
+++ b/yarn-project/stdlib/src/interfaces/get_logs_response.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { ExtendedContractClassLog } from '../logs/extended_contract_class_log.js';
 import { ExtendedPublicLog } from '../logs/extended_public_log.js';
-import type { ZodFor } from '../schemas/index.js';
+import { zodFor } from '../schemas/index.js';
 
 /** Response for the getContractClassLogs archiver call. */
 export type GetContractClassLogsResponse = {
@@ -12,10 +12,12 @@ export type GetContractClassLogsResponse = {
   maxLogsHit: boolean;
 };
 
-export const GetContractClassLogsResponseSchema: ZodFor<GetContractClassLogsResponse> = z.object({
-  logs: z.array(ExtendedContractClassLog.schema),
-  maxLogsHit: z.boolean(),
-});
+export const GetContractClassLogsResponseSchema = zodFor<GetContractClassLogsResponse>()(
+  z.object({
+    logs: z.array(ExtendedContractClassLog.schema),
+    maxLogsHit: z.boolean(),
+  }),
+);
 
 /** Response for the getPublicLogs archiver call. */
 export type GetPublicLogsResponse = {
@@ -25,7 +27,9 @@ export type GetPublicLogsResponse = {
   maxLogsHit: boolean;
 };
 
-export const GetPublicLogsResponseSchema = z.object({
-  logs: z.array(ExtendedPublicLog.schema),
-  maxLogsHit: z.boolean(),
-}) satisfies ZodFor<GetPublicLogsResponse>;
+export const GetPublicLogsResponseSchema = zodFor<GetPublicLogsResponse>()(
+  z.object({
+    logs: z.array(ExtendedPublicLog.schema),
+    maxLogsHit: z.boolean(),
+  }),
+);

--- a/yarn-project/stdlib/src/interfaces/prover-client.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-client.ts
@@ -3,7 +3,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { z } from 'zod';
 
-import { type ZodFor, schemas } from '../schemas/index.js';
+import { schemas, zodFor } from '../schemas/index.js';
 import type { TxHash } from '../tx/tx_hash.js';
 import type { EpochProver } from './epoch-prover.js';
 import type { ProvingJobConsumer } from './prover-broker.js';
@@ -33,15 +33,18 @@ export type ProverConfig = ActualProverConfig & {
   failedProofStore?: string;
 };
 
-export const ProverConfigSchema = z.object({
-  nodeUrl: z.string().optional(),
-  realProofs: z.boolean(),
-  proverId: schemas.EthAddress.optional(),
-  proverTestDelayType: z.enum(['fixed', 'realistic']),
-  proverTestDelayMs: z.number(),
-  proverTestDelayFactor: z.number(),
-  proverAgentCount: z.number(),
-}) satisfies ZodFor<ProverConfig>;
+export const ProverConfigSchema = zodFor<ProverConfig>()(
+  z.object({
+    nodeUrl: z.string().optional(),
+    realProofs: z.boolean(),
+    proverId: schemas.EthAddress.optional(),
+    proverTestDelayType: z.enum(['fixed', 'realistic']),
+    proverTestDelayMs: z.number(),
+    proverTestDelayFactor: z.number(),
+    proverAgentCount: z.number(),
+    failedProofStore: z.string().optional(),
+  }),
+);
 
 export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   nodeUrl: {

--- a/yarn-project/stdlib/src/interfaces/slasher.ts
+++ b/yarn-project/stdlib/src/interfaces/slasher.ts
@@ -1,5 +1,5 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
@@ -27,24 +27,26 @@ export interface SlasherConfig {
   slashExecuteRoundsLookBack: number; // How many rounds to look back when searching for a round to execute
 }
 
-export const SlasherConfigSchema = z.object({
-  slashOverridePayload: schemas.EthAddress.optional(),
-  slashMinPenaltyPercentage: z.number(),
-  slashMaxPenaltyPercentage: z.number(),
-  slashValidatorsAlways: z.array(schemas.EthAddress),
-  slashValidatorsNever: z.array(schemas.EthAddress),
-  slashPrunePenalty: schemas.BigInt,
-  slashDataWithholdingPenalty: schemas.BigInt,
-  slashInactivityTargetPercentage: z.number(),
-  slashInactivityConsecutiveEpochThreshold: z.number(),
-  slashInactivityPenalty: schemas.BigInt,
-  slashProposeInvalidAttestationsPenalty: schemas.BigInt,
-  slashAttestDescendantOfInvalidPenalty: schemas.BigInt,
-  slashUnknownPenalty: schemas.BigInt,
-  slashOffenseExpirationRounds: z.number(),
-  slashMaxPayloadSize: z.number(),
-  slashGracePeriodL2Slots: z.number(),
-  slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
-  slashExecuteRoundsLookBack: z.number(),
-  slashSelfAllowed: z.boolean().optional(),
-}) satisfies ZodFor<SlasherConfig>;
+export const SlasherConfigSchema = zodFor<SlasherConfig>()(
+  z.object({
+    slashOverridePayload: schemas.EthAddress.optional(),
+    slashMinPenaltyPercentage: z.number(),
+    slashMaxPenaltyPercentage: z.number(),
+    slashValidatorsAlways: z.array(schemas.EthAddress),
+    slashValidatorsNever: z.array(schemas.EthAddress),
+    slashPrunePenalty: schemas.BigInt,
+    slashDataWithholdingPenalty: schemas.BigInt,
+    slashInactivityTargetPercentage: z.number(),
+    slashInactivityConsecutiveEpochThreshold: z.number(),
+    slashInactivityPenalty: schemas.BigInt,
+    slashProposeInvalidAttestationsPenalty: schemas.BigInt,
+    slashAttestDescendantOfInvalidPenalty: schemas.BigInt,
+    slashUnknownPenalty: schemas.BigInt,
+    slashOffenseExpirationRounds: z.number(),
+    slashMaxPayloadSize: z.number(),
+    slashGracePeriodL2Slots: z.number(),
+    slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
+    slashExecuteRoundsLookBack: z.number(),
+    slashSelfAllowed: z.boolean().optional(),
+  }),
+);

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -2,7 +2,7 @@ import type { SecretValue } from '@aztec/foundation/config';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 import type { SequencerConfig, SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import type { BlockAttestation, BlockProposal, BlockProposalOptions } from '@aztec/stdlib/p2p';
 import type { Tx } from '@aztec/stdlib/tx';
@@ -56,23 +56,27 @@ export type ValidatorClientFullConfig = ValidatorClientConfig &
     disableTransactions?: boolean;
   };
 
-export const ValidatorClientConfigSchema = z.object({
-  validatorAddresses: z.array(schemas.EthAddress).optional(),
-  disableValidator: z.boolean(),
-  disabledValidators: z.array(schemas.EthAddress),
-  attestationPollingIntervalMs: z.number().min(0),
-  validatorReexecute: z.boolean(),
-  validatorReexecuteDeadlineMs: z.number().min(0),
-  alwaysReexecuteBlockProposals: z.boolean().optional(),
-  fishermanMode: z.boolean().optional(),
-}) satisfies ZodFor<Omit<ValidatorClientConfig, 'validatorPrivateKeys'>>;
+export const ValidatorClientConfigSchema = zodFor<Omit<ValidatorClientConfig, 'validatorPrivateKeys'>>()(
+  z.object({
+    validatorAddresses: z.array(schemas.EthAddress).optional(),
+    disableValidator: z.boolean(),
+    disabledValidators: z.array(schemas.EthAddress),
+    attestationPollingIntervalMs: z.number().min(0),
+    validatorReexecute: z.boolean(),
+    validatorReexecuteDeadlineMs: z.number().min(0),
+    alwaysReexecuteBlockProposals: z.boolean().optional(),
+    fishermanMode: z.boolean().optional(),
+  }),
+);
 
-export const ValidatorClientFullConfigSchema = ValidatorClientConfigSchema.extend({
-  txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
-  broadcastInvalidBlockProposal: z.boolean().optional(),
-  slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
-  disableTransactions: z.boolean().optional(),
-}) satisfies ZodFor<Omit<ValidatorClientFullConfig, 'validatorPrivateKeys'>>;
+export const ValidatorClientFullConfigSchema = zodFor<Omit<ValidatorClientFullConfig, 'validatorPrivateKeys'>>()(
+  ValidatorClientConfigSchema.extend({
+    txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
+    broadcastInvalidBlockProposal: z.boolean().optional(),
+    slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
+    disableTransactions: z.boolean().optional(),
+  }),
+);
 
 export interface Validator {
   start(): Promise<void>;

--- a/yarn-project/stdlib/src/schemas/schemas.ts
+++ b/yarn-project/stdlib/src/schemas/schemas.ts
@@ -94,6 +94,7 @@ export const NullishToUndefined = (schema: ZodFor<any>) => schema.nullish().tran
 
 export {
   type ZodFor,
+  zodFor,
   bufferSchema,
   hexSchema,
   hexSchemaFor,

--- a/yarn-project/stdlib/src/slashing/types.ts
+++ b/yarn-project/stdlib/src/slashing/types.ts
@@ -2,7 +2,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { z } from 'zod';
 
-import { type ZodFor, schemas } from '../schemas/index.js';
+import { schemas, zodFor } from '../schemas/index.js';
 
 export enum OffenseType {
   UNKNOWN = 0,
@@ -90,12 +90,14 @@ export type Offense = {
 
 export type OffenseIdentifier = Pick<Offense, 'validator' | 'offenseType' | 'epochOrSlot'>;
 
-export const OffenseSchema = z.object({
-  validator: schemas.EthAddress,
-  amount: schemas.BigInt,
-  offenseType: OffenseTypeSchema,
-  epochOrSlot: schemas.BigInt,
-}) satisfies ZodFor<Offense>;
+export const OffenseSchema = zodFor<Offense>()(
+  z.object({
+    validator: schemas.EthAddress,
+    amount: schemas.BigInt,
+    offenseType: OffenseTypeSchema,
+    epochOrSlot: schemas.BigInt,
+  }),
+);
 
 /** Offense by a validator in the context of a slash payload */
 export type ValidatorSlashOffense = {
@@ -120,19 +122,21 @@ export type SlashPayload = {
 /** Slash payload with round information from empire slash proposer */
 export type SlashPayloadRound = SlashPayload & { votes: bigint; round: bigint };
 
-export const SlashPayloadRoundSchema = z.object({
-  address: schemas.EthAddress,
-  timestamp: schemas.BigInt,
-  votes: schemas.BigInt,
-  round: schemas.BigInt,
-  slashes: z.array(
-    z.object({
-      validator: schemas.EthAddress,
-      amount: schemas.BigInt,
-      offenses: z.array(z.object({ offenseType: OffenseTypeSchema, epochOrSlot: schemas.BigInt })),
-    }),
-  ),
-}) satisfies ZodFor<SlashPayloadRound>;
+export const SlashPayloadRoundSchema = zodFor<SlashPayloadRound>()(
+  z.object({
+    address: schemas.EthAddress,
+    timestamp: schemas.BigInt,
+    votes: schemas.BigInt,
+    round: schemas.BigInt,
+    slashes: z.array(
+      z.object({
+        validator: schemas.EthAddress,
+        amount: schemas.BigInt,
+        offenses: z.array(z.object({ offenseType: OffenseTypeSchema, epochOrSlot: schemas.BigInt })),
+      }),
+    ),
+  }),
+);
 
 /** Votes for a validator slash in the consensus slash proposer */
 export type ValidatorSlashVote = number;

--- a/yarn-project/stdlib/src/snapshots/types.ts
+++ b/yarn-project/stdlib/src/snapshots/types.ts
@@ -1,5 +1,5 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
@@ -38,33 +38,37 @@ export type SnapshotsIndex = SnapshotsIndexMetadata & {
 export type UploadSnapshotMetadata = Pick<SnapshotMetadata, 'l2BlockNumber' | 'l2BlockHash' | 'l1BlockNumber'> &
   Pick<SnapshotsIndex, 'l1ChainId' | 'rollupVersion' | 'rollupAddress'>;
 
-export const SnapshotsIndexSchema = z.object({
-  l1ChainId: z.number(),
-  rollupVersion: z.number(),
-  rollupAddress: schemas.EthAddress,
-  snapshots: z.array(
-    z.object({
-      l2BlockNumber: z.number(),
-      l2BlockHash: z.string(),
-      l1BlockNumber: z.number(),
-      timestamp: z.number(),
-      schemaVersions: z.object({
-        archiver: z.number(),
-        worldState: z.number(),
+export const SnapshotsIndexSchema = zodFor<SnapshotsIndex>()(
+  z.object({
+    l1ChainId: z.number(),
+    rollupVersion: z.number(),
+    rollupAddress: schemas.EthAddress,
+    snapshots: z.array(
+      z.object({
+        l2BlockNumber: z.number(),
+        l2BlockHash: z.string(),
+        l1BlockNumber: z.number(),
+        timestamp: z.number(),
+        schemaVersions: z.object({
+          archiver: z.number(),
+          worldState: z.number(),
+        }),
+        dataUrls: z
+          .record(z.enum(SnapshotDataKeys), z.string())
+          // See https://stackoverflow.com/questions/77958464/zod-record-with-required-keys
+          .refine((obj): obj is Required<typeof obj> => SnapshotDataKeys.every(key => !!obj[key])),
       }),
-      dataUrls: z
-        .record(z.enum(SnapshotDataKeys), z.string())
-        // See https://stackoverflow.com/questions/77958464/zod-record-with-required-keys
-        .refine((obj): obj is Required<typeof obj> => SnapshotDataKeys.every(key => !!obj[key])),
-    }),
-  ),
-}) satisfies ZodFor<SnapshotsIndex>;
+    ),
+  }),
+);
 
-export const UploadSnapshotMetadataSchema = z.object({
-  l2BlockNumber: z.number(),
-  l2BlockHash: z.string(),
-  l1BlockNumber: z.number(),
-  l1ChainId: z.number(),
-  rollupVersion: z.number(),
-  rollupAddress: schemas.EthAddress,
-}) satisfies ZodFor<UploadSnapshotMetadata>;
+export const UploadSnapshotMetadataSchema = zodFor<UploadSnapshotMetadata>()(
+  z.object({
+    l2BlockNumber: z.number(),
+    l2BlockHash: z.string(),
+    l1BlockNumber: z.number(),
+    l1ChainId: z.number(),
+    rollupVersion: z.number(),
+    rollupAddress: schemas.EthAddress,
+  }),
+);

--- a/yarn-project/stdlib/src/tx/validator/tx_validator.ts
+++ b/yarn-project/stdlib/src/tx/validator/tx_validator.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { ZodFor } from '../../schemas/schemas.js';
+import { zodFor } from '../../schemas/schemas.js';
 import type { ProcessedTx } from '../processed_tx.js';
 import type { Tx } from '../tx.js';
 import type { TxHash } from '../tx_hash.js';
@@ -24,8 +24,10 @@ export interface TxValidator<T extends AnyTx = AnyTx> {
   validateTx(tx: T): Promise<TxValidationResult>;
 }
 
-export const TxValidationResultSchema = z.discriminatedUnion('result', [
-  z.object({ result: z.literal('valid'), reason: z.array(z.string()).optional() }),
-  z.object({ result: z.literal('invalid'), reason: z.array(z.string()) }),
-  z.object({ result: z.literal('skipped'), reason: z.array(z.string()) }),
-]) satisfies ZodFor<TxValidationResult>;
+export const TxValidationResultSchema = zodFor<TxValidationResult>()(
+  z.discriminatedUnion('result', [
+    z.object({ result: z.literal('valid') }),
+    z.object({ result: z.literal('invalid'), reason: z.array(z.string()) }),
+    z.object({ result: z.literal('skipped'), reason: z.array(z.string()) }),
+  ]),
+);

--- a/yarn-project/stdlib/src/validators/schemas.ts
+++ b/yarn-project/stdlib/src/validators/schemas.ts
@@ -1,4 +1,4 @@
-import { type ZodFor, schemas } from '@aztec/foundation/schemas';
+import { schemas, zodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
@@ -11,20 +11,18 @@ import type {
   ValidatorsStats,
 } from './types.js';
 
-export const ValidatorStatusInSlotSchema = z.enum([
-  'block-mined',
-  'block-proposed',
-  'block-missed',
-  'attestation-sent',
-  'attestation-missed',
-]) satisfies ZodFor<ValidatorStatusInSlot>;
+export const ValidatorStatusInSlotSchema = zodFor<ValidatorStatusInSlot>()(
+  z.enum(['block-mined', 'block-proposed', 'block-missed', 'attestation-sent', 'attestation-missed']),
+);
 
-export const ValidatorStatusHistorySchema = z.array(
-  z.object({
-    slot: schemas.SlotNumber,
-    status: ValidatorStatusInSlotSchema,
-  }),
-) satisfies ZodFor<ValidatorStatusHistory>;
+export const ValidatorStatusHistorySchema = zodFor<ValidatorStatusHistory>()(
+  z.array(
+    z.object({
+      slot: schemas.SlotNumber,
+      status: ValidatorStatusInSlotSchema,
+    }),
+  ),
+);
 
 export const ValidatorStatusHistorySchemaArray = z.array(ValidatorStatusHistorySchema);
 
@@ -36,40 +34,48 @@ const ValidatorTimeStatSchema = z.object({
   date: z.string(),
 });
 
-const ValidatorMissedStatsSchema = z.object({
-  currentStreak: schemas.Integer,
-  rate: z.number().optional(),
-  count: schemas.Integer,
-  total: schemas.Integer,
-}) satisfies ZodFor<ValidatorMissedStats>;
+const ValidatorMissedStatsSchema = zodFor<ValidatorMissedStats>()(
+  z.object({
+    currentStreak: schemas.Integer,
+    rate: z.number().optional(),
+    count: schemas.Integer,
+    total: schemas.Integer,
+  }),
+);
 
-export const ValidatorStatsSchema = z.object({
-  address: schemas.EthAddress,
-  lastProposal: ValidatorTimeStatSchema.optional(),
-  lastAttestation: ValidatorTimeStatSchema.optional(),
-  totalSlots: schemas.Integer,
-  missedProposals: ValidatorMissedStatsSchema,
-  missedAttestations: ValidatorMissedStatsSchema,
-  history: ValidatorStatusHistorySchema,
-}) satisfies ZodFor<ValidatorStats>;
+export const ValidatorStatsSchema = zodFor<ValidatorStats>()(
+  z.object({
+    address: schemas.EthAddress,
+    lastProposal: ValidatorTimeStatSchema.optional(),
+    lastAttestation: ValidatorTimeStatSchema.optional(),
+    totalSlots: schemas.Integer,
+    missedProposals: ValidatorMissedStatsSchema,
+    missedAttestations: ValidatorMissedStatsSchema,
+    history: ValidatorStatusHistorySchema,
+  }),
+);
 
-export const ValidatorsStatsSchema = z.object({
-  stats: z.record(ValidatorStatsSchema),
-  lastProcessedSlot: schemas.SlotNumber.optional(),
-  initialSlot: schemas.SlotNumber.optional(),
-  slotWindow: schemas.Integer,
-}) satisfies ZodFor<ValidatorsStats>;
+export const ValidatorsStatsSchema = zodFor<ValidatorsStats>()(
+  z.object({
+    stats: z.record(ValidatorStatsSchema),
+    lastProcessedSlot: schemas.SlotNumber.optional(),
+    initialSlot: schemas.SlotNumber.optional(),
+    slotWindow: schemas.Integer,
+  }),
+);
 
-export const SingleValidatorStatsSchema = z.object({
-  validator: ValidatorStatsSchema,
-  allTimeProvenPerformance: z.array(
-    z.object({
-      missed: schemas.Integer,
-      total: schemas.Integer,
-      epoch: schemas.EpochNumber,
-    }),
-  ),
-  lastProcessedSlot: schemas.SlotNumber.optional(),
-  initialSlot: schemas.SlotNumber.optional(),
-  slotWindow: schemas.Integer,
-}) satisfies ZodFor<SingleValidatorStats>;
+export const SingleValidatorStatsSchema = zodFor<SingleValidatorStats>()(
+  z.object({
+    validator: ValidatorStatsSchema,
+    allTimeProvenPerformance: z.array(
+      z.object({
+        missed: schemas.Integer,
+        total: schemas.Integer,
+        epoch: schemas.EpochNumber,
+      }),
+    ),
+    lastProcessedSlot: schemas.SlotNumber.optional(),
+    initialSlot: schemas.SlotNumber.optional(),
+    slotWindow: schemas.Integer,
+  }),
+);

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -12,7 +12,8 @@ import type { Logger } from '@aztec/foundation/log';
 import { type ProtocolContract, protocolContractNames } from '@aztec/protocol-contracts';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
 import { computeArtifactHash } from '@aztec/stdlib/contract';
-import type { ApiSchemaFor, ZodFor } from '@aztec/stdlib/schemas';
+import type { ApiSchemaFor } from '@aztec/stdlib/schemas';
+import { zodFor } from '@aztec/stdlib/schemas';
 
 import { createHash } from 'crypto';
 import { createReadStream } from 'fs';
@@ -53,16 +54,18 @@ type TXEForeignCallInput = {
   inputs: ForeignCallArgs;
 };
 
-const TXEForeignCallInputSchema = z.object({
-  // eslint-disable-next-line camelcase
-  session_id: z.number().int().nonnegative(),
-  function: z.string() as ZodFor<TXEOracleFunctionName>,
-  // eslint-disable-next-line camelcase
-  root_path: z.string(),
-  // eslint-disable-next-line camelcase
-  package_name: z.string(),
-  inputs: ForeignCallArgsSchema,
-}) satisfies ZodFor<TXEForeignCallInput>;
+const TXEForeignCallInputSchema = zodFor<TXEForeignCallInput>()(
+  z.object({
+    // eslint-disable-next-line camelcase
+    session_id: z.number().int().nonnegative(),
+    function: z.string() as z.ZodType<TXEOracleFunctionName>,
+    // eslint-disable-next-line camelcase
+    root_path: z.string(),
+    // eslint-disable-next-line camelcase
+    package_name: z.string(),
+    inputs: ForeignCallArgsSchema,
+  }),
+);
 
 class TXEDispatcher {
   private protocolContracts!: ProtocolContract[];


### PR DESCRIPTION
The former `satisfies ZodFor<T>` approach didn't catch missing optional properties of the type in the schema. This introduces a new Claude-generated `zodFor` function that does catch them.

I suggest reviewing with whitespace diff hidden.