### PR TITLE
fix: memory leak in broker instrumentation

### DIFF
--- a/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
@@ -776,6 +776,48 @@ describe.each([
       await broker.reportProvingJobSuccess(id, makeOutputsUri());
       await assertJobStatus(id, 'not-found');
     });
+
+    it('cleans up enqueuedAt map after job completion', async () => {
+      // This test verifies that the enqueuedAt map is properly cleaned up
+      // after jobs complete to prevent memory leaks
+
+      const provingJob1: ProvingJob = {
+        id: makeRandomProvingJobId(),
+        type: ProvingRequestType.PARITY_BASE,
+        epochNumber: EpochNumber(1),
+        inputsUri: makeInputsUri(),
+      };
+
+      const provingJob2: ProvingJob = {
+        id: makeRandomProvingJobId(),
+        type: ProvingRequestType.PARITY_BASE,
+        epochNumber: EpochNumber(1),
+        inputsUri: makeInputsUri(),
+      };
+
+      // Access the private enqueuedAt map
+      const getEnqueuedAtSize = () => (broker as any).enqueuedAt.size;
+
+      expect(getEnqueuedAtSize()).toBe(0);
+
+      await broker.enqueueProvingJob(provingJob1);
+      await broker.enqueueProvingJob(provingJob2);
+
+      expect(getEnqueuedAtSize()).toBe(2);
+
+      await broker.getProvingJob();
+      await broker.getProvingJob();
+
+      expect(getEnqueuedAtSize()).toBe(0);
+
+      await broker.reportProvingJobSuccess(provingJob1.id, makeOutputsUri());
+      await broker.reportProvingJobSuccess(provingJob2.id, makeOutputsUri());
+
+      await assertJobStatus(provingJob1.id, 'fulfilled');
+      await assertJobStatus(provingJob2.id, 'fulfilled');
+
+      expect(getEnqueuedAtSize()).toBe(0);
+    });
   });
 
   describe('Timeouts', () => {

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -302,6 +302,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Tr
       this.resultsCache.delete(id);
       this.inProgress.delete(id);
       this.retries.delete(id);
+      this.enqueuedAt.delete(id);
     }
   }
 
@@ -354,6 +355,8 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Tr
           const enqueuedAt = this.enqueuedAt.get(job.id);
           if (enqueuedAt) {
             this.instrumentation.recordJobWait(job.type, enqueuedAt);
+            // we can clear this flag now.
+            this.enqueuedAt.delete(job.id);
           }
 
           return { job, time };


### PR DESCRIPTION
This PR fixes a memory leak where timers were left open in a map used by the ProverBroker to track how long a job sat in the queue.