### PR TITLE
chore: Optimise dsl testing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
@@ -136,7 +136,7 @@ class ArithmeticConstraintsTestingFunctions {
         return result;
     }
 
-    void generate_constraints(AcirConstraint& arithmetic_constraint, WitnessVector& witness_values)
+    static void generate_constraints(AcirConstraint& arithmetic_constraint, WitnessVector& witness_values)
     {
         // (scalar, (lhs_index, lhs_value), (rhs_index, rhs_value))
         std::vector<std::tuple<bb::fr, std::pair<uint32_t, bb::fr>, std::pair<uint32_t, bb::fr>>> mul_terms;
@@ -238,9 +238,9 @@ class ArithmeticConstraintsTestingFunctions {
         }
     }
 
-    void invalidate_witness(AcirConstraint& constraint,
-                            WitnessVector& witness_values,
-                            const typename InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness(AcirConstraint& constraint,
+                                   WitnessVector& witness_values,
+                                   const typename InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
@@ -238,9 +238,10 @@ class ArithmeticConstraintsTestingFunctions {
         }
     }
 
-    static void invalidate_witness(AcirConstraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const typename InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint,
+        WitnessVector witness_values,
+        const typename InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -264,6 +265,8 @@ class ArithmeticConstraintsTestingFunctions {
             break;
         }
         };
+
+        return { constraint, witness_values };
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
@@ -31,9 +31,9 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    void invalidate_witness(Blake2sConstraint& constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness(Blake2sConstraint& constraint,
+                                   WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input: {
@@ -59,7 +59,7 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
     /**
      * @brief Generate a valid Blake2sConstraint with correct witness values
      */
-    void generate_constraints(Blake2sConstraint& blake2s_constraint, WitnessVector& witness_values)
+    static void generate_constraints(Blake2sConstraint& blake2s_constraint, WitnessVector& witness_values)
     {
         // Helper to add a state: either as witness or constant
         auto construct_state = [&](const std::vector<uint8_t>& state,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
@@ -31,9 +31,8 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    static void invalidate_witness(Blake2sConstraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input: {
@@ -54,6 +53,8 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { constraint, witness_values };
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
@@ -31,9 +31,9 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    void invalidate_witness(Blake3Constraint& constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness(Blake3Constraint& constraint,
+                                   WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input: {
@@ -59,7 +59,7 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
     /**
      * @brief Generate a valid Blake3Constraint with correct witness values
      */
-    void generate_constraints(Blake3Constraint& blake3_constraint, WitnessVector& witness_values)
+    static void generate_constraints(Blake3Constraint& blake3_constraint, WitnessVector& witness_values)
     {
         // Helper to add a state: either as witness or constant
         auto construct_state = [&](const std::vector<uint8_t>& state,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
@@ -31,9 +31,8 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    static void invalidate_witness(Blake3Constraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint, WitnessVector& witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input: {
@@ -54,6 +53,8 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { constraint, witness_values };
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -220,9 +220,6 @@ class RAMTestingFunctions {
         uint32_t witness_index;
     };
 
-    // Instance member to track reads for invalidating witnesses.
-    std::vector<WitnessValue> read_values;
-
     class InvalidWitness {
       public:
         enum class Target : uint8_t { None, ReadValueIncremented };
@@ -244,11 +241,8 @@ class RAMTestingFunctions {
         };
     };
 
-    void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
+    static void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
     {
-        // Clear any previous state
-        read_values.clear();
-
         // Create initial memory values "natively". RAM tables always start out initialized.
         std::vector<bb::fr> table_values;
         table_values.reserve(table_size);
@@ -299,9 +293,6 @@ class RAMTestingFunctions {
                     bb::fr read_value = table_values[ram_index_to_read];
                     const uint32_t value_for_read = add_to_witness_and_track_indices(witness_values, read_value);
 
-                    // Record this read value and its witness index
-                    read_values.push_back({ .value = read_value, .witness_index = value_for_read });
-
                     mem_op = { .access_type = AccessType::Read,
                                .index = WitnessOrConstant<bb::fr>::from_index(index_for_read),
                                .value = WitnessOrConstant<bb::fr>::from_index(value_for_read) };
@@ -330,28 +321,29 @@ class RAMTestingFunctions {
                 add_constant_ops<AccessType::Read>(table_size, table_values, witness_values, trace);
                 add_constant_ops<AccessType::Write>(table_size, table_values, witness_values, trace);
             }
-
-            BB_ASSERT_EQ(read_values.size(), num_reads); // sanity check to make sure the number of reads is correct.
-            // Create the MemoryConstraint
         }
+
+        // Create the MemoryConstraint
         memory_constraint = AcirConstraint{ .init = init_indices, .trace = trace, .type = BlockType::RAM };
     }
 
-    void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
+                                   WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
             break;
         case InvalidWitness::Target::ReadValueIncremented:
             if constexpr (num_reads > 0 && table_size > 0) {
-                // Tamper with a random read value using the recorded witness index
-                if (!read_values.empty()) {
-                    const size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % read_values.size());
-                    const uint32_t witness_idx = read_values[random_read_idx].witness_index;
-                    witness_values[witness_idx] += bb::fr(1);
+                // Tamper with a random read value
+                size_t random_read_idx = static_cast<size_t>(engine.get_random_uint32() % (num_reads + num_writes));
+                while (memory_constraint.trace[random_read_idx].access_type != AccessType::Read) {
+                    // Find a read operation
+                    random_read_idx = static_cast<size_t>(engine.get_random_uint32() % (num_reads + num_writes));
                 }
+                const uint32_t witness_idx = memory_constraint.trace[random_read_idx].value.index;
+                witness_values[witness_idx] += bb::fr(1);
             }
             break;
         }
@@ -439,7 +431,7 @@ class CallDataTestingFunctions {
         }
     };
 
-    void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
+    static void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
     {
 
         // Create initial memory values "natively". Memory tables always start out initialized.
@@ -484,9 +476,9 @@ class CallDataTestingFunctions {
         };
     }
 
-    void invalidate_witness(AcirConstraint& memory_constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness(AcirConstraint& memory_constraint,
+                                   WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -551,7 +543,7 @@ class ReturnDataTestingFunctions {
         static std::vector<std::string> get_labels() { return { "None" }; };
     };
 
-    void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
+    static void generate_constraints(AcirConstraint& memory_constraint, WitnessVector& witness_values)
     {
         // Create initial memory values "natively". Memory tables always start out initialized.
         std::vector<bb::fr> returndata_values;
@@ -571,9 +563,9 @@ class ReturnDataTestingFunctions {
         memory_constraint = AcirConstraint{ .init = init_indices, .trace = {}, .type = BlockType::ReturnData };
     }
 
-    void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
-                            [[maybe_unused]] WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
+                                   [[maybe_unused]] WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/block_constraint.test.cpp
@@ -143,9 +143,10 @@ template <typename Builder_, size_t table_size, size_t num_reads, bool perform_c
         memory_constraint = AcirConstraint{ .init = init_indices, .trace = trace, .type = BlockType::ROM };
     }
 
-    static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        [[maybe_unused]] AcirConstraint memory_constraint,
+        WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -161,6 +162,8 @@ template <typename Builder_, size_t table_size, size_t num_reads, bool perform_c
             }
             break;
         }
+
+        return { memory_constraint, witness_values };
     }
 };
 template <typename Params>
@@ -327,9 +330,10 @@ class RAMTestingFunctions {
         memory_constraint = AcirConstraint{ .init = init_indices, .trace = trace, .type = BlockType::RAM };
     }
 
-    static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        [[maybe_unused]] AcirConstraint memory_constraint,
+        WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -347,6 +351,8 @@ class RAMTestingFunctions {
             }
             break;
         }
+
+        return { memory_constraint, witness_values };
     }
 };
 
@@ -476,9 +482,10 @@ class CallDataTestingFunctions {
         };
     }
 
-    static void invalidate_witness(AcirConstraint& memory_constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint memory_constraint,
+        WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -492,6 +499,8 @@ class CallDataTestingFunctions {
             }
             break;
         }
+
+        return { memory_constraint, witness_values };
     }
 };
 
@@ -563,14 +572,17 @@ class ReturnDataTestingFunctions {
         memory_constraint = AcirConstraint{ .init = init_indices, .trace = {}, .type = BlockType::ReturnData };
     }
 
-    static void invalidate_witness([[maybe_unused]] AcirConstraint& memory_constraint,
-                                   [[maybe_unused]] WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        [[maybe_unused]] AcirConstraint memory_constraint,
+        [[maybe_unused]] WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { memory_constraint, witness_values };
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ec_operations.test.cpp
@@ -97,9 +97,8 @@ template <typename Builder_, InputConstancy Constancy> class EcOperationsTesting
         };
     }
 
-    static void invalidate_witness(AcirConstraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input1: {
@@ -131,6 +130,8 @@ template <typename Builder_, InputConstancy Constancy> class EcOperationsTesting
         default:
             break;
         }
+
+        return { constraint, witness_values };
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ecdsa_constraints.test.cpp
@@ -52,9 +52,10 @@ template <class Curve> class EcdsaTestingFunctions {
     static constexpr FrNative private_key =
         FrNative("0xd67abee717b3fc725adf59e2cc8cd916435c348b277dd814a34e3ceb279436c2");
 
-    static void invalidate_witness(EcdsaConstraint& ecdsa_constraints,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint ecdsa_constraints,
+        WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         // For most ECDSA invalidation cases, we set result=0 to ensure that the failure mode caught by the test is
         // specific to the particular case being tested, not just simple verification failure.
@@ -101,6 +102,8 @@ template <class Curve> class EcdsaTestingFunctions {
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { ecdsa_constraints, witness_values };
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
@@ -248,19 +248,22 @@ TYPED_TEST(LogicConstraintTestsBothConstant, GenerateVKFromConstraints)
 
 TYPED_TEST(LogicConstraintTestsBothConstant, Tampering)
 {
+    typename TestFixture::AcirConstraint constraint;
+    WitnessVector witness_values;
+    TestFixture::Base::generate_constraints(constraint, witness_values);
+
     // We need to test tampering by hand because when both inputs are constant making the bit size invalid will not
     // make the builder fail, it will raise an error.
     {
         auto [circuit_checker_result, builder_failed, builder_err] =
-            TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::None);
-
+            TestFixture::test_constraints(constraint, witness_values, TestFixture::InvalidWitnessTarget::None);
         EXPECT_TRUE(circuit_checker_result) << "Circuit checker failed unexpectedly for invalid witness target None";
         EXPECT_FALSE(builder_failed) << "Builder failed unexpectedly for invalid witness target None";
     }
 
     {
         auto [circuit_checker_result, builder_failed, builder_err] =
-            TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Inputs);
+            TestFixture::test_constraints(constraint, witness_values, TestFixture::InvalidWitnessTarget::Inputs);
         bool circuit_check_failed = !circuit_checker_result;
         bool assert_eq_error_present = (builder_err.find("assert_eq") != std::string::npos);
         EXPECT_TRUE(circuit_check_failed || assert_eq_error_present)
@@ -269,12 +272,14 @@ TYPED_TEST(LogicConstraintTestsBothConstant, Tampering)
     }
 
     {
-        EXPECT_THROW_WITH_MESSAGE(TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input1BitSize),
-                                  "field_t: Left operand in logic gate exceeds specified bit length");
+        EXPECT_THROW_WITH_MESSAGE(
+            TestFixture::test_constraints(constraint, witness_values, TestFixture::InvalidWitnessTarget::Input1BitSize),
+            "field_t: Left operand in logic gate exceeds specified bit length");
     }
 
     {
-        EXPECT_THROW_WITH_MESSAGE(TestFixture::test_constraints(TestFixture::InvalidWitnessTarget::Input2BitSize),
-                                  "field_t: Right operand in logic gate exceeds specified bit length");
+        EXPECT_THROW_WITH_MESSAGE(
+            TestFixture::test_constraints(constraint, witness_values, TestFixture::InvalidWitnessTarget::Input2BitSize),
+            "field_t: Right operand in logic gate exceeds specified bit length");
     }
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/logic_constraint.test.cpp
@@ -86,9 +86,8 @@ class LogicConstraintTestingFunctions {
         };
     };
 
-    static void invalidate_witness(AcirConstraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::None:
@@ -123,6 +122,8 @@ class LogicConstraintTestingFunctions {
             break;
         }
         }
+
+        return { constraint, witness_values };
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/multi_scalar_mul.test.cpp
@@ -115,9 +115,8 @@ template <typename Builder_, InputConstancy Constancy> class MultiScalarMulTesti
         };
     }
 
-    static void invalidate_witness(AcirConstraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        AcirConstraint constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Points: {
@@ -149,6 +148,8 @@ template <typename Builder_, InputConstancy Constancy> class MultiScalarMulTesti
         default:
             break;
         }
+
+        return { constraint, witness_values };
     };
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
@@ -33,9 +33,9 @@ template <class BuilderType> class Poseidon2TestingFunctions {
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    void invalidate_witness(Poseidon2Constraint& constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static void invalidate_witness(Poseidon2Constraint& constraint,
+                                   WitnessVector& witness_values,
+                                   const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input:
@@ -54,7 +54,7 @@ template <class BuilderType> class Poseidon2TestingFunctions {
     /**
      * @brief Generate valid Poseidon2 constraint with correct witness values
      */
-    void generate_constraints(Poseidon2Constraint& poseidon2_constraint, WitnessVector& witness_values)
+    static void generate_constraints(Poseidon2Constraint& poseidon2_constraint, WitnessVector& witness_values)
     {
         // Start with the zero variable at index 0
         witness_values.emplace_back(bb::fr(0));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/poseidon2_constraint.test.cpp
@@ -33,9 +33,10 @@ template <class BuilderType> class Poseidon2TestingFunctions {
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    static void invalidate_witness(Poseidon2Constraint& constraint,
-                                   WitnessVector& witness_values,
-                                   const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        Poseidon2Constraint constraint,
+        WitnessVector witness_values,
+        const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
         case InvalidWitness::Target::Input:
@@ -49,6 +50,8 @@ template <class BuilderType> class Poseidon2TestingFunctions {
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { constraint, witness_values };
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -584,8 +584,8 @@ template <TestBase Base_> class TestClass {
      * tests circuit_serde_to_acir_format, which would otherwise only be tested via the tests in acir_tests.
      *
      */
-    static std::tuple<bool, bool, std::string> test_constraints(const AcirConstraint& constraint,
-                                                                const WitnessVector& witness_values,
+    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint& constraint,
+                                                                WitnessVector& witness_values,
                                                                 const InvalidWitnessTarget& invalid_witness_target)
     {
         auto [updated_constraint, updated_witness_values] =

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -536,22 +536,29 @@ concept TestBase = requires {
     { T::InvalidWitness::get_all() } -> std::same_as<std::vector<typename T::InvalidWitness::Target>>;
     { T::InvalidWitness::get_labels() } -> std::same_as<std::vector<std::string>>;
 
-    // Required constraint manipulation methods (can be static or non-static)
-    requires requires(T& instance,
-                      typename T::AcirConstraint& constraint,
-                      WitnessVector& witness_values,
-                      const typename T::InvalidWitness::Target& invalid_witness_target) {
+    // Required constraint manipulation methods
+    requires requires(T& instance, typename T::AcirConstraint& constraint, WitnessVector& witness_values) {
         /**
          * @brief Generate valid constraints.
          *
          */
         { T::generate_constraints(constraint, witness_values) } -> std::same_as<void>;
+    };
 
+    requires requires(T& instance,
+                      typename T::AcirConstraint constraint,
+                      WitnessVector witness_values,
+                      const typename T::InvalidWitness::Target& invalid_witness_target) {
         /**
          * @brief Invalidate witness values to test that invalid witnesses produce unsatisfied constraints.
          *
+         * @note The constraint and witness values must be copied otherwise this would affect later calls to this
+         * function
+         *
          */
-        { T::invalidate_witness(constraint, witness_values, invalid_witness_target) } -> std::same_as<void>;
+        {
+            T::invalidate_witness(constraint, witness_values, invalid_witness_target)
+        } -> std::same_as<std::pair<typename T::AcirConstraint, WitnessVector>>;
     };
 };
 
@@ -576,19 +583,18 @@ template <TestBase Base_> class TestClass {
      * serialization/deserialization. The rationale for doing the rewinding is ensuring that barretenberg internally
      * tests circuit_serde_to_acir_format, which would otherwise only be tested via the tests in acir_tests.
      *
-     * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint constraint,
-                                                                WitnessVector witness_values,
+    static std::tuple<bool, bool, std::string> test_constraints(const AcirConstraint& constraint,
+                                                                const WitnessVector& witness_values,
                                                                 const InvalidWitnessTarget& invalid_witness_target)
     {
-        Base::invalidate_witness(constraint, witness_values, invalid_witness_target);
+        auto [updated_constraint, updated_witness_values] =
+            Base::invalidate_witness(constraint, witness_values, invalid_witness_target);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
         AcirFormat constraint_system = constraint_to_acir_format(
-            constraint, /*max_witness_index=*/static_cast<uint32_t>(witness_values.size()) - 1);
-
-        AcirProgram program{ constraint_system, witness_values };
+            updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+        AcirProgram program{ constraint_system, updated_witness_values };
         auto builder = create_circuit<Builder>(program);
 
         return { CircuitChecker::check(builder), builder.failed(), builder.err() };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -545,42 +545,26 @@ concept TestBase = requires {
          * @brief Generate valid constraints.
          *
          */
-        { instance.generate_constraints(constraint, witness_values) } -> std::same_as<void>;
+        { T::generate_constraints(constraint, witness_values) } -> std::same_as<void>;
 
         /**
          * @brief Invalidate witness values to test that invalid witnesses produce unsatisfied constraints.
          *
          */
-        { instance.invalidate_witness(constraint, witness_values, invalid_witness_target) } -> std::same_as<void>;
+        { T::invalidate_witness(constraint, witness_values, invalid_witness_target) } -> std::same_as<void>;
     };
 };
 
-template <TestBase Base> class TestClass {
+template <TestBase Base_> class TestClass {
   public:
+    using Base = Base_;
     using Builder = Base::Builder;
     using AcirConstraint = Base::AcirConstraint;
     using InvalidWitness = Base::InvalidWitness;
     using InvalidWitnessTarget = Base::InvalidWitness::Target;
 
     /**
-     * @brief Generate constraints and witness values based on the invalidation target.
-     */
-    static std::pair<AcirConstraint, WitnessVector> generate_constraints(
-        const InvalidWitnessTarget& invalid_witness_target = InvalidWitnessTarget::None)
-    {
-        AcirConstraint constraint;
-        WitnessVector witness_values;
-
-        // Create an instance to allow for non-static methods
-        Base base_instance;
-        base_instance.generate_constraints(constraint, witness_values);
-        base_instance.invalidate_witness(constraint, witness_values, invalid_witness_target);
-
-        return { constraint, witness_values };
-    }
-
-    /**
-     * @brief General purpose testing function. It generates the test based on the predicate and invalidation target.
+     * @brief General purpose testing function. It tests the constraints based on the invalidation target.
      *
      * @details In a real flow, we have:
      *          Noir --> ACIR --> Bytes --> AcirFormat (via circuit_buf_to_acir_format) --> Builder
@@ -592,10 +576,13 @@ template <TestBase Base> class TestClass {
      * serialization/deserialization. The rationale for doing the rewinding is ensuring that barretenberg internally
      * tests circuit_serde_to_acir_format, which would otherwise only be tested via the tests in acir_tests.
      *
+     * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static std::tuple<bool, bool, std::string> test_constraints(const InvalidWitnessTarget& invalid_witness_target)
+    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint constraint,
+                                                                WitnessVector witness_values,
+                                                                const InvalidWitnessTarget& invalid_witness_target)
     {
-        auto [constraint, witness_values] = generate_constraints(invalid_witness_target);
+        Base::invalidate_witness(constraint, witness_values, invalid_witness_target);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
         AcirFormat constraint_system = constraint_to_acir_format(
@@ -623,7 +610,9 @@ template <TestBase Base> class TestClass {
         size_t num_gates = 0;
 
         // Generate the constraint system
-        auto [constraint, witness_values] = generate_constraints();
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
         AcirFormat constraint_system = constraint_to_acir_format(
@@ -664,8 +653,15 @@ template <TestBase Base> class TestClass {
     static std::vector<std::string> test_tampering()
     {
         std::vector<std::string> error_msgs;
+
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         for (auto [target, label] : zip_view(InvalidWitness::get_all(), InvalidWitness::get_labels())) {
-            auto [circuit_checker_result, builder_failed, builder_err] = test_constraints(target);
+            auto [circuit_checker_result, builder_failed, builder_err] =
+                test_constraints(constraint, witness_values, target);
             error_msgs.emplace_back(builder_err);
 
             if (target != InvalidWitness::Target::None) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -92,8 +92,9 @@ concept TestBaseWithPredicate = requires {
 /**
  * @brief Test class for ACIR constraints that contain a predicate.
  */
-template <TestBaseWithPredicate Base> class TestClassWithPredicate {
+template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
   public:
+    using Base = Base_;
     using Builder = Base::Builder;
     using InvalidWitness = Base::InvalidWitness;
     using InvalidWitnessTarget = InvalidWitness::Target;
@@ -107,6 +108,8 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      * @param mode
      * @param forced_invalidation If true, forces the witness to be invalidated even if the predicate is not witness
      * false. Used to check that the circuit fails if the predicate is witness true and witnesses are invalid.
+     *
+     * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
     static void update_witness_based_on_predicate(AcirConstraint& constraint,
                                                   WitnessVector& witness_values,
@@ -129,20 +132,7 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
     }
 
     /**
-     * @brief Generate constraints and witness values based on the predicate and the invalidation target.
-     */
-    static std::pair<AcirConstraint, WitnessVector> generate_constraints(const Predicate<InvalidWitnessTarget>& mode)
-    {
-        AcirConstraint constraint;
-        WitnessVector witness_values;
-        Base::generate_constraints(constraint, witness_values);
-        update_witness_based_on_predicate(constraint, witness_values, mode);
-
-        return { constraint, witness_values };
-    }
-
-    /**
-     * @brief General purpose testing function. It generates the test based on the predicate and invalidation target.
+     * @brief General purpose testing function. It tests the contraints based on the predicate and invalidation target.
      *
      * @details In a real flow, we have:
      *          Noir --> ACIR --> Bytes --> AcirFormat (via circuit_buf_to_acir_format) --> Builder
@@ -154,13 +144,16 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      * serialization/deserialization. The rationale for doing the rewinding is ensuring that barretenberg internally
      * tests circuit_serde_to_acir_format, which would otherwise only be tested via the tests in acir_tests.
      *
+     * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static std::tuple<bool, bool, std::string> test_constraints(const PredicateTestCase& test_case,
+    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint constraint,
+                                                                WitnessVector witness_values,
+                                                                const PredicateTestCase& test_case,
                                                                 const InvalidWitnessTarget& invalid_witness_target)
     {
         Predicate<InvalidWitnessTarget> predicate = { .test_case = test_case,
                                                       .invalid_witness = invalid_witness_target };
-        auto [constraint, witness_values] = generate_constraints(predicate);
+        update_witness_based_on_predicate(constraint, witness_values, predicate);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
         AcirFormat constraint_system = constraint_to_acir_format(
@@ -187,14 +180,22 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
 
         std::vector<size_t> num_gates;
 
+        // Generate the constraint system
+        AcirConstraint valid_constraint;
+        WitnessVector valid_witness_values;
+        Base::generate_constraints(valid_constraint, valid_witness_values);
+
         for (auto [predicate_case, label] :
              zip_view(Predicate<InvalidWitnessTarget>::get_all(), Predicate<InvalidWitnessTarget>::get_labels())) {
             vinfo("Testing vk independence for predicate case: ", label);
 
-            // Generate the constraint system
+            // Copy valid constraints and witness values
+            AcirConstraint constraint(valid_constraint);
+            WitnessVector witness_values(valid_witness_values);
+            // Update the constraint system based on the predicate mode
             Predicate<InvalidWitnessTarget> predicate = { .test_case = predicate_case,
                                                           .invalid_witness = InvalidWitnessTarget::None };
-            auto [constraint, witness_values] = generate_constraints(predicate);
+            update_witness_based_on_predicate(constraint, witness_values, predicate);
 
             // Use the full ACIR flow
             AcirFormat constraint_system = constraint_to_acir_format(
@@ -242,18 +243,23 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      */
     static void test_constant_true(InvalidWitnessTarget default_invalid_witness_target)
     {
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         // Constant true, no invalidation
         {
-            auto [circuit_checker_result, builder_failed, _] =
-                test_constraints(PredicateTestCase::ConstantTrue, InvalidWitnessTarget::None);
+            auto [circuit_checker_result, builder_failed, _] = test_constraints(
+                constraint, witness_values, PredicateTestCase::ConstantTrue, InvalidWitnessTarget::None);
             EXPECT_TRUE(circuit_checker_result) << "Circuit checker failed.";
             EXPECT_FALSE(builder_failed) << "Builder failed unexpectedly.";
         }
 
         // Constant true, default invalidation
         {
-            auto [circuit_checker_result, builder_failed, builder_err] =
-                test_constraints(PredicateTestCase::ConstantTrue, default_invalid_witness_target);
+            auto [circuit_checker_result, builder_failed, builder_err] = test_constraints(
+                constraint, witness_values, PredicateTestCase::ConstantTrue, default_invalid_witness_target);
             // As `assert_equal` doesn't make the CircuitChecker fail, we need to check that either the CircuitChecker
             // failed, or the builder error resulted from an assert_eq.
             bool circuit_check_failed = !circuit_checker_result;
@@ -277,18 +283,23 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      */
     static void test_witness_true(InvalidWitnessTarget default_invalid_witness_target)
     {
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         // Witness true, no invalidation
         {
-            auto [circuit_checker_result, builder_failed, _] =
-                test_constraints(PredicateTestCase::WitnessTrue, InvalidWitnessTarget::None);
+            auto [circuit_checker_result, builder_failed, _] = test_constraints(
+                constraint, witness_values, PredicateTestCase::WitnessTrue, InvalidWitnessTarget::None);
             EXPECT_TRUE(circuit_checker_result) << "Circuit checker failed.";
             EXPECT_FALSE(builder_failed) << "Builder failed unexpectedly.";
         }
 
         // Witness true, default invalidation
         {
-            auto [circuit_checker_result, builder_failed, builder_err] =
-                test_constraints(PredicateTestCase::WitnessTrue, default_invalid_witness_target);
+            auto [circuit_checker_result, builder_failed, builder_err] = test_constraints(
+                constraint, witness_values, PredicateTestCase::WitnessTrue, default_invalid_witness_target);
             // As `assert_equal` doesn't make the CircuitChecker fail, we need to check that either the CircuitChecker
             // failed, or the builder error resulted from an assert_eq.
             bool circuit_check_failed = !circuit_checker_result;
@@ -308,12 +319,17 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      */
     static void test_witness_false()
     {
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         for (auto [invalid_witness_target, target_label] :
              zip_view(InvalidWitness::get_all(), InvalidWitness::get_labels())) {
             vinfo("Testing invalid witness target: ", target_label);
 
             auto [circuit_checker_result, builder_failed, _] =
-                test_constraints(PredicateTestCase::WitnessFalse, invalid_witness_target);
+                test_constraints(constraint, witness_values, PredicateTestCase::WitnessFalse, invalid_witness_target);
 
             EXPECT_TRUE(circuit_checker_result) << "Check builder failed for invalid witness target " + target_label;
             EXPECT_FALSE(builder_failed) << "Builder failed for invalid witness target " + target_label;
@@ -335,12 +351,17 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
      */
     static void test_witness_false_slow()
     {
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         for (auto [invalid_witness_target, target_label] :
              zip_view(InvalidWitness::get_all(), InvalidWitness::get_labels())) {
             vinfo("Testing invalid witness target: ", target_label);
 
             auto [circuit_checker_result, builder_failed, _] =
-                test_constraints(PredicateTestCase::WitnessFalse, invalid_witness_target);
+                test_constraints(constraint, witness_values, PredicateTestCase::WitnessFalse, invalid_witness_target);
 
             EXPECT_TRUE(circuit_checker_result) << "Check builder failed for invalid witness target " + target_label;
             EXPECT_FALSE(builder_failed) << "Builder failed for invalid witness target " + target_label;
@@ -349,8 +370,8 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
             // Only validate witness true failure for actual invalidation targets (skip None)
             if (invalid_witness_target != InvalidWitnessTarget::None) {
                 // Check that the same configuration would have failed if the predicate was witness true
-                auto [circuit_checker_result, builder_failed, builder_err] =
-                    test_constraints(PredicateTestCase::WitnessTrue, invalid_witness_target);
+                auto [circuit_checker_result, builder_failed, builder_err] = test_constraints(
+                    constraint, witness_values, PredicateTestCase::WitnessTrue, invalid_witness_target);
 
                 // As `assert_equal` doesn't make the CircuitChecker fail, we need to check that either the
                 // CircuitChecker failed, or the builder error resulted from an assert_eq.
@@ -382,10 +403,17 @@ template <TestBaseWithPredicate Base> class TestClassWithPredicate {
     static std::vector<std::string> test_invalid_witnesses()
     {
         std::vector<std::string> error_msgs;
+
+        // Generate the constraint system
+        AcirConstraint constraint;
+        WitnessVector witness_values;
+        Base::generate_constraints(constraint, witness_values);
+
         for (auto [predicate_case, predicate_label] :
              zip_view(Predicate<InvalidWitnessTarget>::get_all(), Predicate<InvalidWitnessTarget>::get_labels())) {
             for (auto [target, label] : zip_view(InvalidWitness::get_all(), InvalidWitness::get_labels())) {
-                auto [circuit_checker_result, builder_failed, builder_err] = test_constraints(predicate_case, target);
+                auto [circuit_checker_result, builder_failed, builder_err] =
+                    test_constraints(constraint, witness_values, predicate_case, target);
                 error_msgs.emplace_back(builder_err);
 
                 if (predicate_case != PredicateTestCase::WitnessFalse) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -68,8 +68,8 @@ concept TestBaseWithPredicate = requires {
     { T::InvalidWitness::get_labels() } -> std::same_as<std::vector<std::string>>;
 
     // Required static constraint manipulation methods
-    requires requires(typename T::AcirConstraint& constraint,
-                      WitnessVector& witness_values,
+    requires requires(typename T::AcirConstraint constraint,
+                      WitnessVector witness_values,
                       const typename T::InvalidWitness::Target& invalid_witness_target) {
         /**
          * @brief Invalidate witness values based on the target
@@ -79,8 +79,12 @@ concept TestBaseWithPredicate = requires {
          * 2. Constraints succeed when predicate is false, regardless of witness validity
          *
          */
-        { T::invalidate_witness(constraint, witness_values, invalid_witness_target) } -> std::same_as<void>;
+        {
+            T::invalidate_witness(constraint, witness_values, invalid_witness_target)
+        } -> std::same_as<std::pair<typename T::AcirConstraint, WitnessVector>>;
+    };
 
+    requires requires(typename T::AcirConstraint& constraint, WitnessVector& witness_values) {
         /**
          * @brief Generate valid constraints with predicate set to a witness holding the value true.
          *
@@ -111,24 +115,29 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
      *
      * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static void update_witness_based_on_predicate(AcirConstraint& constraint,
-                                                  WitnessVector& witness_values,
-                                                  const Predicate<InvalidWitnessTarget>& mode)
+    static std::pair<AcirConstraint, WitnessVector> update_witness_based_on_predicate(
+        const AcirConstraint& constraint,
+        const WitnessVector& witness_values,
+        const Predicate<InvalidWitnessTarget>& mode)
     {
+        // Apply witness invalidation for all cases
+        auto [invalid_constraint, invalid_witness_values] =
+            Base::invalidate_witness(constraint, witness_values, mode.invalid_witness);
+
         switch (mode.test_case) {
         case PredicateTestCase::ConstantTrue:
-            constraint.predicate = WitnessOrConstant<bb::fr>::from_constant(bb::fr(1));
-            witness_values.pop_back();
+            invalid_constraint.predicate = WitnessOrConstant<bb::fr>::from_constant(bb::fr(1));
+            invalid_witness_values.pop_back();
             break;
         case PredicateTestCase::WitnessTrue:
             // Nothing to do - keep default witness predicate
             break;
         case PredicateTestCase::WitnessFalse:
-            witness_values[constraint.predicate.index] = bb::fr(0);
+            invalid_witness_values[invalid_constraint.predicate.index] = bb::fr(0);
             break;
         }
-        // Apply witness invalidation for all cases
-        Base::invalidate_witness(constraint, witness_values, mode.invalid_witness);
+
+        return { invalid_constraint, invalid_witness_values };
     }
 
     /**
@@ -146,20 +155,20 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
      *
      * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint constraint,
-                                                                WitnessVector witness_values,
+    static std::tuple<bool, bool, std::string> test_constraints(const AcirConstraint& constraint,
+                                                                const WitnessVector& witness_values,
                                                                 const PredicateTestCase& test_case,
                                                                 const InvalidWitnessTarget& invalid_witness_target)
     {
         Predicate<InvalidWitnessTarget> predicate = { .test_case = test_case,
                                                       .invalid_witness = invalid_witness_target };
-        update_witness_based_on_predicate(constraint, witness_values, predicate);
+        auto [updated_constraint, updated_witness_values] =
+            update_witness_based_on_predicate(constraint, witness_values, predicate);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
         AcirFormat constraint_system = constraint_to_acir_format(
-            constraint, /*max_witness_index=*/static_cast<uint32_t>(witness_values.size()) - 1);
-
-        AcirProgram program{ constraint_system, witness_values };
+            updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+        AcirProgram program{ constraint_system, updated_witness_values };
         auto builder = create_circuit<Builder>(program);
 
         return { CircuitChecker::check(builder), builder.failed(), builder.err() };
@@ -195,16 +204,16 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
             // Update the constraint system based on the predicate mode
             Predicate<InvalidWitnessTarget> predicate = { .test_case = predicate_case,
                                                           .invalid_witness = InvalidWitnessTarget::None };
-            update_witness_based_on_predicate(constraint, witness_values, predicate);
+            auto [updated_constraint, updated_witness_values] =
+                update_witness_based_on_predicate(constraint, witness_values, predicate);
 
             // Use the full ACIR flow
             AcirFormat constraint_system = constraint_to_acir_format(
-                constraint, /*max_witness_index=*/static_cast<uint32_t>(witness_values.size()) - 1);
-
+                updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
             // Construct the vks
             std::shared_ptr<VerificationKey> vk_from_witness;
             {
-                AcirProgram program{ constraint_system, witness_values };
+                AcirProgram program{ constraint_system, updated_witness_values };
                 auto builder = create_circuit<Builder>(program);
                 num_gates.emplace_back(builder.get_num_finalized_gates_inefficient());
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -78,6 +78,8 @@ concept TestBaseWithPredicate = requires {
          * 1. Constraints fail when predicate is true and witnesses are invalid
          * 2. Constraints succeed when predicate is false, regardless of witness validity
          *
+         * @note The constraint and witness values must be copied otherwise this would affect later calls to this
+         * function
          */
         {
             T::invalidate_witness(constraint, witness_values, invalid_witness_target)

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -155,8 +155,8 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
      *
      * @note The constraint and witness values must be copied otherwise this would affect later calls to this function
      */
-    static std::tuple<bool, bool, std::string> test_constraints(const AcirConstraint& constraint,
-                                                                const WitnessVector& witness_values,
+    static std::tuple<bool, bool, std::string> test_constraints(AcirConstraint& constraint,
+                                                                WitnessVector& witness_values,
                                                                 const PredicateTestCase& test_case,
                                                                 const InvalidWitnessTarget& invalid_witness_target)
     {


### PR DESCRIPTION
We refactor the test classes `TestClass` and `TestClassWithPredicate` so that they build constraints only once and modify them. This trades off the time to construct the constraint with the memory require to copy these constraints and modify them. At the moment, there is no speed up in the tests where we used them, but this change should help tests in which constraint construction is heavy (e.g. Honk recursion constraint, AVM recursion constraint, Hypernova recursion constraint, Chonk recursion constraint).

We also turn `TestClass` back to its original version with static methods