### PR TITLE
feat: make message encoding and decoding consistent

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -3,7 +3,7 @@ use crate::{
     event::{event_emission::NewEvent, event_interface::EventInterface},
     messages::{
         encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::{event::private_event_to_message_plaintext, utils::prefix_with_tag},
+        logs::{event::encode_private_event_message, utils::prefix_with_tag},
         message_delivery::MessageDelivery,
         offchain_messages::deliver_offchain_message,
     },
@@ -72,7 +72,7 @@ where
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
             || AES128::encrypt(
-                private_event_to_message_plaintext(new_event.event, new_event.randomness),
+                encode_private_event_message(new_event.event, new_event.randomness),
                 recipient,
             ),
         );

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -238,7 +238,7 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
             /// This function is automatically injected by the `#[aztec]` macro.
             #[contract_library_method]
             unconstrained fn _compute_note_hash_and_nullifier(
-                packed_note: BoundedVec<Field, aztec::messages::discovery::private_notes::MAX_NOTE_PACKED_LEN>,
+                packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
                 owner: aztec::protocol_types::address::AztecAddress,
                 storage_slot: Field,
                 note_type_id: Field,
@@ -262,7 +262,7 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
             /// This function is automatically injected by the `#[aztec]` macro.
             #[contract_library_method]
             unconstrained fn _compute_note_hash_and_nullifier(
-                _packed_note: BoundedVec<Field, aztec::messages::discovery::private_notes::MAX_NOTE_PACKED_LEN>,
+                _packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
                 _owner: aztec::protocol_types::address::AztecAddress,
                 _storage_slot: Field,
                 _note_type_id: Field,

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -33,7 +33,7 @@ comptime fn generate_note_type_impl(s: TypeDefinition, note_type_id: Field) -> Q
     let name = s.name();
     let typ = s.as_type();
     let note_type_name: str<_> = f"{name}".as_ctstring().as_quoted_str!();
-    let max_note_packed_len = crate::messages::discovery::private_notes::MAX_NOTE_PACKED_LEN;
+    let max_note_packed_len = crate::messages::logs::note::MAX_NOTE_PACKED_LEN;
 
     quote {
         impl aztec::note::note_interface::NoteType for $name {

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -8,9 +8,8 @@ pub mod process_message;
 
 use crate::{
     messages::{
-        discovery::{
-            private_notes::MAX_NOTE_PACKED_LEN, process_message::process_message_ciphertext,
-        },
+        discovery::process_message::process_message_ciphertext,
+        logs::note::MAX_NOTE_PACKED_LEN,
         processing::{
             get_private_logs, pending_tagged_log::PendingTaggedLog,
             validate_enqueued_notes_and_events,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
@@ -1,4 +1,4 @@
-use crate::messages::discovery::{ComputeNoteHashAndNullifier, private_notes::MAX_NOTE_PACKED_LEN};
+use crate::messages::{discovery::ComputeNoteHashAndNullifier, logs::note::MAX_NOTE_PACKED_LEN};
 
 use dep::protocol_types::{
     address::AztecAddress,
@@ -96,7 +96,7 @@ pub unconstrained fn attempt_note_nonce_discovery<Env>(
 
 mod test {
     use crate::{
-        messages::discovery::{NoteHashAndNullifier, private_notes::MAX_NOTE_PACKED_LEN},
+        messages::{discovery::NoteHashAndNullifier, logs::note::MAX_NOTE_PACKED_LEN},
         note::{
             note_interface::{NoteHash, NoteType},
             note_metadata::SettledNoteMetadata,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -3,6 +3,9 @@ use crate::{
     messages::{
         discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
         encoding::MAX_MESSAGE_CONTENT_LEN,
+        logs::partial_note::{
+            decode_partial_note_private_message, MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN,
+        },
         processing::{
             enqueue_note_for_validation, get_pending_partial_notes_completion_logs,
             log_retrieval_response::LogRetrievalResponse,
@@ -15,20 +18,8 @@ use protocol_types::{
     address::AztecAddress,
     debug_log::debug_log_format,
     hash::sha256_to_field,
-    traits::{Deserialize, FromField, Serialize},
+    traits::{Deserialize, Serialize},
 };
-
-/// [ owner, storage slot, randomness, note_completion_log_tag ]
-global PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN: u32 = 4;
-global PARTIAL_NOTE_PRIVATE_MSG_CONTENT_OWNER_INDEX: u32 = 0;
-global PARTIAL_NOTE_PRIVATE_MSG_CONTENT_STORAGE_SLOT_INDEX: u32 = 1;
-global PARTIAL_NOTE_PRIVATE_MSG_CONTENT_RANDOMNESS_INDEX: u32 = 2;
-global PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NOTE_COMPLETION_LOG_TAG_INDEX: u32 = 3;
-
-/// Partial notes have a maximum packed length of their private fields bound by extra content in their private message
-/// (e.g. the storage slot, note completion log tag, etc.).
-pub global MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN: u32 =
-    MAX_MESSAGE_CONTENT_LEN - PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN;
 
 /// The slot in the PXE capsules where we store a `CapsuleArray` of `DeliveredPendingPartialNote`.
 pub global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sha256_to_field(
@@ -39,10 +30,10 @@ pub global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sh
 /// log that will complete it and lead to a note being discovered and delivered.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct DeliveredPendingPartialNote {
-    pub(crate) note_completion_log_tag: Field,
     pub(crate) owner: AztecAddress,
     pub(crate) storage_slot: Field,
     pub(crate) randomness: Field,
+    pub(crate) note_completion_log_tag: Field,
     pub(crate) note_type_id: Field,
     pub(crate) packed_private_note_content: BoundedVec<Field, MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN>,
     pub(crate) recipient: AztecAddress,
@@ -56,7 +47,18 @@ pub unconstrained fn process_partial_note_private_msg(
 ) {
     // We store the information of the partial note we found in a persistent capsule in PXE, so that we can later search
     // for the public log that will complete it.
-    let pending = decode_partial_note_private_msg(msg_metadata, msg_content, recipient);
+    let (owner, storage_slot, randomness, note_completion_log_tag, note_type_id, packed_private_note_content) =
+        decode_partial_note_private_message(msg_metadata, msg_content);
+
+    let pending = DeliveredPendingPartialNote {
+        owner,
+        storage_slot,
+        randomness,
+        note_completion_log_tag,
+        note_type_id,
+        packed_private_note_content,
+        recipient,
+    };
 
     CapsuleArray::at(
         contract_address,
@@ -168,52 +170,4 @@ pub unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
             pending_partial_notes.remove(i);
         }
     });
-}
-
-fn decode_partial_note_private_msg(
-    msg_metadata: u64,
-    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
-    recipient: AztecAddress,
-) -> DeliveredPendingPartialNote {
-    let note_type_id = msg_metadata as Field; // TODO: make note type id not be a full field
-
-    // The following ensures that the message content contains at least the minimum number of fields required for a
-    // valid partial note private message. (Refer to the description of
-    // PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN for more information about these fields.)
-    assert(
-        msg_content.len() >= PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN,
-        f"Invalid private note message: all partial note private messages must have at least {PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN} fields",
-    );
-
-    // If PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN is changed, causing the assertion below to fail, then the
-    // destructuring of the partial note private message encoding below must be updated as well.
-    std::static_assert(
-        PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN == 4,
-        "unexpected value for PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN",
-    );
-
-    // We currently have four fields that are not the partial note's packed representation,
-    // which are the owner, the storage slot, the randomness, and the note completion log tag.
-    let owner = AztecAddress::from_field(msg_content.get(
-        PARTIAL_NOTE_PRIVATE_MSG_CONTENT_OWNER_INDEX,
-    ));
-    let storage_slot = msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_CONTENT_STORAGE_SLOT_INDEX);
-    let randomness = msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_CONTENT_RANDOMNESS_INDEX);
-    let note_completion_log_tag =
-        msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NOTE_COMPLETION_LOG_TAG_INDEX);
-
-    let packed_private_note_content: BoundedVec<Field, MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN> = array::subbvec(
-        msg_content,
-        PARTIAL_NOTE_PRIVATE_MSG_CONTENT_NON_NOTE_FIELDS_LEN,
-    );
-
-    DeliveredPendingPartialNote {
-        note_completion_log_tag,
-        owner,
-        storage_slot,
-        randomness,
-        note_type_id,
-        packed_private_note_content,
-        recipient,
-    }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -1,21 +1,8 @@
-use crate::{
-    event::event_selector::EventSelector,
-    messages::{encoding::MAX_MESSAGE_CONTENT_LEN, processing::enqueue_event_for_validation},
-    utils::array,
+use crate::messages::{
+    encoding::MAX_MESSAGE_CONTENT_LEN, logs::event::decode_private_event_message,
+    processing::enqueue_event_for_validation,
 };
-use protocol_types::{
-    address::AztecAddress, constants::GENERATOR_INDEX__EVENT_COMMITMENT,
-    hash::poseidon2_hash_with_separator_bounded_vec, traits::FromField,
-};
-
-/// The number of fields in a private event message content that are not the event's serialized representation
-/// (1 field for randomness).
-global PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN: u32 = 1;
-
-/// The maximum length of the packed representation of an event's contents. This is limited by private log size,
-/// encryption overhead and extra fields in the message (e.g. message type id, randomness, etc.).
-pub global MAX_EVENT_SERIALIZED_LEN: u32 =
-    MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN;
+use protocol_types::address::AztecAddress;
 
 pub unconstrained fn process_private_event_msg(
     contract_address: AztecAddress,
@@ -24,34 +11,8 @@ pub unconstrained fn process_private_event_msg(
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
     tx_hash: Field,
 ) {
-    // In the case of events, the msg metadata is the event selector.
-    let event_type_id = EventSelector::from_field(msg_metadata as Field);
-
-    assert(
-        msg_content.len() > PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN,
-        f"Invalid private event message: all private event messages must have at least {PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN} fields",
-    );
-
-    // If PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN is changed, causing the assertion below to fail, then the
-    // destructuring of the private event message encoding below must be updated as well.
-    std::static_assert(
-        PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN == 1,
-        "unexpected value for PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN",
-    );
-
-    let serialized_event_with_randomness = msg_content;
-
-    let event_commitment = poseidon2_hash_with_separator_bounded_vec(
-        serialized_event_with_randomness,
-        GENERATOR_INDEX__EVENT_COMMITMENT,
-    );
-
-    // Randomness was injected into the event payload in `emit_event_in_private` but we have already used it
-    // to compute the event commitment, so we can safely discard it now.
-    let serialized_event = array::subbvec(
-        serialized_event_with_randomness,
-        PRIVATE_EVENT_MSG_CONTENT_NON_EVENT_FIELDS_LEN,
-    );
+    let (event_type_id, serialized_event, event_commitment) =
+        decode_private_event_message(msg_metadata, msg_content);
 
     enqueue_event_for_validation(
         contract_address,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
@@ -1,27 +1,12 @@
-use crate::{
-    messages::{
-        discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
-        encoding::MAX_MESSAGE_CONTENT_LEN,
-        processing::enqueue_note_for_validation,
-    },
-    utils::array,
+use crate::messages::{
+    discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
+    encoding::MAX_MESSAGE_CONTENT_LEN,
+    logs::note::{decode_private_note_message, MAX_NOTE_PACKED_LEN},
+    processing::enqueue_note_for_validation,
 };
 use protocol_types::{
     address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX, debug_log::debug_log_format,
-    traits::FromField,
 };
-
-/// The number of fields in a private note message content that are not the note's packed representation.
-// See the call to `std::static_assert` below to see what's in these fields.
-global PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN: u32 = 3;
-global PRIVATE_NOTE_MSG_CONTENT_OWNER_INDEX: u32 = 0;
-global PRIVATE_NOTE_MSG_CONTENT_STORAGE_SLOT_INDEX: u32 = 1;
-global PRIVATE_NOTE_MSG_CONTENT_RANDOMNESS_INDEX: u32 = 2;
-
-/// The maximum length of the packed representation of a note's contents. This is limited by private log size,
-/// encryption overhead and extra fields in the message (e.g. message type id, storage slot, randomness, etc.).
-pub global MAX_NOTE_PACKED_LEN: u32 =
-    MAX_MESSAGE_CONTENT_LEN - PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN;
 
 pub unconstrained fn process_private_note_msg<Env>(
     contract_address: AztecAddress,
@@ -34,7 +19,7 @@ pub unconstrained fn process_private_note_msg<Env>(
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
 ) {
     let (note_type_id, owner, storage_slot, randomness, packed_note) =
-        decode_private_note_msg(msg_metadata, msg_content);
+        decode_private_note_message(msg_metadata, msg_content);
 
     attempt_note_discovery(
         contract_address,
@@ -97,31 +82,4 @@ pub unconstrained fn attempt_note_discovery<Env>(
             recipient,
         );
     });
-}
-
-fn decode_private_note_msg(
-    msg_metadata: u64,
-    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
-) -> (Field, AztecAddress, Field, Field, BoundedVec<Field, MAX_NOTE_PACKED_LEN>) {
-    let note_type_id = msg_metadata as Field; // TODO: make note type id not be a full field
-
-    assert(
-        msg_content.len() > PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN,
-        f"Invalid private note message: all private note messages must have at least {PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN} fields",
-    );
-
-    // If PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN is changed, causing the assertion below to fail, then the
-    // destructuring of the private note message encoding below must be updated as well.
-    std::static_assert(
-        PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN == 3,
-        "unexpected value for PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN",
-    );
-
-    // We currently have two fields that are not the note's packed representation, which are the owner and the storage slot.
-    let owner = AztecAddress::from_field(msg_content.get(PRIVATE_NOTE_MSG_CONTENT_OWNER_INDEX));
-    let storage_slot = msg_content.get(PRIVATE_NOTE_MSG_CONTENT_STORAGE_SLOT_INDEX);
-    let randomness = msg_content.get(PRIVATE_NOTE_MSG_CONTENT_RANDOMNESS_INDEX);
-    let packed_note = array::subbvec(msg_content, PRIVATE_NOTE_MSG_CONTENT_NON_NOTE_FIELDS_LEN);
-
-    (note_type_id, owner, storage_slot, randomness, packed_note)
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -1,20 +1,34 @@
 use crate::{
-    event::event_interface::EventInterface,
+    event::{event_interface::EventInterface, event_selector::EventSelector},
     messages::{
-        encoding::{encode_message, MESSAGE_EXPANDED_METADATA_LEN},
+        encoding::{encode_message, MAX_MESSAGE_CONTENT_LEN, MESSAGE_EXPANDED_METADATA_LEN},
         msg_type::PRIVATE_EVENT_MSG_TYPE_ID,
     },
+    utils::array,
 };
-use protocol_types::traits::{Serialize, ToField};
+use protocol_types::{
+    constants::GENERATOR_INDEX__EVENT_COMMITMENT,
+    hash::poseidon2_hash_with_separator_bounded_vec,
+    traits::{FromField, Serialize, ToField},
+};
 
-global PRIVATE_EVENT_RESERVED_FIELDS: u32 = 1;
-global PRIVATE_EVENT_RANDOMNESS_INDEX: u32 = 0;
+/// The number of fields in a private event message content that are not the event's serialized representation
+/// (1 field for randomness).
+pub(crate) global PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN: u32 = 1;
+pub(crate) global PRIVATE_EVENT_MSG_PLAINTEXT_RANDOMNESS_INDEX: u32 = 0;
+
+/// The maximum length of the packed representation of an event's contents. This is limited by private log size,
+/// encryption overhead and extra fields in the message (e.g. message type id, randomness, etc.).
+pub(crate) global MAX_EVENT_SERIALIZED_LEN: u32 =
+    MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN;
 
 /// Creates the plaintext for a private event message (i.e. one of type [PRIVATE_EVENT_MSG_TYPE_ID]).
-pub fn private_event_to_message_plaintext<Event>(
+///
+/// This plaintext is meant to be decoded via [decode_private_event_message].
+pub fn encode_private_event_message<Event>(
     event: Event,
     randomness: Field,
-    ) -> [Field; PRIVATE_EVENT_RESERVED_FIELDS + <Event as Serialize>::N + MESSAGE_EXPANDED_METADATA_LEN]
+    ) -> [Field; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Event as Serialize>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
     Event: EventInterface + Serialize,
 {
@@ -24,17 +38,102 @@ where
     // worth the savings in DA (for public events) and proving time (when encrypting private event messages).
     let serialized_event = event.serialize();
 
-    let mut msg_content = [0; PRIVATE_EVENT_RESERVED_FIELDS + <Event as Serialize>::N];
-    msg_content[PRIVATE_EVENT_RANDOMNESS_INDEX] = randomness;
+    // If PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // encoding below must be updated as well.
+    std::static_assert(
+        PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 1,
+        "unexpected value for PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
+    );
+
+    let mut msg_plaintext =
+        [0; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Event as Serialize>::N];
+    msg_plaintext[PRIVATE_EVENT_MSG_PLAINTEXT_RANDOMNESS_INDEX] = randomness;
 
     for i in 0..serialized_event.len() {
-        msg_content[PRIVATE_EVENT_RESERVED_FIELDS + i] = serialized_event[i];
+        msg_plaintext[PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + i] = serialized_event[i];
     }
 
     // Private events use the event type id for metadata
     encode_message(
         PRIVATE_EVENT_MSG_TYPE_ID,
         Event::get_event_type_id().to_field() as u64,
-        msg_content,
+        msg_plaintext,
     )
+}
+
+/// Decodes the plaintext from a private event message (i.e. one of type [PRIVATE_EVENT_MSG_TYPE_ID]).
+///
+/// This plaintext is meant to have originated from [encode_private_event_message].
+///
+/// Note that while [encode_private_event_message] returns a fixed-size array, this function takes a [BoundedVec]
+/// instead. This is because when decoding we're typically processing runtime-sized plaintexts, more specifically, those
+/// that originate from [crate::messages::encryption::message_encryption::MessageEncryption::decrypt].
+pub(crate) unconstrained fn decode_private_event_message(
+    msg_metadata: u64,
+    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
+) -> (EventSelector, BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>, Field) {
+    // In the case of events, the msg metadata is the event selector.
+    let event_type_id = EventSelector::from_field(msg_metadata as Field);
+
+    assert(
+        msg_content.len() > PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
+        f"Invalid private event message: all private event messages must have at least {PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN} fields",
+    );
+
+    // If PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // destructuring of the private event message encoding below must be updated as well.
+    std::static_assert(
+        PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 1,
+        "unexpected value for PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
+    );
+
+    let serialized_event_with_randomness = msg_content;
+
+    let event_commitment = poseidon2_hash_with_separator_bounded_vec(
+        serialized_event_with_randomness,
+        GENERATOR_INDEX__EVENT_COMMITMENT,
+    );
+
+    // Randomness was injected into the event payload in `emit_event_in_private` but we have already used it
+    // to compute the event commitment, so we can safely discard it now.
+    let serialized_event = array::subbvec(
+        serialized_event_with_randomness,
+        PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
+    );
+
+    (event_type_id, serialized_event, event_commitment)
+}
+
+mod test {
+    use crate::{
+        event::event_interface::EventInterface,
+        messages::{
+            encoding::decode_message,
+            logs::event::{decode_private_event_message, encode_private_event_message},
+            msg_type::PRIVATE_EVENT_MSG_TYPE_ID,
+        },
+    };
+    use crate::test::mocks::mock_event::MockEvent;
+    use protocol_types::traits::Serialize;
+
+    global VALUE: Field = 7;
+    global RANDOMNESS: Field = 10;
+
+    #[test]
+    unconstrained fn encode_decode() {
+        let event = MockEvent::new(VALUE).build_event();
+
+        let message_plaintext = encode_private_event_message(event, RANDOMNESS);
+
+        let (msg_type_id, msg_metadata, msg_content) =
+            decode_message(BoundedVec::from_array(message_plaintext));
+
+        assert_eq(msg_type_id, PRIVATE_EVENT_MSG_TYPE_ID);
+
+        let (event_type_id, serialized_event, _) =
+            decode_private_event_message(msg_metadata, msg_content);
+
+        assert_eq(event_type_id, MockEvent::get_event_type_id());
+        assert_eq(serialized_event, BoundedVec::from_array(event.serialize()));
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/mod.nr
@@ -1,4 +1,5 @@
 pub mod arithmetic_generics_utils;
 pub mod event;
 pub mod note;
+pub mod partial_note;
 pub mod utils;

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -1,94 +1,127 @@
 use crate::{
     messages::{
-        encoding::{encode_message, MESSAGE_EXPANDED_METADATA_LEN},
-        encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::utils::prefix_with_tag,
-        msg_type::{PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID},
+        encoding::{encode_message, MAX_MESSAGE_CONTENT_LEN, MESSAGE_EXPANDED_METADATA_LEN},
+        msg_type::PRIVATE_NOTE_MSG_TYPE_ID,
     },
     note::note_interface::NoteType,
+    utils::array,
 };
-use protocol_types::{
-    address::AztecAddress,
-    constants::PRIVATE_LOG_SIZE_IN_FIELDS,
-    traits::{Packable, ToField},
-};
+use protocol_types::{address::AztecAddress, traits::{FromField, Packable, ToField}};
 
-global PRIVATE_NOTE_RESERVED_FIELDS: u32 = 3;
-global PRIVATE_NOTE_OWNER_INDEX: u32 = 0;
-global PRIVATE_NOTE_STORAGE_SLOT_INDEX: u32 = 1;
-global PRIVATE_NOTE_RANDOMNESS_INDEX: u32 = 2;
+/// The number of fields in a private note message content that are not the note's packed representation.
+pub(crate) global PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN: u32 = 3;
 
-// TODO(#16881): once partial notes support delivery via an offchain message we will most likely want to remove this.
-pub fn compute_partial_note_private_content_log<PartialNotePrivateContent>(
-    partial_note_private_content: PartialNotePrivateContent,
-    owner: AztecAddress,
-    storage_slot: Field,
-    randomness: Field,
-    recipient: AztecAddress,
-) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
-where
-    PartialNotePrivateContent: NoteType + Packable,
-{
-    let message_plaintext = partial_note_private_content_to_message_plaintext(
-        partial_note_private_content,
-        owner,
-        storage_slot,
-        randomness,
-    );
-    let message_ciphertext = AES128::encrypt(message_plaintext, recipient);
+pub(crate) global PRIVATE_NOTE_MSG_PLAINTEXT_OWNER_INDEX: u32 = 0;
+pub(crate) global PRIVATE_NOTE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX: u32 = 1;
+pub(crate) global PRIVATE_NOTE_MSG_PLAINTEXT_RANDOMNESS_INDEX: u32 = 2;
 
-    prefix_with_tag(message_ciphertext, recipient)
-}
+/// The maximum length of the packed representation of a note's contents. This is limited by private log size,
+/// encryption overhead and extra fields in the message (e.g. message type id, storage slot, randomness, etc.).
+pub global MAX_NOTE_PACKED_LEN: u32 =
+    MAX_MESSAGE_CONTENT_LEN - PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN;
 
 /// Creates the plaintext for a private note message (i.e. one of type [PRIVATE_NOTE_MSG_TYPE_ID]).
-pub fn private_note_to_message_plaintext<Note>(
+///
+/// This plaintext is meant to be decoded via [decode_private_note_message].
+pub fn encode_private_note_message<Note>(
     note: Note,
     owner: AztecAddress,
     storage_slot: Field,
     randomness: Field,
-) -> [Field; PRIVATE_NOTE_RESERVED_FIELDS + <Note as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
+    ) -> [Field; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Note as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
     Note: NoteType + Packable,
 {
     let packed_note = note.pack();
 
-    let mut msg_content = [0; PRIVATE_NOTE_RESERVED_FIELDS + <Note as Packable>::N];
-    msg_content[PRIVATE_NOTE_OWNER_INDEX] = owner.to_field();
-    msg_content[PRIVATE_NOTE_STORAGE_SLOT_INDEX] = storage_slot;
-    msg_content[PRIVATE_NOTE_RANDOMNESS_INDEX] = randomness;
+    // If PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // encoding below must be updated as well.
+    std::static_assert(
+        PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 3,
+        "unexpected value for PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
+    );
+
+    let mut msg_content =
+        [0; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Note as Packable>::N];
+    msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_OWNER_INDEX] = owner.to_field();
+    msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX] = storage_slot;
+    msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_RANDOMNESS_INDEX] = randomness;
     for i in 0..packed_note.len() {
-        msg_content[PRIVATE_NOTE_RESERVED_FIELDS + i] = packed_note[i];
+        msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + i] = packed_note[i];
     }
 
     // Notes use the note type id for metadata
     encode_message(PRIVATE_NOTE_MSG_TYPE_ID, Note::get_id() as u64, msg_content)
 }
 
-/// Creates the plaintext for a partial note private message (i.e. one of type [PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID]).
-pub fn partial_note_private_content_to_message_plaintext<PartialNotePrivateContent>(
-    partial_note_private_content: PartialNotePrivateContent,
-    owner: AztecAddress,
-    storage_slot: Field,
-    randomness: Field,
-    ) -> [Field; PRIVATE_NOTE_RESERVED_FIELDS + <PartialNotePrivateContent as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
-where
-    PartialNotePrivateContent: NoteType + Packable,
-{
-    let packed_private_content = partial_note_private_content.pack();
+/// Decodes the plaintext from a private note message (i.e. one of type [PRIVATE_NOTE_MSG_TYPE_ID]).
+///
+/// This plaintext is meant to have originated from [encode_private_note_message].
+///
+/// Note that while [encode_private_note_message] returns a fixed-size array, this function takes a [BoundedVec]
+/// instead. This is because when decoding we're typically processing runtime-sized plaintexts, more specifically, those
+/// that originate from [crate::messages::encryption::message_encryption::MessageEncryption::decrypt].
+pub(crate) unconstrained fn decode_private_note_message(
+    msg_metadata: u64,
+    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
+) -> (Field, AztecAddress, Field, Field, BoundedVec<Field, MAX_NOTE_PACKED_LEN>) {
+    let note_type_id = msg_metadata as Field; // TODO: make note type id not be a full field
 
-    let mut msg_content =
-        [0; PRIVATE_NOTE_RESERVED_FIELDS + <PartialNotePrivateContent as Packable>::N];
-    msg_content[PRIVATE_NOTE_OWNER_INDEX] = owner.to_field();
-    msg_content[PRIVATE_NOTE_STORAGE_SLOT_INDEX] = storage_slot;
-    msg_content[PRIVATE_NOTE_RANDOMNESS_INDEX] = randomness;
-    for i in 0..packed_private_content.len() {
-        msg_content[PRIVATE_NOTE_RESERVED_FIELDS + i] = packed_private_content[i];
+    assert(
+        msg_content.len() > PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
+        f"Invalid private note message: all private note messages must have at least {PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN} fields",
+    );
+
+    // If PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // decoding below must be updated as well.
+    std::static_assert(
+        PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 3,
+        "unexpected value for PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
+    );
+
+    let owner = AztecAddress::from_field(msg_content.get(PRIVATE_NOTE_MSG_PLAINTEXT_OWNER_INDEX));
+    let storage_slot = msg_content.get(PRIVATE_NOTE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX);
+    let randomness = msg_content.get(PRIVATE_NOTE_MSG_PLAINTEXT_RANDOMNESS_INDEX);
+    let packed_note = array::subbvec(msg_content, PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN);
+
+    (note_type_id, owner, storage_slot, randomness, packed_note)
+}
+
+mod test {
+    use crate::{
+        messages::{
+            encoding::decode_message,
+            logs::note::{decode_private_note_message, encode_private_note_message},
+            msg_type::PRIVATE_NOTE_MSG_TYPE_ID,
+        },
+        note::note_interface::NoteType,
+    };
+    use crate::test::mocks::mock_note::MockNote;
+    use protocol_types::{address::AztecAddress, traits::{FromField, Packable}};
+
+    global VALUE: Field = 7;
+    global OWNER: AztecAddress = AztecAddress::from_field(8);
+    global STORAGE_SLOT: Field = 9;
+    global RANDOMNESS: Field = 10;
+
+    #[test]
+    unconstrained fn encode_decode() {
+        let note = MockNote::new(VALUE).build_note();
+
+        let message_plaintext = encode_private_note_message(note, OWNER, STORAGE_SLOT, RANDOMNESS);
+
+        let (msg_type_id, msg_metadata, msg_content) =
+            decode_message(BoundedVec::from_array(message_plaintext));
+
+        assert_eq(msg_type_id, PRIVATE_NOTE_MSG_TYPE_ID);
+
+        let (note_type_id, owner, storage_slot, randomness, packed_note) =
+            decode_private_note_message(msg_metadata, msg_content);
+
+        assert_eq(note_type_id, MockNote::get_id());
+        assert_eq(owner, OWNER);
+        assert_eq(storage_slot, STORAGE_SLOT);
+        assert_eq(randomness, RANDOMNESS);
+        assert_eq(packed_note, BoundedVec::from_array(note.pack()));
     }
-
-    encode_message(
-        PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
-        // Notes use the note type id for metadata
-        PartialNotePrivateContent::get_id() as u64,
-        msg_content,
-    )
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/partial_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/partial_note.nr
@@ -1,0 +1,195 @@
+use crate::{
+    messages::{
+        encoding::{encode_message, MAX_MESSAGE_CONTENT_LEN, MESSAGE_EXPANDED_METADATA_LEN},
+        encryption::{aes128::AES128, message_encryption::MessageEncryption},
+        logs::utils::prefix_with_tag,
+        msg_type::PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+    },
+    note::note_interface::NoteType,
+    utils::array,
+};
+use protocol_types::{
+    address::AztecAddress,
+    constants::PRIVATE_LOG_SIZE_IN_FIELDS,
+    traits::{FromField, Packable, ToField},
+};
+
+/// The number of fields in a private note message content that are not the note's packed representation.
+pub(crate) global PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN: u32 = 4;
+pub(crate) global PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_OWNER_INDEX: u32 = 0;
+pub(crate) global PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX: u32 = 1;
+pub(crate) global PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RANDOMNESS_INDEX: u32 = 2;
+pub(crate) global PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NOTE_COMPLETION_LOG_TAG_INDEX: u32 = 3;
+
+/// Partial notes have a maximum packed length of their private fields bound by extra content in their private message
+/// (e.g. the storage slot, note completion log tag, etc.).
+pub global MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN: u32 =
+    MAX_MESSAGE_CONTENT_LEN - PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN;
+
+// TODO(#16881): once partial notes support delivery via an offchain message we will most likely want to remove this.
+pub fn compute_partial_note_private_content_log<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
+    owner: AztecAddress,
+    storage_slot: Field,
+    randomness: Field,
+    recipient: AztecAddress,
+    note_completion_log_tag: Field,
+) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
+where
+    PartialNotePrivateContent: NoteType + Packable,
+{
+    let message_plaintext = encode_partial_note_private_message(
+        partial_note_private_content,
+        owner,
+        storage_slot,
+        randomness,
+        note_completion_log_tag,
+    );
+    let message_ciphertext = AES128::encrypt(message_plaintext, recipient);
+
+    prefix_with_tag(message_ciphertext, recipient)
+}
+
+/// Creates the plaintext for a partial note private message (i.e. one of type [PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID]).
+///
+/// This plaintext is meant to be decoded via [decode_partial_note_private_message].
+pub fn encode_partial_note_private_message<PartialNotePrivateContent>(
+    partial_note_private_content: PartialNotePrivateContent,
+    owner: AztecAddress,
+    storage_slot: Field,
+    randomness: Field,
+    note_completion_log_tag: Field,
+    ) -> [Field; PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <PartialNotePrivateContent as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
+where
+    PartialNotePrivateContent: NoteType + Packable,
+{
+    let packed_private_content = partial_note_private_content.pack();
+
+    // If PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NON_NOTE_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // encoding below must be updated as well.
+    std::static_assert(
+        PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 4,
+        "unexpected value for PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NON_NOTE_FIELDS_LEN",
+    );
+
+    let mut msg_content = [
+        0; PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN
+            + <PartialNotePrivateContent as Packable>::N
+    ];
+    msg_content[PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_OWNER_INDEX] = owner.to_field();
+    msg_content[PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX] = storage_slot;
+    msg_content[PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RANDOMNESS_INDEX] = randomness;
+    msg_content[PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NOTE_COMPLETION_LOG_TAG_INDEX] =
+        note_completion_log_tag;
+
+    for i in 0..packed_private_content.len() {
+        msg_content[PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + i] =
+            packed_private_content[i];
+    }
+
+    encode_message(
+        PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+        // Notes use the note type id for metadata
+        PartialNotePrivateContent::get_id() as u64,
+        msg_content,
+    )
+}
+
+/// Decodes the plaintext from a private note message (i.e. one of type [PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID]).
+///
+/// This plaintext is meant to have originated from [encode_partial_note_private_message].
+///
+/// Note that while [encode_partial_note_private_message] returns a fixed-size array, this function takes a [BoundedVec]
+/// instead. This is because when decoding we're typically processing runtime-sized plaintexts, more specifically, those
+/// that originate from [crate::messages::encryption::message_encryption::MessageEncryption::decrypt].
+pub(crate) unconstrained fn decode_partial_note_private_message(
+    msg_metadata: u64,
+    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
+    ) -> (AztecAddress, Field, Field, Field, Field, BoundedVec<Field, MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN>) {
+    let note_type_id = msg_metadata as Field; // TODO: make note type id not be a full field
+
+    // The following ensures that the message content contains at least the minimum number of fields required for a
+    // valid partial note private message. (Refer to the description of
+    // PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NON_NOTE_FIELDS_LEN for more information about these fields.)
+    assert(
+        msg_content.len() >= PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
+        f"Invalid private note message: all partial note private messages must have at least {PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN} fields",
+    );
+
+    // If PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NON_NOTE_FIELDS_LEN is changed, causing the assertion below to fail, then the
+    // destructuring of the partial note private message encoding below must be updated as well.
+    std::static_assert(
+        PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN == 4,
+        "unexpected value for PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NON_NOTE_FIELDS_LEN",
+    );
+
+    // We currently have four fields that are not the partial note's packed representation,
+    // which are the owner, the storage slot, the randomness, and the note completion log tag.
+    let owner = AztecAddress::from_field(msg_content.get(
+        PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_OWNER_INDEX,
+    ));
+    let storage_slot = msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX);
+    let randomness = msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RANDOMNESS_INDEX);
+    let note_completion_log_tag =
+        msg_content.get(PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_NOTE_COMPLETION_LOG_TAG_INDEX);
+
+    let packed_private_note_content: BoundedVec<Field, MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN> = array::subbvec(
+        msg_content,
+        PARTIAL_NOTE_PRIVATE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
+    );
+
+    (
+        owner, storage_slot, randomness, note_completion_log_tag, note_type_id,
+        packed_private_note_content,
+    )
+}
+
+mod test {
+    use crate::{
+        messages::{
+            encoding::decode_message,
+            logs::partial_note::{
+                decode_partial_note_private_message, encode_partial_note_private_message,
+            },
+            msg_type::PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID,
+        },
+        note::note_interface::NoteType,
+    };
+    use crate::test::mocks::mock_note::MockNote;
+    use protocol_types::{address::AztecAddress, traits::{FromField, Packable}};
+
+    global VALUE: Field = 7;
+    global OWNER: AztecAddress = AztecAddress::from_field(8);
+    global STORAGE_SLOT: Field = 9;
+    global RANDOMNESS: Field = 10;
+    global NOTE_COMPLETION_LOG_TAG: Field = 11;
+
+    #[test]
+    unconstrained fn encode_decode() {
+        // Note that here we use MockNote as the private fields of a partial note
+        let note = MockNote::new(VALUE).build_note();
+
+        let message_plaintext = encode_partial_note_private_message(
+            note,
+            OWNER,
+            STORAGE_SLOT,
+            RANDOMNESS,
+            NOTE_COMPLETION_LOG_TAG,
+        );
+
+        let (msg_type_id, msg_metadata, msg_content) =
+            decode_message(BoundedVec::from_array(message_plaintext));
+
+        assert_eq(msg_type_id, PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID);
+
+        let (owner, storage_slot, randomness, note_completion_log_tag, note_type_id, packed_note) =
+            decode_partial_note_private_message(msg_metadata, msg_content);
+
+        assert_eq(note_type_id, MockNote::get_id());
+        assert_eq(owner, OWNER);
+        assert_eq(storage_slot, STORAGE_SLOT);
+        assert_eq(randomness, RANDOMNESS);
+        assert_eq(note_completion_log_tag, NOTE_COMPLETION_LOG_TAG);
+        assert_eq(packed_note, BoundedVec::from_array(note.pack()));
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
@@ -1,7 +1,4 @@
-use crate::{
-    event::event_selector::EventSelector,
-    messages::discovery::private_events::MAX_EVENT_SERIALIZED_LEN,
-};
+use crate::{event::event_selector::EventSelector, messages::logs::event::MAX_EVENT_SERIALIZED_LEN};
 use protocol_types::{address::AztecAddress, traits::Serialize};
 
 /// Intermediate struct used to perform batch event validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_response.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_response.nr
@@ -1,4 +1,4 @@
-use crate::messages::discovery::private_notes::MAX_NOTE_PACKED_LEN;
+use crate::messages::logs::note::MAX_NOTE_PACKED_LEN;
 use protocol_types::{
     constants::{MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_CIPHERTEXT_LEN},
     traits::Deserialize,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -9,10 +9,8 @@ use crate::{
     capsules::CapsuleArray,
     event::event_selector::EventSelector,
     messages::{
-        discovery::{
-            partial_notes::DeliveredPendingPartialNote, private_events::MAX_EVENT_SERIALIZED_LEN,
-            private_notes::MAX_NOTE_PACKED_LEN,
-        },
+        discovery::partial_notes::DeliveredPendingPartialNote,
+        logs::{event::MAX_EVENT_SERIALIZED_LEN, note::MAX_NOTE_PACKED_LEN},
         processing::{
             log_retrieval_request::LogRetrievalRequest,
             log_retrieval_response::LogRetrievalResponse,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
@@ -1,4 +1,4 @@
-use crate::messages::discovery::private_notes::MAX_NOTE_PACKED_LEN;
+use crate::messages::logs::note::MAX_NOTE_PACKED_LEN;
 use protocol_types::{address::AztecAddress, traits::Serialize};
 
 /// Intermediate struct used to perform batch note validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle

--- a/noir-projects/aztec-nr/aztec/src/note/note_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_message.nr
@@ -2,7 +2,7 @@ use crate::{
     context::PrivateContext,
     messages::{
         encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::{note::private_note_to_message_plaintext, utils::prefix_with_tag},
+        logs::{note::encode_private_note_message, utils::prefix_with_tag},
         message_delivery::MessageDelivery,
         offchain_messages::deliver_offchain_message,
     },
@@ -88,7 +88,7 @@ where
         let ciphertext = remove_constraints_if(
             !constrained_encryption,
             || AES128::encrypt(
-                private_note_to_message_plaintext(
+                encode_private_note_message(
                     new_note.note,
                     new_note.owner,
                     new_note.storage_slot,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -17,7 +17,7 @@ use crate::{
             process_message::process_message_plaintext,
         },
         encoding::MESSAGE_PLAINTEXT_LEN,
-        logs::{event::private_event_to_message_plaintext, note::private_note_to_message_plaintext},
+        logs::{event::encode_private_event_message, note::encode_private_note_message},
         processing::{message_context::MessageContext, validate_enqueued_notes_and_events},
     },
     note::{
@@ -757,7 +757,7 @@ impl TestEnvironment {
         // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
         // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
         // sized).
-        let message_plaintext = BoundedVec::from_array(private_note_to_message_plaintext(
+        let message_plaintext = BoundedVec::from_array(encode_private_note_message(
             note_message.new_note.note,
             note_message.new_note.owner,
             note_message.new_note.storage_slot,
@@ -886,7 +886,7 @@ impl TestEnvironment {
         // Note that we need to convert the fixed-size array produced by the encoding functions into a BoundedVec, which
         // is what the decoding functions expect (because they are built to manage protocol logs, which are arbitrarily
         // sized).
-        let message_plaintext = BoundedVec::from_array(private_event_to_message_plaintext(
+        let message_plaintext = BoundedVec::from_array(encode_private_event_message(
             event_message.new_event.event,
             event_message.new_event.randomness,
         ));

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -3,7 +3,7 @@ use dep::aztec::{
     history::nullifier_inclusion::ProveNullifierInclusion,
     keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::custom_note,
-    messages::logs::note,
+    messages::logs::partial_note::compute_partial_note_private_content_log,
     note::note_interface::{NoteHash, NoteType},
     oracle::random::random,
     protocol_types::{
@@ -129,14 +129,15 @@ impl UintNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = UintPartialNotePrivateLogContent { public_log_tag: commitment };
+        let private_log_content = UintPartialNotePrivateLogContent {};
 
-        let encrypted_log = note::compute_partial_note_private_content_log(
+        let encrypted_log = compute_partial_note_private_content_log(
             private_log_content,
             owner,
             storage_slot,
             randomness,
             recipient,
+            commitment,
         );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
@@ -171,9 +172,9 @@ fn compute_partial_commitment(
 // docs:end:compute_partial_commitment
 
 #[derive(Packable)]
-struct UintPartialNotePrivateLogContent {
-    public_log_tag: Field,
-}
+// This note does not have any non-metadata (i.e. storage slot, owner, randomness) private content, as the only field
+// (value) will be public in the partial note.
+struct UintPartialNotePrivateLogContent {}
 
 impl NoteType for UintPartialNotePrivateLogContent {
     fn get_id() -> Field {
@@ -306,13 +307,10 @@ impl FromField for PartialUintNote {
 }
 
 mod test {
-    use super::{
-        compute_partial_commitment, PartialUintNote, UintNote, UintPartialNotePrivateLogContent,
-    };
+    use super::{compute_partial_commitment, PartialUintNote, UintNote};
     use dep::aztec::{
         note::note_interface::NoteHash,
-        protocol_types::{address::AztecAddress, traits::{Deserialize, FromField, Packable}},
-        utils::array::subarray,
+        protocol_types::{address::AztecAddress, traits::FromField},
     };
 
     global value: u128 = 17;
@@ -334,32 +332,5 @@ mod test {
         let completed_partial_note_hash = partial_note.compute_complete_note_hash(value);
 
         assert_eq(note_hash, completed_partial_note_hash);
-    }
-
-    #[test]
-    fn unpack_from_partial_note_encoding() {
-        // Tests that the packed representation of a regular UintNote can be reconstructed given the partial note
-        // private fields log and the public completion log, ensuring the recipient will be able to compute the
-        // completed note as if it were a regular UintNote.
-        let note = UintNote { value };
-
-        let commitment = compute_partial_commitment(owner, storage_slot, randomness);
-
-        let private_log_content = UintPartialNotePrivateLogContent { public_log_tag: commitment };
-        // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
-        // letting devs manually construct it when they shouldn't be able to.
-        let partial_note = PartialUintNote::deserialize([commitment]);
-
-        // The first field of the partial note private content is the public completion log tag, so it should match the
-        // first field of the public log.
-        assert_eq(
-            private_log_content.pack()[0],
-            partial_note.compute_note_completion_log(value)[0],
-        );
-
-        // The completion log without the tag should match the note's packed representation.
-        let public_log_without_tag: [_; 1] =
-            subarray(partial_note.compute_note_completion_log(value), 1);
-        assert_eq(public_log_without_tag, note.pack());
     }
 }

--- a/noir-projects/noir-contracts-comp-failures/contracts/invalid_note/src/invalid_note.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/invalid_note/src/invalid_note.nr
@@ -1,6 +1,6 @@
 use aztec::{
     macros::notes::note,
-    messages::discovery::private_notes::MAX_NOTE_PACKED_LEN,
+    messages::logs::note::MAX_NOTE_PACKED_LEN,
     protocol_types::traits::Packable,
 };
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -2,7 +2,7 @@ use dep::aztec::{
     context::{PrivateContext, PublicContext},
     keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::custom_note,
-    messages::logs::note,
+    messages::logs::partial_note::compute_partial_note_private_content_log,
     note::note_interface::{NoteHash, NoteType},
     oracle::random::random,
     protocol_types::{
@@ -124,14 +124,15 @@ impl NFTNote {
         //  - the commitment is already public information, so we're not revealing anything else
         //  - we don't need to create any additional information, private or public, for the tag
         //  - other contracts cannot impersonate us and emit logs with the same tag due to public log siloing
-        let private_log_content = NFTPartialNotePrivateLogContent { public_log_tag: commitment };
+        let private_log_content = NFTPartialNotePrivateLogContent {};
 
-        let encrypted_log = note::compute_partial_note_private_content_log(
+        let encrypted_log = compute_partial_note_private_content_log(
             private_log_content,
             owner,
             storage_slot,
             randomness,
             recipient,
+            commitment,
         );
         // Regardless of the original content size, the log is padded with random bytes up to
         // `PRIVATE_LOG_SIZE_IN_FIELDS` to prevent leaking information about the actual size.
@@ -164,9 +165,9 @@ fn compute_partial_commitment(
 }
 
 #[derive(Packable)]
-struct NFTPartialNotePrivateLogContent {
-    public_log_tag: Field,
-}
+// This note does not have any non-metadata (i.e. storage slot, owner, randomness) private content, as the only field
+// (token_id) will be public in the partial note.
+struct NFTPartialNotePrivateLogContent {}
 
 impl NoteType for NFTPartialNotePrivateLogContent {
     fn get_id() -> Field {
@@ -237,13 +238,10 @@ impl PartialNFTNote {
 }
 
 mod test {
-    use super::{
-        compute_partial_commitment, NFTNote, NFTPartialNotePrivateLogContent, PartialNFTNote,
-    };
+    use super::{compute_partial_commitment, NFTNote, PartialNFTNote};
     use dep::aztec::{
         note::note_interface::NoteHash,
-        protocol_types::{address::AztecAddress, traits::{Deserialize, FromField, Packable}},
-        utils::array::subarray,
+        protocol_types::{address::AztecAddress, traits::FromField},
     };
 
     global token_id: Field = 17;
@@ -266,34 +264,5 @@ mod test {
         let completed_partial_note_hash = partial_note.compute_complete_note_hash(token_id);
 
         assert_eq(note_hash, completed_partial_note_hash);
-    }
-
-    #[test]
-    fn unpack_from_partial_note_encoding() {
-        // Tests that the packed representation of a regular NFTNote can be reconstructed given the partial note
-        // private fields log and the public completion log, ensuring the recipient will be able to compute the
-        // completed note as if it were a regular NFTNote.
-
-        let note = NFTNote { token_id };
-
-        let commitment = compute_partial_commitment(owner, storage_slot, randomness);
-
-        let private_log_content = NFTPartialNotePrivateLogContent { public_log_tag: commitment };
-        // The following is a misuse of the `deserialize` function, but this is just a test and it's better than
-        // letting devs manually construct it when they shouldn't be able to.
-        let partial_note = PartialNFTNote::deserialize([commitment]);
-
-        // The first field of the partial note private content is the public completion log tag, so it should match the
-        // first field of the public log.
-        assert_eq(
-            private_log_content.pack()[0],
-            partial_note.compute_note_completion_log(token_id)[0],
-        );
-
-        // The completion log without the tag should match the note's packed representation.
-        let public_log_without_tag: [_; 1] =
-            subarray(partial_note.compute_note_completion_log(token_id), 1);
-
-        assert_eq(public_log_without_tag, note.pack());
     }
 }


### PR DESCRIPTION
We used to have lots of hapzardly put together encoding and decoding functions, now they all live in the same place and follow similar structures and have tests.  We still want to move them (https://github.com/AztecProtocol/aztec-packages/issues/16771), and we still want to review what we call 'content' and what we call 'plaintext', but that'll be a task for later.

These changes very nicely show how events are currently undercommitted and underdecoded, but with them it's very easy to fix these things.