### PR TITLE
chore(docs): Update Noir links

### DIFF
--- a/docs/docs-developers/docs/resources/glossary.md
+++ b/docs/docs-developers/docs/resources/glossary.md
@@ -68,7 +68,7 @@ Merkle trees in Aztec are used to store cryptographic commitments. They are used
 
 With `nargo`, you can start new projects, compile, execute, and test your Noir programs.
 
-You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
+You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/quick_start#installation) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
 
 ### Noir
 
@@ -166,7 +166,7 @@ Previously in [Aztec Connect](https://medium.com/aztec-protocol/sunsetting-aztec
 
 Programs that run on the Aztec network are called smart contracts, similar to [programs](https://ethereum.org/en/developers/docs/smart-contracts/) that run on Ethereum.
 
-However, these will be written in the [Noir](https://noir-lang.org/index.html) programming language, and may optionally include private state and private functions.
+However, these will be written in the [Noir](https://noir-lang.org/) programming language, and may optionally include private state and private functions.
 
 ### Statement
 

--- a/docs/docs-developers/overview.md
+++ b/docs/docs-developers/overview.md
@@ -77,4 +77,4 @@ As Aztec has native account abstraction, accounts do not automatically have a si
 
 ## Noir
 
-Noir is a zero-knowledge domain specific language used for writing smart contracts for the Aztec network. It is also possible to write circuits with Noir that can be verified on or offchain. For more in-depth docs into the features of Noir, go to the [Noir documentation](https://noir-lang.org/).
+Noir is a zero-knowledge domain specific language used for writing smart contracts for the Aztec network. It is also possible to write circuits with Noir that can be verified on or offchain. For more in-depth docs into the features of Noir, go to the [Noir website](https://noir-lang.org/).


### PR DESCRIPTION
Update broken links to Noir on the Glossary page, and link description on the Overview page.