### PR TITLE
chore: Deflake e2e_l1_publisher test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -58,6 +58,7 @@ import {
 import { L1PublishedData } from '@aztec/stdlib/checkpoint';
 import { type L1RollupConstants, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees, GasSettings } from '@aztec/stdlib/gas';
+import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { SlashFactoryContract } from '@aztec/stdlib/l1-contracts';
 import { orderAttestations } from '@aztec/stdlib/p2p';
 import {
@@ -162,8 +163,9 @@ describe('L1Publisher integration', () => {
     }
   };
 
+  let port = 8545; // We increase the port for each test to avoid anvil conflicts
   const setup = async (deployL1ContractsArgs: Partial<DeployAztecL1ContractsArgs> = {}) => {
-    ({ rpcUrl, anvil } = await startAnvil());
+    ({ rpcUrl, anvil } = await startAnvil({ port: port++ }));
     config.l1RpcUrls = [rpcUrl];
 
     deployerAccount = privateKeyToAccount(deployerPK);
@@ -299,8 +301,8 @@ describe('L1Publisher integration', () => {
   };
 
   afterEach(async () => {
-    await anvil.stop();
-    await worldStateSynchronizer.stop();
+    await tryStop(anvil);
+    await tryStop(worldStateSynchronizer);
   });
 
   const makeProcessedTx = (seed = 0x1): Promise<ProcessedTx> =>


### PR DESCRIPTION
We were getting errors stopping anvil at the end of some tests. This adds a try/catch around stopping anvil, and initializes each anvil instance in a different port to prevent a test from bleeding into the next if an anvil stop actually fails.

Failed test run: http://ci.aztec-labs.com/109d17afbdad557d
