### PR TITLE
fix: Handle prunes when computing current base fees

### DIFF
--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -2,6 +2,7 @@ import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/bra
 import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemSignature } from '@aztec/foundation/eth-signature';
+import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { RollupStorage } from '@aztec/l1-artifacts/RollupStorage';
 
@@ -418,6 +419,21 @@ export class RollupContract {
 
   getCheckpoint(checkpointNumber: CheckpointNumber) {
     return this.rollup.read.getCheckpoint([BigInt(checkpointNumber)]);
+  }
+
+  /** Returns the pending checkpoint from the rollup contract */
+  getPendingCheckpoint() {
+    // We retry because of race conditions during prunes: we may get a pending checkpoint number which is immediately
+    // reorged out due to a prune happening, causing the subsequent getCheckpoint call to fail. So we try again in that case.
+    return retry(
+      async () => {
+        const pendingCheckpointNumber = await this.getCheckpointNumber();
+        const pendingCheckpoint = await this.getCheckpoint(pendingCheckpointNumber);
+        return pendingCheckpoint;
+      },
+      'getting pending checkpoint',
+      makeBackoff([0.5, 0.5, 0.5]),
+    );
   }
 
   async getTips(): Promise<{ pending: CheckpointNumber; proven: CheckpointNumber }> {

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -69,7 +69,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
     // we need to fetch the last block written, and estimate the earliest timestamp for the next block.
     // The timestamp of that last block will act as a lower bound for the next block.
 
-    const lastBlock = await this.rollupContract.getCheckpoint(await this.rollupContract.getCheckpointNumber());
+    const lastBlock = await this.rollupContract.getPendingCheckpoint();
     const earliestTimestamp = await this.rollupContract.getTimestampForSlot(
       SlotNumber.fromBigInt(lastBlock.slotNumber + 1n),
     );


### PR DESCRIPTION
In [this failed run](http://ci.aztec-labs.com/b0c735d3bf1a0925) of `e2e_cross_chain_messaging l1_to_l2` we see a
`Rollup__UnavailableTempCheckpointLog` that's coming from `computeCurrentBaseFees`.

This was caused by trying to send a tx while a prune was happening. This adds retries to `getPendingCheckpoint` so it tries getting the latest checkpoint again if it fails because the checkpoint number it's trying to fetch has been pruned out.
