### PR TITLE
feat: add noir tests for events

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -12,7 +12,6 @@ use protocol_types::traits::{Serialize, ToField};
 pub struct NewEvent<Event> {
     pub(crate) event: Event,
     pub(crate) randomness: Field,
-    pub(crate) commitment: Field,
 }
 
 /// Equivalent to `self.emit(event)`: see [crate::contract_self::ContractSelf::emit].
@@ -38,7 +37,7 @@ where
     let commitment = compute_private_event_commitment(event, randomness);
     context.push_nullifier(commitment);
 
-    EventMessage::new(NewEvent { event, randomness, commitment }, context)
+    EventMessage::new(NewEvent { event, randomness }, context)
 }
 
 /// Equivalent to `self.emit(event)`: see [crate::contract_self::ContractSelf::emit].

--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -17,7 +17,7 @@ use protocol_types::{address::AztecAddress, traits::Serialize};
 /// Use [EventMessage::deliver_to] to select a delivery mechanism.
 #[must_use = "Unused EventMessage result - use the `deliver_to` function to prevent the event information from being lost forever"]
 pub struct EventMessage<Event> {
-    new_event: NewEvent<Event>,
+    pub(crate) new_event: NewEvent<Event>,
 
     // EventMessage is constructed when an event is emitted, which means that the `context` object will be in scope. By
     // storing a reference to it inside this object we remove the need for its methods to receive it, resulting in a

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,7 +1,7 @@
 use protocol_types::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
-    traits::{Deserialize, Packable},
+    traits::{Deserialize, Packable, Serialize},
 };
 
 use crate::{
@@ -9,13 +9,15 @@ use crate::{
         PrivateCall, PrivateContext, PrivateStaticCall, PublicCall, PublicContext, PublicStaticCall,
         UtilityCall, UtilityContext,
     },
+    event::{event_interface::EventInterface, event_message::EventMessage},
     hash::hash_args,
     messages::{
         discovery::{
             ComputeNoteHashAndNullifier, NoteHashAndNullifier,
             process_message::process_message_plaintext,
         },
-        logs::note::private_note_to_message_plaintext,
+        encoding::MESSAGE_PLAINTEXT_LEN,
+        logs::{event::private_event_to_message_plaintext, note::private_note_to_message_plaintext},
         processing::{message_context::MessageContext, validate_enqueued_notes_and_events},
     },
     note::{
@@ -128,6 +130,10 @@ struct NoteDiscoveryOptions {
     contract_address: Option<AztecAddress>,
 }
 
+struct EventDiscoveryOptions {
+    contract_address: Option<AztecAddress>,
+}
+
 impl TestEnvironment {
     /// Creates a new `TestEnvironment`. This function should only be called once per test.
     pub unconstrained fn new() -> Self {
@@ -137,6 +143,12 @@ impl TestEnvironment {
             contract_account_secret: Counter::new(),
             contract_deployment_secret: Counter::new(),
         }
+    }
+
+    /// Returns the default address used by [TestEnvironment::private_context] and other functions that do not take a
+    /// contract address.
+    pub(crate) unconstrained fn get_default_address() -> AztecAddress {
+        txe_oracles::get_default_address()
     }
 
     /// Creates a `PublicContext`, which allows using aztec-nr features as if inside a public contract function. Useful
@@ -667,13 +679,13 @@ impl TestEnvironment {
         T::deserialize(serialized_return_values)
     }
 
-    /// Discovers a note from a [NewNoteMessage], which is expected to have been created in the last transaction
-    /// (typically via `private_context()`) so that it can be retrieved in later transactions. This mimics the normal
-    /// note discovery process that takes place automatically in contracts.
+    /// Discovers a note from a [NoteMessage], which is expected to have been created in the last transaction
+    /// (typically via [TestEnvironment::private_context]) so that it can be retrieved in later transactions. This
+    /// mimics the normal message processing that takes place automatically in contracts.
     ///
-    /// [NewNoteMessage] values are typically returned by aztec-nr state variables that create notes and need to notify
+    /// [NoteMessage] values are typically returned by aztec-nr state variables that create notes and need to notify
     /// a recipient of their existence. Instead of going through the message encoding, encryption and delivery that
-    /// would regularly take place in a contract, this function simply takes the [NewNoteMessage] and processes it as
+    /// would regularly take place in a contract, this function simply takes the [NoteMessage] and processes it as
     /// needed to discover the underlying note.
     ///
     /// See [TestEnvironment::discover_note_at] for a variant that allows specifying the contract address the note
@@ -682,7 +694,7 @@ impl TestEnvironment {
     /// ### Sample usage
     ///
     /// The most common way to invoke this function is to obtain a note message created during the execution of a
-    /// `private_context`:
+    /// [TestEnvironment::private_context]:
     ///
     /// ```noir
     /// let note_message = env.private_context(|context| create_note(context, storage_slot, note));
@@ -701,8 +713,9 @@ impl TestEnvironment {
         );
     }
 
-    /// Variant of `discover_note` which allows specifying the contract address the note belongs to, which is required
-    /// when the note was not emitted in the default address used by `private_context`.
+    /// Variant of [TestEnvironment::discover_note] which allows specifying the contract address the note belongs to,
+    /// which is required when the note was not emitted in the default address used by
+    /// [TestEnvironment::private_context].
     ///
     /// ```noir
     /// let note_message = env.private_context_at(contract_address, |context| {
@@ -740,7 +753,7 @@ impl TestEnvironment {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message created from the received note message.
 
-        // First we produce the message itself. We skip encryption/decryption since we're not interested in that here.
+        // First we produce the message plaintext. We skip encryption/decryption since we're not interested in that here.
         // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
         // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
         // sized).
@@ -750,24 +763,6 @@ impl TestEnvironment {
             note_message.new_note.storage_slot,
             note_message.new_note.randomness,
         ));
-
-        // Then we fetch the transaction effects from the latest transaction, in which the note from the message is
-        // expected to have been created. In a real contract this data would have either been supplied by the
-        // `process_message` caller, of retrieved along with the message from a tagged log.
-        let (tx_hash, unique_note_hashes_in_tx, nullifiers_in_tx) =
-            txe_oracles::get_last_tx_effects();
-
-        // Real messages would also have a recipient, a concept which does not translate to anything in
-        // `TestEnvironment` since it works with a single PXE with global scopes. We therefore simply set the zero
-        // address as the recipient, which PXE accepts as a note scope despite this not being a registered account.
-        let recipient = AztecAddress::zero();
-
-        let message_context = MessageContext {
-            tx_hash,
-            unique_note_hashes_in_tx,
-            first_nullifier_in_tx: nullifiers_in_tx.get(0),
-            recipient,
-        };
 
         // We also need to provide an implementation for the `compute_note_hash_and_nullifier` function, which would
         // typically be created by the macros for the different notes in a given contract. Here we build one specialized
@@ -796,21 +791,163 @@ impl TestEnvironment {
             Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
         };
 
-        // Both private and utility functions perform message processing and note discovery. We do it in an utility
-        // context here as that one is more lightweight and does not create new blocks, which also allows for
-        // `discover_notes` to be called repeatedly with multiple messages from the same transaction.
-        self.utility_context_opts(
-            UtilityContextOptions { contract_address: opts.contract_address },
-            |context| {
-                process_message_plaintext(
-                    context.this_address(),
-                    compute_note_hash_and_nullifier,
-                    message_plaintext,
-                    message_context,
-                );
-
-                validate_enqueued_notes_and_events(context.this_address());
-            },
+        self.discover_data_in_message_plaintext(
+            message_plaintext,
+            opts.contract_address,
+            Option::none(),
+            compute_note_hash_and_nullifier,
         );
+    }
+
+    /// EXPERIMENTAL - not yet part of the public API
+    ///
+    /// Discovers an event from an [EventMessage], which is expected to have been created in the last transaction
+    /// (typically via [TestEnvironment::private_context]) so that it can be retrieved in queries. This mimics the
+    /// normal message processing that takes place automatically in contracts.
+    ///
+    /// [EventMessage] values are returned by aztec-nr private event emitting functions, like
+    /// [crate::contract_self::ContractSelf::emit], which need to notify a `recipient` of their existence. Instead of
+    /// going through the message encoding, encryption and delivery that would regularly take place in a contract, this
+    /// function simply takes the [EventMessage] and processes it as needed to discover the underlying event.
+    ///
+    /// As this mimics regular event processing, only `recipient` will have knowledge of the event: other accounts will
+    /// not be able to read it.
+    ///
+    /// See [TestEnvironment::discover_event_at] for a variant that allows specifying the contract address the event
+    /// belongs to.
+    ///
+    /// ### Sample usage
+    ///
+    /// The most common way to invoke this function is to obtain a note message created during the execution of a
+    /// [TestEnvironment::private_context]:
+    ///
+    /// ```noir
+    /// let event_message = env.private_context(|context| emit_event_in_private(context, event));
+    ///
+    /// env.discover_event(event_message, recipient);
+    /// ```
+    pub(crate) unconstrained fn discover_event<Event>(
+        self: Self,
+        event_message: EventMessage<Event>,
+        recipient: AztecAddress,
+    )
+    where
+        Event: Serialize + EventInterface,
+    {
+        self.discover_event_opts(
+            EventDiscoveryOptions { contract_address: Option::none() },
+            event_message,
+            recipient,
+        );
+    }
+
+    /// EXPERIMENTAL - not yet part of the public API
+    ///
+    /// Variant of [TestEnvironment::discover_event] which allows specifying the contract address the event belongs to,
+    /// which is required when the event was not emitted in the default address used by
+    /// [TestEnvironment::private_context].
+    ///
+    /// ```noir
+    /// let event_message = env.private_context_at(contract_address, |context| {
+    ///     emit_event_in_private(context, event)
+    /// });
+    ///
+    /// env.discover_event_at(contract_address, event_message);
+    /// ```
+    pub(crate) unconstrained fn discover_event_at<Event>(
+        self: Self,
+        addr: AztecAddress,
+        event_message: EventMessage<Event>,
+        recipient: AztecAddress,
+    )
+    where
+        Event: Serialize + EventInterface,
+    {
+        self.discover_event_opts(
+            EventDiscoveryOptions { contract_address: Option::some(addr) },
+            event_message,
+            recipient,
+        );
+    }
+
+    unconstrained fn discover_event_opts<Event>(
+        self: Self,
+        opts: EventDiscoveryOptions,
+        event_message: EventMessage<Event>,
+        recipient: AztecAddress,
+    )
+    where
+        Event: Serialize + EventInterface,
+    {
+        // This function will emulate the message discovery and processing that would happen in a real contract, based
+        // on a message created from the received event message.
+
+        // First we produce the message plaintext. We skip encryption/decryption since we're not interested in that here.
+        // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
+        // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
+        // sized).
+        let message_plaintext = BoundedVec::from_array(private_event_to_message_plaintext(
+            event_message.new_event.event,
+            event_message.new_event.randomness,
+        ));
+
+        // We also need to provide an implementation for the `compute_note_hash_and_nullifier` function, which would
+        // typically be created by the macros for the different notes in a given contract. Here we build an empty one,
+        // since it will never be invoked as this is an event and not a note message.
+        let compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<_> = |_packed_note, _owner, _storage_slot, _note_type_id, _contract_address, _randomness, _note_nonce| {
+            panic(
+                f"Unexpected compute_note_hash_and_nullifier invocation in TestEnvironment::discover_event",
+            )
+        };
+
+        self.discover_data_in_message_plaintext(
+            message_plaintext,
+            opts.contract_address,
+            Option::some(recipient),
+            compute_note_hash_and_nullifier,
+        );
+    }
+
+    unconstrained fn discover_data_in_message_plaintext<Env>(
+        self,
+        message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
+        contract_address: Option<AztecAddress>,
+        recipient: Option<AztecAddress>,
+        compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    ) {
+        // This function will emulate the message discovery and processing that would happen in a real contract, based
+        // on a message plaintext.
+
+        // First we fetch the transaction effects from the latest transaction, which are required to create the
+        // `MessageContext`, and might contain information about data (e.g. notes, events) contained in the message. In
+        // a real contract this data would have either been supplied by the `process_message` caller, of retrieved
+        // along with the message from a tagged log.
+        let (tx_hash, unique_note_hashes_in_tx, nullifiers_in_tx) =
+            txe_oracles::get_last_tx_effects();
+
+        // Real messages would also have a recipient, a concept which is currently half-supported in `TestEnvironment`
+        // as events are properly scoped by recipient, but notes use a global scope instead. We therefore simply set the
+        // zero address as the recipient if one is not supplied, which PXE accepts as a scope despite this not being a
+        // registered account.
+        let message_context = MessageContext {
+            tx_hash,
+            unique_note_hashes_in_tx,
+            first_nullifier_in_tx: nullifiers_in_tx.get(0),
+            recipient: recipient.unwrap_or(AztecAddress::zero()),
+        };
+
+        // Both private and utility functions perform message processing . We do it in an utility context here as that
+        // one is more lightweight and does not create new blocks, which also allows for `discover_note` and
+        // `discover_event` to be called repeatedly with multiple messages from the same transaction.
+        self.utility_context_opts(UtilityContextOptions { contract_address }, |context| {
+            process_message_plaintext(
+                context.this_address(),
+                compute_note_hash_and_nullifier,
+                message_plaintext,
+                message_context,
+            );
+
+            validate_enqueued_notes_and_events(context.this_address());
+        });
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -1,5 +1,6 @@
 mod accounts;
 mod deployment;
+mod events;
 mod private_context;
 mod public_context;
 mod utility_context;

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/events.nr
@@ -1,0 +1,123 @@
+use crate::event::{event_emission::emit_event_in_private, event_interface::EventInterface};
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_event::MockEvent};
+use protocol_types::traits::Serialize;
+
+global VALUE: Field = 7;
+
+#[test]
+unconstrained fn emit_and_discover_event() {
+    let mut env = TestEnvironment::new();
+
+    let recipient = env.create_light_account();
+
+    let event = MockEvent::new(VALUE).build_event();
+
+    let event_message = env.private_context(|context| emit_event_in_private(context, event));
+
+    env.discover_event(event_message, recipient);
+
+    let events = crate::test::helpers::txe_oracles::get_private_events(
+        MockEvent::get_event_type_id(),
+        TestEnvironment::get_default_address(),
+        recipient,
+    );
+
+    assert_eq(events.len(), 1);
+    assert_eq(events.get(0), BoundedVec::from_array(event.serialize()));
+}
+
+#[test]
+unconstrained fn emit_and_discover_multiple_events() {
+    let mut env = TestEnvironment::new();
+
+    let recipient = env.create_light_account();
+
+    let event = MockEvent::new(VALUE).build_event();
+    let other_event = MockEvent::new(VALUE + 1).build_event();
+
+    let event_messages = env.private_context(|context| {
+        (emit_event_in_private(context, event), emit_event_in_private(context, other_event))
+    });
+
+    env.discover_event(event_messages.0, recipient);
+    env.discover_event(event_messages.1, recipient);
+
+    let events = crate::test::helpers::txe_oracles::get_private_events(
+        MockEvent::get_event_type_id(),
+        TestEnvironment::get_default_address(),
+        recipient,
+    );
+
+    assert_eq(events.len(), 2);
+    assert(events.any(|ev| ev == BoundedVec::from_array(event.serialize())));
+    assert(events.any(|ev| ev == BoundedVec::from_array(other_event.serialize())));
+}
+
+#[test]
+unconstrained fn emit_and_discover_same_event_multiple_times() {
+    let mut env = TestEnvironment::new();
+
+    let recipient = env.create_light_account();
+
+    let event = MockEvent::new(VALUE).build_event();
+
+    let event_message = env.private_context(|context| emit_event_in_private(context, event));
+
+    env.discover_event(event_message, recipient);
+    env.discover_event(event_message, recipient);
+
+    let events = crate::test::helpers::txe_oracles::get_private_events(
+        MockEvent::get_event_type_id(),
+        TestEnvironment::get_default_address(),
+        recipient,
+    );
+
+    assert_eq(events.len(), 1);
+    assert_eq(events.get(0), BoundedVec::from_array(event.serialize()));
+}
+
+#[test]
+unconstrained fn emit_and_fail_to_discover_event_as_other_recipient() {
+    let mut env = TestEnvironment::new();
+
+    let recipient = env.create_light_account();
+    let other_recipient = env.create_light_account();
+
+    let event = MockEvent::new(VALUE).build_event();
+
+    let event_message = env.private_context(|context| emit_event_in_private(context, event));
+
+    env.discover_event(event_message, recipient);
+
+    let events = crate::test::helpers::txe_oracles::get_private_events(
+        MockEvent::get_event_type_id(),
+        TestEnvironment::get_default_address(),
+        other_recipient,
+    );
+
+    assert_eq(events.len(), 0);
+}
+
+#[test]
+unconstrained fn emit_and_discover_event_multiple_recipients() {
+    let mut env = TestEnvironment::new();
+
+    let recipient = env.create_light_account();
+    let other_recipient = env.create_light_account();
+
+    let event = MockEvent::new(VALUE).build_event();
+
+    let event_message = env.private_context(|context| emit_event_in_private(context, event));
+
+    env.discover_event(event_message, recipient);
+    env.discover_event(event_message, other_recipient);
+
+    let events = crate::test::helpers::txe_oracles::get_private_events(
+        MockEvent::get_event_type_id(),
+        TestEnvironment::get_default_address(),
+        recipient,
+    );
+
+    assert_eq(events.len(), 1);
+    assert_eq(events.get(0), BoundedVec::from_array(event.serialize()));
+}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -1,4 +1,7 @@
-use crate::{context::inputs::PrivateContextInputs, test::helpers::utils::TestAccount};
+use crate::{
+    context::inputs::PrivateContextInputs, event::event_selector::EventSelector,
+    test::helpers::utils::TestAccount,
+};
 
 use protocol_types::{
     abis::function_selector::FunctionSelector,
@@ -10,6 +13,9 @@ use protocol_types::{
     contract_instance::ContractInstance,
     traits::{Deserialize, ToField},
 };
+
+global MAX_PRIVATE_EVENTS_PER_TXE_QUERY: u32 = 5;
+global MAX_EVENT_SERIALIZATION_LENGTH: u32 = 12;
 
 pub unconstrained fn deploy<let M: u32, let N: u32, let P: u32>(
     path: str<N>,
@@ -72,6 +78,36 @@ pub unconstrained fn get_last_block_timestamp() -> u64 {}
 
 #[oracle(txeGetLastTxEffects)]
 pub unconstrained fn get_last_tx_effects() -> (Field, BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>, BoundedVec<Field, MAX_NULLIFIERS_PER_TX>) {}
+
+#[oracle(txeGetDefaultAddress)]
+pub unconstrained fn get_default_address() -> AztecAddress {}
+
+// experimental
+pub(crate) unconstrained fn get_private_events(
+    selector: EventSelector,
+    contract_address: AztecAddress,
+    scope: AztecAddress,
+    ) -> BoundedVec<BoundedVec<Field, MAX_EVENT_SERIALIZATION_LENGTH>, MAX_PRIVATE_EVENTS_PER_TXE_QUERY> {
+    // This is a workaround as Noir does not currently let us return nested structs with arrays. We instead return a raw
+    // multidimensional array in get_private_events_oracle and create the BoundedVecs here.
+
+    let (raw_array_storage, event_lengths, query_length) =
+        get_private_events_oracle(selector, contract_address, scope);
+
+    let mut events = BoundedVec::new();
+    for i in 0..query_length {
+        events.push(BoundedVec::from_parts(raw_array_storage[i], event_lengths[i]));
+    }
+
+    events
+}
+
+#[oracle(txeGetPrivateEvents)]
+unconstrained fn get_private_events_oracle(
+    selector: EventSelector,
+    contract_address: AztecAddress,
+    scope: AztecAddress,
+    ) -> ([[Field; MAX_EVENT_SERIALIZATION_LENGTH]; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], [u32; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], u32) {}
 
 #[oracle(txeAdvanceBlocksBy)]
 pub unconstrained fn advance_blocks_by(blocks: u32) {}

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_event.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_event.nr
@@ -1,0 +1,56 @@
+use crate::{
+    event::{
+        event_emission::NewEvent, event_interface::EventInterface, event_selector::EventSelector,
+    },
+    oracle::random::random,
+};
+
+use dep::protocol_types::traits::{FromField, Serialize};
+
+#[derive(Eq, Serialize)]
+pub(crate) struct MockEvent {
+    pub(crate) value: Field,
+}
+
+impl EventInterface for MockEvent {
+    fn get_event_type_id() -> EventSelector {
+        // randomly chosen event type id --> has to fit within 32 bits
+        EventSelector::from_field(89)
+    }
+}
+
+pub(crate) struct MockEventBuilder {
+    value: Field,
+    randomness: Option<Field>,
+}
+
+impl MockEventBuilder {
+    pub(crate) fn new(value: Field) -> Self {
+        MockEventBuilder { value, randomness: Option::none() }
+    }
+
+    pub(crate) fn randomness(&mut self, randomness: Field) -> &mut Self {
+        self.randomness = Option::some(randomness);
+        self
+    }
+
+    pub(crate) fn build_event(self) -> MockEvent {
+        MockEvent { value: self.value }
+    }
+
+    pub(crate) fn build_new_event(self) -> NewEvent<MockEvent> {
+        NewEvent {
+            event: self.build_event(),
+            randomness: self.randomness.unwrap_or(
+                // Safety: this is meant to be used in tests.
+                unsafe { random() },
+            ),
+        }
+    }
+}
+
+impl MockEvent {
+    pub(crate) fn new(value: Field) -> MockEventBuilder {
+        MockEventBuilder::new(value)
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mod.nr
@@ -1,2 +1,3 @@
+pub mod mock_event;
 pub mod mock_note;
 pub mod mock_struct;

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -4,7 +4,7 @@ import type { ContractInstanceWithAddress } from '@aztec/aztec.js/contracts';
 import { TxHash } from '@aztec/aztec.js/tx';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
-import type { FunctionSelector } from '@aztec/stdlib/abi';
+import type { EventSelector, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { UInt64 } from '@aztec/stdlib/types';
 
@@ -44,6 +44,7 @@ export interface IAvmExecutionOracle {
 export interface ITxeExecutionOracle {
   isTxe: true;
 
+  txeGetDefaultAddress(): AztecAddress;
   txeGetNextBlockNumber(): Promise<BlockNumber>;
   txeGetNextBlockTimestamp(): Promise<UInt64>;
   txeAdvanceBlocksBy(blocks: number): Promise<void>;
@@ -62,6 +63,7 @@ export interface ITxeExecutionOracle {
     noteHashes: Fr[];
     nullifiers: Fr[];
   }>;
+  txeGetPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
   txePrivateCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress,

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -16,6 +16,7 @@ import {
   AddressDataProvider,
   ORACLE_VERSION,
   PXEOracleInterface,
+  PrivateEventDataProvider,
   enrichPublicSimulationError,
 } from '@aztec/pxe/server';
 import {
@@ -44,7 +45,7 @@ import {
   PublicContractsDB,
   PublicProcessor,
 } from '@aztec/simulator/server';
-import { type ContractArtifact, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
+import { type ContractArtifact, EventSelector, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -76,6 +77,7 @@ import type { UInt64 } from '@aztec/stdlib/types';
 import { ForkCheckpoint } from '@aztec/world-state';
 
 import type { TXEStateMachine } from '../state_machine/index.js';
+import { DEFAULT_ADDRESS } from '../txe_session.js';
 import type { TXEAccountDataProvider } from '../util/txe_account_data_provider.js';
 import type { TXEContractDataProvider } from '../util/txe_contract_data_provider.js';
 import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_source.js';
@@ -93,6 +95,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private contractDataProvider: TXEContractDataProvider,
     private keyStore: KeyStore,
     private addressDataProvider: AddressDataProvider,
+    private privateEventDataProvider: PrivateEventDataProvider,
     private accountDataProvider: TXEAccountDataProvider,
     private pxeOracleInterface: PXEOracleInterface,
     private nextBlockTimestamp: bigint,
@@ -128,6 +131,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     this.logger[levelName](`${applyStringFormatting(message, fields)}`, { module: `${this.logger.module}:debug_log` });
   }
 
+  txeGetDefaultAddress(): AztecAddress {
+    return DEFAULT_ADDRESS;
+  }
+
   async txeGetNextBlockNumber(): Promise<BlockNumber> {
     return BlockNumber((await this.getLastBlockNumber()) + 1);
   }
@@ -151,6 +158,17 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     const txEffects = block!.body.txEffects[0];
 
     return { txHash: txEffects.txHash, noteHashes: txEffects.noteHashes, nullifiers: txEffects.nullifiers };
+  }
+
+  async txeGetPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress) {
+    return (
+      await this.privateEventDataProvider.getPrivateEvents(selector, {
+        contractAddress,
+        scopes: [scope],
+        fromBlock: 0,
+        toBlock: (await this.getLastBlockNumber()) + 1,
+      })
+    ).map(e => e.packedEvent);
   }
 
   async txeAdvanceBlocksBy(blocks: number) {

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -8,7 +8,7 @@ import {
   type IUtilityExecutionOracle,
   packAsRetrievedNote,
 } from '@aztec/pxe/simulator';
-import { type ContractArtifact, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
+import { type ContractArtifact, EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -29,6 +29,9 @@ import {
   toForeignCallResult,
   toSingle,
 } from './util/encoding.js';
+
+const MAX_EVENT_LEN = 12; // This is MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVENT_RESERVED_FIELDS
+const MAX_PRIVATE_EVENTS_PER_TXE_QUERY = 5;
 
 export class UnavailableOracleError extends Error {
   constructor(oracleName: string) {
@@ -156,6 +159,12 @@ export class RPCTranslator {
 
   // TXE-specific oracles
 
+  txeGetDefaultAddress() {
+    const defaultAddress = this.handlerAsTxe().txeGetDefaultAddress();
+
+    return toForeignCallResult([toSingle(defaultAddress)]);
+  }
+
   async txeGetNextBlockNumber() {
     const nextBlockNumber = await this.handlerAsTxe().txeGetNextBlockNumber();
 
@@ -265,6 +274,39 @@ export class RPCTranslator {
       ...arrayToBoundedVec(toArray(noteHashes), MAX_NOTE_HASHES_PER_TX),
       ...arrayToBoundedVec(toArray(nullifiers), MAX_NULLIFIERS_PER_TX),
     ]);
+  }
+
+  async txeGetPrivateEvents(
+    foreignSelector: ForeignCallSingle,
+    foreignContractAddress: ForeignCallSingle,
+    foreignScope: ForeignCallSingle,
+  ) {
+    const selector = EventSelector.fromField(fromSingle(foreignSelector));
+    const contractAddress = addressFromSingle(foreignContractAddress);
+    const scope = addressFromSingle(foreignScope);
+
+    const events = await this.handlerAsTxe().txeGetPrivateEvents(selector, contractAddress, scope);
+
+    if (events.length > MAX_PRIVATE_EVENTS_PER_TXE_QUERY) {
+      throw new Error(`Array of length ${events.length} larger than maxLen ${MAX_PRIVATE_EVENTS_PER_TXE_QUERY}`);
+    }
+
+    if (events.some(e => e.length > MAX_EVENT_LEN)) {
+      throw new Error(`Some private event has length larger than maxLen ${MAX_EVENT_LEN}`);
+    }
+
+    // This is a workaround as Noir does not currently let us return nested structs with arrays. We instead return a raw
+    // multidimensional array in get_private_events_oracle and create the BoundedVecs here.
+    const rawArrayStorage = events
+      .map(e => e.concat(Array(MAX_EVENT_LEN - e.length).fill(new Fr(0))))
+      .concat(Array(MAX_PRIVATE_EVENTS_PER_TXE_QUERY - events.length).fill(Array(MAX_EVENT_LEN).fill(new Fr(0))))
+      .flat();
+    const eventLengths = events
+      .map(e => new Fr(e.length))
+      .concat(Array(MAX_PRIVATE_EVENTS_PER_TXE_QUERY - events.length).fill(new Fr(0)));
+    const queryLength = new Fr(events.length);
+
+    return toForeignCallResult([toArray(rawArrayStorage), toArray(eventLengths), toSingle(queryLength)]);
   }
 
   privateStoreInExecutionCache(foreignValues: ForeignCallArray, foreignHash: ForeignCallSingle) {

--- a/yarn-project/txe/src/txe_session.test.ts
+++ b/yarn-project/txe/src/txe_session.test.ts
@@ -15,6 +15,7 @@ describe('TXESession.processFunction', () => {
       {} as any, // keyStore
       {} as any, // addressDataProvider
       {} as any, // accountDataProvider
+      {} as any, // privateEventDataProvider
       new Fr(1), // chainId
       new Fr(1), // version
       0n, // nextBlockTimestamp

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -101,7 +101,7 @@ export interface TXESessionStateHandler {
   enterUtilityState(contractAddress?: AztecAddress): Promise<void>;
 }
 
-const DEFAULT_ADDRESS = AztecAddress.fromNumber(42);
+export const DEFAULT_ADDRESS = AztecAddress.fromNumber(42);
 
 /**
  * A `TXESession` corresponds to a Noir `#[test]` function, and handles all of its oracle calls, stores test-specific
@@ -122,6 +122,7 @@ export class TXESession implements TXESessionStateHandler {
     private contractDataProvider: TXEContractDataProvider,
     private keyStore: KeyStore,
     private addressDataProvider: AddressDataProvider,
+    private privateEventDataProvider: PrivateEventDataProvider,
     private accountDataProvider: TXEAccountDataProvider,
     private chainId: Fr,
     private version: Fr,
@@ -170,6 +171,7 @@ export class TXESession implements TXESessionStateHandler {
       contractDataProvider,
       keyStore,
       addressDataProvider,
+      privateEventDataProvider,
       accountDataProvider,
       pxeOracleInterface,
       nextBlockTimestamp,
@@ -186,6 +188,7 @@ export class TXESession implements TXESessionStateHandler {
       contractDataProvider,
       keyStore,
       addressDataProvider,
+      privateEventDataProvider,
       accountDataProvider,
       version,
       chainId,
@@ -252,6 +255,7 @@ export class TXESession implements TXESessionStateHandler {
       this.contractDataProvider,
       this.keyStore,
       this.addressDataProvider,
+      this.privateEventDataProvider,
       this.accountDataProvider,
       this.pxeOracleInterface,
       this.nextBlockTimestamp,
@@ -395,6 +399,7 @@ export class TXESession implements TXESessionStateHandler {
 
     // We rely on the note cache to determine the effects of the transaction. This is incomplete as it doesn't private
     // logs (other effects like enqueued public calls don't need to be considered since those are not allowed).
+
     const txEffect = await makeTxEffect(
       this.state.noteCache,
       this.state.protocolNullifier,


### PR DESCRIPTION
This started out as me wanting to remove the commitment from an event message, as it is unused, and then realizing that testing this was quite sad because we had no infra to do it.

We now do.

I did not publicly expose it yet as there are some open questions (what to do if we get too many events? how do we handle events emitted by contracts?), but those are more API questions and not related to the internals. With this we can at least use the capabilities ourselves for internal testing.