### PR TITLE
feat(avm): faster interactions tracegen

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "barretenberg/common/utils.hpp"
 #include <cstddef>
 #include <functional>
 #include <vector>
+
+#include "barretenberg/common/tuple.hpp"
+#include "barretenberg/common/utils.hpp"
 
 // Specialization of std::hash for std::vector<T> to be used as a key in unordered_flat_map.
 namespace std {
@@ -30,6 +32,14 @@ template <typename T, size_t SIZE> struct hash<std::array<T, SIZE>> {
         return [&arr]<size_t... Is>(std::index_sequence<Is...>) {
             return bb::utils::hash_as_tuple(arr[Is]...);
         }(std::make_index_sequence<SIZE>{});
+    }
+};
+
+// Define a hash function for flat_tuple::tuple so that it can be used as a key in a std::unordered_map.
+template <typename... Ts> struct hash<bb::flat_tuple::tuple<Ts...>> {
+    inline std::size_t operator()(const bb::flat_tuple::tuple<Ts...>& tup) const noexcept
+    {
+        return bb::flat_tuple::apply([](const auto&... args) { return bb::utils::hash_as_tuple(args...); }, tup);
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+// Specialization of std::hash for std::vector<T> to be used as a key in unordered_flat_map.
+namespace std {
+
+template <typename T> struct hash<std::vector<T>> {
+    size_t operator()(const std::vector<T>& vec) const
+    {
+        size_t seed = vec.size();
+        for (const auto& item : vec) {
+            seed ^= std::hash<T>{}(item) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
+};
+
+} // namespace std

--- a/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include "barretenberg/common/utils.hpp"
 #include <cstddef>
+#include <functional>
 #include <vector>
 
 // Specialization of std::hash for std::vector<T> to be used as a key in unordered_flat_map.
 namespace std {
+
+template <typename T> struct hash<std::reference_wrapper<const T>> {
+    size_t operator()(const std::reference_wrapper<const T>& ref) const { return std::hash<T>{}(ref.get()); }
+};
 
 template <typename T> struct hash<std::vector<T>> {
     size_t operator()(const std::vector<T>& vec) const
@@ -14,6 +20,16 @@ template <typename T> struct hash<std::vector<T>> {
             seed ^= std::hash<T>{}(item) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         }
         return seed;
+    }
+};
+
+// Define a hash function for std::array so that it can be used as a key in a std::unordered_map.
+template <typename T, size_t SIZE> struct hash<std::array<T, SIZE>> {
+    inline std::size_t operator()(const std::array<T, SIZE>& arr) const noexcept
+    {
+        return [&arr]<size_t... Is>(std::index_sequence<Is...>) {
+            return bb::utils::hash_as_tuple(arr[Is]...);
+        }(std::make_index_sequence<SIZE>{});
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/common/stringify.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/stringify.hpp
@@ -5,7 +5,9 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 
+#include "barretenberg/common/tuple.hpp"
 #include "barretenberg/numeric/uint128/uint128.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
@@ -51,6 +53,22 @@ std::string column_values_to_string(const std::array<FF, N>& arr, const std::arr
             stream << ", ";
         }
     }
+    stream << "}";
+    return stream.str();
+}
+
+template <typename... Ts, size_t N>
+std::string column_values_to_string(const flat_tuple::tuple<Ts...>& tup, const std::array<ColumnAndShifts, N>& columns)
+{
+    static_assert(sizeof...(Ts) == N, "Tuple and columns array must have the same size");
+    std::ostringstream stream;
+    stream << "{";
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+        size_t i = 0;
+        ((stream << (i++ > 0 ? ", " : "") << COLUMN_NAMES[static_cast<size_t>(columns[Is])] << ": "
+                 << field_to_string(flat_tuple::get<Is>(tup))),
+         ...);
+    }(std::make_index_sequence<N>{});
     stream << "}";
     return stream.str();
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/tx.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/tx.test.cpp
@@ -578,9 +578,9 @@ TEST(TxExecutionConstrainingTest, WriteTreeValue)
     tracegen::PrecomputedTraceBuilder precomputed_builder;
     precomputed_builder.process_misc(trace, AVM_PUBLIC_INPUTS_COLUMNS_MAX_LENGTH);
 
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_tree_insert_value_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_l2_l1_msg_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_write_l2_l1_msg_settings>()->process(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_tree_insert_value_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_l2_l1_msg_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_write_l2_l1_msg_settings>(trace);
 }
 
 TEST_F(TxExecutionConstrainingTestHelper, CollectFees)
@@ -691,11 +691,11 @@ TEST_F(TxExecutionConstrainingTestHelper, CollectFees)
     precomputed_builder.process_misc(trace, AVM_PUBLIC_INPUTS_COLUMNS_MAX_LENGTH);
 
     check_relation<tx>(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_phase_spec_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_phase_length_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_public_call_request_phase_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_effective_fee_public_inputs_settings>()->process(trace);
-    TxTraceBuilder::interactions.get_test_job<lookup_tx_read_fee_payer_public_inputs_settings>()->process(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_phase_spec_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_phase_length_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_public_call_request_phase_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_effective_fee_public_inputs_settings>(trace);
+    check_interaction<TxTraceBuilder, lookup_tx_read_fee_payer_public_inputs_settings>(trace);
 }
 
 TEST(TxExecutionConstrainingTest, NegativeTreePaddingChecks)

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
@@ -10,6 +10,7 @@
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
 #include "barretenberg/vm2/constraining/polynomials.hpp"
+#include "barretenberg/vm2/tracegen/lib/shared_index_cache.hpp"
 #include "barretenberg/vm2/tracegen/test_trace_container.hpp"
 
 namespace bb::avm2::constraining {
@@ -73,23 +74,35 @@ template <typename Relation> void check_relation(const tracegen::TestTraceContai
     [&]<size_t... Is>(std::index_sequence<Is...>) { check_relation<Relation>(trace, Is...); }(subrelations);
 }
 
-template <typename TraceBuilder, typename... Setting> inline void check_interaction(tracegen::TestTraceContainer& trace)
+// Get a default cache for test convenience (used for backwards compatibility in tests).
+inline tracegen::SharedIndexCache& get_default_test_cache()
 {
-    (TraceBuilder::interactions.template get_test_job<Setting>()->process(trace), ...);
+    static tracegen::SharedIndexCache cache;
+    return cache;
+}
+
+template <typename TraceBuilder, typename... Setting>
+inline void check_interaction(tracegen::TestTraceContainer& trace,
+                              tracegen::SharedIndexCache& cache = get_default_test_cache())
+{
+    (TraceBuilder::interactions.template get_test_job<Setting>(cache)->process(trace), ...);
 }
 
 // Warning: The below requires ALL permutation settings as defined in InteractionDefinition.add():
 template <typename TraceBuilder, typename... Setting>
-inline void check_multipermutation_interaction(tracegen::TestTraceContainer& trace)
+inline void check_multipermutation_interaction(tracegen::TestTraceContainer& trace,
+                                               tracegen::SharedIndexCache& cache = get_default_test_cache())
 {
     // Concatenates the names of given permutation interactions:
     std::string name = (std::string(Setting::NAME) + ...);
-    TraceBuilder::interactions.get_test_job(name)->process(trace);
+    TraceBuilder::interactions.get_test_job(name, cache)->process(trace);
 }
 
-template <typename TraceBuilder> inline void check_all_interactions(tracegen::TestTraceContainer& trace)
+template <typename TraceBuilder>
+inline void check_all_interactions(tracegen::TestTraceContainer& trace,
+                                   tracegen::SharedIndexCache& cache = get_default_test_cache())
 {
-    for (auto& job : TraceBuilder::interactions.get_all_test_jobs()) {
+    for (auto& job : TraceBuilder::interactions.get_all_test_jobs(cache)) {
         job->process(trace);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
@@ -74,34 +74,25 @@ template <typename Relation> void check_relation(const tracegen::TestTraceContai
     [&]<size_t... Is>(std::index_sequence<Is...>) { check_relation<Relation>(trace, Is...); }(subrelations);
 }
 
-// Get a default cache for test convenience (used for backwards compatibility in tests).
-inline tracegen::SharedIndexCache& get_default_test_cache()
+template <typename TraceBuilder, typename... Setting> inline void check_interaction(tracegen::TestTraceContainer& trace)
 {
-    static tracegen::SharedIndexCache cache;
-    return cache;
-}
-
-template <typename TraceBuilder, typename... Setting>
-inline void check_interaction(tracegen::TestTraceContainer& trace,
-                              tracegen::SharedIndexCache& cache = get_default_test_cache())
-{
+    tracegen::SharedIndexCache cache;
     (TraceBuilder::interactions.template get_test_job<Setting>(cache)->process(trace), ...);
 }
 
 // Warning: The below requires ALL permutation settings as defined in InteractionDefinition.add():
 template <typename TraceBuilder, typename... Setting>
-inline void check_multipermutation_interaction(tracegen::TestTraceContainer& trace,
-                                               tracegen::SharedIndexCache& cache = get_default_test_cache())
+inline void check_multipermutation_interaction(tracegen::TestTraceContainer& trace)
 {
+    tracegen::SharedIndexCache cache;
     // Concatenates the names of given permutation interactions:
     std::string name = (std::string(Setting::NAME) + ...);
     TraceBuilder::interactions.get_test_job(name, cache)->process(trace);
 }
 
-template <typename TraceBuilder>
-inline void check_all_interactions(tracegen::TestTraceContainer& trace,
-                                   tracegen::SharedIndexCache& cache = get_default_test_cache())
+template <typename TraceBuilder> inline void check_all_interactions(tracegen::TestTraceContainer& trace)
 {
+    tracegen::SharedIndexCache cache;
     for (auto& job : TraceBuilder::interactions.get_all_test_jobs(cache)) {
         job->process(trace);
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/db_types.hpp
@@ -4,6 +4,7 @@
 #include "barretenberg/crypto/merkle_tree/types.hpp"
 #include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/map_hashes.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 
 namespace bb::avm2::simulation {
@@ -83,18 +84,3 @@ auto& get_tree_info_helper(world_state::MerkleTreeId tree_id, auto& tree_roots)
         throw std::runtime_error("AVM cannot process tree id: " + std::to_string(static_cast<uint64_t>(tree_id)));
     }
 }
-
-// Specialization of std::hash for std::vector<FF> to be used as a key in unordered_flat_map.
-// Used in raw_data_dbs and hinting_dbs
-namespace std {
-template <> struct hash<std::vector<bb::avm2::FF>> {
-    size_t operator()(const std::vector<bb::avm2::FF>& vec) const
-    {
-        size_t seed = vec.size();
-        for (const auto& item : vec) {
-            seed ^= std::hash<bb::avm2::FF>{}(item) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        }
-        return seed;
-    }
-};
-} // namespace std

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.cpp
@@ -1,0 +1,26 @@
+#include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
+
+#include <algorithm>
+#include <unordered_set>
+
+namespace bb::avm2::tracegen {
+
+void order_jobs_by_destination_columns(std::vector<std::unique_ptr<InteractionBuilderInterface>>& jobs)
+{
+    // Identify first occurrences of each fingerprint.
+    std::unordered_set<size_t> seen_fingerprints;
+    std::unordered_set<InteractionBuilderInterface*> first_occurrence_jobs;
+
+    for (const auto& job : jobs) {
+        auto fp = job->get_destination_columns_fingerprint();
+        auto [_, inserted] = seen_fingerprints.insert(fp);
+        if (inserted) {
+            first_occurrence_jobs.insert(job.get());
+        }
+    }
+
+    // Stable partition: first occurrences come first.
+    std::ranges::stable_partition(jobs, [&](const auto& job) { return first_occurrence_jobs.contains(job.get()); });
+}
+
+} // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.cpp
@@ -1,15 +1,16 @@
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
 
 #include <algorithm>
-#include <unordered_set>
+
+#include "barretenberg/vm2/common/set.hpp"
 
 namespace bb::avm2::tracegen {
 
 void order_jobs_by_destination_columns(std::vector<std::unique_ptr<InteractionBuilderInterface>>& jobs)
 {
     // Identify first occurrences of each fingerprint.
-    std::unordered_set<size_t> seen_fingerprints;
-    std::unordered_set<InteractionBuilderInterface*> first_occurrence_jobs;
+    unordered_flat_set<size_t> seen_fingerprints;
+    unordered_flat_set<InteractionBuilderInterface*> first_occurrence_jobs;
 
     for (const auto& job : jobs) {
         auto fp = job->get_destination_columns_fingerprint();

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
@@ -22,13 +22,3 @@ template <typename T> std::vector<T> concatenate_jobs(std::vector<T>&& first, au
 }
 
 } // namespace bb::avm2::tracegen
-
-// Define a hash function for std::array so that it can be used as a key in a std::unordered_map.
-template <typename T, size_t SIZE> struct std::hash<std::array<T, SIZE>> {
-    inline std::size_t operator()(const std::array<T, SIZE>& arr) const noexcept
-    {
-        return [&arr]<size_t... Is>(std::index_sequence<Is...>) {
-            return bb::utils::hash_as_tuple(arr[Is]...);
-        }(std::make_index_sequence<SIZE>{});
-    }
-};

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
@@ -10,6 +10,16 @@
 
 namespace bb::avm2::tracegen {
 
+// Helper to generate a tuple type with N const FF& elements.
+namespace detail {
+template <size_t N, typename = std::make_index_sequence<N>> struct RefTupleHelper;
+template <size_t N, size_t... Is> struct RefTupleHelper<N, std::index_sequence<Is...>> {
+    template <size_t> using ConstFFRef = const FF&;
+    using type = flat_tuple::tuple<ConstFFRef<Is>...>;
+};
+} // namespace detail
+template <size_t N> using RefTuple = typename detail::RefTupleHelper<N>::type;
+
 class InteractionBuilderInterface {
   public:
     virtual ~InteractionBuilderInterface() = default;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_builder.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <memory>
+#include <optional>
 #include <vector>
 
+#include "barretenberg/vm2/generated/columns.hpp"
+#include "barretenberg/vm2/tracegen/lib/shared_index_cache.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
 namespace bb::avm2::tracegen {
@@ -10,6 +14,10 @@ class InteractionBuilderInterface {
   public:
     virtual ~InteractionBuilderInterface() = default;
     virtual void process(TraceContainer& trace) = 0;
+    // Fingerprint of the destination columns.
+    // Used to identify jobs that share the same destination columns and prevent them
+    // from building the index at the same time.
+    virtual size_t get_destination_columns_fingerprint() const { return 0; }
 };
 
 // A concatenate that works with movable objects.
@@ -20,5 +28,12 @@ template <typename T> std::vector<T> concatenate_jobs(std::vector<T>&& first, au
     (std::move(rest.begin(), rest.end(), std::back_inserter(result)), ...);
     return result;
 }
+
+// Orders jobs to minimize index building contention.
+// Jobs with first occurrences of each destination column key come first, followed by jobs that share
+// destination column keys with previously seen ones.
+// This ordering helps the SharedIndexCache by ensuring that when multiple jobs share
+// the same destination, only the first one builds the index while others wait.
+void order_jobs_by_destination_columns(std::vector<std::unique_ptr<InteractionBuilderInterface>>& jobs);
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.cpp
@@ -2,35 +2,38 @@
 
 namespace bb::avm2::tracegen {
 
-std::vector<std::unique_ptr<InteractionBuilderInterface>> InteractionDefinition::get_all_jobs() const
+std::vector<std::unique_ptr<InteractionBuilderInterface>> InteractionDefinition::get_all_jobs(
+    SharedIndexCache& cache) const
 {
     std::vector<std::unique_ptr<InteractionBuilderInterface>> jobs;
     jobs.reserve(interactions.size());
     for (const auto& key : std::ranges::views::keys(interactions)) {
-        jobs.push_back(get_job(key));
+        jobs.push_back(get_job(key, cache));
     }
     return jobs;
 }
 
-std::vector<std::unique_ptr<InteractionBuilderInterface>> InteractionDefinition::get_all_test_jobs() const
+std::vector<std::unique_ptr<InteractionBuilderInterface>> InteractionDefinition::get_all_test_jobs(
+    SharedIndexCache& cache) const
 {
     std::vector<std::unique_ptr<InteractionBuilderInterface>> jobs;
     jobs.reserve(interactions.size());
     for (const auto& key : std::ranges::views::keys(interactions)) {
-        jobs.push_back(get_test_job(key));
+        jobs.push_back(get_test_job(key, cache));
     }
     return jobs;
 }
 
-std::unique_ptr<InteractionBuilderInterface> InteractionDefinition::get_job(const std::string& interaction_name) const
+std::unique_ptr<InteractionBuilderInterface> InteractionDefinition::get_job(const std::string& interaction_name,
+                                                                            SharedIndexCache& cache) const
 {
-    return get_job_internal(interaction_name)(/*strict=*/false);
+    return get_job_internal(interaction_name)(/*strict=*/false, cache);
 }
 
-std::unique_ptr<InteractionBuilderInterface> InteractionDefinition::get_test_job(
-    const std::string& interaction_name) const
+std::unique_ptr<InteractionBuilderInterface> InteractionDefinition::get_test_job(const std::string& interaction_name,
+                                                                                 SharedIndexCache& cache) const
 {
-    return get_job_internal(interaction_name)(/*strict=*/true);
+    return get_job_internal(interaction_name)(/*strict=*/true, cache);
 }
 
 const InteractionDefinition::Factory& InteractionDefinition::get_job_internal(const std::string& interaction_name) const

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp"
 #include "barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp"
 #include "barretenberg/vm2/tracegen/lib/permutation_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/shared_index_cache.hpp"
 #include "barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp"
 
 namespace bb::avm2::tracegen {
@@ -46,60 +47,65 @@ class InteractionDefinition {
         return *this;
     }
 
-    // Jobs for production.
-    std::vector<std::unique_ptr<InteractionBuilderInterface>> get_all_jobs() const;
+    // Jobs for production (with shared index cache for efficient lookup index sharing).
+    std::vector<std::unique_ptr<InteractionBuilderInterface>> get_all_jobs(SharedIndexCache& cache) const;
     // Stricter/more assertive jobs for testing.
-    std::vector<std::unique_ptr<InteractionBuilderInterface>> get_all_test_jobs() const;
+    std::vector<std::unique_ptr<InteractionBuilderInterface>> get_all_test_jobs(SharedIndexCache& cache) const;
 
-    std::unique_ptr<InteractionBuilderInterface> get_job(const std::string& interaction_name) const;
-    std::unique_ptr<InteractionBuilderInterface> get_test_job(const std::string& interaction_name) const;
-    template <typename InteractionSettings> std::unique_ptr<InteractionBuilderInterface> get_test_job() const
+    std::unique_ptr<InteractionBuilderInterface> get_job(const std::string& interaction_name,
+                                                         SharedIndexCache& cache) const;
+    std::unique_ptr<InteractionBuilderInterface> get_test_job(const std::string& interaction_name,
+                                                              SharedIndexCache& cache) const;
+    template <typename InteractionSettings>
+    std::unique_ptr<InteractionBuilderInterface> get_test_job(SharedIndexCache& cache) const
     {
-        return get_test_job(std::string(InteractionSettings::NAME));
+        return get_test_job(std::string(InteractionSettings::NAME), cache);
     }
 
   private:
-    using Factory = std::function<std::unique_ptr<InteractionBuilderInterface>(bool strict)>;
+    // Factory takes (strict, cache) and returns the interaction builder.
+    using Factory = std::function<std::unique_ptr<InteractionBuilderInterface>(bool strict, SharedIndexCache& cache)>;
     std::unordered_map<std::string, Factory> interactions;
 
     template <InteractionType type, typename... InteractionSettings>
     static Factory get_interaction_factory(auto&&... args)
     {
         if constexpr (type == InteractionType::LookupGeneric) {
-            return [args...](bool) {
+            return [args...](bool, SharedIndexCache& cache) {
                 // This class always checks.
-                return std::make_unique<LookupIntoDynamicTableGeneric<InteractionSettings...>>(args...);
+                return std::make_unique<LookupIntoDynamicTableGeneric<InteractionSettings...>>(cache, args...);
             };
         } else if constexpr (type == InteractionType::LookupIntoBitwise) {
-            return [args...](bool strict) {
+            return [args...](bool strict, SharedIndexCache&) {
                 return strict ? std::make_unique<AddChecksToBuilder<LookupIntoBitwise<InteractionSettings...>>>(args...)
                               : std::make_unique<LookupIntoBitwise<InteractionSettings...>>(args...);
             };
         } else if constexpr (type == InteractionType::LookupIntoIndexedByClk) {
-            return [args...](bool strict) {
+            return [args...](bool strict, SharedIndexCache&) {
                 return strict ? std::make_unique<AddChecksToBuilder<LookupIntoIndexedByClk<InteractionSettings...>>>(
                                     args...)
                               : std::make_unique<LookupIntoIndexedByClk<InteractionSettings...>>(args...);
             };
         } else if constexpr (type == InteractionType::LookupIntoPDecomposition) {
-            return [args...](bool strict) {
+            return [args...](bool strict, SharedIndexCache&) {
                 return strict ? std::make_unique<AddChecksToBuilder<LookupIntoPDecomposition<InteractionSettings...>>>(
                                     args...)
                               : std::make_unique<LookupIntoPDecomposition<InteractionSettings...>>(args...);
             };
         } else if constexpr (type == InteractionType::LookupSequential) {
-            return [args...](bool) {
+            return [args...](bool, SharedIndexCache&) {
                 // This class always checks.
                 return std::make_unique<LookupIntoDynamicTableSequential<InteractionSettings...>>(args...);
             };
         } else if constexpr (type == InteractionType::Permutation) {
-            return [args...](bool strict) {
+            return [args...](bool strict, SharedIndexCache&) {
                 return strict ? std::make_unique<CheckingPermutationBuilder<InteractionSettings...>>(args...)
                               : std::make_unique<PermutationBuilder<InteractionSettings...>>(args...);
             };
         } else if constexpr (type == InteractionType::MultiPermutation) {
-            return
-                [args...](bool) { return std::make_unique<MultiPermutationBuilder<InteractionSettings...>>(args...); };
+            return [args...](bool, SharedIndexCache&) {
+                return std::make_unique<MultiPermutationBuilder<InteractionSettings...>>(args...);
+            };
         } else {
             throw std::runtime_error("Interaction type not supported: " + std::to_string(static_cast<int>(type)));
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -20,16 +20,6 @@
 
 namespace bb::avm2::tracegen {
 
-// Helper to generate a tuple type with N const FF& elements.
-namespace detail {
-template <size_t N, typename = std::make_index_sequence<N>> struct RefTupleHelper;
-template <size_t N, size_t... Is> struct RefTupleHelper<N, std::index_sequence<Is...>> {
-    template <size_t> using ConstFFRef = const FF&;
-    using type = flat_tuple::tuple<ConstFFRef<Is>...>;
-};
-} // namespace detail
-template <size_t N> using RefTuple = typename detail::RefTupleHelper<N>::type;
-
 // A lookup builder that uses a function `find_in_dst` to find the destination row for a given source tuple.
 template <typename LookupSettings_> class IndexedLookupTraceBuilder : public InteractionBuilderInterface {
   public:
@@ -119,11 +109,11 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
         size_t key_hash = std::hash<TupleType>{}(tup);
         auto it = index_ptr_->find(key_hash);
         if (it != index_ptr_->end()) {
-            uint32_t row = it->second;
-            // Verify the actual values match (handles hash collisions).
-            auto dst_values = trace_ptr_->get_multiple(LookupSettings::DST_COLUMNS, row);
-            if (dst_values == tup) {
-                return row;
+            const auto& rows = it->second;
+            for (uint32_t row : rows) {
+                if (trace_ptr_->get_multiple(LookupSettings::DST_COLUMNS, row) == tup) {
+                    return row;
+                }
             }
         }
         throw std::runtime_error("Failed computing counts for " + std::string(LookupSettings::NAME) +
@@ -139,9 +129,21 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
         trace.visit_column(this->outer_dst_selector, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(LookupSettings::DST_COLUMNS, row);
             size_t key_hash = std::hash<decltype(dst_values)>{}(dst_values);
-            // FIXME: THIS IS NOT CORRECT!!!
-            // If hash collision, keep the first one (don't insert if key already exists).
-            idx.insert({ key_hash, row });
+
+            auto& rows = idx[key_hash];
+            // We need to handle possible hash collisions.
+            bool found_match = false;
+            for (uint32_t existing_row : rows) {
+                if (trace.get_multiple(LookupSettings::DST_COLUMNS, existing_row) == dst_values) {
+                    found_match = true;
+                    break;
+                }
+            }
+            // If we find a match, we keep that row.
+            // If we don't find a match, we add the new row.
+            if (!found_match) {
+                rows.push_back(row);
+            }
         });
         return idx;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -5,7 +5,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 
+#include "barretenberg/common/tuple.hpp"
 #include "barretenberg/common/utils.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
@@ -16,6 +18,16 @@
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
 namespace bb::avm2::tracegen {
+
+// Helper to generate a tuple type with N const FF& elements.
+namespace detail {
+template <size_t N, typename = std::make_index_sequence<N>> struct RefTupleHelper;
+template <size_t N, size_t... Is> struct RefTupleHelper<N, std::index_sequence<Is...>> {
+    template <size_t> using ConstFFRef = const FF&;
+    using type = flat_tuple::tuple<ConstFFRef<Is>...>;
+};
+} // namespace detail
+template <size_t N> using RefTuple = typename detail::RefTupleHelper<N>::type;
 
 // A lookup builder that uses a function `find_in_dst` to find the destination row for a given source tuple.
 template <typename LookupSettings_> class IndexedLookupTraceBuilder : public InteractionBuilderInterface {
@@ -58,7 +70,8 @@ template <typename LookupSettings_> class IndexedLookupTraceBuilder : public Int
 
   protected:
     using LookupSettings = LookupSettings_;
-    virtual uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const = 0;
+    using TupleType = RefTuple<LookupSettings::LOOKUP_TUPLE_SIZE>;
+    virtual uint32_t find_in_dst(const TupleType& tup) const = 0;
     virtual void init(TraceContainer&) {}; // Optional initialization step.
 
     // The outer (bigger) table selector.
@@ -84,7 +97,7 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
 
   protected:
     using LookupSettings = LookupSettings_;
-    using ArrayTuple = std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>;
+    using TupleType = RefTuple<LookupSettings::LOOKUP_TUPLE_SIZE>;
 
     void init(TraceContainer& trace) override
     {
@@ -95,9 +108,9 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
                                           [this](const TraceContainer& t) { return build_index(t); });
     }
 
-    uint32_t find_in_dst(const ArrayTuple& tup) const override
+    uint32_t find_in_dst(const TupleType& tup) const override
     {
-        size_t key_hash = std::hash<ArrayTuple>{}(tup);
+        size_t key_hash = std::hash<TupleType>{}(tup);
         auto it = index_ptr_->find(key_hash);
         if (it != index_ptr_->end()) {
             uint32_t row = it->second;
@@ -119,7 +132,7 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
         idx.reserve(trace.get_column_rows(this->outer_dst_selector));
         trace.visit_column(this->outer_dst_selector, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(LookupSettings::DST_COLUMNS, row);
-            size_t key_hash = std::hash<ArrayTuple>{}(dst_values);
+            size_t key_hash = std::hash<decltype(dst_values)>{}(dst_values);
             // FIXME: THIS IS NOT CORRECT!!!
             // If hash collision, keep the first one (don't insert if key already exists).
             idx.insert({ key_hash, row });

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/shared_index_cache.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
 namespace bb::avm2::tracegen {
@@ -66,16 +67,18 @@ template <typename LookupSettings_> class IndexedLookupTraceBuilder : public Int
 
 // This class is used when the lookup is into a non-precomputed table.
 // It calculates the counts by trying to find the tuple in the destination columns.
-// It creates an index of the destination columns on init, and uses it to find the tuple efficiently.
+// It uses a SharedIndexCache to avoid rebuilding the index when multiple lookups target the same destination.
 // This class should work for any lookup that is not precomputed.
 template <typename LookupSettings_>
 class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSettings_> {
   public:
-    LookupIntoDynamicTableGeneric()
+    LookupIntoDynamicTableGeneric(SharedIndexCache& cache)
         : IndexedLookupTraceBuilder<LookupSettings_>()
+        , cache_(cache)
     {}
-    LookupIntoDynamicTableGeneric(Column outer_dst_selector)
+    LookupIntoDynamicTableGeneric(SharedIndexCache& cache, Column outer_dst_selector)
         : IndexedLookupTraceBuilder<LookupSettings_>(outer_dst_selector)
+        , cache_(cache)
     {}
     virtual ~LookupIntoDynamicTableGeneric() = default;
 
@@ -85,17 +88,18 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
 
     void init(TraceContainer& trace) override
     {
-        row_idx.reserve(trace.get_column_rows(this->outer_dst_selector));
-        trace.visit_column(this->outer_dst_selector, [&](uint32_t row, const FF&) {
-            auto dst_values = trace.get_multiple(LookupSettings::DST_COLUMNS, row);
-            row_idx.insert({ dst_values, row });
-        });
+        index_ptr_ = &cache_.get_or_build(this->outer_dst_selector,
+                                          LookupSettings::DST_COLUMNS,
+                                          trace,
+                                          [this](const TraceContainer& t) { return build_index(t); });
     }
 
     uint32_t find_in_dst(const ArrayTuple& tup) const override
     {
-        auto it = row_idx.find(tup);
-        if (it != row_idx.end()) {
+        // Convert array to vector for lookup in the shared index.
+        std::vector<FF> key(tup.begin(), tup.end());
+        auto it = index_ptr_->find(key);
+        if (it != index_ptr_->end()) {
             return it->second;
         }
         throw std::runtime_error("Failed computing counts for " + std::string(LookupSettings::NAME) +
@@ -104,8 +108,20 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
     }
 
   private:
-    // TODO: Using the whole tuple as the key is not memory efficient.
-    unordered_flat_map<ArrayTuple, uint32_t> row_idx;
+    DstIndex build_index(const TraceContainer& trace)
+    {
+        DstIndex idx;
+        idx.reserve(trace.get_column_rows(this->outer_dst_selector));
+        trace.visit_column(this->outer_dst_selector, [&](uint32_t row, const FF&) {
+            auto dst_values = trace.get_multiple(LookupSettings::DST_COLUMNS, row);
+            std::vector<FF> key(dst_values.begin(), dst_values.end());
+            idx.insert({ std::move(key), row });
+        });
+        return idx;
+    }
+
+    SharedIndexCache& cache_;
+    const DstIndex* index_ptr_ = nullptr;
 };
 
 // This class is used when the lookup is into a non-precomputed table.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -11,6 +11,7 @@
 #include "barretenberg/common/utils.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/map_hashes.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
@@ -94,6 +95,11 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
         , cache_(cache)
     {}
     virtual ~LookupIntoDynamicTableGeneric() = default;
+
+    size_t get_destination_columns_fingerprint() const override
+    {
+        return bb::utils::hash_as_tuple(this->outer_dst_selector, LookupSettings::DST_COLUMNS);
+    }
 
   protected:
     using LookupSettings = LookupSettings_;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -88,6 +88,7 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
 
     void init(TraceContainer& trace) override
     {
+        trace_ptr_ = &trace;
         index_ptr_ = &cache_.get_or_build(this->outer_dst_selector,
                                           LookupSettings::DST_COLUMNS,
                                           trace,
@@ -96,11 +97,15 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
 
     uint32_t find_in_dst(const ArrayTuple& tup) const override
     {
-        // Convert array to vector for lookup in the shared index.
-        std::vector<FF> key(tup.begin(), tup.end());
-        auto it = index_ptr_->find(key);
+        size_t key_hash = std::hash<ArrayTuple>{}(tup);
+        auto it = index_ptr_->find(key_hash);
         if (it != index_ptr_->end()) {
-            return it->second;
+            uint32_t row = it->second;
+            // Verify the actual values match (handles hash collisions).
+            auto dst_values = trace_ptr_->get_multiple(LookupSettings::DST_COLUMNS, row);
+            if (dst_values == tup) {
+                return row;
+            }
         }
         throw std::runtime_error("Failed computing counts for " + std::string(LookupSettings::NAME) +
                                  ". Could not find tuple in destination. " +
@@ -114,14 +119,17 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
         idx.reserve(trace.get_column_rows(this->outer_dst_selector));
         trace.visit_column(this->outer_dst_selector, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(LookupSettings::DST_COLUMNS, row);
-            std::vector<FF> key(dst_values.begin(), dst_values.end());
-            idx.insert({ std::move(key), row });
+            size_t key_hash = std::hash<ArrayTuple>{}(dst_values);
+            // FIXME: THIS IS NOT CORRECT!!!
+            // If hash collision, keep the first one (don't insert if key already exists).
+            idx.insert({ key_hash, row });
         });
         return idx;
     }
 
     SharedIndexCache& cache_;
     const DstIndex* index_ptr_ = nullptr;
+    const TraceContainer* trace_ptr_ = nullptr;
 };
 
 // This class is used when the lookup is into a non-precomputed table.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -145,6 +145,7 @@ class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSet
                 rows.push_back(row);
             }
         });
+
         return idx;
     }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_bitwise.hpp
@@ -8,8 +8,9 @@ namespace bb::avm2::tracegen {
 
 template <typename LookupSettings> class LookupIntoBitwise : public IndexedLookupTraceBuilder<LookupSettings> {
   protected:
+    using TupleType = typename IndexedLookupTraceBuilder<LookupSettings>::TupleType;
     // This is an efficient implementation of indexing into the precomputed table.
-    uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
+    uint32_t find_in_dst(const TupleType& tup) const override
     {
         // row # is derived as:
         //     - input_b: bits 0...7 (0 being LSB)

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_indexed_by_clk.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_indexed_by_clk.hpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 
+#include "barretenberg/common/tuple.hpp"
 #include "barretenberg/vm2/tracegen/lib/lookup_builder.hpp"
 
 namespace bb::avm2::tracegen {
@@ -16,11 +17,9 @@ namespace bb::avm2::tracegen {
  */
 template <typename LookupSettings> class LookupIntoIndexedByClk : public IndexedLookupTraceBuilder<LookupSettings> {
   protected:
+    using TupleType = typename IndexedLookupTraceBuilder<LookupSettings>::TupleType;
     // This is an efficient implementation of indexing into the precomputed table.
-    uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
-    {
-        return static_cast<uint32_t>(tup[0]);
-    }
+    uint32_t find_in_dst(const TupleType& tup) const override { return static_cast<uint32_t>(flat_tuple::get<0>(tup)); }
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp
@@ -10,7 +10,8 @@ namespace bb::avm2::tracegen {
 
 template <typename LookupSettings> class LookupIntoPDecomposition : public IndexedLookupTraceBuilder<LookupSettings> {
   protected:
-    uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
+    using TupleType = typename IndexedLookupTraceBuilder<LookupSettings>::TupleType;
+    uint32_t find_in_dst(const TupleType& tup) const override
     {
         const auto& [radix, limb_index, _] = tup;
         size_t radix_index = static_cast<size_t>(uint64_t(radix));

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
@@ -11,7 +11,6 @@
 #include "barretenberg/common/utils.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
-#include "barretenberg/vm2/common/small_vector.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
@@ -56,7 +56,8 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
         // Find each source tuple in the destination table, and set a 1 in the destination selector.
         trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
             auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
-            auto index_it = row_idx.find(src_values);
+            size_t key_hash = std::hash<decltype(src_values)>{}(src_values);
+            auto index_it = row_idx.find(key_hash);
             if (index_it == row_idx.end() || index_it->second.empty()) {
                 throw std::runtime_error("Failed setting selectors for " + std::string(PermutationSettings::NAME) +
                                          ". Could not find tuple in destination.\nSRC tuple (row " +
@@ -83,7 +84,10 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
         row_idx.reserve(trace.get_column_rows(dst_table_selector));
         trace.visit_column(dst_table_selector, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(DST_COLUMNS, row);
-            row_idx[dst_values].push_back(row);
+            size_t key_hash = std::hash<decltype(dst_values)>{}(dst_values);
+            // FIXME: THIS IS NOT CORRECT!!!
+            // If hash collision, keep the first one (don't insert if key already exists).
+            row_idx[key_hash].push_back(row);
         });
     }
 
@@ -101,9 +105,7 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
     // (a, b, c, ...) in some destination table. That is, you want a row number in the destination table.
     // The following map contains (a, b, c, ...) -> [row_number_1, row_number_2, ...].
     // That is, you can efficiently find all the rows in the destination table that match the src tuple.
-    // TODO: Using the whole tuple as the key is not memory efficient.
-    using ArrayTuple = std::array<FF, COLUMNS_PER_SET>;
-    unordered_flat_map<ArrayTuple, /*rows*/ std::vector<uint32_t>> row_idx;
+    unordered_flat_map</*columns hash*/ size_t, /*rows*/ std::vector<uint32_t>> row_idx;
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/multi_permutation_builder.hpp
@@ -11,6 +11,7 @@
 #include "barretenberg/common/utils.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/small_vector.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
@@ -56,8 +57,7 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
         // Find each source tuple in the destination table, and set a 1 in the destination selector.
         trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
             auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
-            size_t key_hash = std::hash<decltype(src_values)>{}(src_values);
-            auto index_it = row_idx.find(key_hash);
+            auto index_it = row_idx.find(src_values);
             if (index_it == row_idx.end() || index_it->second.empty()) {
                 throw std::runtime_error("Failed setting selectors for " + std::string(PermutationSettings::NAME) +
                                          ". Could not find tuple in destination.\nSRC tuple (row " +
@@ -66,7 +66,7 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
             }
             // Get one of the available rows for the tuple.
             // TODO: This could be done in parallel, with only a lock on the row vector.
-            std::vector<uint32_t>& possible_dst_rows = index_it->second;
+            auto& possible_dst_rows = index_it->second;
             uint32_t dst_row = possible_dst_rows.back();
             trace.set(PermutationSettings::DST_SELECTOR, dst_row, 1);
             // We remove the used row from the list of possible rows.
@@ -84,10 +84,7 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
         row_idx.reserve(trace.get_column_rows(dst_table_selector));
         trace.visit_column(dst_table_selector, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(DST_COLUMNS, row);
-            size_t key_hash = std::hash<decltype(dst_values)>{}(dst_values);
-            // FIXME: THIS IS NOT CORRECT!!!
-            // If hash collision, keep the first one (don't insert if key already exists).
-            row_idx[key_hash].push_back(row);
+            row_idx[dst_values].push_back(row);
         });
     }
 
@@ -105,7 +102,7 @@ template <typename... PermutationSettings_> class MultiPermutationBuilder : publ
     // (a, b, c, ...) in some destination table. That is, you want a row number in the destination table.
     // The following map contains (a, b, c, ...) -> [row_number_1, row_number_2, ...].
     // That is, you can efficiently find all the rows in the destination table that match the src tuple.
-    unordered_flat_map</*columns hash*/ size_t, /*rows*/ std::vector<uint32_t>> row_idx;
+    unordered_flat_map<RefTuple<DST_COLUMNS.size()>, /*rows*/ std::vector<uint32_t>> row_idx;
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -10,6 +10,7 @@
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
 #include "barretenberg/vm2/common/map_hashes.hpp"
+#include "barretenberg/vm2/common/small_vector.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
@@ -27,7 +28,7 @@ struct IndexKey {
 
 // The index type: maps a hash of field element tuples to a row number.
 // The actual tuple values are verified during lookup using the TraceContainer.
-using DstIndex = unordered_flat_map<size_t, uint32_t>;
+using DstIndex = unordered_flat_map<size_t, std::vector<uint32_t>>;
 
 // A thread-safe cache for destination table indices.
 // Multiple lookup builders targeting the same destination table can share an index,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -45,11 +45,8 @@ class SharedIndexCache {
     // Get or build an index for the given destination table.
     // If the index already exists or is being built, this will wait for it and return a reference.
     // If the index doesn't exist, the calling thread will build it using the provided build function.
-    //
-    // Template parameter N is the tuple size (number of destination columns).
-    template <size_t N>
     const DstIndex& get_or_build(Column outer_dst_selector,
-                                 const std::array<ColumnAndShifts, N>& dst_columns,
+                                 std::span<const ColumnAndShifts> dst_columns,
                                  const TraceContainer& trace,
                                  std::function<DstIndex(const TraceContainer&)> build_fn)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <mutex>
+#include <vector>
+
+#include "barretenberg/common/utils.hpp"
+#include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/map_hashes.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
+#include "barretenberg/vm2/tracegen/trace_container.hpp"
+
+namespace bb::avm2::tracegen {
+
+// A key that uniquely identifies a destination table index.
+// An index can be shared if both the outer destination selector and the destination columns match.
+struct IndexKey {
+    Column outer_dst_selector;
+    std::vector<ColumnAndShifts> dst_columns;
+
+    bool operator==(const IndexKey&) const = default;
+    size_t hash() const { return bb::utils::hash_as_tuple(outer_dst_selector, dst_columns); }
+};
+
+// The index type: maps a vector of field elements (the tuple values) to a row number.
+using DstIndex = unordered_flat_map<std::vector<FF>, uint32_t>;
+
+// A thread-safe cache for destination table indices.
+// Multiple lookup builders targeting the same destination table can share an index,
+// avoiding redundant computation and memory usage.
+class SharedIndexCache {
+  public:
+    SharedIndexCache() = default;
+
+    // Non-copyable and non-movable (due to std::mutex).
+    SharedIndexCache(const SharedIndexCache&) = delete;
+    SharedIndexCache& operator=(const SharedIndexCache&) = delete;
+    SharedIndexCache(SharedIndexCache&&) = delete;
+    SharedIndexCache& operator=(SharedIndexCache&&) = delete;
+
+    // Get or build an index for the given destination table.
+    // If the index already exists or is being built, this will wait for it and return a reference.
+    // If the index doesn't exist, the calling thread will build it using the provided build function.
+    //
+    // Template parameter N is the tuple size (number of destination columns).
+    template <size_t N>
+    const DstIndex& get_or_build(Column outer_dst_selector,
+                                 const std::array<ColumnAndShifts, N>& dst_columns,
+                                 const TraceContainer& trace,
+                                 std::function<DstIndex(const TraceContainer&)> build_fn)
+    {
+        IndexKey key{ outer_dst_selector, { dst_columns.begin(), dst_columns.end() } };
+
+        std::unique_lock lock(mutex_);
+
+        auto it = cache_.find(key);
+        if (it != cache_.end()) {
+            // Index exists or is being built. Release lock before waiting.
+            auto future = it->second;
+            lock.unlock();
+            return *future.get();
+        }
+
+        // We are the first to request this index. Create a promise and store the future.
+        auto promise = std::make_shared<std::promise<std::shared_ptr<DstIndex>>>();
+        cache_[key] = promise->get_future().share();
+        lock.unlock();
+
+        // Build the index outside the lock.
+        try {
+            auto index = std::make_shared<DstIndex>(build_fn(trace));
+            promise->set_value(index);
+            return *index;
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+            throw;
+        }
+    }
+
+  private:
+    std::mutex mutex_;
+    // The cache stores shared futures that resolve to shared pointers to the indices.
+    // Using shared_ptr ensures the index outlives all references to it.
+    unordered_flat_map<IndexKey, std::shared_future<std::shared_ptr<DstIndex>>> cache_;
+};
+
+} // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -25,8 +25,9 @@ struct IndexKey {
     size_t hash() const { return bb::utils::hash_as_tuple(outer_dst_selector, dst_columns); }
 };
 
-// The index type: maps a vector of field elements (the tuple values) to a row number.
-using DstIndex = unordered_flat_map<std::vector<FF>, uint32_t>;
+// The index type: maps a hash of field element tuples to a row number.
+// The actual tuple values are verified during lookup using the TraceContainer.
+using DstIndex = unordered_flat_map<size_t, uint32_t>;
 
 // A thread-safe cache for destination table indices.
 // Multiple lookup builders targeting the same destination table can share an index,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -42,6 +42,13 @@ class SharedIndexCache {
     SharedIndexCache(SharedIndexCache&&) = delete;
     SharedIndexCache& operator=(SharedIndexCache&&) = delete;
 
+    // Clear all cached indices. This should be called when the underlying trace changes.
+    void clear()
+    {
+        std::unique_lock lock(mutex_);
+        cache_.clear();
+    }
+
     // Get or build an index for the given destination table.
     // If the index already exists or is being built, this will wait for it and return a reference.
     // If the index doesn't exist, the calling thread will build it using the provided build function.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/shared_index_cache.hpp
@@ -10,7 +10,6 @@
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
 #include "barretenberg/vm2/common/map_hashes.hpp"
-#include "barretenberg/vm2/common/small_vector.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp
@@ -2,8 +2,10 @@
 
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/common/tuple.hpp"
 #include "barretenberg/vm2/common/map.hpp"
 #include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
@@ -19,6 +21,7 @@ template <typename BaseBuilder> class AddChecksToBuilder : public BaseBuilder {
                   "BaseBuilder must be an IndexedLookupTraceBuilder");
 
   public:
+    using TupleType = typename BaseBuilder::TupleType;
     ~AddChecksToBuilder() override = default;
 
     void init(TraceContainer& trace) override
@@ -27,8 +30,7 @@ template <typename BaseBuilder> class AddChecksToBuilder : public BaseBuilder {
         this->trace = &trace;
     }
 
-    uint32_t find_in_dst(
-        const std::array<FF, BaseBuilder::LookupSettings::LOOKUP_TUPLE_SIZE>& src_values) const override
+    uint32_t find_in_dst(const TupleType& src_values) const override
     {
         uint32_t dst_row = BaseBuilder::find_in_dst(src_values);
 
@@ -51,6 +53,7 @@ template <typename BaseBuilder> class AddChecksToBuilder : public BaseBuilder {
 template <typename PermutationSettings>
 class CheckingPermutationBuilder : public PermutationBuilder<PermutationSettings> {
   public:
+    // Use array for storage in map keys (tuples of references can't be stored).
     using ArrayTuple = std::array<FF, PermutationSettings::COLUMNS_PER_SET>;
 
     void process(TraceContainer& trace) override
@@ -61,12 +64,12 @@ class CheckingPermutationBuilder : public PermutationBuilder<PermutationSettings
         source_tuples.clear();
         trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
             auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
-            source_tuples[src_values].insert(row);
+            source_tuples[to_array(src_values)].insert(row);
         });
         destination_tuples.clear();
         trace.visit_column(PermutationSettings::DST_SELECTOR, [&](uint32_t row, const FF&) {
             auto dst_values = trace.get_multiple(PermutationSettings::DST_COLUMNS, row);
-            destination_tuples[dst_values].insert(row);
+            destination_tuples[to_array(dst_values)].insert(row);
         });
 
         auto build_error_message =
@@ -112,6 +115,14 @@ class CheckingPermutationBuilder : public PermutationBuilder<PermutationSettings
     }
 
   private:
+    // Helper to convert tuple of references to array for storage.
+    template <typename... Ts> static ArrayTuple to_array(const flat_tuple::tuple<Ts...>& tup)
+    {
+        return [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return ArrayTuple{ flat_tuple::get<Is>(tup)... };
+        }(std::make_index_sequence<sizeof...(Ts)>{});
+    }
+
     unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> source_tuples;
     unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> destination_tuples;
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
@@ -8,7 +8,9 @@
 #include <shared_mutex>
 #include <span>
 #include <unordered_map>
+#include <utility>
 
+#include "barretenberg/common/tuple.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
 #include "barretenberg/vm2/constraining/flavor_settings.hpp"
@@ -24,18 +26,12 @@ class TraceContainer {
     TraceContainer();
 
     const FF& get(Column col, uint32_t row) const;
-    template <size_t N> std::array<FF, N> get_multiple(const std::array<ColumnAndShifts, N>& cols, uint32_t row) const
+    // Returns a tuple of const references to the values in the specified columns.
+    template <size_t N> auto get_multiple(const std::array<ColumnAndShifts, N>& cols, uint32_t row) const
     {
-        std::array<FF, N> result;
-        for (size_t i = 0; i < N; ++i) {
-            if (!is_shift(cols[i])) {
-                result[i] = get(static_cast<Column>(cols[i]), row);
-            } else {
-                Column unshifted_col = unshift_column(cols[i]).value();
-                result[i] = get(unshifted_col, row + 1);
-            }
-        }
-        return result;
+        return [&]<size_t... Is>(std::index_sequence<Is...>) {
+            return flat_tuple::forward_as_tuple(get_column_or_shift(cols[Is], row)...);
+        }(std::make_index_sequence<N>{});
     }
     // Extended version of get that works with shifted columns. More expensive.
     const FF& get_column_or_shift(ColumnAndShifts col, uint32_t row) const;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <functional>
+#include <random>
 #include <span>
 #include <string>
 #include <vector>
@@ -31,6 +32,7 @@
 #include "barretenberg/vm2/tracegen/keccakf1600_trace.hpp"
 #include "barretenberg/vm2/tracegen/l1_to_l2_message_tree_trace.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/shared_index_cache.hpp"
 #include "barretenberg/vm2/tracegen/memory_trace.hpp"
 #include "barretenberg/vm2/tracegen/merkle_check_trace.hpp"
 #include "barretenberg/vm2/tracegen/note_hash_tree_check_trace.hpp"
@@ -436,36 +438,40 @@ void AvmTraceGenHelper::fill_trace_interactions(TraceContainer& trace)
 {
     // Now we can compute lookups and permutations.
     {
+        // We use a shared index cache so that lookups targeting the same destination table
+        // can share the same index, avoiding redundant computation and memory usage.
+        SharedIndexCache index_cache;
+
         auto jobs_interactions =
-            concatenate_jobs(MemoryTraceBuilder::interactions.get_all_jobs(),
-                             TxTraceBuilder::interactions.get_all_jobs(),
-                             ExecutionTraceBuilder::interactions.get_all_jobs(),
-                             AluTraceBuilder::interactions.get_all_jobs(),
-                             Poseidon2TraceBuilder::interactions.get_all_jobs(),
-                             RangeCheckTraceBuilder::interactions.get_all_jobs(),
-                             BitwiseTraceBuilder::interactions.get_all_jobs(),
-                             Sha256TraceBuilder::interactions.get_all_jobs(),
-                             KeccakF1600TraceBuilder::interactions.get_all_jobs(),
-                             BytecodeTraceBuilder::interactions.get_all_jobs(),
-                             ClassIdDerivationTraceBuilder::interactions.get_all_jobs(),
-                             EccTraceBuilder::interactions.get_all_jobs(),
-                             ToRadixTraceBuilder::interactions.get_all_jobs(),
-                             AddressDerivationTraceBuilder::interactions.get_all_jobs(),
-                             FieldGreaterThanTraceBuilder::interactions.get_all_jobs(),
-                             MerkleCheckTraceBuilder::interactions.get_all_jobs(),
-                             PublicDataTreeTraceBuilder::interactions.get_all_jobs(),
-                             UpdateCheckTraceBuilder::interactions.get_all_jobs(),
-                             NullifierTreeCheckTraceBuilder::interactions.get_all_jobs(),
-                             DataCopyTraceBuilder::interactions.get_all_jobs(),
-                             CalldataTraceBuilder::interactions.get_all_jobs(),
-                             NoteHashTreeCheckTraceBuilder::interactions.get_all_jobs(),
-                             WrittenPublicDataSlotsTreeCheckTraceBuilder::interactions.get_all_jobs(),
-                             GreaterThanTraceBuilder::interactions.get_all_jobs(),
-                             ContractInstanceRetrievalTraceBuilder::interactions.get_all_jobs(),
-                             GetContractInstanceTraceBuilder::interactions.get_all_jobs(),
-                             L1ToL2MessageTreeCheckTraceBuilder::interactions.get_all_jobs(),
-                             EmitUnencryptedLogTraceBuilder::interactions.get_all_jobs(),
-                             RetrievedBytecodesTreeCheckTraceBuilder::interactions.get_all_jobs());
+            concatenate_jobs(MemoryTraceBuilder::interactions.get_all_jobs(index_cache),
+                             TxTraceBuilder::interactions.get_all_jobs(index_cache),
+                             ExecutionTraceBuilder::interactions.get_all_jobs(index_cache),
+                             AluTraceBuilder::interactions.get_all_jobs(index_cache),
+                             Poseidon2TraceBuilder::interactions.get_all_jobs(index_cache),
+                             RangeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             BitwiseTraceBuilder::interactions.get_all_jobs(index_cache),
+                             Sha256TraceBuilder::interactions.get_all_jobs(index_cache),
+                             KeccakF1600TraceBuilder::interactions.get_all_jobs(index_cache),
+                             BytecodeTraceBuilder::interactions.get_all_jobs(index_cache),
+                             ClassIdDerivationTraceBuilder::interactions.get_all_jobs(index_cache),
+                             EccTraceBuilder::interactions.get_all_jobs(index_cache),
+                             ToRadixTraceBuilder::interactions.get_all_jobs(index_cache),
+                             AddressDerivationTraceBuilder::interactions.get_all_jobs(index_cache),
+                             FieldGreaterThanTraceBuilder::interactions.get_all_jobs(index_cache),
+                             MerkleCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             PublicDataTreeTraceBuilder::interactions.get_all_jobs(index_cache),
+                             UpdateCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             NullifierTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             DataCopyTraceBuilder::interactions.get_all_jobs(index_cache),
+                             CalldataTraceBuilder::interactions.get_all_jobs(index_cache),
+                             NoteHashTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             WrittenPublicDataSlotsTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             GreaterThanTraceBuilder::interactions.get_all_jobs(index_cache),
+                             ContractInstanceRetrievalTraceBuilder::interactions.get_all_jobs(index_cache),
+                             GetContractInstanceTraceBuilder::interactions.get_all_jobs(index_cache),
+                             L1ToL2MessageTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
+                             EmitUnencryptedLogTraceBuilder::interactions.get_all_jobs(index_cache),
+                             RetrievedBytecodesTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache));
 
         AVM_TRACK_TIME("tracegen/interactions",
                        parallel_for(jobs_interactions.size(), [&](size_t i) { jobs_interactions[i]->process(trace); }));

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen_helper.cpp
@@ -2,7 +2,6 @@
 
 #include <array>
 #include <functional>
-#include <random>
 #include <span>
 #include <string>
 #include <vector>
@@ -438,7 +437,7 @@ void AvmTraceGenHelper::fill_trace_interactions(TraceContainer& trace)
 {
     // Now we can compute lookups and permutations.
     {
-        // We use a shared index cache so that lookups targeting the same destination table
+        // We use a shared index cache so that lookups targeting the same destination columns
         // can share the same index, avoiding redundant computation and memory usage.
         SharedIndexCache index_cache;
 
@@ -472,6 +471,11 @@ void AvmTraceGenHelper::fill_trace_interactions(TraceContainer& trace)
                              L1ToL2MessageTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache),
                              EmitUnencryptedLogTraceBuilder::interactions.get_all_jobs(index_cache),
                              RetrievedBytecodesTreeCheckTraceBuilder::interactions.get_all_jobs(index_cache));
+
+        // Order jobs to minimize index building contention:
+        // Jobs with unique destination columns come first, then jobs that share destinations with earlier ones.
+        AVM_TRACK_TIME("tracegen/order_jobs_by_destination_columns",
+                       order_jobs_by_destination_columns(jobs_interactions));
 
         AVM_TRACK_TIME("tracegen/interactions",
                        parallel_for(jobs_interactions.size(), [&](size_t i) { jobs_interactions[i]->process(trace); }));


### PR DESCRIPTION
# Faster Interactions Tracegen

This PR optimizes the trace generation for interactions, particularly focusing on lookup operations, to improve performance and reduce memory usage.

```
Tracegen (interactions)

Megabulk: 4400ms -> 1700ms
Bulk: 1400ms -> 700ms
```

## Key Changes

### 1. Shared Indices for Generic Lookups

Introduced `SharedIndexCache` to enable multiple lookup builders targeting the same destination columns to share a single index. This avoids redundant index computation and reduces memory usage when multiple lookups operate on the same destination table.

- **New class**: `SharedIndexCache` provides thread-safe caching of destination table indices
- **Thread-safe design**: Uses `std::shared_future` to coordinate concurrent index building - only the first job builds the index while others wait for completion
- **Memory efficient**: Indices are stored as `shared_ptr` to ensure they outlive all references

### 2. Better Interaction Job Ordering to Avoid Contention

Added `order_jobs_by_destination_columns()` function that reorders interaction jobs to minimize index building contention.

- Jobs with unique destination column fingerprints are processed first
- Jobs that share destination columns with previously seen ones are processed later
- This ordering ensures that when multiple jobs share the same destination, only the first one builds the index while others wait, reducing contention

### 3. `get_multiple` Returns Tuple of References

Changed `TraceContainer::get_multiple()` to return a tuple of const references instead of copying values into an array.

- **Before**: Returned `std::array<FF, N>` (copies values)
- **After**: Returns `flat_tuple::tuple<const FF&, ...>` (references)
- **Benefit**: Avoids unnecessary copying of field elements during lookup operations
- Uses `flat_tuple::forward_as_tuple` to construct the tuple efficiently

### 4. Index Maps Don't Store Field Elements

Optimized the destination index structure to store only hash values and row numbers, not the actual field element values.

- **Index type**: `unordered_flat_map<size_t, std::vector<uint32_t>>` - maps hash of tuple to row numbers
- **Verification**: Actual tuple values are verified during lookup using the `TraceContainer`, ensuring correctness while saving memory
- **Memory savings**: Significantly reduces memory footprint for large lookup tables

## Implementation Details

- Added `map_hashes.hpp` with hash specializations for `std::vector`, `std::array`, and `flat_tuple::tuple` to support using these types as map keys
- Extended `InteractionBuilderInterface` with `get_destination_columns_fingerprint()` method to identify jobs that can share indices
- Updated all interaction factory methods to accept `SharedIndexCache&` parameter
- Modified `LookupIntoDynamicTableGeneric` to use the shared cache instead of building its own index
- Updated test helpers to use the new `SharedIndexCache` API

## Performance Impact

These changes improve trace generation performance by:
- Eliminating redundant index building for shared destination tables
- Reducing memory allocations through reference-based tuple returns
- Minimizing memory footprint by storing only hashes in indices
- Reducing contention through intelligent job ordering

## Testing

All existing tests pass with the new implementation. The changes maintain backward compatibility at the API level while improving internal efficiency.

