### PR TITLE
fix(avm): sha256 tracegen batched tag checks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/sha256_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/sha256_trace.cpp
@@ -404,17 +404,21 @@ void Sha256TraceBuilder::process(
 
         if (invalid_state_tag_err) {
             // This is the more efficient batched tag check we perform in the circuit
-            uint64_t batched_check = 0;
+            FF batched_tag_check = 0;
             // Batch the state tag checks
+            FF target_tag = FF(static_cast<uint8_t>(MemoryTag::U32));
             for (uint32_t i = 0; i < event.state.size(); i++) {
-                batched_check |=
-                    (static_cast<uint64_t>(event.state[i].get_tag()) - static_cast<uint64_t>(MemoryTag::U32))
-                    << (i * 3);
+                // Compute the batched tag check step by step to match the circuit implementation
+                FF mem_tag = FF(static_cast<uint8_t>(event.state[i].get_tag()));
+                FF state_tag_diff = mem_tag - target_tag;
+                FF exponent = FF(1 << (i * 3)); // exponent is 1, 8, 64, 512, ...
+                batched_tag_check += state_tag_diff * exponent;
             }
             trace.set(row,
                       { {
                           { C::sha256_sel_invalid_state_tag_err, 1 },
-                          { C::sha256_batch_tag_inv, FF(batched_check).invert() },
+                          // Guaranteed non-zero (so inversion is safe) since we have an invalid tag
+                          { C::sha256_batch_tag_inv, FF(batched_tag_check).invert() },
                           { C::sha256_latch, 1 },
                           { C::sha256_err, 1 }, // Set the error flag
                       } });


### PR DESCRIPTION
When I implemented the batched tag checks, I made the invalid assumption the values would be within 64 bits ( 1-width bigger than the 32-bits that Sha256 uses). This can easily be shown to be wrong `(Tag::FF - Tag::U32 => p - 4)`, good thing the fuzzer caught it