### PR TITLE
chore: Another deflake attempt at multiple validator sentinel e2e

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
@@ -161,7 +161,7 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
       ),
     ]);
 
-    const slotForSentinel = t.monitor.l2SlotNumber;
+    const slotForSentinel = (await t.monitor.run()).l2SlotNumber;
     t.logger.info(`Waiting until sentinel processed until slot ${slotForSentinel}`);
     await retryUntil(
       async () => {
@@ -179,7 +179,7 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
     // Check that all of the first node validators have attestations recorded
     for (const validator of firstNodeValidators) {
       const validatorStats = stats.stats[validator.toString().toLowerCase()];
-      const history = validatorStats?.history.filter(h => h.slot > initialSlot && h.slot <= targetSlot) ?? [];
+      const history = validatorStats?.history.filter(h => h.slot > initialSlot && h.slot <= slotForSentinel) ?? [];
       t.logger.info(`Asserting stats for online validator ${validator}`, { history });
       expect(history.filter(h => h.status === 'attestation-missed' || h.status === 'block-missed')).toBeEmpty();
     }
@@ -187,14 +187,14 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
     // At least one of the first node validators must have been seen as proposer
     const firstNodeBlockProposedHistory = firstNodeValidators
       .flatMap(v => stats.stats[v.toString().toLowerCase()].history)
-      .filter(h => h.slot > initialSlot && h.slot <= targetSlot)
+      .filter(h => h.slot > initialSlot && h.slot <= slotForSentinel)
       .filter(h => h.status === 'block-proposed');
     expect(firstNodeBlockProposedHistory).not.toBeEmpty();
 
     // And all of the proposers for the offline node must be seen as missed attestation or proposal
     for (const validator of offlineValidators) {
       const validatorStats = stats.stats[validator.toString().toLowerCase()];
-      const history = validatorStats.history?.filter(h => h.slot > initialSlot && h.slot <= targetSlot) ?? [];
+      const history = validatorStats.history?.filter(h => h.slot > initialSlot && h.slot <= slotForSentinel) ?? [];
       t.logger.info(`Asserting stats for offline validator ${validator}`, { history });
       expect(history.filter(h => h.status === 'attestation-missed' || h.status === 'block-missed')).not.toBeEmpty();
     }


### PR DESCRIPTION
In this test, we were waiting for `SLOT_COUNT` to pass and for the first node to be elected as proposer at least once. But then, when we inspected the sentinel history, we filtered only by the first `SLOT_COUNT` slots. So if the first node was elected as proposer after `SLOT_COUNT`, its history would be empty, which is the error we were seeing in failed runs like [this one](http://ci.aztec-labs.com/a88649af146bf02e).
