### PR TITLE
fix(avm): log gadget fuzzer merge fix

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.cpp
@@ -134,14 +134,12 @@ std::unique_ptr<ContextInterface> GadgetFuzzerContextHelper::make_nested_fuzzing
         0);
 }
 
-SideEffectTrackingDB GadgetFuzzerContextHelper::make_empty_merkle_db()
+PureMerkleDB GadgetFuzzerContextHelper::make_empty_merkle_db()
 {
     // DBs: Just for now - TODO(MW) use fuzzing dbs?
     HintedRawMerkleDB raw_merkle_db(hints);
     PureMerkleDB base_merkle_db(
         hints.tx.non_revertible_accumulated_data.nullifiers[0], raw_merkle_db, written_public_data_slots_tree_check);
-    SideEffectTrackingDB merkle_db(
-        hints.tx.non_revertible_accumulated_data.nullifiers[0], base_merkle_db, side_effect_tracker);
-    return merkle_db;
+    return base_merkle_db;
 }
 } // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/context_helper.hpp
@@ -19,7 +19,7 @@
 #include "barretenberg/vm2/simulation/interfaces/context.hpp"
 #include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
 #include "barretenberg/vm2/simulation/lib/side_effect_tracker.hpp"
-#include "barretenberg/vm2/simulation/lib/side_effect_tracking_db.hpp"
+#include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
 
 namespace bb::avm2::fuzzing {
 
@@ -104,7 +104,7 @@ class GadgetFuzzerContextHelper {
     // Misc:
     GlobalVariables global_variables;
     ExecutionHints hints;
-    SideEffectTrackingDB make_empty_merkle_db();
+    PureMerkleDB make_empty_merkle_db();
 };
 
 } // namespace bb::avm2::fuzzing

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/harness/emit_unencrypted_log.fuzzer.cpp
@@ -35,15 +35,13 @@ using bb::avm2::MemoryValue;
 using emit_log_rel = bb::avm2::emit_unencrypted_log<FF>;
 
 const uint8_t default_log_fields = 16;
-// TODO(MW): Set to slightly above the maximum size (FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH) so we hit
-// error_too_many_log_fields, but can be slow. Could instead set to < 1000 and explicitly set an edge case of > max in
-// the custom mutator?
-const uint32_t max_log_fields = 4100;
+// Set to slightly above the maximum size so we hit error_too_many_log_fields
+const uint32_t max_log_fields = FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH + 5;
 
 struct EmitUnencryptedLogFuzzerInput {
     AztecAddress contract_address;
     MemoryAddress log_offset = 1;
-    uint32_t log_size;
+    uint32_t log_size = 0;
     uint64_t selection_encoding = 0;
     bool is_static = false;
     bool tag_mismatch =
@@ -331,6 +329,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     // TODO(MW): Set before_context_event.prev_num_unencrypted_log_fields in multiple calls
     ExecutionEvent ex_event = { .wire_instruction =
                                     bb::avm2::testing::InstructionBuilder(WireOpCode::EMITUNENCRYPTEDLOG).build(),
+                                .inputs = { MemoryValue::from<uint32_t>(input.log_size) },
                                 .after_context_event = fill_context_event(context) };
     ex_builder.process({ ex_event }, trace);
     auto exec_log_row = trace.get_column_rows(avm2::Column::execution_sel_exec_dispatch_emit_unencrypted_log);


### PR DESCRIPTION
A quick fix to the log gadget fuzzer - we now must set `.inputs` in `ExecutionEvent`s and this was merged in just before the log fuzzer, so I missed it (sorry!).

For some reason, after rebasing I continued to get segfaults which went away when I just used a lighter `PureMerkleDB` in the context helper rather than `SideEffectTrackingDB` (this is fine for the log fuzzer as it uses the actual side effect tracker linked to the context to grab info, but I'll probably need to revisit this for further gadget fuzzers).

Coverage still at 100%, but does seem pretty slow to get there (possibly upstream changes slowed this down a bit, also causing the db segfaults?)
