### PR TITLE
chore(docs): Revise Noir descriptions in Overview

### DIFF
--- a/docs/docs-developers/overview.md
+++ b/docs/docs-developers/overview.md
@@ -77,4 +77,4 @@ As Aztec has native account abstraction, accounts do not automatically have a si
 
 ## Noir
 
-Noir is a zero-knowledge domain specific language used for writing smart contracts for the Aztec network. It is also possible to write circuits with Noir that can be verified on or offchain. For more in-depth docs into the features of Noir, go to the [Noir documentation](https://noir-lang.org/).
+Smart contracts on the Aztec network are written in Noir, an open-source, zero-knowledge programming language. Noir is useable for developing zero-knowledge applications on Aztec, on other blockchains, as well as offchain. For more information about Noir, visit the [Noir website](https://noir-lang.org/).


### PR DESCRIPTION
Rewriting the Noir portion on the docs' Overview page to update link description and better align wordings.