### PR TITLE
fix: only notify Slack when merge-train PR is dequeued without being merged

### DIFF
--- a/.github/workflows/merge-queue-dequeue-notify.yml
+++ b/.github/workflows/merge-queue-dequeue-notify.yml
@@ -8,7 +8,7 @@ jobs:
   notify-slack:
     name: Notify Slack
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.head.ref, 'merge-train/')
+    if: startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.event.pull_request.merged != true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip Slack notification when a merge-train PR is dequeued due to successful merge
- Only notify when the PR is removed from the merge queue for other reasons (failed checks, conflicts, etc.)

## Test plan
- Merge to next, verify no notification when merge-train PR merges successfully
- Verify notification still fires when merge-train PR is dequeued due to failure