### PR TITLE
feat(avm): fuzzer toradixbe

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -624,6 +624,17 @@ struct SHA256COMPRESSION_Instruction {
     MSGPACK_FIELDS(state_address, input_address, dst_address);
 };
 
+/// @brief TORADIXBE: Convert a field element to a vector of limbs in big-endian radix representation
+/// M[dst_address:dst_address+num_limbs] = to_radix_be(M[value_address], radix, num_limbs)
+struct TORADIXBE_Instruction {
+    ParamRef value_address;       // FF: value to convert
+    ParamRef radix_address;       // U32: the radix/base
+    ParamRef num_limbs_address;   // U32: number of output limbs
+    ParamRef output_bits_address; // U1: whether output is bits
+    AddressRef dst_address;       // destination for limbs
+    MSGPACK_FIELDS(value_address, radix_address, num_limbs_address, output_bits_address, dst_address);
+};
+
 using FuzzInstruction = std::variant<ADD_8_Instruction,
                                      FDIV_8_Instruction,
                                      SET_8_Instruction,
@@ -679,7 +690,8 @@ using FuzzInstruction = std::variant<ADD_8_Instruction,
                                      ECADD_Instruction,
                                      POSEIDON2PERM_Instruction,
                                      KECCAKF1600_Instruction,
-                                     SHA256COMPRESSION_Instruction>;
+                                     SHA256COMPRESSION_Instruction,
+                                     TORADIXBE_Instruction>;
 
 template <class... Ts> struct overloaded : Ts... {
     using Ts::operator()...;
@@ -885,6 +897,10 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzInstruction& instruc
             [&](SHA256COMPRESSION_Instruction arg) {
                 os << "SHA256COMPRESSION_Instruction " << arg.state_address << " " << arg.input_address << " "
                    << arg.dst_address;
+            },
+            [&](TORADIXBE_Instruction arg) {
+                os << "TORADIXBE_Instruction " << arg.value_address << " " << arg.radix_address << " "
+                   << arg.num_limbs_address << " " << arg.output_bits_address << " " << arg.dst_address;
             },
             [&](auto) { os << "Unknown instruction"; },
         },

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -485,6 +485,15 @@ struct NULLIFIEREXISTS_Instruction {
     MSGPACK_FIELDS(nullifier_address, contract_address_address, result_address);
 };
 
+/// @brief L1TOL2MSGEXISTS: Check if a L1 to L2 message exists
+/// M[result_address] = L1TOL2MSGEXISTS(M[msg_hash_address], M[leaf_index_address])
+struct L1TOL2MSGEXISTS_Instruction {
+    ParamRef msg_hash_address;   // FF: the message hash
+    ParamRef leaf_index_address; // U64: leaf index in the message tree
+    AddressRef result_address;   // result (U1)
+    MSGPACK_FIELDS(msg_hash_address, leaf_index_address, result_address);
+};
+
 /// @brief EMITNOTEHASH: M[note_hash_offset] = note_hash; emit note hash to the note hash tree
 struct EMITNOTEHASH_Instruction {
     AddressRef note_hash_address; // absolute address where the note hash will be stored
@@ -632,7 +641,8 @@ struct TORADIXBE_Instruction {
     ParamRef num_limbs_address;   // U32: number of output limbs
     ParamRef output_bits_address; // U1: whether output is bits
     AddressRef dst_address;       // destination for limbs
-    MSGPACK_FIELDS(value_address, radix_address, num_limbs_address, output_bits_address, dst_address);
+    bool is_output_bits;          // known at generation time for memory tracking (U1 if true, U8 if false)
+    MSGPACK_FIELDS(value_address, radix_address, num_limbs_address, output_bits_address, dst_address, is_output_bits);
 };
 
 using FuzzInstruction = std::variant<ADD_8_Instruction,
@@ -678,6 +688,7 @@ using FuzzInstruction = std::variant<ADD_8_Instruction,
                                      GETENVVAR_Instruction,
                                      EMITNULLIFIER_Instruction,
                                      NULLIFIEREXISTS_Instruction,
+                                     L1TOL2MSGEXISTS_Instruction,
                                      EMITNOTEHASH_Instruction,
                                      NOTEHASHEXISTS_Instruction,
                                      CALLDATACOPY_Instruction,
@@ -853,6 +864,10 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzInstruction& instruc
                 os << "NULLIFIEREXISTS_Instruction " << arg.nullifier_address << " " << arg.contract_address_address
                    << " " << arg.result_address;
             },
+            [&](L1TOL2MSGEXISTS_Instruction arg) {
+                os << "L1TOL2MSGEXISTS_Instruction " << arg.msg_hash_address << " " << arg.leaf_index_address << " "
+                   << arg.result_address;
+            },
             [&](EMITNOTEHASH_Instruction arg) {
                 os << "EMITNOTEHASH_Instruction " << arg.note_hash_address << " " << arg.note_hash;
             },
@@ -900,7 +915,8 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzInstruction& instruc
             },
             [&](TORADIXBE_Instruction arg) {
                 os << "TORADIXBE_Instruction " << arg.value_address << " " << arg.radix_address << " "
-                   << arg.num_limbs_address << " " << arg.output_bits_address << " " << arg.dst_address;
+                   << arg.num_limbs_address << " " << arg.output_bits_address << " " << arg.dst_address << " "
+                   << arg.is_output_bits;
             },
             [&](auto) { os << "Unknown instruction"; },
         },

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
@@ -1494,6 +1494,62 @@ void ProgramBlock::process_sha256compression_instruction(SHA256COMPRESSION_Instr
     }
 }
 
+void ProgramBlock::process_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction instruction)
+{
+    auto msg_hash_operand = memory_manager.get_resolved_address_and_operand_16(instruction.msg_hash_address);
+    auto leaf_index_operand = memory_manager.get_resolved_address_and_operand_16(instruction.leaf_index_address);
+    auto result_operand = memory_manager.get_resolved_address_and_operand_16(instruction.result_address);
+
+    if (!msg_hash_operand.has_value() || !leaf_index_operand.has_value() || !result_operand.has_value()) {
+        return;
+    }
+
+    preprocess_memory_addresses(msg_hash_operand.value().first);
+    preprocess_memory_addresses(leaf_index_operand.value().first);
+    preprocess_memory_addresses(result_operand.value().first);
+
+    auto l1tol2msgexists_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::L1TOL2MSGEXISTS)
+                                           .operand(msg_hash_operand.value().second)
+                                           .operand(leaf_index_operand.value().second)
+                                           .operand(result_operand.value().second)
+                                           .build();
+    instructions.push_back(l1tol2msgexists_instruction);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, result_operand.value().first.absolute_address);
+}
+
+void ProgramBlock::process_toradixbe_instruction(TORADIXBE_Instruction instruction)
+{
+    auto value_operand = memory_manager.get_resolved_address_and_operand_16(instruction.value_address);
+    auto radix_operand = memory_manager.get_resolved_address_and_operand_16(instruction.radix_address);
+    auto num_limbs_operand = memory_manager.get_resolved_address_and_operand_16(instruction.num_limbs_address);
+    auto output_bits_operand = memory_manager.get_resolved_address_and_operand_16(instruction.output_bits_address);
+    auto dst_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
+
+    if (!value_operand.has_value() || !radix_operand.has_value() || !num_limbs_operand.has_value() ||
+        !output_bits_operand.has_value() || !dst_operand.has_value()) {
+        return;
+    }
+
+    preprocess_memory_addresses(value_operand.value().first);
+    preprocess_memory_addresses(radix_operand.value().first);
+    preprocess_memory_addresses(num_limbs_operand.value().first);
+    preprocess_memory_addresses(output_bits_operand.value().first);
+    preprocess_memory_addresses(dst_operand.value().first);
+
+    auto toradixbe_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::TORADIXBE)
+                                     .operand(dst_operand.value().second)
+                                     .operand(value_operand.value().second)
+                                     .operand(radix_operand.value().second)
+                                     .operand(num_limbs_operand.value().second)
+                                     .operand(output_bits_operand.value().second)
+                                     .build();
+    instructions.push_back(toradixbe_instruction);
+
+    // Use is_output_bits to determine the output memory tag
+    auto output_tag = instruction.is_output_bits ? bb::avm2::MemoryTag::U1 : bb::avm2::MemoryTag::U8;
+    memory_manager.set_memory_address(output_tag, dst_operand.value().first.absolute_address);
+}
+
 void ProgramBlock::finalize_with_return(uint8_t return_size,
                                         MemoryTagWrapper return_value_tag,
                                         uint16_t return_value_offset_index)
@@ -1682,6 +1738,10 @@ void ProgramBlock::process_instruction(FuzzInstruction instruction)
             [this](SHA256COMPRESSION_Instruction instruction) {
                 return this->process_sha256compression_instruction(instruction);
             },
+            [this](L1TOL2MSGEXISTS_Instruction instruction) {
+                return this->process_l1tol2msgexists_instruction(instruction);
+            },
+            [this](TORADIXBE_Instruction instruction) { return this->process_toradixbe_instruction(instruction); },
             [](auto) { throw std::runtime_error("Unknown instruction"); },
         },
         instruction);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
@@ -110,6 +110,8 @@ class ProgramBlock {
     void process_poseidon2perm_instruction(POSEIDON2PERM_Instruction instruction);
     void process_keccakf1600_instruction(KECCAKF1600_Instruction instruction);
     void process_sha256compression_instruction(SHA256COMPRESSION_Instruction instruction);
+    void process_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction instruction);
+    void process_toradixbe_instruction(TORADIXBE_Instruction instruction);
 
   public:
     std::vector<ProgramBlock*> successors;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -271,9 +271,10 @@ enum class InstructionGenerationOptions {
     POSEIDON2PERM,
     KECCAKF1600,
     SHA256COMPRESSION,
+    TORADIXBE,
 };
 
-using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 54>;
+using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 55>;
 
 constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION = InstructionGenerationConfig({
     { InstructionGenerationOptions::ADD_8, 1 },
@@ -330,6 +331,7 @@ constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION
     { InstructionGenerationOptions::POSEIDON2PERM, 1 },
     { InstructionGenerationOptions::KECCAKF1600, 1 },
     { InstructionGenerationOptions::SHA256COMPRESSION, 1 },
+    { InstructionGenerationOptions::TORADIXBE, 1 },
 });
 
 enum class SStoreMutationOptions { src_address, result_address, slot };
@@ -471,6 +473,23 @@ using SuccessCopyMutationConfig = WeightedSelectionConfig<SuccessCopyMutationOpt
 
 constexpr SuccessCopyMutationConfig BASIC_SUCCESSCOPY_MUTATION_CONFIGURATION = SuccessCopyMutationConfig({
     { SuccessCopyMutationOptions::dst_address, 1 },
+});
+
+enum class ToRadixBEMutationOptions {
+    value_address,
+    radix_address,
+    num_limbs_address,
+    output_bits_address,
+    dst_address
+};
+using ToRadixBEMutationConfig = WeightedSelectionConfig<ToRadixBEMutationOptions, 5>;
+
+constexpr ToRadixBEMutationConfig BASIC_TORADIXBE_MUTATION_CONFIGURATION = ToRadixBEMutationConfig({
+    { ToRadixBEMutationOptions::value_address, 1 },
+    { ToRadixBEMutationOptions::radix_address, 1 },
+    { ToRadixBEMutationOptions::num_limbs_address, 1 },
+    { ToRadixBEMutationOptions::output_bits_address, 1 },
+    { ToRadixBEMutationOptions::dst_address, 1 },
 });
 
 enum class ReturnOptionsMutationOptions { return_size, return_value_tag, return_value_offset_index };

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -237,6 +237,8 @@ enum class InstructionGenerationOptions {
     SET_64,
     SET_128,
     SET_FF,
+    MOV_8,
+    MOV_16,
     ADD_16,
     SUB_16,
     MUL_16,
@@ -258,6 +260,7 @@ enum class InstructionGenerationOptions {
     GETENVVAR,
     EMITNULLIFIER,
     NULLIFIEREXISTS,
+    L1TOL2MSGEXISTS,
     EMITNOTEHASH,
     NOTEHASHEXISTS,
     CALLDATACOPY,
@@ -274,7 +277,7 @@ enum class InstructionGenerationOptions {
     TORADIXBE,
 };
 
-using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 55>;
+using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 58>;
 
 constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION = InstructionGenerationConfig({
     { InstructionGenerationOptions::ADD_8, 1 },
@@ -297,6 +300,8 @@ constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION
     { InstructionGenerationOptions::SET_64, 1 },
     { InstructionGenerationOptions::SET_128, 1 },
     { InstructionGenerationOptions::SET_FF, 1 },
+    { InstructionGenerationOptions::MOV_8, 1 },
+    { InstructionGenerationOptions::MOV_16, 1 },
     { InstructionGenerationOptions::ADD_16, 1 },
     { InstructionGenerationOptions::SUB_16, 1 },
     { InstructionGenerationOptions::MUL_16, 1 },
@@ -318,6 +323,7 @@ constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION
     { InstructionGenerationOptions::GETENVVAR, 1 },
     { InstructionGenerationOptions::EMITNULLIFIER, 1 },
     { InstructionGenerationOptions::NULLIFIEREXISTS, 1 },
+    { InstructionGenerationOptions::L1TOL2MSGEXISTS, 1 },
     { InstructionGenerationOptions::EMITNOTEHASH, 1 },
     { InstructionGenerationOptions::NOTEHASHEXISTS, 1 },
     { InstructionGenerationOptions::CALLDATACOPY, 1 },
@@ -367,6 +373,15 @@ constexpr NullifierExistsMutationConfig BASIC_NULLIFIER_EXISTS_MUTATION_CONFIGUR
     { NullifierExistsMutationOptions::nullifier_address, 1 },
     { NullifierExistsMutationOptions::contract_address_address, 1 },
     { NullifierExistsMutationOptions::result_address, 1 },
+});
+
+enum class L1ToL2MsgExistsMutationOptions { msg_hash_address, leaf_index_address, result_address };
+using L1ToL2MsgExistsMutationConfig = WeightedSelectionConfig<L1ToL2MsgExistsMutationOptions, 3>;
+
+constexpr L1ToL2MsgExistsMutationConfig BASIC_L1TOL2MSGEXISTS_MUTATION_CONFIGURATION = L1ToL2MsgExistsMutationConfig({
+    { L1ToL2MsgExistsMutationOptions::msg_hash_address, 1 },
+    { L1ToL2MsgExistsMutationOptions::leaf_index_address, 1 },
+    { L1ToL2MsgExistsMutationOptions::result_address, 1 },
 });
 
 enum class EmitNoteHashMutationOptions { note_hash_address, note_hash };
@@ -480,9 +495,10 @@ enum class ToRadixBEMutationOptions {
     radix_address,
     num_limbs_address,
     output_bits_address,
-    dst_address
+    dst_address,
+    is_output_bits
 };
-using ToRadixBEMutationConfig = WeightedSelectionConfig<ToRadixBEMutationOptions, 5>;
+using ToRadixBEMutationConfig = WeightedSelectionConfig<ToRadixBEMutationOptions, 6>;
 
 constexpr ToRadixBEMutationConfig BASIC_TORADIXBE_MUTATION_CONFIGURATION = ToRadixBEMutationConfig({
     { ToRadixBEMutationOptions::value_address, 1 },
@@ -490,6 +506,7 @@ constexpr ToRadixBEMutationConfig BASIC_TORADIXBE_MUTATION_CONFIGURATION = ToRad
     { ToRadixBEMutationOptions::num_limbs_address, 1 },
     { ToRadixBEMutationOptions::output_bits_address, 1 },
     { ToRadixBEMutationOptions::dst_address, 1 },
+    { ToRadixBEMutationOptions::is_output_bits, 1 },
 });
 
 enum class ReturnOptionsMutationOptions { return_size, return_value_tag, return_value_offset_index };

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -311,7 +311,8 @@ std::vector<FuzzInstruction> generate_toradixbe_instruction(std::mt19937_64& rng
                                         .radix_address = generate_variable_ref(rng),
                                         .num_limbs_address = generate_variable_ref(rng),
                                         .output_bits_address = generate_variable_ref(rng),
-                                        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+                                        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                        .is_output_bits = std::uniform_int_distribution<int>(0, 1)(rng) == 0 } };
     }
     // Backfill mode: set up proper typed values
     // value: FF, radix: U32, num_limbs: U32, output_bits: U1
@@ -354,7 +355,8 @@ std::vector<FuzzInstruction> generate_toradixbe_instruction(std::mt19937_64& rng
                                                   .radix_address = radix_addr,
                                                   .num_limbs_address = num_limbs_addr,
                                                   .output_bits_address = output_bits_addr,
-                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                                  .is_output_bits = is_output_bits });
     return instructions;
 }
 
@@ -428,6 +430,14 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
         return { SET_FF_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
                                      .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
                                      .value = generate_random_field(rng) } };
+    case InstructionGenerationOptions::MOV_8:
+        return { MOV_8_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
+                                    .src_address = generate_variable_ref(rng),
+                                    .result_address = generate_address_ref(rng, MAX_8BIT_OPERAND) } };
+    case InstructionGenerationOptions::MOV_16:
+        return { MOV_16_Instruction{ .value_tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION),
+                                     .src_address = generate_variable_ref(rng),
+                                     .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
     case InstructionGenerationOptions::ADD_16:
         return generate_alu_with_matching_tags<ADD_16_Instruction>(rng, MAX_16BIT_OPERAND);
     case InstructionGenerationOptions::SUB_16:
@@ -495,6 +505,10 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
     case InstructionGenerationOptions::NULLIFIEREXISTS:
         return { NULLIFIEREXISTS_Instruction{ .nullifier_address = generate_variable_ref(rng),
                                               .contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                              .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    case InstructionGenerationOptions::L1TOL2MSGEXISTS:
+        return { L1TOL2MSGEXISTS_Instruction{ .msg_hash_address = generate_variable_ref(rng),
+                                              .leaf_index_address = generate_variable_ref(rng),
                                               .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
     case InstructionGenerationOptions::EMITNOTEHASH:
         return { EMITNOTEHASH_Instruction{ .note_hash_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
@@ -780,6 +794,38 @@ void mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64&
     }
 }
 
+void mutate_mov_8_instruction(MOV_8_Instruction& instruction, std::mt19937_64& rng)
+{
+    int choice = std::uniform_int_distribution<int>(0, 2)(rng);
+    switch (choice) {
+    case 0:
+        mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
+        break;
+    case 1:
+        mutate_param_ref(instruction.src_address, rng, std::nullopt, MAX_8BIT_OPERAND);
+        break;
+    case 2:
+        mutate_address_ref(instruction.result_address, rng, MAX_8BIT_OPERAND);
+        break;
+    }
+}
+
+void mutate_mov_16_instruction(MOV_16_Instruction& instruction, std::mt19937_64& rng)
+{
+    int choice = std::uniform_int_distribution<int>(0, 2)(rng);
+    switch (choice) {
+    case 0:
+        mutate_memory_tag(instruction.value_tag.value, rng, BASIC_MEMORY_TAG_MUTATION_CONFIGURATION);
+        break;
+    case 1:
+        mutate_param_ref(instruction.src_address, rng, std::nullopt, MAX_16BIT_OPERAND);
+        break;
+    case 2:
+        mutate_address_ref(instruction.result_address, rng, MAX_16BIT_OPERAND);
+        break;
+    }
+}
+
 void mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64& rng)
 {
 
@@ -895,6 +941,22 @@ void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instructio
         mutate_address_ref(instruction.contract_address_address, rng, MAX_16BIT_OPERAND);
         break;
     case NullifierExistsMutationOptions::result_address:
+        mutate_address_ref(instruction.result_address, rng, MAX_16BIT_OPERAND);
+        break;
+    }
+}
+
+void mutate_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction& instruction, std::mt19937_64& rng)
+{
+    L1ToL2MsgExistsMutationOptions option = BASIC_L1TOL2MSGEXISTS_MUTATION_CONFIGURATION.select(rng);
+    switch (option) {
+    case L1ToL2MsgExistsMutationOptions::msg_hash_address:
+        mutate_param_ref(instruction.msg_hash_address, rng, MemoryTag::FF, MAX_16BIT_OPERAND);
+        break;
+    case L1ToL2MsgExistsMutationOptions::leaf_index_address:
+        mutate_param_ref(instruction.leaf_index_address, rng, MemoryTag::U64, MAX_16BIT_OPERAND);
+        break;
+    case L1ToL2MsgExistsMutationOptions::result_address:
         mutate_address_ref(instruction.result_address, rng, MAX_16BIT_OPERAND);
         break;
     }
@@ -1181,6 +1243,9 @@ void mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt199
     case ToRadixBEMutationOptions::dst_address:
         mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);
         break;
+    case ToRadixBEMutationOptions::is_output_bits:
+        instruction.is_output_bits = !instruction.is_output_bits;
+        break;
     }
 }
 
@@ -1206,6 +1271,8 @@ void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng)
             [&rng](SET_64_Instruction& instr) { mutate_set_64_instruction(instr, rng); },
             [&rng](SET_128_Instruction& instr) { mutate_set_128_instruction(instr, rng); },
             [&rng](SET_FF_Instruction& instr) { mutate_set_ff_instruction(instr, rng); },
+            [&rng](MOV_8_Instruction& instr) { mutate_mov_8_instruction(instr, rng); },
+            [&rng](MOV_16_Instruction& instr) { mutate_mov_16_instruction(instr, rng); },
             [&rng](FDIV_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
             [&rng](NOT_8_Instruction& instr) { mutate_not_8_instruction(instr, rng); },
             [&rng](ADD_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
@@ -1229,6 +1296,7 @@ void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng)
             [&rng](GETENVVAR_Instruction& instr) { mutate_getenvvar_instruction(instr, rng); },
             [&rng](EMITNULLIFIER_Instruction& instr) { mutate_emit_nullifier_instruction(instr, rng); },
             [&rng](NULLIFIEREXISTS_Instruction& instr) { mutate_nullifier_exists_instruction(instr, rng); },
+            [&rng](L1TOL2MSGEXISTS_Instruction& instr) { mutate_l1tol2msgexists_instruction(instr, rng); },
             [&rng](EMITNOTEHASH_Instruction& instr) { mutate_emit_note_hash_instruction(instr, rng); },
             [&rng](NOTEHASHEXISTS_Instruction& instr) { mutate_note_hash_exists_instruction(instr, rng); },
             [&rng](CALLDATACOPY_Instruction& instr) { mutate_calldatacopy_instruction(instr, rng); },

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -302,6 +302,62 @@ std::vector<FuzzInstruction> generate_sha256compression_instruction(std::mt19937
     return instructions;
 }
 
+std::vector<FuzzInstruction> generate_toradixbe_instruction(std::mt19937_64& rng)
+{
+    bool use_backfill = std::uniform_int_distribution<int>(0, 1)(rng) == 0;
+    if (!use_backfill) {
+        // Random mode
+        return { TORADIXBE_Instruction{ .value_address = generate_variable_ref(rng),
+                                        .radix_address = generate_variable_ref(rng),
+                                        .num_limbs_address = generate_variable_ref(rng),
+                                        .output_bits_address = generate_variable_ref(rng),
+                                        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+    // Backfill mode: set up proper typed values
+    // value: FF, radix: U32, num_limbs: U32, output_bits: U1
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(5);
+
+    AddressRef value_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef radix_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef num_limbs_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef output_bits_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
+
+    // SET the radix (U32) - pick radix between 2 and 256
+    uint32_t radix = std::uniform_int_distribution<uint32_t>(2, 256)(rng);
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = radix_addr, .value = radix });
+
+    // SET the num_limbs (U32) - reasonable range based on radix
+    uint32_t num_limbs = std::uniform_int_distribution<uint32_t>(1, 256)(rng);
+    instructions.push_back(SET_32_Instruction{
+        .value_tag = bb::avm2::MemoryTag::U32, .result_address = num_limbs_addr, .value = num_limbs });
+
+    // SET the output_bits (U1)
+    bool is_output_bits = radix == 2;
+    instructions.push_back(SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
+                                              .result_address = output_bits_addr,
+                                              .value = static_cast<uint8_t>(is_output_bits ? 1 : 0) });
+    // Pick the value such that it fits within the specified number of limbs and radix, if we truncate it will error
+    bb::avm2::FF value = 0;
+    bb::avm2::FF exponent = radix;
+    for (uint32_t i = 0; i < num_limbs; i++) {
+        value += bb::avm2::FF(generate_random_uint32(rng) % radix) * exponent;
+        exponent *= radix;
+    }
+    // SET the value (FF)
+    instructions.push_back(
+        SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = value_addr, .value = value });
+
+    // TORADIXBE instruction
+    instructions.push_back(TORADIXBE_Instruction{ .value_address = value_addr,
+                                                  .radix_address = radix_addr,
+                                                  .num_limbs_address = num_limbs_addr,
+                                                  .output_bits_address = output_bits_addr,
+                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+    return instructions;
+}
+
 std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
 {
     InstructionGenerationOptions option = BASIC_INSTRUCTION_GENERATION_CONFIGURATION.select(rng);
@@ -496,6 +552,8 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
         return generate_keccakf_instruction(rng);
     case InstructionGenerationOptions::SHA256COMPRESSION:
         return generate_sha256compression_instruction(rng);
+    case InstructionGenerationOptions::TORADIXBE:
+        return generate_toradixbe_instruction(rng);
     }
 }
 /// Most of the tags will be equal to the default tag
@@ -1104,6 +1162,28 @@ void mutate_sha256compression_instruction(SHA256COMPRESSION_Instruction& instruc
     }
 }
 
+void mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt19937_64& rng)
+{
+    ToRadixBEMutationOptions option = BASIC_TORADIXBE_MUTATION_CONFIGURATION.select(rng);
+    switch (option) {
+    case ToRadixBEMutationOptions::value_address:
+        mutate_param_ref(instruction.value_address, rng, MemoryTag::FF, MAX_16BIT_OPERAND);
+        break;
+    case ToRadixBEMutationOptions::radix_address:
+        mutate_param_ref(instruction.radix_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
+        break;
+    case ToRadixBEMutationOptions::num_limbs_address:
+        mutate_param_ref(instruction.num_limbs_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
+        break;
+    case ToRadixBEMutationOptions::output_bits_address:
+        mutate_param_ref(instruction.output_bits_address, rng, MemoryTag::U1, MAX_16BIT_OPERAND);
+        break;
+    case ToRadixBEMutationOptions::dst_address:
+        mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);
+        break;
+    }
+}
+
 void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng)
 {
     std::visit(
@@ -1164,6 +1244,7 @@ void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng)
             [&rng](POSEIDON2PERM_Instruction& instr) { mutate_poseidon2perm_instruction(instr, rng); },
             [&rng](KECCAKF1600_Instruction& instr) { mutate_keccakf1600_instruction(instr, rng); },
             [&rng](SHA256COMPRESSION_Instruction& instr) { mutate_sha256compression_instruction(instr, rng); },
+            [&rng](TORADIXBE_Instruction& instr) { mutate_toradixbe_instruction(instr, rng); },
             [](auto&) { throw std::runtime_error("Unknown instruction"); } },
         instruction);
 }


### PR DESCRIPTION
To Radix BE for the fuzzer. Contains a method to generate the toradix "smartly" since there are many ways for it to fail early

I folded the PR that was previously on top of this as it contained some fixes for toradixBE. That PR also had a bunch more stuff for L1L2MsgExists and MOV