### PR TITLE
feat: Add ci-barretenberg-full CI mode

### DIFF
--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -76,6 +76,8 @@ function determine_ci_mode {
     CI_MODE="docs"
   elif has_label "ci-barretenberg" || [ "${TARGET_BRANCH:-}" == "merge-train/barretenberg" ]; then
     CI_MODE="barretenberg"
+  elif has_label "ci-barretenberg-full"; then
+    CI_MODE="barretenberg-full"
   # We don't distinguish nightlies currently.
   # elif [[ "${GITHUB_REF:-}" == *"-nightly."* ]] || [[ "${GITHUB_REF:-}" == *"-rc."* ]]; then
   #   CI_MODE="nightly"

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -25,8 +25,12 @@ case "$cmd" in
   hash)
     hash
     ;;
-  ""|clean|ci|test|test_cmds|bench|bench_cmds|release)
+  ""|clean|test|test_cmds|bench|bench_cmds|release)
     bootstrap_all $@
+    ;;
+  ci)
+    bootstrap_all
+    bootstrap_all test
     ;;
   "release-preview")
     ./docs/bootstrap.sh release-preview

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -592,6 +592,13 @@ case "$cmd" in
     export AVM_TRANSPILER=0
     barretenberg/cpp/bootstrap.sh ci
     ;;
+  "ci-barretenberg-full")
+    export CI=1
+    export USE_TEST_CACHE=1
+    export AVM=0
+    export AVM_TRANSPILER=0
+    barretenberg/bootstrap.sh ci
+    ;;
   "ci-avm-inputs-collection")
     # Nightly job: Run e2e tests with AVM circuit inputs dumping, upload to cache
     export CI=1


### PR DESCRIPTION
## Summary
- Adds a new `ci-barretenberg-full` CI mode triggered by the `ci-barretenberg-full` label
- Runs the full `barretenberg/bootstrap.sh ci` instead of just `barretenberg/cpp/bootstrap.sh ci`
- This builds and tests all barretenberg components: cpp, ts, rust, acir_tests, sol, and docs

## Test plan
- [ ] Merge this PR first (using `ci-full` or default mode)
- [ ] On subsequent PRs, use the `ci-barretenberg-full` label to trigger full barretenberg CI