### PR TITLE
feat(avm): tx<>prover fuzzer

### DIFF
--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -28,6 +28,7 @@ option(OMP_MULTITHREADING "Enable OMP multi-threading" OFF)
 option(FUZZING "Build ONLY fuzzing harnesses" OFF)
 option(ENABLE_PAR_ALGOS "Enable parallel algorithms" OFF)
 option(COVERAGE "Enable collecting coverage from tests" OFF)
+option(COVERAGE_AVM "Enable coverage filtered to AVM code only" OFF)
 option(ENABLE_ASAN "Address sanitizer for debugging tricky memory corruption" OFF)
 option(ENABLE_HEAVY_TESTS "Enable heavy tests when collecting coverage" OFF)
 # Note: Must do 'sudo apt-get install libdw-dev' or equivalent
@@ -72,6 +73,10 @@ if(ENABLE_ASAN)
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)
     set(DISABLE_ASM ON)
+endif()
+
+if(COVERAGE_AVM)
+    add_compile_options(-DCOVERAGE_AVM)
 endif()
 
 if(FUZZING)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
@@ -3,188 +3,20 @@
 #include <cstdint>
 #include <vector>
 
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/crypto/merkle_tree/indexed_tree/indexed_leaf.hpp"
 #include "barretenberg/crypto/poseidon2/poseidon2.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
+#include "barretenberg/vm2/simulation/lib/merkle.hpp"
 
 using namespace bb::avm2::simulation;
 using Poseidon2 = bb::crypto::Poseidon2<bb::crypto::Poseidon2Bn254ScalarFieldParams>;
-using namespace bb::crypto::merkle_tree;
 using namespace bb::world_state;
 
-// TODO(ilyas): implement other methods as needed
 namespace bb::avm2::fuzzer {
-
-TreeSnapshots FuzzerLowLevelDB::get_tree_roots() const
-{
-    return {
-        .l1_to_l2_message_tree = { .root = FF(0), .next_available_leaf_index = 0 },
-        .note_hash_tree = { .root = FF(0), .next_available_leaf_index = next_available_note_hash_index },
-        .nullifier_tree = { .root = FF(0), .next_available_leaf_index = next_available_nullifier_index },
-        .public_data_tree = { .root = FF(0), .next_available_leaf_index = next_available_public_data_index },
-    };
-}
-
-SiblingPath FuzzerLowLevelDB::get_sibling_path([[maybe_unused]] MerkleTreeId tree_id,
-                                               [[maybe_unused]] index_t leaf_index) const
-{
-    throw_or_abort("FuzzerLowLevelDB::get_sibling_path not implemented");
-}
-
-std::pair<FF, index_t> FuzzerLowLevelDB::get_indexed_low_leaf_helper(
-    const std::vector<std::pair<FF, index_t>>& value_sorted_leaves, const FF& value) const
-{
-    for (size_t i = 0; i < value_sorted_leaves.size(); ++i) {
-        if (value_sorted_leaves[i].first == value) {
-            return value_sorted_leaves[i];
-        }
-        if (value_sorted_leaves[i].first > value) {
-            return value_sorted_leaves[i - 1];
-        }
-    }
-    // If we reach here, the value is larger than any leaf in the tree, return the last leaf
-    return value_sorted_leaves.back();
-}
-
-GetLowIndexedLeafResponse FuzzerLowLevelDB::get_low_indexed_leaf(MerkleTreeId tree_id, const FF& value) const
-{
-    switch (tree_id) {
-    case MerkleTreeId::NULLIFIER_TREE: {
-        auto [low_value, low_index] = get_indexed_low_leaf_helper(nullifier_values, value);
-        return GetLowIndexedLeafResponse(low_value == value, low_index);
-        break;
-    }
-    case MerkleTreeId::PUBLIC_DATA_TREE: {
-        auto [low_value, low_index] = get_indexed_low_leaf_helper(public_data_slots, value);
-        return GetLowIndexedLeafResponse(low_value == value, low_index);
-        break;
-    }
-    default:
-        break;
-    }
-    return GetLowIndexedLeafResponse(false, 0);
-}
-FF FuzzerLowLevelDB::get_leaf_value(MerkleTreeId tree_id, index_t leaf_index) const
-{
-    switch (tree_id) {
-    case MerkleTreeId::NULLIFIER_TREE:
-        return nullifier_leaves.at(leaf_index).nullifier;
-    case MerkleTreeId::PUBLIC_DATA_TREE:
-        return public_data_leaves.at(leaf_index).value;
-    case MerkleTreeId::NOTE_HASH_TREE:
-        return note_hash_leaves.at(leaf_index);
-    default:
-        break;
-    }
-    return FF(0);
-}
-simulation::IndexedLeaf<PublicDataLeafValue> FuzzerLowLevelDB::get_leaf_preimage_public_data_tree(
-    index_t leaf_index) const
-{
-    PublicDataLeafValue leaf_value = public_data_leaves.at(leaf_index);
-    std::pair<FF, index_t> value_index_pair = { leaf_value.value, leaf_index };
-    // Find index in public_data_slots
-    auto it = std::ranges::find_if(
-        public_data_slots.begin(), public_data_slots.end(), [&value_index_pair](const std::pair<FF, index_t>& pair) {
-            return pair.second == value_index_pair.second;
-        });
-    if (it == public_data_slots.end()) {
-        throw_or_abort("FuzzerLowLevelDB::get_leaf_preimage_public_data_tree: leaf not found in public_data_slots");
-    }
-    it++; // Now iterator is at the next element
-    if (it == public_data_slots.end()) {
-        // If this is the last leaf, return with index 0
-        return simulation::IndexedLeaf<PublicDataLeafValue>(leaf_value, 0, 0);
-    }
-    auto [next_value, next_index] = *it;
-    return bb::crypto::merkle_tree::IndexedLeaf<PublicDataLeafValue>(leaf_value, next_index, next_value);
-}
-
-simulation::IndexedLeaf<NullifierLeafValue> FuzzerLowLevelDB::get_leaf_preimage_nullifier_tree(index_t leaf_index) const
-{
-    auto leaf_value = nullifier_leaves.at(leaf_index);
-    std::pair<FF, index_t> value_index_pair = { leaf_value.nullifier, leaf_index };
-    // Find index in nullifiers_values
-    auto it = std::ranges::find_if(
-        nullifier_values.begin(), nullifier_values.end(), [&value_index_pair](const std::pair<FF, index_t>& pair) {
-            return pair.second == value_index_pair.second;
-        });
-    if (it == nullifier_values.end()) {
-        throw_or_abort("FuzzerLowLevelDB::get_leaf_preimage_nullifier_tree: leaf not found in nullifier_values");
-    }
-
-    it++; // Now iterator is at the next element
-
-    if (it == nullifier_values.end()) {
-        // If this is the last leaf, return with index 0
-        return simulation::IndexedLeaf<NullifierLeafValue>(leaf_value, 0, 0);
-    }
-    auto [next_value, next_index] = *it;
-    return simulation::IndexedLeaf<NullifierLeafValue>(leaf_value, next_index, next_value);
-}
-
-simulation::SequentialInsertionResult<PublicDataLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_public_data_tree(
-    const PublicDataLeafValue& leaf_value)
-{
-    // Add to map
-    public_data_leaves[next_available_public_data_index] = leaf_value;
-    // Add to sorted vector
-    public_data_slots.push_back({ leaf_value.slot, next_available_public_data_index });
-    // Sort vector
-    std::ranges::sort(
-        public_data_slots.begin(),
-        public_data_slots.end(),
-        [](const std::pair<FF, index_t>& a, const std::pair<FF, index_t>& b) { return a.first < b.first; });
-
-    // Increment next available index
-    next_available_public_data_index++;
-    // Don't return any witness data for now, as it's not used for pure calls.
-    return {};
-}
-
-simulation::SequentialInsertionResult<NullifierLeafValue> FuzzerLowLevelDB::insert_indexed_leaves_nullifier_tree(
-    const NullifierLeafValue& leaf_value)
-{
-    // Add to map
-    nullifier_leaves[next_available_nullifier_index] = leaf_value;
-    // Add to sorted vector
-    nullifier_values.push_back({ leaf_value.nullifier, next_available_nullifier_index });
-    // Sort vector
-    std::ranges::sort(
-        nullifier_values.begin(),
-        nullifier_values.end(),
-        [](const std::pair<FF, index_t>& a, const std::pair<FF, index_t>& b) { return a.first < b.first; });
-
-    // Increment next available index
-    next_available_nullifier_index++;
-    // Don't return any witness data for now, as it's not used for pure calls.
-    return {};
-}
-
-void FuzzerLowLevelDB::append_leaves([[maybe_unused]] MerkleTreeId tree_id, std::span<const FF> leaves)
-{
-    note_hash_leaves.insert(note_hash_leaves.end(), leaves.begin(), leaves.end());
-    next_available_note_hash_index += leaves.size();
-}
-void FuzzerLowLevelDB::pad_tree([[maybe_unused]] MerkleTreeId tree_id, [[maybe_unused]] size_t num_leaves) {}
-
-void FuzzerLowLevelDB::create_checkpoint() {}
-void FuzzerLowLevelDB::commit_checkpoint() {}
-void FuzzerLowLevelDB::revert_checkpoint() {}
-uint32_t FuzzerLowLevelDB::get_checkpoint_id() const
-{
-    return 0;
-}
-
-// Helper to insert a contract address into the nullifier tree
-void FuzzerLowLevelDB::insert_contract_address(const AztecAddress& contract_address)
-{
-    auto contract_nullifier =
-        simulation::unconstrained_silo_nullifier(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, contract_address);
-    insert_indexed_leaves_nullifier_tree(contract_nullifier);
-}
 
 ////////////////////////////////
 /// ContractDBInterface methods
@@ -207,13 +39,12 @@ std::optional<ContractClass> FuzzerContractDB::get_contract_class(const Contract
 
 std::optional<FF> FuzzerContractDB::get_bytecode_commitment(const ContractClassId& class_id) const
 {
-    // Return 0 might be an issue, in the pure bytecode manager we cache based on this value
-    // This might cause different classes to be treated as the same if they return 0 here.
-    // For now we just return the class_id as it should be as unique as the bytecode commitment
     if (!contract_classes.contains(class_id)) {
         return std::nullopt;
     }
-    return class_id;
+    // Compute the actual bytecode commitment from the stored bytecode
+    const auto& klass = contract_classes.at(class_id);
+    return compute_public_bytecode_commitment(klass.packed_bytecode);
 }
 std::optional<std::string> FuzzerContractDB::get_debug_function_name(
     [[maybe_unused]] const AztecAddress& address, [[maybe_unused]] const FunctionSelector& selector) const
@@ -239,12 +70,21 @@ void FuzzerContractDB::add_contracts(const ContractDeploymentData& contract_depl
 
 void FuzzerContractDB::add_contract_class(const ContractClassId& class_id, const ContractClass& contract_class)
 {
-    contract_classes[class_id] = contract_class;
+    // todo(ilyas): think of a nicer way without both map and vector
+    // Only push to vector if not already present, otherwise we get duplicates sent to the TS simulator
+    if (contract_classes.contains(class_id)) {
+        return;
+    }
     contract_classes_vector.push_back(contract_class);
+    contract_classes[class_id] = contract_class;
 }
 
 void FuzzerContractDB::add_contract_instance(const AztecAddress& address, const ContractInstance& contract_instance)
 {
+    // todo(ilyas): think of a nicer way without both map and vector
+    if (contract_instances.contains(address)) {
+        return;
+    }
     contract_instances[address] = contract_instance;
     contract_instances_vector.push_back({ address, contract_instance });
 }
@@ -379,6 +219,7 @@ void FuzzerWorldStateManager::register_contract_address(const AztecAddress& cont
 {
     NullifierLeafValue contract_nullifier =
         unconstrained_silo_nullifier(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, contract_address);
+    fuzz_info("Registering contract address in world state: ", contract_nullifier.nullifier);
     auto fork_id = fork_ids.top();
     ws->insert_indexed_leaves<NullifierLeafValue>(MerkleTreeId::NULLIFIER_TREE, { contract_nullifier }, fork_id);
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
@@ -1,66 +1,14 @@
 #pragma once
 
+#include <memory>
 #include <stack>
 
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
-#include "barretenberg/vm2/simulation/lib/merkle.hpp"
 #include "barretenberg/world_state/types.hpp"
 #include "barretenberg/world_state/world_state.hpp"
-#include <memory>
-#include <stack>
 
 namespace bb::avm2::fuzzer {
-
-// FIXME(ilyas): This is now unused for the fuzzer, but I have a plan to experiment with this later.
-class FuzzerLowLevelDB : public bb::avm2::simulation::LowLevelMerkleDBInterface {
-  public:
-    TreeSnapshots get_tree_roots() const override;
-
-    simulation::SiblingPath get_sibling_path(simulation::MerkleTreeId tree_id, index_t leaf_index) const override;
-
-    GetLowIndexedLeafResponse get_low_indexed_leaf(simulation::MerkleTreeId tree_id, const FF& value) const override;
-
-    FF get_leaf_value(simulation::MerkleTreeId tree_id, index_t leaf_index) const override;
-
-    simulation::IndexedLeaf<PublicDataLeafValue> get_leaf_preimage_public_data_tree(index_t leaf_index) const override;
-
-    simulation::IndexedLeaf<NullifierLeafValue> get_leaf_preimage_nullifier_tree(index_t leaf_index) const override;
-
-    simulation::SequentialInsertionResult<PublicDataLeafValue> insert_indexed_leaves_public_data_tree(
-        const PublicDataLeafValue& leaf_value) override;
-
-    simulation::SequentialInsertionResult<NullifierLeafValue> insert_indexed_leaves_nullifier_tree(
-        const NullifierLeafValue& leaf_value) override;
-
-    void append_leaves(simulation::MerkleTreeId tree_id, std::span<const FF> leaves) override;
-
-    void pad_tree(simulation::MerkleTreeId tree_id, size_t num_leaves) override;
-    void create_checkpoint() override;
-    void commit_checkpoint() override;
-    void revert_checkpoint() override;
-    uint32_t get_checkpoint_id() const override;
-
-    // Some helper functions for the fuzzer to use
-    void insert_contract_address(const AztecAddress& contract_address);
-
-  private:
-    std::pair<FF, index_t> get_indexed_low_leaf_helper(const std::vector<std::pair<FF, index_t>>& value_sorted_leaves,
-                                                       const FF& value) const;
-
-    // Stored leaves sorted by value/slots for low-indexed leaf retrieval
-    std::vector<std::pair<FF, index_t>> nullifier_values{ { 0, 0 } };
-    std::vector<std::pair<FF, index_t>> public_data_slots{ { 0, 0 } };
-    // Stored leaves with their indices
-    std::unordered_map<index_t, NullifierLeafValue> nullifier_leaves{ { 0, NullifierLeafValue(0) } };
-    std::unordered_map<index_t, PublicDataLeafValue> public_data_leaves{ { 0, PublicDataLeafValue(0, 0) } };
-    std::vector<FF> note_hash_leaves;
-
-    // Indices
-    uint64_t next_available_nullifier_index = 1;
-    uint64_t next_available_public_data_index = 1;
-    uint64_t next_available_note_hash_index = 0;
-};
 
 class FuzzerContractDB : public simulation::ContractDBInterface {
   public:

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_comparison_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_comparison_helper.cpp
@@ -1,0 +1,107 @@
+// This file contains helper functions to compare simulation results from different AVM2 C++ simulator runs.
+// It is needed as opposed to relying on operator== because some fields (like halting_message) are not compared (since
+// they are known to be different)
+#include "barretenberg/avm_fuzzer/fuzzer_comparison_helper.hpp"
+
+#include <string>
+#include <vector>
+
+#include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
+
+using namespace bb::avm2;
+
+bool compare_call_stack_metadata(const CallStackMetadata& a, const CallStackMetadata& b)
+{
+    if (a.timestamp != b.timestamp || a.phase != b.phase || a.contract_address != b.contract_address ||
+        a.caller_pc != b.caller_pc || a.calldata != b.calldata || a.is_static_call != b.is_static_call ||
+        a.gas_limit != b.gas_limit || a.output != b.output || a.reverted != b.reverted ||
+        a.internal_call_stack_at_exit != b.internal_call_stack_at_exit || a.num_nested_calls != b.num_nested_calls) {
+        return false;
+    }
+    // Compare nested calls recursively
+    if (a.nested.size() != b.nested.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.nested.size(); ++i) {
+        if (!compare_call_stack_metadata(a.nested[i], b.nested[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool compare_call_stack_metadata_vec(const std::vector<CallStackMetadata>& a, const std::vector<CallStackMetadata>& b)
+{
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (!compare_call_stack_metadata(a[i], b[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool compare_cpp_simulator_results(const std::vector<TxSimulationResult>& results)
+{
+    BB_ASSERT(results.size() >= 2, "Need at least 2 results to compare");
+    BB_ASSERT(std::all_of(results.begin(),
+                          results.end(),
+                          [](const TxSimulationResult& result) { return result.public_inputs.has_value(); }),
+              "All results must have public_inputs to compare");
+
+    for (size_t i = 1; i < results.size(); ++i) {
+        const auto& prev = results[i - 1];
+        const auto& curr = results[i];
+
+        std::vector<std::string> mismatches;
+
+        // Compare TxSimulationResult fields
+        if (prev.gas_used != curr.gas_used) {
+            mismatches.push_back("gas_used");
+        }
+        if (prev.revert_code != curr.revert_code) {
+            mismatches.push_back("revert_code");
+        }
+        if (prev.public_tx_effect != curr.public_tx_effect) {
+            mismatches.push_back("public_tx_effect");
+        }
+        // call_stack_metadata uses custom comparison that ignores halting_message
+        if (!compare_call_stack_metadata_vec(prev.call_stack_metadata, curr.call_stack_metadata)) {
+            mismatches.push_back("call_stack_metadata");
+        }
+
+        // Compare public_inputs output fields (guaranteed present by assertion)
+        const auto& pi_prev = prev.public_inputs.value();
+        const auto& pi_curr = curr.public_inputs.value();
+
+        if (pi_prev.end_tree_snapshots != pi_curr.end_tree_snapshots) {
+            mismatches.push_back("public_inputs.end_tree_snapshots");
+        }
+        if (pi_prev.end_gas_used != pi_curr.end_gas_used) {
+            mismatches.push_back("public_inputs.end_gas_used");
+        }
+        if (pi_prev.accumulated_data_array_lengths != pi_curr.accumulated_data_array_lengths) {
+            mismatches.push_back("public_inputs.accumulated_data_array_lengths");
+        }
+        if (pi_prev.accumulated_data != pi_curr.accumulated_data) {
+            mismatches.push_back("public_inputs.accumulated_data");
+        }
+        if (pi_prev.transaction_fee != pi_curr.transaction_fee) {
+            mismatches.push_back("public_inputs.transaction_fee");
+        }
+        if (pi_prev.reverted != pi_curr.reverted) {
+            mismatches.push_back("public_inputs.reverted");
+        }
+
+        if (!mismatches.empty()) {
+            fuzz_info("=== Mismatch between results ", i - 1, " and ", i, " ===");
+            for (const auto& field : mismatches) {
+                fuzz_info("  MISMATCH in ", field);
+            }
+            return false;
+        }
+    }
+    return true;
+}

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_comparison_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_comparison_helper.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <vector>
+
+#include "barretenberg/vm2/common/avm_io.hpp"
+
+using namespace bb::avm2;
+
+// Compare CallStackMetadata ignoring halting_message (recursive for nested calls)
+bool compare_call_stack_metadata(const CallStackMetadata& a, const CallStackMetadata& b);
+
+// Compare vectors of CallStackMetadata ignoring halting_message
+bool compare_call_stack_metadata_vec(const std::vector<CallStackMetadata>& a, const std::vector<CallStackMetadata>& b);
+
+// Compare TxSimulationResult objects and report mismatches
+// Ignores halting_message in call_stack_metadata
+// Returns true if all results match, false otherwise
+bool compare_cpp_simulator_results(const std::vector<TxSimulationResult>& results);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
@@ -1,29 +1,31 @@
-#include "barretenberg/avm_fuzzer/tx.fuzzer.hpp"
+#include "barretenberg/avm_fuzzer/fuzzer_lib.hpp"
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "barretenberg/api/file_io.hpp"
 #include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
+#include "barretenberg/avm_fuzzer/fuzzer_comparison_helper.hpp"
 #include "barretenberg/avm_fuzzer/mutations/fuzzer_data.hpp"
 #include "barretenberg/avm_fuzzer/mutations/tx_data.hpp"
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/avm_api.hpp"
+#include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
+#include "barretenberg/vm2/simulation_helper.hpp"
+#include "barretenberg/vm2/tooling/stats.hpp"
 
 using namespace bb::avm2::fuzzer;
 using namespace bb::avm2::simulation;
+using namespace bb::world_state;
 
-/// @brief Fuzz CPP vs JS simulator with a full transaction containing multiple enqueued calls
-/// @param tx_data The transaction data containing multiple enqueued calls
-/// @returns The simulator result if the results are the same
-/// @throws An exception if the simulator results are different
-SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
+void setup_fuzzer_state(FuzzerWorldStateManager& ws_mgr, FuzzerContractDB& contract_db, const FuzzerTxData& tx_data)
 {
-    FuzzerWorldStateManager* ws_mgr = FuzzerWorldStateManager::getInstance();
-    FuzzerContractDB contract_db;
+    // Add all contract classes and instances to the contract DB
     for (size_t i = 0; i < tx_data.contract_classes.size(); ++i) {
         const auto& contract_class = tx_data.contract_classes[i];
         const auto& contract_instance = tx_data.contract_instances[i];
@@ -31,8 +33,8 @@ SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
         contract_db.add_contract_class(contract_class.id, contract_class);
         contract_db.add_contract_instance(contract_address, contract_instance);
     }
-    // Now that we are done with mutations, we need to recompute the contract addresses
-    // Now they need to be de-duplicated and sorted so that we can register them in the same order in TS
+
+    // Register the de-duplicated set of contract addresses to the world state
     auto contract_addresses = tx_data.contract_addresses;
     std::ranges::sort(contract_addresses.begin(),
                       contract_addresses.end(),
@@ -41,26 +43,36 @@ SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
                              contract_addresses.end());
 
     for (const auto& addr : contract_addresses) {
-        ws_mgr->register_contract_address(addr);
+        fuzz_info("Registering contract address in world state: ", addr);
+        ws_mgr.register_contract_address(addr);
     }
+}
 
+void fund_fee_payer(FuzzerWorldStateManager& ws_mgr, const Tx& tx)
+{
     // Compute fee from gas limits and max fees per gas (upper bound on fee)
-    FF fee_required_da =
-        FF(tx_data.tx.gas_settings.gas_limits.da_gas) * FF(tx_data.tx.gas_settings.max_fees_per_gas.fee_per_da_gas);
-    FF fee_required_l2 =
-        FF(tx_data.tx.gas_settings.gas_limits.l2_gas) * FF(tx_data.tx.gas_settings.max_fees_per_gas.fee_per_l2_gas);
+    FF fee_required_da = FF(tx.gas_settings.gas_limits.da_gas) * FF(tx.gas_settings.max_fees_per_gas.fee_per_da_gas);
+    FF fee_required_l2 = FF(tx.gas_settings.gas_limits.l2_gas) * FF(tx.gas_settings.max_fees_per_gas.fee_per_l2_gas);
 
-    ws_mgr->write_fee_payer_balance(tx_data.tx.fee_payer, fee_required_da + fee_required_l2);
+    // Fund fee payer with required fee
+    ws_mgr.write_fee_payer_balance(tx.fee_payer, fee_required_da + fee_required_l2);
+}
 
+/// @brief Fuzz CPP vs JS simulator with a full transaction containing multiple enqueued calls
+/// @param tx_data The transaction data containing multiple enqueued calls
+/// @returns The simulator result if the results are the same
+/// @throws An exception if the simulator results are different
+SimulatorResult fuzz_tx(FuzzerWorldStateManager& ws_mgr, FuzzerContractDB& contract_db, FuzzerTxData& tx_data)
+{
     // Run simulators
     auto cpp_simulator = CppSimulator();
     JsSimulator* js_simulator = JsSimulator::getInstance();
     SimulatorResult cpp_result;
 
     try {
-        ws_mgr->checkpoint();
-        cpp_result = cpp_simulator.simulate(*ws_mgr, contract_db, tx_data.tx);
-        ws_mgr->revert();
+        ws_mgr.checkpoint();
+        cpp_result = cpp_simulator.simulate(ws_mgr, contract_db, tx_data.tx);
+        ws_mgr.revert();
     } catch (const std::exception& e) {
         fuzz_info("CppSimulator threw an exception: ", e.what());
         cpp_result = SimulatorResult{
@@ -69,11 +81,11 @@ SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
             .end_tree_snapshots = TreeSnapshots(),
             .revert_reason = e.what(),
         };
-        ws_mgr->revert();
+        ws_mgr.revert();
     }
 
-    ws_mgr->checkpoint();
-    auto js_result = js_simulator->simulate(*ws_mgr, contract_db, tx_data.tx);
+    ws_mgr.checkpoint();
+    auto js_result = js_simulator->simulate(ws_mgr, contract_db, tx_data.tx);
 
     // If the results do not match
     if (!compare_simulator_results(cpp_result, js_result)) {
@@ -86,6 +98,93 @@ SimulatorResult fuzz_tx(FuzzerTxData& tx_data)
     fuzz_info("JsSimulator  ", js_result);
 
     return cpp_result;
+}
+
+/// @brief Run the prover fuzzer: fast simulation, hint collection, comparison, and check_circuit
+/// @param ws_mgr The world state manager (should already be forked)
+/// @param contract_db The contract database
+/// @param tx_data The transaction data
+/// @returns 0 on success
+/// @throws An exception if simulation results differ or check_circuit fails
+int fuzz_prover(FuzzerWorldStateManager& ws_mgr, FuzzerContractDB& contract_db, FuzzerTxData& tx_data)
+{
+    ProtocolContracts protocol_contracts{};
+    WorldState& ws = ws_mgr.get_world_state();
+    WorldStateRevision ws_rev = ws_mgr.get_current_revision();
+    AvmSimulationHelper helper;
+
+    // Reset stats for this iteration
+    bb::avm2::Stats::get().reset();
+
+    const PublicSimulatorConfig sim_fast_config{
+        .skip_fee_enforcement = false,
+        .collect_call_metadata = true,
+        .collect_public_inputs = true,
+    };
+
+    const PublicSimulatorConfig sim_hint_config{
+        .skip_fee_enforcement = false,
+        .collect_call_metadata = true,
+        .collect_hints = true,
+        .collect_public_inputs = true,
+    };
+
+    // 1. Run simulate_fast_with_existing_ws
+    // It is the only one that may throw, so we wrap it in try-catch. If it fails, we do not proceed
+    TxSimulationResult fast_result;
+    try {
+        ws_mgr.checkpoint();
+        fast_result = AVM_TRACK_TIME_V(
+            "fuzzer/simulate_fast",
+            helper.simulate_fast_with_existing_ws(
+                contract_db, ws_rev, ws, sim_fast_config, tx_data.tx, tx_data.global_variables, protocol_contracts));
+        ws_mgr.revert();
+    } catch (const std::exception& e) {
+        ws_mgr.revert();
+        fuzz_info("simulate_fast_with_existing_ws threw an exception: ", e.what());
+        return 0;
+    }
+
+    // 2. Run simulate_for_hint_collection
+    ws_mgr.checkpoint();
+    TxSimulationResult hint_result = AVM_TRACK_TIME_V(
+        "fuzzer/simulate_hints",
+        helper.simulate_for_hint_collection(
+            contract_db, ws_rev, ws, sim_hint_config, tx_data.tx, tx_data.global_variables, protocol_contracts));
+    ws_mgr.revert();
+
+    // 2a. Construct proving inputs from hint result
+    bb::avm2::AvmProvingInputs proving_inputs{
+        .public_inputs = hint_result.public_inputs.value(),
+        .hints = hint_result.hints.value(),
+    };
+
+    // 3. (optional) Simulate Fast with hinted db
+    TxSimulationResult sim_fast_hinted_result =
+        helper.simulate_fast_with_hinted_dbs(proving_inputs.hints, sim_fast_config);
+
+    // 4. Compare results from all 3 simulations
+    bool result = compare_cpp_simulator_results({ fast_result, hint_result, sim_fast_hinted_result });
+    BB_ASSERT(result,
+              "Simulation results do not match between simulate_fast, simulate_for_hint_collection, "
+              "and simulate_fast_with_hinted_dbs");
+
+    // 5. Run check_circuit (skip in coverage builds since it's slow and not needed for coverage measurement)
+
+#ifndef COVERAGE_AVM
+    avm2::AvmAPI avm_api;
+    bool check_circuit_result = avm_api.check_circuit(proving_inputs);
+    BB_ASSERT(check_circuit_result,
+              "check_circuit returned false in fuzzer with no exception, this indicates a failure");
+#else
+    // In coverage builds, run simulate_for_witgen instead of check_circuit
+    // This gives us coverage the the event and tracegen code paths without the overhead of check_circuit
+    vinfo("Running simulate_for_witgen in coverage build (skipping check_circuit)");
+    avm2::AvmSimulationHelper simulation_helper;
+    simulation_helper.simulate_for_witgen(proving_inputs.hints);
+#endif
+
+    return 0;
 }
 
 // Initialize FuzzerTxData with sensible defaults
@@ -107,6 +206,12 @@ FuzzerTxData create_default_tx_data(std::mt19937_64& rng)
         .protocol_contracts = {},
     };
     return tx_data;
+}
+
+FuzzerTxData create_default_tx_data()
+{
+    std::mt19937_64 rng(0);
+    return create_default_tx_data(rng);
 }
 
 ContractArtifacts build_bytecode_and_artifacts(FuzzerData& fuzzer_data)
@@ -131,6 +236,12 @@ ContractArtifacts build_bytecode_and_artifacts(FuzzerData& fuzzer_data)
         .deployer = MSG_SENDER,
         .current_contract_class_id = class_id, // Initial and current are the same
         .original_contract_class_id = class_id,
+        .public_keys = {
+            .nullifier_key = { 0, 0 },
+            .incoming_viewing_key = grumpkin::g1::element::one(),
+            .outgoing_viewing_key = { 0, 0 },
+            .tagging_key = { 0, 0 },
+        },
     };
     return { bytecode, contract_class, contract_instance };
 }
@@ -158,7 +269,9 @@ size_t mutate_tx_data(uint8_t* serialized_fuzzer_data,
     }
 
     // Build up bytecodes, contract classes and instances from the fuzzer data
-    std::vector<ContractArtifacts> contract_artifacts_vec;
+    tx_data.contract_classes.clear();
+    tx_data.contract_instances.clear();
+    tx_data.contract_addresses.clear();
     std::vector<AztecAddress> contract_addresses;
 
     for (auto& fuzzer_data : tx_data.input_programs) {
@@ -167,15 +280,6 @@ size_t mutate_tx_data(uint8_t* serialized_fuzzer_data,
         auto contract_address = simulation::compute_contract_address(contract_instance);
         contract_addresses.push_back(contract_address);
 
-        contract_artifacts_vec.push_back({ bytecode, contract_class, contract_instance });
-    }
-
-    // Store built artifacts back into tx_data
-    tx_data.contract_classes.clear();
-    tx_data.contract_instances.clear();
-    tx_data.contract_addresses.clear();
-
-    for (const auto& [bytecode, contract_class, contract_instance] : contract_artifacts_vec) {
         tx_data.contract_classes.push_back(contract_class);
         tx_data.contract_instances.push_back(contract_instance);
     }
@@ -222,16 +326,14 @@ size_t mutate_tx_data(uint8_t* serialized_fuzzer_data,
     // Ensure at least 1 app_logic enqueued call exists (mutations may have deleted all)
     if (tx_data.tx.app_logic_enqueued_calls.empty() && !contract_addresses.empty()) {
         auto idx = std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1)(rng);
-        tx_data.tx.app_logic_enqueued_calls.push_back(PublicCallRequestWithCalldata{
-            .request =
-                PublicCallRequest{
-                    .msg_sender = MSG_SENDER,
-                    .contract_address = contract_addresses[idx],
-                    .is_static_call = false,
-                    .calldata_hash = compute_calldata_hash({}),
-                },
-            .calldata = {},
-        });
+        std::vector<FF> calldata = {};
+        auto calldata_hash = compute_calldata_hash(calldata);
+        tx_data.tx.app_logic_enqueued_calls.push_back(
+            PublicCallRequestWithCalldata{ .request = PublicCallRequest{ .msg_sender = MSG_SENDER,
+                                                                         .contract_address = contract_addresses[idx],
+                                                                         .is_static_call = false,
+                                                                         .calldata_hash = calldata_hash },
+                                           .calldata = calldata });
     }
     auto [mutated_serialized_fuzzer_data, mutated_serialized_fuzzer_data_size] = msgpack_encode_buffer(tx_data);
     if (mutated_serialized_fuzzer_data_size > max_size) {

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <vector>
 
+#include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/simulator.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
@@ -17,6 +18,7 @@ struct FuzzerTxData {
     // Enqueued calls data
     std::vector<FuzzerData> input_programs;
     // These are the contract classes and instances that will be registered to addresses in the WS
+    // The contract addresses may contain duplicates if multiple contracts derive to the same address
     std::vector<ContractClass> contract_classes;
     std::vector<ContractInstance> contract_instances;
     std::vector<AztecAddress> contract_addresses;
@@ -61,10 +63,27 @@ enum class TxDataMutationType : uint8_t {
 ContractArtifacts build_bytecode_and_artifacts(FuzzerData& fuzzer_data);
 
 // Create a default FuzzerTxData with sensible defaults
+FuzzerTxData create_default_tx_data(std::mt19937_64& rng);
 FuzzerTxData create_default_tx_data();
 
+// Setup fuzzer state: register contracts and addresses in the world state
+void setup_fuzzer_state(bb::avm2::fuzzer::FuzzerWorldStateManager& ws_mgr,
+                        bb::avm2::fuzzer::FuzzerContractDB& contract_db,
+                        const FuzzerTxData& tx_data);
+
+// Fund the fee payer with enough balance for the transaction
+void fund_fee_payer(bb::avm2::fuzzer::FuzzerWorldStateManager& ws_mgr, const Tx& tx);
+
 // Run the differential fuzzer comparing CPP vs JS simulator
-SimulatorResult fuzz_tx(FuzzerTxData& tx_data);
+SimulatorResult fuzz_tx(bb::avm2::fuzzer::FuzzerWorldStateManager& ws_mgr,
+                        bb::avm2::fuzzer::FuzzerContractDB& contract_db,
+                        FuzzerTxData& tx_data);
+
+// Run the prover fuzzer: fast simulation, hint collection, comparison, and check_circuit
+// Returns 0 on success, -1 if the input should be rejected
+int fuzz_prover(bb::avm2::fuzzer::FuzzerWorldStateManager& ws_mgr,
+                bb::avm2::fuzzer::FuzzerContractDB& contract_db,
+                FuzzerTxData& tx_data);
 
 // Common custom mutator logic shared between fuzzers
 // Returns the new size of the mutated data, or 0 if mutation failed
@@ -72,3 +91,5 @@ size_t mutate_tx_data(uint8_t* serialized_fuzzer_data,
                       size_t serialized_fuzzer_data_size,
                       size_t max_size,
                       unsigned int seed);
+
+bool compare_cpp_simulator_results(const std::vector<TxSimulationResult>& results);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
@@ -7,6 +7,7 @@
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/tagged_value.hpp"
+#include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 #include <random>
 
@@ -323,7 +324,7 @@ PublicCallRequestWithCalldata generate_public_call_request(std::vector<AztecAddr
     fuzz_info("Generating new public call request");
     // Generate random calldata
     size_t calldata_size = std::uniform_int_distribution<size_t>(0, 256)(rng);
-    std::vector<FF> calldata;
+    std::vector<FF> calldata{};
     for (size_t i = 0; i < calldata_size; ++i) {
         calldata.push_back(generate_random_field(rng));
     }
@@ -333,13 +334,14 @@ PublicCallRequestWithCalldata generate_public_call_request(std::vector<AztecAddr
             ? generate_random_field(rng)
             : contract_addresses[std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1)(rng)];
     fuzz_info("Using contract address: ", contract_address);
+    FF calldata_hash = simulation::compute_calldata_hash(calldata);
     return PublicCallRequestWithCalldata{
         .request =
             PublicCallRequest{
                 .msg_sender = generate_random_field(rng),
                 .contract_address = contract_address,
                 .is_static_call = (std::uniform_int_distribution<uint8_t>(0, 1)(rng) == 1),
-                .calldata_hash = 0, // fixme: compute hash when we do tracegen versions
+                .calldata_hash = calldata_hash,
             },
         .calldata = calldata,
     };

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/prover.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/prover.fuzzer.cpp
@@ -1,24 +1,20 @@
 #include "barretenberg/avm_fuzzer/fuzzer_lib.hpp"
 
 #include <cstdint>
+#include <filesystem>
 #include <string>
 
 #include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
-#include "barretenberg/avm_fuzzer/fuzz_lib/fuzz.hpp"
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/tooling/stats.hpp"
 
 using namespace bb::avm2::fuzzer;
-using namespace bb::avm2::simulation;
 
 extern "C" int LLVMFuzzerInitialize(int*, char***)
 {
-    const char* simulator_path = std::getenv("AVM_SIMULATOR_BIN");
-    if (simulator_path == nullptr) {
-        throw std::runtime_error("AVM_SIMULATOR_BIN is not set");
-    }
-    std::string simulator_path_str(simulator_path);
-    JsSimulator::initialize(simulator_path_str);
     FuzzerWorldStateManager::initialize();
+    std::filesystem::create_directories("proving_inputs");
     return 0;
 }
 
@@ -45,11 +41,16 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     ws_mgr->fork();
 
     // Setup contracts and fund fee payer
+    // Fuzzer state is dependent on the tx data
     setup_fuzzer_state(*ws_mgr, contract_db, tx_data);
     fund_fee_payer(*ws_mgr, tx_data.tx);
 
-    fuzz_tx(*ws_mgr, contract_db, tx_data);
+    int result = fuzz_prover(*ws_mgr, contract_db, tx_data);
+
+    // Print timing stats for this iteration
+    vinfo("Timing stats:\n", bb::avm2::Stats::get().to_string());
+
     ws_mgr->reset_world_state();
 
-    return 0;
+    return result;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
@@ -31,6 +31,7 @@ if [ "$COMMAND" = "list-targets" ]; then
     echo "Available fuzzing options (<target_name>):"
     echo "  avm - AVM fuzzer (avm_fuzzer_avm_fuzzer)"
     echo "  tx - Transaction fuzzer (avm_fuzzer_tx_fuzzer)"
+    echo "  prover - Prover fuzzer (avm_fuzzer_prover_fuzzer)"
     echo "  alu - ALU fuzzer (harness_alu_fuzzer)"
     echo "  bitwise - Bitwise fuzzer (harness_bitwise_fuzzer)"
     echo "  ecc - ECC fuzzer (harness_ecc_fuzzer)"
@@ -74,6 +75,7 @@ fi
 case "$FUZZER_ALIAS" in
     avm) FUZZER_TYPE="avm_fuzzer_avm_fuzzer" ;;
     tx) FUZZER_TYPE="avm_fuzzer_tx_fuzzer" ;;
+    prover) FUZZER_TYPE="avm_fuzzer_prover_fuzzer" ;;
     alu) FUZZER_TYPE="harness_alu_fuzzer" ;;
     bitwise) FUZZER_TYPE="harness_bitwise_fuzzer" ;;
     ecc) FUZZER_TYPE="harness_ecc_fuzzer" ;;
@@ -83,7 +85,7 @@ case "$FUZZER_ALIAS" in
     emit_unencrypted_log) FUZZER_TYPE="harness_emit_unencrypted_log_fuzzer" ;;
     *)
         echo "Error: Invalid fuzzer type '$FUZZER_ALIAS'"
-        echo "Valid options: 'avm', 'tx', 'alu', 'bitwise', 'ecc', 'gt', 'merkle_check', 'calldata', or 'emit_unencrypted_log'"
+        echo "Valid options: 'avm', 'tx', 'prover', 'alu', 'bitwise', 'ecc', 'gt', 'merkle_check', 'calldata', or 'emit_unencrypted_log'"
         exit 1
         ;;
 esac
@@ -97,8 +99,8 @@ CPP_DIR="$BARRETENBERG_ROOT/cpp"
 # Set AVM_SIMULATOR_BIN environment variable (relative to PROJECT_ROOT)
 export AVM_SIMULATOR_BIN="${AVM_SIMULATOR_BIN:-$PROJECT_ROOT/yarn-project/simulator/dest/public/fuzzing/avm_simulator_bin.js}"
 
-# Check if AVM_SIMULATOR_BIN exists (only for avm and tx fuzzers)
-if [ "$COMMAND" = "fuzz" ] && { [ "$FUZZER_ALIAS" = "avm" ] || [ "$FUZZER_ALIAS" = "tx" ]; } && [ ! -f "$AVM_SIMULATOR_BIN" ]; then
+# Check if AVM_SIMULATOR_BIN exists (only for avm, tx, and prover fuzzers)
+if [ "$COMMAND" = "fuzz" ] && { [ "$FUZZER_ALIAS" = "avm" ] || [ "$FUZZER_ALIAS" = "tx" ] || [ "$FUZZER_ALIAS" = "prover" ]; } && [ ! -f "$AVM_SIMULATOR_BIN" ]; then
     echo "Error: AVM simulator binary not found at: $AVM_SIMULATOR_BIN"
     echo ""
     echo "To build the AVM simulator fuzzer binary:"
@@ -112,7 +114,7 @@ fi
 if [ "$COMMAND" = "coverage" ]; then
     BUILD_DIR="$CPP_DIR/build-coverage"
     BUILD_PRESET="clang20-coverage"
-    BUILD_CMAKE_FLAGS="-DFUZZING=ON -DFUZZING_AVM=ON"
+    BUILD_CMAKE_FLAGS="-DCOVERAGE_AVM=ON -DFUZZING=ON -DFUZZING_AVM=ON"
 else
     BUILD_DIR="$CPP_DIR/build-fuzzing-avm"
     BUILD_PRESET="fuzzing-avm"
@@ -170,6 +172,13 @@ fi
 CORPUS_DIR="$SCRIPT_DIR/corpus/$FUZZER_ALIAS"
 # Sync corpus is used for parallel fuzzing - allows multiple workers to share discovered inputs
 SYNC_CORPUS_DIR="$SCRIPT_DIR/sync_corpus/$FUZZER_ALIAS"
+
+# Prover fuzzer shares corpus with tx fuzzer
+if [ "$FUZZER_ALIAS" = "prover" ]; then
+    CORPUS_DIR="$SCRIPT_DIR/corpus/tx"
+    SYNC_CORPUS_DIR="$SCRIPT_DIR/sync_corpus/tx"
+fi
+
 CRASHES_DIR="$CORPUS_DIR/crashes"
 
 # Create corpus, sync_corpus, and crashes directories
@@ -213,6 +222,7 @@ echo ""
 if [ "$COMMAND" = "coverage" ]; then
     export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-coverage.profraw}"
     echo "Coverage profiling enabled: LLVM_PROFILE_FILE=$LLVM_PROFILE_FILE"
+    echo "COVERAGE_AVM: check_circuit is skipped in coverage builds"
     echo ""
 fi
 
@@ -279,10 +289,15 @@ if [ "$COMMAND" = "coverage" ] && [ -f "$LLVM_PROFILE_FILE" ]; then
     # Set path filter for vm2 directory
     VM2_PATH_FILTER="$CPP_DIR/src/barretenberg/vm2"
 
+    # Ignore patterns for generated and constraining directories
+    IGNORE_REGEX="(vm2/generated|vm2/constraining|vm2/testing|vm2/tooling)"
+
     if [ "$COVERAGE_FORMAT" = "html" ]; then
         REPORT_DIR="out/report"
         mkdir -p "$REPORT_DIR"
-        llvm-cov-20 show -output-dir="$REPORT_DIR" -format=html ./bin/$FUZZER_TYPE -instr-profile="$COVERAGE_DATA" "$VM2_PATH_FILTER"
+        llvm-cov-20 show -output-dir="$REPORT_DIR" -format=html \
+            -ignore-filename-regex="$IGNORE_REGEX" \
+            ./bin/$FUZZER_TYPE -instr-profile="$COVERAGE_DATA" "$VM2_PATH_FILTER"
 
         if [ $? -eq 0 ]; then
             REPORT_DIR_ABS="$(cd "$REPORT_DIR" && pwd)"
@@ -301,7 +316,9 @@ if [ "$COMMAND" = "coverage" ] && [ -f "$LLVM_PROFILE_FILE" ]; then
         fi
     else
         # report format
-        llvm-cov-20 report ./bin/$FUZZER_TYPE -instr-profile="$COVERAGE_DATA" "$VM2_PATH_FILTER"
+        llvm-cov-20 report \
+            -ignore-filename-regex="$IGNORE_REGEX" \
+            ./bin/$FUZZER_TYPE -instr-profile="$COVERAGE_DATA" "$VM2_PATH_FILTER"
 
         if [ $? -ne 0 ]; then
             echo "Error: Failed to generate coverage report"

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.cpp
@@ -40,7 +40,10 @@ TxSimulationResult AvmSimAPI::simulate_with_hinted_dbs(const ProvingInputs& inpu
 {
     vinfo("Simulating...");
     AvmSimulationHelper simulation_helper;
-    return AVM_TRACK_TIME_V("simulation/all", simulation_helper.simulate_fast_with_hinted_dbs(inputs.hints));
+
+    // Placeholder for future use of config from inputs.
+    const PublicSimulatorConfig config = {};
+    return AVM_TRACK_TIME_V("simulation/all", simulation_helper.simulate_fast_with_hinted_dbs(inputs.hints, config));
 }
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -77,11 +77,11 @@ bool AvmProvingHelper::check_circuit(tracegen::TraceContainer&& trace)
     // of the circuit.
     const size_t num_rows = trace.get_num_rows_without_clk() + 1;
     const bool skippable_enabled = (getenv("AVM_DISABLE_SKIPPABLE") == nullptr);
-    info("Running check ",
-         skippable_enabled ? "(with skippable)" : "(without skippable)",
-         " circuit over ",
-         num_rows,
-         " rows.");
+    vinfo("Running check ",
+          skippable_enabled ? "(with skippable)" : "(without skippable)",
+          " circuit over ",
+          num_rows,
+          " rows.");
 
     // Warning: this destroys the trace.
     auto polynomials = AVM_TRACK_TIME_V("proving/prove:compute_polynomials", constraining::compute_polynomials(trace));
@@ -91,7 +91,7 @@ bool AvmProvingHelper::check_circuit(tracegen::TraceContainer&& trace)
     } catch (std::runtime_error& e) {
         // FIXME: This exception is never caught because it's thrown in a different thread.
         // Execution never gets here!
-        info("Circuit check failed: ", e.what());
+        vinfo("Circuit check failed: ", e.what());
     }
 
     return true;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/contract_crypto.cpp
@@ -78,6 +78,8 @@ FF compute_contract_address(const ContractInstance& contract_instance)
     FF h = poseidon2::hash({ GENERATOR_INDEX__CONTRACT_ADDRESS_V1, public_keys_hash, partial_address });
     // This is safe since BN254_Fr < GRUMPKIN_Fr so we know there is no modulo reduction
     grumpkin::fr h_fq = grumpkin::fr(h);
+    BB_ASSERT(contract_instance.public_keys.incoming_viewing_key.on_curve(),
+              "Incoming viewing key is not on the curve when computing contract address");
     return (grumpkin::g1::affine_one * h_fq + contract_instance.public_keys.incoming_viewing_key).x;
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -625,11 +625,9 @@ EventsContainer AvmSimulationHelper::simulate_for_witgen(const ExecutionHints& h
     return std::move(events);
 }
 
-TxSimulationResult AvmSimulationHelper::simulate_fast_with_hinted_dbs(const ExecutionHints& hints)
+TxSimulationResult AvmSimulationHelper::simulate_fast_with_hinted_dbs(const ExecutionHints& hints,
+                                                                      const PublicSimulatorConfig& config)
 {
-    // TODO(fcarreiro): decide if we want to pass a config here.
-    const PublicSimulatorConfig config{};
-
     HintedRawContractDB raw_contract_db(hints);
     HintedRawMerkleDB raw_merkle_db(hints);
     return simulate_fast_internal(

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
@@ -32,7 +32,7 @@ class AvmSimulationHelper {
     simulation::EventsContainer simulate_for_witgen(const ExecutionHints& hints);
 
     // An extra entry point that is not used in production.
-    TxSimulationResult simulate_fast_with_hinted_dbs(const ExecutionHints& hints);
+    TxSimulationResult simulate_fast_with_hinted_dbs(const ExecutionHints& hints, const PublicSimulatorConfig& config);
 
   protected:
     TxSimulationResult simulate_fast_internal(simulation::ContractDBInterface& raw_contract_db,


### PR DESCRIPTION
A cpp only fuzzer that diffs our various simulators. Currently does
1) `simulate_fast` (the cpp simulator)
2) `simulate_for_hint_collection` (a prover orchestrator may run this)
3) `simulate_fast_with_hinted_dbs` (the original cpp implementation)
4) `simulate_for_witgen` (implicity run via `check_circuit`)
