### PR TITLE
chore(fix): bump validator timeout on tf deployment and increase prob…

### DIFF
--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -136,8 +136,9 @@ locals {
     } : null
 
     validators = tonumber(var.VALIDATOR_REPLICAS) > 0 ? {
-      name  = "${var.RELEASE_PREFIX}-validator"
-      chart = "aztec-validator"
+      name    = "${var.RELEASE_PREFIX}-validator"
+      chart   = "aztec-validator"
+      timeout = 1800
       values = [
         "common.yaml",
         "validator.yaml",
@@ -491,7 +492,7 @@ resource "helm_release" "releases" {
   force_update     = true
   recreate_pods    = true
   reuse_values     = false
-  timeout          = 600
+  timeout          = lookup(each.value, "timeout", 600)
   wait             = each.value.wait
   wait_for_jobs    = true
 

--- a/spartan/terraform/deploy-aztec-infra/values/validator.yaml
+++ b/spartan/terraform/deploy-aztec-infra/values/validator.yaml
@@ -7,7 +7,7 @@ validator:
       periodSeconds: 30
       timeoutSeconds: 5
       initialDelaySeconds: 0
-      failureThreshold: 40
+      failureThreshold: 60
     preStartScript: |
       source /scripts/setup-attester-keystore.sh
 

--- a/yarn-project/end-to-end/src/spartan/validator_nuke_and_suppression.test.ts
+++ b/yarn-project/end-to-end/src/spartan/validator_nuke_and_suppression.test.ts
@@ -28,7 +28,7 @@ import {
 } from './utils.js';
 
 describe('validator suppression and nuke with slashing assertions', () => {
-  jest.setTimeout(60 * 60 * 1000); // 60 minutes
+  jest.setTimeout(2 * 60 * 60 * 1000); // 120 minutes
 
   const logger = createLogger('e2e:spartan:suppress-nuke-slash');
   const config = setupEnvironment(process.env);


### PR DESCRIPTION
It seems for validator startup, sometimes after the log line,

`Downloading CRS of size 2 into /root/.bb-crs` 

will take longer time than current defaults (>10min) and fail deployment. 
Bumping timeouts for now to address upper bound.