### PR TITLE
feat: propagate bb options

### DIFF
--- a/barretenberg/ts/src/bb_backends/index.ts
+++ b/barretenberg/ts/src/bb_backends/index.ts
@@ -28,6 +28,9 @@ export type BackendOptions = {
   /** @description Custom path to bb binary for native backend (overrides automatic detection) */
   bbPath?: string;
 
+  /** @description Custom path to bb NAPI module for native backend (overrides automatic detection) */
+  napiPath?: string;
+
   /**
    * @description Logging function
    * Warning: Attaching a logger can prevent nodejs from exiting without explicitly destroying the backend.

--- a/barretenberg/ts/src/bb_backends/node/index.ts
+++ b/barretenberg/ts/src/bb_backends/node/index.ts
@@ -35,12 +35,17 @@ export async function createAsyncBackend(
       if (!bbPath) {
         throw new Error('Native backend requires bb binary.');
       }
-      const napiPath = findNapiBinary();
+      const napiPath = findNapiBinary(options.napiPath);
       if (!napiPath) {
         throw new Error('Native async backend requires napi client stub.');
       }
       logger(`Using native shared memory async backend: ${bbPath}`);
-      const asyncBackend = await BarretenbergNativeShmAsyncBackend.new(bbPath, options.threads, options.logger);
+      const asyncBackend = await BarretenbergNativeShmAsyncBackend.new(
+        bbPath,
+        napiPath,
+        options.threads,
+        options.logger,
+      );
       return new Barretenberg(asyncBackend, options);
     }
 
@@ -82,12 +87,12 @@ export async function createSyncBackend(
       if (!bbPath) {
         throw new Error('Native backend requires bb binary.');
       }
-      const napiPath = findNapiBinary();
+      const napiPath = findNapiBinary(options.napiPath);
       if (!napiPath) {
         throw new Error('Native sync backend requires napi client stub.');
       }
       logger(`Using native shared memory backend: ${bbPath}`);
-      const shm = await BarretenbergNativeShmSyncBackend.new(bbPath, options.threads, options.logger);
+      const shm = await BarretenbergNativeShmSyncBackend.new(bbPath, napiPath, options.threads, options.logger);
       return new BarretenbergSync(shm);
     }
 

--- a/barretenberg/ts/src/bb_backends/node/native_shm.ts
+++ b/barretenberg/ts/src/bb_backends/node/native_shm.ts
@@ -4,21 +4,6 @@ import { openSync, closeSync } from 'fs';
 import { IMsgpackBackendSync } from '../interface.js';
 import { findNapiBinary, findPackageRoot } from './platform.js';
 
-// Import the NAPI module
-// The addon is built to the nodejs_module directory
-const addonPath = findNapiBinary();
-// Try loading, but don't throw if it doesn't exist (will be caught in constructor)
-let addon: any = null;
-try {
-  if (addonPath) {
-    const require = createRequire(findPackageRoot()!);
-    addon = require(addonPath);
-  }
-} catch (err) {
-  // Addon not built yet or not available
-  addon = null;
-}
-
 let instanceCounter = 0;
 
 /**
@@ -50,11 +35,21 @@ export class BarretenbergNativeShmSyncBackend implements IMsgpackBackendSync {
    */
   static async new(
     bbBinaryPath: string,
+    napiPath: string,
     threads?: number,
     logger?: (msg: string) => void,
   ): Promise<BarretenbergNativeShmSyncBackend> {
-    if (!addon || !addon.MsgpackClient) {
-      throw new Error('Shared memory NAPI not available.');
+    // Import the NAPI module
+    // The addon is built to the nodejs_module directory
+    const addonPath = findNapiBinary(napiPath);
+    // Try loading
+    let addon: any = null;
+    try {
+      const require = createRequire(findPackageRoot()!);
+      addon = require(addonPath!);
+    } catch (err) {
+      // Addon not built yet or not available
+      throw new Error('Shared memory sync NAPI not available.');
     }
 
     // Create a unique shared memory name

--- a/barretenberg/ts/src/bb_backends/node/native_shm_async.ts
+++ b/barretenberg/ts/src/bb_backends/node/native_shm_async.ts
@@ -4,21 +4,6 @@ import { openSync, closeSync } from 'fs';
 import { IMsgpackBackendAsync } from '../interface.js';
 import { findNapiBinary, findPackageRoot } from './platform.js';
 
-// Import the NAPI module
-// The addon is built to the nodejs_module directory
-const addonPath = findNapiBinary();
-// Try loading, but don't throw if it doesn't exist (will be caught in constructor)
-let addon: any = null;
-try {
-  if (addonPath) {
-    const require = createRequire(findPackageRoot()!);
-    addon = require(addonPath);
-  }
-} catch (err) {
-  // Addon not built yet or not available
-  addon = null;
-}
-
 let instanceCounter = 0;
 
 /**
@@ -86,18 +71,28 @@ export class BarretenbergNativeShmAsyncBackend implements IMsgpackBackendAsync {
    */
   static async new(
     bbBinaryPath: string,
+    napiPath: string,
     threads?: number,
     logger?: (msg: string) => void,
   ): Promise<BarretenbergNativeShmAsyncBackend> {
-    if (!addon || !addon.MsgpackClientAsync) {
+    // Import the NAPI module
+    // The addon is built to the nodejs_module directory
+    const addonPath = findNapiBinary(napiPath);
+    // Try loading
+    let addon: any = null;
+    try {
+      const require = createRequire(findPackageRoot()!);
+      addon = require(addonPath!);
+    } catch (err) {
+      // Addon not built yet or not available
       throw new Error('Shared memory async NAPI not available.');
     }
 
     // Create a unique shared memory name
     const shmName = `bb-async-${process.pid}-${instanceCounter++}`;
 
-    // If threads not set use num cpu cores, max 32 (same as socket backend)
-    const hwc = threads ? threads.toString() : '1';
+    // If threads not set use num cpu cores, max 16 (same as socket backend)
+    const hwc = threads ? threads.toString() : '16';
     const env = { ...process.env, HARDWARE_CONCURRENCY: hwc };
 
     // Set up file logging if logger is provided

--- a/barretenberg/ts/src/bb_backends/node/native_socket.ts
+++ b/barretenberg/ts/src/bb_backends/node/native_socket.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { IMsgpackBackendAsync } from '../interface.js';
-import { findPackageRoot } from './platform.js';
 import readline from 'readline';
 
 /**
@@ -58,9 +57,9 @@ export class BarretenbergNativeSocketAsyncBackend implements IMsgpackBackendAsyn
       connectionReject = reject;
     });
 
-    // If threads not set use num cpu cores, max 32.
-    const hwc = threads ? threads.toString() : Math.min(32, os.cpus.length).toString();
-    const env = { ...process.env, HARDWARE_CONCURRENCY: '1' };
+    // If threads not set use num cpu cores, max 16.
+    const hwc = threads ? threads.toString() : Math.min(16, os.cpus().length).toString();
+    const env = { ...process.env, HARDWARE_CONCURRENCY: hwc };
 
     // Spawn bb process - it will create the socket server
     const args = ['msgpack', 'run', '--input', this.socketPath];

--- a/barretenberg/ts/src/bb_backends/node/platform.ts
+++ b/barretenberg/ts/src/bb_backends/node/platform.ts
@@ -24,7 +24,12 @@ export function findPackageRoot(): string | null {
   while (currentDir !== root) {
     const packageJsonPath = path.join(currentDir, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
-      return currentDir;
+      // Check if this is the actual package root by verifying it has a 'build' directory
+      // This ensures we skip intermediate package.json files (e.g., in dest/node-cjs/)
+      const buildDir = path.join(currentDir, 'build');
+      if (fs.existsSync(buildDir)) {
+        return currentDir;
+      }
     }
     currentDir = path.dirname(currentDir);
   }

--- a/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
@@ -1,5 +1,5 @@
-import { AztecClientBackend, Barretenberg } from '@aztec/bb.js';
-import { createLogger } from '@aztec/foundation/log';
+import { AztecClientBackend, type BackendOptions, Barretenberg } from '@aztec/bb.js';
+import { type LogLevel, type Logger, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { serializeWitness } from '@aztec/noir-noirc_abi';
 import {
@@ -45,12 +45,17 @@ import type { CircuitSimulationStats, CircuitWitnessGenerationStats } from '@azt
 
 import { ungzip } from 'pako';
 
+export type BBPrivateKernelProverOptions = Omit<BackendOptions, 'logger'> & { logger?: Logger };
 export abstract class BBPrivateKernelProver implements PrivateKernelProver {
+  private log: Logger;
+
   constructor(
     protected artifactProvider: ArtifactProvider,
     protected simulator: CircuitSimulator,
-    protected log = createLogger('bb-prover'),
-  ) {}
+    protected options: BBPrivateKernelProverOptions = {},
+  ) {
+    this.log = options.logger || createLogger('bb-prover:private-kernel');
+  }
 
   public async generateInitOutput(
     inputs: PrivateKernelInitCircuitPrivateInputs,
@@ -271,9 +276,13 @@ export abstract class BBPrivateKernelProver implements PrivateKernelProver {
   public async createChonkProof(executionSteps: PrivateExecutionStep[]): Promise<ChonkProofWithPublicInputs> {
     const timer = new Timer();
     this.log.info(`Generating ClientIVC proof...`);
+    const barretenberg = await Barretenberg.initSingleton({
+      ...this.options,
+      logger: this.options.logger?.[(process.env.LOG_LEVEL as LogLevel) || 'verbose'],
+    });
     const backend = new AztecClientBackend(
       executionSteps.map(step => ungzip(step.bytecode)),
-      await Barretenberg.initSingleton(),
+      barretenberg,
     );
 
     const [proof] = await backend.prove(
@@ -290,7 +299,11 @@ export abstract class BBPrivateKernelProver implements PrivateKernelProver {
 
   public async computeGateCountForCircuit(_bytecode: Buffer, _circuitName: string): Promise<number> {
     // Note we do not pass the vk to the backend. This is unneeded for gate counts.
-    const backend = new AztecClientBackend([ungzip(_bytecode)], await Barretenberg.initSingleton());
+    const barretenberg = await Barretenberg.initSingleton({
+      ...this.options,
+      logger: this.options.logger?.[(process.env.LOG_LEVEL as LogLevel) || 'verbose'],
+    });
+    const backend = new AztecClientBackend([ungzip(_bytecode)], barretenberg);
     const gateCount = await backend.gates();
     return gateCount[0];
   }

--- a/yarn-project/bb-prover/src/prover/client/bundle.ts
+++ b/yarn-project/bb-prover/src/prover/client/bundle.ts
@@ -1,11 +1,10 @@
-import { createLogger } from '@aztec/foundation/log';
 import { BundleArtifactProvider } from '@aztec/noir-protocol-circuits-types/client/bundle';
 import type { CircuitSimulator } from '@aztec/simulator/client';
 
-import { BBPrivateKernelProver } from './bb_private_kernel_prover.js';
+import { BBPrivateKernelProver, type BBPrivateKernelProverOptions } from './bb_private_kernel_prover.js';
 
 export class BBBundlePrivateKernelProver extends BBPrivateKernelProver {
-  constructor(simulator: CircuitSimulator, log = createLogger('bb-prover:bundle')) {
-    super(new BundleArtifactProvider(), simulator, log);
+  constructor(simulator: CircuitSimulator, options: BBPrivateKernelProverOptions = {}) {
+    super(new BundleArtifactProvider(), simulator, options);
   }
 }

--- a/yarn-project/bb-prover/src/prover/client/lazy.ts
+++ b/yarn-project/bb-prover/src/prover/client/lazy.ts
@@ -1,11 +1,10 @@
-import { createLogger } from '@aztec/foundation/log';
 import { LazyArtifactProvider } from '@aztec/noir-protocol-circuits-types/client/lazy';
 import type { CircuitSimulator } from '@aztec/simulator/client';
 
-import { BBPrivateKernelProver } from './bb_private_kernel_prover.js';
+import { BBPrivateKernelProver, type BBPrivateKernelProverOptions } from './bb_private_kernel_prover.js';
 
 export class BBLazyPrivateKernelProver extends BBPrivateKernelProver {
-  constructor(simulator: CircuitSimulator, log = createLogger('bb-prover:lazy')) {
-    super(new LazyArtifactProvider(), simulator, log);
+  constructor(simulator: CircuitSimulator, options: BBPrivateKernelProverOptions = {}) {
+    super(new LazyArtifactProvider(), simulator, options);
   }
 }

--- a/yarn-project/end-to-end/src/bench/client_flows/data_extractor.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/data_extractor.ts
@@ -22,7 +22,7 @@ async function main() {
   logger.info(`Flows in ${ivcFolder}: \n${flows.map(flowName => `\t- ${flowName}`).join('\n')}`);
   const simulator = new WASMSimulator();
   const log = proxyLogger.createLogger('bb:prover');
-  const prover = new BBBundlePrivateKernelProver(simulator, log);
+  const prover = new BBBundlePrivateKernelProver(simulator, { logger: log });
 
   const userLog = createLogger('chonk_flows:data_processor');
 

--- a/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
@@ -1,3 +1,4 @@
+import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBBundlePrivateKernelProver } from '@aztec/bb-prover/client/bundle';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { createLogger } from '@aztec/foundation/log';
@@ -49,7 +50,12 @@ export async function createPXE(
     ? loggers.prover
     : createLogger('pxe:bb:wasm:bundle' + (logSuffix ? `:${logSuffix}` : ''));
 
-  const prover = options.prover ?? new BBBundlePrivateKernelProver(simulator, proverLogger);
+  let prover;
+  if (options.proverOrOptions instanceof BBPrivateKernelProver) {
+    prover = options.proverOrOptions;
+  } else {
+    prover = new BBBundlePrivateKernelProver(simulator, { ...options.proverOrOptions, logger: proverLogger });
+  }
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));

--- a/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
@@ -1,3 +1,4 @@
+import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBLazyPrivateKernelProver } from '@aztec/bb-prover/client/lazy';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { createLogger } from '@aztec/foundation/log';
@@ -48,8 +49,12 @@ export async function createPXE(
     ? loggers.prover
     : createLogger('pxe:bb:wasm:bundle' + (logSuffix ? `:${logSuffix}` : ''));
 
-  const prover = options.prover ?? new BBLazyPrivateKernelProver(simulator, proverLogger);
-
+  let prover;
+  if (options.proverOrOptions instanceof BBPrivateKernelProver) {
+    prover = options.proverOrOptions;
+  } else {
+    prover = new BBLazyPrivateKernelProver(simulator, { ...options.proverOrOptions, logger: proverLogger });
+  }
   const protocolContractsProvider = new LazyProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));

--- a/yarn-project/pxe/src/entrypoints/pxe_creation_options.ts
+++ b/yarn-project/pxe/src/entrypoints/pxe_creation_options.ts
@@ -1,3 +1,4 @@
+import type { BBPrivateKernelProverOptions } from '@aztec/bb-prover/client';
 import type { Logger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { CircuitSimulator } from '@aztec/simulator/client';
@@ -6,7 +7,7 @@ import type { PrivateKernelProver } from '@aztec/stdlib/interfaces/client';
 export type PXECreationOptions = {
   loggers?: { store?: Logger; pxe?: Logger; prover?: Logger };
   useLogSuffix?: boolean | string;
-  prover?: PrivateKernelProver;
+  proverOrOptions?: PrivateKernelProver | BBPrivateKernelProverOptions;
   store?: AztecAsyncKVStore;
   simulator?: CircuitSimulator;
 };

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -1,13 +1,10 @@
+import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBBundlePrivateKernelProver } from '@aztec/bb-prover/client/bundle';
 import { randomBytes } from '@aztec/foundation/crypto/random';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
+import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
-import {
-  type CircuitSimulator,
-  MemoryCircuitRecorder,
-  SimulatorRecorderWrapper,
-  WASMSimulator,
-} from '@aztec/simulator/client';
+import { MemoryCircuitRecorder, SimulatorRecorderWrapper, WASMSimulator } from '@aztec/simulator/client';
 import { FileCircuitRecorder } from '@aztec/simulator/testing';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
@@ -46,9 +43,6 @@ export async function createPXE(
   };
 
   if (!options.store) {
-    // TODO once https://github.com/AztecProtocol/aztec-packages/issues/13656 is fixed, we can remove this and always
-    // import the lmdb-v2 version
-    const { createStore } = await import('@aztec/kv-store/lmdb-v2');
     const storeLogger = loggers.store
       ? loggers.store
       : createLogger('pxe:data:lmdb' + (logSuffix ? `:${logSuffix}` : ''));
@@ -58,7 +52,13 @@ export async function createPXE(
     ? loggers.prover
     : createLogger('pxe:bb:native' + (logSuffix ? `:${logSuffix}` : ''));
 
-  const prover = options.prover ?? createProver(simulator, proverLogger);
+  let prover;
+  if (options.proverOrOptions instanceof BBPrivateKernelProver) {
+    prover = options.proverOrOptions;
+  } else {
+    prover = new BBBundlePrivateKernelProver(simulator, { ...options.proverOrOptions, logger: proverLogger });
+  }
+
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));
@@ -72,8 +72,4 @@ export async function createPXE(
     pxeLogger,
   );
   return pxe;
-}
-
-function createProver(simulator: CircuitSimulator, logger?: Logger) {
-  return new BBBundlePrivateKernelProver(simulator, logger);
 }


### PR DESCRIPTION
Fixes a few problems with the new bb.js initialization, namely:

* Not forwarding hwc to the native unix socket backend, which made it run single threaded
* Unusable NAPI backends under CJS

And adds the possibility of forwarding backend options from "Aztec land" so the consumers can customize how to run proving. Besides allowing for more flexibility, this recovers bb logging from the playground, which was lost a while ago.