### PR TITLE
chore: Deflake epochs_proof_public_cross_chain test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -1,6 +1,7 @@
 import { generateClaimSecret } from '@aztec/aztec.js/ethereum';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
+import { waitForL1ToL2MessageReady } from '@aztec/aztec.js/messaging';
 import { TxStatus } from '@aztec/aztec.js/tx';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { retryUntil } from '@aztec/foundation/retry';
@@ -51,11 +52,10 @@ describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
     const { msgHash, globalLeafIndex } = await sendL1ToL2Message(message, context.deployL1ContractsValues);
 
     logger.warn(`Waiting for message ${msgHash} with index ${globalLeafIndex} to be synced`);
-    await retryUntil(
-      () => context.aztecNode.isL1ToL2MessageSynced(msgHash),
-      'message sync',
-      test.L2_SLOT_DURATION_IN_S * 4,
-    );
+    await waitForL1ToL2MessageReady(context.aztecNode, msgHash, {
+      forPublicConsumption: true,
+      timeoutSeconds: test.L2_SLOT_DURATION_IN_S * 6,
+    });
 
     // And we consume the message using the test contract. It's important that we don't wait for the membership witness
     // to be available, since we want to test the scenario where the message becomes available on the same block the tx lands.


### PR DESCRIPTION
This test was using a deprecated helper for checking when an L1 to L2 message was ready for consumption. Let's see if updating it to the correct helper makes a difference.

Failed run: http://ci.aztec-labs.com/56900023bee935c0
