### PR TITLE
fix(avm_differential_fuzzer): fix memory leak in ContractDBProxy 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/contract_db_proxy.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/contract_db_proxy.cpp
@@ -147,6 +147,7 @@ FF ContractDBProxy::get_function_address(size_t index)
 void ContractDBProxy::reset_instance()
 {
     if (instance != nullptr) {
+        delete instance->contract_db;
         delete instance;
         instance = new ContractDBProxy();
     }


### PR DESCRIPTION
I forgot to delete contractdb... 