### PR TITLE
fix: simplify fee strategies to run promises internally

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/fee-strategies.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/fee-strategies.test.ts
@@ -1,0 +1,177 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import { jest } from '@jest/globals';
+
+import type { ViemClient } from '../../types.js';
+import type { L1TxUtilsConfig } from '../config.js';
+import { P75AllTxsPriorityFeeStrategy } from './p75_competitive.js';
+import type { PriorityFeeStrategy, PriorityFeeStrategyContext } from './types.js';
+
+const logger = createLogger('ethereum:test:fee-strategies');
+
+describe('PriorityFeeStrategy', () => {
+  describe('execute runs all RPC calls internally', () => {
+    it('P75AllTxsPriorityFeeStrategy executes and returns priority fee with block data', async () => {
+      const mockClient = {
+        getBlock: jest.fn().mockImplementation((args: any) => {
+          if (args.blockTag === 'latest') {
+            return Promise.resolve({
+              number: 100n,
+              baseFeePerGas: 1000000000n,
+              transactions: [],
+            });
+          }
+          // pending block
+          return Promise.resolve({ transactions: [] });
+        }),
+        getBlobBaseFee: jest.fn<() => Promise<bigint>>().mockResolvedValue(100000000n),
+        estimateMaxPriorityFeePerGas: jest.fn<() => Promise<bigint>>().mockResolvedValue(1000000000n),
+        getFeeHistory: jest.fn<() => Promise<{ reward: bigint[][] }>>().mockResolvedValue({ reward: [[1000000000n]] }),
+      } as unknown as ViemClient;
+
+      const context: PriorityFeeStrategyContext = {
+        gasConfig: {} as L1TxUtilsConfig,
+        isBlobTx: false,
+        logger,
+      };
+
+      const result = await P75AllTxsPriorityFeeStrategy.execute(mockClient, context);
+
+      // Should return priority fee
+      expect(result.priorityFee).toBeGreaterThanOrEqual(0n);
+
+      // Should return latest block
+      expect(result.latestBlock).toBeDefined();
+      expect(result.latestBlock.number).toBe(100n);
+
+      // Should not return blob base fee for non-blob tx
+      expect(result.blobBaseFee).toBeUndefined();
+
+      // RPC methods should have been called
+      expect(mockClient.getBlock).toHaveBeenCalled();
+      expect(mockClient.estimateMaxPriorityFeePerGas).toHaveBeenCalled();
+      expect(mockClient.getFeeHistory).toHaveBeenCalled();
+    });
+
+    it('returns blob base fee for blob transactions', async () => {
+      const mockClient = {
+        getBlock: jest.fn().mockImplementation((args: any) => {
+          if (args.blockTag === 'latest') {
+            return Promise.resolve({
+              number: 100n,
+              baseFeePerGas: 1000000000n,
+              transactions: [],
+            });
+          }
+          return Promise.resolve({ transactions: [] });
+        }),
+        getBlobBaseFee: jest.fn<() => Promise<bigint>>().mockResolvedValue(500000000n),
+        estimateMaxPriorityFeePerGas: jest.fn<() => Promise<bigint>>().mockResolvedValue(1000000000n),
+        getFeeHistory: jest.fn<() => Promise<{ reward: bigint[][] }>>().mockResolvedValue({ reward: [[1000000000n]] }),
+      } as unknown as ViemClient;
+
+      const context: PriorityFeeStrategyContext = {
+        gasConfig: {} as L1TxUtilsConfig,
+        isBlobTx: true,
+        logger,
+      };
+
+      const result = await P75AllTxsPriorityFeeStrategy.execute(mockClient, context);
+
+      // Should return blob base fee for blob tx
+      expect(result.blobBaseFee).toBe(500000000n);
+      expect(mockClient.getBlobBaseFee).toHaveBeenCalled();
+    });
+
+    it('handles RPC failures gracefully', async () => {
+      const mockClient = {
+        getBlock: jest.fn().mockImplementation((args: any) => {
+          if (args.blockTag === 'latest') {
+            return Promise.resolve({
+              number: 100n,
+              baseFeePerGas: 1000000000n,
+              transactions: [],
+            });
+          }
+          return Promise.reject(new Error('RPC error'));
+        }),
+        getBlobBaseFee: jest.fn<() => Promise<bigint>>().mockRejectedValue(new Error('RPC error')),
+        estimateMaxPriorityFeePerGas: jest.fn<() => Promise<bigint>>().mockRejectedValue(new Error('RPC error')),
+        getFeeHistory: jest.fn<() => Promise<unknown>>().mockRejectedValue(new Error('RPC error')),
+      } as unknown as ViemClient;
+
+      const context: PriorityFeeStrategyContext = {
+        gasConfig: {} as L1TxUtilsConfig,
+        isBlobTx: false,
+        logger,
+      };
+
+      // Should not throw, should return a result (with fallback values)
+      const result = await P75AllTxsPriorityFeeStrategy.execute(mockClient, context);
+
+      // Strategy should handle failures gracefully (falls back to 0n)
+      expect(result.priorityFee).toBe(0n);
+      expect(result.latestBlock).toBeDefined();
+    });
+
+    it('throws if latest block fetch fails', async () => {
+      const mockClient = {
+        getBlock: jest.fn<() => Promise<any>>().mockRejectedValue(new Error('RPC error')),
+        getBlobBaseFee: jest.fn<() => Promise<bigint>>().mockResolvedValue(100000000n),
+        estimateMaxPriorityFeePerGas: jest.fn<() => Promise<bigint>>().mockResolvedValue(1000000000n),
+        getFeeHistory: jest.fn<() => Promise<{ reward: bigint[][] }>>().mockResolvedValue({ reward: [[1000000000n]] }),
+      } as unknown as ViemClient;
+
+      const context: PriorityFeeStrategyContext = {
+        gasConfig: {} as L1TxUtilsConfig,
+        isBlobTx: false,
+        logger,
+      };
+
+      // Should throw because latest block is required
+      await expect(P75AllTxsPriorityFeeStrategy.execute(mockClient, context)).rejects.toThrow(
+        'Failed to get latest block',
+      );
+    });
+  });
+
+  describe('custom strategy', () => {
+    it('allows custom strategies with execute function', async () => {
+      let executeCalled = false;
+
+      const customStrategy: PriorityFeeStrategy = {
+        id: 'test-custom',
+        name: 'Test Custom Strategy',
+        execute: async (client, _context) => {
+          executeCalled = true;
+          const latestBlock = await client.getBlock({ blockTag: 'latest' });
+          return {
+            priorityFee: 5000000000n,
+            latestBlock,
+            debugInfo: { custom: 'test' },
+          };
+        },
+      };
+
+      const mockClient = {
+        getBlock: jest.fn<() => Promise<any>>().mockResolvedValue({
+          number: 100n,
+          baseFeePerGas: 1000000000n,
+        }),
+      } as unknown as ViemClient;
+
+      const context: PriorityFeeStrategyContext = {
+        gasConfig: {} as L1TxUtilsConfig,
+        isBlobTx: false,
+        logger,
+      };
+
+      const result = await customStrategy.execute(mockClient, context);
+
+      expect(executeCalled).toBe(true);
+      expect(result.priorityFee).toBe(5000000000n);
+      expect(result.latestBlock.number).toBe(100n);
+      expect(result.debugInfo).toEqual({ custom: 'test' });
+    });
+  });
+});

--- a/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/index.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/index.ts
@@ -4,13 +4,13 @@ import type { PriorityFeeStrategy } from './types.js';
 
 export {
   HISTORICAL_BLOCK_COUNT,
-  executeStrategy,
   type PriorityFeeStrategy,
   type PriorityFeeStrategyContext,
   type PriorityFeeStrategyResult,
 } from './types.js';
 
 export { P75AllTxsPriorityFeeStrategy } from './p75_competitive.js';
+export { P75BlobTxsOnlyPriorityFeeStrategy } from './p75_competitive_blob_txs_only.js';
 
 /**
  * Default list of priority fee strategies to analyze.

--- a/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/p75_competitive.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/p75_competitive.ts
@@ -13,49 +13,53 @@ import {
 } from './types.js';
 
 /**
- * Type for the promises required by the competitive strategy
- */
-type P75AllTxsStrategyPromises = {
-  networkEstimate: Promise<bigint>;
-  pendingBlock: Promise<Awaited<ReturnType<ViemClient['getBlock']>> | null>;
-  feeHistory: Promise<Awaited<ReturnType<ViemClient['getFeeHistory']>> | null>;
-};
-
-/**
  * Our current competitive priority fee strategy.
  * Analyzes p75 of pending transactions and 5-block fee history to determine a competitive priority fee.
  * Falls back to network estimate if data is unavailable.
  */
-export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategyPromises> = {
+export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy = {
   name: 'Competitive (P75 + History) - CURRENT',
   id: 'p75_pending_txs_and_history_all_txs',
 
-  getRequiredPromises(client: ViemClient): P75AllTxsStrategyPromises {
-    return {
-      networkEstimate: client.estimateMaxPriorityFeePerGas().catch(() => 0n),
-      pendingBlock: client.getBlock({ blockTag: 'pending', includeTransactions: true }).catch(() => null),
-      feeHistory: client
-        .getFeeHistory({
-          blockCount: HISTORICAL_BLOCK_COUNT,
-          rewardPercentiles: [75],
-          blockTag: 'latest',
-        })
-        .catch(() => null),
-    };
-  },
+  async execute(client: ViemClient, context: PriorityFeeStrategyContext): Promise<PriorityFeeStrategyResult> {
+    const { isBlobTx, logger } = context;
 
-  calculate(
-    results: {
-      [K in keyof P75AllTxsStrategyPromises]: PromiseSettledResult<Awaited<P75AllTxsStrategyPromises[K]>>;
-    },
-    context: PriorityFeeStrategyContext,
-  ): PriorityFeeStrategyResult {
-    const { logger } = context;
+    // Fire all RPC calls in parallel
+    const [latestBlockResult, blobBaseFeeResult, networkEstimateResult, pendingBlockResult, feeHistoryResult] =
+      await Promise.allSettled([
+        client.getBlock({ blockTag: 'latest' }),
+        isBlobTx ? client.getBlobBaseFee() : Promise.resolve(undefined),
+        client.estimateMaxPriorityFeePerGas().catch(() => 0n),
+        client.getBlock({ blockTag: 'pending', includeTransactions: true }).catch(() => null),
+        client
+          .getFeeHistory({
+            blockCount: HISTORICAL_BLOCK_COUNT,
+            rewardPercentiles: [75],
+            blockTag: 'latest',
+          })
+          .catch(() => null),
+      ]);
 
-    // Extract network estimate from settled result
+    // Extract latest block
+    if (latestBlockResult.status === 'rejected') {
+      throw new Error(`Failed to get latest block: ${latestBlockResult.reason}`);
+    }
+    const latestBlock = latestBlockResult.value;
+
+    // Extract blob base fee (only for blob txs)
+    let blobBaseFee: bigint | undefined;
+    if (isBlobTx) {
+      if (blobBaseFeeResult.status === 'fulfilled' && typeof blobBaseFeeResult.value === 'bigint') {
+        blobBaseFee = blobBaseFeeResult.value;
+      } else {
+        logger?.warn('Failed to get L1 blob base fee');
+      }
+    }
+
+    // Extract network estimate
     const networkEstimate =
-      results.networkEstimate.status === 'fulfilled' && typeof results.networkEstimate.value === 'bigint'
-        ? results.networkEstimate.value
+      networkEstimateResult.status === 'fulfilled' && typeof networkEstimateResult.value === 'bigint'
+        ? networkEstimateResult.value
         : 0n;
 
     let competitiveFee = networkEstimate;
@@ -63,8 +67,8 @@ export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategy
       networkEstimateGwei: formatGwei(networkEstimate),
     };
 
-    // Extract pending block from settled result
-    const pendingBlock = results.pendingBlock.status === 'fulfilled' ? results.pendingBlock.value : null;
+    // Extract pending block
+    const pendingBlock = pendingBlockResult.status === 'fulfilled' ? pendingBlockResult.value : null;
 
     // Analyze pending block transactions
     if (pendingBlock?.transactions && pendingBlock.transactions.length > 0) {
@@ -73,9 +77,7 @@ export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategy
           if (typeof tx === 'string') {
             return 0n;
           }
-          const fee = tx.maxPriorityFeePerGas || 0n;
-
-          return fee;
+          return tx.maxPriorityFeePerGas || 0n;
         })
         .filter((fee: bigint) => fee > 0n);
 
@@ -97,8 +99,8 @@ export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategy
       }
     }
 
-    // Extract fee history from settled result
-    const feeHistory = results.feeHistory.status === 'fulfilled' ? results.feeHistory.value : null;
+    // Extract fee history
+    const feeHistory = feeHistoryResult.status === 'fulfilled' ? feeHistoryResult.value : null;
 
     // Analyze fee history
     if (feeHistory?.reward && feeHistory.reward.length > 0) {
@@ -153,6 +155,8 @@ export const P75AllTxsPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategy
 
     return {
       priorityFee: competitiveFee,
+      latestBlock,
+      blobBaseFee,
       debugInfo,
     };
   },

--- a/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/p75_competitive_blob_txs_only.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/p75_competitive_blob_txs_only.ts
@@ -13,15 +13,6 @@ import {
 } from './types.js';
 
 /**
- * Type for the promises required by the competitive strategy
- */
-type P75AllTxsStrategyPromises = {
-  networkEstimate: Promise<bigint>;
-  pendingBlock: Promise<Awaited<ReturnType<ViemClient['getBlock']>> | null>;
-  feeHistory: Promise<Awaited<ReturnType<ViemClient['getFeeHistory']>> | null>;
-};
-
-/**
  * Fetches historical blocks and calculates reward percentiles for blob transactions only.
  * Returns data in the same format as getFeeHistory for easy drop-in replacement.
  *
@@ -114,38 +105,51 @@ export async function getBlobPriorityFeeHistory(
  * Analyzes p75 of pending transactions and 5-block fee history to determine a competitive priority fee.
  * Falls back to network estimate if data is unavailable.
  */
-export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStrategyPromises> = {
+export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy = {
   name: 'Competitive (P75 + History) - Blob Txs Only',
   id: 'p75_pending_txs_and_history_blob_txs_only',
 
-  getRequiredPromises(client: ViemClient, opts: PriorityFeeStrategyContext): P75AllTxsStrategyPromises {
-    return {
-      networkEstimate: client.estimateMaxPriorityFeePerGas().catch(() => 0n),
-      pendingBlock: client.getBlock({ blockTag: 'pending', includeTransactions: true }).catch(() => null),
-      feeHistory: opts.isBlobTx
-        ? getBlobPriorityFeeHistory(client, HISTORICAL_BLOCK_COUNT, [75])
-        : client
-            .getFeeHistory({
-              blockCount: HISTORICAL_BLOCK_COUNT,
-              rewardPercentiles: [75],
-              blockTag: 'latest',
-            })
-            .catch(() => null),
-    };
-  },
+  async execute(client: ViemClient, context: PriorityFeeStrategyContext): Promise<PriorityFeeStrategyResult> {
+    const { isBlobTx, logger } = context;
 
-  calculate(
-    results: {
-      [K in keyof P75AllTxsStrategyPromises]: PromiseSettledResult<Awaited<P75AllTxsStrategyPromises[K]>>;
-    },
-    context: PriorityFeeStrategyContext,
-  ): PriorityFeeStrategyResult {
-    const { logger } = context;
+    // Fire all RPC calls in parallel
+    const [latestBlockResult, blobBaseFeeResult, networkEstimateResult, pendingBlockResult, feeHistoryResult] =
+      await Promise.allSettled([
+        client.getBlock({ blockTag: 'latest' }),
+        isBlobTx ? client.getBlobBaseFee() : Promise.resolve(undefined),
+        client.estimateMaxPriorityFeePerGas().catch(() => 0n),
+        client.getBlock({ blockTag: 'pending', includeTransactions: true }).catch(() => null),
+        isBlobTx
+          ? getBlobPriorityFeeHistory(client, HISTORICAL_BLOCK_COUNT, [75])
+          : client
+              .getFeeHistory({
+                blockCount: HISTORICAL_BLOCK_COUNT,
+                rewardPercentiles: [75],
+                blockTag: 'latest',
+              })
+              .catch(() => null),
+      ]);
 
-    // Extract network estimate from settled result
+    // Extract latest block (required)
+    if (latestBlockResult.status === 'rejected') {
+      throw new Error(`Failed to get latest block: ${latestBlockResult.reason}`);
+    }
+    const latestBlock = latestBlockResult.value;
+
+    // Extract blob base fee (only for blob txs)
+    let blobBaseFee: bigint | undefined;
+    if (isBlobTx) {
+      if (blobBaseFeeResult.status === 'fulfilled' && typeof blobBaseFeeResult.value === 'bigint') {
+        blobBaseFee = blobBaseFeeResult.value;
+      } else {
+        logger?.warn('Failed to get L1 blob base fee');
+      }
+    }
+
+    // Extract network estimate
     const networkEstimate =
-      results.networkEstimate.status === 'fulfilled' && typeof results.networkEstimate.value === 'bigint'
-        ? results.networkEstimate.value
+      networkEstimateResult.status === 'fulfilled' && typeof networkEstimateResult.value === 'bigint'
+        ? networkEstimateResult.value
         : 0n;
 
     let competitiveFee = networkEstimate;
@@ -153,8 +157,8 @@ export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStr
       networkEstimateGwei: formatGwei(networkEstimate),
     };
 
-    // Extract pending block from settled result
-    const pendingBlock = results.pendingBlock.status === 'fulfilled' ? results.pendingBlock.value : null;
+    // Extract pending block
+    const pendingBlock = pendingBlockResult.status === 'fulfilled' ? pendingBlockResult.value : null;
 
     // Analyze pending block transactions
     if (pendingBlock?.transactions && pendingBlock.transactions.length > 0) {
@@ -163,14 +167,12 @@ export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStr
           if (typeof tx === 'string') {
             return 0n;
           }
-          if (context.isBlobTx) {
+          if (isBlobTx) {
             if (!isBlobTransaction(tx)) {
               return 0n;
             }
           }
-          const fee = tx.maxPriorityFeePerGas || 0n;
-
-          return fee;
+          return tx.maxPriorityFeePerGas || 0n;
         })
         .filter((fee: bigint) => fee > 0n);
 
@@ -191,8 +193,8 @@ export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStr
       }
     }
 
-    // Extract fee history from settled result
-    const feeHistory = results.feeHistory.status === 'fulfilled' ? results.feeHistory.value : null;
+    // Extract fee history
+    const feeHistory = feeHistoryResult.status === 'fulfilled' ? feeHistoryResult.value : null;
 
     // Analyze fee history
     if (feeHistory?.reward && feeHistory.reward.length > 0) {
@@ -235,6 +237,8 @@ export const P75BlobTxsOnlyPriorityFeeStrategy: PriorityFeeStrategy<P75AllTxsStr
 
     return {
       priorityFee: competitiveFee,
+      latestBlock,
+      blobBaseFee,
       debugInfo,
     };
   },

--- a/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/types.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/fee-strategies/types.ts
@@ -1,5 +1,7 @@
 import type { Logger } from '@aztec/foundation/log';
 
+import type { Block } from 'viem';
+
 import type { ViemClient } from '../../types.js';
 import type { L1TxUtilsConfig } from '../config.js';
 
@@ -14,12 +16,16 @@ export const HISTORICAL_BLOCK_COUNT = 5;
 export interface PriorityFeeStrategyResult {
   /** The calculated priority fee in wei */
   priorityFee: bigint;
+  /** The latest block (fetched as part of the strategy) */
+  latestBlock: Block;
+  /** The blob base fee (only present for blob transactions) */
+  blobBaseFee?: bigint;
   /** Optional debug info about how the fee was calculated */
   debugInfo?: Record<string, string | number>;
 }
 
 /**
- * Context passed to the strategy calculation function (excluding promise results)
+ * Context passed to the strategy function
  */
 export interface PriorityFeeStrategyContext {
   /** Gas configuration */
@@ -32,57 +38,19 @@ export interface PriorityFeeStrategyContext {
 
 /**
  * A strategy for calculating the priority fee for L1 transactions.
- * Each strategy defines what promises it needs and how to calculate the fee from their results.
- * This design allows strategies to be plugged into both L1FeeAnalyzer and ReadOnlyL1TxUtils.
+ * The function handles all RPC calls and returns
+ * the priority fee, along with any block data needed by the caller.
  */
-export interface PriorityFeeStrategy<TPromises extends Record<string, Promise<any>> = Record<string, Promise<any>>> {
+export type PriorityFeeStrategy = {
   /** Human-readable name for logging */
   name: string;
   /** Unique identifier for metrics */
   id: string;
   /**
-   * Returns the promises that need to be executed for this strategy.
-   * These will be run in parallel with Promise.allSettled.
+   * Calculate the priority fee.
    * @param client - The viem client to use for RPC calls
-   * @returns An object of promises keyed by name
-   */
-  getRequiredPromises(client: ViemClient, opts: Partial<PriorityFeeStrategyContext>): TPromises;
-  /**
-   * Calculate the priority fee based on the settled promise results.
-   * @param results - The settled results of the promises from getRequiredPromises
    * @param context - Contains gas config, whether it's a blob tx, and logger
-   * @returns The calculated priority fee result
+   * @returns The calculated priority fee result including block data
    */
-  calculate(
-    results: { [K in keyof TPromises]: PromiseSettledResult<Awaited<TPromises[K]>> },
-    context: PriorityFeeStrategyContext,
-  ): PriorityFeeStrategyResult;
-}
-
-/**
- * Helper function to execute a strategy's promises and calculate the result.
- * This can be used by both L1FeeAnalyzer and ReadOnlyL1TxUtils.
- * @param strategy - The strategy to execute
- * @param client - The viem client to use for RPC calls
- * @param context - The context for calculation
- * @returns The strategy result
- */
-export async function executeStrategy<TPromises extends Record<string, Promise<any>>>(
-  strategy: PriorityFeeStrategy<TPromises>,
-  client: ViemClient,
-  context: PriorityFeeStrategyContext,
-): Promise<PriorityFeeStrategyResult> {
-  const promises = strategy.getRequiredPromises(client, { isBlobTx: context.isBlobTx });
-  const keys = Object.keys(promises) as Array<keyof TPromises>;
-  const promiseArray = keys.map(k => promises[k]);
-
-  const settledResults = await Promise.allSettled(promiseArray);
-
-  // Reconstruct the results object with the same keys, preserving the type mapping
-  const results = {} as { [K in keyof TPromises]: PromiseSettledResult<Awaited<TPromises[K]>> };
-  keys.forEach((key, index) => {
-    results[key] = settledResults[index] as PromiseSettledResult<Awaited<TPromises[typeof key]>>;
-  });
-
-  return strategy.calculate(results, context);
-}
+  execute: (client: ViemClient, context: PriorityFeeStrategyContext) => Promise<PriorityFeeStrategyResult>;
+};

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.test.ts
@@ -408,13 +408,14 @@ describe('L1FeeAnalyzer', () => {
       const customStrategy: PriorityFeeStrategy = {
         id: 'test-custom',
         name: 'Test Custom Strategy',
-        getRequiredPromises: () => ({
-          feeHistory: Promise.resolve(undefined),
-        }),
-        calculate: () => ({
-          priorityFee: parseGwei('5'),
-          debugInfo: { custom: 'test' },
-        }),
+        execute: async client => {
+          const latestBlock = await client.getBlock({ blockTag: 'latest' });
+          return {
+            priorityFee: parseGwei('5'),
+            latestBlock,
+            debugInfo: { custom: 'test' },
+          };
+        },
       };
 
       const customAnalyzer = new L1FeeAnalyzer(l1Client, new DateProvider(), logger, 100, [customStrategy]);

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_fee_analyzer.ts
@@ -13,7 +13,6 @@ import {
   DEFAULT_PRIORITY_FEE_STRATEGIES,
   type PriorityFeeStrategy,
   type PriorityFeeStrategyContext,
-  executeStrategy,
 } from './fee-strategies/index.js';
 import type { L1BlobInputs, L1TxRequest } from './types.js';
 
@@ -262,7 +261,7 @@ export class L1FeeAnalyzer {
 
   /**
    * Executes all configured strategies and returns their results.
-   * Each strategy defines its own promises which are executed and passed to calculate.
+   * Each strategy handles its own RPC calls internally.
    * @param isBlobTx - Whether this is a blob transaction
    * @returns Array of strategy results
    */
@@ -276,7 +275,7 @@ export class L1FeeAnalyzer {
 
     for (const strategy of this.strategies) {
       try {
-        const result = await executeStrategy(strategy, this.client, context);
+        const result = await strategy.execute(this.client, context);
 
         results.push({
           strategyId: strategy.id,

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -84,63 +84,31 @@ export class ReadOnlyL1TxUtils {
   ): Promise<GasPrice> {
     const gasConfig = merge(this.config, gasConfigOverrides);
 
-    // Make all RPC calls in parallel upfront with retry logic
-    // First 2 calls are necessary to complete
-    const latestBlockPromise = this.tryTwice(
-      () => this.client.getBlock({ blockTag: 'latest' }),
-      'Getting latest block',
+    // Execute strategy - it handles all RPC calls internally and returns everything we need
+    const strategyResult = await retry(
+      () =>
+        CurrentStrategy.execute(this.client, {
+          gasConfig,
+          isBlobTx,
+          logger: this.logger,
+        }),
+      'Executing priority fee strategy',
+      makeBackoff(times(2, () => 0)),
+      this.logger,
+      true,
     );
 
-    let blobBaseFeePromise = null;
-    if (isBlobTx) {
-      blobBaseFeePromise = this.tryTwice(() => this.client.getBlobBaseFee(), 'Getting blob base fee');
-    }
+    const { latestBlock, blobBaseFee, priorityFee: strategyPriorityFee } = strategyResult;
 
-    // Get strategy promises for priority fee calculation
-    const strategyPromises = CurrentStrategy.getRequiredPromises(this.client, { isBlobTx });
-    const strategyPromiseKeys = [];
-    const strategyPromisesArr = [];
-    for (const [key, promise] of Object.entries(strategyPromises)) {
-      strategyPromiseKeys.push(key);
-      strategyPromisesArr.push(this.tryTwice(() => promise, `Getting strategy data for ${key}`));
-    }
+    // Extract base fee from latest block
+    const baseFee = latestBlock.baseFeePerGas ?? 0n;
 
-    const [latestBlockResult, blobBaseFeeResult, ...strategyResults] = await Promise.allSettled([
-      latestBlockPromise,
-      blobBaseFeePromise ?? Promise.resolve(0n),
-      ...strategyPromisesArr,
-    ]);
-
-    // Extract results
-    const baseFee =
-      latestBlockResult.status === 'fulfilled' &&
-      typeof latestBlockResult.value === 'object' &&
-      latestBlockResult.value.baseFeePerGas
-        ? latestBlockResult.value.baseFeePerGas
-        : 0n;
-
-    // Get blob base fee if available
-    let blobBaseFee = 0n;
-    if (isBlobTx && blobBaseFeeResult.status === 'fulfilled' && typeof blobBaseFeeResult.value === 'bigint') {
-      blobBaseFee = blobBaseFeeResult.value;
-    } else if (isBlobTx) {
+    // Handle blob base fee
+    if (isBlobTx && blobBaseFee === undefined) {
       this.logger?.warn('Failed to get L1 blob base fee', attempt);
     }
 
-    let priorityFee: bigint;
-    // Get competitive priority fee using strategy
-    // Reconstruct the results object with the same keys as the promises
-    const resultsObject: Record<string, PromiseSettledResult<unknown>> = {};
-    strategyPromiseKeys.forEach((key, index) => {
-      resultsObject[key] = strategyResults[index];
-    });
-
-    const result = CurrentStrategy.calculate(resultsObject as any, {
-      gasConfig,
-      isBlobTx,
-      logger: this.logger,
-    });
-    priorityFee = result.priorityFee;
+    let priorityFee = strategyPriorityFee;
 
     // Apply minimum priority fee floor if configured
     if (gasConfig.minimumPriorityFeePerGas) {
@@ -156,7 +124,7 @@ export class ReadOnlyL1TxUtils {
     }
     let maxFeePerGas = baseFee;
 
-    let maxFeePerBlobGas = blobBaseFee;
+    let maxFeePerBlobGas = blobBaseFee ?? 0n;
 
     // Bump base fee so it's valid for next blocks if it stalls
     const numBlocks = Math.ceil(gasConfig.stallTimeMs! / BLOCK_TIME_MS);
@@ -250,7 +218,7 @@ export class ReadOnlyL1TxUtils {
         baseFee: formatGwei(baseFee),
         maxFeePerGas: formatGwei(maxFeePerGas),
         maxPriorityFeePerGas: formatGwei(maxPriorityFeePerGas),
-        blobBaseFee: formatGwei(blobBaseFee),
+        blobBaseFee: formatGwei(blobBaseFee ?? 0n),
         maxFeePerBlobGas: formatGwei(maxFeePerBlobGas),
       },
     );
@@ -447,12 +415,5 @@ export class ReadOnlyL1TxUtils {
       bumpedGasLimit,
     });
     return bumpedGasLimit;
-  }
-
-  /**
-   * Helper function to retry RPC calls twice
-   */
-  private tryTwice<T>(fn: () => Promise<T>, description: string): Promise<T> {
-    return retry<T>(fn, description, makeBackoff(times(2, () => 0)), this.logger, true);
   }
 }


### PR DESCRIPTION
small fix to return factories rather than triggered promises in fee strategies (`tryTwice` was not working properly)