### PR TITLE
feat(bb): Add FfiBackend for direct C FFI calls to Barretenberg

### DIFF
--- a/barretenberg/rust/README.md
+++ b/barretenberg/rust/README.md
@@ -4,6 +4,10 @@ Rust bindings for the Barretenberg cryptographic library using msgpack protocol.
 
 ## Quick Start
 
+### Using PipeBackend (default)
+
+Communicates with BB via stdin/stdout - no linking required:
+
 ```rust
 use barretenberg_rs::{BarretenbergApi, backends::PipeBackend};
 
@@ -19,18 +23,62 @@ println!("Hash: {:?}", response.hash);
 api.destroy()?;
 ```
 
+### Using FfiBackend (for mobile/embedded)
+
+Calls Barretenberg directly via FFI - maximum performance, requires linking:
+
+```rust
+use barretenberg_rs::{BarretenbergApi, backends::FfiBackend};
+
+// Create FFI backend (requires libbarretenberg linked)
+let backend = FfiBackend::new()?;
+let mut api = BarretenbergApi::new(backend);
+
+// Same API as PipeBackend
+let response = api.blake2s(b"hello world")?;
+println!("Hash: {:?}", response.hash);
+```
+
+To use FFI backend:
+1. Build `libbarretenberg.a` for your target platform
+2. Enable the `ffi` feature: `cargo build --features ffi`
+3. Set `BARRETENBERG_LIB_DIR` to the directory containing `libbarretenberg.a`
+
 ## Architecture
 
 The crate provides a pluggable backend system:
 
-- **PipeBackend**: Production backend communicating via stdin/stdout with the BB binary
-- **Custom Backend**: Implement the `Backend` trait for WASM, FFI, or other IPC
+- **PipeBackend**: Spawns BB process, communicates via stdin/stdout pipes
+- **FfiBackend**: Direct C FFI calls to libbarretenberg (no process overhead)
+- **Custom Backend**: Implement the `Backend` trait for WASM, JSI, or other IPC
+
+```
+┌─────────────────────────────────────────┐
+│          BarretenbergApi                │
+│  (generated, type-safe Rust API)        │
+└─────────────────────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────┐
+│           Backend trait                 │
+│  fn call(&mut self, &[u8]) -> Vec<u8>   │
+└─────────────────────────────────────────┘
+         │                    │
+         ▼                    ▼
+┌─────────────────┐  ┌─────────────────┐
+│   PipeBackend   │  │   FfiBackend    │
+│  (bb process)   │  │ (libbarretenberg)│
+└─────────────────┘  └─────────────────┘
+```
 
 ## Testing
 
 ```bash
-# Run tests (requires BB binary)
+# Run tests with PipeBackend (requires BB binary)
 cargo test --release
+
+# Run tests with FfiBackend (requires libbarretenberg)
+BARRETENBERG_LIB_DIR=/path/to/lib cargo test --release --features ffi
 ```
 
 ## Generated Code
@@ -44,4 +92,5 @@ cd ../ts && yarn generate
 ## Features
 
 - `native` (default): Enables `PipeBackend` and async runtime
+- `ffi`: Enables `FfiBackend` for direct C FFI calls
 - `async`: Enables async/await support

--- a/barretenberg/rust/README.md
+++ b/barretenberg/rust/README.md
@@ -42,7 +42,7 @@ println!("Hash: {:?}", response.hash);
 To use FFI backend:
 1. Build `libbarretenberg.a` for your target platform
 2. Enable the `ffi` feature: `cargo build --features ffi`
-3. Set `BARRETENBERG_LIB_DIR` to the directory containing `libbarretenberg.a`
+3. Configure the library path via `.cargo/config.toml` or `RUSTFLAGS="-L /path/to/lib"`
 
 ## Architecture
 
@@ -78,7 +78,7 @@ The crate provides a pluggable backend system:
 cargo test --release
 
 # Run tests with FfiBackend (requires libbarretenberg)
-BARRETENBERG_LIB_DIR=/path/to/lib cargo test --release --features ffi
+RUSTFLAGS="-L /path/to/lib" cargo test --release --features ffi
 ```
 
 ## Generated Code

--- a/barretenberg/rust/README.md
+++ b/barretenberg/rust/README.md
@@ -25,12 +25,12 @@ api.destroy()?;
 
 ### Using FfiBackend (for mobile/embedded)
 
-Calls Barretenberg directly via FFI - maximum performance, requires linking:
+Calls Barretenberg directly via FFI - maximum performance, enabled by default:
 
 ```rust
 use barretenberg_rs::{BarretenbergApi, backends::FfiBackend};
 
-// Create FFI backend (requires libbarretenberg linked)
+// Create FFI backend (links to libbarretenberg automatically)
 let backend = FfiBackend::new()?;
 let mut api = BarretenbergApi::new(backend);
 
@@ -39,10 +39,8 @@ let response = api.blake2s(b"hello world")?;
 println!("Hash: {:?}", response.hash);
 ```
 
-To use FFI backend:
-1. Build `libbarretenberg.a` for your target platform
-2. Enable the `ffi` feature: `cargo build --features ffi`
-3. Configure the library path via `.cargo/config.toml` or `RUSTFLAGS="-L /path/to/lib"`
+The FFI backend requires `libbarretenberg.a` from the cpp build (run `barretenberg/cpp/bootstrap.sh` first).
+The library path is automatically configured via `build.rs`.
 
 ## Architecture
 
@@ -74,11 +72,11 @@ The crate provides a pluggable backend system:
 ## Testing
 
 ```bash
-# Run tests with PipeBackend (requires BB binary)
+# Run all tests (FFI enabled by default, requires cpp build)
 cargo test --release
 
-# Run tests with FfiBackend (requires libbarretenberg)
-RUSTFLAGS="-L /path/to/lib" cargo test --release --features ffi
+# Run tests without FFI (pipe backend only)
+cargo test --release --no-default-features --features native
 ```
 
 ## Generated Code
@@ -92,5 +90,5 @@ cd ../ts && yarn generate
 ## Features
 
 - `native` (default): Enables `PipeBackend` and async runtime
-- `ffi`: Enables `FfiBackend` for direct C FFI calls
+- `ffi` (default): Enables `FfiBackend` for direct C FFI calls, auto-links to cpp/build/lib
 - `async`: Enables async/await support

--- a/barretenberg/rust/barretenberg-rs/Cargo.toml
+++ b/barretenberg/rust/barretenberg-rs/Cargo.toml
@@ -24,9 +24,8 @@ tracing = { workspace = true, optional = true }
 hex.workspace = true
 
 [features]
-default = ["native"]
+default = ["native", "ffi"]
 native = ["tokio", "nix", "tracing"]
 async = ["tokio"]
-# FFI backend - requires linking against libbarretenberg.
-# Configure via .cargo/config.toml or RUSTFLAGS="-L /path/to/lib"
+# FFI backend - links against libbarretenberg from cpp build
 ffi = []

--- a/barretenberg/rust/barretenberg-rs/Cargo.toml
+++ b/barretenberg/rust/barretenberg-rs/Cargo.toml
@@ -27,6 +27,6 @@ hex.workspace = true
 default = ["native"]
 native = ["tokio", "nix", "tracing"]
 async = ["tokio"]
-# FFI backend - requires linking against libbarretenberg
-# Set BARRETENBERG_LIB_DIR to the directory containing libbarretenberg.a
+# FFI backend - requires linking against libbarretenberg.
+# Configure via .cargo/config.toml or RUSTFLAGS="-L /path/to/lib"
 ffi = []

--- a/barretenberg/rust/barretenberg-rs/Cargo.toml
+++ b/barretenberg/rust/barretenberg-rs/Cargo.toml
@@ -27,3 +27,6 @@ hex.workspace = true
 default = ["native"]
 native = ["tokio", "nix", "tracing"]
 async = ["tokio"]
+# FFI backend - requires linking against libbarretenberg
+# Set BARRETENBERG_LIB_DIR to the directory containing libbarretenberg.a
+ffi = []

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // Only for ffi feature - specify link order for libbarretenberg
+    #[cfg(feature = "ffi")]
+    {
+        // Link order matters for static libraries!
+        // libbarretenberg depends on libenv for logstr/throw_or_abort_impl
+        println!("cargo:rustc-link-lib=static=barretenberg");
+        println!("cargo:rustc-link-lib=static=env");
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
+}

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -1,7 +1,16 @@
 fn main() {
-    // Only for ffi feature - specify link order for libbarretenberg
+    // Only for ffi feature - link libbarretenberg from cpp build
     #[cfg(feature = "ffi")]
     {
+        // Find the cpp build lib directory relative to this crate
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let lib_dir = std::path::Path::new(&manifest_dir)
+            .join("../../cpp/build/lib")
+            .canonicalize()
+            .expect("Failed to find cpp/build/lib - run barretenberg/cpp/bootstrap.sh first");
+
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+
         // Link order matters for static libraries!
         // libbarretenberg depends on libenv for logstr/throw_or_abort_impl
         println!("cargo:rustc-link-lib=static=barretenberg");

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -11,10 +11,16 @@ fn main() {
 
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
-        // Link order matters for static libraries!
-        // libbarretenberg depends on libenv for logstr/throw_or_abort_impl
+        // Use link group to handle circular dependencies between static libraries
+        // libbarretenberg depends on libvm2 for AVM constraints
+        // libvm2 depends on libcommon for utilities
+        // libenv provides logstr/throw_or_abort_impl
+        println!("cargo:rustc-link-arg=-Wl,--start-group");
         println!("cargo:rustc-link-lib=static=barretenberg");
+        println!("cargo:rustc-link-lib=static=vm2");
+        println!("cargo:rustc-link-lib=static=common");
         println!("cargo:rustc-link-lib=static=env");
+        println!("cargo:rustc-link-arg=-Wl,--end-group");
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 }

--- a/barretenberg/rust/barretenberg-rs/src/backend.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backend.rs
@@ -10,12 +10,6 @@ use crate::error::Result;
 /// Implement this trait to create a custom backend for Barretenberg.
 /// The backend handles msgpack-encoded command/response communication.
 ///
-/// # Implementation Requirements
-///
-/// Implementors **must** also implement [`Drop`] to ensure cleanup happens
-/// even if [`Backend::destroy`] is not called explicitly. The `destroy` method
-/// exists to allow error reporting during cleanup, which `Drop` cannot provide.
-///
 /// # Example
 ///
 /// ```ignore
@@ -32,13 +26,6 @@ use crate::error::Result;
 ///     fn destroy(&mut self) -> Result<()> {
 ///         // Clean up resources
 ///         Ok(())
-///     }
-/// }
-///
-/// impl Drop for MyCustomBackend {
-///     fn drop(&mut self) {
-///         // Best-effort cleanup (errors cannot be reported)
-///         let _ = self.destroy();
 ///     }
 /// }
 /// ```

--- a/barretenberg/rust/barretenberg-rs/src/backend.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backend.rs
@@ -10,6 +10,12 @@ use crate::error::Result;
 /// Implement this trait to create a custom backend for Barretenberg.
 /// The backend handles msgpack-encoded command/response communication.
 ///
+/// # Implementation Requirements
+///
+/// Implementors **must** also implement [`Drop`] to ensure cleanup happens
+/// even if [`Backend::destroy`] is not called explicitly. The `destroy` method
+/// exists to allow error reporting during cleanup, which `Drop` cannot provide.
+///
 /// # Example
 ///
 /// ```ignore
@@ -26,6 +32,13 @@ use crate::error::Result;
 ///     fn destroy(&mut self) -> Result<()> {
 ///         // Clean up resources
 ///         Ok(())
+///     }
+/// }
+///
+/// impl Drop for MyCustomBackend {
+///     fn drop(&mut self) {
+///         // Best-effort cleanup (errors cannot be reported)
+///         let _ = self.destroy();
 ///     }
 /// }
 /// ```

--- a/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
@@ -140,15 +140,24 @@ impl Default for FfiBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // Note: These tests require libbarretenberg to be linked.
-    // They are ignored by default and can be run with:
-    // cargo test --features ffi -- --ignored
+    use crate::api::BarretenbergApi;
 
     #[test]
-    #[ignore]
     fn test_ffi_backend_creation() {
         let backend = FfiBackend::new();
         assert!(backend.is_ok());
+    }
+
+    #[test]
+    fn test_ffi_blake2s() {
+        let backend = FfiBackend::new().unwrap();
+        let mut api = BarretenbergApi::new(backend);
+
+        let response = api.blake2s(b"hello world").unwrap();
+        assert_eq!(response.hash.len(), 32);
+
+        // Verify deterministic output
+        let response2 = api.blake2s(b"hello world").unwrap();
+        assert_eq!(response.hash, response2.hash);
     }
 }

--- a/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
@@ -1,0 +1,152 @@
+//! FFI backend for Barretenberg
+//!
+//! This backend calls the Barretenberg C API directly via FFI,
+//! eliminating process spawn overhead. Ideal for mobile and embedded use cases.
+//!
+//! # Requirements
+//!
+//! This backend requires linking against `libbarretenberg`. You must:
+//! 1. Build Barretenberg as a static library (`libbarretenberg.a`)
+//! 2. Set the library search path via `BARRETENBERG_LIB_DIR` or cargo config
+//!
+//! # Example
+//!
+//! ```ignore
+//! use barretenberg_rs::{BarretenbergApi, backends::FfiBackend};
+//!
+//! let backend = FfiBackend::new()?;
+//! let mut api = BarretenbergApi::new(backend);
+//!
+//! let response = api.blake2s(b"hello world")?;
+//! println!("Hash: {:?}", response.hash);
+//! ```
+
+use crate::backend::Backend;
+use crate::error::{BarretenbergError, Result};
+use std::ptr;
+
+// C API exported by Barretenberg
+// See: barretenberg/cpp/src/barretenberg/bbapi/c_bind.hpp
+#[link(name = "barretenberg")]
+extern "C" {
+    /// Execute a msgpack-encoded command and return msgpack-encoded response.
+    ///
+    /// # Safety
+    /// - `input_in` must point to valid memory of `input_len_in` bytes
+    /// - `output_out` and `output_len_out` must be valid pointers
+    /// - Caller must free `*output_out` using `libc::free`
+    fn bbapi(
+        input_in: *const u8,
+        input_len_in: usize,
+        output_out: *mut *mut u8,
+        output_len_out: *mut usize,
+    );
+}
+
+/// FFI backend that calls Barretenberg directly via C API.
+///
+/// This is the most performant backend option as it avoids process spawning
+/// and IPC overhead. However, it requires linking against `libbarretenberg`.
+///
+/// # Thread Safety
+///
+/// This backend is **not** thread-safe. Each thread should have its own
+/// `FfiBackend` instance, or access should be synchronized externally.
+pub struct FfiBackend {
+    _initialized: bool,
+}
+
+impl FfiBackend {
+    /// Create a new FFI backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Barretenberg initialization fails.
+    pub fn new() -> Result<Self> {
+        // Future: Could add SRS initialization here if needed
+        // For now, Barretenberg initializes lazily on first use
+        Ok(Self { _initialized: true })
+    }
+}
+
+impl Backend for FfiBackend {
+    fn call(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+        let mut output_ptr: *mut u8 = ptr::null_mut();
+        let mut output_len: usize = 0;
+
+        // SAFETY:
+        // - input.as_ptr() is valid for input.len() bytes
+        // - output_ptr and output_len are valid stack pointers
+        // - bbapi allocates output using malloc, which we free below
+        unsafe {
+            bbapi(
+                input.as_ptr(),
+                input.len(),
+                &mut output_ptr,
+                &mut output_len,
+            );
+        }
+
+        if output_ptr.is_null() {
+            return Err(BarretenbergError::Backend(
+                "bbapi returned null pointer".to_string(),
+            ));
+        }
+
+        if output_len == 0 {
+            // Free the pointer even if length is 0
+            unsafe {
+                libc::free(output_ptr as *mut libc::c_void);
+            }
+            return Err(BarretenbergError::Backend(
+                "bbapi returned empty response".to_string(),
+            ));
+        }
+
+        // SAFETY: output_ptr is valid for output_len bytes, allocated by malloc
+        let output = unsafe { std::slice::from_raw_parts(output_ptr, output_len).to_vec() };
+
+        // Free the C-allocated memory
+        // SAFETY: output_ptr was allocated by bbapi using malloc
+        unsafe {
+            libc::free(output_ptr as *mut libc::c_void);
+        }
+
+        Ok(output)
+    }
+
+    fn destroy(&mut self) -> Result<()> {
+        // No cleanup needed - Barretenberg manages its own state
+        // Future: Could send Shutdown command here if needed
+        self._initialized = false;
+        Ok(())
+    }
+}
+
+impl Drop for FfiBackend {
+    fn drop(&mut self) {
+        let _ = self.destroy();
+    }
+}
+
+impl Default for FfiBackend {
+    fn default() -> Self {
+        Self::new().expect("Failed to initialize FfiBackend")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: These tests require libbarretenberg to be linked.
+    // They are ignored by default and can be run with:
+    // cargo test --features ffi -- --ignored
+
+    #[test]
+    #[ignore]
+    fn test_ffi_backend_creation() {
+        let backend = FfiBackend::new();
+        assert!(backend.is_ok());
+    }
+}

--- a/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
@@ -29,7 +29,7 @@ use std::ptr;
 
 // C API exported by Barretenberg
 // See: barretenberg/cpp/src/barretenberg/bbapi/c_bind.hpp
-#[link(name = "barretenberg")]
+// Link directives are in build.rs to control link order (barretenberg depends on env)
 extern "C" {
     /// Execute a msgpack-encoded command and return msgpack-encoded response.
     ///

--- a/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
+++ b/barretenberg/rust/barretenberg-rs/src/backends/ffi.rs
@@ -7,7 +7,9 @@
 //!
 //! This backend requires linking against `libbarretenberg`. You must:
 //! 1. Build Barretenberg as a static library (`libbarretenberg.a`)
-//! 2. Set the library search path via `BARRETENBERG_LIB_DIR` or cargo config
+//! 2. Configure the library search path, either via:
+//!    - `.cargo/config.toml`: `[build] rustflags = ["-L", "/path/to/lib"]`
+//!    - Environment: `RUSTFLAGS="-L /path/to/lib"`
 //!
 //! # Example
 //!

--- a/barretenberg/rust/barretenberg-rs/src/lib.rs
+++ b/barretenberg/rust/barretenberg-rs/src/lib.rs
@@ -62,8 +62,14 @@ pub use api::BarretenbergApi;
 pub use error::{BarretenbergError, Result};
 
 /// Backend implementations
-#[cfg(feature = "native")]
 pub mod backends {
+    #[cfg(feature = "native")]
     pub mod pipe;
+    #[cfg(feature = "native")]
     pub use pipe::PipeBackend;
+
+    #[cfg(feature = "ffi")]
+    pub mod ffi;
+    #[cfg(feature = "ffi")]
+    pub use ffi::FfiBackend;
 }

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -34,8 +34,8 @@ function test {
     source "$HOME/.cargo/env"
   fi
 
-  # Run all tests including FFI (requires libbarretenberg from cpp build)
-  RUSTFLAGS="-L ../cpp/build/lib" cargo test --release --features ffi
+  # Run all tests (FFI is enabled by default, links to cpp/build/lib automatically)
+  cargo test --release
 }
 
 case "$cmd" in

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -34,8 +34,8 @@ function test {
     source "$HOME/.cargo/env"
   fi
 
-  # Run all tests
-  cargo test --release
+  # Run all tests including FFI (requires libbarretenberg from cpp build)
+  RUSTFLAGS="-L ../cpp/build/lib" cargo test --release --features ffi
 }
 
 case "$cmd" in

--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -eu
 
-cd "$(dirname "$0")/.."
+# Get absolute paths before changing directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUST_DIR="$SCRIPT_DIR/.."
+LIB_DIR="$SCRIPT_DIR/../../cpp/build/lib"
+
+cd "$RUST_DIR"
 
 # Ensure Cargo is in PATH
 if [ -f "$HOME/.cargo/env" ]; then
@@ -13,7 +18,6 @@ echo "Running PipeBackend tests..."
 cargo test --release
 
 # Run FFI tests - requires libbarretenberg from cpp build
-LIB_DIR="$(dirname "$0")/../../cpp/build/lib"
 if [ ! -f "$LIB_DIR/libbarretenberg.a" ] || [ ! -f "$LIB_DIR/libenv.a" ]; then
   echo "ERROR: libbarretenberg.a or libenv.a not found at $LIB_DIR"
   echo "Run barretenberg/cpp/bootstrap.sh first"

--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -1,28 +1,15 @@
 #!/usr/bin/env bash
 set -eu
 
-# Get absolute paths before changing directory
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-RUST_DIR="$SCRIPT_DIR/.."
-LIB_DIR="$SCRIPT_DIR/../../cpp/build/lib"
-
-cd "$RUST_DIR"
+cd "$(dirname "$0")/.."
 
 # Ensure Cargo is in PATH
 if [ -f "$HOME/.cargo/env" ]; then
   source "$HOME/.cargo/env"
 fi
 
-# Run PipeBackend tests (default)
-echo "Running PipeBackend tests..."
-cargo test --release
+LIB_DIR="../cpp/build/lib"
 
-# Run FFI tests - requires libbarretenberg from cpp build
-if [ ! -f "$LIB_DIR/libbarretenberg.a" ] || [ ! -f "$LIB_DIR/libenv.a" ]; then
-  echo "ERROR: libbarretenberg.a or libenv.a not found at $LIB_DIR"
-  echo "Run barretenberg/cpp/bootstrap.sh first"
-  exit 1
-fi
-
-echo "Running FfiBackend tests..."
-RUSTFLAGS="-L $LIB_DIR" cargo test --release --features ffi --lib
+# Run all tests including FFI (requires libbarretenberg from cpp build)
+echo "Running all tests with FFI..."
+RUSTFLAGS="-L $LIB_DIR" cargo test --release --features ffi

--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -8,5 +8,17 @@ if [ -f "$HOME/.cargo/env" ]; then
   source "$HOME/.cargo/env"
 fi
 
-# Run all Rust tests
+# Run PipeBackend tests (default)
+echo "Running PipeBackend tests..."
 cargo test --release
+
+# Run FFI tests - requires libbarretenberg from cpp build
+LIB_DIR="$(dirname "$0")/../../cpp/build/lib"
+if [ ! -f "$LIB_DIR/libbarretenberg.a" ] || [ ! -f "$LIB_DIR/libenv.a" ]; then
+  echo "ERROR: libbarretenberg.a or libenv.a not found at $LIB_DIR"
+  echo "Run barretenberg/cpp/bootstrap.sh first"
+  exit 1
+fi
+
+echo "Running FfiBackend tests..."
+RUSTFLAGS="-L $LIB_DIR" cargo test --release --features ffi --lib

--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -8,8 +8,5 @@ if [ -f "$HOME/.cargo/env" ]; then
   source "$HOME/.cargo/env"
 fi
 
-LIB_DIR="../cpp/build/lib"
-
-# Run all tests including FFI (requires libbarretenberg from cpp build)
-echo "Running all tests with FFI..."
-RUSTFLAGS="-L $LIB_DIR" cargo test --release --features ffi
+# Run all tests (FFI is enabled by default, links to cpp/build/lib automatically)
+cargo test --release


### PR DESCRIPTION
## Summary

Adds an `FfiBackend` implementation that calls the Barretenberg C API directly via FFI, eliminating process spawn overhead. This is ideal for mobile and embedded use cases where performance is critical.

This builds on #17831 which added the Rust bindings infrastructure with `PipeBackend`.

## Key Changes

- New `FfiBackend` in `backends/ffi.rs` - enabled by default
- `build.rs` auto-links to `cpp/build/lib` with proper link order
- Links `libbarretenberg`, `libvm2`, `libcommon`, `libenv` using linker groups
- FFI tests included that actually call `blake2s` through the C API

## Architecture

```
┌─────────────────────────────────────────┐
│          BarretenbergApi                │
│  (generated, type-safe Rust API)        │
└─────────────────────────────────────────┘
                    │
                    ▼
┌─────────────────────────────────────────┐
│           Backend trait                 │
│  fn call(&mut self, &[u8]) -> Vec<u8>   │
└─────────────────────────────────────────┘
         │                    │
         ▼                    ▼
┌─────────────────┐  ┌─────────────────┐
│   PipeBackend   │  │   FfiBackend    │
│  (bb process)   │  │ (libbarretenberg)│
└─────────────────┘  └─────────────────┘
```

## Usage

```rust
use barretenberg_rs::{BarretenbergApi, backends::FfiBackend};

let backend = FfiBackend::new()?;
let mut api = BarretenbergApi::new(backend);

let response = api.blake2s(b"hello world")?;
```

## Motivation

This enables mobile projects to use the official Rust bindings without maintaining a fork. They still need to:
1. Build `libbarretenberg.a` for their target platform (e.g., iOS ARM64)
2. Create any platform-specific bridge layer (e.g., JSI for React Native)

But they no longer need to maintain manually-defined Rust types for the BB API.

## Test Plan

- [x] Existing `PipeBackend` tests still pass
- [x] `FfiBackend` links and tests pass with `cargo test --release`
- [x] FFI test (`test_ffi_blake2s`) exercises actual C API calls