### PR TITLE
feat: avm allow and ignore list for fuzzer preset

### DIFF
--- a/barretenberg/cpp/cmake/fuzzing-avm-allowlist.txt
+++ b/barretenberg/cpp/cmake/fuzzing-avm-allowlist.txt
@@ -1,0 +1,2 @@
+# Instrument vm2
+src:*/vm2/*

--- a/barretenberg/cpp/cmake/fuzzing-avm-ignorelist.txt
+++ b/barretenberg/cpp/cmake/fuzzing-avm-ignorelist.txt
@@ -1,0 +1,9 @@
+# Fuzzer instrumentation blocklist for AVM fuzzing
+# These directories contain heavy constraint/circuit code that we don't want instrumented
+# Format: src:<pattern> to match source files
+
+# Exclude constraining code (circuit constraint generation)
+src:*barretenberg/vm2/constraining/*
+
+# Exclude generated code (auto-generated circuit definitions)
+src:*barretenberg/vm2/generated/*

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -91,6 +91,14 @@ function(barretenberg_module_with_sources MODULE_NAME)
                 PRIVATE
                 -fsanitize=fuzzer-no-link
             )
+            if(FUZZING_AVM)
+                target_compile_options(
+                    ${MODULE_NAME}_objects
+                    PRIVATE
+                    -fsanitize-coverage-allowlist=${CMAKE_SOURCE_DIR}/cmake/fuzzing-avm-allowlist.txt
+                    -fsanitize-coverage-ignorelist=${CMAKE_SOURCE_DIR}/cmake/fuzzing-avm-ignorelist.txt
+                )
+            endif()
         endif()
 
         # enable msgpack downloading via dependency (solves race condition)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(AVM AND FUZZING)
+if(FUZZING_AVM)
     # Collect source files, excluding the harness subdirectory to avoid duplicate targets
     file(GLOB_RECURSE SOURCE_FILES
         "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
@@ -8,6 +8,7 @@ set -e
 show_usage() {
     echo "Usage: $0 <command> <fuzzer_type> [options] [-- fuzzer_args...]"
     echo "Commands:"
+    echo "  build <fuzzer_type>                        - Build the fuzzer binary"
     echo "  fuzz <fuzzer_type> [--log] [-- args...]     - Run the fuzzer (--log to tail fuzz-0.log)"
     echo "  coverage <fuzzer_type> [type]              - Generate coverage report (type: html or report, default: html)"
     echo "  list-targets                               - List all available fuzzing targets"
@@ -118,22 +119,51 @@ else
     BUILD_CMAKE_FLAGS=""
 fi
 
+# Build function
+build_fuzzer() {
+    echo "Building fuzzer: $FUZZER_TYPE"
+    echo "Build directory: $BUILD_DIR"
+    echo "Preset: $BUILD_PRESET"
+    if [ -n "$BUILD_CMAKE_FLAGS" ]; then
+        echo "Extra CMake flags: $BUILD_CMAKE_FLAGS"
+    fi
+    echo ""
+
+    cd "$CPP_DIR"
+
+    # Configure if build dir doesn't exist or CMakeCache is missing
+    if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+        echo "Configuring cmake..."
+        if [ -n "$BUILD_CMAKE_FLAGS" ]; then
+            cmake --preset "$BUILD_PRESET" $BUILD_CMAKE_FLAGS
+        else
+            cmake --preset "$BUILD_PRESET"
+        fi
+    fi
+
+    # Build the target
+    echo "Building target: $FUZZER_TYPE"
+    cmake --build "$BUILD_DIR" --target "$FUZZER_TYPE"
+
+    echo ""
+    echo "Build complete: $FUZZER_BIN"
+}
+
 # Check if fuzzer build/binary exists
 FUZZER_BIN="$BUILD_DIR/bin/$FUZZER_TYPE"
-if [ ! -d "$BUILD_DIR" ] || [ ! -f "$FUZZER_BIN" ]; then
-    echo "Error: Fuzzer binary not found: $FUZZER_BIN"
+
+# Handle build command
+if [ "$COMMAND" = "build" ]; then
+    build_fuzzer
+    exit 0
+fi
+
+# Auto-build if binary doesn't exist
+if [ ! -f "$FUZZER_BIN" ]; then
+    echo "Fuzzer binary not found: $FUZZER_BIN"
+    echo "Auto-building..."
     echo ""
-    echo "Please build the fuzzer by running:"
-    echo "  cd $CPP_DIR"
-    if [ -n "$BUILD_CMAKE_FLAGS" ]; then
-        echo "  cmake --preset $BUILD_PRESET $BUILD_CMAKE_FLAGS"
-    else
-        echo "  cmake --preset $BUILD_PRESET"
-    fi
-    echo "  cmake --build --preset $BUILD_PRESET --target $FUZZER_TYPE"
-    echo ""
-    echo "Use './run_fuzzer.sh list-targets' to see all available targets"
-    exit 1
+    build_fuzzer
 fi
 
 # Set corpus directory based on fuzzer type


### PR DESCRIPTION
This adds an ignore and allow list for lib fuzzer, this makes things a little bit faster for the tx fuzzer and **significantly** faster for the prover.fuzzer (in an upstream PR).

This also adds some `build` commands for the fuzzing script because i kept forgetting