### PR TITLE
chore: Bump wait timeouts in epochs e2e tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -305,7 +305,7 @@ export class EpochsTestContext {
   }
 
   /** Waits until the given checkpoint number is mined. */
-  public async waitUntilCheckpointNumber(target: CheckpointNumber, timeout = 60) {
+  public async waitUntilCheckpointNumber(target: CheckpointNumber, timeout = 120) {
     await retryUntil(
       () => Promise.resolve(target <= this.monitor.checkpointNumber),
       `Wait until checkpoint ${target}`,
@@ -315,7 +315,7 @@ export class EpochsTestContext {
   }
 
   /** Waits until the given checkpoint number is marked as proven. */
-  public async waitUntilProvenCheckpointNumber(target: CheckpointNumber, timeout = 60) {
+  public async waitUntilProvenCheckpointNumber(target: CheckpointNumber, timeout = 120) {
     await retryUntil(
       () => Promise.resolve(target <= this.monitor.provenCheckpointNumber),
       `Wait proven checkpoint ${target}`,


### PR DESCRIPTION
We were waiting for an epoch proof that takes about 60s (having to wait for the whole epoch to finish) with a 60s timeout.
