### PR TITLE
fix: Replace missed CI_ENABLE_DISK_LOGS with CI_USE_BUILD_INSTANCE_KEY

### DIFF
--- a/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
+++ b/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
@@ -120,7 +120,7 @@ chonk_flow $1 $2
 runtime="$1"
 flow_name="$(basename $2)"
 
-if [[ "${CI:-}" == "1" ]] && [[ "${CI_ENABLE_DISK_LOGS:-0}" == "1" ]]; then
+if [[ "${CI:-}" == "1" ]] && [[ "${CI_USE_BUILD_INSTANCE_KEY:-0}" == "1" ]]; then
   echo_header "Uploading Barretenberg benchmark breakdowns for $flow_name"
 
   benchmark_breakdown_file="bench-out/app-proving/$flow_name/$runtime/benchmark_breakdown.json"


### PR DESCRIPTION
## Summary
- Fixes a missed replacement of `CI_ENABLE_DISK_LOGS` with `CI_USE_BUILD_INSTANCE_KEY` in `ci_benchmark_ivc_flows.sh`
- This was missed in b738e8387a1799847438e85c3e6e90e68e8132a6

## Test plan
- CI should pass and benchmark breakdowns should be uploaded.