### PR TITLE
fix: Disable json rpc batching in viem http transports

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -230,7 +230,7 @@ export class Archiver
     const chain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);
     const publicClient = createPublicClient({
       chain: chain.chainInfo,
-      transport: fallback(config.l1RpcUrls.map(url => http(url))),
+      transport: fallback(config.l1RpcUrls.map(url => http(url, { batch: false }))),
       pollingInterval: config.viemPollingIntervalMS,
     });
 
@@ -238,7 +238,7 @@ export class Archiver
     const debugRpcUrls = config.l1DebugRpcUrls.length > 0 ? config.l1DebugRpcUrls : config.l1RpcUrls;
     const debugClient = createPublicClient({
       chain: chain.chainInfo,
-      transport: fallback(debugRpcUrls.map(url => http(url))),
+      transport: fallback(debugRpcUrls.map(url => http(url, { batch: false }))),
       pollingInterval: config.viemPollingIntervalMS,
     }) as ViemPublicDebugClient;
 

--- a/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
+++ b/yarn-project/archiver/src/archiver/l1/bin/retrieve-calldata.ts
@@ -76,7 +76,7 @@ async function main() {
     // Create viem public client
     const publicClient = createPublicClient({
       chain: mainnet,
-      transport: http(rpcUrl),
+      transport: http(rpcUrl, { batch: false }),
     });
 
     logger.info('Fetching transaction...');

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -242,7 +242,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
     const publicClient = createPublicClient({
       chain: ethereumChain.chainInfo,
-      transport: fallback(config.l1RpcUrls.map((url: string) => http(url))),
+      transport: fallback(config.l1RpcUrls.map((url: string) => http(url, { batch: false }))),
       pollingInterval: config.viemPollingIntervalMS,
     });
 

--- a/yarn-project/blob-client/src/client/http.ts
+++ b/yarn-project/blob-client/src/client/http.ts
@@ -504,7 +504,7 @@ export class HttpBlobClient implements BlobClientInterface {
     // Ping execution node to get the parentBeaconBlockRoot for this block
     let parentBeaconBlockRoot: string | undefined;
     const client = createPublicClient({
-      transport: fallback(l1RpcUrls.map(url => http(url))),
+      transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
     });
     try {
       const res: RpcBlock = await client.request({

--- a/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
@@ -26,14 +26,14 @@ export async function sequencers(opts: {
   const chain = createEthereumChain(l1RpcUrls, chainId);
   const publicClient = createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(l1RpcUrls.map(url => http(url))),
+    transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
   });
 
   const walletClient = mnemonic
     ? createWalletClient({
         account: mnemonicToAccount(mnemonic),
         chain: chain.chainInfo,
-        transport: fallback(l1RpcUrls.map(url => http(url))),
+        transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
       })
     : undefined;
 

--- a/yarn-project/cli/src/cmds/l1/get_l1_addresses.ts
+++ b/yarn-project/cli/src/cmds/l1/get_l1_addresses.ts
@@ -17,7 +17,7 @@ export async function getL1Addresses(
   const chain = createEthereumChain(rpcUrls, chainId);
   const publicClient: ViemPublicClient = createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(rpcUrls.map(url => http(url))),
+    transport: fallback(rpcUrls.map(url => http(url, { batch: false }))),
     pollingInterval: 100,
   });
   const addresses = await RegistryContract.collectAddresses(publicClient, registryAddress.toString(), rollupVersion);

--- a/yarn-project/cli/src/cmds/l1/get_l1_balance.ts
+++ b/yarn-project/cli/src/cmds/l1/get_l1_balance.ts
@@ -18,7 +18,7 @@ export async function getL1Balance(
   const chain = createEthereumChain(l1RpcUrls, chainId);
   const publicClient = createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(l1RpcUrls.map(url => http(url))),
+    transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
   });
 
   let balance = 0n;

--- a/yarn-project/cli/src/cmds/l1/prover_stats.ts
+++ b/yarn-project/cli/src/cmds/l1/prover_stats.ts
@@ -47,7 +47,10 @@ export async function proverStats(opts: {
         .then(a => a.rollupAddress);
 
   const chain = createEthereumChain(l1RpcUrls, chainId).chainInfo;
-  const publicClient = createPublicClient({ chain, transport: fallback(l1RpcUrls.map(url => http(url))) });
+  const publicClient = createPublicClient({
+    chain,
+    transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
+  });
   const lastBlockNum = endBlock ?? (await publicClient.getBlockNumber());
   debugLog.verbose(`Querying events on rollup at ${rollup.toString()} from ${startBlock} up to ${lastBlockNum}`);
 

--- a/yarn-project/cli/src/cmds/validator_keys/new.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/new.ts
@@ -135,7 +135,7 @@ export async function newValidatorKeystore(options: NewValidatorKeystoreOptions,
     const chain = createEthereumChain(l1RpcUrls, l1ChainId);
     const publicClient = createPublicClient({
       chain: chain.chainInfo,
-      transport: fallback(l1RpcUrls.map(url => http(url))),
+      transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
     });
     const gse = new GSEContract(publicClient, gseAddress);
 

--- a/yarn-project/cli/src/cmds/validator_keys/staker.ts
+++ b/yarn-project/cli/src/cmds/validator_keys/staker.ts
@@ -273,7 +273,7 @@ export async function generateStakerJson(options: StakerOptions, log: LogFn): Pr
   const chain = createEthereumChain(l1RpcUrls, l1ChainId);
   const publicClient = createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(l1RpcUrls.map(url => http(url))),
+    transport: fallback(l1RpcUrls.map(url => http(url, { batch: false }))),
   });
   const gse = new GSEContract(publicClient, gseAddress);
 

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -44,7 +44,7 @@ describe('smoke test', () => {
     const chain = createEthereumChain([ethereumUrl], nodeInfo.l1ChainId);
     ethereumClient = createPublicClient({
       chain: chain.chainInfo,
-      transport: fallback([http(ethereumUrl)]),
+      transport: fallback([http(ethereumUrl, { batch: false })]),
     });
   });
 

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -963,7 +963,7 @@ export async function getPublicViemClient(
       containerPort: 8545,
     });
     const url = `http://127.0.0.1:${port}`;
-    const client: ViemPublicClient = createPublicClient({ transport: fallback([http(url)]) });
+    const client: ViemPublicClient = createPublicClient({ transport: fallback([http(url, { batch: false })]) });
     if (processes) {
       processes.push(process);
     }
@@ -973,7 +973,9 @@ export async function getPublicViemClient(
     if (!L1_RPC_URLS_JSON) {
       throw new Error(`L1_RPC_URLS_JSON is not defined`);
     }
-    const client: ViemPublicClient = createPublicClient({ transport: fallback([http(L1_RPC_URLS_JSON)]) });
+    const client: ViemPublicClient = createPublicClient({
+      transport: fallback([http(L1_RPC_URLS_JSON, { batch: false })]),
+    });
     return { url: L1_RPC_URLS_JSON, client };
   }
 }

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -94,7 +94,7 @@ export class EpochCache implements EpochCacheInterface {
       const chain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);
       const publicClient = createPublicClient({
         chain: chain.chainInfo,
-        transport: fallback(config.l1RpcUrls.map(url => http(url))),
+        transport: fallback(config.l1RpcUrls.map(url => http(url, { batch: false }))),
         pollingInterval: config.viemPollingIntervalMS,
       });
       rollup = new RollupContract(publicClient, rollupOrAddress.toString());

--- a/yarn-project/ethereum/src/client.ts
+++ b/yarn-project/ethereum/src/client.ts
@@ -36,7 +36,7 @@ export function getPublicClient(config: Config): ViemPublicClient {
   const chain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);
   return createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(config.l1RpcUrls.map(url => http(url))),
+    transport: fallback(config.l1RpcUrls.map(url => http(url, { batch: false }))),
     pollingInterval: config.viemPollingIntervalMS,
   });
 }
@@ -88,7 +88,7 @@ export function createExtendedL1Client(
   const extendedClient = createWalletClient({
     account: hdAccount,
     chain,
-    transport: fallback(rpcUrls.map(url => http(url))),
+    transport: fallback(rpcUrls.map(url => http(url, { batch: false }))),
     pollingInterval: pollingIntervalMS,
   }).extend(publicActions);
 

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -823,7 +823,7 @@ describe('L1TxUtils', () => {
     it('strips ABI from non-revert errors', async () => {
       // Create a client with an invalid RPC URL to trigger a real error
       const invalidClient = createPublicClient({
-        transport: http('https://foobar.com'),
+        transport: http('https://foobar.com', { batch: false }),
         chain: foundry,
       });
 

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -35,7 +35,7 @@ export class EthCheatCodes {
     public chain: Chain = foundry,
   ) {
     this.publicClient = createPublicClient({
-      transport: fallback(this.rpcUrls.map(url => http(url))),
+      transport: fallback(this.rpcUrls.map(url => http(url, { batch: false }))),
       chain: chain,
     });
   }

--- a/yarn-project/ethereum/src/test/fallback_transport.test.ts
+++ b/yarn-project/ethereum/src/test/fallback_transport.test.ts
@@ -61,12 +61,12 @@ describe('fallback_transport', () => {
 
     // Create public clients to directly check each node
     publicClient1 = createPublicClient({
-      transport: http(rpcUrl1),
+      transport: http(rpcUrl1, { batch: false }),
       chain: foundry,
     });
 
     publicClient2 = createPublicClient({
-      transport: http(rpcUrl2),
+      transport: http(rpcUrl2, { batch: false }),
       chain: foundry,
     });
 
@@ -76,7 +76,7 @@ describe('fallback_transport', () => {
   it('sends a transaction using the first node', async () => {
     // Create a client with the first node
     const client = createWalletClient({
-      transport: http(rpcUrl1),
+      transport: http(rpcUrl1, { batch: false }),
       chain: foundry,
       account,
     }).extend(publicActions);
@@ -124,7 +124,7 @@ describe('fallback_transport', () => {
         // Log the call
         node2Mock(method, params);
         // Forward to the real node
-        const transport = http(rpcUrl2)({});
+        const transport = http(rpcUrl2, { batch: false })({});
         return await transport.request({ method, params });
       }) as EIP1193RequestFn,
     });
@@ -179,7 +179,7 @@ describe('fallback_transport', () => {
         // Log the call
         node1Mock(method, params);
         // Forward to the real node
-        const transport = http(rpcUrl1)({});
+        const transport = http(rpcUrl1, { batch: false })({});
         return await transport.request({ method, params });
       }) as EIP1193RequestFn,
     });
@@ -189,7 +189,7 @@ describe('fallback_transport', () => {
         // Log the call
         node2Mock(method, params);
         // Forward to the real node
-        const transport = http(rpcUrl2)({});
+        const transport = http(rpcUrl2, { batch: false })({});
         return await transport.request({ method, params });
       }) as EIP1193RequestFn,
     });

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -32,7 +32,7 @@ export class RollupCheatCodes {
   ) {
     this.client = createPublicClient({
       chain: ethCheatCodes.chain,
-      transport: fallback(ethCheatCodes.rpcUrls.map(url => http(url))),
+      transport: fallback(ethCheatCodes.rpcUrls.map(url => http(url, { batch: false }))),
     });
     this.rollup = getContract({
       abi: RollupAbi,

--- a/yarn-project/ethereum/src/test/start_anvil.test.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.test.ts
@@ -32,7 +32,7 @@ describe('start_anvil', () => {
     const host = new URL(rpcUrl).hostname;
     expect(anvil.host).toEqual(host);
 
-    const publicClient = createPublicClient({ transport: http(rpcUrl) });
+    const publicClient = createPublicClient({ transport: http(rpcUrl, { batch: false }) });
     const chainId = await publicClient.getChainId();
     expect(chainId).toEqual(31337);
     expect(anvil.status).toEqual('listening');
@@ -42,7 +42,7 @@ describe('start_anvil', () => {
   });
 
   it('ignores errors uninstalling filters during teardown', async () => {
-    const publicClient = createPublicClient({ transport: http(rpcUrl) });
+    const publicClient = createPublicClient({ transport: http(rpcUrl, { batch: false }) });
     const abiItem = parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)');
 
     const stopWatching = publicClient.watchEvent({ event: abiItem, onLogs: () => {} });

--- a/yarn-project/ethereum/src/test/tx_delayer.test.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.test.ts
@@ -37,7 +37,7 @@ describe('tx_delayer', () => {
     account = privateKeyToAccount('0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80');
     dateProvider = new TestDateProvider();
     const _client = createWalletClient({
-      transport: fallback([http(rpcUrl)]),
+      transport: fallback([http(rpcUrl, { batch: false })]),
       chain: foundry,
       account,
     }).extend(publicActions);

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -126,7 +126,7 @@ export async function createProverNode(
 
   const publicClient = createPublicClient({
     chain: chain.chainInfo,
-    transport: fallback(config.l1RpcUrls.map((url: string) => http(url))),
+    transport: fallback(config.l1RpcUrls.map((url: string) => http(url, { batch: false }))),
     pollingInterval: config.viemPollingIntervalMS,
   });
 

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -53,7 +53,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
 
     this.publicClient = createPublicClient({
       chain: chain.chainInfo,
-      transport: fallback(chain.rpcUrls.map(url => http(url))),
+      transport: fallback(chain.rpcUrls.map(url => http(url, { batch: false }))),
       pollingInterval: config.viemPollingIntervalMS,
     });
 


### PR DESCRIPTION
We are getting sporadic `Transaction creation failed` in next. These are produced by viem when the execution client returns a -32003 error code, which geth produces only when the size of a batch response exceeds a threshold.

Under the hood, viem defaults to batching requests. So if we disable batching altogether, maybe we stop seeing this error. Worth a try.
