### PR TITLE
feat: add p2p metrics

### DIFF
--- a/yarn-project/p2p/src/mem_pools/instrumentation.ts
+++ b/yarn-project/p2p/src/mem_pools/instrumentation.ts
@@ -1,4 +1,5 @@
 import type { Gossipable } from '@aztec/stdlib/p2p';
+import type { Tx, TxHash } from '@aztec/stdlib/tx';
 import {
   Attributes,
   type BatchObservableResult,
@@ -22,6 +23,7 @@ type MetricsLabels = {
   objectInMempool: MetricsType;
   objectSize: MetricsType;
   itemsAdded: MetricsType;
+  itemMinedDelay: MetricsType;
 };
 
 /**
@@ -35,12 +37,14 @@ function getMetricsLabels(name: PoolName): MetricsLabels {
       objectInMempool: Metrics.MEMPOOL_TX_COUNT,
       objectSize: Metrics.MEMPOOL_TX_SIZE,
       itemsAdded: Metrics.MEMPOOL_TX_ADDED_COUNT,
+      itemMinedDelay: Metrics.MEMPOOL_TX_MINED_DELAY,
     };
   } else if (name === PoolName.ATTESTATION_POOL) {
     return {
       objectInMempool: Metrics.MEMPOOL_ATTESTATIONS_COUNT,
       objectSize: Metrics.MEMPOOL_ATTESTATIONS_SIZE,
       itemsAdded: Metrics.MEMPOOL_ATTESTATIONS_ADDED_COUNT,
+      itemMinedDelay: Metrics.MEMPOOL_ATTESTATIONS_MINED_DELAY,
     };
   }
 
@@ -60,11 +64,15 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
   private addObjectCounter: UpDownCounter;
   /** Tracks tx size */
   private objectSize: Histogram;
+  /** Track delay between transaction added and evicted */
+  private minedDelay: Histogram;
 
   private dbMetrics: LmdbMetrics;
 
   private defaultAttributes;
   private meter: Meter;
+
+  private txAddedTimestamp: Map<string, number> = new Map<string, number>();
 
   constructor(
     telemetry: TelemetryClient,
@@ -98,6 +106,10 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
       description: 'The number of transactions added to the mempool',
     });
 
+    this.minedDelay = this.meter.createHistogram(metricsLabels.itemMinedDelay, {
+      description: 'Delay between transaction added and evicted from the mempool',
+    });
+
     this.meter.addBatchObservableCallback(this.observeStats, [this.objectsInMempool]);
   }
 
@@ -107,6 +119,25 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
 
   public incrementAddedObjects(count: number) {
     this.addObjectCounter.add(count);
+  }
+
+  public transactionsAdded(transactions: Tx[]) {
+    const timestamp = Date.now();
+    for (const transaction of transactions) {
+      this.txAddedTimestamp.set(transaction.txHash.toString(), timestamp);
+    }
+  }
+
+  public transactionsRemoved(hashes: TxHash[]) {
+    const timestamp = Date.now();
+    for (const hash of hashes) {
+      const key = hash.toString();
+      const addedAt = this.txAddedTimestamp.get(key);
+      if (addedAt) {
+        this.txAddedTimestamp.delete(key);
+        this.minedDelay.record(addedAt - timestamp);
+      }
+    }
   }
 
   private observeStats = async (observer: BatchObservableResult) => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -187,6 +187,7 @@ export class AztecKVTxPool extends (EventEmitter as new () => TypedEventEmitter<
 
       await this.evictInvalidTxsAfterMining(txHashes, blockHeader, minedNullifiers, minedFeePayers);
     });
+    this.#metrics.transactionsRemoved(txHashes);
     // We update this after the transaction above. This ensures that the non-evictable transactions are not evicted
     // until any that have been mined are marked as such.
     // The non-evictable set is not considered when evicting transactions that are invalid after a block is mined.
@@ -329,6 +330,7 @@ export class AztecKVTxPool extends (EventEmitter as new () => TypedEventEmitter<
     });
 
     if (addedTxs.length > 0) {
+      this.#metrics.transactionsAdded(addedTxs);
       this.emit('txs-added', { ...opts, txs: addedTxs });
     }
     return addedTxs.length;
@@ -384,6 +386,7 @@ export class AztecKVTxPool extends (EventEmitter as new () => TypedEventEmitter<
 
       await this.#pendingTxSize.set(pendingTxSize);
     });
+    this.#metrics.transactionsRemoved(txHashes);
     this.#log.debug(`Deleted ${txHashes.length} txs from pool`, { txHashes });
     return this.#archivedTxLimit ? poolDbTx.then(() => this.archiveTxs(deletedTxs)) : poolDbTx;
   }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -76,6 +76,7 @@ export class InMemoryTxPool extends (EventEmitter as new () => TypedEventEmitter
       this.minedTxs.set(key, blockHeader.globalVariables.blockNumber);
       this.pendingTxs.delete(key);
     }
+    this.metrics.transactionsRemoved(txHashes);
     return Promise.resolve();
   }
 
@@ -190,6 +191,7 @@ export class InMemoryTxPool extends (EventEmitter as new () => TypedEventEmitter
     if (added.length > 0) {
       this.emit('txs-added', { ...opts, txs: added });
     }
+    this.metrics.transactionsAdded(added);
     return Promise.resolve(added.length);
   }
 
@@ -224,6 +226,7 @@ export class InMemoryTxPool extends (EventEmitter as new () => TypedEventEmitter
         }
       }
     }
+    this.metrics.transactionsRemoved(txHashes);
 
     return Promise.resolve();
   }

--- a/yarn-project/p2p/src/services/tx_provider.ts
+++ b/yarn-project/p2p/src/services/tx_provider.ts
@@ -160,13 +160,13 @@ export class TxProvider implements ITxProvider {
 
     // Start tx collection from the network if needed, while we validate the txs taken from the proposal in parallel
     const [txsFromNetwork] = await Promise.all([
-      this.txCollection.collectFastFor(request, [...missingTxHashes], opts),
+      this.collectFromP2P(request, [...missingTxHashes], opts),
       this.processProposalTxs(txsFromProposal),
     ] as const);
 
     if (txsFromNetwork.length > 0) {
       txsFromNetwork.forEach(tx => missingTxHashes.delete(tx.txHash.toString()));
-      this.instrumentation.incTxsFromP2P(txsFromNetwork.length);
+      this.instrumentation.incTxsFromP2P(txsFromNetwork.length, txHashes.length);
       this.log.debug(
         `Retrieved ${txsFromNetwork.length} txs from network for block proposal (${missingTxHashes.size} pending)`,
         { ...blockInfo, missingTxHashes: [...missingTxHashes] },
@@ -198,6 +198,18 @@ export class TxProvider implements ITxProvider {
       txsFromProposal,
       missingTxHashes: [...missingTxHashes],
     };
+  }
+
+  private async collectFromP2P(
+    input: FastCollectionRequestInput,
+    txHashes: TxHash[] | string[],
+    opts: { deadline: Date; pinnedPeer?: PeerId },
+  ): Promise<Tx[]> {
+    const requestedAt = Date.now();
+    const result = await this.txCollection.collectFastFor(input, txHashes, opts);
+    const requestProcessedAt = Date.now();
+    this.instrumentation.recordTxsRequestDelay(requestProcessedAt - requestedAt);
+    return result;
   }
 
   private extractFromProposal(proposal: BlockProposal | undefined, missingTxHashes: string[]): Tx[] {

--- a/yarn-project/p2p/src/services/tx_provider_instrumentation.ts
+++ b/yarn-project/p2p/src/services/tx_provider_instrumentation.ts
@@ -1,10 +1,13 @@
-import { Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
+import { type Histogram, Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
 
 export class TxProviderInstrumentation {
   private txFromProposalCount: UpDownCounter;
   private txFromMempoolCount: UpDownCounter;
   private txFromP2PCount: UpDownCounter;
   private missingTxsCount: UpDownCounter;
+
+  private fractionOfTxsRequestedFromP2P: Histogram;
+  private txsRequestDelay: Histogram;
 
   constructor(client: TelemetryClient, name: string) {
     const meter = client.getMeter(name);
@@ -24,6 +27,15 @@ export class TxProviderInstrumentation {
     this.missingTxsCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_MISSING_TXS_COUNT, {
       description: 'The number of txs not found anywhere',
     });
+
+    this.fractionOfTxsRequestedFromP2P = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION, {
+      description: 'The fraction of transaction requested from peers',
+    });
+
+    this.txsRequestDelay = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUEST_DELAY, {
+      unit: 'ms',
+      description: 'The time it took to request missing transactions from p2p',
+    });
   }
 
   incTxsFromProposals(count: number) {
@@ -34,8 +46,13 @@ export class TxProviderInstrumentation {
     this.txFromMempoolCount.add(count);
   }
 
-  incTxsFromP2P(count: number) {
+  incTxsFromP2P(count: number, total: number) {
     this.txFromP2PCount.add(count);
+    this.fractionOfTxsRequestedFromP2P.record(count / total);
+  }
+
+  recordTxsRequestDelay(delay: number) {
+    this.txsRequestDelay.record(delay);
   }
 
   incMissingTxs(count: number) {

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -214,10 +214,14 @@ export class CheckpointProposalJob {
         this.proposer,
         blockProposalOptions,
       );
+      const blockProposedAt = this.dateProvider.now();
       await this.p2pClient.broadcastProposal(proposal);
 
       this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.slot);
       const attestations = await this.waitForAttestations(proposal);
+      const blockAttestedAt = this.dateProvider.now();
+
+      this.metrics.recordBlockAttestationDelay(blockAttestedAt - blockProposedAt);
 
       // Proposer must sign over the attestations before pushing them to L1
       const signer = this.proposer ?? this.publisher.getSenderAddress();

--- a/yarn-project/sequencer-client/src/sequencer/metrics.ts
+++ b/yarn-project/sequencer-client/src/sequencer/metrics.ts
@@ -44,6 +44,7 @@ export class SequencerMetrics {
   private blockProposalPrecheckFailed: UpDownCounter;
   private checkpointSuccess: UpDownCounter;
   private slashingAttempts: UpDownCounter;
+  private blockAttestationDelay: Histogram;
 
   // Fisherman fee analysis metrics
   private fishermanWouldBeIncluded: UpDownCounter;
@@ -90,6 +91,12 @@ export class SequencerMetrics {
         valueType: ValueType.INT,
       },
     );
+
+    this.blockAttestationDelay = this.meter.createHistogram(Metrics.SEQUENCER_BLOCK_ATTESTATION_DELAY, {
+      unit: 'ms',
+      description: 'The time difference between block proposal and minimal attestation count reached,',
+      valueType: ValueType.INT,
+    });
 
     // Init gauges and counters
     this.blockCounter.add(0, {
@@ -255,6 +262,10 @@ export class SequencerMetrics {
     // reset
     this.collectedAttestions.record(0);
     this.timeToCollectAttestations.record(0);
+  }
+
+  public recordBlockAttestationDelay(duration: number) {
+    this.blockAttestationDelay.record(duration);
   }
 
   public recordCollectedAttestations(count: number, durationMs: number) {

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -35,6 +35,8 @@ export const CIRCUIT_SIZE = 'aztec.circuit.size';
 export const MEMPOOL_TX_COUNT = 'aztec.mempool.tx_count';
 export const MEMPOOL_TX_SIZE = 'aztec.mempool.tx_size';
 export const MEMPOOL_TX_ADDED_COUNT = 'aztec.mempool.tx_added_count';
+export const MEMPOOL_TX_MINED_DELAY = 'aztec.mempool.tx_mined_delay';
+
 export const DB_NUM_ITEMS = 'aztec.db.num_items';
 export const DB_MAP_SIZE = 'aztec.db.map_size';
 export const DB_PHYSICAL_FILE_SIZE = 'aztec.db.physical_file_size';
@@ -43,6 +45,7 @@ export const DB_USED_SIZE = 'aztec.db.used_size';
 export const MEMPOOL_ATTESTATIONS_COUNT = 'aztec.mempool.attestations_count';
 export const MEMPOOL_ATTESTATIONS_SIZE = 'aztec.mempool.attestations_size';
 export const MEMPOOL_ATTESTATIONS_ADDED_COUNT = 'aztec.mempool.attestations_added_count';
+export const MEMPOOL_ATTESTATIONS_MINED_DELAY = 'aztec.mempool.attestations_mined_delay';
 
 export const ARCHIVER_L1_BLOCK_HEIGHT = 'aztec.archiver.l1_block_height';
 export const ARCHIVER_BLOCK_HEIGHT = 'aztec.archiver.block_height';
@@ -77,6 +80,8 @@ export const SEQUENCER_BLOCK_COUNT = 'aztec.sequencer.block.count';
 export const SEQUENCER_CURRENT_BLOCK_REWARDS = 'aztec.sequencer.current_block_rewards';
 export const SEQUENCER_SLOT_COUNT = 'aztec.sequencer.slot.total_count';
 export const SEQUENCER_FILLED_SLOT_COUNT = 'aztec.sequencer.slot.filled_count';
+
+export const SEQUENCER_BLOCK_ATTESTATION_DELAY = 'aztec.sequencer.block.attestation_delay';
 
 export const SEQUENCER_COLLECTED_ATTESTATIONS_COUNT = 'aztec.sequencer.attestations.collected_count';
 export const SEQUENCER_REQUIRED_ATTESTATIONS_COUNT = 'aztec.sequencer.attestations.required_count';
@@ -258,6 +263,8 @@ export const TX_PROVIDER_TXS_FROM_PROPOSALS_COUNT = 'aztec.tx_collector.txs_from
 export const TX_PROVIDER_TXS_FROM_MEMPOOL_COUNT = 'aztec.tx_collector.txs_from_mempool_count';
 export const TX_PROVIDER_TXS_FROM_P2P_COUNT = 'aztec.tx_collector.txs_from_p2p_count';
 export const TX_PROVIDER_MISSING_TXS_COUNT = 'aztec.tx_collector.missing_txs_count';
+export const TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION = 'aztec.tx_collector.txs_requested_fraction';
+export const TX_PROVIDER_P2P_TXS_REQUEST_DELAY = 'aztec.tx_collector.txs_requested_delay';
 
 export const TX_COLLECTOR_COUNT = 'aztec.tx_collector.tx_count';
 export const TX_COLLECTOR_DURATION_PER_REQUEST = 'aztec.tx_collector.duration_per_request';


### PR DESCRIPTION
Ref: A-334, A-411, A-409

Time between the proposer submitting the block and collecting 2/3rd attestation
Each node should track how long txs spend in the mempool.
Request/response percentage(how many transactions had to been fetched via req/resp subsystem)
Request/response latency(Time to collect all missing txs for block we are attesting to)