### PR TITLE
chore: Add `DISABLE_ASSERTS` in some Honk recursion constraint tampering tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -364,16 +364,19 @@ TYPED_TEST(HonkRecursionConstraintTestWithPredicate, GenerateVKFromConstraints)
 
 TYPED_TEST(HonkRecursionConstraintTestWithPredicate, ConstantTrue)
 {
+    BB_DISABLE_ASSERTS();
     TestFixture::test_constant_true(TestFixture::InvalidWitnessTarget::VKHash);
 }
 
 TYPED_TEST(HonkRecursionConstraintTestWithPredicate, WitnessTrue)
 {
+    BB_DISABLE_ASSERTS();
     TestFixture::test_witness_true(TestFixture::InvalidWitnessTarget::VKHash);
 }
 
 TYPED_TEST(HonkRecursionConstraintTestWithPredicate, WitnessFalseSlow)
 {
+    BB_DISABLE_ASSERTS();
     TestFixture::test_witness_false_slow();
 }
 
@@ -468,6 +471,7 @@ TYPED_TEST(HonkRecursionConstraintTestWithoutPredicate, GenerateVKFromConstraint
 
 TYPED_TEST(HonkRecursionConstraintTestWithoutPredicate, Tampering)
 {
+    BB_DISABLE_ASSERTS();
     [[maybe_unused]] std::vector<std::string> _ = TestFixture::test_tampering();
 }
 


### PR DESCRIPTION
We have recently added a vk hash consistency check in the Ultra Recursive verifier. This menas that some tampering tests (when run in debug mode) fail instead of returning `false` for Honk Recursion Constraints. This PR adds `DISABLE_ASSERTS` so that the test pass (i.e. they return `false`)