### PR TITLE
chore: run ensure-funded-environments sequentially

### DIFF
--- a/.github/workflows/ensure-funded-environments.yml
+++ b/.github/workflows/ensure-funded-environments.yml
@@ -24,50 +24,24 @@ concurrency:
   cancel-in-progress: false # Don't cancel funding operations
 
 jobs:
-  fund-staging-public:
+  fund:
+    continue-on-error: true
+    strategy:
+      # we can only run one funding operation at a time because all jobs fund from the same address
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        environment: 
+          - staging-public
+          - staging-ignition
+          - next-net
+          - testnet
+          - devnet
+          - devnet-next
     uses: ./.github/workflows/ensure-funded-environment.yml
     with:
-      environment: staging-public
+      environment: ${{ matrix.environment }}
       low_watermark: ${{ inputs.low_watermark || '5.0' }}
       high_watermark: ${{ inputs.high_watermark || '10.0' }}
     secrets: inherit
 
-  fund-next-net:
-    uses: ./.github/workflows/ensure-funded-environment.yml
-    with:
-      environment: next-net
-      low_watermark: ${{ inputs.low_watermark || '5.0' }}
-      high_watermark: ${{ inputs.high_watermark || '10.0' }}
-    secrets: inherit
-
-  fund-staging-ignition:
-    uses: ./.github/workflows/ensure-funded-environment.yml
-    with:
-      environment: staging-ignition
-      low_watermark: ${{ inputs.low_watermark || '5.0' }}
-      high_watermark: ${{ inputs.high_watermark || '10.0' }}
-    secrets: inherit
-
-  fund-testnet:
-    uses: ./.github/workflows/ensure-funded-environment.yml
-    with:
-      environment: testnet
-      low_watermark: ${{ inputs.low_watermark || '5.0' }}
-      high_watermark: ${{ inputs.high_watermark || '10.0' }}
-    secrets: inherit
-
-  fund-devnet:
-    uses: ./.github/workflows/ensure-funded-environment.yml
-    with:
-      environment: devnet
-      low_watermark: ${{ inputs.low_watermark || '5.0' }}
-      high_watermark: ${{ inputs.high_watermark || '10.0' }}
-    secrets: inherit
-
-  fund-devnet-next:
-    uses: ./.github/workflows/ensure-funded-environment.yml
-    with:
-      environment: devnet-next
-      low_watermark: ${{ inputs.low_watermark || '5.0' }}
-      high_watermark: ${{ inputs.high_watermark || '10.0' }}
-    secrets: inherit


### PR DESCRIPTION
This PR refactors `ensure-funded-environments` such that it funds each network sequentially rather than in parallel. This fixes the issue where multiple environments need to be funded at the same time which could cause nonce issues.