### PR TITLE
refactor: move overflow check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -157,6 +157,7 @@
     "ierc",
     "IGSE",
     "incentivized",
+    "incrementation",
     "indexeddb",
     "interruptible",
     "IPFS",

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
@@ -41,8 +41,6 @@ impl<let NumPreviousRollups: u32, let NumVkIndices: u32> CheckpointRootInputsVal
         }
 
         self.validate_start_states();
-
-        self.validate_end_states();
     }
 
     fn validate_previous_rollup_proofs_and_vks(self) {
@@ -113,21 +111,5 @@ impl<let NumPreviousRollups: u32, let NumVkIndices: u32> CheckpointRootInputsVal
             ),
             "Hash of the previous block header is not the last leaf in the archive tree",
         );
-    }
-
-    fn validate_end_states(self) {
-        let end_sponge_blob =
-            self.previous_rollups[NumPreviousRollups - 1].public_inputs.end_sponge_blob;
-
-        // Check that the number of absorbed blob fields is not larger than the maximum number of fields allowed.
-        // Note: It must not equal the max allowed number because an additional checkpoint end marker will be absorbed
-        // in `checkpoint_rollup_public_inputs_composer`.
-        assert(
-            end_sponge_blob.num_absorbed_fields < FIELDS_PER_BLOB * BLOBS_PER_CHECKPOINT,
-            "Attempted to overfill blobs",
-        );
-
-        // The `end_sponge_blob` is validated against the injected blob fields in
-        // `checkpoint_rollup_public_inputs_composer.nr`, after the checkpoint end marker is absorbed.
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/sponge_blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/blob_data/sponge_blob.nr
@@ -90,8 +90,15 @@ impl SpongeBlob {
     }
 
     pub fn absorb_checkpoint_end_marker(&mut self) {
+        // If you ever increase the size of an `end_marker` beyond 1 Field, you need to adjust this
+        // incrementation accordingly:
         self.num_absorbed_fields += 1;
-        let end_marker = create_checkpoint_end_marker(self.num_absorbed_fields);
+        // Check that the number of absorbed blob fields is not larger than the maximum number of fields allowed.
+        assert(
+            self.num_absorbed_fields <= FIELDS_PER_BLOB * BLOBS_PER_CHECKPOINT,
+            "Attempted to overfill blobs",
+        );
+        let end_marker: Field = create_checkpoint_end_marker(self.num_absorbed_fields);
         self.sponge.absorb(end_marker);
     }
 


### PR DESCRIPTION
Moves the blob overflow check to the final "checkpoint end data" absorption.
Gets rid of a function. If we ever change the size of a checkpoint end marker, this should make it easier to notice the problem.