### PR TITLE
chore: force install of foundry in known folder

### DIFF
--- a/spartan/scripts/install_deps.sh
+++ b/spartan/scripts/install_deps.sh
@@ -123,8 +123,9 @@ fi
 FOUNDRY_VERSION="v1.4.1"
 if ! command -v cast &> /dev/null; then
   log "Installing cast (foundry $FOUNDRY_VERSION)..."
+  export FOUNDRY_DIR="$HOME/.foundry"
   curl -L https://foundry.paradigm.xyz | bash
-  FOUNDRY_BIN_DIR="${FOUNDRY_DIR:-$HOME/.foundry}/bin"
+  FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
   "$FOUNDRY_BIN_DIR/foundryup" -i "$FOUNDRY_VERSION"
   sudo mv "$FOUNDRY_BIN_DIR/cast" /usr/local/bin/cast
   sudo chmod +x /usr/local/bin/cast


### PR DESCRIPTION
Foundry installed itself in a different folder instead of the expected one.