### PR TITLE
fix: make fee asset handler optional for L1TokenManager

### DIFF
--- a/yarn-project/aztec.js/src/ethereum/portal_manager.ts
+++ b/yarn-project/aztec.js/src/ethereum/portal_manager.ts
@@ -132,7 +132,7 @@ export class L1FeeJuicePortalManager {
   constructor(
     portalAddress: EthAddress,
     tokenAddress: EthAddress,
-    handlerAddress: EthAddress,
+    handlerAddress: EthAddress | undefined,
     private readonly extendedClient: ExtendedViemWalletClient,
     private readonly logger: Logger,
   ) {
@@ -157,9 +157,9 @@ export class L1FeeJuicePortalManager {
    */
   public async bridgeTokensPublic(to: AztecAddress, amount: bigint | undefined, mint = false): Promise<L2AmountClaim> {
     const [claimSecret, claimSecretHash] = await generateClaimSecret();
-    const mintableAmount = await this.tokenManager.getMintAmount();
-    const amountToBridge = amount ?? mintableAmount;
+    const amountToBridge = amount ?? (await this.tokenManager.getMintAmount());
     if (mint) {
+      const mintableAmount = await this.tokenManager.getMintAmount();
       if (amountToBridge !== mintableAmount) {
         throw new Error(`Minting amount must be ${mintableAmount}`);
       }
@@ -233,17 +233,12 @@ export class L1FeeJuicePortalManager {
     if (feeJuiceAddress.isZero() || feeJuicePortalAddress.isZero()) {
       throw new Error('Portal or token not deployed on L1');
     }
-    if (!feeAssetHandlerAddress || feeAssetHandlerAddress.isZero()) {
-      throw new Error('Handler not deployed on L1, or handler address is zero');
-    }
 
-    return new L1FeeJuicePortalManager(
-      feeJuicePortalAddress,
-      feeJuiceAddress,
-      feeAssetHandlerAddress,
-      extendedClient,
-      logger,
-    );
+    // Handler is optional - it's only needed for minting tokens during testing
+    const handlerAddress =
+      feeAssetHandlerAddress && !feeAssetHandlerAddress.isZero() ? feeAssetHandlerAddress : undefined;
+
+    return new L1FeeJuicePortalManager(feeJuicePortalAddress, feeJuiceAddress, handlerAddress, extendedClient, logger);
   }
 }
 


### PR DESCRIPTION
# Make Fee Asset Handler Optional in L1FeeJuicePortalManager

This PR modifies the `L1FeeJuicePortalManager` to make the fee asset handler address optional. The handler is only needed for minting tokens during testing, so this change allows the manager to be created without requiring a handler address.

Key changes:
- Updated the constructor to accept `handlerAddress` as `EthAddress | undefined`
- Modified the `create` method to make the handler optional when creating a new manager
- Removed the error thrown when handler address is zero or undefined
- Optimized the token amount calculation in `bridgeTokensPublic` method