### PR TITLE
chore: Try deflake multiple-proofs test

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -282,11 +282,17 @@ export class ReadOnlyL1TxUtils {
         ..._blobInputs,
         maxFeePerBlobGas: gasPrice.maxFeePerBlobGas!,
         gas: LARGE_GAS_LIMIT,
+        blockTag: 'latest',
       });
 
       this.logger?.trace(`Estimated gas for blob tx: ${initialEstimate}`);
     } else {
-      initialEstimate = await this.client.estimateGas({ account, ...request, gas: LARGE_GAS_LIMIT });
+      initialEstimate = await this.client.estimateGas({
+        account,
+        ...request,
+        gas: LARGE_GAS_LIMIT,
+        blockTag: 'latest',
+      });
       this.logger?.trace(`Estimated gas for non-blob tx: ${initialEstimate}`);
     }
 


### PR DESCRIPTION
The epochs multi proof test [was flaking](http://ci.aztec-labs.com/dbc215a9169a9184) with some prover txs reverting. Looking at their txs and receipts, it seems a prover was sending their tx with a low gas estimate, so the revert was most likely due to out of gas.

Now, in the logs, we see that the reverting tx is mined along with another successful tx within the block. The successful tx is sent first with a high gas estimate, then the failed tx is sent with a low estimate, and then the block gets mined.

However, when inspecting the receipts, we see the failed tx is mined first in the block. See the `transactionIndex` of each:

```
20:43:59 [20:43:59.149] WARN: prover-node:2:prover-node L1 transaction 0x2f2a0cd45c900f71008a3939764566d7ab288dd77dd1e1f8d8897e266485f6fd with nonce 0 reverted {
  "receipt": {
    "blobGasPrice": 1,
    "blockHash": "0xe51c4af7abafed9ec0f370893230d12d87440aa1e0e1b81eeefaad96a3b31f4f",
    "blockNumber": 28,
    "contractAddress": null,
    "cumulativeGasUsed": 330606,
    "effectiveGasPrice": 103845296949,
    "from": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
    "gasUsed": 330606,
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "status": "reverted",
    "to": "0x322813fd9a801c5507c9de605d63cea4f2ce6c44",
    "transactionHash": "0x2f2a0cd45c900f71008a3939764566d7ab288dd77dd1e1f8d8897e266485f6fd",
    "transactionIndex": 0,
    "type": "eip1559"
  },
  "nonce": 0,
  "account": "0x90f79bf6eb2c4f870365e785982e1f101e93b906"
}

20:43:59 [20:43:59.155] INFO: prover-node:1:prover-node L1 transaction 0xcf634617f7b5ec2bef2c9cd39dc258b8fb67a3724149b28bb3c3853429fcb206 with nonce 0 mined {
  "receipt": {
    "blobGasPrice": 1,
    "blockHash": "0xe51c4af7abafed9ec0f370893230d12d87440aa1e0e1b81eeefaad96a3b31f4f",
    "blockNumber": 28,
    "contractAddress": null,
    "cumulativeGasUsed": 736374,
    "effectiveGasPrice": 86543717110,
    "from": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
    "gasUsed": 405768,
    "logs": [
      {
        "address": "0xa513e6e4b8f2a923d98304ec87f64353c4d5c853",
        "blockHash": "0xe51c4af7abafed9ec0f370893230d12d87440aa1e0e1b81eeefaad96a3b31f4f",
        "blockNumber": 28,
        "blockTimestamp": "0x6949ae7e",
        "data": "0x00000000000000000000000000000000000000000000002b5e3af16b18800000",
        "logIndex": 0,
        "removed": false,
        "topics": [
          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
          "0x0000000000000000000000008daf17a20c9dba35f005b6324f493785d239719d",
          "0x000000000000000000000000322813fd9a801c5507c9de605d63cea4f2ce6c44"
        ],
        "transactionHash": "0xcf634617f7b5ec2bef2c9cd39dc258b8fb67a3724149b28bb3c3853429fcb206",
        "transactionIndex": 1
      },
      {
        "address": "0x322813fd9a801c5507c9de605d63cea4f2ce6c44",
        "blockHash": "0xe51c4af7abafed9ec0f370893230d12d87440aa1e0e1b81eeefaad96a3b31f4f",
        "blockNumber": 28,
        "blockTimestamp": "0x6949ae7e",
        "data": "0x",
        "logIndex": 1,
        "removed": false,
        "topics": [
          "0x034dd13d657aeb14f8dec7291c4a8ddb3b20d40cf2412714e72f97f19c735609",
          "0x0000000000000000000000000000000000000000000000000000000000000002",
          "0x0000000000000000000000000000000000000001000000000000000000000000"
        ],
        "transactionHash": "0xcf634617f7b5ec2bef2c9cd39dc258b8fb67a3724149b28bb3c3853429fcb206",
        "transactionIndex": 1
      }
    ],
    "logsBloom": "0x04000000000020000000000000000000000000000000000000000000000000010000004000800000000000040000000000000000000000000000000000000000000000000080804000000008000000000000000010000000011000000000000000000000000000000000000000000000000000000000000000000010080000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000900000000000000000000000008008000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000001000000000000000000000008000000000000000000000",
    "status": "success",
    "to": "0x322813fd9a801c5507c9de605d63cea4f2ce6c44",
    "transactionHash": "0xcf634617f7b5ec2bef2c9cd39dc258b8fb67a3724149b28bb3c3853429fcb206",
    "transactionIndex": 1,
    "type": "eip1559"
  },
  "nonce": 0,
  "account": "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc"
}
```

Why is this important? The first prover to prove an epoch has to pay slightly mire  gas in order to update the proven block tip, and the next one doesn't. So if you _assumed_ that the epoch was already proven, your gas estimate would be lower.

And how could this happen? Well, it turns out that anvil defaults to using the pending block tag when estimating gas, which (thanks to Claude) it implies that simulation is done using all the previous pending txs in anvil's mempool. But then that ordering is (clearly) not respected when mining the block.

- **Default State**: When eth_estimateGas is called without specifying a block, it defaults to BlockNumber::Pending ([api.rs:1339](vscode-webview://11tencnr6ljv5jepm97fddc7ebqndosf7u28iiv33rks9fsdgmrn/crates/anvil/src/eth/api.rs#L1339))
- **Pending Tx Collection**: For pending blocks, Anvil collects all ready transactions from the mempool via pool.ready_transactions() ([api.rs:563](vscode-webview://11tencnr6ljv5jepm97fddc7ebqndosf7u28iiv33rks9fsdgmrn/crates/anvil/src/eth/api.rs#L563))
- **State Simulation**: It creates a cached state layer on top of the last mined block and executes all ready pending transactions sequentially to create a virtual "pending block" state ([mem/mod.rs:1253-1290](vscode-webview://11tencnr6ljv5jepm97fddc7ebqndosf7u28iiv33rks9fsdgmrn/crates/anvil/src/eth/backend/mem/mod.rs#L1253-L1290))
- **Gas Estimation**: The gas estimation then runs against this modified state that includes the effects of all pending transactions ([api.rs:2946](vscode-webview://11tencnr6ljv5jepm97fddc7ebqndosf7u28iiv33rks9fsdgmrn/crates/anvil/src/eth/api.rs#L2946))

This PR changes the gas estimate call in the L1 tx utils to force the usage of the `latest` block tag instead. Let's see if that works.