### PR TITLE
fix(avm): alu gadget fuzzer serialisation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/alu.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/alu.fuzzer.cpp
@@ -44,8 +44,9 @@ struct AluFuzzerInput {
     MemoryValue a;
     MemoryValue b;
     MemoryValue c = MemoryValue::from_tag(MemoryTag::FF, 0); // Placeholder for result
-    int op_id = 0;                                           // For execution trace alu_op_id
-
+    uint16_t op_id = 0;                                      // For execution trace alu_op_id
+    // We serialise MemoryValues as FF + 1 byte for tag to save 31 bytes per value:
+    static const size_t size = (3 * (sizeof(FF) + 1)) + sizeof(uint16_t);
     // Serialize to buffer
     void to_buffer(uint8_t* buffer) const
     {
@@ -60,7 +61,7 @@ struct AluFuzzerInput {
         buffer += sizeof(FF) + 1;
         write_mem_value(buffer, c);
         buffer += sizeof(FF) + 1;
-        serialize::write(buffer, static_cast<uint16_t>(op_id));
+        serialize::write(buffer, op_id);
     }
 
     static AluFuzzerInput from_buffer(const uint8_t* buffer)
@@ -90,11 +91,11 @@ struct AluFuzzerInput {
 
 extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max_size, unsigned int seed)
 {
-    if (size < sizeof(AluFuzzerInput)) {
+    if (size < AluFuzzerInput::size) {
         // Initialize with default input
         AluFuzzerInput input;
         input.to_buffer(data);
-        return sizeof(AluFuzzerInput);
+        return AluFuzzerInput::size;
     }
 
     std::mt19937_64 rng(seed);
@@ -121,7 +122,6 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
 
     auto random_mem_value_from_tag = [&rng](MemoryTag tag) -> MemoryValue {
         std::uniform_int_distribution<uint64_t> dist(0, std::numeric_limits<uint64_t>::max());
-        // TODO(MW): Use array?
         FF value = FF(dist(rng), dist(rng), dist(rng), dist(rng));
         // Do we want the option of making "invalid tag" values, where the value is out of range for the tag?
         // These aren't currently possible with this function since MemoryValue::from_tag will throw in that case.
@@ -137,9 +137,9 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
     // Deserialize current input
     AluFuzzerInput input = AluFuzzerInput::from_buffer(data);
 
-    // Choose random ALU operation
+    // Choose random ALU operation (11 possible operations with op_id = 2^index)
     std::uniform_int_distribution<int> dist(0, 11);
-    input.op_id = 1 << dist(rng);
+    input.op_id = static_cast<uint16_t>(1 << dist(rng));
 
     // Choose test case (TODO(MW): what else do we want here?)
     dist = std::uniform_int_distribution<int>(0, 4);
@@ -189,18 +189,18 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size, size_t max
     // Serialize mutated input back to buffer
     input.to_buffer(data);
 
-    if (max_size > sizeof(AluFuzzerInput)) {
-        return sizeof(AluFuzzerInput);
+    if (max_size > AluFuzzerInput::size) {
+        return AluFuzzerInput::size;
     }
 
-    return sizeof(AluFuzzerInput);
+    return AluFuzzerInput::size;
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     using bb::avm2::MemoryValue;
 
-    if (size < sizeof(AluFuzzerInput)) {
+    if (size < AluFuzzerInput::size) {
         info("Input size too small");
         return 0;
     }


### PR DESCRIPTION
An attempt to resolve [AVM-148](https://linear.app/aztec-labs/issue/AVM-148/alu-fuzzer-frombuffer-tag-error)

Unfortunately, the full crash logs have expired but it's likely the failure came from a use of `MemoryValue::from_tag_truncating` inside `AluFuzzerInput from_buffer`. I couldn't repro the issue in running the fuzzer for a few hours, but did notice that the gadget incorrectly uses `sizeof(AluFuzzerInput)`.

This PR ensures that the custom mutator refers to the size of the serialised buffer from `to_buffer` (101) rather than `sizeof(AluFuzzerInput)` (224) - I write just the `FF` value and `tag` rather than using the default serialisation for `MemoryValues` to save a bit of buffer space. This may have caused the issue, but I'm not sure!
