### PR TITLE
chore: deduplicate poseidon2 trace

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/map_hashes.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <tuple>
 #include <vector>
 
 #include "barretenberg/common/tuple.hpp"
@@ -12,6 +13,14 @@ namespace std {
 
 template <typename T> struct hash<std::reference_wrapper<const T>> {
     size_t operator()(const std::reference_wrapper<const T>& ref) const { return std::hash<T>{}(ref.get()); }
+};
+
+// Define a hash function for std::tuple so that it can be used as a key in a std::unordered_map.
+template <typename... Ts> struct hash<std::tuple<Ts...>> {
+    size_t operator()(const std::tuple<Ts...>& tup) const
+    {
+        return std::apply([](const auto&... args) { return bb::utils::hash_as_tuple(args...); }, tup);
+    }
 };
 
 template <typename T> struct hash<std::vector<T>> {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/merkle_check_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/merkle_check_event.hpp
@@ -3,6 +3,8 @@
 #include "barretenberg/vm2/common/field.hpp"
 
 #include <cstdint>
+#include <optional>
+#include <tuple>
 #include <vector>
 
 namespace bb::avm2::simulation {
@@ -21,6 +23,13 @@ struct MerkleCheckEvent {
     std::vector<FF> sibling_path;
     FF root = 0;
     std::optional<FF> new_root;
+
+    // To be used with deduplicating event emitters.
+    // The key captures all inputs that determine the merkle check computation.
+    // For READs: (leaf_value, leaf_index, sibling_path, root)
+    // For WRITEs: additionally includes new_leaf_value (new_root is derived)
+    using Key = std::tuple<FF, std::optional<FF>, uint64_t, std::vector<FF>, FF>;
+    Key get_key() const { return { leaf_value, new_leaf_value, leaf_index, sibling_path, root }; }
 
     bool operator==(const MerkleCheckEvent& other) const = default;
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/poseidon2_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/poseidon2_event.hpp
@@ -18,6 +18,13 @@ struct Poseidon2HashEvent {
     std::vector<FF> inputs; // This input is padded to a multiple of 3
     std::vector<std::array<FF, 4>> intermediate_states;
     FF output;
+
+    // To be used with deduplicating event emitters.
+    // The key is the inputs since the same inputs always produce the same output.
+    using Key = std::vector<FF>;
+    Key get_key() const { return inputs; }
+
+    bool operator==(const Poseidon2HashEvent& other) const = default;
 };
 
 struct Poseidon2PermutationEvent {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/poseidon2_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/poseidon2_event.hpp
@@ -30,6 +30,13 @@ struct Poseidon2HashEvent {
 struct Poseidon2PermutationEvent {
     std::array<FF, 4> input;
     std::array<FF, 4> output;
+
+    // To be used with deduplicating event emitters.
+    // The key is the input since the same input always produces the same output.
+    using Key = std::array<FF, 4>;
+    Key get_key() const { return input; }
+
+    bool operator==(const Poseidon2PermutationEvent& other) const = default;
 };
 
 struct Poseidon2PermutationMemoryEvent {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -151,7 +151,7 @@ std::tuple<EventsContainer, TxSimulationResult> AvmSimulationHelper::simulate_fo
     DefaultEventEmitter<ScalarMulEvent> scalar_mul_emitter;
     DefaultEventEmitter<EccAddMemoryEvent> ecc_add_memory_emitter;
     DefaultDeduplicatingEventEmitter<Poseidon2HashEvent> poseidon2_hash_emitter;
-    DefaultEventEmitter<Poseidon2PermutationEvent> poseidon2_perm_emitter;
+    DefaultDeduplicatingEventEmitter<Poseidon2PermutationEvent> poseidon2_perm_emitter;
     DefaultEventEmitter<Poseidon2PermutationMemoryEvent> poseidon2_perm_mem_emitter;
     DefaultEventEmitter<KeccakF1600Event> keccakf1600_emitter;
     DefaultEventEmitter<ToRadixEvent> to_radix_emitter;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -157,7 +157,7 @@ std::tuple<EventsContainer, TxSimulationResult> AvmSimulationHelper::simulate_fo
     DefaultEventEmitter<ToRadixEvent> to_radix_emitter;
     DefaultEventEmitter<ToRadixMemoryEvent> to_radix_memory_emitter;
     DefaultDeduplicatingEventEmitter<FieldGreaterThanEvent> field_gt_emitter;
-    DefaultEventEmitter<MerkleCheckEvent> merkle_check_emitter;
+    DefaultDeduplicatingEventEmitter<MerkleCheckEvent> merkle_check_emitter;
     DefaultDeduplicatingEventEmitter<RangeCheckEvent> range_check_emitter;
     DefaultEventEmitter<ContextStackEvent> context_stack_emitter;
     DefaultEventEmitter<PublicDataTreeCheckEvent> public_data_tree_check_emitter;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -150,7 +150,7 @@ std::tuple<EventsContainer, TxSimulationResult> AvmSimulationHelper::simulate_fo
     DefaultEventEmitter<EccAddEvent> ecc_add_emitter;
     DefaultEventEmitter<ScalarMulEvent> scalar_mul_emitter;
     DefaultEventEmitter<EccAddMemoryEvent> ecc_add_memory_emitter;
-    DefaultEventEmitter<Poseidon2HashEvent> poseidon2_hash_emitter;
+    DefaultDeduplicatingEventEmitter<Poseidon2HashEvent> poseidon2_hash_emitter;
     DefaultEventEmitter<Poseidon2PermutationEvent> poseidon2_perm_emitter;
     DefaultEventEmitter<Poseidon2PermutationMemoryEvent> poseidon2_perm_mem_emitter;
     DefaultEventEmitter<KeccakF1600Event> keccakf1600_emitter;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/address_derivation_trace.cpp
@@ -62,16 +62,23 @@ void AddressDerivationTraceBuilder::process(
 const InteractionDefinition AddressDerivationTraceBuilder::interactions =
     InteractionDefinition()
         .add<lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings,
-             InteractionType::LookupSequential>()
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
         .add<lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings,
-             InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_partial_address_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_public_keys_hash_poseidon2_0_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_public_keys_hash_poseidon2_1_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_public_keys_hash_poseidon2_2_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_public_keys_hash_poseidon2_3_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_public_keys_hash_poseidon2_4_settings, InteractionType::LookupSequential>()
-        .add<lookup_address_derivation_preaddress_poseidon2_settings, InteractionType::LookupSequential>()
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_partial_address_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_public_keys_hash_poseidon2_0_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_public_keys_hash_poseidon2_1_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_public_keys_hash_poseidon2_2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_public_keys_hash_poseidon2_3_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_public_keys_hash_poseidon2_4_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_address_derivation_preaddress_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
         .add<lookup_address_derivation_preaddress_scalar_mul_settings, InteractionType::LookupSequential>()
         .add<lookup_address_derivation_address_ecadd_settings, InteractionType::LookupSequential>();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -438,7 +438,7 @@ const InteractionDefinition BytecodeTraceBuilder::interactions =
     InteractionDefinition()
         // Bytecode Hashing
         .add<lookup_bc_hashing_check_final_bytes_remaining_settings, InteractionType::LookupSequential>()
-        .add<lookup_bc_hashing_poseidon2_hash_settings, InteractionType::LookupSequential>()
+        .add<lookup_bc_hashing_poseidon2_hash_settings, InteractionType::LookupGeneric>() // poseidon2 deduplicates
         // Bytecode Retrieval
         .add<lookup_bc_retrieval_class_id_derivation_settings, InteractionType::LookupGeneric>()
         .add<lookup_bc_retrieval_contract_instance_retrieval_settings, InteractionType::LookupSequential>()

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
@@ -37,7 +37,9 @@ void ClassIdDerivationTraceBuilder::process(
 
 const InteractionDefinition ClassIdDerivationTraceBuilder::interactions =
     InteractionDefinition()
-        .add<lookup_class_id_derivation_class_id_poseidon2_0_settings, InteractionType::LookupSequential>()
-        .add<lookup_class_id_derivation_class_id_poseidon2_1_settings, InteractionType::LookupSequential>();
+        .add<lookup_class_id_derivation_class_id_poseidon2_0_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_class_id_derivation_class_id_poseidon2_1_settings,
+             InteractionType::LookupGeneric>(); // poseidon2 deduplicates
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.cpp
@@ -122,7 +122,7 @@ void MerkleCheckTraceBuilder::process(
 
 const InteractionDefinition MerkleCheckTraceBuilder::interactions =
     InteractionDefinition()
-        .add<lookup_merkle_check_merkle_poseidon2_read_settings, InteractionType::LookupSequential>()
-        .add<lookup_merkle_check_merkle_poseidon2_write_settings, InteractionType::LookupSequential>();
+        .add<lookup_merkle_check_merkle_poseidon2_read_settings, InteractionType::LookupGeneric>()
+        .add<lookup_merkle_check_merkle_poseidon2_write_settings, InteractionType::LookupGeneric>();
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/nullifier_tree_check_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/nullifier_tree_check_trace.cpp
@@ -98,16 +98,19 @@ void NullifierTreeCheckTraceBuilder::process(
 
 const InteractionDefinition NullifierTreeCheckTraceBuilder::interactions =
     InteractionDefinition()
-        .add<lookup_nullifier_check_silo_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_low_leaf_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_updated_low_leaf_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_low_leaf_merkle_check_settings, InteractionType::LookupSequential>()
+        .add<lookup_nullifier_check_silo_poseidon2_settings, InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_nullifier_check_low_leaf_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_nullifier_check_updated_low_leaf_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_nullifier_check_low_leaf_merkle_check_settings, InteractionType::LookupGeneric>()
         .add<lookup_nullifier_check_low_leaf_nullifier_validation_settings,
              InteractionType::LookupGeneric>() // ff_gt deduplicates
         .add<lookup_nullifier_check_low_leaf_next_nullifier_validation_settings,
              InteractionType::LookupGeneric>() // ff_gt deduplicates
-        .add<lookup_nullifier_check_new_leaf_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_nullifier_check_new_leaf_merkle_check_settings, InteractionType::LookupSequential>()
+        .add<lookup_nullifier_check_new_leaf_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_nullifier_check_new_leaf_merkle_check_settings, InteractionType::LookupGeneric>()
         .add<lookup_nullifier_check_write_nullifier_to_public_inputs_settings,
              InteractionType::LookupIntoIndexedByClk>();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/poseidon2_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/poseidon2_trace.cpp
@@ -511,9 +511,11 @@ void Poseidon2TraceBuilder::process_permutation_with_memory(
 
 const InteractionDefinition Poseidon2TraceBuilder::interactions =
     InteractionDefinition()
-        .add<lookup_poseidon2_hash_poseidon2_perm_settings, InteractionType::LookupSequential>()
+        .add<lookup_poseidon2_hash_poseidon2_perm_settings,
+             InteractionType::LookupGeneric>() // poseidon2_perm deduplicates
         // Poseidon2 Memory to Permutation Subtrace
-        .add<lookup_poseidon2_mem_input_output_poseidon2_perm_settings, InteractionType::LookupSequential>()
+        .add<lookup_poseidon2_mem_input_output_poseidon2_perm_settings,
+             InteractionType::LookupGeneric>() // poseidon2_perm deduplicates
         // Lookups to Greater Than Subtrace
         .add<lookup_poseidon2_mem_check_src_addr_in_range_settings, InteractionType::LookupGeneric>(Column::gt_sel)
         .add<lookup_poseidon2_mem_check_dst_addr_in_range_settings, InteractionType::LookupGeneric>(Column::gt_sel);

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/tx_trace.cpp
@@ -727,7 +727,7 @@ const InteractionDefinition TxTraceBuilder::interactions =
         // Cannot be sequential (sorting happens in public data tree trace)
         .add<lookup_tx_balance_read_settings, InteractionType::LookupGeneric>()
         .add<lookup_tx_write_fee_public_inputs_settings, InteractionType::LookupIntoIndexedByClk>()
-        .add<lookup_tx_balance_slot_poseidon2_settings, InteractionType::LookupSequential>()
+        .add<lookup_tx_balance_slot_poseidon2_settings, InteractionType::LookupGeneric>() // poseidon2 deduplicates
         // Lookups from tx_context.pil
         .add<lookup_tx_context_public_inputs_note_hash_tree_settings, InteractionType::LookupIntoIndexedByClk>()
         .add<lookup_tx_context_public_inputs_nullifier_tree_settings, InteractionType::LookupIntoIndexedByClk>()

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/update_check_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/update_check_trace.cpp
@@ -76,8 +76,10 @@ void UpdateCheckTraceBuilder::process(
 const InteractionDefinition UpdateCheckTraceBuilder::interactions =
     InteractionDefinition()
         .add<lookup_update_check_timestamp_from_public_inputs_settings, InteractionType::LookupGeneric>()
-        .add<lookup_update_check_update_hash_poseidon2_settings, InteractionType::LookupSequential>()
-        .add<lookup_update_check_delayed_public_mutable_slot_poseidon2_settings, InteractionType::LookupSequential>()
+        .add<lookup_update_check_update_hash_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
+        .add<lookup_update_check_delayed_public_mutable_slot_poseidon2_settings,
+             InteractionType::LookupGeneric>() // poseidon2 deduplicates
         .add<lookup_update_check_update_hash_public_data_read_settings, InteractionType::LookupGeneric>()
         .add<lookup_update_check_update_hi_metadata_range_settings, InteractionType::LookupGeneric>()
         .add<lookup_update_check_update_lo_metadata_range_settings, InteractionType::LookupGeneric>()


### PR DESCRIPTION
### Summary

This PR implements trace deduplication for Poseidon2 hash, Poseidon2 permutation, and Merkle check operations in the AVM. Previously, identical operations generated duplicate trace rows, causing significant trace bloat for merkle-heavy workloads like `NOTEHASHEXISTS`.

### Problem

The AVM was not deduplicating merkle or poseidon2 operations:

1. **No deduplication at event emission level** - `Poseidon2HashEvent`, `Poseidon2PermutationEvent`, and `MerkleCheckEvent` all used regular `EventEmitter` instead of `DeduplicatingEventEmitter`

2. **Sequential lookups prevented deduplication** - The `merkle_check` trace used `LookupSequential` for poseidon2 lookups, which requires traces to maintain strict ordering and is incompatible with deduplicated traces (explicitly warned in `lookup_builder.hpp:233`)

3. **No caching at simulation level** - Each merkle operation computed all hashes from scratch

**Impact**: For N identical `NOTEHASHEXISTS` checks on the same leaf:
- merkle_check: N × 40 rows
- poseidon2_hash: N × 40 rows
- poseidon2_perm: N × 40 rows
- **Total: 120N rows** for what should be a single computation

### Solution

1. **Add deduplication keys** to events:
   - `Poseidon2HashEvent::Key` = inputs vector
   - `Poseidon2PermutationEvent::Key` = input array
   - `MerkleCheckEvent::Key` = (leaf_value, new_leaf_value, leaf_index, sibling_path, root)

2. **Switch to `DeduplicatingEventEmitter`** for:
   - `poseidon2_hash_emitter`
   - `poseidon2_perm_emitter`
   - `merkle_check_emitter`

3. **Convert lookups from Sequential to Generic** (25 lookups across 8 files):
   - `merkle_check_trace.cpp`: 2 lookups → poseidon2_hash
   - `poseidon2_trace.cpp`: 2 lookups → poseidon2_perm
   - `nullifier_tree_check_trace.cpp`: 6 lookups
   - `address_derivation_trace.cpp`: 9 lookups
   - `class_id_derivation_trace.cpp`: 2 lookups
   - `bytecode_trace.cpp`: 1 lookup
   - `tx_trace.cpp`: 1 lookup
   - `update_check_trace.cpp`: 2 lookups

4. **Add hash support** for `std::tuple` in `map_hashes.hpp`

### Expected Impact

For N identical merkle operations:
- **Before**: 120N trace rows
- **After**: 120 trace rows (constant)

**Reduction factor: N×** for repeated identical operations.

This significantly benefits transactions that:
- Check the same note hash exists multiple times
- Perform repeated nullifier checks on the same values
- Access the same public data slots repeatedly

### Trade-offs

Generic lookups use hash-based indexing (O(1) per lookup) vs sequential scanning. This is actually faster for the sparse lookup pattern that deduplication creates (many source rows matching few destination rows).

### Test Plan

- [x] All 1668 vm2_tests pass
- [x] MerkleCheck tests pass with deduplication enabled
- [x] Poseidon2 tests pass with deduplication enabled
- [x] NullifierTreeCheck interaction tests pass
- [ ] Benchmark NOTEHASHEXISTS-heavy workloads to measure improvement
