### PR TITLE
feat: Handle multiple blocks per slot in timetable

### DIFF
--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -10,6 +10,7 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   L2Block,
   L2BlockHash,
+  L2BlockNew,
   type L2BlockSource,
   type L2Tips,
   PublishedL2Block,
@@ -103,6 +104,16 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
    */
   public getBlock(number: number) {
     return Promise.resolve(this.l2Blocks[number - 1]);
+  }
+
+  /**
+   * Gets an L2 block (new format).
+   * @param number - The block number to return.
+   * @returns The requested L2 block.
+   */
+  public getL2BlockNew(number: BlockNumber): Promise<L2BlockNew | undefined> {
+    const block = this.l2Blocks[number - 1];
+    return Promise.resolve(block?.toL2Block());
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -101,9 +101,11 @@ describe('e2e_block_building', () => {
       // This will leave the sequencer with just a few seconds to build the block, so it shouldn't
       // be able to squeeze in more than a few txs in each. This is sensitive to the time it takes
       // to pick up and validate the txs, so we may need to bump it to work on CI.
-      jest
-        .spyOn(sequencer.sequencer.timetable, 'getProposerExecTimeEnd')
-        .mockImplementation((secondsIntoSlot: number) => secondsIntoSlot + 1);
+      jest.spyOn(sequencer.sequencer.timetable, 'canStartNextBlock').mockImplementation((secondsIntoSlot: number) => ({
+        canStart: true,
+        deadline: secondsIntoSlot + 1, // Give only 1 second for building
+        isLastBlock: true,
+      }));
 
       // Flood the mempool with TX_COUNT simultaneous txs
       const methods = times(TX_COUNT, i => contract.methods.increment_public_value(ownerAddress, i));

--- a/yarn-project/sequencer-client/src/sequencer/README.md
+++ b/yarn-project/sequencer-client/src/sequencer/README.md
@@ -1,0 +1,531 @@
+# Sequencer Timing Model
+
+The Aztec sequencer divides each slot into **fixed-duration sub-slots**. Each sub-slot has a pre-defined start and end time based on an initialization offset (how much time we expect syncing the previous slot will take), a finalization time (how much time we need for closing a checkpoint and publishing it to L1), and the configured block duration.
+
+**Example: 72-second slot with 8-second sub-slots**
+
+```
+0s:  Slot starts
+0-2s: Sync + proposer check (fixed 2s offset)
+
+Sub-slot 1:  2s-10s  → Build Block 1, deadline at 10s
+Sub-slot 2:  10s-18s → Build Block 2, deadline at 18s
+Sub-slot 3:  18s-26s → Build Block 3, deadline at 26s
+Sub-slot 4:  26s-34s → Build Block 4, deadline at 34s
+Sub-slot 5:  34s-42s → Build Block 5 (last block), deadline at 42s
+Sub-slot 6:  42s-50s → Reserved for validators to re-execute Block 5
+
+42s:  Broadcast checkpoint with Block 5
+44s:  Validators receive proposal (2s propagation)
+44-52s: Validators re-execute Block 5 (8s)
+52s:  Validators send attestations
+54s:  Proposer receives attestations (2s propagation)
+54-55s: Finalize checkpoint (1s)
+55-67s: Publish to L1 (12s)
+72s:  Slot ends
+```
+
+Deadlines are fixed relative to slot start, not relative to when work actually completes. If you finish initialization at 1s instead of 2s, you get bonus time for Block 1. If you finish at 3s, you have less time. If you finish at 9s, you skip the first sub-slot altogether and start building for the second one.
+
+---
+
+## Overview
+
+The Aztec sequencer operates in fixed-duration **slots** (typically 72 seconds). During each slot, a designated proposer builds multiple **blocks** containing transactions over multiple **sub-slots**, then collects a single round of attestations for the entire **checkpoint** from validators, and finally publishes the resulting checkpoint to L1 Ethereum.
+
+## Key Concepts
+
+### Slot vs Block vs Checkpoint vs Sub-Slot
+
+- **Slot**: A fixed time window (e.g., 72 seconds) during which a proposer can build blocks
+- **Block**: A single batch of transactions, executed and validated
+- **Checkpoint**: The collection of all blocks built in a slot, attested by validators and published to L1
+- **Sub-slot**: A fixed-duration time window within a slot (e.g., 8 seconds) during which a block should be built
+
+In a typical configuration, a 72-second slot contains:
+- 1 initialization period (2 seconds)
+- 5 block-building sub-slots (8 seconds each = 40 seconds)
+- 1 last validator re-execution sub-slot (8 seconds)
+- 1 attestation and publishing period (17 seconds)
+
+### The Fixed Sub-Slot Model
+
+Building multiple blocks per slot uses **fixed sub-slots** with predictable deadlines:
+
+1. **Equal-duration sub-slots**: All sub-slots have the same duration (`BLOCK_DURATION`)
+2. **Fixed deadlines**: Block N deadline = `initializationOffset + N * BLOCK_DURATION`
+3. **Last sub-slot reserved**: The final sub-slot is reserved for validators to re-execute the last block (no block is built during this sub-slot)
+4. **Skip if too late**: If we can't start a block with at least `MIN_EXECUTION_TIME` remaining before its deadline, we immediately start building in the next sub-slot
+
+## Timing Components
+
+Understanding slot timing requires knowing these time constants:
+
+| Component | Example Value | Purpose |
+|-----------|---------------|---------|
+| **Slot Duration** | 72s | Total time available for the entire checkpoint |
+| **Block Duration** | 8s | Duration of each sub-slot (time budget for building one block) |
+| **Initialization Offset** | 2s | Fixed estimate for sync + proposer check |
+| **Propagation Time** | 2s | Time for messages to travel across the P2P network (one-way) |
+| **Finalization Time** | 1s | Time to finalize checkpoint and prepare proposal message |
+| **L1 Publishing Time** | 12s | Time reserved for L1 transaction to land in an Ethereum block |
+| **Min Execution Time** | 3s | Minimum time needed to meaningfully build a block |
+
+These values are configurable but must satisfy certain constraints (explained below). Example values may differ from the ones in the source code.
+
+## Calculating Sub-Slots and Blocks
+
+Given a slot configuration, we calculate how many blocks fit using this formula:
+
+```
+timeReservedAtEnd = blockDuration                              (last sub-slot for reexecution)
+                  + propagationTime                            (validators receive proposal)
+                  + propagationTime                            (attestations come back)
+                  + finalizationTime                           (checkpoint finalization)
+                  + l1PublishingTime                           (L1 transaction)
+
+timeAvailableForBlocks = slotDuration - initializationOffset - timeReservedAtEnd
+
+numberOfBlocks = floor(timeAvailableForBlocks / blockDuration)
+```
+
+**Example with typical values:**
+```
+timeReservedAtEnd = 8s + 2s + 2s + 1s + 12s = 25s
+timeAvailableForBlocks = 72s - 2s - 25s = 45s
+numberOfBlocks = floor(45s / 8s) = 5 blocks
+```
+
+This means:
+- Sub-slots 1-5: Build blocks 1-5
+- Sub-slot 6: Reserved for validator re-execution of block 5
+- After sub-slot 6: Attestation collection, finalization, and L1 publishing
+
+## The Sequencer's Work
+
+When elected as proposer for a slot, the sequencer performs these tasks:
+
+### 1. Initialization Phase
+
+Before building any blocks, the sequencer must:
+- Verify it's the designated proposer
+- Check all subsystems are synced
+- Initialize checkpoint state
+- Prepare global variables
+
+Note that the initialization phase has a **fixed time budget** (`initializationOffset`, typically 2s). This is an *estimate*, not a deadline. The sequencer will take as long as it needs for initialization, but the sub-slot deadlines remain fixed regardless.
+
+### 2. Block Building Loop
+
+The sequencer builds blocks in **fixed sub-slots** based on the configured block duration.
+
+#### Sub-slot deadline calculation
+
+Each sub-slot has a fixed start time and deadline:
+
+```
+subSlotStart[N] = initializationOffset + (N - 1) * blockDuration
+subSlotDeadline[N] = initializationOffset + N * blockDuration
+```
+
+Where N is the sub-slot number (1-indexed).
+
+**Example with 2s offset and 8s block duration:**
+```
+Sub-slot 1: starts at 2s,  deadline at 10s
+Sub-slot 2: starts at 10s, deadline at 18s
+Sub-slot 3: starts at 18s, deadline at 26s
+Sub-slot 4: starts at 26s, deadline at 34s
+Sub-slot 5: starts at 34s, deadline at 42s
+```
+
+#### Building a block
+
+For each sub-slot, the sequencer:
+
+1. **Checks if we can start**: If current time is past `deadline - MIN_EXECUTION_TIME`, skip this sub-slot, and start building the block as if it were on the next sub-slot
+2. **Waits for transactions** (if needed): Wait up to the deadline for minimum number of transactions
+3. **Builds block**: Execute transactions until the deadline of the sub-slot
+4. **Signs and broadcasts**: Finalize block and broadcast proposal to validators
+
+**Key point:** The deadline is **fixed** based on the sub-slot number, not based on when the previous block finished.
+
+Note that if a block finishes early, then the sequencer waits until the next sub-slot starts to maintain the regular interval. This prevents "rushing ahead" and keeps the timing predictable. Conversely, if the block finishes later than expected, this "eats into" the time budget for the next block.
+
+#### Waiting for minimum transactions
+
+Before building a block, the sequencer must ensure there are enough transactions in the mempool. This waiting phase has its own timing constraints:
+
+**Configuration:**
+- `minTxsPerBlock`: Minimum number of transactions required (configurable, e.g., 1-4)
+- Polling interval: 500ms (checks mempool every half-second)
+- Deadline: `blockDeadline - 1000ms` (must start building at least 1 second before the block deadline)
+
+**Behavior:**
+1. Check current pending transaction count
+2. If count >= `minTxsPerBlock`, proceed to build immediately
+3. If count < `minTxsPerBlock`, poll every 500ms until either:
+   - Enough transactions arrive (proceed to build)
+   - Deadline is reached (skip building this block)
+
+**Special cases:**
+- **Last block with empty checkpoint allowed**: If `buildCheckpointIfEmpty` is true and this is the last block, skip waiting and force build with 0+ transactions
+- **Non-enforced timetable**: If enforcement is disabled, exit immediately if not enough transactions (don't wait)
+
+**Example:**
+```
+Sub-slot 3 deadline: 26s
+Transaction wait deadline: 25s (26s - 1s)
+Current time: 20s
+
+20.0s: Check mempool → 2 txs (need 4)
+20.5s: Check mempool → 2 txs (need 4)
+21.0s: Check mempool → 4 txs (need 4) ✓ Start building!
+21-26s: Build block with those 4+ transactions
+```
+
+If the deadline (25s) is reached with only 2 transactions, the block is skipped and the sequencer moves to the next sub-slot.
+
+### 3. Last Block and Validator Re-execution
+
+The **last block** is built during the **penultimate sub-slot**. The final sub-slot is reserved for validators to re-execute the last block.
+
+**Why the last sub-slot is reserved:**
+
+Validators execute blocks **sequentially**. While the proposer builds Block N+1, validators are re-executing Block N (with a ~2s delay due to propagation). However, for the **last block**, there's no "Block N+1" to build while validators re-execute. We must wait for them to finish so they can attest.
+
+**Timeline for the last block:**
+
+```
+T:      Last block finishes building, checkpoint proposal broadcast
+        Last sub-slot begins (duration: blockDuration)
+T+2s:   Validators receive proposal (propagation delay)
+T+2s to T+2s+blockDuration: Validators re-execute last block
+T+2s+blockDuration: Validators finish re-execution, send attestations
+T+4s+blockDuration: Proposer receives attestations (propagation delay)
+```
+
+**Example with 8s block duration:**
+```
+42s:    Block 5 finishes, checkpoint broadcast, sub-slot 6 starts
+44s:    Validators receive checkpoint (42s + 2s)
+44-52s: Validators re-execute Block 5 (8s)
+52s:    Validators send attestations
+54s:    Proposer receives attestations (52s + 2s)
+```
+
+Note that validators finish at `52s`, which is `2s` after the last sub-slot ends at `50s`. This is expected and accounted for in the `timeReservedAtEnd` calculation.
+
+### 4. Attestation Collection and L1 Publishing
+
+After the last block is built and validators have re-executed it:
+
+1. **Collect attestations**: Wait for validators to send their signatures (arrive at T+4s+blockDuration)
+2. **Finalize checkpoint**: Sign over attestations, assemble final checkpoint (1s)
+3. **Publish to L1**: Submit transaction to Ethereum (needs 12s to land)
+
+**Time reserved:** `2*propagationTime + finalizationTime + l1PublishingTime = 2s + 2s + 1s + 12s = 17s`
+
+This 17s comes after the last sub-slot, ensuring we have enough time to complete the checkpoint. If the sequencer receives the necessary attestations before the reserved time, the L1 tx is submitted earlier.
+
+## Handling Timing Variations
+
+How does the sequencer timetable handle deviations from the expected times.
+
+### Fast Initialization
+
+**Scenario:** Initialization completes at 1s instead of 2s
+
+```
+0-1s:   SYNCHRONIZING, PROPOSER_CHECK (1s actual, vs 2s estimate)
+1s:     Ready to build Block 1
+1-10s:  Build Block 1 (9s available vs 8s budgeted)
+10s:    Block 1 deadline
+10-18s: Build Block 2
+...
+```
+
+**Result:** Block 1 gets a bonus 1s of execution time. The extra time allows for more transactions or more complex execution.
+
+### Slow Initialization
+
+**Scenario:** Initialization completes at 3s instead of 2s
+
+This may happen if the sequencer has a slow L1 RPC endpoint and syncing the previous checkpoint from L1 takes longer than expected.
+
+```
+0-3s:   SYNCHRONIZING, PROPOSER_CHECK (3s actual, vs 2s estimate)
+3s:     Ready to build Block 1
+3-10s:  Build Block 1 (7s available vs 8s budgeted)
+10s:    Block 1 deadline
+10-18s: Build Block 2
+...
+```
+
+**Result:** Block 1 has 1s less time (7s instead of 8s). Still enough time to build a block, just with fewer transactions or simpler execution.
+
+### Very Slow Initialization
+
+**Scenario:** Initialization completes at 9s instead of 2s
+
+While extremely unlikely, we still account for this scenario. We'd expect it to be related to faults to syncing blob data.
+
+```
+0-9s:   SYNCHRONIZING, PROPOSER_CHECK (9s actual, vs 2s estimate)
+9s:     Ready to build Block 1
+        Check: Can we start Block 1 in sub-slot 1?
+        - Sub-slot 1 deadline: 10s
+        - Current time: 9s
+        - Time available: 1s
+        - MIN_EXECUTION_TIME: 3s
+        - 1s < 3s, so CANNOT use sub-slot 1
+
+        Use sub-slot 2 instead:
+9s:     Start building Block 1 using sub-slot 2
+9-18s:  Build Block 1 (9s available vs 8s budgeted)
+18s:    Block 1 deadline (sub-slot 2)
+18-26s: Build Block 2 using sub-slot 3
+...
+```
+
+**Result:** Sub-slot 1 is skipped entirely. We build 4 blocks instead of 5 (using sub-slots 2-5). Block 1 gets a bonus 1s of time.
+
+### Block Takes Longer Than Expected
+
+**Scenario:** Block 2 takes 9s instead of 8s
+
+This scenario should not happen since the sequencer forcefully stops the block builder at the given deadline, but we still consider it.
+
+```
+10s:    Start building Block 2
+19s:    Block 2 finishes (1s late, deadline was 18s)
+19s:    Broadcast Block 2
+        Check: Can we start Block 3?
+        - Block 3 deadline: 26s
+        - Current time: 19s
+        - Time available: 7s
+        - MIN_EXECUTION_TIME: 3s
+        - 7s >= 3s, so CAN start Block 3
+
+19-26s: Build Block 3 (7s available vs 8s budgeted)
+26s:    Block 3 deadline
+```
+
+**Result:** Block 3 has less time (7s instead of 8s), but we still build it. The delay propagates but doesn't cascade uncontrollably.
+
+**Extreme case:** If Block 2 finishes at 24s (6s late):
+```
+24s:    Block 2 finishes (6s late)
+        Check: Can we start Block 3 in sub-slot 3?
+        - Sub-slot 3 deadline: 26s
+        - Current time: 24s
+        - Time available: 2s
+        - MIN_EXECUTION_TIME: 3s
+        - 2s < 3s, so CANNOT use sub-slot 3
+
+        Use sub-slot 4 instead:
+24-34s: Build Block 3 using sub-slot 4 (10s available vs 8s budgeted)
+```
+
+**Result:** Sub-slot 3 is skipped, we build Block 3 using sub-slot 4 instead with bonus time.
+
+### Block Finishes Early
+
+**Scenario:** Block 2 finishes at 15s instead of 18s
+
+This can happen if the sequencer hits a block limit (number of txs, gas, size, etc) or runs out of available txs before the sub-slot deadline:
+
+```
+10-15s: Build Block 2 (5s used vs 8s budgeted)
+15s:    Block 2 finished
+15s:    Broadcast Block 2
+        Check: Should we start Block 3 now or wait?
+        - Next sub-slot starts at 18s
+        - Wait until 18s to maintain regular intervals
+
+15-18s: WAITING_UNTIL_NEXT_BLOCK
+18s:    Start building Block 3
+18-26s: Build Block 3
+```
+
+**Result:** We wait until the next sub-slot starts. This prevents "rushing ahead" and maintains consistent block intervals, which is better for validators who are re-executing blocks in parallel.
+
+## Parallel execution between Proposers and Validators
+
+A key aspect of this design is **parallel execution** between proposer and validators.
+
+### Timeline Example (8-second sub-slots)
+
+```
+Time | Proposer                    | Validators
+-----|----------------------------|---------------------------
+2s   | Start building Block 1     | (idle)
+10s  | Finish Block 1, broadcast  | (idle)
+10s  | Start building Block 2     |
+12s  |                            | Receive Block 1 (10s + 2s)
+     |                            | Start re-executing Block 1
+18s  | Finish Block 2, broadcast  |
+20s  |                            | Finish re-executing Block 1 (12s + 8s)
+     |                            | Receive Block 2 (18s + 2s)
+     |                            | Start re-executing Block 2
+18s  | Start building Block 3     |
+26s  | Finish Block 3, broadcast  |
+28s  |                            | Finish re-executing Block 2 (20s + 8s)
+     |                            | Receive Block 3 (26s + 2s)
+     |                            | Start re-executing Block 3
+...
+42s  | Finish Block 5, broadcast  |
+     | checkpoint proposal        |
+44s  |                            | Finish re-executing Block 4 (36s + 8s)
+     |                            | Receive Block 5 + checkpoint (42s + 2s)
+     |                            | Start re-executing Block 5
+42-54s| COLLECTING_ATTESTATIONS   |
+52s  |                            | Finish re-executing Block 5 (44s + 8s)
+     |                            | Send attestations
+54s  | Receive attestations       | (done)
+54-55s| ASSEMBLING_CHECKPOINT     |
+55s  | PUBLISHING_CHECKPOINT      |
+```
+
+**Key observations:**
+- Validators lag by ~2s (propagation delay)
+- While proposer builds Block N+1, validators re-execute Block N (parallel work)
+- For the last block, proposer waits while validators re-execute
+- The last sub-slot provides the time budget for this waiting period
+
+## Configuration Guidelines
+
+When configuring timing parameters, ensure these constraints are satisfied:
+
+### Minimum Slot Duration
+
+For a valid configuration:
+```
+slotDuration >= initializationOffset
+              + blockDuration * 2                          (at least 2 blocks)
+              + blockDuration                              (last sub-slot)
+              + 2 * propagationTime                        (round-trip)
+              + finalizationTime                           (checkpoint finalization)
+              + l1PublishingTime                           (L1 publishing)
+```
+
+Simplified:
+```
+slotDuration >= initializationOffset + 3*blockDuration + 2*propagationTime + finalizationTime + l1PublishingTime
+```
+
+**Example:**
+```
+slotDuration >= 2s + 3*8s + 2*2s + 1s + 12s = 2s + 24s + 4s + 1s + 12s = 43s
+```
+
+For a 72s slot, this leaves `72s - 43s = 29s` of slack, allowing for about 3-4 additional blocks (29s / 8s ≈ 3.6).
+
+### Block Duration Constraints
+
+Block duration should be greater than the min execution time, and ideally a divisor of the time available for building.
+
+```
+blockDuration >= MIN_EXECUTION_TIME (3s practical minimum for meaningful execution)
+```
+
+### Initialization Offset
+
+The initialization offset should be set based on empirical measurements of how long initialization typically takes, with typical values being 1-3 seconds.
+
+**Key point:** This is an *estimate*, not a hard deadline. The sequencer will take as long as needed for initialization. If it takes longer than the offset, the first block just has less time. If it takes less, the first block has bonus time.
+
+### Propagation Time
+
+Should be measured empirically on the actual P2P network, accounting for:
+- Network latency between geographically distributed validators
+- Gossip network propagation (not direct communication)
+- Block/checkpoint size (larger messages take longer)
+
+Typical values: 1-3 seconds
+
+### L1 Publishing Time
+
+Must account for Ethereum slot duration (12s) and blob propagation time:
+- Bare minimum: 8s (Ethereum allows txs up to 4s into the slot)
+- Recommended minimum: 12s (full Ethereum slot)
+- With high blob congestion: 24s (two slots)
+
+## State Machine
+
+The sequencer transitions through these states during a slot:
+
+| State | Time Budget | Purpose |
+|-------|-------------|---------|
+| **SYNCHRONIZING** | No limit | Wait for all subsystems to sync |
+| **PROPOSER_CHECK** | Part of init offset | Verify we're the proposer |
+| **INITIALIZING_CHECKPOINT** | Part of init offset | Set up checkpoint state |
+| **WAITING_FOR_TXS** | Until block deadline | Wait for enough transactions |
+| **CREATING_BLOCK** | Until block deadline | Execute transactions and build block |
+| **WAITING_UNTIL_NEXT_BLOCK** | Until next sub-slot start | Sleep between blocks to maintain intervals |
+| **ASSEMBLING_CHECKPOINT** | assembleTime (1s) | Assemble final checkpoint |
+| **COLLECTING_ATTESTATIONS** | Until L1 publish deadline | Wait for validator signatures |
+| **PUBLISHING_CHECKPOINT** | Until slot end | Submit to L1 |
+
+## Complete Example: 72-Second Slot with 8-Second Sub-Slots
+
+Let's walk through a complete slot with the happy path:
+
+```
+T=0s    Slot begins for slot N
+
+T=0-2s  SYNCHRONIZING, PROPOSER_CHECK, INITIALIZING_CHECKPOINT
+        Actual time: 1.8s (slightly faster than 2s estimate)
+
+T=2s    Sub-slot 1 deadline calculation: 2s + 1*8s = 10s
+T=1.8s  Ready to build, start Block 1 immediately
+        Available time: 10s - 1.8s = 8.2s (bonus 0.2s!)
+T=1.8-9.5s  CREATING_BLOCK 1
+T=9.5s  Block 1 complete, broadcast
+T=9.5-10s  Wait for next sub-slot
+
+T=10s   Sub-slot 2 starts, deadline: 2s + 2*8s = 18s
+T=10-17.5s  CREATING_BLOCK 2
+T=17.5s Block 2 complete, broadcast
+T=17.5-18s Wait for next sub-slot
+
+T=18s   Sub-slot 3 starts, deadline: 2s + 3*8s = 26s
+T=18-25s  CREATING_BLOCK 3
+T=25s   Block 3 complete, broadcast
+T=25-26s Wait for next sub-slot
+
+T=26s   Sub-slot 4 starts, deadline: 2s + 4*8s = 34s
+T=26-33.5s  CREATING_BLOCK 4
+T=33.5s Block 4 complete, broadcast
+T=33.5-34s Wait for next sub-slot
+
+T=34s   Sub-slot 5 starts, deadline: 2s + 5*8s = 42s
+T=34-41s  CREATING_BLOCK 5 (last block)
+T=41s   Block 5 complete
+
+T=41s   ASSEMBLING_CHECKPOINT (1s)
+T=42s   Checkpoint proposal broadcast
+        Sub-slot 6 starts (last sub-slot, reserved for validator reexec)
+
+T=44s   Validators receive checkpoint (42s + 2s propagation)
+        Validators start re-executing Block 5
+
+T=52s   Validators finish re-executing Block 5 (44s + 8s)
+        Validators send attestations
+
+T=54s   COLLECTING_ATTESTATIONS
+        Proposer receives attestations (52s + 2s propagation)
+
+T=55s   PUBLISHING_CHECKPOINT
+        Sign over attestations, submit L1 transaction
+
+T=67s   L1 transaction lands in Ethereum block (12s)
+
+T=72s   Slot ends (5s buffer remaining)
+```
+
+**Summary:**
+- Built 5 blocks (sub-slots 1-5)
+- Last sub-slot (6) reserved for validator re-execution
+- Total time: 72s
+- Buffer: 5s (72s - 67s)

--- a/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
@@ -22,6 +22,7 @@ import {
   BlockHeader,
   type FailedTx,
   GlobalVariables,
+  NestedProcessReturnValues,
   type ProcessedTx,
   Tx,
   makeProcessedTxFromPrivateOnlyTx,
@@ -133,24 +134,27 @@ describe('BlockBuilder', () => {
     publicProcessor = mock<PublicProcessor>();
     validator = mock<PublicProcessorValidator>();
 
-    publicProcessor.process.mockImplementation(async (pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>) => {
-      const processedTxs: ProcessedTx[] = [];
-      const allTxs: Tx[] = [];
+    publicProcessor.process.mockImplementation(
+      async (
+        pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>,
+      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[]]> => {
+        const processedTxs: ProcessedTx[] = [];
+        const allTxs: Tx[] = [];
 
-      for await (const tx of pendingTxsIterator) {
-        allTxs.push(tx);
-        const processedTx = makeProcessedTxFromPrivateOnlyTx(
-          tx,
-          Fr.ZERO,
-          new PublicDataWrite(Fr.random(), Fr.random()),
-          globalVariables,
-        );
-        processedTxs.push(processedTx);
-      }
-      // Return [processedTxs, failedTxs, usedTxs, nestedReturnValues]
-      // Assuming all txs are processed successfully and none failed for this mock
-      return [processedTxs, [], allTxs, []] as any;
-    });
+        for await (const tx of pendingTxsIterator) {
+          allTxs.push(tx);
+          const processedTx = makeProcessedTxFromPrivateOnlyTx(
+            tx,
+            Fr.ZERO,
+            new PublicDataWrite(Fr.random(), Fr.random()),
+            globalVariables,
+          );
+          processedTxs.push(processedTx);
+        }
+        // Assuming all txs are processed successfully and none failed for this mock
+        return [processedTxs, [], allTxs, []];
+      },
+    );
     blockBuilder = new TestBlockBuilder(l1Constants, worldState, contractDataSource, dateProvider);
   });
 
@@ -204,30 +208,33 @@ describe('BlockBuilder', () => {
     const invalidTx = txs[1];
     const validTxHashes = await Promise.all(validTxs.map(tx => tx.getTxHash()));
 
-    publicProcessor.process.mockImplementation(async (pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>) => {
-      const processedTxs: ProcessedTx[] = [];
-      const usedTxs: Tx[] = [];
-      const failedTxs: FailedTx[] = [];
+    publicProcessor.process.mockImplementation(
+      async (
+        pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>,
+      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[]]> => {
+        const processedTxs: ProcessedTx[] = [];
+        const usedTxs: Tx[] = [];
+        const failedTxs: FailedTx[] = [];
 
-      for await (const tx of pendingTxsIterator) {
-        if (validTxHashes.includes(tx.getTxHash())) {
-          usedTxs.push(tx);
-          const processedTx = makeProcessedTxFromPrivateOnlyTx(
-            tx,
-            Fr.ZERO,
-            new PublicDataWrite(Fr.random(), Fr.random()),
-            globalVariables,
-          );
+        for await (const tx of pendingTxsIterator) {
+          if (validTxHashes.includes(tx.getTxHash())) {
+            usedTxs.push(tx);
+            const processedTx = makeProcessedTxFromPrivateOnlyTx(
+              tx,
+              Fr.ZERO,
+              new PublicDataWrite(Fr.random(), Fr.random()),
+              globalVariables,
+            );
 
-          processedTxs.push(processedTx);
-        } else {
-          failedTxs.push({ tx, error: new Error() });
+            processedTxs.push(processedTx);
+          } else {
+            failedTxs.push({ tx, error: new Error() });
+          }
         }
-      }
-      // Return [processedTxs, failedTxs, usedTxs, nestedReturnValues]
-      // Assuming all txs are processed successfully and none failed for this mock
-      return [processedTxs, failedTxs, usedTxs, []] as any;
-    });
+        // Assuming all txs are processed successfully and none failed for this mock
+        return [processedTxs, failedTxs, usedTxs, []];
+      },
+    );
 
     const blockResult = await blockBuilder.buildBlock(txs, [], globalVariables, {});
     expect(blockResult.failedTxs).toEqual([{ tx: invalidTx, error: new Error() }]);

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -1,0 +1,685 @@
+import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { TimeoutError } from '@aztec/foundation/error';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { Signature } from '@aztec/foundation/eth-signature';
+import { createLogger } from '@aztec/foundation/log';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import type { TypedEventEmitter } from '@aztec/foundation/types';
+import { type P2P, P2PClientState } from '@aztec/p2p';
+import type { SlasherClientInterface } from '@aztec/slasher';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { CommitteeAttestation } from '@aztec/stdlib/block';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { GasFees } from '@aztec/stdlib/gas';
+import type {
+  MerkleTreeWriteOperations,
+  ResolvedSequencerConfig,
+  WorldStateSynchronizer,
+} from '@aztec/stdlib/interfaces/server';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import { BlockProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
+import { GlobalVariables } from '@aztec/stdlib/tx';
+import { AttestationTimeoutError } from '@aztec/stdlib/validators';
+import type { ValidatorClient } from '@aztec/validator-client';
+
+import { expect, jest } from '@jest/globals';
+import EventEmitter from 'events';
+import { type MockProxy, mock, mockDeep, mockFn } from 'jest-mock-extended';
+import type { TransactionReceipt } from 'viem';
+
+import { DefaultSequencerConfig } from '../config.js';
+import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
+import type { SequencerPublisher } from '../publisher/sequencer-publisher.js';
+import {
+  MockCheckpointBuilder,
+  MockCheckpointsBuilder,
+  createBlockAttestation,
+  makeBlock,
+  makeTx,
+  mockPendingTxs,
+  mockTxIterator,
+  setupTxsAndBlock,
+} from '../test/utils.js';
+import type { FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
+import { CheckpointProposalJob } from './checkpoint_proposal_job.js';
+import type { SequencerEvents } from './events.js';
+import type { SequencerMetrics } from './metrics.js';
+import { SequencerTimetable } from './timetable.js';
+
+describe('CheckpointProposalJob', () => {
+  let publisher: MockProxy<SequencerPublisher>;
+  let epochCache: MockProxy<EpochCache>;
+  let validatorClient: MockProxy<ValidatorClient>;
+  let globalVariableBuilder: MockProxy<GlobalVariableBuilder>;
+  let p2p: MockProxy<P2P>;
+  let worldState: MockProxy<WorldStateSynchronizer>;
+  let checkpointsBuilder: MockCheckpointsBuilder;
+  let checkpointBuilder: MockCheckpointBuilder;
+  let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
+  let slasherClient: MockProxy<SlasherClientInterface>;
+  let dateProvider: TestDateProvider;
+  let metrics: MockProxy<SequencerMetrics>;
+  let job: TestCheckpointProposalJob;
+
+  let timetable: SequencerTimetable;
+  let l1Constants: L1RollupConstants;
+  let config: ResolvedSequencerConfig;
+
+  let lastBlockNumber: BlockNumber;
+  let newBlockNumber: BlockNumber;
+  let newSlotNumber: number;
+  let checkpointNumber: CheckpointNumber;
+  let hash: string;
+
+  let globalVariables: GlobalVariables;
+  let feeRecipient: AztecAddress;
+
+  const slotDuration = 24;
+  const ethereumSlotDuration = 12;
+  const chainId = new Fr(12345);
+  const version = Fr.ZERO;
+  const coinbase = EthAddress.random();
+  const gasFees = GasFees.empty();
+
+  const signer = Secp256k1Signer.random();
+  const mockedSig = Signature.random();
+  const mockedAttestation = new CommitteeAttestation(signer.address, mockedSig);
+  const committee = [signer.address];
+  const attestorAddress = EthAddress.random();
+  const proposer = EthAddress.random();
+
+  const getSignatures = () => [mockedAttestation];
+
+  const getAttestations = (block: any) => {
+    const attestation = createBlockAttestation(block, mockedSig, committee[0]);
+    return [attestation];
+  };
+
+  beforeEach(async () => {
+    feeRecipient = await AztecAddress.random();
+    lastBlockNumber = BlockNumber.ZERO;
+    newBlockNumber = BlockNumber(lastBlockNumber + 1);
+    newSlotNumber = 1;
+    checkpointNumber = CheckpointNumber.fromBlockNumber(newBlockNumber);
+    hash = Fr.ZERO.toString();
+
+    globalVariables = new GlobalVariables(
+      chainId,
+      version,
+      newBlockNumber,
+      SlotNumber(newSlotNumber),
+      /*timestamp=*/ 0n,
+      coinbase,
+      feeRecipient,
+      gasFees,
+    );
+
+    const l1GenesisTime = BigInt(Math.floor(Date.now() / 1000));
+    l1Constants = {
+      l1GenesisTime,
+      slotDuration,
+      ethereumSlotDuration,
+      l1StartBlock: 0n,
+      epochDuration: 16,
+      proofSubmissionEpochs: 4,
+    };
+
+    dateProvider = new TestDateProvider();
+    // Set time to be at the start of the slot (slot 1 starts at l1GenesisTime + slotDuration - ethereumSlotDuration)
+    const slotStartTime = Number(l1GenesisTime) + newSlotNumber * slotDuration - ethereumSlotDuration;
+    dateProvider.setTime(slotStartTime * 1000); // Convert to milliseconds
+
+    epochCache = mockDeep<EpochCache>();
+    epochCache.getCommittee.mockResolvedValue({ committee, seed: 1n, epoch: EpochNumber(1) } as EpochCommitteeInfo);
+
+    publisher = mockDeep<SequencerPublisher>();
+    publisher.epochCache = epochCache;
+    publisher.getSenderAddress.mockImplementation(() => attestorAddress);
+    publisher.enqueueProposeCheckpoint.mockResolvedValue(undefined);
+    publisher.enqueueGovernanceCastSignal.mockResolvedValue(true);
+    publisher.enqueueSlashingActions.mockResolvedValue(true);
+    publisher.sendRequests.mockResolvedValue({
+      result: { receipt: { status: 'success' } as TransactionReceipt, errorMsg: undefined },
+      successfulActions: ['propose'],
+      failedActions: [],
+      sentActions: ['propose'],
+      expiredActions: [],
+    });
+
+    globalVariableBuilder = mock<GlobalVariableBuilder>();
+    globalVariableBuilder.buildCheckpointGlobalVariables.mockResolvedValue({
+      slotNumber: globalVariables.slotNumber,
+      timestamp: globalVariables.timestamp,
+      coinbase: globalVariables.coinbase,
+      feeRecipient: globalVariables.feeRecipient,
+      gasFees: globalVariables.gasFees,
+      chainId: globalVariables.chainId,
+      version: globalVariables.version,
+    });
+
+    p2p = mock<P2P>({
+      getStatus: mockFn().mockResolvedValue({
+        state: P2PClientState.IDLE,
+        syncedToL2Block: { number: lastBlockNumber, hash },
+      }),
+    });
+    p2p.broadcastProposal.mockResolvedValue(undefined);
+
+    worldState = mockDeep<WorldStateSynchronizer>();
+    const mockFork = mock<MerkleTreeWriteOperations>({ [Symbol.dispose]: jest.fn() });
+    worldState.fork.mockResolvedValue(mockFork);
+
+    // Create fake CheckpointsBuilder and CheckpointBuilder
+    const checkpointConstants = {
+      slotNumber: globalVariables.slotNumber,
+      timestamp: globalVariables.timestamp,
+      coinbase: globalVariables.coinbase,
+      feeRecipient: globalVariables.feeRecipient,
+      gasFees: globalVariables.gasFees,
+      chainId: globalVariables.chainId,
+      version: globalVariables.version,
+    };
+    checkpointsBuilder = new MockCheckpointsBuilder();
+    checkpointBuilder = checkpointsBuilder.createCheckpointBuilder(checkpointConstants, checkpointNumber);
+
+    l1ToL2MessageSource = mock<L1ToL2MessageSource>();
+    l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue(Array(4).fill(Fr.ZERO));
+
+    validatorClient = mock<ValidatorClient>();
+    validatorClient.collectAttestations.mockImplementation(() => Promise.resolve([]));
+    validatorClient.createBlockProposal.mockImplementation((_blockNumber, checkpointHeader, archiveRoot, txs) => {
+      // Create a block proposal directly with the checkpoint header instead of using fromBlock
+      // which would require a full L2Block with toCheckpointHeader method
+      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot);
+      return Promise.resolve(
+        new BlockProposal(
+          consensusPayload,
+          mockedSig,
+          (txs ?? []).map((tx: any) => tx.txHash),
+        ),
+      );
+    });
+    validatorClient.createCheckpointProposal.mockImplementation((checkpointHeader, archiveRoot, txs) => {
+      // Create a minimal BlockProposal for the checkpoint
+      const consensusPayload = new ConsensusPayload(checkpointHeader, archiveRoot);
+      return Promise.resolve(
+        new BlockProposal(
+          consensusPayload,
+          mockedSig,
+          (txs ?? []).map(tx => tx.txHash),
+        ),
+      );
+    });
+    validatorClient.signAttestationsAndSigners.mockImplementation(() => Promise.resolve(getSignatures()[0].signature));
+    validatorClient.getCoinbaseForAttestor.mockReturnValue(coinbase);
+    validatorClient.getFeeRecipientForAttestor.mockReturnValue(feeRecipient);
+
+    slasherClient = mock<SlasherClientInterface>();
+    slasherClient.getProposerActions.mockResolvedValue([]);
+
+    metrics = mockDeep<SequencerMetrics>();
+
+    config = {
+      ...DefaultSequencerConfig,
+      enforceTimeTable: true,
+      maxTxsPerBlock: 4,
+      minTxsPerBlock: 1,
+      publishTxsWithProposals: false,
+      broadcastInvalidBlockProposal: false,
+      fishermanMode: false,
+      buildCheckpointIfEmpty: false,
+      skipInvalidateBlockAsProposer: false,
+      skipCollectingAttestations: false,
+      injectFakeAttestation: false,
+      shuffleAttestationOrdering: false,
+    };
+
+    timetable = new SequencerTimetable({
+      ethereumSlotDuration,
+      aztecSlotDuration: slotDuration,
+      l1PublishingTime: ethereumSlotDuration,
+      enforce: config.enforceTimeTable,
+    });
+
+    job = createCheckpointProposalJob();
+  });
+
+  describe('single block mode', () => {
+    beforeEach(() => {
+      // Single block mode: no blockDurationMs set
+      job.setTimetable(
+        new SequencerTimetable({
+          ethereumSlotDuration,
+          aztecSlotDuration: slotDuration,
+          l1PublishingTime: ethereumSlotDuration,
+          enforce: config.enforceTimeTable,
+        }),
+      );
+    });
+
+    it('builds one block with sufficient txs', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 2, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips building if not enough txs and not forced', async () => {
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      mockPendingTxs(p2p, txs);
+
+      job.updateConfig({ minTxsPerBlock: 2 });
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeUndefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('forces empty block when buildCheckpointIfEmpty is set', async () => {
+      mockPendingTxs(p2p, []);
+
+      const emptyBlock = await makeBlock([], globalVariables);
+      checkpointBuilder.seedBlocks([emptyBlock], [[]]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(emptyBlock));
+
+      job.updateConfig({ buildCheckpointIfEmpty: true, minTxsPerBlock: 1 });
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(checkpointBuilder.buildBlockCalls[0]).toEqual(
+        expect.objectContaining({
+          blockNumber: newBlockNumber,
+          opts: expect.objectContaining({
+            maxTransactions: config.maxTxsPerBlock,
+          }),
+        }),
+      );
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
+    });
+
+    it('collects attestations after building the single block', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      await job.execute();
+
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Number),
+        expect.any(Date),
+      );
+    });
+  });
+
+  /**
+   * Helper to create a TestCheckpointProposalJob instance with current mocks.
+   * Uses TestCheckpointProposalJob which has waitUntilTimeInSlot as a no-op.
+   * Called in beforeEach to create the job, and tests can use job.updateConfig()
+   * to modify config after creation.
+   */
+  function createCheckpointProposalJob(): TestCheckpointProposalJob {
+    const setStateFn = jest.fn();
+    const eventEmitter = new EventEmitter() as TypedEventEmitter<SequencerEvents>;
+
+    return new TestCheckpointProposalJob(
+      SlotNumber(newSlotNumber),
+      checkpointNumber,
+      lastBlockNumber,
+      proposer,
+      publisher,
+      attestorAddress,
+      undefined, // invalidateBlock
+      validatorClient,
+      globalVariableBuilder,
+      p2p,
+      worldState,
+      l1ToL2MessageSource,
+      checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
+      l1Constants,
+      config,
+      timetable,
+      slasherClient,
+      epochCache,
+      dateProvider,
+      metrics,
+      eventEmitter,
+      setStateFn,
+      createLogger('sequencer:checkpoint-proposal-job'),
+    );
+  }
+
+  describe('multiple block mode', () => {
+    beforeEach(() => {
+      // Multiple block mode: set blockDurationMs to 8 seconds
+      job.setTimetable(
+        new SequencerTimetable({
+          ethereumSlotDuration,
+          aztecSlotDuration: slotDuration,
+          l1PublishingTime: ethereumSlotDuration,
+          blockDurationMs: 8000,
+          enforce: true,
+        }),
+      );
+    });
+
+    it('builds multiple blocks with sufficient txs', async () => {
+      // Mock timetable to allow 2 blocks
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 10, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 18, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      // Create enough txs for 2 blocks
+      const txs = await Promise.all([makeTx(1, chainId), makeTx(2, chainId), makeTx(3, chainId)]);
+
+      // Always have txs available
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      // Create 2 blocks
+      const block1 = await makeBlock(txs.slice(0, 2), globalVariables);
+      const globalVariables2 = new GlobalVariables(
+        chainId,
+        version,
+        BlockNumber(newBlockNumber + 1),
+        SlotNumber(newSlotNumber),
+        0n,
+        coinbase,
+        feeRecipient,
+        gasFees,
+      );
+      const block2 = await makeBlock([txs[2]], globalVariables2);
+
+      // Seed MockCheckpointBuilder with blocks to return sequentially
+      checkpointBuilder.seedBlocks([block1, block2], [txs.slice(0, 2), [txs[2]]]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block2));
+
+      // Install spy on waitUntilTimeInSlot to verify it's called with expected deadlines
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(2);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+
+      // Verify waitUntilTimeInSlot was called between blocks
+      // After building the first non-last block, it waits for the next block time
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+      // The wait time is until the next block deadline
+      expect(waitSpy.mock.calls[0][0]).toEqual(10);
+    });
+
+    it('stops building when canStartNextBlock returns false', async () => {
+      // Mock timetable to stop after 1 block (simulating time running out)
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 10, isLastBlock: false })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      const txs = await Promise.all([makeTx(1, chainId), makeTx(2, chainId)]);
+      const block = await makeBlock(txs, globalVariables);
+
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      // Install spy on waitUntilTimeInSlot
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      // Only one block built due to time constraints
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+
+      // Since isLastBlock was false but canStart became false after first block,
+      // waitUntilTimeInSlot should have been called once (after first block, before checking canStart again)
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls waitUntilTimeInSlot with expected deadline based on block duration', async () => {
+      const blockDurationSeconds = 8; // 8000ms / 1000
+
+      // Mock timetable to allow 3 blocks
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 2 + blockDurationSeconds, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 2 + 2 * blockDurationSeconds, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 2 + 3 * blockDurationSeconds, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      const txs = await Promise.all([makeTx(1, chainId), makeTx(2, chainId), makeTx(3, chainId)]);
+      const block = await makeBlock(txs, globalVariables);
+
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      // Seed with 3 identical blocks (each with 1 tx)
+      checkpointBuilder.seedBlocks([block, block, block], [[txs[0]], [txs[1]], [txs[2]]]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      await job.execute();
+
+      // With 3 blocks where the 3rd is the last, waitUntilTimeInSlot should be called twice
+      // (after block 1 and block 2, but not after block 3 since it's the last)
+      expect(waitSpy).toHaveBeenCalledTimes(2);
+      expect(waitSpy.mock.calls[0][0]).toEqual(10);
+      expect(waitSpy.mock.calls[1][0]).toEqual(18);
+    });
+
+    it('does not call waitUntilTimeInSlot when building the last block', async () => {
+      // Mock timetable to allow only 1 block (which is the last)
+      jest.spyOn(job.getTimetable(), 'canStartNextBlock').mockReturnValue({
+        canStart: true,
+        deadline: 30,
+        isLastBlock: true, // First and only block is the last
+      });
+
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      const block = await makeBlock(txs, globalVariables);
+
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+
+      // waitUntilTimeInSlot should NOT be called since the only block is the last block
+      expect(waitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('timing edge cases', () => {
+    it('handles insufficient time remaining in slot', async () => {
+      // Mock canStartNextBlock to return false (not enough time)
+      jest.spyOn(job.getTimetable(), 'canStartNextBlock').mockReturnValue({
+        canStart: false,
+        deadline: undefined,
+        isLastBlock: false,
+      });
+
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      const checkpoint = await job.execute();
+
+      // Should return undefined when no time available
+      expect(checkpoint).toBeUndefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
+    });
+
+    it('forces checkpoint build when buildCheckpointIfEmpty is true and time allows', async () => {
+      // Mock minimal txs (less than minTxsPerBlock)
+      p2p.getPendingTxCount.mockResolvedValue(1);
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      const block = await makeBlock(txs, globalVariables);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+    });
+
+    it('respects buildDeadline when checking time availability', async () => {
+      // Mock canStartNextBlock to indicate we're at the deadline
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 1, isLastBlock: true }) // Very tight deadline
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      const block = await makeBlock(txs, globalVariables);
+
+      p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block));
+
+      const checkpoint = await job.execute();
+
+      // Should still complete if first block succeeds
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles block build failure gracefully', async () => {
+      const txs = await Promise.all([makeTx(1, chainId)]);
+      p2p.getPendingTxCount.mockResolvedValue(txs.length);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      // Set up MockCheckpointBuilder to throw on build
+      checkpointBuilder.errorOnBuild = new Error('Block build failed');
+
+      // The job catches the error internally and returns undefined
+      const checkpoint = await job.execute();
+      expect(checkpoint).toBeUndefined();
+    });
+
+    it('handles attestation collection timeout', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      // Mock collectAttestations to fail with timeout
+      validatorClient.collectAttestations.mockRejectedValue(new AttestationTimeoutError(0, 3, SlotNumber.ZERO));
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeUndefined();
+      expect(validatorClient.collectAttestations).toHaveBeenCalled();
+    });
+
+    it('handles empty committee gracefully', async () => {
+      // Mock empty committee
+      epochCache.getCommittee.mockResolvedValue({
+        committee: [],
+        seed: 1n,
+        epoch: EpochNumber(1),
+      } as EpochCommitteeInfo);
+
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      const checkpoint = await job.execute();
+
+      // Should complete even with empty committee
+      expect(checkpoint).toBeDefined();
+    });
+  });
+
+  describe('attestation collection', () => {
+    it('collects attestations in normal flow', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      const attestations = getAttestations(block);
+      validatorClient.collectAttestations.mockResolvedValue(attestations);
+
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(validatorClient.collectAttestations).toHaveBeenCalled();
+    });
+
+    it('handles attestation collection throwing TimeoutError', async () => {
+      const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);
+      checkpointBuilder.seedBlocks([block], [txs]);
+
+      validatorClient.collectAttestations.mockRejectedValue(new TimeoutError('Attestation collection timed out'));
+
+      await job.execute();
+
+      // Should handle timeout gracefully
+      expect(validatorClient.collectAttestations).toHaveBeenCalled();
+    });
+  });
+});
+
+class TestCheckpointProposalJob extends CheckpointProposalJob {
+  /** Override to be a no-op for testing - allows tests to run without timing delays */
+  public override waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
+    this.log.warn(`Skipping waitUntilTimeInSlot(${targetSecondsIntoSlot}) in test`);
+    return Promise.resolve();
+  }
+
+  /** Update config for testing - allows tests to modify config after job creation */
+  public updateConfig(partialConfig: Partial<ResolvedSequencerConfig>): void {
+    this.config = { ...this.config, ...partialConfig };
+  }
+
+  /** Set timetable for testing - allows tests to modify timetable after job creation */
+  public setTimetable(newTimetable: SequencerTimetable): void {
+    this.timetable = newTimetable;
+  }
+
+  /** Get timetable for testing - allows tests to spy on methods */
+  public getTimetable(): SequencerTimetable {
+    return this.timetable;
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -48,9 +48,6 @@ import { SequencerState } from './utils.js';
 /** How much time to sleep while waiting for min transactions to accumulate for a block */
 const TXS_POLLING_MS = 500;
 
-/** What's the latest time before a block build deadline we're willing to *start* building it */
-const MIN_BLOCK_BUILD_TIME_MS = 1000;
-
 /**
  * Handles the execution of a checkpoint proposal after the initial preparation phase.
  * This includes building blocks, collecting attestations, and publishing the checkpoint to L1,
@@ -74,15 +71,15 @@ export class CheckpointProposalJob {
     private readonly l1ToL2MessageSource: L1ToL2MessageSource,
     private readonly checkpointsBuilder: FullNodeCheckpointsBuilder,
     private readonly l1Constants: SequencerRollupConstants,
-    private readonly config: ResolvedSequencerConfig,
-    private readonly timetable: SequencerTimetable,
+    protected config: ResolvedSequencerConfig,
+    protected timetable: SequencerTimetable,
     private readonly slasherClient: SlasherClientInterface | undefined,
     private readonly epochCache: EpochCache,
     private readonly dateProvider: DateProvider,
     private readonly metrics: SequencerMetrics,
     private readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
     private readonly setStateFn: (state: SequencerState, slot?: SlotNumber) => void,
-    private readonly log: Logger,
+    protected readonly log: Logger,
   ) {}
 
   /**
@@ -188,7 +185,7 @@ export class CheckpointProposalJob {
 
       // Assemble and broadcast the checkpoint proposal, including the last block that was not
       // broadcasted yet, and wait to collect the committee attestations.
-      this.setStateFn(SequencerState.FINALIZING_CHECKPOINT, this.slot);
+      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.slot);
       const checkpoint = await checkpointBuilder.completeCheckpoint();
 
       // Do not collect attestations nor publish to L1 in fisherman mode
@@ -290,12 +287,15 @@ export class CheckpointProposalJob {
       });
 
       if (!buildResult && timingInfo.isLastBlock) {
-        // If no block was produced due to not enough txs and this was the last one, exit
+        // If no block was produced due to not enough txs and this was the last subslot, exit
         break;
-      } else if (!buildResult) {
-        // But if there is still time for more blocks, wait until the next block time and try again
-        await this.waitUntilNextBlock(secondsIntoSlot);
+      } else if (!buildResult && timingInfo.deadline !== undefined) {
+        // But if there is still time for more blocks, wait until the next subslot and try again
+        await this.waitUntilNextSubslot(timingInfo.deadline);
         continue;
+      } else if (!buildResult) {
+        // Exit if there is no possibility of building more blocks
+        break;
       } else if ('error' in buildResult) {
         // If there was an error building the block, just exit the loop and give up the rest of the slot
         if (!(buildResult.error instanceof SequencerInterruptedError)) {
@@ -343,7 +343,7 @@ export class CheckpointProposalJob {
       }
 
       // Wait until the next block's start time
-      await this.waitUntilNextBlock(secondsIntoSlot);
+      await this.waitUntilNextSubslot(timingInfo.deadline);
     }
 
     this.log.verbose(`Block building loop completed for slot ${this.slot}`, {
@@ -358,12 +358,10 @@ export class CheckpointProposalJob {
   }
 
   /** Sleeps until it is time to produce the next block in the slot */
-  private async waitUntilNextBlock(blockStartedAtSecondsIntoSlot: number) {
+  private async waitUntilNextSubslot(nextSubslotStart: number) {
     this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.slot);
-    const blockDurationSeconds = this.timetable.blockDuration!;
-    const nextBlockStart = blockStartedAtSecondsIntoSlot + blockDurationSeconds;
-    this.log.verbose(`Waiting until time for the next block at ${nextBlockStart}s into slot`, { slot: this.slot });
-    await this.waitUntilTimeInSlot(nextBlockStart);
+    this.log.verbose(`Waiting until time for the next block at ${nextSubslotStart}s into slot`, { slot: this.slot });
+    await this.waitUntilTimeInSlot(nextSubslotStart);
   }
 
   /** Builds a single block. Called from the main block building loop. */
@@ -489,7 +487,7 @@ export class CheckpointProposalJob {
 
     // Deadline is undefined if we are not enforcing the timetable, meaning we'll exit immediately when out of time
     const startBuildingDeadline = buildDeadline
-      ? new Date(buildDeadline.getTime() - MIN_BLOCK_BUILD_TIME_MS)
+      ? new Date(buildDeadline.getTime() - this.timetable.minExecutionTime * 1000)
       : undefined;
 
     let availableTxs = await this.p2pClient.getPendingTxCount();
@@ -680,7 +678,7 @@ export class CheckpointProposalJob {
   }
 
   /** Waits until a specific time within the current slot */
-  private async waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
+  protected async waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
     const slotStartTimestamp = this.getSlotStartBuildTimestamp();
     const targetTimestamp = slotStartTimestamp + targetSecondsIntoSlot;
     await sleepUntil(new Date(targetTimestamp * 1000), this.dateProvider.nowAsDate());

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,5 +1,4 @@
-import { Body, L2Block } from '@aztec/aztec.js/block';
-import { GENESIS_BLOCK_HEADER_HASH, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
+import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import type { RollupContract } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -8,24 +7,21 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
-import { TestDateProvider, Timer } from '@aztec/foundation/timer';
-import { type P2P, P2PClientState } from '@aztec/p2p';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
-import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   CommitteeAttestation,
   CommitteeAttestationsAndSigners,
-  L2BlockHeader,
+  L2BlockNew,
   type L2BlockSource,
   type ValidateBlockNegativeResult,
 } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
-import { Gas, GasFees } from '@aztec/stdlib/gas';
+import { GasFees } from '@aztec/stdlib/gas';
 import {
-  type MerkleTreeReadOperations,
-  type MerkleTreeWriteOperations,
   type SequencerConfig,
   WorldStateRunningState,
   type WorldStateSyncStatus,
@@ -33,19 +29,18 @@ import {
   type WorldStateSynchronizerStatus,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { BlockAttestation, BlockProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
-import { makeAppendOnlyTreeSnapshot, mockTxForRollup } from '@aztec/stdlib/testing';
-import type { MerkleTreeId } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, type Tx, makeProcessedTxFromPrivateOnlyTx } from '@aztec/stdlib/tx';
+import { GlobalVariables, type Tx } from '@aztec/stdlib/tx';
 import type { ValidatorClient } from '@aztec/validator-client';
 
-import { expect, jest } from '@jest/globals';
+import { expect } from '@jest/globals';
 import { type MockProxy, mock, mockDeep, mockFn } from 'jest-mock-extended';
 
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import type { AttestorPublisherPair, SequencerPublisherFactory } from '../publisher/sequencer-publisher-factory.js';
-import type { SequencerPublisher } from '../publisher/sequencer-publisher.js';
-import { CheckpointBuilder, FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
+import type { InvalidateBlockRequest, SequencerPublisher } from '../publisher/sequencer-publisher.js';
+import { MockCheckpointBuilder, MockCheckpointsBuilder } from '../test/utils.js';
+import * as TestUtils from '../test/utils.js';
+import type { FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
 import { Sequencer } from './sequencer.js';
 import { SequencerState } from './utils.js';
 
@@ -56,10 +51,8 @@ describe('sequencer', () => {
   let globalVariableBuilder: MockProxy<GlobalVariableBuilder>;
   let p2p: MockProxy<P2P>;
   let worldState: MockProxy<WorldStateSynchronizer>;
-  let fork: MockProxy<MerkleTreeWriteOperations>;
-  let checkpointsBuilder: MockProxy<FullNodeCheckpointsBuilder>;
-  let checkpointBuilder: MockProxy<CheckpointBuilder>;
-  let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
+  let checkpointsBuilder: MockCheckpointsBuilder;
+  let checkpointBuilder: MockCheckpointBuilder;
   let l2BlockSource: MockProxy<L2BlockSource>;
   let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
   let slasherClient: MockProxy<SlasherClientInterface>;
@@ -69,18 +62,16 @@ describe('sequencer', () => {
 
   let dateProvider: TestDateProvider;
 
-  let initialBlockHeader: BlockHeader;
   let lastBlockNumber: BlockNumber;
   let newBlockNumber: BlockNumber;
   let newSlotNumber: number;
   let hash: string;
 
-  let block: L2Block;
+  let block: L2BlockNew;
   let globalVariables: GlobalVariables;
   let l1Constants: Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration'>;
-  // Note: Removed unused l1Contracts declaration
 
-  let sequencer: TestSubject;
+  let sequencer: TestSequencer;
 
   const slotDuration = 8;
   const ethereumSlotDuration = 4;
@@ -100,52 +91,27 @@ describe('sequencer', () => {
   const getSignatures = () => [mockedAttestation];
 
   const getAttestations = () => {
-    const consensusPayload = ConsensusPayload.fromBlock(block);
-    const attestation = new BlockAttestation(consensusPayload, mockedSig, mockedSig);
-    (attestation as any).sender = committee[0];
-    return [attestation];
+    return [TestUtils.createBlockAttestation(block, mockedSig, committee[0])];
   };
 
   const createBlockProposal = () => {
-    const consensusPayload = ConsensusPayload.fromBlock(block);
-    const txHashes = block.body.txEffects.map(tx => tx.txHash);
-    return new BlockProposal(consensusPayload, mockedSig, txHashes);
-  };
-
-  const processTxs = async (txs: Tx[]) => {
-    return await Promise.all(
-      txs.map(tx =>
-        makeProcessedTxFromPrivateOnlyTx(tx, Fr.ZERO, new PublicDataWrite(Fr.random(), Fr.random()), globalVariables),
-      ),
-    );
-  };
-
-  const mockTxIterator = async function* (txs: Promise<Tx[]>): AsyncIterableIterator<Tx> {
-    for (const tx of await txs) {
-      yield tx;
-    }
-  };
-
-  const mockPendingTxs = (txs: Tx[]) => {
-    p2p.getPendingTxCount.mockResolvedValue(txs.length);
-    // make sure a new iterator is created for every invocation of iteratePendingTxs
-    // otherwise we risk iterating over the same iterator more than once (yielding no more values)
-    p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+    return TestUtils.createBlockProposal(block, mockedSig);
   };
 
   const makeBlock = async (txs: Tx[]) => {
-    const processedTxs = await processTxs(txs);
-    const body = new Body(processedTxs.map(tx => tx.txEffect));
-    const header = L2BlockHeader.empty({ globalVariables: globalVariables });
-    const archive = makeAppendOnlyTreeSnapshot(newBlockNumber + 1);
-
-    block = new L2Block(archive, header, body);
+    block = await TestUtils.makeBlock(txs, globalVariables);
     return block;
   };
 
-  const makeTx = async (seed?: number) => {
-    const tx = await mockTxForRollup(seed);
-    tx.data.constants.txContext.chainId = chainId;
+  const makeTx = (seed?: number) => {
+    return TestUtils.makeTx(seed, chainId);
+  };
+
+  /** Creates a single tx, makes a block from it, and mocks it as pending */
+  const setupSingleTxBlock = async (seed?: number) => {
+    const tx = await makeTx(seed);
+    block = await makeBlock([tx]);
+    TestUtils.mockPendingTxs(p2p, [tx]);
     return tx;
   };
 
@@ -164,7 +130,6 @@ describe('sequencer', () => {
 
   beforeEach(async () => {
     feeRecipient = await AztecAddress.random();
-    initialBlockHeader = BlockHeader.empty();
     lastBlockNumber = BlockNumber.ZERO;
     newBlockNumber = BlockNumber(lastBlockNumber + 1);
     newSlotNumber = newBlockNumber;
@@ -218,29 +183,14 @@ describe('sequencer', () => {
     globalVariableBuilder.buildGlobalVariables.mockResolvedValue(globalVariables);
     globalVariableBuilder.buildCheckpointGlobalVariables.mockResolvedValue(omit(globalVariables, 'blockNumber'));
 
-    merkleTreeOps = mock<MerkleTreeReadOperations>();
-    merkleTreeOps.findLeafIndices.mockImplementation((_treeId: MerkleTreeId, _value: any[]) => {
-      return Promise.resolve([undefined]);
-    });
-    merkleTreeOps.getTreeInfo.mockImplementation((treeId: MerkleTreeId) => {
-      return Promise.resolve({ treeId, root: Fr.random().toBuffer(), size: 99n, depth: 5 });
-    });
-
     p2p = mock<P2P>({
-      getStatus: mockFn().mockResolvedValue({
-        state: P2PClientState.IDLE,
-        syncedToL2Block: { number: lastBlockNumber, hash },
-      }),
-    });
-
-    fork = mock<MerkleTreeWriteOperations>({
-      getInitialHeader: () => initialBlockHeader,
+      getStatus: mockFn().mockResolvedValue({ syncedToL2Block: { number: lastBlockNumber, hash } }),
     });
 
     worldState = mock<WorldStateSynchronizer>({
-      fork: () => Promise.resolve(fork),
-      syncImmediate: () => Promise.resolve(lastBlockNumber),
-      getCommitted: () => merkleTreeOps,
+      getCommitted: mockFn().mockReturnValue({
+        getTreeInfo: mockFn().mockResolvedValue({ root: Fr.random().toBuffer(), size: 99n, depth: 5 }),
+      }),
       status: mockFn().mockResolvedValue({
         state: WorldStateRunningState.IDLE,
         syncSummary: {
@@ -253,33 +203,27 @@ describe('sequencer', () => {
       } satisfies WorldStateSynchronizerStatus),
     });
 
-    checkpointBuilder = mock<CheckpointBuilder>();
-    checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) =>
-      Promise.resolve({
-        block: block as any,
-        publicGas: Gas.empty(),
-        publicProcessorDuration: 0,
-        numTxs: block.body.txEffects.length,
-        blockBuildingTimer: new Timer(),
-        usedTxs: [],
-        failedTxs: [],
-      }),
+    // Create fake CheckpointsBuilder and CheckpointBuilder
+    // Uses blockProvider to return the current `block` variable (set per-test)
+    const checkpointConstants = {
+      slotNumber: globalVariables.slotNumber,
+      timestamp: globalVariables.timestamp,
+      coinbase: globalVariables.coinbase,
+      feeRecipient: globalVariables.feeRecipient,
+      gasFees: globalVariables.gasFees,
+      chainId: globalVariables.chainId,
+      version: globalVariables.version,
+    };
+    checkpointsBuilder = new MockCheckpointsBuilder();
+    checkpointBuilder = checkpointsBuilder.createCheckpointBuilder(
+      checkpointConstants,
+      CheckpointNumber.fromBlockNumber(newBlockNumber),
     );
-    checkpointBuilder.completeCheckpoint.mockImplementation(() => {
-      const checkpoint = new Checkpoint(
-        makeAppendOnlyTreeSnapshot(newBlockNumber + 1),
-        block.header as any,
-        [block as any],
-        CheckpointNumber(0),
-      );
-      return Promise.resolve(checkpoint);
-    });
-
-    checkpointsBuilder = mock<FullNodeCheckpointsBuilder>();
-    checkpointsBuilder.startCheckpoint.mockResolvedValue(checkpointBuilder);
+    // Use blockProvider so the mock returns whatever `block` is set to at call time
+    checkpointBuilder.setBlockProvider(() => block);
 
     l2BlockSource = mock<L2BlockSource>({
-      getBlock: mockFn().mockResolvedValue(L2Block.empty()),
+      getL2BlockNew: mockFn().mockResolvedValue(L2BlockNew.empty()),
       getBlockNumber: mockFn().mockResolvedValue(lastBlockNumber),
       getL2Tips: mockFn().mockResolvedValue({ latest: { number: lastBlockNumber, hash } }),
       getL1Timestamp: mockFn().mockResolvedValue(1000n),
@@ -304,9 +248,8 @@ describe('sequencer', () => {
     dateProvider = new TestDateProvider();
 
     const config: SequencerConfig = { enforceTimeTable: true, maxTxsPerBlock: 4 };
-    sequencer = new TestSubject(
+    sequencer = new TestSequencer(
       publisherFactory,
-      // TODO(md): add the relevant methods to the validator client that will prevent it stalling when waiting for attestations
       validatorClient,
       globalVariableBuilder,
       p2p,
@@ -314,7 +257,7 @@ describe('sequencer', () => {
       slasherClient,
       l2BlockSource,
       l1ToL2MessageSource,
-      checkpointsBuilder,
+      checkpointsBuilder as unknown as FullNodeCheckpointsBuilder,
       l1Constants,
       dateProvider,
       epochCache,
@@ -326,21 +269,16 @@ describe('sequencer', () => {
 
   describe('block building', () => {
     it('builds a block out of a single tx', async () => {
-      const tx = await makeTx();
-
-      block = await makeBlock([tx]);
-      mockPendingTxs([tx]);
+      await setupSingleTxBlock();
       await sequencer.work();
 
       expectPublisherProposeL2Block();
     });
 
     it('does not build a block if it does not have enough time left in the slot', async () => {
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
+      await setupSingleTxBlock();
 
-      // deadline for initializing proposal is 1s, so we go 2s past it
+      // Deadline for initializing proposal is 1s, so we go 2s past it
       expect(sequencer.getTimeTable().initializeDeadline).toEqual(1);
       const l1TsForL2Slot1 = Number(l1Constants.l1GenesisTime) + slotDuration;
       dateProvider.setTime((l1TsForL2Slot1 + 2) * 1000);
@@ -351,45 +289,20 @@ describe('sequencer', () => {
         }),
       );
 
-      expect(checkpointBuilder.buildBlock).not.toHaveBeenCalled();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
       expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
       expect(publisher.canProposeAtNextEthBlock).not.toHaveBeenCalled();
     });
 
-    it('does not build a block if there is not enough time left in the slot', async () => {
-      expect(sequencer.getTimeTable().l1PublishingTime).toEqual(ethereumSlotDuration);
-      const l1TsForL2Slot1 = Number(l1Constants.l1GenesisTime) + slotDuration;
-
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
-
-      // Set time very late in the slot (1s before the L1 slot ends)
-      // This means there's not enough time to build a block and publish it
-      dateProvider.setTime((l1TsForL2Slot1 + ethereumSlotDuration - 1) * 1000);
-
-      // The sequencer should detect it's too late and not attempt to build
-      // With enforcement enabled, it will throw SequencerTooSlowError
-      await expect(sequencer.work()).rejects.toThrow('Too far into slot');
-
-      // With the new timing checks, we detect insufficient time upfront and don't build
-      expect(checkpointBuilder.buildBlock).not.toHaveBeenCalled();
-      expect(validatorClient.collectAttestations).not.toHaveBeenCalled();
-      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
-    });
-
     it('builds a checkpoint when it is their turn', async () => {
-      const tx = await makeTx();
-
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
+      await setupSingleTxBlock();
 
       // Not your turn! canProposeAtNextEthBlock returns undefined
       publisher.canProposeAtNextEthBlock.mockResolvedValue(undefined);
 
       await sequencer.work();
       // When it's not our turn, we should not build the checkpoint
-      expect(checkpointBuilder.buildBlock).not.toHaveBeenCalled();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
 
       // Now it's our turn!
       publisher.canProposeAtNextEthBlock.mockResolvedValue({
@@ -400,95 +313,34 @@ describe('sequencer', () => {
 
       await sequencer.work();
       // Now we should build and publish the checkpoint
-      expect(checkpointBuilder.buildBlock).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.any(BigInt),
-        expect.anything(),
-      );
+      expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
       expectPublisherProposeL2Block();
     });
 
     it('does not build a block if not enough txs', async () => {
       const txs: Tx[] = await timesParallel(8, i => makeTx(i * 0x10000));
       sequencer.updateConfig({ minTxsPerBlock: 4 });
-      mockPendingTxs(txs.slice(0, 3));
+      TestUtils.mockPendingTxs(p2p, txs.slice(0, 3));
       block = await makeBlock(txs);
 
       await sequencer.work();
-      expect(checkpointBuilder.buildBlock).toHaveBeenCalledTimes(0);
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
     });
 
     it('builds a block only when enough txs are available', async () => {
       const txs: Tx[] = await timesParallel(4, i => makeTx(i * 0x10000));
       sequencer.updateConfig({ minTxsPerBlock: 4 });
-      mockPendingTxs(txs);
+      TestUtils.mockPendingTxs(p2p, txs);
       block = await makeBlock(txs);
 
       await sequencer.work();
 
-      expect(checkpointBuilder.buildBlock).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.any(BigInt),
-        expect.anything(),
-      );
-
+      expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
       expectPublisherProposeL2Block();
     });
 
-    it('settles on the chain tip before it starts building a block', async () => {
-      // this test simulates a synch happening right after the sequencer starts building a block
-      // simulate every component being synched
-      const firstBlock = await L2Block.random(BlockNumber(1));
-      const currentTip = firstBlock;
-      const syncedToL2Block = { number: currentTip.number, hash: (await currentTip.hash()).toString() };
-      worldState.status.mockImplementation(() =>
-        Promise.resolve({
-          state: WorldStateRunningState.IDLE,
-          syncSummary: {
-            latestBlockNumber: syncedToL2Block.number,
-            latestBlockHash: syncedToL2Block.hash,
-          } as WorldStateSyncStatus,
-        }),
-      );
-      p2p.getStatus.mockImplementation(() => Promise.resolve({ state: P2PClientState.IDLE, syncedToL2Block }));
-      l2BlockSource.getL2Tips.mockImplementation(() =>
-        Promise.resolve({
-          latest: syncedToL2Block,
-          proven: { number: BlockNumber.ZERO, hash: GENESIS_BLOCK_HEADER_HASH.toString() },
-          finalized: { number: BlockNumber.ZERO, hash: GENESIS_BLOCK_HEADER_HASH.toString() },
-        }),
-      );
-      l1ToL2MessageSource.getL2Tips.mockImplementation(() =>
-        Promise.resolve({
-          latest: syncedToL2Block,
-          proven: { number: BlockNumber.ZERO, hash: GENESIS_BLOCK_HEADER_HASH.toString() },
-          finalized: { number: BlockNumber.ZERO, hash: GENESIS_BLOCK_HEADER_HASH.toString() },
-        }),
-      );
-
-      // simulate a synch happening right after
-      l2BlockSource.getBlockNumber.mockResolvedValueOnce(currentTip.number);
-      l2BlockSource.getBlockNumber.mockResolvedValueOnce(BlockNumber(currentTip.number + 1));
-      // now the new tip is actually block 2
-      l2BlockSource.getBlock.mockImplementation(n =>
-        n === -1
-          ? L2Block.random(BlockNumber(currentTip.number + 1))
-          : n === currentTip.number
-            ? Promise.resolve(currentTip)
-            : Promise.resolve(undefined),
-      );
-
-      publisher.canProposeAtNextEthBlock.mockResolvedValueOnce(undefined);
-      await sequencer.work();
-      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
-    });
-
     it('builds a block only when synced to previous L1 slot', async () => {
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
+      await setupSingleTxBlock();
 
       l2BlockSource.getL1Timestamp.mockResolvedValue(1000n - BigInt(ethereumSlotDuration) - 1n);
       await sequencer.work();
@@ -501,9 +353,7 @@ describe('sequencer', () => {
 
     // TODO(palla/mbps): Reinstante the validateBlockHeader call
     it.skip('aborts building a block if the chain moves underneath it', async () => {
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
+      await setupSingleTxBlock();
 
       // This could practically be for any reason, e.g., could also be that we have entered a new slot.
       publisher.validateBlockHeader.mockRejectedValueOnce(new Error('No block for you'));
@@ -513,26 +363,8 @@ describe('sequencer', () => {
       expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
     });
 
-    // TODO(palla/mbps): Re-enable once checkpoint proposal failure handling is implemented
-    it.skip('does not publish a checkpoint if the checkpoint proposal failed', async () => {
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
-
-      // When createCheckpointProposal returns undefined, the checkpoint should not be published
-      // Currently the implementation doesn't check for undefined proposal
-      validatorClient.createCheckpointProposal.mockResolvedValue(undefined as any);
-
-      await sequencer.work();
-
-      // The checkpoint should not be enqueued for publishing
-      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
-    });
-
     it('handles when enqueueProposeCheckpoint throws', async () => {
-      const tx = await makeTx();
-      mockPendingTxs([tx]);
-      block = await makeBlock([tx]);
+      await setupSingleTxBlock();
 
       publisher.enqueueProposeCheckpoint.mockRejectedValueOnce(new Error('Failed to enqueue propose checkpoint'));
 
@@ -549,7 +381,7 @@ describe('sequencer', () => {
 
       // Mock that we have some pending transactions
       const txs = [await makeTx(1), await makeTx(2)];
-      mockPendingTxs(txs);
+      TestUtils.mockPendingTxs(p2p, txs);
       block = await makeBlock(txs);
 
       await sequencer.work();
@@ -564,78 +396,43 @@ describe('sequencer', () => {
   });
 
   describe('multi-eoa publishing', () => {
-    let publishers: SequencerPublisher[];
-    beforeEach(() => {
-      publishers = times(3, i => {
-        const publisher = mockDeep<SequencerPublisher>();
-        publisher.epochCache = epochCache;
-        publisher.getSenderAddress.mockImplementation(() => EthAddress.random());
-        publisher.validateBlockHeader.mockResolvedValue();
-        publisher.enqueueProposeCheckpoint.mockResolvedValue(undefined);
-        publisher.enqueueGovernanceCastSignal.mockResolvedValue(true);
-        publisher.enqueueSlashingActions.mockResolvedValue(true);
-        publisher.canProposeAtNextEthBlock.mockResolvedValue({
+    it('requests a publisher for each block', async () => {
+      // Create multiple publishers for the test
+      const publishers = times(2, i => {
+        const pub = mockDeep<SequencerPublisher>();
+        pub.epochCache = epochCache;
+        pub.getSenderAddress.mockImplementation(() => EthAddress.random());
+        pub.validateBlockHeader.mockResolvedValue();
+        pub.enqueueProposeCheckpoint.mockResolvedValue(undefined);
+        pub.enqueueGovernanceCastSignal.mockResolvedValue(true);
+        pub.enqueueSlashingActions.mockResolvedValue(true);
+        pub.canProposeAtNextEthBlock.mockResolvedValue({
           slot: SlotNumber(newSlotNumber + i),
           checkpointNumber: CheckpointNumber.fromBlockNumber(BlockNumber(newBlockNumber)),
           timeOfNextL1Slot: 1000n,
         });
-
-        return publisher;
+        return pub;
       });
 
-      publisherFactory = mockDeep<SequencerPublisherFactory>();
+      // Configure factory to return different publishers on each call
+      publisherFactory.create.mockReset();
       publisherFactory.create
-        .mockResolvedValueOnce({
-          attestorAddress: publishers[0].getSenderAddress(),
-          publisher: publishers[0],
-        })
-        .mockResolvedValueOnce({
-          attestorAddress: publishers[1].getSenderAddress(),
-          publisher: publishers[1],
-        });
+        .mockResolvedValueOnce({ attestorAddress: publishers[0].getSenderAddress(), publisher: publishers[0] })
+        .mockResolvedValueOnce({ attestorAddress: publishers[1].getSenderAddress(), publisher: publishers[1] });
 
-      const config: SequencerConfig = { enforceTimeTable: false, maxTxsPerBlock: 4 };
-      sequencer = new TestSubject(
-        publisherFactory,
-        validatorClient,
-        globalVariableBuilder,
-        p2p,
-        worldState,
-        slasherClient,
-        l2BlockSource,
-        l1ToL2MessageSource,
-        checkpointsBuilder,
-        l1Constants,
-        dateProvider,
-        epochCache,
-        rollupContract,
-        config,
-      );
-      sequencer.updateConfig(config);
-    });
-
-    it('requests a publisher for each block', async () => {
+      // Configure epoch cache to return different slots
       epochCache.getEpochAndSlotInNextL1Slot
         .mockReset()
-        .mockReturnValueOnce({
-          epoch: EpochNumber(1),
-          slot: SlotNumber(1),
-          ts: 1000n,
-          now: 1000n,
-        })
-        .mockReturnValueOnce({
-          epoch: EpochNumber(1),
-          slot: SlotNumber(2),
-          ts: 1000n,
-          now: 1000n,
-        });
+        .mockReturnValueOnce({ epoch: EpochNumber(1), slot: SlotNumber(1), ts: 1000n, now: 1000n })
+        .mockReturnValueOnce({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 1000n, now: 1000n });
+
+      sequencer.updateConfig({ enforceTimeTable: false, maxTxsPerBlock: 4 });
 
       // Build and publish 2 blocks, the sequencer should request a new publisher each time
       for (let i = 0; i < 2; i++) {
         const tx = await makeTx();
-
-        mockPendingTxs([tx]);
         block = await makeBlock([tx]);
+        TestUtils.mockPendingTxs(p2p, [tx]);
         await sequencer.work();
 
         const attestationsAndSigners = new CommitteeAttestationsAndSigners(getSignatures());
@@ -827,7 +624,7 @@ describe('sequencer', () => {
 
       publisher.simulateInvalidateBlock.mockResolvedValue({
         forcePendingBlockNumber: lastBlockNumber,
-      } as any);
+      } as InvalidateBlockRequest);
     });
 
     it('should use committee member when invalidating as committee member', async () => {
@@ -911,400 +708,51 @@ describe('sequencer', () => {
     });
   });
 
-  // TODO(palla/mbps): Review and enable these tests once multi-block checkpoints are supported.
-  // For now this is just a massive block of unreviewed Claude generated code.
-  describe.skip('multi-block checkpoints', () => {
-    describe('single block mode (default)', () => {
-      it('should build only one block when blockDurationMs is not set', async () => {
-        const tx = await makeTx();
-        block = await makeBlock([tx]);
-        mockPendingTxs([tx]);
+  describe('modes', () => {
+    it('non-enforced mode', async () => {
+      sequencer.updateConfig({ enforceTimeTable: false, maxTxsPerBlock: 4 });
 
-        // Track block-proposed events
-        const proposedEvents: any[] = [];
-        sequencer.on('block-proposed', evt => proposedEvents.push(evt));
+      await setupSingleTxBlock();
 
-        await sequencer.work();
+      await sequencer.work();
 
-        // Should build exactly one block
-        expect(checkpointBuilder.buildBlock).toHaveBeenCalledTimes(1);
-        expect(proposedEvents).toHaveLength(1);
-        expect(proposedEvents[0]).toEqual({
-          blockNumber: newBlockNumber,
-          slot: newSlotNumber,
-        });
-      });
-
-      it('should collect attestations in single block mode', async () => {
-        const tx = await makeTx();
-        block = await makeBlock([tx]);
-        mockPendingTxs([tx]);
-
-        await sequencer.work();
-
-        expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
-        expectPublisherProposeL2Block();
-      });
+      // Verify checkpoint was built and proposed
+      expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(0);
+      expect(validatorClient.createCheckpointProposal).toHaveBeenCalled();
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
     });
 
-    describe('multi-block mode', () => {
-      it('should build multiple blocks when blockDurationMs is set and time permits', async () => {
-        // Configure multi-block mode with 12 second block duration
-        // Disable time enforcement so the mocked timetable controls timing
-        sequencer.updateConfig({ blockDurationMs: 12000, enforceTimeTable: false });
+    it('single block mode', async () => {
+      sequencer.updateConfig({ enforceTimeTable: true, maxTxsPerBlock: 4 });
 
-        // Create multiple transactions
-        const txs = await Promise.all([makeTx(1), makeTx(2), makeTx(3)]);
+      await setupSingleTxBlock();
 
-        // Mock timetable to allow 3 blocks (must be after updateConfig which recreates timetable)
-        const timetableMock = sequencer.getTimeTable();
-        let blockCount = 0;
-        jest.spyOn(timetableMock, 'canStartNextBlock').mockImplementation(() => {
-          blockCount++;
-          return {
-            canStart: blockCount <= 3,
-            deadline: 30,
-            isLastBlock: blockCount === 3,
-          };
-        });
+      await sequencer.work();
 
-        // Create 3 different blocks for each call
-        const blocks = await Promise.all([makeBlock([txs[0]]), makeBlock([txs[1]]), makeBlock([txs[2]])]);
-
-        let buildCallCount = 0;
-        checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) => {
-          const currentBlock = blocks[buildCallCount++];
-          return Promise.resolve({
-            block: currentBlock as any,
-            publicGas: Gas.empty(),
-            publicProcessorDuration: 0,
-            numTxs: currentBlock.body.txEffects.length,
-            blockBuildingTimer: new Timer(),
-            usedTxs: [],
-            failedTxs: [],
-          });
-        });
-
-        // Make sure we always have txs available
-        p2p.getPendingTxCount.mockResolvedValue(10);
-        p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
-
-        // Mock successful L1 publish
-        publisher.sendRequests.mockResolvedValue({
-          result: { receipt: {} as any, errorMsg: undefined },
-          successfulActions: ['propose'],
-          failedActions: [],
-          sentActions: ['propose'],
-          expiredActions: [],
-        });
-
-        // Track events
-        const proposedEvents: any[] = [];
-        const checkpointEvents: any[] = [];
-        sequencer.on('block-proposed', evt => proposedEvents.push(evt));
-        sequencer.on('checkpoint-published', evt => checkpointEvents.push(evt));
-
-        await sequencer.work();
-
-        // Should build 3 blocks
-        expect(checkpointBuilder.buildBlock).toHaveBeenCalledTimes(3);
-        expect(proposedEvents).toHaveLength(3);
-
-        // Should emit one checkpoint-published event
-        expect(checkpointEvents).toHaveLength(1);
-      });
-
-      it('should only collect attestations on the last block', async () => {
-        // Configure multi-block mode
-        // Disable time enforcement so the mocked timetable controls timing
-        sequencer.updateConfig({ blockDurationMs: 12000, enforceTimeTable: false });
-
-        const txs = await Promise.all([makeTx(1), makeTx(2)]);
-
-        // Mock timetable to allow 2 blocks (must be after updateConfig)
-        const timetableMock = sequencer.getTimeTable();
-        let blockCount = 0;
-        jest.spyOn(timetableMock, 'canStartNextBlock').mockImplementation(() => {
-          blockCount++;
-          return {
-            canStart: blockCount <= 2,
-            deadline: 20,
-            isLastBlock: blockCount === 2,
-          };
-        });
-
-        const blocks = await Promise.all([makeBlock([txs[0]]), makeBlock([txs[1]])]);
-
-        let buildCallCount = 0;
-        checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) => {
-          const currentBlock = blocks[buildCallCount++];
-          return Promise.resolve({
-            block: currentBlock as any,
-            publicGas: Gas.empty(),
-            publicProcessorDuration: 0,
-            numTxs: currentBlock.body.txEffects.length,
-            blockBuildingTimer: new Timer(),
-            usedTxs: [],
-            failedTxs: [],
-          });
-        });
-
-        p2p.getPendingTxCount.mockResolvedValue(10);
-        p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
-
-        // Mock successful L1 publish
-        publisher.sendRequests.mockResolvedValue({
-          result: { receipt: {} as any, errorMsg: undefined },
-          successfulActions: ['propose'],
-          failedActions: [],
-          sentActions: ['propose'],
-          expiredActions: [],
-        });
-
-        await sequencer.work();
-
-        // Attestations should be collected exactly once (on the last block)
-        expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
-        // Publisher should be called once with the last block
-        expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
-      });
-
-      it('should stop building blocks when timing runs out', async () => {
-        // Configure multi-block mode
-        // Disable time enforcement so the mocked timetable controls timing
-        sequencer.updateConfig({ blockDurationMs: 12000, enforceTimeTable: false });
-
-        const txs = await Promise.all([makeTx(1), makeTx(2), makeTx(3)]);
-
-        // Mock timetable to only allow 2 blocks (must be after updateConfig)
-        const timetableMock = sequencer.getTimeTable();
-        let blockCount = 0;
-        jest.spyOn(timetableMock, 'canStartNextBlock').mockImplementation(() => {
-          blockCount++;
-          return {
-            canStart: blockCount <= 2,
-            deadline: 20,
-            isLastBlock: blockCount === 2,
-          };
-        });
-
-        const blocks = await Promise.all([makeBlock([txs[0]]), makeBlock([txs[1]])]);
-
-        let buildCallCount = 0;
-        checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) => {
-          const currentBlock = blocks[buildCallCount++];
-          return Promise.resolve({
-            block: currentBlock as any,
-            publicGas: Gas.empty(),
-            publicProcessorDuration: 0,
-            numTxs: currentBlock.body.txEffects.length,
-            blockBuildingTimer: new Timer(),
-            usedTxs: [],
-            failedTxs: [],
-          });
-        });
-
-        p2p.getPendingTxCount.mockResolvedValue(10);
-        p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
-
-        // Mock successful L1 publish
-        publisher.sendRequests.mockResolvedValue({
-          result: { receipt: {} as any, errorMsg: undefined },
-          successfulActions: ['propose'],
-          failedActions: [],
-          sentActions: ['propose'],
-          expiredActions: [],
-        });
-
-        const proposedEvents: any[] = [];
-        sequencer.on('block-proposed', evt => proposedEvents.push(evt));
-
-        await sequencer.work();
-
-        // Should build exactly 2 blocks, not 3
-        expect(checkpointBuilder.buildBlock).toHaveBeenCalledTimes(2);
-        expect(proposedEvents).toHaveLength(2);
-      });
-
-      it('should handle block building failure gracefully', async () => {
-        // Configure multi-block mode
-        // Disable time enforcement so the mocked timetable controls timing
-        sequencer.updateConfig({ blockDurationMs: 12000, enforceTimeTable: false });
-
-        const tx = await makeTx();
-
-        // Mock timetable to allow 2 blocks (must be after updateConfig)
-        const timetableMock = sequencer.getTimeTable();
-        let blockCount = 0;
-        jest.spyOn(timetableMock, 'canStartNextBlock').mockImplementation(() => {
-          blockCount++;
-          return {
-            canStart: blockCount <= 2,
-            deadline: 20,
-            isLastBlock: blockCount === 2,
-          };
-        });
-
-        // First block succeeds, second fails
-        block = await makeBlock([tx]);
-        let buildCallCount = 0;
-        checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) => {
-          buildCallCount++;
-          if (buildCallCount === 1) {
-            return Promise.resolve({
-              block: block as any,
-              publicGas: Gas.empty(),
-              publicProcessorDuration: 0,
-              numTxs: block.body.txEffects.length,
-              blockBuildingTimer: new Timer(),
-              usedTxs: [],
-              failedTxs: [],
-            });
-          }
-          throw new Error('Block building failed');
-        });
-
-        p2p.getPendingTxCount.mockResolvedValue(10);
-        p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve([tx])));
-
-        const proposedEvents: any[] = [];
-        const failedEvents: any[] = [];
-        sequencer.on('block-proposed', evt => proposedEvents.push(evt));
-        sequencer.on('block-build-failed', evt => failedEvents.push(evt));
-
-        await sequencer.work();
-
-        // First block should succeed
-        expect(proposedEvents).toHaveLength(1);
-        // Should have a failure event (either from build failure or timing)
-        expect(failedEvents).toHaveLength(1);
-        expect(failedEvents[0].reason).toMatch(/Block building failed|Too far into slot/);
-      });
-
-      it('should emit correct events for multi-block checkpoint', async () => {
-        // Configure multi-block mode
-        // Disable time enforcement so the mocked timetable controls timing
-        sequencer.updateConfig({ blockDurationMs: 12000, enforceTimeTable: false });
-
-        const txs = await Promise.all([makeTx(1), makeTx(2)]);
-
-        // Mock timetable to allow 2 blocks (must be after updateConfig)
-        const timetableMock = sequencer.getTimeTable();
-        let blockCount = 0;
-        jest.spyOn(timetableMock, 'canStartNextBlock').mockImplementation(() => {
-          blockCount++;
-          return {
-            canStart: blockCount <= 2,
-            deadline: 20,
-            isLastBlock: blockCount === 2,
-          };
-        });
-
-        // Mock buildBlock to return blocks with incrementing block numbers
-        let buildCallCount = 0;
-        checkpointBuilder.buildBlock.mockImplementation((_pendingTxs, _blockNumber, _timestamp, _opts) => {
-          const tx = txs[buildCallCount % txs.length];
-          const blockForCallPromise = makeBlock([tx]);
-          return blockForCallPromise.then(blockForCall => {
-            // Override the block number to match what the sequencer expects
-            (blockForCall.header as any).globalVariables = new GlobalVariables(
-              chainId,
-              version,
-              BlockNumber(newBlockNumber + buildCallCount),
-              SlotNumber(newSlotNumber),
-              /*timestamp=*/ 0n,
-              coinbase,
-              feeRecipient,
-              gasFees,
-            );
-            buildCallCount++;
-            return {
-              block: blockForCall as any,
-              publicGas: Gas.empty(),
-              publicProcessorDuration: 0,
-              numTxs: blockForCall.body.txEffects.length,
-              blockBuildingTimer: new Timer(),
-              usedTxs: [],
-              failedTxs: [],
-            };
-          });
-        });
-
-        p2p.getPendingTxCount.mockResolvedValue(10);
-        p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
-
-        const proposedEvents: any[] = [];
-        const checkpointEvents: any[] = [];
-        sequencer.on('block-proposed', evt => proposedEvents.push(evt));
-        sequencer.on('checkpoint-published', evt => checkpointEvents.push(evt));
-
-        // Mock successful L1 publish
-        publisher.sendRequests.mockResolvedValue({
-          result: { receipt: {} as any, errorMsg: undefined },
-          successfulActions: ['propose'],
-          failedActions: [],
-          sentActions: ['propose'],
-          expiredActions: [],
-        });
-
-        await sequencer.work();
-
-        // Should emit 2 block-proposed events
-        expect(checkpointBuilder.buildBlock).toHaveBeenCalledTimes(2);
-        expect(proposedEvents).toHaveLength(2);
-        expect(proposedEvents[0].blockNumber).toBe(newBlockNumber);
-        expect(proposedEvents[1].blockNumber).toBe(newBlockNumber + 1);
-
-        // Should emit 1 checkpoint-published event for the last block
-        expect(checkpointEvents).toHaveLength(1);
-        expect(checkpointEvents[0].blockNumber).toBe(newBlockNumber + 1);
-        expect(checkpointEvents[0].slot).toBe(newSlotNumber);
-      });
+      // Verify checkpoint was built and proposed
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(checkpointBuilder.completeCheckpointCalled).toBe(true);
+      expect(validatorClient.createCheckpointProposal).toHaveBeenCalled();
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
     });
 
-    describe('event naming', () => {
-      it('should emit block-tx-count-check-failed when not enough txs', async () => {
-        const failedEvents: any[] = [];
-        sequencer.on('block-tx-count-check-failed', evt => failedEvents.push(evt));
+    it('multi block mode', async () => {
+      sequencer.updateConfig({ enforceTimeTable: true, maxTxsPerBlock: 4, blockDurationMs: 500 });
 
-        // No pending txs
-        mockPendingTxs([]);
+      const txs = await timesParallel(8, i => makeTx(i * 0x10000));
+      block = await makeBlock(txs);
+      TestUtils.mockPendingTxs(p2p, txs);
 
-        await sequencer.work();
+      await sequencer.work();
 
-        expect(failedEvents).toHaveLength(1);
-        expect(failedEvents[0]).toEqual({
-          minTxs: expect.any(Number),
-          availableTxs: 0,
-        });
-      });
-
-      it('should emit checkpoint-publish-failed when L1 publish fails', async () => {
-        const tx = await makeTx();
-        block = await makeBlock([tx]);
-        mockPendingTxs([tx]);
-
-        const failedEvents: any[] = [];
-        sequencer.on('checkpoint-publish-failed', evt => failedEvents.push(evt));
-
-        // Mock failed L1 publish
-        publisher.sendRequests.mockResolvedValue({
-          result: { receipt: {} as any, errorMsg: 'Test error' },
-          successfulActions: [],
-          failedActions: ['propose'],
-          sentActions: ['propose'],
-          expiredActions: [],
-        });
-
-        await sequencer.work();
-
-        expect(failedEvents).toHaveLength(1);
-      });
+      expect(checkpointBuilder.buildBlockCalls.length).toBeGreaterThan(1);
+      expect(validatorClient.createCheckpointProposal).toHaveBeenCalled();
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalled();
     });
   });
 });
 
-class TestSubject extends Sequencer {
+class TestSequencer extends Sequencer {
   public getTimeTable() {
     return this.timetable;
   }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,4 +1,3 @@
-import { L2Block } from '@aztec/aztec.js/block';
 import { getKzg } from '@aztec/blob-lib';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
@@ -13,7 +12,7 @@ import type { DateProvider } from '@aztec/foundation/timer';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
-import type { L2BlockSource, ValidateBlockResult } from '@aztec/stdlib/block';
+import type { L2BlockNew, L2BlockSource, ValidateBlockResult } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { getSlotAtTimestamp, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import {
@@ -225,6 +224,8 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.logStrategyComparison(epoch, checkpointProposalJob.getPublisher());
       this.lastEpochForStrategyComparison = epoch;
     }
+
+    return checkpoint;
   }
 
   /**
@@ -496,8 +497,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return { blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM - 1), archive, l1Timestamp, pendingChainValidationStatus };
     }
 
-    // TODO(palla/mbps): This should be a new L2Block
-    const block = await this.l2BlockSource.getBlock(blockNumber);
+    const block = await this.l2BlockSource.getL2BlockNew(blockNumber);
     if (!block) {
       // this shouldn't really happen because a moment ago we checked that all components were in sync
       this.log.error(`Failed to get L2 block ${blockNumber} from the archiver with all components in sync`);
@@ -788,7 +788,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 }
 
 type SequencerSyncCheckResult = {
-  block?: L2Block;
+  block?: L2BlockNew;
   blockNumber: BlockNumber;
   archive: Fr;
   l1Timestamp: bigint;

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_ATTESTATION_PROPAGATION_TIME } from '../config.js';
-import { CHECKPOINT_FINALIZATION_TIME, SequencerTimetable } from './timetable.js';
+import { MIN_EXECUTION_TIME, SequencerTimetable } from './timetable.js';
 import { SequencerState } from './utils.js';
 
 describe('sequencer-timetable', () => {
@@ -33,8 +32,8 @@ describe('sequencer-timetable', () => {
       ).toThrow(/initialize deadline cannot be negative/i);
     });
 
-    it('allows a slot duration of at least two ethereum slots', () => {
-      const aztecSlotDuration = ETHEREUM_SLOT_DURATION * 2;
+    it('allows a slot duration with enough time for initialization and execution', () => {
+      const aztecSlotDuration = ETHEREUM_SLOT_DURATION * 3; // 36s
       const timetable = new SequencerTimetable({
         ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
         aztecSlotDuration,
@@ -45,11 +44,11 @@ describe('sequencer-timetable', () => {
         aztecSlotDuration -
           L1_PUBLISHING_TIME - // time to publish to L1
           2 * timetable.p2pPropagationTime - // time to propagate the attestation
-          timetable.checkpointFinalizationTime - // time to validate the block
-          timetable.checkpointInitializationTime - // time to prepare the block
-          2 * timetable.minExecutionTime, // min guaranteed time to execute the block
+          timetable.checkpointAssembleTime - // time to assemble the block
+          timetable.initializationOffset - // time to prepare the block
+          2 * MIN_EXECUTION_TIME, // min guaranteed time to execute the block
       );
-      expect(timetable.initializeDeadline).toEqual(4);
+      expect(timetable.initializeDeadline).toEqual(14);
     });
   });
 
@@ -106,102 +105,8 @@ describe('sequencer-timetable', () => {
     });
   });
 
-  describe('getBlockProposalExecTimeEnd', () => {
-    it('sets deadline considering unused time from init phase', () => {
-      const actual = timetable.getProposerExecTimeEnd(1);
-      const available =
-        AZTEC_SLOT_DURATION -
-        timetable.p2pPropagationTime * 2 -
-        timetable.l1PublishingTime -
-        timetable.checkpointFinalizationTime -
-        1;
-      const expected = available / 2 + 1;
-      expect(actual).toEqual(expected);
-      expect(expected).toEqual(10);
-    });
-
-    it('sets deadline considering starting before slot', () => {
-      const actual = timetable.getProposerExecTimeEnd(-1);
-      const available =
-        AZTEC_SLOT_DURATION -
-        timetable.p2pPropagationTime * 2 -
-        timetable.l1PublishingTime -
-        timetable.checkpointFinalizationTime +
-        1;
-      const expected = available / 2 - 1;
-      expect(actual).toEqual(expected);
-      expect(expected).toEqual(9);
-    });
-
-    it('sets deadline when building on time', () => {
-      const intoSlot = timetable.initializeDeadline + timetable.checkpointInitializationTime;
-      const actual = timetable.getProposerExecTimeEnd(intoSlot);
-      const available =
-        AZTEC_SLOT_DURATION -
-        timetable.p2pPropagationTime * 2 -
-        timetable.l1PublishingTime -
-        timetable.checkpointFinalizationTime -
-        intoSlot;
-      const expected = available / 2 + intoSlot;
-      expect(actual).toEqual(expected);
-      expect(expected).toEqual(18);
-    });
-
-    it('sets deadline before current time if too late', () => {
-      const intoSlot = AZTEC_SLOT_DURATION - 4;
-      const actual = timetable.getProposerExecTimeEnd(intoSlot);
-      expect(actual).toBeLessThan(intoSlot);
-    });
-  });
-
-  describe('getValidatorReexecTimeEnd', () => {
-    it('sets deadline', () => {
-      const actual = timetable.getValidatorReexecTimeEnd(10);
-      const available = AZTEC_SLOT_DURATION - timetable.p2pPropagationTime - timetable.l1PublishingTime - 10;
-      const expected = available + 10;
-      expect(actual).toEqual(expected);
-      expect(expected).toEqual(22);
-    });
-
-    it('sets time available equal to block building', () => {
-      const {
-        checkpointFinalizationTime: blockValidationTime,
-        p2pPropagationTime: attestationPropagationTime,
-        l1PublishingTime,
-      } = timetable;
-
-      const intoSlot = 3;
-      const blockBuildDeadline = timetable.getProposerExecTimeEnd(intoSlot);
-      const blockBuildAvailable = blockBuildDeadline - intoSlot;
-
-      const validatorIntoSlot = blockBuildDeadline + blockValidationTime + attestationPropagationTime;
-      const validatorDeadline = timetable.getValidatorReexecTimeEnd(validatorIntoSlot);
-      const validatorAvailable = validatorDeadline - validatorIntoSlot;
-
-      expect(blockBuildAvailable).toEqual(validatorAvailable);
-
-      expect(
-        blockBuildAvailable +
-          validatorAvailable +
-          intoSlot +
-          blockValidationTime +
-          attestationPropagationTime * 2 +
-          l1PublishingTime,
-      ).toEqual(AZTEC_SLOT_DURATION);
-    });
-  });
-
-  describe('getBlockTimingInfo', () => {
+  describe('canStartNextBlock', () => {
     const AZTEC_SLOT_DURATION = 72;
-
-    let afterBlockBuildingTimeNeededWithoutReexec: number;
-    let slotBuildDeadline: number;
-
-    beforeEach(() => {
-      afterBlockBuildingTimeNeededWithoutReexec =
-        CHECKPOINT_FINALIZATION_TIME + 2 * DEFAULT_ATTESTATION_PROPAGATION_TIME + L1_PUBLISHING_TIME;
-      slotBuildDeadline = AZTEC_SLOT_DURATION - afterBlockBuildingTimeNeededWithoutReexec;
-    });
 
     describe('single block per slot', () => {
       beforeEach(() => {
@@ -213,27 +118,269 @@ describe('sequencer-timetable', () => {
         });
       });
 
-      it('should handle only block at the start of the slot', () => {
+      it('should allow starting at the beginning of the slot', () => {
         const result = timetable.canStartNextBlock(0);
         expect(result.isLastBlock).toBe(true);
         expect(result.canStart).toBe(true);
-        expect(result.deadline).toBe(slotBuildDeadline / 2); // We need to account for reexecution
+        // In single block mode, deadline dynamically splits available time between execution and re-execution
+        const maxAllowed = AZTEC_SLOT_DURATION - timetable.checkpointFinalizationTime;
+        const available = maxAllowed - 0;
+        const expectedDeadline = 0 + available / 2;
+        expect(result.deadline).toBe(expectedDeadline);
       });
 
-      it('should handle only block into the slot', () => {
-        const secondsIntoSlot = 4;
+      it('should allow starting within the initialize deadline', () => {
+        const secondsIntoSlot = timetable.initializeDeadline - 1;
         const result = timetable.canStartNextBlock(secondsIntoSlot);
         expect(result.isLastBlock).toBe(true);
         expect(result.canStart).toBe(true);
-        // When starting secondsIntoSlot into slot: available time is split 50/50 for execution and reexecution
-        const available = slotBuildDeadline - secondsIntoSlot;
+        const maxAllowed = AZTEC_SLOT_DURATION - timetable.checkpointFinalizationTime;
+        const available = maxAllowed - secondsIntoSlot;
         const expectedDeadline = secondsIntoSlot + available / 2;
         expect(result.deadline).toBe(expectedDeadline);
       });
 
-      it('should refuse to start with too little time available', () => {
-        const result = timetable.canStartNextBlock(AZTEC_SLOT_DURATION - afterBlockBuildingTimeNeededWithoutReexec - 1);
+      it('should refuse to start without enough time to build', () => {
+        const secondsIntoSlot =
+          AZTEC_SLOT_DURATION - timetable.checkpointFinalizationTime - 2 * timetable.minExecutionTime + 1;
+        const result = timetable.canStartNextBlock(secondsIntoSlot);
         expect(result.canStart).toBe(false);
+      });
+    });
+
+    describe('multiple blocks per slot', () => {
+      const BLOCK_DURATION_MS = 8000; // 8 seconds
+
+      beforeEach(() => {
+        timetable = new SequencerTimetable({
+          ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+          aztecSlotDuration: AZTEC_SLOT_DURATION,
+          l1PublishingTime: L1_PUBLISHING_TIME,
+          blockDurationMs: BLOCK_DURATION_MS,
+          enforce: ENFORCE_TIMETABLE,
+        });
+      });
+
+      it('should allow starting first block early in the slot', () => {
+        const result = timetable.canStartNextBlock(1);
+        expect(result.canStart).toBe(true);
+        expect(result.isLastBlock).toBe(false);
+        // First sub-slot deadline: initializationOffset + 1 * blockDuration
+        expect(result.deadline).toBe(timetable.initializationOffset + 8);
+      });
+
+      it('should skip to second sub-slot if first sub-slot has insufficient time', () => {
+        // If we're at 8s and first sub-slot deadline is at 9s (initOffset=1s + blockDuration=8s),
+        // we only have 1s left which is < MIN_EXECUTION_TIME (2s)
+        // So we should skip to sub-slot 2 (deadline at 17s)
+        const result = timetable.canStartNextBlock(8);
+        expect(result.canStart).toBe(true);
+        expect(result.deadline).toBe(timetable.initializationOffset + 2 * 8);
+      });
+
+      it('should detect last block correctly', () => {
+        // With 72s slot, 8s blocks, 1s init offset:
+        // Reserved at end: 8s (last sub-slot) + 2*2s (prop) + 1s (final) + 12s (L1) = 25s
+        // Available: 72 - 1 - 25 = 46s
+        // Max blocks: floor(46/8) = 5
+        // So if we're at second 33 (after 4 blocks would finish at 1 + 4*8 = 33),
+        // we should get the 5th sub-slot as the last block
+        const result = timetable.canStartNextBlock(33);
+        expect(result.canStart).toBe(true);
+        expect(result.isLastBlock).toBe(true);
+        expect(result.deadline).toBe(timetable.initializationOffset + 5 * 8);
+      });
+
+      it('should refuse to start if no time left', () => {
+        // Very late in the slot - no sub-slots available
+        const result = timetable.canStartNextBlock(AZTEC_SLOT_DURATION - 10);
+        expect(result.canStart).toBe(false);
+        expect(result.isLastBlock).toBe(false);
+      });
+    });
+
+    describe('non-enforced mode', () => {
+      beforeEach(() => {
+        timetable = new SequencerTimetable({
+          ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+          aztecSlotDuration: AZTEC_SLOT_DURATION,
+          l1PublishingTime: L1_PUBLISHING_TIME,
+          enforce: false, // Non-enforced mode
+        });
+      });
+
+      it('should always return canStart=true regardless of time', () => {
+        // Very late in the slot - would normally be rejected
+        const result = timetable.canStartNextBlock(AZTEC_SLOT_DURATION + 1000);
+        expect(result.canStart).toBe(true);
+        expect(result.isLastBlock).toBe(true);
+      });
+
+      it('should not return a deadline in non-enforced mode', () => {
+        const result = timetable.canStartNextBlock(0);
+        expect(result.deadline).toBeUndefined();
+      });
+
+      it('should not throw on assertTimeLeft regardless of time', () => {
+        expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_CHECKPOINT, 10000)).not.toThrow();
+        expect(() => timetable.assertTimeLeft(SequencerState.CREATING_BLOCK, 10000)).not.toThrow();
+        expect(() => timetable.assertTimeLeft(SequencerState.COLLECTING_ATTESTATIONS, 10000)).not.toThrow();
+      });
+
+      it('should still compute maxAllowedTime correctly', () => {
+        // Even in non-enforced mode, time calculations should be correct for monitoring/logging
+        const maxAllowed = timetable.getMaxAllowedTime(SequencerState.INITIALIZING_CHECKPOINT);
+        expect(maxAllowed).toEqual(timetable.initializeDeadline);
+      });
+    });
+
+    describe('edge cases', () => {
+      describe('sub-slot boundary timing', () => {
+        const BLOCK_DURATION_MS = 8000;
+
+        beforeEach(() => {
+          timetable = new SequencerTimetable({
+            ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+            aztecSlotDuration: AZTEC_SLOT_DURATION,
+            l1PublishingTime: L1_PUBLISHING_TIME,
+            blockDurationMs: BLOCK_DURATION_MS,
+            enforce: ENFORCE_TIMETABLE,
+          });
+        });
+
+        it('should handle exact sub-slot boundary timing', () => {
+          // Exactly at the first sub-slot deadline
+          const exactDeadline = timetable.initializationOffset + 8;
+          const result = timetable.canStartNextBlock(exactDeadline);
+          expect(result.canStart).toBe(true);
+          // Should skip to next sub-slot since we're exactly at the deadline
+          expect(result.deadline).toBe(timetable.initializationOffset + 2 * 8);
+        });
+
+        it('should handle timing just before sub-slot boundary', () => {
+          const justBefore = timetable.initializationOffset + 8 - 0.1;
+          const result = timetable.canStartNextBlock(justBefore);
+          expect(result.canStart).toBe(true);
+          // Deadline should be in a reasonable sub-slot
+          expect(result.deadline).toBeGreaterThan(justBefore);
+        });
+
+        it('should handle timing just after sub-slot boundary', () => {
+          const justAfter = timetable.initializationOffset + 8 + 0.1;
+          const result = timetable.canStartNextBlock(justAfter);
+          expect(result.canStart).toBe(true);
+          // Should skip to next sub-slot
+          expect(result.deadline).toBe(timetable.initializationOffset + 2 * 8);
+        });
+      });
+
+      describe('maxNumberOfBlocks calculation', () => {
+        it.each([
+          { aztecSlot: 36, blockDuration: 8000 },
+          { aztecSlot: 72, blockDuration: 8000 },
+          { aztecSlot: 120, blockDuration: 10000 },
+        ])(
+          'should calculate max blocks with aztecSlot=$aztecSlot blockDuration=$blockDuration)',
+          ({ aztecSlot, blockDuration }) => {
+            const tt = new SequencerTimetable({
+              ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+              aztecSlotDuration: aztecSlot,
+              l1PublishingTime: L1_PUBLISHING_TIME,
+              blockDurationMs: blockDuration,
+              enforce: ENFORCE_TIMETABLE,
+            });
+
+            // The max number of blocks should be positive
+            const result = tt.canStartNextBlock(0);
+            expect(result.canStart).toBe(true);
+
+            // Longer slots should allow more blocks
+            if (aztecSlot === 120) {
+              // Should allow multiple blocks in a long slot
+              const result2 = tt.canStartNextBlock(20);
+              expect(result2.canStart).toBe(true);
+            }
+          },
+        );
+
+        it('should default to single block mode when blockDurationMs is undefined', () => {
+          const tt = new SequencerTimetable({
+            ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+            aztecSlotDuration: AZTEC_SLOT_DURATION,
+            l1PublishingTime: L1_PUBLISHING_TIME,
+            blockDurationMs: undefined,
+            enforce: ENFORCE_TIMETABLE,
+          });
+
+          const result = tt.canStartNextBlock(0);
+          expect(result.isLastBlock).toBe(true); // Should always be last block in single block mode
+        });
+      });
+
+      describe('extreme timing scenarios', () => {
+        beforeEach(() => {
+          timetable = new SequencerTimetable({
+            ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+            aztecSlotDuration: AZTEC_SLOT_DURATION,
+            l1PublishingTime: L1_PUBLISHING_TIME,
+            enforce: ENFORCE_TIMETABLE,
+          });
+        });
+
+        it('should handle very early start (negative time)', () => {
+          const result = timetable.canStartNextBlock(-5);
+          expect(result.canStart).toBe(true);
+          expect(result.isLastBlock).toBe(true);
+        });
+
+        it('should handle start exactly at initialize deadline', () => {
+          const result = timetable.canStartNextBlock(timetable.initializeDeadline);
+          // Should still allow starting, but with less time
+          expect(result.canStart).toBe(true);
+          expect(result.deadline).toBeGreaterThan(timetable.initializeDeadline);
+        });
+
+        it('should refuse start past checkpoint finalization threshold', () => {
+          const tooLate = AZTEC_SLOT_DURATION - timetable.checkpointFinalizationTime + 1;
+          const result = timetable.canStartNextBlock(tooLate);
+          expect(result.canStart).toBe(false);
+        });
+      });
+
+      describe('state transition timing', () => {
+        beforeEach(() => {
+          timetable = new SequencerTimetable({
+            ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+            aztecSlotDuration: AZTEC_SLOT_DURATION,
+            l1PublishingTime: L1_PUBLISHING_TIME,
+            enforce: ENFORCE_TIMETABLE,
+          });
+        });
+
+        it('should provide increasing deadlines through state lifecycle', () => {
+          const states = [
+            SequencerState.INITIALIZING_CHECKPOINT,
+            SequencerState.CREATING_BLOCK,
+            SequencerState.COLLECTING_ATTESTATIONS,
+            SequencerState.PUBLISHING_CHECKPOINT,
+          ];
+
+          const times = states.map(state => timetable.getMaxAllowedTime(state));
+
+          // Each stage should have more time than the previous
+          for (let i = 1; i < times.length; i++) {
+            expect(times[i]).toBeGreaterThan(times[i - 1]!);
+          }
+        });
+
+        it('should throw at appropriate times for each state', () => {
+          // Just past initialize deadline - should fail for INITIALIZING
+          const pastInit = timetable.initializeDeadline + 0.1;
+          expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_CHECKPOINT, pastInit)).toThrow();
+
+          // But CREATING_BLOCK should still be ok
+          expect(() => timetable.assertTimeLeft(SequencerState.CREATING_BLOCK, pastInit)).not.toThrow();
+        });
       });
     });
   });

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -5,9 +5,9 @@ import { SequencerTooSlowError } from './errors.js';
 import type { SequencerMetrics } from './metrics.js';
 import { SequencerState } from './utils.js';
 
-export const MIN_EXECUTION_TIME = 1;
+export const MIN_EXECUTION_TIME = 2;
 export const CHECKPOINT_INITIALIZATION_TIME = 1;
-export const CHECKPOINT_FINALIZATION_TIME = 1;
+export const CHECKPOINT_ASSEMBLE_TIME = 1;
 
 export class SequencerTimetable {
   /**
@@ -16,6 +16,21 @@ export class SequencerTimetable {
    * starts building at this time, and all times hold, it will have at least `minExecutionTime` to execute txs for the block.
    */
   public readonly initializeDeadline: number;
+
+  /**
+   * Fixed time offset (in seconds) when the first sub-slot starts, used as baseline for all block deadlines.
+   * This is an estimate of how long initialization (sync + proposer check) typically takes.
+   * If actual initialization takes longer/shorter, blocks just get less/more time accordingly.
+   */
+  public readonly initializationOffset: number;
+
+  /**
+   * Total time needed to finalize and publish a checkpoint, including:
+   * - Assembling the checkpoint
+   * - Round-trip p2p propagation for the checkpoint proposal and its corresponding attestations
+   * - Publishing to L1
+   */
+  public readonly checkpointFinalizationTime: number;
 
   /**
    * How long it takes to get a published block into L1. L1 builders typically accept txs up to 4 seconds into their slot,
@@ -36,8 +51,8 @@ export class SequencerTimetable {
   /** How long it takes to for proposals and attestations to travel across the p2p layer (one-way) */
   public readonly p2pPropagationTime: number;
 
-  /** How much time we spend validating and processing a checkpoint after building it */
-  public readonly checkpointFinalizationTime: number = CHECKPOINT_FINALIZATION_TIME;
+  /** How much time we spend assembling a checkpoint after building the last block */
+  public readonly checkpointAssembleTime: number = CHECKPOINT_ASSEMBLE_TIME;
 
   /** Ethereum slot duration in seconds */
   public readonly ethereumSlotDuration: number;
@@ -50,6 +65,9 @@ export class SequencerTimetable {
 
   /** Duration per block when building multiple blocks per slot (undefined = single block per slot) */
   public readonly blockDuration: number | undefined;
+
+  /** Maximum number of blocks that can be built in this slot configuration */
+  public readonly maxNumberOfBlocks: number;
 
   constructor(
     opts: {
@@ -68,75 +86,74 @@ export class SequencerTimetable {
     this.l1PublishingTime = opts.l1PublishingTime;
     this.p2pPropagationTime = opts.p2pPropagationTime ?? DEFAULT_P2P_PROPAGATION_TIME;
     this.blockDuration = opts.blockDurationMs ? opts.blockDurationMs / 1000 : undefined;
-    this.minExecutionTime = MIN_EXECUTION_TIME;
     this.enforce = opts.enforce;
 
     // Assume zero-cost propagation time and faster runs in test environments where L1 slot duration is shortened
     if (this.ethereumSlotDuration < 8) {
       this.p2pPropagationTime = 0;
-      this.checkpointFinalizationTime = 0.5;
+      this.checkpointAssembleTime = 0.5;
       this.checkpointInitializationTime = 0.5;
+      this.minExecutionTime = 1;
+    }
+
+    // Min execution time cannot be less than the block duration if set
+    if (this.blockDuration !== undefined && this.minExecutionTime > this.blockDuration) {
+      this.minExecutionTime = this.blockDuration;
+    }
+
+    // Calculate initialization offset - estimate of time needed for sync + proposer check
+    // This is the baseline for all sub-slot deadlines
+    this.initializationOffset = this.checkpointInitializationTime;
+
+    // Calculate total checkpoint finalization time (assembly + attestations + L1 publishing)
+    this.checkpointFinalizationTime =
+      this.checkpointAssembleTime +
+      this.p2pPropagationTime * 2 + // Round-trip propagation
+      this.l1PublishingTime; // L1 publishing
+
+    // Calculate maximum number of blocks that fit in this slot
+    if (!this.blockDuration) {
+      this.maxNumberOfBlocks = 1; // Single block per slot
+    } else {
+      const timeReservedAtEnd =
+        this.blockDuration + // Last sub-slot for validator re-execution
+        this.checkpointFinalizationTime; // Checkpoint finalization
+      const timeAvailableForBlocks = this.aztecSlotDuration - this.initializationOffset - timeReservedAtEnd;
+      this.maxNumberOfBlocks = Math.floor(timeAvailableForBlocks / this.blockDuration);
     }
 
     // Minimum work to do within a slot for building a block with the minimum time for execution and publishing its checkpoint
     const minWorkToDo =
-      this.checkpointInitializationTime +
+      this.initializationOffset +
       this.minExecutionTime * 2 + // Execution and reexecution
-      this.checkpointFinalizationTime +
-      this.p2pPropagationTime * 2 + // Send proposal and receive attestations
-      this.l1PublishingTime; // Submit to L1
+      this.checkpointFinalizationTime;
 
     const initializeDeadline = this.aztecSlotDuration - minWorkToDo;
     this.initializeDeadline = initializeDeadline;
 
-    this.log.verbose(`Sequencer timetable initialized (${this.enforce ? 'enforced' : 'not enforced'})`, {
-      ethereumSlotDuration: this.ethereumSlotDuration,
-      aztecSlotDuration: this.aztecSlotDuration,
-      l1PublishingTime: this.l1PublishingTime,
-      minExecutionTime: this.minExecutionTime,
-      blockPrepareTime: this.checkpointInitializationTime,
-      p2pPropagationTime: this.p2pPropagationTime,
-      blockValidationTime: this.checkpointFinalizationTime,
-      initializeDeadline: this.initializeDeadline,
-      enforce: this.enforce,
-      allWorkToDo: minWorkToDo,
-    });
+    this.log.verbose(
+      `Sequencer timetable initialized with ${this.maxNumberOfBlocks} blocks per slot (${this.enforce ? 'enforced' : 'not enforced'})`,
+      {
+        ethereumSlotDuration: this.ethereumSlotDuration,
+        aztecSlotDuration: this.aztecSlotDuration,
+        l1PublishingTime: this.l1PublishingTime,
+        minExecutionTime: this.minExecutionTime,
+        blockPrepareTime: this.checkpointInitializationTime,
+        p2pPropagationTime: this.p2pPropagationTime,
+        blockAssembleTime: this.checkpointAssembleTime,
+        initializeDeadline: this.initializeDeadline,
+        enforce: this.enforce,
+        minWorkToDo,
+        blockDuration: this.blockDuration,
+        maxNumberOfBlocks: this.maxNumberOfBlocks,
+      },
+    );
 
     if (initializeDeadline <= 0) {
       throw new Error(
         `Block proposal initialize deadline cannot be negative (got ${initializeDeadline} from total time needed ${minWorkToDo} and a slot duration of ${this.aztecSlotDuration}).`,
       );
     }
-  }
-
-  /** Deadline for a block proposal execution. Ensures we have enough time left for reexecution and publishing. */
-  public getProposerExecTimeEnd(secondsIntoSlot: number): number {
-    // We are N seconds into the slot. We need to account for `afterBlockBuildingTimeNeededWithoutReexec` seconds,
-    // send then split the remaining time between the re-execution and the block building.
-    const afterBlockBuildingTimeNeededWithoutReexec =
-      this.checkpointFinalizationTime + this.p2pPropagationTime * 2 + this.l1PublishingTime;
-    const maxAllowed = this.aztecSlotDuration - afterBlockBuildingTimeNeededWithoutReexec;
-    const available = maxAllowed - secondsIntoSlot;
-    const executionTimeEnd = secondsIntoSlot + available / 2;
-    this.log.debug(`Block proposal execution time deadline is ${executionTimeEnd}`, {
-      secondsIntoSlot,
-      maxAllowed,
-      available,
-      executionTimeEnd,
-    });
-    return executionTimeEnd;
-  }
-
-  /** Deadline for block proposal reexecution. Ensures the proposer has enough time for publishing. */
-  public getValidatorReexecTimeEnd(secondsIntoSlot?: number): number {
-    // We need to leave for `afterBlockReexecTimeNeeded` seconds available.
-    const afterBlockReexecTimeNeeded = this.p2pPropagationTime + this.l1PublishingTime;
-    const validationTimeEnd = this.aztecSlotDuration - afterBlockReexecTimeNeeded;
-    this.log.debug(`Validator re-execution time deadline is ${validationTimeEnd}`, {
-      secondsIntoSlot,
-      validationTimeEnd,
-    });
-    return validationTimeEnd;
   }
 
   public getMaxAllowedTime(
@@ -160,7 +177,7 @@ export class SequencerTimetable {
       case SequencerState.CREATING_BLOCK:
       case SequencerState.WAITING_UNTIL_NEXT_BLOCK:
         return this.initializeDeadline + this.checkpointInitializationTime;
-      case SequencerState.FINALIZING_CHECKPOINT:
+      case SequencerState.ASSEMBLING_CHECKPOINT:
       case SequencerState.COLLECTING_ATTESTATIONS:
         return this.aztecSlotDuration - this.l1PublishingTime - 2 * this.p2pPropagationTime;
       case SequencerState.PUBLISHING_CHECKPOINT:
@@ -192,32 +209,74 @@ export class SequencerTimetable {
   }
 
   /**
-   * Get timing information for building blocks within a slot.
-   * @param secondsIntoSlot - Current seconds into the slot
-   * @returns Object containing:
-   *   - canStart: boolean - Whether there's time to start a block now
-   *   - deadline: number - Deadline (seconds into slot) for building the block
-   *   - isLastBlock: boolean - Whether the next block would be the last one in the checkpoint
+   * Determines if we can start building the next block and returns its deadline.
+   *
+   * The timetable divides the slot into fixed sub-slots. This method finds the next
+   * available sub-slot that has enough time remaining to build a block.
+   *
+   * @param secondsIntoSlot - Current time (seconds into the slot)
+   * @returns Object with canStart flag, deadline, and whether this is the last block
    */
-  public canStartNextBlock(secondsIntoSlot: number): {
-    canStart: boolean;
-    deadline: number | undefined;
-    isLastBlock: boolean;
-  } {
-    const minExecutionTime = this.minExecutionTime;
-    const deadline = this.enforce ? this.getProposerExecTimeEnd(secondsIntoSlot) : undefined;
-
-    // Always allow to start if we don't enforce the timetable
-    const canStart = !this.enforce || deadline === undefined || deadline - secondsIntoSlot >= minExecutionTime;
-
-    // Single block per slot
-    if (this.blockDuration === undefined) {
-      this.log.debug(`${canStart ? 'Can' : 'Cannot'} start single-block checkpoint at ${secondsIntoSlot}s into slot`);
-      return { deadline, canStart, isLastBlock: true };
+  public canStartNextBlock(
+    secondsIntoSlot: number,
+  ):
+    | { canStart: true; deadline: undefined; isLastBlock: true }
+    | { canStart: false; deadline: undefined; isLastBlock: false }
+    | { canStart: boolean; deadline: number; isLastBlock: boolean } {
+    // When timetable enforcement is disabled, always allow starting,
+    // and build a single block with no deadline. This is here just to
+    // satisfy a subset of e2e tests and the sandbox that assume that the
+    // sequencer is permanently mining every tx sent.
+    if (!this.enforce) {
+      return { canStart: true, deadline: undefined, isLastBlock: true };
     }
 
-    // Multiple blocks per slot
-    // TODO(palla/mbps) Implement me
-    return { deadline, canStart, isLastBlock: true };
+    // If no block duration is set, then we're in single-block mode, which
+    // is handled for backwards compatibility towards another subset of e2e tests.
+    if (this.blockDuration === undefined) {
+      // In single block mode, execution and re-execution happen sequentially, so we need to
+      // split the available time between them. After building, we need time for attestations and L1.
+      const maxAllowed = this.aztecSlotDuration - this.checkpointFinalizationTime;
+      const available = (maxAllowed - secondsIntoSlot) / 2; // Split remaining time: half for execution, half for re-execution
+      const canStart = available >= this.minExecutionTime;
+      const deadline = secondsIntoSlot + available;
+
+      this.log.verbose(
+        `${canStart ? 'Can' : 'Cannot'} start single-block checkpoint at ${secondsIntoSlot}s into slot`,
+        { secondsIntoSlot, maxAllowed, available, deadline },
+      );
+      return { canStart, deadline, isLastBlock: true };
+    }
+
+    // Otherwise, we're in multi-block-per-slot mode, the default when running in production
+    // Find the next available sub-slot that has enough time remaining
+    for (let subSlot = 1; subSlot <= this.maxNumberOfBlocks; subSlot++) {
+      // Calculate end for this sub-slot
+      const deadline = this.initializationOffset + subSlot * this.blockDuration;
+
+      // Check if we have enough time to build a block with this deadline
+      const timeUntilDeadline = deadline - secondsIntoSlot;
+
+      if (timeUntilDeadline >= this.minExecutionTime) {
+        // Found an available sub-slot! Is this the last one?
+        const isLastBlock = subSlot === this.maxNumberOfBlocks;
+
+        this.log.verbose(
+          `Can start ${isLastBlock ? 'last block' : 'block'} in sub-slot ${subSlot} with deadline ${deadline}s`,
+          { secondsIntoSlot, deadline, timeUntilDeadline, subSlot, maxBlocks: this.maxNumberOfBlocks },
+        );
+
+        return { canStart: true, deadline, isLastBlock };
+      }
+    }
+
+    // No sub-slots available with enough time
+    this.log.verbose(`No time left to start any more blocks`, {
+      secondsIntoSlot,
+      maxBlocks: this.maxNumberOfBlocks,
+      initializationOffset: this.initializationOffset,
+    });
+
+    return { canStart: false, deadline: undefined, isLastBlock: false };
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/utils.ts
+++ b/yarn-project/sequencer-client/src/sequencer/utils.ts
@@ -17,8 +17,8 @@ export enum SequencerState {
   CREATING_BLOCK = 'CREATING_BLOCK',
   /** Waiting until the next block can be created. */
   WAITING_UNTIL_NEXT_BLOCK = 'WAITING_UNTIL_NEXT_BLOCK',
-  /** Finalizing and broadcasting the checkpoint. */
-  FINALIZING_CHECKPOINT = 'FINALIZING_CHECKPOINT',
+  /** Assembling and broadcasting the checkpoint. */
+  ASSEMBLING_CHECKPOINT = 'ASSEMBLING_CHECKPOINT',
   /** Collecting attestations from its peers. */
   COLLECTING_ATTESTATIONS = 'COLLECTING_ATTESTATIONS',
   /** Sending the tx to L1 with the L2 checkpoint data and awaiting it to be mined.. */
@@ -33,7 +33,7 @@ export type SequencerStateWithSlot =
   | SequencerState.COLLECTING_ATTESTATIONS
   | SequencerState.PUBLISHING_CHECKPOINT
   | SequencerState.PROPOSER_CHECK
-  | SequencerState.FINALIZING_CHECKPOINT;
+  | SequencerState.ASSEMBLING_CHECKPOINT;
 
 export type SequencerStateCallback = () => SequencerState;
 

--- a/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
+++ b/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
@@ -1,0 +1,247 @@
+import { type BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { Timer } from '@aztec/foundation/timer';
+import type { FunctionsOf } from '@aztec/foundation/types';
+import { L2BlockNew } from '@aztec/stdlib/block';
+import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { Gas } from '@aztec/stdlib/gas';
+import type { FullNodeBlockBuilderConfig, PublicProcessorLimits } from '@aztec/stdlib/interfaces/server';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { makeAppendOnlyTreeSnapshot } from '@aztec/stdlib/testing';
+import type { CheckpointGlobalVariables, Tx } from '@aztec/stdlib/tx';
+
+import type {
+  BuildBlockInCheckpointResult,
+  CheckpointBuilder,
+  FullNodeCheckpointsBuilder,
+} from '../sequencer/checkpoint_builder.js';
+
+/**
+ * A fake CheckpointBuilder for testing that implements the same interface as the real one.
+ * Can be seeded with blocks to return sequentially on each `buildBlock` call.
+ */
+export class MockCheckpointBuilder implements FunctionsOf<CheckpointBuilder> {
+  private blocks: L2BlockNew[] = [];
+  private builtBlocks: L2BlockNew[] = [];
+  private usedTxsPerBlock: Tx[][] = [];
+  private blockIndex = 0;
+
+  /** Optional function to dynamically provide the block (alternative to seedBlocks) */
+  private blockProvider: (() => L2BlockNew) | undefined = undefined;
+
+  /** Track calls for assertions */
+  public buildBlockCalls: Array<{
+    blockNumber: BlockNumber;
+    timestamp: bigint;
+    opts: PublicProcessorLimits;
+  }> = [];
+  public completeCheckpointCalled = false;
+  public getCheckpointCalled = false;
+
+  /** Set to an error to make buildBlock throw on next call */
+  public errorOnBuild: Error | undefined = undefined;
+
+  constructor(
+    private readonly constants: CheckpointGlobalVariables,
+    private readonly checkpointNumber: CheckpointNumber,
+  ) {}
+
+  /** Seed the builder with blocks to return on successive buildBlock calls */
+  seedBlocks(blocks: L2BlockNew[], usedTxsPerBlock?: Tx[][]): this {
+    this.blocks = blocks;
+    this.usedTxsPerBlock = usedTxsPerBlock ?? blocks.map(() => []);
+    this.blockIndex = 0;
+    this.blockProvider = undefined;
+    return this;
+  }
+
+  /**
+   * Set a function that provides blocks dynamically.
+   * Useful for tests where the block is determined at call time (e.g., sequencer tests).
+   */
+  setBlockProvider(provider: () => L2BlockNew): this {
+    this.blockProvider = provider;
+    this.blocks = [];
+    return this;
+  }
+
+  getConstantData(): CheckpointGlobalVariables {
+    return this.constants;
+  }
+
+  buildBlock(
+    _pendingTxs: Iterable<Tx> | AsyncIterable<Tx>,
+    blockNumber: BlockNumber,
+    timestamp: bigint,
+    opts: PublicProcessorLimits,
+  ): Promise<BuildBlockInCheckpointResult> {
+    this.buildBlockCalls.push({ blockNumber, timestamp, opts });
+
+    if (this.errorOnBuild) {
+      return Promise.reject(this.errorOnBuild);
+    }
+
+    let block: L2BlockNew;
+    let usedTxs: Tx[];
+
+    if (this.blockProvider) {
+      // Dynamic mode: get block from provider
+      block = this.blockProvider();
+      usedTxs = [];
+      this.builtBlocks.push(block);
+    } else {
+      // Seeded mode: get block from pre-seeded list
+      block = this.blocks[this.blockIndex];
+      usedTxs = this.usedTxsPerBlock[this.blockIndex] ?? [];
+      this.blockIndex++;
+      this.builtBlocks.push(block);
+    }
+
+    return Promise.resolve({
+      block,
+      publicGas: Gas.empty(),
+      publicProcessorDuration: 0,
+      numTxs: block?.body?.txEffects?.length ?? usedTxs.length,
+      blockBuildingTimer: new Timer(),
+      usedTxs,
+      failedTxs: [],
+    });
+  }
+
+  completeCheckpoint(): Promise<Checkpoint> {
+    this.completeCheckpointCalled = true;
+    const allBlocks = this.blockProvider ? this.builtBlocks : this.blocks;
+    const lastBlock = allBlocks[allBlocks.length - 1];
+    // Create a CheckpointHeader from the last block's header for testing
+    const checkpointHeader = this.createCheckpointHeader(lastBlock);
+    return Promise.resolve(
+      new Checkpoint(
+        makeAppendOnlyTreeSnapshot(lastBlock.header.globalVariables.blockNumber + 1),
+        checkpointHeader,
+        allBlocks,
+        this.checkpointNumber,
+      ),
+    );
+  }
+
+  getCheckpoint(): Promise<Checkpoint> {
+    this.getCheckpointCalled = true;
+    const builtBlocks = this.blockProvider ? this.builtBlocks : this.blocks.slice(0, this.blockIndex);
+    const lastBlock = builtBlocks[builtBlocks.length - 1];
+    if (!lastBlock) {
+      throw new Error('No blocks built yet');
+    }
+    // Create a CheckpointHeader from the last block's header for testing
+    const checkpointHeader = this.createCheckpointHeader(lastBlock);
+    return Promise.resolve(
+      new Checkpoint(
+        makeAppendOnlyTreeSnapshot(lastBlock.header.globalVariables.blockNumber + 1),
+        checkpointHeader,
+        builtBlocks,
+        this.checkpointNumber,
+      ),
+    );
+  }
+
+  /**
+   * Creates a CheckpointHeader from a block's header for testing.
+   * This is a simplified version that creates a minimal CheckpointHeader.
+   */
+  private createCheckpointHeader(block: L2BlockNew): CheckpointHeader {
+    const header = block.header;
+    const gv = header.globalVariables;
+    return CheckpointHeader.empty({
+      lastArchiveRoot: header.lastArchive.root,
+      blockHeadersHash: Fr.random(), // Use random for testing
+      slotNumber: gv.slotNumber,
+      timestamp: gv.timestamp,
+      coinbase: gv.coinbase,
+      feeRecipient: gv.feeRecipient,
+      gasFees: gv.gasFees,
+      totalManaUsed: header.totalManaUsed,
+    });
+  }
+
+  /** Reset for reuse in another test */
+  reset(): void {
+    this.blocks = [];
+    this.builtBlocks = [];
+    this.usedTxsPerBlock = [];
+    this.blockIndex = 0;
+    this.buildBlockCalls = [];
+    this.completeCheckpointCalled = false;
+    this.getCheckpointCalled = false;
+    this.errorOnBuild = undefined;
+    this.blockProvider = undefined;
+  }
+}
+
+/**
+ * A fake CheckpointsBuilder (factory) for testing that implements the same interface
+ * as FullNodeCheckpointsBuilder. Returns MockCheckpointBuilder instances.
+ * Does NOT use jest mocks - this is a proper test double.
+ */
+export class MockCheckpointsBuilder implements FunctionsOf<FullNodeCheckpointsBuilder> {
+  private checkpointBuilder: MockCheckpointBuilder | undefined;
+
+  /** Track calls for assertions */
+  public startCheckpointCalls: Array<{
+    checkpointNumber: CheckpointNumber;
+    constants: CheckpointGlobalVariables;
+    l1ToL2Messages: Fr[];
+  }> = [];
+  public updateConfigCalls: Array<Partial<FullNodeBlockBuilderConfig>> = [];
+
+  /**
+   * Set the MockCheckpointBuilder to return from startCheckpoint.
+   * Must be called before startCheckpoint is invoked.
+   */
+  setCheckpointBuilder(builder: MockCheckpointBuilder): this {
+    this.checkpointBuilder = builder;
+    return this;
+  }
+
+  /**
+   * Creates a new MockCheckpointBuilder with the given constants.
+   * Convenience method that creates and sets the builder in one call.
+   */
+  createCheckpointBuilder(
+    constants: CheckpointGlobalVariables,
+    checkpointNumber: CheckpointNumber,
+  ): MockCheckpointBuilder {
+    this.checkpointBuilder = new MockCheckpointBuilder(constants, checkpointNumber);
+    return this.checkpointBuilder;
+  }
+
+  /** Get the current checkpoint builder (for assertions) */
+  getCheckpointBuilder(): MockCheckpointBuilder | undefined {
+    return this.checkpointBuilder;
+  }
+
+  updateConfig(config: Partial<FullNodeBlockBuilderConfig>): void {
+    this.updateConfigCalls.push(config);
+  }
+
+  startCheckpoint(
+    checkpointNumber: CheckpointNumber,
+    constants: CheckpointGlobalVariables,
+    l1ToL2Messages: Fr[],
+    _fork: unknown,
+  ): Promise<CheckpointBuilder> {
+    this.startCheckpointCalls.push({ checkpointNumber, constants, l1ToL2Messages });
+
+    if (!this.checkpointBuilder) {
+      // Auto-create a builder if none was set
+      this.checkpointBuilder = new MockCheckpointBuilder(constants, checkpointNumber);
+    }
+
+    return Promise.resolve(this.checkpointBuilder as unknown as CheckpointBuilder);
+  }
+
+  /** Reset for reuse in another test */
+  reset(): void {
+    this.checkpointBuilder = undefined;
+    this.startCheckpointCalls = [];
+    this.updateConfigCalls = [];
+  }
+}

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -1,0 +1,137 @@
+import { Body } from '@aztec/aztec.js/block';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
+import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { EthAddress } from '@aztec/foundation/eth-address';
+import { Signature } from '@aztec/foundation/eth-signature';
+import type { P2P } from '@aztec/p2p';
+import { PublicDataWrite } from '@aztec/stdlib/avm';
+import { CommitteeAttestation, L2BlockNew } from '@aztec/stdlib/block';
+import { BlockAttestation, BlockProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import { makeAppendOnlyTreeSnapshot, mockTxForRollup } from '@aztec/stdlib/testing';
+import {
+  BlockHeader,
+  ContentCommitment,
+  GlobalVariables,
+  type Tx,
+  makeProcessedTxFromPrivateOnlyTx,
+} from '@aztec/stdlib/tx';
+
+import type { MockProxy } from 'jest-mock-extended';
+
+// Re-export mock classes from their dedicated file
+export { MockCheckpointBuilder, MockCheckpointsBuilder } from './mock_checkpoint_builder.js';
+
+/**
+ * Creates a mock transaction with a specific seed for deterministic testing
+ */
+export async function makeTx(seed?: number, chainId?: Fr): Promise<Tx> {
+  const tx = await mockTxForRollup(seed);
+  if (chainId) {
+    tx.data.constants.txContext.chainId = chainId;
+  }
+  return tx;
+}
+
+/**
+ * Creates an L2BlockNew from transactions and global variables
+ */
+export async function makeBlock(txs: Tx[], globalVariables: GlobalVariables): Promise<L2BlockNew> {
+  const processedTxs = await Promise.all(
+    txs.map(tx =>
+      makeProcessedTxFromPrivateOnlyTx(tx, Fr.ZERO, new PublicDataWrite(Fr.random(), Fr.random()), globalVariables),
+    ),
+  );
+  const body = new Body(processedTxs.map(tx => tx.txEffect));
+  const header = BlockHeader.empty({ globalVariables });
+  const archive = makeAppendOnlyTreeSnapshot(globalVariables.blockNumber + 1);
+  return new L2BlockNew(archive, header, body, CheckpointNumber(globalVariables.blockNumber), 0);
+}
+
+/**
+ * Mocks the P2P client to return specific pending transactions
+ */
+export function mockPendingTxs(p2p: MockProxy<P2P>, txs: Tx[]): void {
+  p2p.getPendingTxCount.mockResolvedValue(txs.length);
+  p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+}
+
+/**
+ * Creates an async iterator for transactions
+ */
+export async function* mockTxIterator(txs: Promise<Tx[]>): AsyncIterableIterator<Tx> {
+  for (const tx of await txs) {
+    yield tx;
+  }
+}
+
+/**
+ * Creates mock committee attestations from a signer
+ */
+export function createMockSignatures(signer: Secp256k1Signer): CommitteeAttestation[] {
+  const mockedSig = Signature.random();
+  return [new CommitteeAttestation(signer.address, mockedSig)];
+}
+
+/**
+ * Creates a CheckpointHeader from an L2BlockNew for testing purposes.
+ * Uses mock values for contentCommitment and blockHeadersHash since
+ * L2BlockNew doesn't have these fields.
+ */
+function createCheckpointHeaderFromBlock(block: L2BlockNew): CheckpointHeader {
+  const gv = block.header.globalVariables;
+  return new CheckpointHeader(
+    block.header.lastArchive.root,
+    Fr.random(), // blockHeadersHash - mock value for testing
+    ContentCommitment.empty(), // contentCommitment - mock value for testing
+    gv.slotNumber,
+    gv.timestamp,
+    gv.coinbase,
+    gv.feeRecipient,
+    gv.gasFees,
+    block.header.totalManaUsed,
+  );
+}
+
+/**
+ * Creates a block proposal from a block and signature
+ */
+export function createBlockProposal(block: L2BlockNew, signature: Signature): BlockProposal {
+  const checkpointHeader = createCheckpointHeaderFromBlock(block);
+  const consensusPayload = new ConsensusPayload(checkpointHeader, block.archive.root);
+  const txHashes = block.body.txEffects.map(tx => tx.txHash);
+  return new BlockProposal(consensusPayload, signature, txHashes);
+}
+
+/**
+ * Creates a block attestation from a block and signature.
+ * Note: We manually set the sender since we use random signatures in tests.
+ * In production, the sender is recovered from the signature.
+ */
+export function createBlockAttestation(block: L2BlockNew, signature: Signature, sender: EthAddress): BlockAttestation {
+  const checkpointHeader = createCheckpointHeaderFromBlock(block);
+  const consensusPayload = new ConsensusPayload(checkpointHeader, block.archive.root);
+  const attestation = new BlockAttestation(consensusPayload, signature, signature);
+  // Set sender directly for testing (bypasses signature recovery)
+
+  (attestation as any).sender = sender;
+  return attestation;
+}
+
+/**
+ * Creates transactions and a block, and mocks P2P to return them.
+ * Helper for tests that need to set up a block with transactions.
+ */
+export async function setupTxsAndBlock(
+  p2p: MockProxy<P2P>,
+  globalVariables: GlobalVariables,
+  txCount: number,
+  chainId: Fr,
+): Promise<{ txs: Tx[]; block: L2BlockNew }> {
+  const txs = await Promise.all(times(txCount, i => makeTx(i + 1, chainId)));
+  const block = await makeBlock(txs, globalVariables);
+  mockPendingTxs(p2p, txs);
+  return { txs, block };
+}

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -95,6 +95,13 @@ export interface L2BlockSource {
   getBlockHeaderByArchive(archive: Fr): Promise<BlockHeader | undefined>;
 
   /**
+   * Gets an L2 block by block number.
+   * @param number - The block number to return.
+   * @returns The requested L2 block (or undefined if not found).
+   */
+  getL2BlockNew(number: BlockNumber): Promise<L2BlockNew | undefined>;
+
+  /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect with block info (or undefined if not found).
@@ -168,6 +175,7 @@ export interface L2BlockSource {
    * Gets an l2 block. If a negative number is passed, the block returned is the most recent.
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.
+   * @deprecated Use getL2BlockNew instead.
    */
   getBlock(number: BlockNumber): Promise<L2Block | undefined>;
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -105,6 +105,11 @@ describe('ArchiverApiSchema', () => {
     expect(result).toBeInstanceOf(BlockHeader);
   });
 
+  it('getL2BlockNew', async () => {
+    const result = await context.client.getL2BlockNew(BlockNumber(1));
+    expect(result).toBeInstanceOf(L2BlockNew);
+  });
+
   it('getBlocks', async () => {
     const result = await context.client.getBlocks(BlockNumber(1), BlockNumber(1));
     expect(result).toEqual([expect.any(L2Block)]);
@@ -401,6 +406,9 @@ class MockArchiver implements ArchiverApi {
   }
   getBlockHeaderByArchive(_archive: Fr): Promise<BlockHeader | undefined> {
     return Promise.resolve(BlockHeader.empty());
+  }
+  getL2BlockNew(number: BlockNumber): Promise<L2BlockNew | undefined> {
+    return L2BlockNew.random(number);
   }
   async getTxEffect(_txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(_txHash).toBeInstanceOf(TxHash);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import { CheckpointedL2Block, PublishedL2Block } from '../block/checkpointed_l2_block.js';
 import { L2Block } from '../block/l2_block.js';
+import { L2BlockNew } from '../block/l2_block_new.js';
 import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
 import { ValidateBlockResultSchema } from '../block/validate_block_result.js';
 import { Checkpoint } from '../checkpoint/checkpoint.js';
@@ -104,6 +105,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getPublishedBlockByArchive: z.function().args(schemas.Fr).returns(PublishedL2Block.schema.optional()),
   getBlockHeaderByHash: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
   getBlockHeaderByArchive: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
+  getL2BlockNew: z.function().args(BlockNumberSchema).returns(L2BlockNew.schema.optional()),
   getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.SlotNumber.optional()),

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -10,6 +10,7 @@ import {
   CommitteeAttestation,
   L2Block,
   type L2BlockId,
+  type L2BlockNew,
   type L2BlockSource,
   type L2Tips,
   PublishedL2Block,
@@ -134,6 +135,18 @@ export class TXEArchiver extends ArchiverStoreHelper implements L2BlockSource {
    */
   public getL2Block(number: BlockNumber | 'latest'): Promise<L2Block | undefined> {
     return this.getPublishedBlock(number != 'latest' ? number : -1).then(b => b?.block);
+  }
+
+  /**
+   * Gets an L2 block (new format).
+   * @param number - The block number to return.
+   * @returns The requested L2 block.
+   */
+  public getL2BlockNew(number: BlockNumber): Promise<L2BlockNew | undefined> {
+    if (number === 0) {
+      return Promise.resolve(undefined);
+    }
+    return this.store.getBlock(number);
   }
 
   /**


### PR DESCRIPTION
Also includes a refactor of the sequencer, checkpoint proposal job, and timetable unit tests, as well as a README with how block building works now within a slot.
