### PR TITLE
feat: caching block hash

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -709,8 +709,8 @@ export function describeArchiverDataStore(
         // getBlock should work for both checkpointed and uncheckpointed blocks
         expect((await store.getBlock(1))?.number).toBe(1);
         expect((await store.getBlock(2))?.number).toBe(2);
-        expect(await store.getBlock(3)).toEqual(block3);
-        expect(await store.getBlock(4)).toEqual(block4);
+        expect((await store.getBlock(3))?.equals(block3)).toBe(true);
+        expect((await store.getBlock(4))?.equals(block4)).toBe(true);
         expect(await store.getBlock(5)).toBeUndefined();
 
         const block5 = await L2BlockNew.random(BlockNumber(5), {
@@ -723,13 +723,13 @@ export function describeArchiverDataStore(
         // Verify the uncheckpointed blocks have correct data
         const retrieved3 = await store.getBlock(3);
         expect(retrieved3!.number).toBe(3);
-        expect(retrieved3).toEqual(block3);
+        expect(retrieved3!.equals(block3)).toBe(true);
         const retrieved4 = await store.getBlock(4);
         expect(retrieved4!.number).toBe(4);
-        expect(retrieved4).toEqual(block4);
+        expect(retrieved4!.equals(block4)).toBe(true);
         const retrieved5 = await store.getBlock(5);
         expect(retrieved5!.number).toBe(5);
-        expect(retrieved5).toEqual(block5);
+        expect(retrieved5!.equals(block5)).toBe(true);
       });
 
       it('getBlockByHash retrieves uncheckpointed blocks', async () => {
@@ -750,10 +750,10 @@ export function describeArchiverDataStore(
         const hash2 = await block2.header.hash();
 
         const retrieved1 = await store.getBlockByHash(hash1);
-        expect(retrieved1).toEqual(block1);
+        expect(retrieved1!.equals(block1)).toBe(true);
 
         const retrieved2 = await store.getBlockByHash(hash2);
-        expect(retrieved2).toEqual(block2);
+        expect(retrieved2!.equals(block2)).toBe(true);
       });
 
       it('getBlockByArchive retrieves uncheckpointed blocks', async () => {
@@ -774,10 +774,10 @@ export function describeArchiverDataStore(
         const archive2 = block2.archive.root;
 
         const retrieved1 = await store.getBlockByArchive(archive1);
-        expect(retrieved1).toEqual(block1);
+        expect(retrieved1!.equals(block1)).toBe(true);
 
         const retrieved2 = await store.getBlockByArchive(archive2);
-        expect(retrieved2).toEqual(block2);
+        expect(retrieved2!.equals(block2)).toBe(true);
       });
 
       it('getCheckpointedBlock returns undefined for uncheckpointed blocks', async () => {
@@ -811,8 +811,8 @@ export function describeArchiverDataStore(
         expect(await store.getCheckpointedBlock(4)).toBeUndefined();
 
         // But getBlock should work for all blocks
-        expect(await store.getBlock(3)).toEqual(block3);
-        expect(await store.getBlock(4)).toEqual(block4);
+        expect((await store.getBlock(3))?.equals(block3)).toBe(true);
+        expect((await store.getBlock(4))?.equals(block4)).toBe(true);
       });
 
       it('getCheckpointedBlockByHash returns undefined for uncheckpointed blocks', async () => {
@@ -829,7 +829,7 @@ export function describeArchiverDataStore(
         expect(await store.getCheckpointedBlockByHash(hash)).toBeUndefined();
 
         // But getBlockByHash should work
-        expect(await store.getBlockByHash(hash)).toEqual(block1);
+        expect((await store.getBlockByHash(hash))?.equals(block1)).toBe(true);
       });
 
       it('getCheckpointedBlockByArchive returns undefined for uncheckpointed blocks', async () => {
@@ -846,7 +846,7 @@ export function describeArchiverDataStore(
         expect(await store.getCheckpointedBlockByArchive(archive)).toBeUndefined();
 
         // But getBlockByArchive should work
-        expect(await store.getBlockByArchive(archive)).toEqual(block1);
+        expect((await store.getBlockByArchive(archive))?.equals(block1)).toBe(true);
       });
 
       it('checkpoint adopts previously added uncheckpointed blocks', async () => {
@@ -1064,8 +1064,8 @@ export function describeArchiverDataStore(
         await expect(store.addBlocks([block3, block4])).resolves.toBe(true);
 
         // Verify blocks were added
-        expect(await store.getBlock(3)).toEqual(block3);
-        expect(await store.getBlock(4)).toEqual(block4);
+        expect((await store.getBlock(3))?.equals(block3)).toBe(true);
+        expect((await store.getBlock(4))?.equals(block4)).toBe(true);
       });
 
       it('allows blocks for the initial checkpoint when store is empty', async () => {
@@ -1083,8 +1083,8 @@ export function describeArchiverDataStore(
         await expect(store.addBlocks([block1, block2])).resolves.toBe(true);
 
         // Verify blocks were added
-        expect(await store.getBlock(1)).toEqual(block1);
-        expect(await store.getBlock(2)).toEqual(block2);
+        expect((await store.getBlock(1))?.equals(block1)).toBe(true);
+        expect((await store.getBlock(2))?.equals(block2)).toBe(true);
         expect(await store.getLatestBlockNumber()).toBe(2);
       });
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -669,7 +669,6 @@ export class BlockStore {
       body,
       CheckpointNumber(blockStorage.checkpointNumber!),
       blockStorage.indexWithinCheckpoint,
-      Fr.fromBuffer(blockHash),
     );
 
     if (block.number !== blockNumber) {

--- a/yarn-project/constants/src/constants.ts
+++ b/yarn-project/constants/src/constants.ts
@@ -21,7 +21,7 @@ export * from './constants.gen.js';
 // eslint-disable-next-line import/export
 export const INITIAL_L2_BLOCK_NUM: BlockNumber = BlockNumber(INITIAL_L2_BLOCK_NUM_RAW);
 
-/** The initial L2 checkpoint number (typed as CheckpointNumber). This is the first checkpont number in the Aztec L2 chain. */
+/** The initial L2 checkpoint number (typed as CheckpointNumber). This is the first checkpoint number in the Aztec L2 chain. */
 // Shadow the export from constants.gen above
 // eslint-disable-next-line import/export
 export const INITIAL_L2_CHECKPOINT_NUM: CheckpointNumber = CheckpointNumber(INITIAL_CHECKPOINT_NUM_RAW);

--- a/yarn-project/prover-client/src/block-factory/light.test.ts
+++ b/yarn-project/prover-client/src/block-factory/light.test.ts
@@ -125,7 +125,7 @@ describe('LightBlockBuilder', () => {
 
     const expectedHeader = await buildExpectedHeader(txs, l1ToL2Messages);
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds a 3 tx header', async () => {
@@ -137,7 +137,7 @@ describe('LightBlockBuilder', () => {
       return Promise.resolve([merge, rollupOutputs[2]]);
     });
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds a 4 tx header', async () => {
@@ -150,7 +150,7 @@ describe('LightBlockBuilder', () => {
       return [mergeLeft, mergeRight];
     });
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds a 4 tx header with no l1 to l2 messages', async () => {
@@ -164,7 +164,7 @@ describe('LightBlockBuilder', () => {
       return [mergeLeft, mergeRight];
     });
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds a 5 tx header', async () => {
@@ -178,7 +178,7 @@ describe('LightBlockBuilder', () => {
       return [merge20, rollupOutputs[4]];
     });
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds a single tx header', async () => {
@@ -187,7 +187,7 @@ describe('LightBlockBuilder', () => {
 
     const expectedHeader = await buildExpectedHeader(txs, l1ToL2Messages);
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   it('builds an empty header', async () => {
@@ -196,7 +196,7 @@ describe('LightBlockBuilder', () => {
 
     const expectedHeader = await buildExpectedHeader(txs, l1ToL2Messages);
 
-    expect(header).toEqual(expectedHeader);
+    expect(header.equals(expectedHeader)).toBe(true);
   });
 
   const makeTx = (i: number) => {

--- a/yarn-project/simulator/src/public/fixtures/utils.ts
+++ b/yarn-project/simulator/src/public/fixtures/utils.ts
@@ -132,8 +132,7 @@ export async function createTxForPublicCalls(
     : Gas.empty();
   const gasSettings = new GasSettings(gasLimits, teardownGasLimits, maxFeesPerGas, GasFees.empty());
   const txContext = new TxContext(Fr.zero(), Fr.zero(), gasSettings);
-  const header = BlockHeader.empty();
-  header.globalVariables = globals;
+  const header = BlockHeader.empty({ globalVariables: globals });
   const constantData = new TxConstantData(header, txContext, Fr.zero(), Fr.zero());
   const includeByTimestamp = 0n; // Not used in the simulator.
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -5,13 +5,9 @@ import {
   GAS_ESTIMATION_TEARDOWN_DA_GAS_LIMIT,
   GAS_ESTIMATION_TEARDOWN_L2_GAS_LIMIT,
   NULLIFIER_SUBTREE_HEIGHT,
-  PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import type { AztecKVStore } from '@aztec/kv-store';
-import { openTmpStore } from '@aztec/kv-store/lmdb';
-import { type AppendOnlyTree, Poseidon, StandardTree, newTree } from '@aztec/merkle-tree';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
 import { PublicDataWrite, PublicSimulatorConfig, PublicTxResult, RevertCode } from '@aztec/stdlib/avm';
@@ -24,8 +20,8 @@ import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server'
 import { countAccumulatedItems } from '@aztec/stdlib/kernel';
 import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { fr, mockTx } from '@aztec/stdlib/testing';
-import { AppendOnlyTreeSnapshot, MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, PartialStateReference, StateReference } from '@aztec/stdlib/tx';
+import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { GlobalVariables } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
@@ -63,10 +59,7 @@ describe('public_tx_simulator', () => {
   let merkleTreesCopy: MerkleTreeWriteOperations;
   let contractsDB: PublicContractsDB;
 
-  let publicDataTree: AppendOnlyTree<Fr>;
-
   let worldStateService: NativeWorldStateService;
-  let treeStore: AztecKVStore;
   let simulator: PublicTxSimulator;
   let simulateInternal: jest.SpiedFunction<
     (
@@ -271,35 +264,11 @@ describe('public_tx_simulator', () => {
     merkleTreesCopy = await worldStateService.fork();
     contractsDB = new PublicContractsDB(mock<ContractDataSource>());
 
-    treeStore = openTmpStore();
-
-    publicDataTree = await newTree(
-      StandardTree,
-      treeStore,
-      new Poseidon(),
-      'PublicData',
-      Fr,
-      PUBLIC_DATA_TREE_HEIGHT,
-      1, // Add a default low leaf for the public data hints to be proved against.
-    );
-    const snap = new AppendOnlyTreeSnapshot(
-      Fr.fromBuffer(publicDataTree.getRoot(true)),
-      Number(publicDataTree.getNumLeaves(true)),
-    );
-    const header = BlockHeader.empty();
-    const stateReference = new StateReference(
-      header.state.l1ToL2MessageTree,
-      new PartialStateReference(header.state.partial.noteHashTree, header.state.partial.nullifierTree, snap),
-    );
-    // Clone the whole state because somewhere down the line (AbstractPhaseManager) the public data root is modified in the referenced header directly :/
-    header.state = StateReference.fromBuffer(stateReference.toBuffer());
-
     simulator = createSimulator({ skipFeeEnforcement: true });
   }, 30_000);
 
   afterEach(async () => {
     await worldStateService.close();
-    await treeStore.delete();
   });
 
   it('runs a tx with enqueued public calls in setup phase only', async () => {

--- a/yarn-project/stdlib/src/block/l2_block_new.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.ts
@@ -27,7 +27,6 @@ export class L2BlockNew {
     public checkpointNumber: CheckpointNumber,
     /** Index of the block within the checkpoint. */
     public indexWithinCheckpoint: number,
-    private blockHash: Fr | undefined = undefined,
   ) {}
 
   get number(): BlockNumber {
@@ -80,11 +79,23 @@ export class L2BlockNew {
    * Returns the block's hash (hash of block header).
    * @returns The block's hash.
    */
-  public async hash(): Promise<Fr> {
-    if (this.blockHash === undefined) {
-      this.blockHash = await this.header.hash();
-    }
-    return this.blockHash;
+  public hash(): Promise<Fr> {
+    return this.header.hash();
+  }
+
+  /**
+   * Checks if this block equals another block.
+   * @param other - The other block to compare with.
+   * @returns True if both blocks are equal.
+   */
+  public equals(other: this): boolean {
+    return (
+      this.archive.equals(other.archive) &&
+      this.header.equals(other.header) &&
+      this.body.equals(other.body) &&
+      this.checkpointNumber === other.checkpointNumber &&
+      this.indexWithinCheckpoint === other.indexWithinCheckpoint
+    );
   }
 
   public toBlobFields(): Fr[] {
@@ -185,7 +196,6 @@ export class L2BlockNew {
 
   toBlockInfo(): L2BlockInfo {
     return {
-      blockHash: this.blockHash,
       archive: this.archive.root,
       lastArchive: this.header.lastArchive.root,
       blockNumber: this.number,

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -17,22 +17,24 @@ import { StateReference } from './state_reference.js';
 
 /** A header of an L2 block. */
 export class BlockHeader {
+  private _cachedHash?: Promise<Fr>;
+
   constructor(
     /** Snapshot of archive before the block is applied. */
-    public lastArchive: AppendOnlyTreeSnapshot,
+    public readonly lastArchive: AppendOnlyTreeSnapshot,
     /** State reference. */
-    public state: StateReference,
+    public readonly state: StateReference,
     /**
      * Hash of the sponge blob after the tx effects of this block has been applied.
      * May contain tx effects from the previous blocks in the same checkpoint.
      */
-    public spongeBlobHash: Fr,
+    public readonly spongeBlobHash: Fr,
     /** Global variables of an L2 block. */
-    public globalVariables: GlobalVariables,
+    public readonly globalVariables: GlobalVariables,
     /** Total fees in the block, computed by the root rollup circuit */
-    public totalFees: Fr,
+    public readonly totalFees: Fr,
     /** Total mana used in the block, computed by the root rollup circuit */
-    public totalManaUsed: Fr,
+    public readonly totalManaUsed: Fr,
   ) {}
 
   static get schema(): ZodFor<BlockHeader> {
@@ -160,7 +162,10 @@ export class BlockHeader {
   }
 
   hash(): Promise<Fr> {
-    return poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH);
+    if (!this._cachedHash) {
+      this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH);
+    }
+    return this._cachedHash;
   }
 
   static random(overrides: Partial<FieldsOf<BlockHeader>> & Partial<FieldsOf<GlobalVariables>> = {}): BlockHeader {

--- a/yarn-project/world-state/src/test/utils.ts
+++ b/yarn-project/world-state/src/test/utils.ts
@@ -16,6 +16,7 @@ import type {
 } from '@aztec/stdlib/interfaces/server';
 import { mockCheckpointAndMessages, mockL1ToL2Messages } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot, MerkleTreeId } from '@aztec/stdlib/trees';
+import { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { NativeWorldStateService } from '../native/native_world_state.js';
 
@@ -59,7 +60,7 @@ export async function updateBlockState(block: L2BlockNew, l1ToL2Messages: Fr[], 
   await Promise.all([publicDataInsert, nullifierInsert, noteHashInsert, messageInsert]);
 
   const state = await fork.getStateReference();
-  block.header.state = state;
+  block.header = BlockHeader.from({ ...block.header, state });
   await fork.updateArchive(block.header);
 
   const archiveState = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);


### PR DESCRIPTION
For [my other work](https://github.com/AztecProtocol/aztec-packages/pull/19030/changes) I need retrieval of a block header hash to be fast.

In this PR I ensure this is the case by caching the hash.