### PR TITLE
fix(avm): precomp trace for get_p_limbs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.hpp
@@ -451,9 +451,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x1f4f53d8c274f2019474fe304b7ec352663f08b2a128de79bdf7bc65e5db32b3")), // precomputed_sel_tag_parameters
             Commitment(
-                uint256_t("0x2437c8d0dbe47dc612ccf4a5ad9cee871c4f57bc794166dcfb96b127fed46398"),
+                uint256_t("0x122c377cad49f6338188909ccb858cf8304b3b00383bd44be42861a3d4158090"),
                 uint256_t(
-                    "0x1fc575fca116894d05b386b745949a6f438122e256d7dd889cc6bd0df5a4d20b")), // precomputed_sel_to_radix_p_limb_counts
+                    "0x2af6b300db680f1713472c2c931cd10ec804eb227a659b7928dbc2bc01a33791")), // precomputed_sel_to_radix_p_limb_counts
             Commitment(
                 uint256_t("0x1aad75d8502dcfee5df4a491c540577ad095025f94405a19bb3c314d9b88af45"),
                 uint256_t(

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/gas.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/gas.test.cpp
@@ -415,5 +415,51 @@ TEST(GasConstrainingTest, DynGasFactorInvalidRadix)
                               execution::SR_DYN_GAS_ID_DECOMPOSITION);
 }
 
+TEST(GasConstrainingTest, DynGasFactorToRadixInvalidRadixLt2)
+{
+    PrecomputedTraceBuilder precomputed_builder;
+
+    uint32_t radix = 1; // Invalid radix (must be >= 2)
+    uint32_t num_limbs = 20;
+    uint32_t num_p_limbs = static_cast<uint32_t>(get_p_limbs_per_radix_size(radix)); // Returns 0
+    TestTraceContainer trace({ {
+                                   { C::execution_sel, 1 },
+                                   { C::execution_register_1_, radix },
+                                   { C::execution_register_2_, num_limbs },
+                                   { C::execution_sel_should_check_gas, 1 },
+                                   // To Radix BE Dynamic Gas
+                                   { C::execution_sel_gas_to_radix, 1 },
+                                   { C::execution_dyn_gas_id, AVM_DYN_GAS_ID_TORADIX },
+                                   { C::execution_two_five_six, 256 },
+                                   { C::execution_sel_radix_gt_256, 0 },
+                                   { C::execution_sel_lookup_num_p_limbs, 1 },
+                                   { C::execution_num_p_limbs, num_p_limbs },
+                                   { C::execution_sel_use_num_limbs, 1 }, // num_limbs (20) > num_p_limbs (0)
+                                   { C::execution_dynamic_l2_gas_factor, num_limbs }, // max(20, 0) = 20
+                                   // GT Trace, used to check if radix > 256
+                                   { C::gt_sel, 1 },
+                                   { C::gt_input_a, radix },
+                                   { C::gt_input_b, 256 },
+                                   { C::gt_res, 0 },
+                               },
+                               {
+                                   // Gt Trace, compare num_limbs > num_p_limbs
+                                   { C::gt_sel, 1 },
+                                   { C::gt_input_a, num_limbs },
+                                   { C::gt_input_b, num_p_limbs },
+                                   { C::gt_res, 1 }, // 20 > 0
+                               } });
+
+    precomputed_builder.process_misc(trace, 257);
+    precomputed_builder.process_to_radix_safe_limbs(trace);
+
+    // To Radix fails because radix < 2, but the lookup constraints must still satisfied for the gas relation to hold.
+    check_interaction<ExecutionTraceBuilder,
+                      lookup_execution_check_radix_gt_256_settings,
+                      lookup_execution_get_p_limbs_settings,
+                      lookup_execution_get_max_limbs_settings>(trace);
+    check_relation<execution>(trace, execution::SR_DYN_L2_FACTOR_TO_RADIX_BE, execution::SR_DYN_GAS_ID_DECOMPOSITION);
+}
+
 } // namespace
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
@@ -136,7 +136,7 @@ TEST_F(AvmRecursionConstraintTest, GateCountAndVKCheck)
     using ProverInstance = ProverInstance_<UltraRollupFlavor>;
 
     static constexpr FF EXPECTED_OUTER_VK_HASH =
-        FF("0x0c17c44b4c643765ef2ffc77cb6b77104910b0d4fc38de7ea0115301346e2b51");
+        FF("0x2b6a12d8695a0dc9a25d2a87df02dc42246be0eed271c41aab603d91901d71b7");
 
     AcirConstraint constraint;
     WitnessVector witness;
@@ -167,7 +167,7 @@ class AvmRecursionInnerCircuitTests : public ::testing::Test {
     using FF = Builder::FF;
 
     static constexpr FF EXPECTED_INNER_VK_HASH =
-        FF("0x0822fef4f7d002ccf7f18512598d0fc1a6b8b13143221330bcb1ce0990eba291");
+        FF("0x0efaaaece4a7b764beaa079f4e75156c56d2d14ea2e99f2421d0fc20c2acaa63");
 
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
@@ -293,11 +293,12 @@ void PrecomputedTraceBuilder::process_to_radix_safe_limbs(TraceContainer& trace)
 
     for (size_t i = 0; i < p_limbs_per_radix.size(); ++i) {
         size_t decomposition_len = p_limbs_per_radix[i].size();
-        if (decomposition_len > 0) {
-            trace.set(C::precomputed_sel_to_radix_p_limb_counts, static_cast<uint32_t>(i), 1);
-            trace.set(C::precomputed_to_radix_safe_limbs, static_cast<uint32_t>(i), decomposition_len - 1);
-            trace.set(C::precomputed_to_radix_num_limbs_for_p, static_cast<uint32_t>(i), decomposition_len);
-        }
+        trace.set(C::precomputed_sel_to_radix_p_limb_counts, static_cast<uint32_t>(i), 1);
+        // Use 0 as fallback when decomposition_len == 0 (i.e. p_limbs_per_radix[0] and p_limbs_per_radix[1])
+        trace.set(C::precomputed_to_radix_safe_limbs,
+                  static_cast<uint32_t>(i),
+                  decomposition_len > 0 ? decomposition_len - 1 : 0);
+        trace.set(C::precomputed_to_radix_num_limbs_for_p, static_cast<uint32_t>(i), decomposition_len);
     }
 }
 


### PR DESCRIPTION
For situations where `radix = 0, 1` we were not building the precomputed trace for `radix_safe_limbs`. Even though the `ToRadix` subtrace will error (since the radix is invalid). We need this lookup in the execution trace to pass for gas computation.

The error was missing by our existing test suite and the to_radix fuzzer becuase the bug only manifests when:
  - You have invalid radix (0 or 1)
  - You generate the actual precomputed trace (which skipped rows 0 and 1)
  - You generate the actual execution trace (which tries to lookup radix=1)
  - You run the actual lookup constraint check