### PR TITLE
fix(avm): Add cancellation token to prevent C++ simulation race condition on timeout

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/cached_content_addressed_tree_store.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/cached_content_addressed_tree_store.hpp
@@ -273,31 +273,36 @@ ContentAddressedCachedTreeStore<LeafValueType>::ContentAddressedCachedTreeStore(
 }
 
 // Much Like the commit/rollback/set finalized/remove historic blocks apis
-// These 3 apis (checkpoint/revert_checkpoint/commit_checkpoint) all assume they are not called
-// during the process of reading/writing uncommitted state
-// This is reasonable, they intended for use by forks at the point of starting/ending a function call
+// These checkpoint apis modify the cache's internal state.
+// They acquire the mutex to prevent races with concurrent read/write operations (e.g., when C++ AVM simulation
+// runs on a worker thread while TypeScript calls revert_checkpoint from a timeout handler).
 template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValueType>::checkpoint()
 {
+    std::unique_lock lock(mtx_);
     cache_.checkpoint();
 }
 
 template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValueType>::revert_checkpoint()
 {
+    std::unique_lock lock(mtx_);
     cache_.revert();
 }
 
 template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValueType>::commit_checkpoint()
 {
+    std::unique_lock lock(mtx_);
     cache_.commit();
 }
 
 template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValueType>::revert_all_checkpoints()
 {
+    std::unique_lock lock(mtx_);
     cache_.revert_all();
 }
 
 template <typename LeafValueType> void ContentAddressedCachedTreeStore<LeafValueType>::commit_all_checkpoints()
 {
+    std::unique_lock lock(mtx_);
     cache_.commit_all();
 }
 

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.cpp
@@ -10,6 +10,7 @@
 #include "barretenberg/serialize/msgpack_impl/msgpack_impl.hpp"
 #include "barretenberg/vm2/avm_sim_api.hpp"
 #include "barretenberg/vm2/common/avm_io.hpp"
+#include "barretenberg/vm2/simulation/lib/cancellation_token.hpp"
 
 namespace bb::nodejs {
 
@@ -116,15 +117,16 @@ Napi::Value AvmSimulateNapi::simulate(const Napi::CallbackInfo& cb_info)
 {
     Napi::Env env = cb_info.Env();
 
-    // Validate arguments - expects 4 arguments
+    // Validate arguments - expects 4-5 arguments
     // arg[0]: inputs Buffer (required)
     // arg[1]: contractProvider object (required)
     // arg[2]: worldStateHandle external (required)
     // arg[3]: logLevel number (required) - index into TS LogLevels array
+    // arg[4]: cancellationToken external (optional)
     if (cb_info.Length() < 4) {
         throw Napi::TypeError::New(env,
-                                   "Wrong number of arguments. Expected 4 arguments: inputs Buffer, contractProvider "
-                                   "object, worldStateHandle, and logLevel.");
+                                   "Wrong number of arguments. Expected 4-5 arguments: inputs Buffer, contractProvider "
+                                   "object, worldStateHandle, logLevel, and optional cancellationToken.");
     }
 
     if (!cb_info[0].IsBuffer()) {
@@ -142,6 +144,19 @@ Napi::Value AvmSimulateNapi::simulate(const Napi::CallbackInfo& cb_info)
 
     if (!cb_info[3].IsNumber()) {
         throw Napi::TypeError::New(env, "Fourth argument must be a log level number (0-7)");
+    }
+
+    // Extract optional cancellation token (5th argument)
+    avm2::simulation::CancellationTokenPtr cancellation_token = nullptr;
+    if (cb_info.Length() > 4 && cb_info[4].IsExternal()) {
+        auto token_external = cb_info[4].As<Napi::External<avm2::simulation::CancellationToken>>();
+        // Wrap the raw pointer in a shared_ptr that does NOT delete (since the External owns it)
+        cancellation_token = std::shared_ptr<avm2::simulation::CancellationToken>(
+            token_external.Data(), [](avm2::simulation::CancellationToken*) {
+                // No-op deleter: the External
+                // (via shared_ptr destructor
+                // callback) owns the token
+            });
     }
 
     // Extract log level and set logging flags
@@ -189,42 +204,46 @@ Napi::Value AvmSimulateNapi::simulate(const Napi::CallbackInfo& cb_info)
     auto deferred = std::make_shared<Napi::Promise::Deferred>(env);
 
     // Create async operation that will run on a worker thread
-    auto* op = new AsyncOperation(env, deferred, [data, tsfns, ws_ptr](msgpack::sbuffer& result_buffer) {
-        // Ensure all thread-safe functions are released in all code paths
-        TsfnReleaser releaser = TsfnReleaser(tsfns.to_vector());
+    auto* op =
+        new AsyncOperation(env, deferred, [data, tsfns, ws_ptr, cancellation_token](msgpack::sbuffer& result_buffer) {
+            // Ensure all thread-safe functions are released in all code paths
+            TsfnReleaser releaser = TsfnReleaser(tsfns.to_vector());
 
-        try {
-            // Deserialize inputs from msgpack
-            avm2::AvmFastSimulationInputs inputs;
-            msgpack::object_handle obj_handle =
-                msgpack::unpack(reinterpret_cast<const char*>(data->data()), data->size());
-            msgpack::object obj = obj_handle.get();
-            obj.convert(inputs);
+            try {
+                // Deserialize inputs from msgpack
+                avm2::AvmFastSimulationInputs inputs;
+                msgpack::object_handle obj_handle =
+                    msgpack::unpack(reinterpret_cast<const char*>(data->data()), data->size());
+                msgpack::object obj = obj_handle.get();
+                obj.convert(inputs);
 
-            // Create TsCallbackContractDB with TypeScript callbacks
-            TsCallbackContractDB contract_db(*tsfns.instance,
-                                             *tsfns.class_,
-                                             *tsfns.add_contracts,
-                                             *tsfns.bytecode,
-                                             *tsfns.debug_name,
-                                             *tsfns.create_checkpoint,
-                                             *tsfns.commit_checkpoint,
-                                             *tsfns.revert_checkpoint);
+                // Create TsCallbackContractDB with TypeScript callbacks
+                TsCallbackContractDB contract_db(*tsfns.instance,
+                                                 *tsfns.class_,
+                                                 *tsfns.add_contracts,
+                                                 *tsfns.bytecode,
+                                                 *tsfns.debug_name,
+                                                 *tsfns.create_checkpoint,
+                                                 *tsfns.commit_checkpoint,
+                                                 *tsfns.revert_checkpoint);
 
-            // Create AVM API and run simulation with the callback-based contracts DB and
-            // WorldState reference
-            avm2::AvmSimAPI avm;
-            avm2::TxSimulationResult result = avm.simulate(inputs, contract_db, *ws_ptr);
+                // Create AVM API and run simulation with the callback-based contracts DB,
+                // WorldState reference, and optional cancellation token
+                avm2::AvmSimAPI avm;
+                avm2::TxSimulationResult result = avm.simulate(inputs, contract_db, *ws_ptr, cancellation_token);
 
-            // Serialize the simulation result with msgpack into the return buffer to TS.
-            msgpack::pack(result_buffer, result);
-        } catch (const std::exception& e) {
-            // Rethrow with context (RAII wrappers will clean up automatically)
-            throw std::runtime_error(std::string("AVM simulation failed: ") + e.what());
-        } catch (...) {
-            throw std::runtime_error("AVM simulation failed with unknown exception");
-        }
-    });
+                // Serialize the simulation result with msgpack into the return buffer to TS.
+                msgpack::pack(result_buffer, result);
+            } catch (const avm2::simulation::CancelledException& e) {
+                // Cancellation is an expected condition, rethrow with context
+                throw std::runtime_error("Simulation cancelled");
+            } catch (const std::exception& e) {
+                // Rethrow with context (RAII wrappers will clean up automatically)
+                throw std::runtime_error(std::string("AVM simulation failed: ") + e.what());
+            } catch (...) {
+                throw std::runtime_error("AVM simulation failed with unknown exception");
+            }
+        });
 
     // Napi is now responsible for destroying this object
     op->Queue();
@@ -297,6 +316,36 @@ Napi::Value AvmSimulateNapi::simulateWithHintedDbs(const Napi::CallbackInfo& cb_
     op->Queue();
 
     return deferred->Promise();
+}
+
+Napi::Value AvmSimulateNapi::createCancellationToken(const Napi::CallbackInfo& cb_info)
+{
+    Napi::Env env = cb_info.Env();
+
+    // Create a new CancellationToken. We use a shared_ptr to manage the lifetime,
+    // and the destructor callback in the External will clean it up when GC runs.
+    auto* token = new avm2::simulation::CancellationToken();
+
+    // Create an External with a destructor callback that deletes the token
+    return Napi::External<avm2::simulation::CancellationToken>::New(
+        env, token, [](Napi::Env /*env*/, avm2::simulation::CancellationToken* t) { delete t; });
+}
+
+Napi::Value AvmSimulateNapi::cancelSimulation(const Napi::CallbackInfo& cb_info)
+{
+    Napi::Env env = cb_info.Env();
+
+    if (cb_info.Length() < 1 || !cb_info[0].IsExternal()) {
+        throw Napi::TypeError::New(env, "Expected a CancellationToken External as argument");
+    }
+
+    auto token_external = cb_info[0].As<Napi::External<avm2::simulation::CancellationToken>>();
+    avm2::simulation::CancellationToken* token = token_external.Data();
+
+    // Signal cancellation - this is thread-safe (atomic store)
+    token->cancel();
+
+    return env.Undefined();
 }
 
 } // namespace bb::nodejs

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/avm_simulate/avm_simulate_napi.hpp
@@ -26,6 +26,8 @@ class AvmSimulateNapi {
      *   - getContractInstance(address: string): Promise<Buffer | undefined>
      *   - getContractClass(classId: string): Promise<Buffer | undefined>
      * - info[2]: External WorldState handle (pointer to world_state::WorldState)
+     * - info[3]: Log level number (0-7)
+     * - info[4]: External CancellationToken handle (optional)
      *
      * Returns: Promise<Buffer> containing serialized simulation results
      *
@@ -33,6 +35,7 @@ class AvmSimulateNapi {
      * @return Napi::Value Promise that resolves with simulation results
      */
     static Napi::Value simulate(const Napi::CallbackInfo& info);
+
     /**
      * @brief NAPI function to simulate AVM execution with pre-collected hints
      *
@@ -43,6 +46,27 @@ class AvmSimulateNapi {
      * @return Napi::Value Promise that resolves with simulation results
      */
     static Napi::Value simulateWithHintedDbs(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Create a cancellation token that can be used to cancel a simulation.
+     *
+     * Returns: External<CancellationToken> - a handle to a new cancellation token
+     *
+     * @param info NAPI callback info (no arguments expected)
+     * @return Napi::Value External handle to the cancellation token
+     */
+    static Napi::Value createCancellationToken(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Cancel a simulation by signaling the provided cancellation token.
+     *
+     * Expected arguments:
+     * - info[0]: External CancellationToken handle
+     *
+     * @param info NAPI callback info containing the token
+     * @return Napi::Value undefined
+     */
+    static Napi::Value cancelSimulation(const Napi::CallbackInfo& info);
 };
 
 } // namespace bb::nodejs

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/init_module.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/init_module.cpp
@@ -16,6 +16,10 @@ Napi::Object Init(Napi::Env env, Napi::Object exports)
     exports.Set(Napi::String::New(env, "avmSimulate"), Napi::Function::New(env, bb::nodejs::AvmSimulateNapi::simulate));
     exports.Set(Napi::String::New(env, "avmSimulateWithHintedDbs"),
                 Napi::Function::New(env, bb::nodejs::AvmSimulateNapi::simulateWithHintedDbs));
+    exports.Set(Napi::String::New(env, "createCancellationToken"),
+                Napi::Function::New(env, bb::nodejs::AvmSimulateNapi::createCancellationToken));
+    exports.Set(Napi::String::New(env, "cancelSimulation"),
+                Napi::Function::New(env, bb::nodejs::AvmSimulateNapi::cancelSimulation));
     return exports;
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.cpp
@@ -10,7 +10,8 @@ using namespace bb::avm2::simulation;
 
 TxSimulationResult AvmSimAPI::simulate(const FastSimulationInputs& inputs,
                                        simulation::ContractDBInterface& contract_db,
-                                       world_state::WorldState& ws)
+                                       world_state::WorldState& ws,
+                                       simulation::CancellationTokenPtr cancellation_token)
 {
     vinfo("Simulating...");
     AvmSimulationHelper simulation_helper;
@@ -23,7 +24,8 @@ TxSimulationResult AvmSimAPI::simulate(const FastSimulationInputs& inputs,
                                                                                inputs.config,
                                                                                inputs.tx,
                                                                                inputs.global_variables,
-                                                                               inputs.protocol_contracts));
+                                                                               inputs.protocol_contracts,
+                                                                               cancellation_token));
     } else {
         return AVM_TRACK_TIME_V("simulation/all",
                                 simulation_helper.simulate_fast_with_existing_ws(contract_db,
@@ -32,7 +34,8 @@ TxSimulationResult AvmSimAPI::simulate(const FastSimulationInputs& inputs,
                                                                                  inputs.config,
                                                                                  inputs.tx,
                                                                                  inputs.global_variables,
-                                                                                 inputs.protocol_contracts));
+                                                                                 inputs.protocol_contracts,
+                                                                                 cancellation_token));
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/avm_sim_api.hpp
@@ -2,6 +2,7 @@
 
 #include "barretenberg/vm2/common/avm_io.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
+#include "barretenberg/vm2/simulation/lib/cancellation_token.hpp"
 
 namespace bb::avm2 {
 
@@ -14,7 +15,8 @@ class AvmSimAPI {
 
     TxSimulationResult simulate(const FastSimulationInputs& inputs,
                                 simulation::ContractDBInterface& contract_db,
-                                world_state::WorldState& ws);
+                                world_state::WorldState& ws,
+                                simulation::CancellationTokenPtr cancellation_token = nullptr);
     TxSimulationResult simulate_with_hinted_dbs(const AvmProvingInputs& inputs);
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -1724,6 +1724,11 @@ EnqueuedCallResult Execution::execute(std::unique_ptr<ContextInterface> enqueued
     external_call_stack.push(std::move(enqueued_call_context));
 
     while (!external_call_stack.empty()) {
+        // Throws CancelledException if cancelled. No-op when cancellation_token_ is nullptr (non-NAPI paths).
+        if (cancellation_token_) {
+            cancellation_token_->check_and_throw();
+        }
+
         // We fix the context at this point. Even if the opcode changes the stack
         // we'll always use this in the loop.
         auto& context = *external_call_stack.top();

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
@@ -30,6 +30,7 @@
 #include "barretenberg/vm2/simulation/interfaces/poseidon2.hpp"
 #include "barretenberg/vm2/simulation/interfaces/sha256.hpp"
 #include "barretenberg/vm2/simulation/interfaces/to_radix.hpp"
+#include "barretenberg/vm2/simulation/lib/cancellation_token.hpp"
 #include "barretenberg/vm2/simulation/lib/execution_id_manager.hpp"
 #include "barretenberg/vm2/simulation/lib/instruction_info.hpp"
 #include "barretenberg/vm2/simulation/lib/serialization.hpp"
@@ -79,7 +80,8 @@ class Execution : public ExecutionInterface {
               EmitUnencryptedLogInterface& emit_unencrypted_log_component,
               DebugLoggerInterface& debug_log_component,
               HighLevelMerkleDBInterface& merkle_db,
-              CallStackMetadataCollectorInterface& call_stack_metadata_collector)
+              CallStackMetadataCollectorInterface& call_stack_metadata_collector,
+              CancellationTokenPtr cancellation_token = nullptr)
         : execution_components(execution_components)
         , instruction_info_db(instruction_info_db)
         , alu(alu)
@@ -100,6 +102,7 @@ class Execution : public ExecutionInterface {
         , events(event_emitter)
         , ctx_stack_events(ctx_stack_emitter)
         , call_stack_metadata_collector(call_stack_metadata_collector)
+        , cancellation_token_(std::move(cancellation_token))
     {}
 
     EnqueuedCallResult execute(std::unique_ptr<ContextInterface> enqueued_call_context) override;
@@ -265,6 +268,10 @@ class Execution : public ExecutionInterface {
     std::vector<MemoryValue> inputs;
     MemoryValue output;
     std::unique_ptr<GasTrackerInterface> gas_tracker;
+
+    // Optional cancellation token for stopping simulation on timeout.
+    // When nullptr, cancellation checks are skipped (no overhead for non-NAPI paths).
+    CancellationTokenPtr cancellation_token_;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/cancellation_token.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/cancellation_token.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+
+namespace bb::avm2::simulation {
+
+/**
+ * @brief Exception thrown when simulation is cancelled.
+ */
+class CancelledException : public std::runtime_error {
+  public:
+    CancelledException()
+        : std::runtime_error("Simulation cancelled")
+    {}
+};
+
+/**
+ * @brief A thread-safe cancellation token for C++ AVM simulation.
+ *
+ * This token is used to signal cancellation from TypeScript to C++ when a simulation
+ * times out. The token is created in TypeScript, passed through NAPI, and checked
+ * periodically during C++ execution.
+ *
+ * Usage:
+ * - TypeScript creates the token and passes it to avmSimulate
+ * - C++ checks is_cancelled() in the execution loop
+ * - On timeout, TypeScript calls cancel()
+ * - C++ throws CancelledException when it observes cancellation
+ *
+ * Thread safety:
+ * - cancel() is called from the TypeScript/main thread
+ * - is_cancelled()/check() are called from the libuv worker thread
+ * - std::atomic ensures visibility between threads
+ */
+class CancellationToken {
+  public:
+    CancellationToken()
+        : cancelled_(false)
+    {}
+
+    // Non-copyable, non-movable
+    CancellationToken(const CancellationToken&) = delete;
+    CancellationToken& operator=(const CancellationToken&) = delete;
+    CancellationToken(CancellationToken&&) = delete;
+    CancellationToken& operator=(CancellationToken&&) = delete;
+
+    /**
+     * @brief Signal cancellation. Called from TypeScript thread.
+     *
+     * This is thread-safe and can be called while C++ simulation is running.
+     */
+    void cancel() { cancelled_.store(true, std::memory_order_release); }
+
+    /**
+     * @brief Check if cancellation has been signaled. Called from C++ simulation thread.
+     *
+     * @return true if cancel() has been called
+     */
+    bool is_cancelled() const { return cancelled_.load(std::memory_order_acquire); }
+
+    /**
+     * @brief Check and throw if cancelled. Called from C++ simulation thread.
+     *
+     * @throws CancelledException if cancel() has been called
+     */
+    void check_and_throw() const
+    {
+        if (is_cancelled()) {
+            throw CancelledException();
+        }
+    }
+
+  private:
+    std::atomic<bool> cancelled_;
+};
+
+using CancellationTokenPtr = std::shared_ptr<CancellationToken>;
+
+} // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
@@ -754,6 +754,9 @@ IndexedLeaf<NullifierLeafValue> PureRawMerkleDB::get_leaf_preimage_nullifier_tre
 SequentialInsertionResult<PublicDataLeafValue> PureRawMerkleDB::insert_indexed_leaves_public_data_tree(
     const PublicDataLeafValue& leaf_value)
 {
+    // Throws CancelledException if cancelled.
+    throw_if_cancelled();
+
     // Invalidate the cached tree roots.
     cached_tree_snapshots = std::nullopt;
 
@@ -765,6 +768,9 @@ SequentialInsertionResult<PublicDataLeafValue> PureRawMerkleDB::insert_indexed_l
 SequentialInsertionResult<NullifierLeafValue> PureRawMerkleDB::insert_indexed_leaves_nullifier_tree(
     const NullifierLeafValue& leaf_value)
 {
+    // Throws CancelledException if cancelled.
+    throw_if_cancelled();
+
     // Invalidate the cached tree roots.
     cached_tree_snapshots = std::nullopt;
 
@@ -775,6 +781,9 @@ SequentialInsertionResult<NullifierLeafValue> PureRawMerkleDB::insert_indexed_le
 
 void PureRawMerkleDB::append_leaves(MerkleTreeId tree_id, std::span<const FF> leaves)
 {
+    // Throws CancelledException if cancelled.
+    throw_if_cancelled();
+
     // Invalidate the cached tree roots.
     cached_tree_snapshots = std::nullopt;
 
@@ -783,6 +792,9 @@ void PureRawMerkleDB::append_leaves(MerkleTreeId tree_id, std::span<const FF> le
 
 void PureRawMerkleDB::pad_tree(MerkleTreeId tree_id, size_t num_leaves)
 {
+    // Throws CancelledException if cancelled.
+    throw_if_cancelled();
+
     // Invalidate the cached tree roots.
     cached_tree_snapshots = std::nullopt;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/common/map.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
+#include "barretenberg/vm2/simulation/lib/cancellation_token.hpp"
 #include "barretenberg/vm2/simulation/lib/db_types.hpp"
 #include "barretenberg/vm2/simulation/lib/written_slots_tree.hpp"
 #include "barretenberg/world_state/types.hpp"
@@ -121,13 +122,16 @@ class PureRawMerkleDB final : public LowLevelMerkleDBInterface {
      *  If true, the tree roots will be cached and returned by get_tree_roots().
      *  If false, the tree roots will be fetched from the world state on each call to get_tree_roots().
      *  It is important to note that if caching is ON, you are assuming nobody else could concurrently modify the trees.
+     * @param cancellation_token Optional cancellation token for stopping writes on timeout.
      */
     PureRawMerkleDB(world_state::WorldStateRevision ws_revision,
                     world_state::WorldState& ws_instance,
-                    bool cache_tree_roots = true)
+                    bool cache_tree_roots = true,
+                    CancellationTokenPtr cancellation_token = nullptr)
         : ws_revision(ws_revision)
         , ws_instance(ws_instance)
         , cache_tree_roots(cache_tree_roots)
+        , cancellation_token_(std::move(cancellation_token))
     {}
 
     TreeSnapshots get_tree_roots() const override;
@@ -153,11 +157,20 @@ class PureRawMerkleDB final : public LowLevelMerkleDBInterface {
     uint32_t get_checkpoint_id() const override;
 
   private:
+    // Helper to check cancellation before write operations - throws CancelledException if cancelled
+    void throw_if_cancelled() const
+    {
+        if (cancellation_token_) {
+            cancellation_token_->check_and_throw();
+        }
+    }
+
     world_state::WorldStateRevision ws_revision;
     world_state::WorldState& ws_instance;
     std::stack<uint32_t> checkpoint_stack{ { 0 } };
     bool cache_tree_roots;
     mutable std::optional<TreeSnapshots> cached_tree_snapshots;
+    CancellationTokenPtr cancellation_token_;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
@@ -26,6 +26,11 @@ EnqueuedCallResult HybridExecution::execute(std::unique_ptr<ContextInterface> en
     external_call_stack.push(std::move(enqueued_call_context));
 
     while (!external_call_stack.empty()) {
+        // Throws CancelledException if cancelled. No-op when cancellation_token_ is nullptr (non-NAPI paths).
+        if (cancellation_token_) {
+            cancellation_token_->check_and_throw();
+        }
+
         // We fix the context at this point. Even if the opcode changes the stack
         // we'll always use this in the loop.
         auto& context = *external_call_stack.top();

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -389,7 +389,8 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_internal(ContractDBInterfa
                                                                const PublicSimulatorConfig& config,
                                                                const Tx& tx,
                                                                const GlobalVariables& global_variables,
-                                                               const ProtocolContracts& protocol_contracts)
+                                                               const ProtocolContracts& protocol_contracts,
+                                                               CancellationTokenPtr cancellation_token)
 {
     BB_BENCH_NAME("AvmSimulationHelper::simulate_fast_internal");
 
@@ -507,7 +508,8 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_internal(ContractDBInterfa
                               emit_unencrypted_log_component,
                               *debug_log_component,
                               merkle_db,
-                              *call_stack_metadata_collector);
+                              *call_stack_metadata_collector,
+                              cancellation_token);
     TxExecution tx_execution(execution,
                              context_provider,
                              contract_db,
@@ -560,15 +562,17 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_with_existing_ws(
     const PublicSimulatorConfig& config,
     const Tx& tx,
     const GlobalVariables& global_variables,
-    const ProtocolContracts& protocol_contracts)
+    const ProtocolContracts& protocol_contracts,
+    CancellationTokenPtr cancellation_token)
 {
     // For collecting hints, use the other method.
     BB_ASSERT(!config.collect_hints && "Use simulate_for_hint_collection instead");
 
-    // Create PureRawMerkleDB with the provided WorldState instance
-    PureRawMerkleDB raw_merkle_db(world_state_revision, ws);
+    // Create PureRawMerkleDB with the provided WorldState instance and cancellation token
+    PureRawMerkleDB raw_merkle_db(world_state_revision, ws, /*cache_tree_roots=*/true, cancellation_token);
 
-    return simulate_fast_internal(raw_contract_db, raw_merkle_db, config, tx, global_variables, protocol_contracts);
+    return simulate_fast_internal(
+        raw_contract_db, raw_merkle_db, config, tx, global_variables, protocol_contracts, cancellation_token);
 }
 
 TxSimulationResult AvmSimulationHelper::simulate_for_hint_collection(
@@ -578,13 +582,14 @@ TxSimulationResult AvmSimulationHelper::simulate_for_hint_collection(
     const PublicSimulatorConfig& config,
     const Tx& tx,
     const GlobalVariables& global_variables,
-    const ProtocolContracts& protocol_contracts)
+    const ProtocolContracts& protocol_contracts,
+    CancellationTokenPtr cancellation_token)
 {
     // If you are not collecting hints, don't use this method.
     BB_ASSERT(config.collect_hints && "Use simulate_fast_with_existing_ws instead");
 
-    // Create PureRawMerkleDB with the provided WorldState instance
-    PureRawMerkleDB raw_merkle_db(world_state_revision, ws);
+    // Create PureRawMerkleDB with the provided WorldState instance and cancellation token
+    PureRawMerkleDB raw_merkle_db(world_state_revision, ws, /*cache_tree_roots=*/true, cancellation_token);
 
     auto starting_tree_roots = raw_merkle_db.get_tree_roots();
     HintingContractsDB hinting_contract_db(raw_contract_db);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.hpp
@@ -5,6 +5,7 @@
 #include "barretenberg/vm2/simulation/events/events_container.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/interfaces/execution.hpp"
+#include "barretenberg/vm2/simulation/lib/cancellation_token.hpp"
 
 namespace bb::avm2 {
 
@@ -17,7 +18,8 @@ class AvmSimulationHelper {
                                                       const PublicSimulatorConfig& config,
                                                       const Tx& tx,
                                                       const GlobalVariables& global_variables,
-                                                      const ProtocolContracts& protocol_contracts);
+                                                      const ProtocolContracts& protocol_contracts,
+                                                      simulation::CancellationTokenPtr cancellation_token = nullptr);
 
     // Simulation to collect hints (used by the prover node).
     TxSimulationResult simulate_for_hint_collection(simulation::ContractDBInterface& raw_contract_db,
@@ -26,7 +28,8 @@ class AvmSimulationHelper {
                                                     const PublicSimulatorConfig& config,
                                                     const Tx& tx,
                                                     const GlobalVariables& global_variables,
-                                                    const ProtocolContracts& protocol_contracts);
+                                                    const ProtocolContracts& protocol_contracts,
+                                                    simulation::CancellationTokenPtr cancellation_token = nullptr);
 
     // Simulation with event collection (used in witgen and proving).
     simulation::EventsContainer simulate_for_witgen(const ExecutionHints& hints);
@@ -40,7 +43,8 @@ class AvmSimulationHelper {
                                               const PublicSimulatorConfig& config,
                                               const Tx& tx,
                                               const GlobalVariables& global_variables,
-                                              const ProtocolContracts& protocol_contracts);
+                                              const ProtocolContracts& protocol_contracts,
+                                              simulation::CancellationTokenPtr cancellation_token = nullptr);
 
     template <template <typename> class DefaultEventEmitter, template <typename> class DefaultDeduplicatingEventEmitter>
     std::tuple<simulation::EventsContainer, TxSimulationResult> simulate_for_witgen_internal(

--- a/yarn-project/native/src/native_module.ts
+++ b/yarn-project/native/src/native_module.ts
@@ -90,12 +90,41 @@ const nativeAvmSimulate = nativeModule.avmSimulate as (
   contractProvider: ContractProvider,
   worldStateHandle: any,
   logLevel: number,
+  cancellationToken?: any,
 ) => Promise<Buffer>;
 
 const nativeAvmSimulateWithHintedDbs = nativeModule.avmSimulateWithHintedDbs as (
   inputs: Buffer,
   logLevel: number,
 ) => Promise<Buffer>;
+
+const nativeCreateCancellationToken = nativeModule.createCancellationToken as () => any;
+const nativeCancelSimulation = nativeModule.cancelSimulation as (token: any) => void;
+
+/**
+ * Cancellation token handle used to cancel C++ AVM simulation.
+ * The token is created via createCancellationToken() and can be cancelled via cancelSimulation().
+ * Pass it to avmSimulate to enable cancellation support.
+ */
+export type CancellationToken = any;
+
+/**
+ * Create a new cancellation token for C++ simulation.
+ * This token can be passed to avmSimulate and later cancelled via cancelSimulation().
+ * @returns A handle to a cancellation token
+ */
+export function createCancellationToken(): CancellationToken {
+  return nativeCreateCancellationToken();
+}
+
+/**
+ * Signal cancellation to a C++ simulation.
+ * The simulation will stop at the next opcode or before the next WorldState write.
+ * @param token - The cancellation token previously passed to avmSimulate
+ */
+export function cancelSimulation(token: CancellationToken): void {
+  nativeCancelSimulation(token);
+}
 
 /**
  * Concurrency limiting for C++ AVM simulation to prevent libuv thread pool exhaustion.
@@ -119,6 +148,7 @@ const avmSimulationSemaphore = new Semaphore(MAX_CONCURRENT_AVM_SIMULATIONS);
  * @param contractProvider - Object with callbacks for fetching contract instances and classes
  * @param worldStateHandle - Native handle to WorldState instance
  * @param logLevel - Log level to control C++ verbosity
+ * @param cancellationToken - Optional token to enable cancellation support
  * @returns Promise resolving to msgpack-serialized AvmCircuitPublicInputs buffer
  */
 export async function avmSimulate(
@@ -126,10 +156,17 @@ export async function avmSimulate(
   contractProvider: ContractProvider,
   worldStateHandle: any,
   logLevel: LogLevel = 'info',
+  cancellationToken?: CancellationToken,
 ): Promise<Buffer> {
   await avmSimulationSemaphore.acquire();
   try {
-    return await nativeAvmSimulate(inputs, contractProvider, worldStateHandle, LogLevels.indexOf(logLevel));
+    return await nativeAvmSimulate(
+      inputs,
+      contractProvider,
+      worldStateHandle,
+      LogLevels.indexOf(logLevel),
+      cancellationToken,
+    );
   } finally {
     avmSimulationSemaphore.release();
   }

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -225,6 +225,25 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     this.metrics.prettyPrint();
   }
 
+  /**
+   * Cancel the current simulation if one is in progress.
+   * This signals the underlying simulator (e.g., C++) to stop at the next safe point.
+   * Safe to call even if no simulation is in progress.
+   *
+   * @param waitTimeoutMs - If provided, wait up to this many ms for the simulation to actually stop.
+   */
+  public async cancel(waitTimeoutMs?: number): Promise<void> {
+    await this.simulator.cancel?.(waitTimeoutMs);
+  }
+
+  /**
+   * Get the underlying simulator for advanced test scenarios.
+   * Use this when you need direct control over simulation (e.g., for testing cancellation).
+   */
+  public getSimulator(): MeasuredPublicTxSimulatorInterface {
+    return this.simulator;
+  }
+
   async #createPubicCallRequestForCall(
     call: TestEnqueuedCall,
     sender: AztecAddress,

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Test to reproduce the C++ simulation timeout race condition.
+ *
+ * Root Cause: When a timeout fires during C++ AVM simulation:
+ * 1. The C++ simulation continues running on a libuv worker thread
+ * 2. It directly accesses WorldState via the native handle
+ * 3. TypeScript calls checkpoint revert operations
+ * 4. Both paths operate on the same WorldState concurrently
+ *
+ * The key issues were:
+ * - GuardedMerkleTreeOperations does not guard C++ access
+ * - Nothing stops C++ simulation on PublicProcessor deadline
+ */
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { GasFees } from '@aztec/stdlib/gas';
+import { MerkleTreeId, merkleTreeIds } from '@aztec/stdlib/trees';
+import { GlobalVariables } from '@aztec/stdlib/tx';
+import { getTelemetryClient } from '@aztec/telemetry-client';
+import { NativeWorldStateService } from '@aztec/world-state';
+
+import { jest } from '@jest/globals';
+
+import { Opcode } from '../../avm/serialization/instruction_serialization.js';
+import { deployCustomBytecode } from '../../fixtures/custom_bytecode_tester.js';
+import { PublicTxSimulationTester, SimpleContractDataSource } from '../../fixtures/index.js';
+import { SPAM_CONFIGS, type SpamConfig, createOpcodeSpamBytecode } from '../../fixtures/opcode_spammer.js';
+import { PublicContractsDB } from '../../public_db_sources.js';
+import { CppPublicTxSimulator } from '../../public_tx_simulator/cpp_public_tx_simulator.js';
+import { GuardedMerkleTreeOperations } from '../guarded_merkle_tree.js';
+import { PublicProcessor } from '../public_processor.js';
+
+/**
+ * SSTORE spammer - writes to PUBLIC_DATA_TREE.
+ * Uses single contract with infinite loop (no per-TX limit when writing same slot).
+ * Provides continuous writes with NO gaps - ideal for race condition detection.
+ */
+const SSTORE_SPAMMER = SPAM_CONFIGS[Opcode.SSTORE]![0]; // "Same slot (no limit)" variant
+
+jest.setTimeout(120_000);
+
+describe('PublicProcessor C++ Timeout Race Condition', () => {
+  const NUM_ITERATIONS = 5;
+  const logger = createLogger('public-processor-timeout-race');
+
+  const admin = AztecAddress.fromNumber(42);
+
+  let worldStateService: NativeWorldStateService;
+
+  beforeEach(async () => {
+    worldStateService = await NativeWorldStateService.tmp();
+  });
+
+  afterEach(async () => {
+    await worldStateService.close();
+  });
+
+  /**
+   * Helper function to run the race condition test at the PublicTxSimulator level.
+   * Both BUG PROOF and FIX PROOF use IDENTICAL code - the ONLY difference is
+   * whether cancellation is signaled and waited for.
+   *
+   * Uses SSTORE spamming to keep C++ constantly writing to PUBLIC_DATA_TREE.
+   * SSTORE "Same slot" has NO per-TX limit, so it writes continuously without gaps.
+   *
+   * For the BUG proof: Don't call cancel() → C++ continues during reverts → corruption
+   * For the FIX proof: Call cancel(100) → wait for C++ to stop → then revert → no corruption
+   *
+   * @param useCancellation - Whether to call cancel() before reverts
+   * @param spammer - Which spammer config to use (defaults to SSTORE for continuous writes)
+   */
+  async function runRaceConditionTest(
+    useCancellation: boolean,
+    spamConfig: SpamConfig = SSTORE_SPAMMER, // Default to SSTORE for continuous writes
+  ): Promise<number> {
+    let raceObservedCount = 0;
+
+    const globals = GlobalVariables.empty();
+    globals.gasFees = new GasFees(2, 3);
+
+    const contractDataSource = new SimpleContractDataSource();
+    const merkleTrees = await worldStateService.fork();
+    const contractsDB = new PublicContractsDB(contractDataSource);
+
+    const simulator = new CppPublicTxSimulator(merkleTrees, contractsDB, globals);
+
+    const tester = new PublicTxSimulationTester(merkleTrees, contractDataSource, globals);
+    await tester.setFeePayerBalance(admin);
+
+    // Deploy spammer contract(s) based on configuration
+    // Single contract: infinite loop of the target opcode until out of gas
+    const bytecode = createOpcodeSpamBytecode(spamConfig);
+    const contract = await deployCustomBytecode(bytecode, tester, `${spamConfig.label!}_Spammer`);
+    const contractAddress = contract.address;
+    const callArgs: Fr[] = [];
+
+    for (let iteration = 0; iteration < NUM_ITERATIONS; iteration++) {
+      // Ensure any previous simulation is fully stopped before starting a new one
+      await simulator.cancel(1000);
+
+      // Get initial state for trees we need to check
+      const initialTreeInfo = new Map<MerkleTreeId, { size: bigint; root: Buffer }>();
+      for (const treeId of merkleTreeIds()) {
+        const info = await merkleTrees.getTreeInfo(treeId);
+        initialTreeInfo.set(treeId, { size: info.size, root: info.root });
+      }
+
+      // Create checkpoint BEFORE simulation (like PublicProcessor does)
+      await merkleTrees.createCheckpoint();
+
+      // Create transaction that calls the spammer contract
+      const tx = await tester.createTx(admin, [], [{ address: contractAddress, args: callArgs }]);
+
+      // Start C++ simulation (not awaiting - like production timeout behavior!)
+      const simulationPromise = simulator.simulate(tx);
+      // Eagerly add catch to prevent unhandled promise rejection warnings
+      simulationPromise.catch(() => {});
+
+      // No delay - immediately try to catch C++ mid-write
+      // This maximizes the chance of hitting the race condition
+
+      // THE ONLY DIFFERENCE: signal cancellation AND WAIT, or not
+      if (useCancellation) {
+        // FIX - Signal cancellation and WAIT for C++ to actually stop (up to 100ms)
+        // This ensures C++ has finished before we proceed with reverts.
+        await simulator.cancel(100);
+      }
+      // BUG - No cancel, C++ continues running during reverts below
+
+      // Revert checkpoint
+      await merkleTrees.revertCheckpoint();
+
+      // Clean up
+      await merkleTrees.revertAllCheckpoints();
+
+      // Wait for simulation promise for cleanup
+      await Promise.race([simulationPromise.catch(() => {}), sleep(100)]);
+
+      // Check state after everything is cleaned up
+      let anyTreeCorrupted = false;
+      for (const treeId of merkleTreeIds()) {
+        const finalInfo = await merkleTrees.getTreeInfo(treeId);
+        const initialInfo = initialTreeInfo.get(treeId)!;
+        const changed = finalInfo.size !== initialInfo.size || !finalInfo.root.equals(initialInfo.root);
+        if (changed) {
+          anyTreeCorrupted = true;
+          break;
+        }
+      }
+
+      if (anyTreeCorrupted) {
+        raceObservedCount++;
+        // Early exit - bug exists, no need to continue
+        logger.verbose(`Early exit`);
+        return raceObservedCount;
+      }
+    }
+
+    return raceObservedCount;
+  }
+
+  /**
+   * PublicTxSimulation BUG - Demonstrate the race condition WITHOUT cancellation.
+   *
+   * This test proves the bug exists by showing that without cancellation:
+   * - C++ simulation continues running after we call revertCheckpoint
+   * - C++ makes writes AFTER the revert, corrupting state
+   *
+   * The race is non-deterministic, so we run multiple iterations.
+   * This test PASSES if we observe corruption (proving the bug exists).
+   */
+  it('CppPublicTxSimulator BUG PROOF: race condition exists WITHOUT cancellation', async () => {
+    const raceObservedCount = await runRaceConditionTest(false);
+    logger.info(`Race condition observed in ${raceObservedCount}/${NUM_ITERATIONS} iterations (expected: >0)`);
+    expect(raceObservedCount).toBeGreaterThan(0);
+  });
+
+  /**
+   * PublicTxSimulation FIX - Demonstrate the fix WITH cancellation.
+   *
+   * This test proves the fix works by showing that with cancellation:
+   * - We signal C++ to stop before it makes more writes
+   * - C++ checks the token before each write and stops
+   * - No corruption occurs even though we revert while C++ is "running"
+   *
+   * This test PASSES if we observe NO corruption (proving the fix works).
+   */
+  it('CppPublicTxSimulator FIX PROOF: no race condition WITH cancellation', async () => {
+    const raceObservedCount = await runRaceConditionTest(true);
+    logger.info(`Race condition observed in ${raceObservedCount}/${NUM_ITERATIONS} iterations (expected: 0)`);
+    expect(raceObservedCount).toBe(0);
+  });
+
+  /**
+   * Helper to run PublicProcessor timeout test (Level 3).
+   * Both BUG and FIX tests use IDENTICAL code - the ONLY difference is whether
+   * cancel() method exists on the simulator.
+   *
+   * Uses SSTORE spamming to keep C++ constantly writing to PUBLIC_DATA_TREE.
+   * SSTORE "Same slot" has NO per-TX limit, so it writes continuously without gaps.
+   * This is more reliable than EMITNULLIFIER which has a cyclic 63-emit-then-REVERT pattern.
+   *
+   * For the BUG proof: cancel is undefined → PublicProcessor can't wait for C++ → corruption
+   * For the FIX proof: cancel exists → PublicProcessor awaits cancel(100) → C++ stops → no corruption
+   *
+   * Returns the number of times state corruption was observed.
+   *
+   * @param useCancellation - Whether to provide cancel() method to PublicProcessor
+   * @param spammer - Which spammer config to use (defaults to SSTORE for continuous writes)
+   */
+  async function runPublicProcessorTimeoutTest(
+    useCancellation: boolean,
+    spamConfig: SpamConfig = SSTORE_SPAMMER, // Default to SSTORE for continuous writes
+  ): Promise<number> {
+    let corruptionCount = 0;
+
+    const globals = GlobalVariables.empty();
+    globals.gasFees = new GasFees(2, 3);
+
+    const contractDataSource = new SimpleContractDataSource();
+    const merkleTrees = await worldStateService.fork();
+    const contractsDB = new PublicContractsDB(contractDataSource);
+
+    // Set up contracts and balances using a tester on the unguarded fork
+    const tester = new PublicTxSimulationTester(merkleTrees, contractDataSource, globals);
+    await tester.setFeePayerBalance(admin);
+
+    // Deploy spammer contract(s) based on configuration
+    // Single contract: infinite loop of the target opcode until out of gas
+    const bytecode = createOpcodeSpamBytecode(spamConfig);
+    const contract = await deployCustomBytecode(bytecode, tester, `${spamConfig.label!}_Spammer`);
+    const contractAddress = contract.address;
+    const callArgs: Fr[] = [];
+
+    for (let iteration = 0; iteration < NUM_ITERATIONS; iteration++) {
+      // Create fresh guarded tree and processor for each iteration because
+      // GuardedMerkleTreeOperations.stop() is called on timeout and can't be reused.
+      const guardedMerkleTrees = new GuardedMerkleTreeOperations(merkleTrees);
+
+      // Create the real C++ simulator
+      const realSimulator = new CppPublicTxSimulator(guardedMerkleTrees, contractsDB, globals);
+
+      // Track the simulation promise so we can await it for cleanup.
+      // Use an object wrapper to avoid TypeScript control flow analysis issues.
+      const simState = { promise: null as Promise<any> | null };
+
+      // Both tests use IDENTICAL code - the ONLY difference is whether cancel() exists.
+      // PublicProcessor now calls: await this.publicTxSimulator.cancel?.(100)
+      // - FIX - cancel exists, waits for C++ to stop before reverts
+      // - BUG - cancel is undefined, reverts proceed while C++ is still running
+      const simulator = {
+        simulate: (tx: any) => {
+          simState.promise = realSimulator.simulate(tx);
+          return simState.promise;
+        },
+        cancel: useCancellation ? (waitTimeoutMs?: number) => realSimulator.cancel(waitTimeoutMs) : undefined, // No cancel method - PublicProcessor can't wait for C++ to stop
+      };
+
+      // Use TestDateProvider to control time
+      const dateProvider = new TestDateProvider();
+
+      // Create PublicProcessor with the simulator
+      const processor = new PublicProcessor(
+        globals,
+        guardedMerkleTrees,
+        contractsDB,
+        simulator,
+        dateProvider,
+        getTelemetryClient(),
+      );
+
+      // Get initial state for trees we need to check
+      const initialTreeInfo = new Map<MerkleTreeId, { size: bigint; root: Buffer }>();
+      for (const treeId of merkleTreeIds()) {
+        const info = await merkleTrees.getTreeInfo(treeId);
+        initialTreeInfo.set(treeId, { size: info.size, root: info.root });
+      }
+
+      // Create transaction that calls the spammer contract
+      const tx = await tester.createTx(admin, [], [{ address: contractAddress, args: callArgs }]);
+
+      // Calculate deadline RIGHT BEFORE process() to ensure we get the full timeout.
+      // Use a 20ms deadline - enough for C++ to start but short enough to timeout mid-simulation.
+      const deadline = new Date(dateProvider.now() + 20);
+
+      // Process the transaction with the short deadline
+      // PublicProcessor flow on timeout:
+      // 1. await this.publicTxSimulator.cancel?.(100)
+      //    - FIX - waits up to 100ms for C++ to stop
+      //    - BUG - cancel is undefined, immediately proceeds
+      // 2. reverts run, then checkWorldStateUnchanged()
+      // 3. process() returns
+      let checkWorldStateUnchangedCaughtIt = false;
+      try {
+        await processor.process([tx], { deadline });
+      } catch (err: any) {
+        // checkWorldStateUnchanged() throws if it detects corruption
+        if (err.message?.includes('state reference changed')) {
+          checkWorldStateUnchangedCaughtIt = true;
+        }
+        // Continue - we'll check state ourselves too
+      }
+
+      // Give C++ time to make corrupting writes, but don't wait for full completion (OOG).
+      // In BUG case: C++ continues running, we wait 100ms for it to corrupt state.
+      // In FIX case: C++ already stopped, this is just a short sleep.
+      await Promise.race([
+        simState.promise?.catch(() => {}),
+        sleep(100), // Enough time for corruption, but don't wait for full OOG
+      ]);
+
+      // Check state after everything is cleaned up
+      let anyTreeCorrupted = false;
+      for (const treeId of merkleTreeIds()) {
+        const finalInfo = await merkleTrees.getTreeInfo(treeId);
+        const initialInfo = initialTreeInfo.get(treeId)!;
+        const changed = finalInfo.size !== initialInfo.size || !finalInfo.root.equals(initialInfo.root);
+        if (changed) {
+          anyTreeCorrupted = true;
+          break;
+        }
+      }
+
+      // Log the comparison: did checkWorldStateUnchanged catch it vs. our check after C++ finished
+      if (checkWorldStateUnchangedCaughtIt || anyTreeCorrupted) {
+        const caughtBy = checkWorldStateUnchangedCaughtIt
+          ? anyTreeCorrupted
+            ? 'BOTH'
+            : 'checkWorldStateUnchanged only'
+          : 'our check only (C++ corrupted AFTER checkWorldStateUnchanged)';
+        logger.verbose(`Iteration ${iteration}: corruption detected by ${caughtBy}`);
+      }
+
+      if (anyTreeCorrupted) {
+        corruptionCount++;
+        // Early exit - bug exists, no need to continue
+        logger.verbose(
+          `Early exit: checkWorldStateUnchanged caught=${checkWorldStateUnchangedCaughtIt}, our check caught=true`,
+        );
+        return corruptionCount;
+      }
+    }
+
+    return corruptionCount;
+  }
+
+  /**
+   * PublicProcessor BUG - state corruption without cancellation.
+   *
+   * This demonstrates that without cancellation, C++ continues making writes after
+   * PublicProcessor's timeout handling completes, corrupting state. This is the root
+   * cause of CI failures like "Fork state reference changed by tx after error".
+   */
+  it('PublicProcessor BUG PROOF: state corruption occurs WITHOUT cancellation', async () => {
+    const corruptionCount = await runPublicProcessorTimeoutTest(false);
+    logger.info(`State corruption detected in ${corruptionCount}/${NUM_ITERATIONS} iterations (expected: >0)`);
+    // BUG - Without cancellation, C++ corrupts state after process() completes
+    expect(corruptionCount).toBeGreaterThan(0);
+  });
+
+  /**
+   * PublicProcessor FIX - no state corruption with cancellation.
+   *
+   * With cancellation, C++ stops before making corrupting writes.
+   * State remains unchanged after process() returns.
+   */
+  it('PublicProcessor FIX PROOF: no state corruption WITH cancellation', async () => {
+    const corruptionCount = await runPublicProcessorTimeoutTest(true);
+    logger.info(`State corruption detected in ${corruptionCount}/${NUM_ITERATIONS} iterations (expected: 0)`);
+    // FIX - With cancellation, state should remain unchanged
+    expect(corruptionCount).toBe(0);
+  });
+});

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -288,7 +288,15 @@ export class PublicProcessor implements Traceable {
         if (err?.name === 'PublicProcessorTimeoutError') {
           this.log.warn(`Stopping tx processing due to timeout.`);
           // We hit the transaction execution deadline.
-          // There may still be a transaction executing. We stop the guarded fork to prevent any further access to the world state.
+          // There may still be a transaction executing on a worker thread (C++ via NAPI).
+          // Signal cancellation AND WAIT for the simulation to actually stop.
+          // This is critical because C++ might be in the middle of a slow operation (e.g., pad_trees)
+          // and won't check the cancellation flag until that operation completes.
+          // Without waiting, we'd proceed to revert checkpoints while C++ is still writing to state.
+          // Wait for C++ to stop gracefully.
+          await this.publicTxSimulator.cancel?.();
+
+          // Now stop the guarded fork to prevent any further TS-side access to the world state.
           await this.guardedMerkleTree.stop();
 
           // We now know there can't be any further access to world state. The fork is in a state where there is:

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
@@ -1,5 +1,6 @@
 import { type Logger, createLogger, logLevel } from '@aztec/foundation/log';
-import { avmSimulate } from '@aztec/native';
+import { sleep } from '@aztec/foundation/sleep';
+import { type CancellationToken, avmSimulate, cancelSimulation, createCancellationToken } from '@aztec/native';
 import { ProtocolContractsList } from '@aztec/protocol-contracts';
 import {
   AvmFastSimulationInputs,
@@ -33,6 +34,10 @@ import type {
  */
 export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxSimulatorInterface {
   protected override log: Logger;
+  /** Current cancellation token for in-flight simulation. */
+  private cancellationToken?: CancellationToken;
+  /** Current simulation promise, used to wait for completion after cancellation. */
+  private simulationPromise?: Promise<Buffer>;
 
   constructor(
     merkleTree: MerkleTreeWriteOperations,
@@ -85,12 +90,25 @@ export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxS
     this.log.trace(`Serializing fast simulation inputs to msgpack...`);
     const inputBuffer = fastSimInputs.serializeWithMessagePack();
 
+    // Create cancellation token for this simulation
+    this.cancellationToken = createCancellationToken();
+
+    // Store the promise so cancel() can wait for it
+    this.log.debug(`Calling C++ simulator for tx ${txHash}`);
+    this.simulationPromise = avmSimulate(inputBuffer, contractProvider, wsCppHandle, logLevel, this.cancellationToken);
+
     let resultBuffer: Buffer;
     try {
-      this.log.debug(`Calling C++ simulator for tx ${txHash}`);
-      resultBuffer = await avmSimulate(inputBuffer, contractProvider, wsCppHandle, logLevel);
+      resultBuffer = await this.simulationPromise;
     } catch (error: any) {
+      // Check if this was a cancellation
+      if (error.message?.includes('Simulation cancelled')) {
+        throw new SimulationError(`C++ simulation cancelled`, []);
+      }
       throw new SimulationError(`C++ simulation failed: ${error.message}`, []);
+    } finally {
+      this.cancellationToken = undefined;
+      this.simulationPromise = undefined;
     }
 
     // If we've reached this point, C++ succeeded during simulation,
@@ -108,6 +126,33 @@ export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxS
     });
 
     return cppResult;
+  }
+
+  /**
+   * Cancel the current simulation if one is in progress.
+   * This signals the C++ simulator to stop at the next opcode or before the next WorldState write.
+   * Safe to call even if no simulation is in progress.
+   *
+   * @param waitTimeoutMs - If provided, wait up to this many ms for the simulation to actually stop.
+   *                        This is important because C++ might be in the middle of a slow operation
+   *                        (e.g., pad_trees) and won't check the cancellation flag until it completes.
+   *                        Default timeout of 100ms after cancellation.
+   */
+  public async cancel(waitTimeoutMs: number = 100): Promise<void> {
+    if (this.cancellationToken) {
+      this.log.debug('Cancelling C++ simulation');
+      cancelSimulation(this.cancellationToken);
+    }
+
+    // Wait for the simulation to actually complete if not already done
+    if (this.simulationPromise) {
+      this.log.debug(`Waiting up to ${waitTimeoutMs}ms for C++ simulation to stop`);
+      await Promise.race([
+        this.simulationPromise.catch(() => {}), // Ignore rejection, just wait for completion
+        sleep(waitTimeoutMs),
+      ]);
+      this.log.debug('C++ simulation stopped or wait timed out');
+    }
   }
 }
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator_interface.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator_interface.ts
@@ -3,8 +3,31 @@ import type { Tx } from '@aztec/stdlib/tx';
 
 export interface PublicTxSimulatorInterface {
   simulate(tx: Tx): Promise<PublicTxResult>;
+  /**
+   * Cancel the current simulation if one is in progress.
+   * This signals the underlying simulator (e.g., C++) to stop at the next safe point.
+   * Safe to call even if no simulation is in progress.
+   * Optional - not all implementations support cancellation.
+   *
+   * @param waitTimeoutMs - If provided, wait up to this many ms for the simulation to actually stop.
+   *                        This is important because signaling cancellation doesn't immediately stop C++ -
+   *                        it only sets a flag that C++ checks at certain points. If C++ is in the middle
+   *                        of a slow operation (e.g., pad_trees), it won't stop until that completes.
+   * @returns Promise that resolves when cancellation is signaled (and optionally when simulation stops)
+   */
+  cancel?(waitTimeoutMs?: number): Promise<void>;
 }
 
 export interface MeasuredPublicTxSimulatorInterface {
   simulate(tx: Tx, txLabel: string): Promise<PublicTxResult>;
+  /**
+   * Cancel the current simulation if one is in progress.
+   * This signals the underlying simulator (e.g., C++) to stop at the next safe point.
+   * Safe to call even if no simulation is in progress.
+   * Optional - not all implementations support cancellation.
+   *
+   * @param waitTimeoutMs - If provided, wait up to this many ms for the simulation to actually stop.
+   * @returns Promise that resolves when cancellation is signaled (and optionally when simulation stops)
+   */
+  cancel?(waitTimeoutMs?: number): Promise<void>;
 }


### PR DESCRIPTION
# fix(avm): Add cancellation token to prevent C++ simulation race condition on timeout

## Summary

Fix race condition where C++ AVM simulation corrupts WorldState after TypeScript timeout. This was done as follows:
- Add `CancellationToken` mechanism to safely stop C++ simulation before reverting checkpoints
- **Primary Fix**:  PublicProcessor cancels public simulation and **waits** for it to die before proceeding and reverting checkpoints
    - C++ simulation polls this cancellation token regularly so that we know it will die quickly after cancellation
- **Secondary Fix**: Add mutex locking to checkpoint operations for thread safety
- Add paired tests proving both the bug exists (without fix) and the fix works (with cancellation)

## The Bug

When a C++ AVM simulation times out via `Promise.race()` in `PublicProcessor`, a race condition occurs:

1. TypeScript's timeout fires and calls `revertCheckpoint()` on WorldState
2. **But C++ simulation continues running** on a libuv worker thread
3. C++ holds a native handle to WorldState obtained before the timeout
4. C++ makes writes to WorldState **after** the checkpoint was reverted
5. This corrupts WorldState, causing `checkWorldStateUnchanged()` to fail

The root causes are:
1.  `GuardedMerkleTreeOperations` only guards TS merkle operations. The C++ code interacts with the same WorldState without guards.
2. Nothing stops C++ from finishing simulation after PublicProcessor reaches deadline.

```
Timeline of the race (BEFORE fix):

TypeScript                          C++ (libuv worker thread)
----------                          -------------------------
Start simulation -----------------> Begins executing opcodes
     |                                    |
     v                                    v
Promise.race timeout fires          Still running (e.g., in pad_trees())
     |                                    |
     v                                    |
     |                                    |
     v                                    |
IMMEDIATELY revertCheckpoint()            |
     |                                    v
     |                              Finishes pad_trees()
     |                              Makes write AFTER revert! (CORRUPTION)
     v                                    |
checkWorldStateUnchanged() FAILS!   
```

## The Fix

The key insight: **signaling cancellation is not enough** - we must **wait** for C++ to actually stop.

```
Timeline (AFTER fix):

TypeScript                          C++ (libuv worker thread)
----------                          -------------------------
Start simulation -----------------> Begins executing opcodes
     |                                    |
     v                                    v
Promise.race timeout fires          Still running (e.g., in pad_trees())
     |                                    |
     v                                    |
cancel(100) sets atomic flag              | (doesn't check flag yet)
     |                                    |
     v                                    v
WAIT for simulation promise         Finishes pad_trees(), checks flag
     |                              Throws CancelledException
     |<-----------------------------Promise rejects
     v
NOW revertCheckpoint() (C++ is done)
     |
     v
checkWorldStateUnchanged() ✓ clean state
```

### C++ Side

1. **`CancellationToken` class** (`cancellation_token.hpp`):
   - Thread-safe `std::atomic<bool>` flag
   - `cancel()` - signals cancellation (called from TS thread)
   - `check()` - throws `CancelledException` if cancelled (called from worker thread)

3. **Check at each opcode** (`execution.cpp`, `hybrid_execution.cpp`):
   ```cpp
   while (!external_call_stack.empty()) {
       if (cancellation_token_) {
           cancellation_token_->check();
       }
       // ... execute opcode
   }
   ```

4. **Check before every WorldState write** (`raw_data_dbs.cpp`):
   ```cpp
   void PureRawMerkleDB::pad_tree(...) {
       check_cancellation();  // Throws if cancelled
       // ... proceed with write
   }
   ```

5. **Mutex locking for checkpoint operations** (`cached_content_addressed_tree_store.hpp`):
   ```cpp
   void ContentAddressedCachedTreeStore::checkpoint() {
       std::unique_lock lock(mtx_);  // Prevent races with C++ writes
       cache_.checkpoint();
   }
   ```

### TypeScript Side

1. **`CppPublicTxSimulator.cancel(waitTimeoutMs)`** - Signal AND wait:
   ```typescript
   public async cancel(waitTimeoutMs?: number): Promise<void> {
       if (this.cancellationToken) {
           cancelSimulation(this.cancellationToken);
       }
       // Wait for simulation to actually complete
       if (waitTimeoutMs !== undefined && this.simulationPromise) {
           await Promise.race([
               this.simulationPromise.catch(() => {}),
               sleep(waitTimeoutMs),
           ]);
       }
   }
   ```
   > Note: ideally we'd like to have no timeout here since we really want to wait for C++ to recognize cancellation. The timeout is really just a safeguard against some cancellation bug.

2. **`PublicProcessor`** timeout handler:
   ```typescript
   if (err?.name === 'PublicProcessorTimeoutError') {
       // Signal cancellation AND WAIT for C++ to stop (up to 100ms)
       await this.publicTxSimulator.cancel?.();
       // NOW safe to stop the guarded fork
       await this.guardedMerkleTree.stop();
   }
   ```

## Test Plan

Four paired tests at two levels verify the bug and fix:

### Replace bug and prove fix at TxSimulator level

Tests using `CppPublicTxSimulator` directly - **identical code**, only difference is whether `cancel()` is called:

```typescript
async function runRaceConditionTest(useCancellation: boolean): Promise<number> {
    // ... setup ...
    const simulationPromise = simulator.simulate(tx);

    if (useCancellation) {
        await simulator.cancel(100);  // FIX: Signal AND wait
    }
    // BUG: No cancel, C++ continues during reverts

    await merkleTrees.revertCheckpoint();
    // Check for corruption...
}

it('BUG PROOF: race condition exists WITHOUT cancellation');   // Expects >0 corruptions
it('FIX PROOF: no race condition WITH cancellation');          // Expects 0 corruptions
```

### Replicate bug and prove fix at PublicProcessor level

Tests using full `PublicProcessor.process()` with deadline timeout:

```typescript
it('PublicProcessor BUG PROOF: state corruption occurs WITHOUT cancellation');
it('PublicProcessor FIX PROOF: no state corruption WITH cancellation');
```

### Running the tests

```bash
cd yarn-project/simulator
yarn test src/public/public_processor/apps_tests/timeout_race.test.ts
```

## Files Changed

### C++ (barretenberg)

| File | Change |
|------|--------|
| `vm2/simulation/lib/cancellation_token.hpp` | **New**: Thread-safe cancellation token class |
| `vm2/simulation/lib/raw_data_dbs.hpp` | Add token to `PureRawMerkleDB` |
| `vm2/simulation/lib/raw_data_dbs.cpp` | Check cancellation before all writes |
| `vm2/simulation/gadgets/execution.hpp` | Add token to `Execution` |
| `vm2/simulation/gadgets/execution.cpp` | Check cancellation at each opcode |
| `vm2/simulation/standalone/hybrid_execution.cpp` | Check cancellation at each opcode |
| `vm2/avm_sim_api.hpp` | Thread token through API |
| `vm2/avm_sim_api.cpp` | Thread token through API |
| `vm2/simulation_helper.hpp` | Thread token to execution |
| `vm2/simulation_helper.cpp` | Thread token to execution |
| `nodejs_module/avm_simulate/avm_simulate_napi.hpp` | NAPI bindings for token |
| `nodejs_module/avm_simulate/avm_simulate_napi.cpp` | NAPI bindings for token |
| `nodejs_module/init_module.cpp` | Register NAPI functions |
| `crypto/merkle_tree/.../cached_content_addressed_tree_store.hpp` | Add mutex to checkpoint ops |

### TypeScript (yarn-project)

| File | Change |
|------|--------|
| `native/src/native_module.ts` | Export `createCancellationToken`, `cancelSimulation` |
| `simulator/.../public_tx_simulator_interface.ts` | Add `cancel?(waitTimeoutMs?)` method |
| `simulator/.../cpp_public_tx_simulator.ts` | Track promise, implement `cancel()` with wait |
| `simulator/.../public_processor.ts` | `await cancel(100)` before reverts |
| `simulator/.../public_tx_simulation_tester.ts` | Add `cancel()` and `getSimulator()` |
| `simulator/.../timeout_race.test.ts` | **New**: Paired proof tests |

## Why This Approach

1. **Wait, don't just signal**: The key fix is awaiting the simulation promise after signaling
2. **Bounded wait**: 100ms timeout prevents indefinite blocking if C++ is stuck
3. **Check before writes**: Prevents partial/corrupted state from cancelled operations
4. **Mutex on checkpoints**: Prevents races between C++ writes and TS checkpoint ops
6. **Minimal overhead**: `std::atomic<bool>` check is very cheap (single memory read)
7. **Backward compatible**: Token is optional, existing code works unchanged
8. **Testable**: Paired tests definitively prove both the bug and the fix

## Future Work

### **Move merkle tree guarding into C++** (out of scope for this PR)

Currently, `GuardedMerkleTreeOperations` in TypeScript wraps merkle tree operations to prevent access after `stop()` is called. However, this guard is ineffective for C++ because:

1. C++ obtains the native WorldState and bypasses TS guarding
2. C++ can still make writes after TS calls `stop()`

### Guard getRevision

I think this is lower-impact, but ideally getRevision should fail if called on a stopped instance.

---

🤖 Description generated with [Claude Code](https://claude.com/claude-code)
