### PR TITLE
feat: add GitHub Action for rollup upgrade

### DIFF
--- a/.github/workflows/create-rollup-upgrade-payload.yml
+++ b/.github/workflows/create-rollup-upgrade-payload.yml
@@ -1,0 +1,60 @@
+# Deploys a new Rollup and creates a RegisterNewRollupVersionPayload for governance.
+# Spins up an EC2 instance to build yarn-project and deploy the upgrade.
+#
+# Contract defaults are loaded from spartan/environments/network-defaults.yml
+# based on the selected network (mainnet/testnet/devnet).
+
+name: Deploy Rollup Upgrade
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Aztec network (determines L1 chain and contract defaults)"
+        required: true
+        type: choice
+        options:
+          - mainnet
+          - testnet
+          - devnet
+      registry_address:
+        description: "Address of the Registry contract"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (branch, tag, or commit, defaults to current SHA)"
+        required: false
+        type: string
+
+jobs:
+  deploy-rollup:
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Store GCP key
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        run: |
+          set +x
+          umask 077
+          printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
+
+      - name: Deploy rollup upgrade via EC2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          NETWORK: ${{ inputs.network }}
+          NO_SPOT: 1
+        run: |
+          ./.github/ci3.sh deploy-rollup-upgrade "${{ inputs.registry_address }}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -719,6 +719,15 @@ case "$cmd" in
     build
     yarn-project/end-to-end/bootstrap.sh avm_check_circuit
     ;;
+  ##########################################
+  # ROLLUP UPGRADE DEPLOYMENT              #
+  ##########################################
+  "ci-deploy-rollup-upgrade")
+    # Env vars: NETWORK, GCP_PROJECT_ID (for GCP secrets)
+    # Args: <registry_address> [KEY=VALUE...]
+    export CI=1
+    exec spartan/scripts/deploy_rollup_upgrade.sh "$@"
+    ;;
 
   ##############################################
   # Default handler, calls our above functions #

--- a/ci.sh
+++ b/ci.sh
@@ -30,6 +30,7 @@ function print_usage {
   echo_cmd "network-tests"         "Spin up an EC2 instance to run tests on a network."
   echo_cmd "network-bench"         "Spin up an EC2 instance to run benchmarks on a network."
   echo_cmd "network-teardown"      "Spin up an EC2 instance to teardown a network deployment."
+  echo_cmd "deploy-rollup-upgrade" "Spin up an EC2 instance to deploy a rollup upgrade."
   echo_cmd "release"               "Spin up an EC2 instance and run bootstrap release."
   echo_cmd "shell-new"             "Spin up an EC2 instance, clone the repo, and drop into a shell."
   echo_cmd "shell"                 "Drop into a shell in the current running build instance container."
@@ -146,6 +147,15 @@ case "$cmd" in
     export CPUS=4
     export INSTANCE_POSTFIX="n-teardown"
     bootstrap_ec2 "./bootstrap.sh ci-network-teardown $*"
+    ;;
+  deploy-rollup-upgrade)
+    # Env vars: NETWORK, GCP_PROJECT_ID (for GCP secrets)
+    # Args: <registry_address>
+    export CI_DASHBOARD="network"
+    export JOB_ID="x-deploy-rollup-upgrade"
+    export CPUS=8
+    export INSTANCE_POSTFIX="rollup-upgrade"
+    bootstrap_ec2 "./bootstrap.sh ci-deploy-rollup-upgrade $*"
     ;;
 
   ############

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -316,6 +316,7 @@ function run {
         -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-} \
         -e AWS_TOKEN=\$aws_token \
         -e NAMESPACE=${NAMESPACE:-} \
+        -e NETWORK=${NETWORK:-} \
         --pids-limit=32768 \
         --shm-size=2g \
         aztecprotocol/devbox:3.0 bash -c $(printf '%q' "$container_script")

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -99,7 +99,7 @@ function build_verifier {
       $(find generated -name '*.sol') \
       test/shouting.t.sol \
       script/deploy/*.s.sol \
-      tests/scripts/*.t.sol
+      test/script/*.t.sol
 
     cache_upload $artifact out cache generated
   fi
@@ -115,6 +115,7 @@ function test_cmds {
   echo "$hash cd l1-contracts && forge fmt --check"
   echo "$hash cd l1-contracts && forge test"
   echo "$hash cd l1-contracts && forge test --no-match-contract UniswapPortalTest --match-contract MerkleCheck --ffi"
+  echo "$hash cd l1-contracts && scripts/test_rollup_upgrade.sh"
   if [[ "${TARGET_BRANCH:-}" == "master" || "${TARGET_BRANCH:-}" == "staging" ]]; then
     echo "$hash cd l1-contracts && forge test --no-match-contract UniswapPortalTest --match-contract ScreamAndShoutTest"
   fi

--- a/l1-contracts/scripts/load_network_defaults.sh
+++ b/l1-contracts/scripts/load_network_defaults.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load L1 contract defaults from network-defaults.yml for a given network.
+# Exports AZTEC_* and ETHEREUM_* env vars with YAML anchor inheritance resolved.
+#
+# Usage:
+#   source ./scripts/load_network_defaults.sh <network>
+#
+# Networks: mainnet, testnet, devnet
+
+network="${1:?Usage: $0 <network>}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+network_defaults="${script_dir}/../../spartan/environments/network-defaults.yml"
+
+if [[ ! -f "$network_defaults" ]]; then
+  echo "ERROR: network-defaults.yml not found at $network_defaults" >&2
+  exit 1
+fi
+
+# explode(.) resolves YAML anchors (<<: *prodlike inheritance)
+# Output as props, filter comments, normalize spacing
+while IFS='=' read -r key value; do
+  export "$key"="$value"
+done < <(yq -o=props "explode(.) | .networks.$network | with_entries(select(.key | test(\"^AZTEC_|^ETHEREUM_\")))" "$network_defaults" \
+  | grep -v '^#' \
+  | grep -v '^$' \
+  | sed 's/ = /=/')

--- a/l1-contracts/scripts/run_rollup_upgrade.sh
+++ b/l1-contracts/scripts/run_rollup_upgrade.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy a rollup upgrade to an existing registry.
+#
+# Usage:
+#   ./run_rollup_upgrade.sh <registry_address>
+#
+# Required environment variables:
+#   L1_RPC_URL                    - RPC URL for the target network
+#   ROLLUP_DEPLOYMENT_PRIVATE_KEY - Private key for the deployer account
+#   AZTEC_* / ETHEREUM_*          - Contract configuration (from network-defaults.yml)
+#   VK_TREE_ROOT, PROTOCOL_CONTRACTS_HASH, GENESIS_ARCHIVE_ROOT - Genesis values
+
+cd "$(dirname "$0")/.."
+
+registry_address="${1:?registry_address is required}"
+
+echo "=== Deploying rollup upgrade ==="
+echo "Registry: $registry_address"
+
+REGISTRY_ADDRESS="$registry_address" \
+REAL_VERIFIER="${REAL_VERIFIER:-true}" \
+forge script script/deploy/DeployRollupForUpgrade.s.sol:DeployRollupForUpgrade \
+  --rpc-url "$L1_RPC_URL" \
+  --private-key "$ROLLUP_DEPLOYMENT_PRIVATE_KEY" \
+  --broadcast \
+  ${ETHERSCAN_API_KEY:+--verify} \
+  -vvv

--- a/l1-contracts/scripts/test_rollup_upgrade.sh
+++ b/l1-contracts/scripts/test_rollup_upgrade.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test rollup upgrade deployment on local anvil with devnet defaults.
+
+cd "$(dirname "$0")/.."
+
+echo "=== Loading devnet defaults ==="
+source ./scripts/load_network_defaults.sh devnet
+
+cleanup() {
+  if [[ -n "${anvil_pid:-}" ]]; then
+    echo "Stopping anvil (PID: $anvil_pid)"
+    kill "$anvil_pid" 2>/dev/null || true
+    wait "$anvil_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "=== Starting anvil ==="
+anvil &
+anvil_pid=$!
+sleep 2
+
+export L1_RPC_URL="http://127.0.0.1:8545"
+export ROLLUP_DEPLOYMENT_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+echo "=== Deploying initial L1 contracts ==="
+forge script script/deploy/DeployAztecL1Contracts.s.sol:DeployAztecL1Contracts \
+  --rpc-url "$L1_RPC_URL" \
+  --private-key "$ROLLUP_DEPLOYMENT_PRIVATE_KEY" \
+  --broadcast \
+  --json > /tmp/initial_deploy.jsonl
+
+deploy_json=$(head -1 /tmp/initial_deploy.jsonl | jq -r '.logs[0]' | sed 's/JSON DEPLOY RESULT: //')
+echo ""
+echo "=== Initial deployment result ==="
+echo "$deploy_json" | jq .
+echo ""
+
+registry_address=$(echo "$deploy_json" | jq -r '.registryAddress')
+if [[ -z "$registry_address" || "$registry_address" == "null" ]]; then
+  echo "ERROR: Could not extract registry address from initial deployment"
+  exit 1
+fi
+
+echo "=== Testing run_rollup_upgrade.sh ==="
+# Use a different genesis to get a different rollup version
+export GENESIS_ARCHIVE_ROOT="0x$(openssl rand -hex 32)"
+
+./scripts/run_rollup_upgrade.sh "$registry_address"
+
+echo ""
+echo "=== Test completed successfully ==="

--- a/l1-contracts/src/periphery/RegisterNewRollupVersionPayload.sol
+++ b/l1-contracts/src/periphery/RegisterNewRollupVersionPayload.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
+import {IGSECore} from "@aztec/governance/GSE.sol";
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
+
+/**
+ * @title RegisterNewRollupVersionPayload
+ * @author Aztec Labs
+ * @notice A payload that registers a new rollup version in the Registry and GSE.
+ */
+contract RegisterNewRollupVersionPayload is IPayload {
+  /// @notice The registry contract where the rollup will be registered
+  IRegistry public immutable REGISTRY;
+
+  /// @notice The rollup instance to register
+  IInstance public immutable ROLLUP;
+
+  /**
+   * @notice Constructs a new RegisterNewRollupVersionPayload
+   * @param _registry The registry contract
+   * @param _rollup The rollup instance to register
+   */
+  constructor(IRegistry _registry, IInstance _rollup) {
+    REGISTRY = _registry;
+    ROLLUP = _rollup;
+  }
+
+  /**
+   * @notice Returns the actions to execute for registering the new rollup version
+   * @return The array of actions to execute
+   */
+  function getActions() external view override(IPayload) returns (IPayload.Action[] memory) {
+    IPayload.Action[] memory res = new IPayload.Action[](2);
+
+    res[0] =
+      Action({target: address(REGISTRY), data: abi.encodeWithSelector(IRegistry.addRollup.selector, address(ROLLUP))});
+
+    res[1] = Action({
+      target: address(ROLLUP.getGSE()), data: abi.encodeWithSelector(IGSECore.addRollup.selector, address(ROLLUP))
+    });
+
+    return res;
+  }
+
+  /**
+   * @notice Returns the URI describing this payload
+   * @return The payload URI string
+   */
+  function getURI() external pure override(IPayload) returns (string memory) {
+    return "RegisterNewRollupVersionPayload";
+  }
+}

--- a/spartan/scripts/deploy_rollup_upgrade.sh
+++ b/spartan/scripts/deploy_rollup_upgrade.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy a new Rollup version and create a RegisterNewRollupVersionPayload for governance.
+#
+# Loads L1 contract defaults from network-defaults.yml (with YAML anchor inheritance),
+# infers L1 chain from L1_CHAIN_ID, fetches GCP secrets, builds yarn-project for
+# genesis values, then calls l1-contracts/scripts/run_rollup_upgrade.sh.
+#
+# Usage:
+#   ./deploy_rollup_upgrade.sh <registry_address>
+#
+# Required environment variables:
+#   NETWORK        - Aztec network (mainnet, testnet, devnet)
+#   GCP_PROJECT_ID - GCP project ID for Secret Manager
+
+repo_root="$(git rev-parse --show-toplevel)"
+source "${repo_root}/ci3/source"
+
+log() { echo "[INFO]  $(date -Is) - $*"; }
+die() { echo "[ERROR] $(date -Is) - $*" >&2; exit 1; }
+
+registry_address="${1:?Usage: $0 <registry_address>}"
+
+: "${NETWORK:?NETWORK is required (mainnet, testnet, devnet)}"
+: "${GCP_PROJECT_ID:?GCP_PROJECT_ID is required}"
+
+log "Starting rollup upgrade deployment"
+log "Network: $NETWORK"
+log "Registry: $registry_address"
+
+# Load network-specific defaults
+log "Loading L1 contract defaults from network-defaults.yml"
+source "${repo_root}/l1-contracts/scripts/load_network_defaults.sh" "$NETWORK"
+
+# Infer L1 chain from L1_CHAIN_ID
+network_defaults="${repo_root}/spartan/environments/network-defaults.yml"
+l1_chain_id=$(yq "explode(.) | .networks.$NETWORK.L1_CHAIN_ID" "$network_defaults")
+case "$l1_chain_id" in
+  1) L1_NETWORK="mainnet" ;;
+  11155111) L1_NETWORK="sepolia" ;;
+  *) die "Unknown L1_CHAIN_ID '$l1_chain_id' for network '$NETWORK'" ;;
+esac
+log "L1 Chain: $L1_NETWORK (chain ID: $l1_chain_id)"
+
+# Fetch secrets from GCP
+log "Fetching secrets from GCP..."
+get_secret() { gcloud secrets versions access latest --secret="$1" --project="$GCP_PROJECT_ID"; }
+export L1_RPC_URL=$(get_secret "${L1_NETWORK}-rpc-urls" | jq -r '.[0]')
+export ROLLUP_DEPLOYMENT_PRIVATE_KEY=$(get_secret "${L1_NETWORK}-labs-rollup-private-key")
+export ETHERSCAN_API_KEY=$(get_secret "etherscan-api-key")
+log "Secrets loaded"
+
+# Build yarn-project for genesis values
+cd "$repo_root"
+log "Building yarn-project..."
+BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+
+# Extract genesis values
+cd yarn-project
+export VK_TREE_ROOT=$(node -e "import('@aztec/noir-protocol-circuits-types/vk-tree').then(m => console.log(m.getVKTreeRoot().toString()))")
+export PROTOCOL_CONTRACTS_HASH=$(node -e "import('@aztec/protocol-contracts').then(m => console.log(m.protocolContractsHash.toString()))")
+export GENESIS_ARCHIVE_ROOT=$(node -e "import('@aztec/constants').then(m => console.log('0x' + m.GENESIS_ARCHIVE_ROOT.toString(16).padStart(64, '0')))")
+cd ..
+
+log "VK_TREE_ROOT: $VK_TREE_ROOT"
+log "PROTOCOL_CONTRACTS_HASH: $PROTOCOL_CONTRACTS_HASH"
+log "GENESIS_ARCHIVE_ROOT: $GENESIS_ARCHIVE_ROOT"
+
+exec l1-contracts/scripts/run_rollup_upgrade.sh "$registry_address"


### PR DESCRIPTION
Adds a GitHub Action workflow to deploy a new Rollup version and create a `RegisterNewRollupVersionPayload` for governance approval.

## Usage

Trigger the workflow from GitHub Actions with:
- **network**: `mainnet`, `testnet`, or `devnet`
- **registry_address**: The existing registry contract address

The workflow will:
1. Build the codebase to generate genesis values (VK tree root, protocol contracts hash, etc.)
2. Deploy a new Rollup contract with the current code
3. Create a `RegisterNewRollupVersionPayload` that governance can execute to register the upgrade

## Network Configuration

All L1 contract parameters are defined in `spartan/environments/network-defaults.yml`. When you select a network:

- **Contract constants** (`AZTEC_EPOCH_DURATION`, `AZTEC_SLOT_DURATION`, thresholds, etc.) are loaded from the network's configuration
- **L1 chain** is inferred from `L1_CHAIN_ID` in the config (mainnet uses Ethereum mainnet, testnet/devnet use Sepolia)
- **Credentials** are fetched from GCP secrets based on the L1 chain (`sepolia-rpc-urls`, `sepolia-labs-rollup-private-key`, etc.)

This means the deployment automatically uses the correct parameters for each network without manual configuration.

## Follow-on tasks
- [TMNT-495](https://linear.app/aztec-labs/issue/TMNT-495/add-mainnet-labs-rollup-private-key-gcp-secret-for-rollup-upgrades): Add mainnet-labs-rollup-private-key GCP secret for rollup upgrades