### PR TITLE
chore(repo): enforce conventional commit messages

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,20 @@
+name: commitlint
+
+on:
+  pull_request:
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+      - run: npx commitlint --from origin/next --to HEAD
+;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,15 @@ If you're looking for a good place to start, look for issues labeled ["good firs
 - I have reviewed my diff in github, line by line and removed unexpected formatting changes, testing logs, or commented-out code.
 - Every change is related to the PR description.
 - I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to relevant issues (if any exist).
+
+## Commit messages
+
+This repository follows the Conventional Commits specification.
+
+Format:
+type(scope)!: short, lowercase description
+
+Examples:
+- fix(avm): correct calldata offset handling
+- chore(ci): avoid duplicate slack notifications
+- feat(bb)!: remove deprecated proving api

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+      'type-enum': [
+        2,
+        'always',
+        ['feat', 'fix', 'chore', 'refactor', 'docs', 'test', 'perf', 'ci'],
+      ],
+      'scope-case': [2, 'always', 'kebab-case'],
+      'subject-case': [2, 'always', ['lower-case']],
+      'subject-full-stop': [2, 'never', '.'],
+    },
+  };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+commit-msg:
+  commands:
+    commitlint:
+      run: npx commitlint --edit {1}


### PR DESCRIPTION
Summary

This PR enforces Conventional Commit messages across the repository.

It adds local validation via commitlint + lefthook, CI validation for pull requests, and documents the expected commit format in CONTRIBUTING.md.
