### PR TITLE
chore: keccak stdlib cleanup

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.cpp
@@ -18,13 +18,13 @@ template <typename Builder> void create_keccak_permutations_constraints(Builder&
     // Create the array containing the permuted state
     std::array<field_ct, bb::stdlib::keccak<Builder>::NUM_KECCAK_LANES> state;
 
-    // Get the witness assignment for each witness index
-    // Write the witness assignment to the byte array
+    // Write the witness assignment to the state
     for (size_t i = 0; i < constraint.state.size(); ++i) {
         state[i] = to_field_ct(constraint.state[i], builder);
     }
 
-    std::array<field_ct, 25> output_state = bb::stdlib::keccak<Builder>::permutation_opcode(state, &builder);
+    std::array<field_ct, bb::stdlib::keccak<Builder>::NUM_KECCAK_LANES> output_state =
+        bb::stdlib::keccak<Builder>::permutation_opcode(state, &builder);
 
     for (size_t i = 0; i < output_state.size(); ++i) {
         output_state[i].assert_equal(field_ct::from_witness_index(&builder, constraint.result[i]));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
@@ -1,0 +1,110 @@
+#include "keccak_constraint.hpp"
+#include "acir_format.hpp"
+#include "acir_format_mocks.hpp"
+#include "barretenberg/crypto/keccak/keccak.hpp"
+#include "barretenberg/crypto/keccak/keccakf1600.cpp"
+#include "barretenberg/dsl/acir_format/test_class.hpp"
+#include "barretenberg/dsl/acir_format/utils.hpp"
+#include "barretenberg/dsl/acir_format/witness_constant.hpp"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace bb;
+using namespace acir_format;
+
+template <class BuilderType> class KeccakTestingFunctions {
+  public:
+    using Builder = BuilderType;
+    using AcirConstraint = Keccakf1600;
+
+    struct InvalidWitness {
+        enum class Target : uint8_t {
+            None,
+            Input,  // Tamper with an input lane witness
+            Output, // Tamper with an output lane witness
+        };
+
+        static std::vector<Target> get_all() { return { Target::None, Target::Input, Target::Output }; }
+        static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
+    };
+
+    void invalidate_witness(Keccakf1600& constraint,
+                            WitnessVector& witness_values,
+                            const InvalidWitness::Target& invalid_witness_target)
+    {
+        switch (invalid_witness_target) {
+        case InvalidWitness::Target::Input: {
+            // Tamper with the first input lane
+            witness_values[constraint.state[0].index] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::Output: {
+            // Tamper with the first output lane
+            witness_values[constraint.result[0]] += bb::fr(1);
+            break;
+        }
+        case InvalidWitness::Target::None:
+            break;
+        }
+    }
+
+    /**
+     * @brief Generate a valid Keccakf1600 constraint with correct witness values
+     *
+     * This produces:
+     *  - 25 input lanes
+     *  - 25 output lanes
+     */
+    void generate_constraints(Keccakf1600& keccak_constraint, WitnessVector& witness_values)
+    {
+        // Start with the zero variable at index 0
+        witness_values.emplace_back(bb::fr(0));
+
+        // Use a reproducible input state
+        std::array<uint64_t, KECCAKF1600_LANES> input_state{};
+        for (size_t i = 0; i < input_state.size(); ++i) {
+            input_state[i] = static_cast<uint64_t>(i);
+        }
+
+        // Compute expected output state using a native Keccak-f[1600] permutation
+        std::array<uint64_t, KECCAKF1600_LANES> output_state = input_state;
+        ethash_keccakf1600(output_state.data());
+
+        // Add input/output states to witness
+        auto input_indices =
+            add_to_witness_and_track_indices<std::array<uint64_t, KECCAKF1600_LANES>, KECCAKF1600_LANES>(witness_values,
+                                                                                                         input_state);
+        auto output_indices =
+            add_to_witness_and_track_indices<std::array<uint64_t, KECCAKF1600_LANES>, KECCAKF1600_LANES>(witness_values,
+                                                                                                         output_state);
+
+        // Create the constraint
+        for (size_t i = 0; i < KECCAKF1600_LANES; ++i) {
+            keccak_constraint.state[i] = WitnessOrConstant<bb::fr>::from_index(input_indices[i]);
+            keccak_constraint.result[i] = output_indices[i];
+        }
+    }
+};
+
+template <class Builder>
+class KeccakConstraintsTest : public ::testing::Test, public TestClass<KeccakTestingFunctions<Builder>> {
+  protected:
+    static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
+};
+
+using BuilderTypes = testing::Types<UltraCircuitBuilder, MegaCircuitBuilder>;
+
+TYPED_TEST_SUITE(KeccakConstraintsTest, BuilderTypes);
+
+TYPED_TEST(KeccakConstraintsTest, GenerateVKFromConstraints)
+{
+    using Flavor = std::conditional_t<std::is_same_v<TypeParam, UltraCircuitBuilder>, UltraFlavor, MegaFlavor>;
+    TestFixture::template test_vk_independence<Flavor>();
+}
+
+TYPED_TEST(KeccakConstraintsTest, Tampering)
+{
+    BB_DISABLE_ASSERTS();
+    [[maybe_unused]] std::vector<std::string> _ = TestFixture::test_tampering();
+}

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
@@ -26,27 +26,27 @@ template <class BuilderType> class KeccakTestingFunctions {
         };
 
         static std::vector<Target> get_all() { return { Target::None, Target::Input, Target::Output }; }
+
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
-    void invalidate_witness(Keccakf1600& constraint,
-                            WitnessVector& witness_values,
-                            const InvalidWitness::Target& invalid_witness_target)
+    static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
+        Keccakf1600 constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {
         switch (invalid_witness_target) {
-        case InvalidWitness::Target::Input: {
-            // Tamper with the first input lane
+        case InvalidWitness::Target::Input:
+            // Tamper with the first input element
             witness_values[constraint.state[0].index] += bb::fr(1);
             break;
-        }
-        case InvalidWitness::Target::Output: {
-            // Tamper with the first output lane
+        case InvalidWitness::Target::Output:
+            // Tamper with the first output element
             witness_values[constraint.result[0]] += bb::fr(1);
             break;
-        }
         case InvalidWitness::Target::None:
             break;
         }
+
+        return { constraint, witness_values };
     }
 
     /**
@@ -56,7 +56,7 @@ template <class BuilderType> class KeccakTestingFunctions {
      *  - 25 input lanes
      *  - 25 output lanes
      */
-    void generate_constraints(Keccakf1600& keccak_constraint, WitnessVector& witness_values)
+    static void generate_constraints(Keccakf1600& keccak_constraint, WitnessVector& witness_values)
     {
         // Start with the zero variable at index 0
         witness_values.emplace_back(bb::fr(0));

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/keccak_constraint.test.cpp
@@ -30,6 +30,8 @@ template <class BuilderType> class KeccakTestingFunctions {
         static std::vector<std::string> get_labels() { return { "None", "Input", "Output" }; }
     };
 
+    static ProgramMetadata generate_metadata() { return ProgramMetadata{}; }
+
     static std::pair<AcirConstraint, WitnessVector> invalidate_witness(
         Keccakf1600 constraint, WitnessVector witness_values, const InvalidWitness::Target& invalid_witness_target)
     {

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -29,7 +29,7 @@ using namespace bb::plookup;
  *
  * @tparam lane_index What keccak lane are we working on?
  * @param limb Input limb we want to normalize and rotate
- * @param msb (return parameter) The most significant bit of the normalized and rotated limb
+ * @param msb (return parameter) The most significant bit of the normalized and unrotated limb
  * @return field_t<Builder> The normalized and rotated output
  */
 template <typename Builder>

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -18,7 +18,7 @@ using namespace bb::plookup;
 
 /**
  * @brief Normalize a base-11 limb and left-rotate by keccak::ROTATIONS[lane_index] bits.
- *        This method also extracts the most significant bit of the normalised rotated limb.
+ *        This method also extracts the most significant bit of the normalised limb.
  *        Used in the RHO and IOTA rounds.
  *
  * Normalize process:
@@ -36,13 +36,13 @@ template <typename Builder>
 template <size_t lane_index>
 field_t<Builder> keccak<Builder>::normalize_and_rotate(const field_ct& limb, field_ct& msb)
 {
-    // left_bits = the number of bits that wrap around 11^64 (left_bits)
+    // left_bits = the number of bits that wrap around 11^{KECCAK_LANE_SIZE} (left_bits)
     constexpr size_t left_bits = ROTATIONS[lane_index];
 
     // right_bits = the number of bits that don't wrap
-    constexpr size_t right_bits = 64 - ROTATIONS[lane_index];
+    constexpr size_t right_bits = KECCAK_LANE_SIZE - ROTATIONS[lane_index];
 
-    // TODO read from same source as plookup table code
+    // Matches the maximum bits per slice (Rho<>::MAXIMUM_MULTITABLE_BITS) used by KECCAK_RHO multitables
     constexpr size_t max_bits_per_table = plookup::keccak_tables::Rho<>::MAXIMUM_MULTITABLE_BITS;
 
     // compute the number of lookups required for our left and right bit slices
@@ -189,7 +189,7 @@ field_t<Builder> keccak<Builder>::normalize_and_rotate(const field_ct& limb, fie
  * the twisted representation is a 65-bit variable [b63, ..., b0, b63]
  *
  * The equivalent of XOR(A, ROTL(B, 1)) is A.twist + 2B.twist (in base-11 form)
- * The output is present in bit slices 1-64
+ * The output is present in bit slices 1 to KECCAK_LANE_SIZE.
  *
  * @tparam Builder
  * @param internal
@@ -208,7 +208,7 @@ template <typename Builder> void keccak<Builder>::compute_twisted_state(keccak_s
  *
  * THETA consists of XOR operations as well as left rotations by 1 bit.
  *
- * We represent 64-bit integers in a base-11 representation where
+ * We represent 64-bit (KECCAK_LANE_SIZE-bit) integers in a base-11 representation where
  *  limb = \sum_{i=0}^63 b_i * 11^i
  *
  * At the start of THETA, all b_i values are either 0 or 1
@@ -283,23 +283,23 @@ template <typename Builder> void keccak<Builder>::theta(keccak_state& internal)
     }
 
     /**
-     * D contains 66 base-11 slices.
+     * D contains 66 (KECCAK_LANE_SIZE+2) base-11 slices.
      *
-     * We need to remove the 2 most significant slices as they
+     * We need to remove the most significant and least significant slices as they
      * are artifacts of our twist operation.
      *
      * We also need to 'normalize' D (i.e. convert each base value to be 0 or 1),
      * to prevent our base from overflowing when we XOR D into internal.state
      *
      * 1. create sliced_D witness, plus lo and hi slices
-     * 2. validate D == lo + (sliced_D * 11) + (hi * 11^65)
+     * 2. validate D == lo + (sliced_D * 11) + (hi * 11^{KECCAK_LANE_SIZE+1})
      * 3. feed sliced_D into KECCAK_THETA_OUTPUT lookup table
      *
      * KECCAK_THETA_OUTPUT currently splices its input into 16 4-bit slices (in base 11 i.e. from 0 to 11^4 - 1)
-     * This ensures that sliced_D is correctly range constrained to be < 11^64
+     * This ensures that sliced_D is correctly range constrained to be < 11^64 = 11^{KECCAK_LANE_SIZE}
      */
-    static constexpr uint256_t divisor = BASE.pow(64);
-    static constexpr uint256_t multiplicand = BASE.pow(65);
+    static constexpr uint256_t divisor = BASE.pow(KECCAK_LANE_SIZE);
+    static constexpr uint256_t multiplicand = BASE.pow(KECCAK_LANE_SIZE + 1);
     for (size_t i = 0; i < 5; ++i) {
         uint256_t D_native = D[i].get_value();
         const auto [D_quotient, lo_native] = D_native.divmod(BASE);
@@ -315,9 +315,9 @@ template <typename Builder> void keccak<Builder>::theta(keccak_state& internal)
         internal.context->create_small_range_constraint(hi.get_witness_index(), static_cast<uint64_t>(BASE));
         internal.context->create_small_range_constraint(lo.get_witness_index(), static_cast<uint64_t>(BASE));
 
-        // If number of bits in KECCAK_THETA_OUTPUT table does NOT cleanly divide 64,
+        // If number of bits in KECCAK_THETA_OUTPUT table does NOT cleanly divide KECCAK_LANE_SIZE=64,
         // we need an additional range constraint to ensure that mid < 11^64
-        if constexpr (64 % plookup::keccak_tables::Theta::TABLE_BITS == 0) {
+        if constexpr (KECCAK_LANE_SIZE % plookup::keccak_tables::Theta::TABLE_BITS == 0) {
             // N.B. we could optimize out 5 gates per round here but it's very fiddly...
             // In previous section, D[i] = X + Y (non shifted equiv and shifted equiv)
             // We also want to validate D[i] == hi' + mid' + lo (where hi', mid' are hi, mid scaled by constants)
@@ -334,13 +334,13 @@ template <typename Builder> void keccak<Builder>::theta(keccak_state& internal)
             const auto accumulators = plookup_read<Builder>::get_lookup_accumulators(KECCAK_THETA_OUTPUT, D[i]);
             D[i] = accumulators[ColumnIdx::C2][0];
 
-            // Ensure input to lookup is < 11^64,
-            // by validating most significant input slice is < 11^{64 mod slice_bits}
+            // Ensure input to lookup is < 11^{KECCAK_LANE_SIZE},
+            // by validating most significant input slice is < 11^{KECCAK_LANE_SIZE mod slice_bits}
             const field_ct most_significant_slice = accumulators[ColumnIdx::C1][accumulators[ColumnIdx::C1].size() - 1];
 
-            // N.B. cheaper to validate (11^{64 mod slice_bits} - slice < 2^14) as this
+            // N.B. cheaper to validate (11^{KECCAK_LANE_SIZE mod slice_bits} - slice < 2^14) as this
             // prevents an extra range table from being created
-            constexpr uint256_t maximum = BASE.pow(64 % plookup::keccak_tables::Theta::TABLE_BITS);
+            constexpr uint256_t maximum = BASE.pow(KECCAK_LANE_SIZE % plookup::keccak_tables::Theta::TABLE_BITS);
             const field_ct target = -most_significant_slice + maximum;
             BB_ASSERT_GT((uint256_t(1) << Builder::DEFAULT_PLOOKUP_RANGE_BITNUM) - 1, maximum);
             target.create_range_constraint(Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
@@ -373,14 +373,14 @@ template <typename Builder> void keccak<Builder>::theta(keccak_state& internal)
  * The KECCAK_RHO_OUTPUT lookup table is used for both. See `normalize_and_rotate` for more details
  *
  * COST PER LIMB...
- *     8 gates for first lane (no rotation. Lookup table is 8-bits per slice = 8 lookups for 64 bits)
+ *     8 gates for first lane (no rotation. Lookup table is 8-bits per slice = 8 lookups for KECCAK_LANE_SIZE bits)
  *     10 gates for other 24 lanes (lookup sequence is split into 6 8-bit slices and 2 slices that sum to 8 bits,
  *     an addition gate is required to complete the rotation)
  *
  * Total costs is 248 gates.
  *
  * N.B. Can reduce lookup costs by using larger lookup tables.
- * Current algo is optimized for lookup tables where sum of all table sizes is < 2^64
+ * Current algo is optimized for lookup tables where sum of all table sizes is < 2^{KECCAK_LANE_SIZE}
  */
 template <typename Builder> void keccak<Builder>::rho(keccak_state& internal)
 {
@@ -498,9 +498,7 @@ template <typename Builder>
 std::array<field_t<Builder>, keccak<Builder>::NUM_KECCAK_LANES> keccak<Builder>::permutation_opcode(
     std::array<field_t<Builder>, NUM_KECCAK_LANES> state, Builder* ctx)
 {
-    std::vector<field_t<Builder>> converted_buffer(NUM_KECCAK_LANES);
-    std::vector<field_t<Builder>> msb_buffer(NUM_KECCAK_LANES);
-    // populate keccak_state, convert our 64-bit lanes into an extended base-11 representation
+    // populate keccak_state, convert our KECCAK_LANE_SIZE-bit lanes into an extended base-11 representation
     keccak_state internal;
     internal.context = ctx;
     for (size_t i = 0; i < state.size(); ++i) {
@@ -514,14 +512,14 @@ std::array<field_t<Builder>, keccak<Builder>::NUM_KECCAK_LANES> keccak<Builder>:
     return extended_2_normal(internal);
 }
 
-// Convert the 'extended' representation of the internal Keccak state into the usual array of 64 bits lanes
+// Convert the 'extended' representation of the internal Keccak state into the usual array of KECCAK_LANE_SIZE bit lanes
 template <typename Builder>
 std::array<field_t<Builder>, keccak<Builder>::NUM_KECCAK_LANES> keccak<Builder>::extended_2_normal(
     keccak_state& internal)
 {
     std::array<field_t<Builder>, NUM_KECCAK_LANES> conversion;
 
-    // Each hash limb represents a little-endian integer. Need to reverse bytes before we write into the output array
+    // Each hash limb represents a little-endian integer.
     for (size_t i = 0; i < internal.state.size(); ++i) {
         field_ct output_limb = plookup_read<Builder>::read_from_1_to_2_table(KECCAK_FORMAT_OUTPUT, internal.state[i]);
         conversion[i] = output_limb;

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
@@ -159,8 +159,20 @@ template <typename Builder> class keccak {
     static void chi(keccak_state& state);
     static void iota(keccak_state& state, size_t round);
 
-    // exposing keccak f1600 permutation
     static void keccakf1600(keccak_state& state);
+
+    static std::vector<uint8_t> hash_native(const std::vector<uint8_t>& data)
+    {
+        auto hash_result = ethash_keccak256(&data[0], data.size());
+
+        std::vector<uint8_t> output;
+        output.resize(32);
+
+        memcpy((void*)&output[0], (void*)&hash_result.word64s[0], 32);
+        return output;
+    }
+
+    // exposing keccak f1600 permutation
 
     static std::array<field_ct, NUM_KECCAK_LANES> permutation_opcode(std::array<field_ct, NUM_KECCAK_LANES> state,
                                                                      Builder* context);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
@@ -37,6 +37,7 @@ template <typename Builder> class keccak {
     // 1 "lane" = 64 bits. Instead of interpreting the keccak sponge as 1,600 bits, it's easier to work over 64-bit
     // "lanes". 1,600 / 64 = 25.
     static constexpr size_t NUM_KECCAK_LANES = 25;
+    static constexpr size_t KECCAK_LANE_SIZE = 64;
 
     // round constants. Used in IOTA round
     static constexpr std::array<uint64_t, NUM_KECCAK_ROUNDS> RC = {
@@ -110,12 +111,12 @@ template <typename Builder> class keccak {
     /**
      * @brief Get the sparse round constants object
      *
-     * @return constexpr std::array<uint256_t, 24>
+     * @return constexpr std::array<uint256_t, NUM_KECCAK_ROUNDS>
      */
     static constexpr std::array<uint256_t, NUM_KECCAK_ROUNDS> get_sparse_round_constants()
     {
-        std::array<uint256_t, 24> output;
-        for (size_t i = 0; i < 24; ++i) {
+        std::array<uint256_t, NUM_KECCAK_ROUNDS> output;
+        for (size_t i = 0; i < NUM_KECCAK_ROUNDS; ++i) {
             output[i] = convert_to_sparse(RC[i]);
         }
         return output;
@@ -158,20 +159,8 @@ template <typename Builder> class keccak {
     static void chi(keccak_state& state);
     static void iota(keccak_state& state, size_t round);
 
-    static void keccakf1600(keccak_state& state);
-
-    static std::vector<uint8_t> hash_native(const std::vector<uint8_t>& data)
-    {
-        auto hash_result = ethash_keccak256(&data[0], data.size());
-
-        std::vector<uint8_t> output;
-        output.resize(32);
-
-        memcpy((void*)&output[0], (void*)&hash_result.word64s[0], 32);
-        return output;
-    }
-
     // exposing keccak f1600 permutation
+    static void keccakf1600(keccak_state& state);
 
     static std::array<field_ct, NUM_KECCAK_LANES> permutation_opcode(std::array<field_ct, NUM_KECCAK_LANES> state,
                                                                      Builder* context);

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.test.cpp
@@ -24,7 +24,17 @@ TEST(stdlib_keccak, keccak_format_input_table)
     for (size_t i = 0; i < 25; ++i) {
         uint64_t limb_native = engine.get_random_uint64();
         field_ct limb(witness_ct(&builder, limb_native));
-        stdlib::plookup_read<Builder>::read_from_1_to_2_table(plookup::KECCAK_FORMAT_INPUT, limb);
+
+        auto accumulators = stdlib::plookup_read<Builder>::get_lookup_accumulators(plookup::KECCAK_FORMAT_INPUT, limb);
+
+        field_ct sparse_limb = accumulators[plookup::ColumnIdx::C2][0];
+        field_ct msb = accumulators[plookup::ColumnIdx::C3][accumulators[plookup::ColumnIdx::C3].size() - 1];
+
+        uint256_t expected_sparse = stdlib::keccak<Builder>::convert_to_sparse(limb_native);
+        uint64_t expected_msb = (limb_native >> 63) & 1ULL;
+
+        EXPECT_EQ(static_cast<uint256_t>(sparse_limb.get_value()), expected_sparse);
+        EXPECT_EQ(static_cast<uint64_t>(msb.get_value()), expected_msb);
     }
 
     bool proof_result = CircuitChecker::check(builder);
@@ -39,7 +49,10 @@ TEST(stdlib_keccak, keccak_format_output_table)
         uint64_t limb_native = engine.get_random_uint64();
         uint256_t extended_native = stdlib::keccak<Builder>::convert_to_sparse(limb_native);
         field_ct limb(witness_ct(&builder, extended_native));
-        stdlib::plookup_read<Builder>::read_from_1_to_2_table(plookup::KECCAK_FORMAT_OUTPUT, limb);
+
+        auto accumulators = stdlib::plookup_read<Builder>::get_lookup_accumulators(plookup::KECCAK_FORMAT_OUTPUT, limb);
+        field_ct normalized_limb = accumulators[plookup::ColumnIdx::C2][0];
+        EXPECT_EQ(static_cast<uint256_t>(normalized_limb.get_value()), limb_native);
     }
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -51,22 +64,28 @@ TEST(stdlib_keccak, keccak_theta_output_table)
 
     for (size_t i = 0; i < 25; ++i) {
         uint256_t extended_native = 0;
+        uint256_t expected_normalized = 0;
         for (size_t j = 0; j < 8; ++j) {
             extended_native *= 11;
+            expected_normalized *= 11;
             uint64_t base_value = (engine.get_random_uint64() % 11);
+            uint64_t bit = base_value & 1;
             extended_native += base_value;
+            expected_normalized += bit;
         }
+
         field_ct limb(witness_ct(&builder, extended_native));
-        stdlib::plookup_read<Builder>::read_from_1_to_2_table(plookup::KECCAK_THETA_OUTPUT, limb);
+        field_ct normalized = stdlib::plookup_read<Builder>::read_from_1_to_2_table(plookup::KECCAK_THETA_OUTPUT, limb);
+
+        EXPECT_EQ(static_cast<uint256_t>(normalized.get_value()), expected_normalized);
     }
+
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 }
 
 TEST(stdlib_keccak, keccak_rho_output_table)
 {
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/662)
-    GTEST_SKIP() << "Bug in constant case?";
     Builder builder = Builder();
 
     constexpr_for<0, 25, 1>([&]<size_t i> {
@@ -86,7 +105,7 @@ TEST(stdlib_keccak, keccak_rho_output_table)
         const uint256_t binary_rotated = left + (right << left_bits);
 
         const uint256_t expected_limb = stdlib::keccak<Builder>::convert_to_sparse(binary_rotated);
-        // msb only is correct iff rotation == 0 (no need to get msb for rotated lookups)
+        // msb is the MSB of the normalized limb without rotation
         const uint256_t expected_msb = (binary_native >> 63);
         field_ct limb(witness_ct(&builder, extended_native));
         field_ct result_msb;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_chi.hpp
@@ -84,13 +84,14 @@ class Chi {
      * Used by the Plookup code to precompute lookup tables and generate witness values
      *
      * @param key (first element = table input. Second element is unused as this lookup does not have 2 keys per value)
-     * @return std::array<bb::fr, 2> table output (normalized input and normalized input / 11^8)
+     * @return std::array<bb::fr, 2> table output (normalized input and normalized input / 11^{divisor_exponent})
      */
     static std::array<bb::fr, 2> get_chi_renormalization_values(const std::array<uint64_t, 2> key)
     {
         uint64_t accumulator = 0;
         uint64_t input = key[0];
         uint64_t base_shift = 1;
+        // want the most significant bit of the 64-bit integer, when this table is used on the most significant slice
         constexpr uint64_t divisor_exponent = (64 % TABLE_BITS == 0) ? (TABLE_BITS - 1) : (64 % TABLE_BITS) - 1;
         constexpr uint64_t divisor = numeric::pow64(BASE, divisor_exponent);
         while (input > 0) {
@@ -239,7 +240,7 @@ class Chi {
     static MultiTable get_chi_output_table(const MultiTableId id = KECCAK_CHI_OUTPUT)
     {
         constexpr size_t num_tables_per_multitable =
-            (64 / TABLE_BITS) + (64 % TABLE_BITS == 0 ? 0 : 1); // 64 bits, 8 bits per entry
+            (64 / TABLE_BITS) + (64 % TABLE_BITS == 0 ? 0 : 1); // 64 bits, 6 bits per entry
 
         // column_multiplier is used to define the gap between rows when deriving colunn values via relative differences
         uint64_t column_multiplier = numeric::pow64(BASE, TABLE_BITS);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
@@ -26,7 +26,7 @@ namespace bb::plookup::keccak_tables {
  *
  * P = \sum_{j=0}^63 b_i * 11^i
  *
- * In this representation we evaluate CHI via the linear expression
+ * In this representation we evaluate THETA via the linear expression
  *
  * C0 = A0 + A1 + A2 + A3 + A4
  * C1 = B0 + B1 + B2 + B3 + B4
@@ -64,39 +64,13 @@ class Theta {
         0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
     };
 
-    // template <size_t i> static std::pair<uint64_t, uint64_t> update_counts(std::array<size_t, TABLE_BITS>& counts)
-    // {
-    //     BB_ASSERT(i <= TABLE_BITS);
-    //     if constexpr (i >= TABLE_BITS) {
-    //         // TODO use concepts or template metaprogramming to put this condition in method declaration
-    //         return std::make_pair(0, 0);
-    //     } else {
-    //         if (counts[i] == BASE - 1) {
-    //             counts[i] = 0;
-    //             return update_counts<i + 1>(counts);
-    //         } else {
-    //             counts[i] += 1;
-    //         }
-
-    //         uint64_t value = 0;
-    //         uint64_t normalized_value = 0;
-    //         uint64_t cumulative_base = 1;
-    //         for (size_t j = 0; j < TABLE_BITS; ++j) {
-    //             value += counts[j] * cumulative_base;
-    //             normalized_value += (THETA_NORMALIZATION_TABLE[counts[j]]) * cumulative_base;
-    //             cumulative_base *= BASE;
-    //         }
-    //         return std::make_pair(value, normalized_value);
-    //     }
-    // }
-
     /**
      * @brief Given a table input value, return the table output value
      *
      * Used by the Plookup code to precompute lookup tables and generate witness values
      *
      * @param key (first element = table input. Second element is unused as this lookup does not have 2 keys per value)
-     * @return std::array<bb::fr, 2> table output (normalized input and normalized input / 11^TABLE_BITS - 1)
+     * @return std::array<bb::fr, 2> table output {normalized, 0}
      */
     static std::array<bb::fr, 2> get_theta_renormalization_values(const std::array<uint64_t, 2> key)
     {
@@ -242,7 +216,7 @@ class Theta {
     static MultiTable get_theta_output_table(const MultiTableId id = KECCAK_THETA_OUTPUT)
     {
         constexpr size_t num_tables_per_multitable =
-            (64 / TABLE_BITS) + (64 % TABLE_BITS == 0 ? 0 : 1); // 64 bits, 5 bits per entry
+            (64 / TABLE_BITS) + (64 % TABLE_BITS == 0 ? 0 : 1); // 64 bits, 4 bits per entry
 
         uint64_t column_multiplier = numeric::pow64(BASE, TABLE_BITS);
         MultiTable table(column_multiplier, column_multiplier, 0, num_tables_per_multitable);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_theta.hpp
@@ -70,7 +70,7 @@ class Theta {
      * Used by the Plookup code to precompute lookup tables and generate witness values
      *
      * @param key (first element = table input. Second element is unused as this lookup does not have 2 keys per value)
-     * @return std::array<bb::fr, 2> table output {normalized, 0}
+     * @return std::array<bb::fr, 2> table output {normalized, 0} where the second entry is an unused placeholder
      */
     static std::array<bb::fr, 2> get_theta_renormalization_values(const std::array<uint64_t, 2> key)
     {


### PR DESCRIPTION
- Add constraint tests in ACIR
- Update literal numbers to named constants
- Clean up the keccak and relevant lookup files
- Update stdlib tests to check correctness of lookup output in addition to the circuit validity