### PR TITLE
fix(avm)!: fix NUM_WIRES

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -106,7 +106,8 @@ template <class Curve> class CommitmentKey {
     };
     /**
      * @brief Batch commitment to multiple polynomials
-     * @details Uses batch_multi_scalar_mul for more efficient processing when committing to multiple polynomials
+     * @details Uses batch_multi_scalar_mul for more efficient processing when committing to multiple polynomials.
+     *          The input polynomials are not const because batch_mul modifies them and then restores them back.
      *
      * @param polynomials vector of polynomial spans to commit to
      * @return std::vector<Commitment> vector of commitments, one for each polynomial

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/scalar_multiplication.cpp
@@ -749,7 +749,8 @@ void MSM<Curve>::consume_point_schedule(std::span<const uint64_t> point_schedule
  *          This is because this method will be able to dispatch equal work to all threads without splitting the input
  *          msms up so much.
  *          The Pippenger algorithm runtime is O(N/log(N)) so there will be slight gains as each inner-thread MSM will
- *          have a larger N
+ *          have a larger N.
+ *          The input scalars are not const because the algorithm converts them out of Montgomery form and then back.
  *
  * @tparam Curve
  * @param points

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.test.cpp
@@ -22,7 +22,7 @@ TEST(AvmFixedVKTests, FixedVKCommitments)
     auto polynomials = compute_polynomials(trace);
     auto proving_key = proving_key_from_polynomials(polynomials);
 
-    AvmVerifier::VerificationKey vk_computed(proving_key);
+    auto vk_computed = AvmVerifier::VerificationKey::from_proving_key(*proving_key);
     auto vk_computed_commitments = vk_computed.get_all();
 
     // Get the fixed VK commitments

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -233,20 +233,23 @@ class AvmFlavor {
 
         VerificationKey() = default;
 
-        VerificationKey(const std::shared_ptr<ProvingKey>& proving_key)
-        {
-            this->log_circuit_size = MAX_AVM_TRACE_LOG_SIZE;
-            for (auto [polynomial, commitment] : zip_view(proving_key->get_precomputed(), this->get_all())) {
-                commitment = proving_key->commitment_key.commit(polynomial);
-            }
-        }
-
         VerificationKey(std::array<Commitment, NUM_PRECOMPUTED_COMMITMENTS> const& precomputed_cmts)
         {
             this->log_circuit_size = MAX_AVM_TRACE_LOG_SIZE;
             for (auto [vk_cmt, cmt] : zip_view(this->get_all(), precomputed_cmts)) {
                 vk_cmt = cmt;
             }
+        }
+
+        // NOTE: This should not be used in production. You should use the fixed VK instead.
+        static VerificationKey from_proving_key(const ProvingKey& proving_key)
+        {
+            VerificationKey vk;
+            vk.log_circuit_size = MAX_AVM_TRACE_LOG_SIZE;
+            for (auto [polynomial, commitment] : zip_view(proving_key.get_precomputed(), vk.get_all())) {
+                commitment = proving_key.commitment_key.commit(polynomial);
+            }
+            return vk;
         }
 
         /**

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -28,11 +28,7 @@ class AvmRecursiveFlavor {
 
     using Relations = NativeFlavor::Relations_<FF>;
 
-    static constexpr size_t NUM_WIRES = NativeFlavor::NUM_WIRES;
     static constexpr size_t NUM_ALL_ENTITIES = NativeFlavor::NUM_ALL_ENTITIES;
-    static constexpr size_t NUM_PRECOMPUTED_ENTITIES = NativeFlavor::NUM_PRECOMPUTED_ENTITIES;
-    static constexpr size_t NUM_WITNESS_ENTITIES = NativeFlavor::NUM_WITNESS_ENTITIES;
-
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = NativeFlavor::BATCHED_RELATION_PARTIAL_LENGTH;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor_variables.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor_variables.hpp
@@ -145,7 +145,7 @@ struct AvmFlavorVariables {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 124;
     static constexpr size_t NUM_WITNESS_ENTITIES = 3061;
     static constexpr size_t NUM_SHIFTED_ENTITIES = 344;
-    static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
+    static constexpr size_t NUM_WIRES = 2595;
     static constexpr size_t NUM_ALL_ENTITIES = 3529;
 
     // Need to be templated for recursive verifier

--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -53,7 +53,6 @@ AvmProvingHelper::VkData AvmProvingHelper::get_verification_key()
 
 std::pair<AvmProvingHelper::Proof, AvmProvingHelper::VkData> AvmProvingHelper::prove(tracegen::TraceContainer&& trace)
 {
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/18934)
     auto polynomials = AVM_TRACK_TIME_V("proving/prove:compute_polynomials", constraining::compute_polynomials(trace));
     auto proving_key =
         AVM_TRACK_TIME_V("proving/prove:proving_key", constraining::proving_key_from_polynomials(polynomials));

--- a/bb-pilcom/bb-pil-backend/templates/flavor_variables.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor_variables.hpp.hbs
@@ -26,7 +26,7 @@ struct AvmFlavorVariables {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = {{len fixed}};
     static constexpr size_t NUM_WITNESS_ENTITIES = {{len witness}};
     static constexpr size_t NUM_SHIFTED_ENTITIES = {{len shifted}};
-    static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
+    static constexpr size_t NUM_WIRES = {{len witness_without_inverses}};
     static constexpr size_t NUM_ALL_ENTITIES = {{len all_cols_and_shifts}};
 
     // Need to be templated for recursive verifier


### PR DESCRIPTION
Closes #18934 because there was nothing to be done. Since https://github.com/AztecProtocol/aztec-packages/pull/18923/ the VK commitments are already not being computed, and everything the prover does works on the "wire/witness" polynomials, which do not include the precomputed ones.

By looking at that, I found that the NUM_WIRES constant was wrong, it was defined as
```
NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
```
but as far as I understand it should actually be "witnesses minus inverses (derived)". See the following diagram from [columns.hpp](https://github.com/AztecProtocol/aztec-packages/blob/next/bb-pilcom/bb-pil-backend/templates/columns.hpp.hbs#L53):
```
 precomputed | wire(not shifted) : wire(counts) : wire(to be shifted) | derived(inverses) | shifted
             \____________________________________________________________________________/
                                            witness
 \________________________________________________________________________________________/
                                           unshifted
```

Funnily enough, fixing this didnt change anything. Looks like the recursive verifier was not using the constants, so I removed them.

PS: I also added a few comments on commitment_key because I went down a rabbit hole of trying to use `batch_commit` only to find that I needed a non-const reference. Since we don't compute the VK in prod, I left it as is without batching.