### PR TITLE
refactor(bb): remove unused MSGPACK_FIELDS from ACIR constraint types

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.hpp
@@ -11,7 +11,6 @@
 
 #include "arithmetic_constraints.hpp"
 #include "barretenberg/chonk/chonk.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include "blake2s_constraint.hpp"
 #include "blake3_constraint.hpp"
 #include "block_constraint.hpp"
@@ -117,28 +116,6 @@ struct AcirFormat {
 
     // Indices of the original opcode that originated each constraint in AcirFormat.
     AcirFormatOriginalOpcodeIndices original_opcode_indices;
-
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(public_inputs,
-                   logic_constraints,
-                   range_constraints,
-                   aes128_constraints,
-                   sha256_compression,
-                   ecdsa_k1_constraints,
-                   ecdsa_r1_constraints,
-                   blake2s_constraints,
-                   blake3_constraints,
-                   keccak_permutations,
-                   poseidon2_constraints,
-                   multi_scalar_mul_constraints,
-                   ec_add_constraints,
-                   honk_recursion_constraints,
-                   avm_recursion_constraints,
-                   hn_recursion_constraints,
-                   chonk_recursion_constraints,
-                   quad_constraints,
-                   big_quad_constraints,
-                   block_constraints);
 
     friend bool operator==(AcirFormat const& lhs, AcirFormat const& rhs) = default;
 };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include <array>
 #include <cstdint>
@@ -18,8 +17,6 @@ struct AES128Input {
     uint32_t witness;
     uint32_t num_bits;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(witness, num_bits);
     friend bool operator==(AES128Input const& lhs, AES128Input const& rhs) = default;
 };
 
@@ -29,8 +26,6 @@ struct AES128Constraint {
     std::array<WitnessOrConstant<bb::fr>, 16> key;
     std::vector<uint32_t> outputs;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(inputs, iv, key, outputs);
     friend bool operator==(AES128Constraint const& lhs, AES128Constraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -17,8 +16,6 @@ struct Blake2sInput {
     WitnessOrConstant<bb::fr> blackbox_input;
     uint32_t num_bits;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(blackbox_input, num_bits);
     friend bool operator==(Blake2sInput const& lhs, Blake2sInput const& rhs) = default;
 };
 
@@ -26,8 +23,6 @@ struct Blake2sConstraint {
     std::vector<Blake2sInput> inputs;
     std::array<uint32_t, 32> result;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(inputs, result);
     friend bool operator==(Blake2sConstraint const& lhs, Blake2sConstraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -17,8 +16,6 @@ struct Blake3Input {
     WitnessOrConstant<bb::fr> blackbox_input;
     uint32_t num_bits;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(blackbox_input, num_bits);
     friend bool operator==(Blake3Input const& lhs, Blake3Input const& rhs) = default;
 };
 
@@ -26,8 +23,6 @@ struct Blake3Constraint {
     std::vector<Blake3Input> inputs;
     std::array<uint32_t, 32> result;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(inputs, result);
     friend bool operator==(Blake3Constraint const& lhs, Blake3Constraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <cstdint>
 
 namespace acir_format {
@@ -44,17 +43,6 @@ struct EcAdd {
     uint32_t result_y;
     uint32_t result_infinite;
 
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(input1_x,
-                   input1_y,
-                   input1_infinite,
-                   input2_x,
-                   input2_y,
-                   input2_infinite,
-                   predicate,
-                   result_x,
-                   result_y,
-                   result_infinite);
     friend bool operator==(EcAdd const& lhs, EcAdd const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.hpp
@@ -7,7 +7,6 @@
 #pragma once
 #include "barretenberg/crypto/ecdsa/ecdsa.hpp"
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.hpp"
 #include <vector>
 
@@ -60,8 +59,6 @@ struct EcdsaConstraint {
     // Expected result of signature verification
     uint32_t result;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(hashed_message, signature, pub_x_indices, pub_y_indices, predicate, result);
     friend bool operator==(EcdsaConstraint const& lhs, EcdsaConstraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -17,8 +16,6 @@ struct Keccakf1600 {
     std::array<WitnessOrConstant<bb::fr>, 25> state;
     std::array<uint32_t, 25> result;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(state, result);
     friend bool operator==(Keccakf1600 const& lhs, Keccakf1600 const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
 #include <cstdint>
 
@@ -32,9 +31,6 @@ struct LogicConstraint {
     bool is_xor_gate;
 
     friend bool operator==(LogicConstraint const& lhs, LogicConstraint const& rhs) = default;
-
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(a, b, result, num_bits, is_xor_gate);
 };
 
 template <typename Builder>

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.hpp
@@ -5,7 +5,6 @@
 // =====================
 
 #pragma once
-#include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "serde/index.hpp"
 #include "witness_constant.hpp"
@@ -26,8 +25,6 @@ struct MultiScalarMul {
     uint32_t out_point_y;
     uint32_t out_point_is_infinite;
 
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(points, scalars, predicate, out_point_x, out_point_y, out_point_is_infinite);
     friend bool operator==(MultiScalarMul const& lhs, MultiScalarMul const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <cstdint>
 #include <vector>
 
@@ -16,8 +15,6 @@ struct Poseidon2Constraint {
     std::vector<WitnessOrConstant<bb::fr>> state;
     std::vector<uint32_t> result;
 
-    // For serialization, update with any new fields
-    MSGPACK_FIELDS(state, result);
     friend bool operator==(Poseidon2Constraint const& lhs, Poseidon2Constraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/range_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/range_constraint.hpp
@@ -5,8 +5,6 @@
 // =====================
 
 #pragma once
-#include "barretenberg/common/serialize.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <cstdint>
 
 namespace acir_format {
@@ -15,8 +13,6 @@ struct RangeConstraint {
     uint32_t witness;
     uint32_t num_bits;
 
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(witness, num_bits);
     friend bool operator==(RangeConstraint const& lhs, RangeConstraint const& rhs) = default;
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 #include "barretenberg/dsl/acir_format/witness_constant.hpp"
-#include "barretenberg/serialize/msgpack.hpp"
 #include <array>
 #include <cstdint>
 #include <vector>
@@ -18,8 +17,6 @@ struct Sha256Input {
     uint32_t num_bits;
 
     friend bool operator==(Sha256Input const& lhs, Sha256Input const& rhs) = default;
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(witness, num_bits);
 };
 
 struct Sha256Compression {
@@ -28,8 +25,6 @@ struct Sha256Compression {
     std::array<uint32_t, 8> result;
 
     friend bool operator==(Sha256Compression const& lhs, Sha256Compression const& rhs) = default;
-    // for serialization, update with any new fields
-    MSGPACK_FIELDS(inputs, hash_values, result);
 };
 
 template <typename Builder>

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/witness_constant.hpp
@@ -5,7 +5,6 @@
 // =====================
 
 #pragma once
-#include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 
@@ -15,7 +14,7 @@ template <typename FF> struct WitnessOrConstant {
     uint32_t index;
     FF value;
     bool is_constant;
-    MSGPACK_FIELDS(index, value, is_constant);
+
     friend bool operator==(WitnessOrConstant const& lhs, WitnessOrConstant const& rhs) = default;
     static WitnessOrConstant from_index(uint32_t index)
     {


### PR DESCRIPTION
## Summary
- Remove unused `MSGPACK_FIELDS` macro from all ACIR constraint types in `dsl/acir_format/*.hpp`
- Remove unused `MSGPACK_FIELDS` macro from crypto types in `crypto/schnorr/` and `crypto/ecdsa/`
- Remove unused `msgpack.hpp` includes from these files
- Remove unused typedefs that were only needed for msgpack serialization

ACIR constraint types are populated programmatically from `serde/acir.hpp`, not deserialized via msgpack. The crypto types (signatures, key pairs, multisig types) are also not serialized via msgpack - bbapi duplicates the fields into its own types.

**ACIR types cleaned up:**
- `AES128Input`, `AES128Constraint`
- `Blake2sInput`, `Blake2sConstraint`
- `Blake3Input`, `Blake3Constraint`
- `EcAdd`
- `EcdsaConstraint`
- `Keccakf1600`
- `LogicConstraint`
- `MultiScalarMul`
- `Poseidon2Constraint`
- `RangeConstraint`
- `Sha256Input`, `Sha256Compression`
- `WitnessOrConstant`
- `AcirFormat`

**Crypto types cleaned up:**
- `schnorr_signature` (crypto/schnorr/schnorr.hpp)
- `ecdsa_key_pair`, `ecdsa_signature` (crypto/ecdsa/ecdsa.hpp)
- `MultiSigPublicKey`, `RoundOnePrivateOutput`, `RoundOnePublicOutput` (crypto/schnorr/multisig.hpp)

## Test plan
- CI build passes (removes dead code only)