### PR TITLE
fix: Fr.fromHexString() throws on values larger than modulus

### DIFF
--- a/yarn-project/foundation/src/curves/bn254/field.test.ts
+++ b/yarn-project/foundation/src/curves/bn254/field.test.ts
@@ -1,11 +1,15 @@
 import { Fq, Fr } from './field.js';
 
-describe('Fr Serialization via schema', () => {
-  it('should serialize and deserialize correctly (hex)', () => {
+describe('Fr Serialization', () => {
+  it('should serialize and deserialize correctly through hex schema', () => {
     const original = Fr.random();
     const string = original.toString();
     const obtained = Fr.schema.parse(string);
     expect(obtained).toEqual(original);
+  });
+
+  it('should validate hex strings', () => {
+    expect(() => Fr.fromHexString(Fr.MODULUS.toString(16))).toThrow('greater or equal to field modulus');
   });
 });
 

--- a/yarn-project/foundation/src/curves/bn254/field.ts
+++ b/yarn-project/foundation/src/curves/bn254/field.ts
@@ -195,7 +195,7 @@ function fromHexString<T extends BaseField>(buf: string, f: DerivedField<T>) {
 
   const buffer = Buffer.from(checked.length % 2 === 1 ? '0' + checked : checked, 'hex');
 
-  return new f(buffer);
+  return new f(toBigIntBE(buffer));
 }
 
 /** Branding to ensure fields are not interchangeable types. */


### PR DESCRIPTION
Check that fields created from hex strings are within range early