### PR TITLE
fix: handle reorgs in private event store

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -11,6 +11,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import { NoteStore } from '../storage/note_store/note_store.js';
+import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 import { BlockSynchronizer } from './block_synchronizer.js';
 
 describe('BlockSynchronizer', () => {
@@ -18,6 +19,7 @@ describe('BlockSynchronizer', () => {
   let tipsStore: L2TipsKVStore;
   let anchorBlockStore: AnchorBlockStore;
   let noteStore: NoteStore;
+  let privateEventStore: PrivateEventStore;
   let aztecNode: MockProxy<AztecNode>;
   let blockStream: MockProxy<L2BlockStream>;
 
@@ -34,7 +36,8 @@ describe('BlockSynchronizer', () => {
     tipsStore = new L2TipsKVStore(store, 'pxe');
     anchorBlockStore = new AnchorBlockStore(store);
     noteStore = await NoteStore.create(store);
-    synchronizer = new TestSynchronizer(aztecNode, anchorBlockStore, noteStore, tipsStore);
+    privateEventStore = new PrivateEventStore(store);
+    synchronizer = new TestSynchronizer(aztecNode, anchorBlockStore, noteStore, privateEventStore, tipsStore);
   });
 
   it('sets header from latest block', async () => {
@@ -60,5 +63,22 @@ describe('BlockSynchronizer', () => {
     await synchronizer.handleBlockStreamEvent({ type: 'chain-pruned', block: { number: BlockNumber(3), hash: '0x3' } });
 
     expect(rollbackNotesAndNullifiers).toHaveBeenCalledWith(3, 4);
+  });
+
+  it('removes private events from db on a reorg', async () => {
+    const rollbackEventsAfterBlock = jest
+      .spyOn(privateEventStore, 'rollbackEventsAfterBlock')
+      .mockImplementation(() => Promise.resolve());
+    aztecNode.getBlockHeader.mockImplementation(async blockNumber =>
+      (await L2Block.random(BlockNumber(blockNumber as number))).getBlockHeader(),
+    );
+
+    await synchronizer.handleBlockStreamEvent({
+      type: 'blocks-added',
+      blocks: await timesParallel(5, randomPublishedL2Block),
+    });
+    await synchronizer.handleBlockStreamEvent({ type: 'chain-pruned', block: { number: BlockNumber(3), hash: '0x3' } });
+
+    expect(rollbackEventsAfterBlock).toHaveBeenCalledWith(3, 4);
   });
 });

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -7,6 +7,7 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { PXEConfig } from '../config/index.js';
 import type { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
+import type { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 
 /**
  * The BlockSynchronizer class orchestrates synchronization between PXE and Aztec node, maintaining an up-to-date
@@ -22,6 +23,7 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     private node: AztecNode,
     private anchorBlockStore: AnchorBlockStore,
     private noteStore: NoteStore,
+    private privateEventStore: PrivateEventStore,
     private l2TipsStore: L2TipsKVStore,
     config: Partial<Pick<PXEConfig, 'l2BlockBatchSize'>> = {},
     loggerOrSuffix?: string | Logger,
@@ -62,6 +64,7 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
         // We first unnullify and then remove so that unnullified notes that were created after the block number end up deleted.
         const lastSynchedBlockNumber = (await this.anchorBlockStore.getBlockHeader()).getBlockNumber();
         await this.noteStore.rollbackNotesAndNullifiers(event.block.number, lastSynchedBlockNumber);
+        await this.privateEventStore.rollbackEventsAfterBlock(event.block.number, lastSynchedBlockNumber);
         // Update the header to the last block.
         const newHeader = await this.node.getBlockHeader(event.block.number);
         if (!newHeader) {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -143,7 +143,15 @@ export class PXE {
     const capsuleStore = new CapsuleStore(store);
     const keyStore = new KeyStore(store);
     const tipsStore = new L2TipsKVStore(store, 'pxe');
-    const synchronizer = new BlockSynchronizer(node, anchorBlockStore, noteStore, tipsStore, config, loggerOrSuffix);
+    const synchronizer = new BlockSynchronizer(
+      node,
+      anchorBlockStore,
+      noteStore,
+      privateEventStore,
+      tipsStore,
+      config,
+      loggerOrSuffix,
+    );
 
     const debugUtils = new PXEDebugUtils(contractStore, noteStore);
 

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -235,4 +235,135 @@ describe('PrivateEventStore', () => {
       expect(events.map(e => e.packedEvent)).toEqual([msgContent1, msgContent2, msgContent3]);
     });
   });
+
+  describe('rollback', () => {
+    let msgContent1: Fr[];
+    let msgContent2: Fr[];
+    let msgContent3: Fr[];
+    let msgContent4: Fr[];
+
+    beforeAll(() => {
+      msgContent1 = getRandomMsgContent();
+      msgContent2 = getRandomMsgContent();
+      msgContent3 = getRandomMsgContent();
+      msgContent4 = getRandomMsgContent();
+    });
+
+    it('removes events after rollback block', async () => {
+      // Store events in blocks 100, 200, 300
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(100),
+        l2BlockHash,
+      });
+      // We add another event in the same block to verify that more events per block work.
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent2, 1, {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(100),
+        l2BlockHash,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent3, 2, {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(200),
+        l2BlockHash,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent4, 3, {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(300),
+        l2BlockHash,
+      });
+
+      // Rollback to block 150 (should remove events from blocks 200 and 300)
+      await privateEventStore.rollbackEventsAfterBlock(150, 300);
+
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
+        scopes: [scope],
+      });
+
+      expect(events.length).toBe(2);
+      expect(events[0].packedEvent).toEqual(msgContent1);
+      expect(events[1].packedEvent).toEqual(msgContent2);
+    });
+
+    it('allows re-adding events after rollback', async () => {
+      // After a reorg, the same transaction might be re-included in the chain in the same block and at the same
+      // position in the block. This test verifies that this scenario works - i.e. that there is no collision in keys.
+      const reorgTxHash = TxHash.random();
+
+      // Store event at block 200
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+        contractAddress,
+        scope,
+        txHash: reorgTxHash,
+        l2BlockNumber: BlockNumber(200),
+        l2BlockHash,
+      });
+
+      // Rollback to block 100
+      await privateEventStore.rollbackEventsAfterBlock(100, 200);
+
+      // Verify event was removed
+      let events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
+        scopes: [scope],
+      });
+      expect(events.length).toBe(0);
+
+      // Re-add the same event (same eventCommitmentIndex and txHash, as happens after a reorg)
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+        contractAddress,
+        scope,
+        txHash: reorgTxHash,
+        l2BlockNumber: BlockNumber(200),
+        l2BlockHash,
+      });
+
+      // Verify event can be retrieved again
+      events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
+        scopes: [scope],
+      });
+      expect(events.length).toBe(1);
+    });
+
+    it('handles rollback with no events to remove', async () => {
+      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber: BlockNumber(100),
+        l2BlockHash,
+      });
+
+      // Rollback after all existing events
+      await privateEventStore.rollbackEventsAfterBlock(200, 300);
+
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
+        scopes: [scope],
+      });
+
+      expect(events.length).toBe(1);
+      expect(events[0].packedEvent).toEqual(msgContent1);
+    });
+  });
 });

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -2,7 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
-import type { AztecAsyncArray, AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
@@ -24,6 +24,8 @@ type PrivateEventEntry = {
   l2BlockNumber: number;
   l2BlockHash: Buffer;
   txHash: Buffer;
+  /** The lookup key for #eventsByContractScopeSelector, used for cleanup during rollback */
+  lookupKey: string;
 };
 
 type PrivateEventMetadata = InTx & {
@@ -36,10 +38,12 @@ type PrivateEventMetadata = InTx & {
  */
 export class PrivateEventStore {
   #store: AztecAsyncKVStore;
-  /** Array storing the actual private event log entries containing the log content and block number */
-  #eventLogs: AztecAsyncArray<PrivateEventEntry>;
-  /** Map from contract_address_scope_eventSelector to array of indices into #eventLogs for efficient lookup */
-  #eventLogIndex: AztecAsyncMap<string, number[]>;
+  /** Map storing the actual private event log entries, keyed by eventCommitmentIndex */
+  #eventLogs: AztecAsyncMap<number, PrivateEventEntry>;
+  /** Map from contractAddress_scope_eventSelector to eventCommitmentIndex[] for efficient lookup */
+  #eventsByContractScopeSelector: AztecAsyncMap<string, number[]>;
+  /** Map from block number to eventCommitmentIndex[] for rollback support */
+  #eventsByBlockNumber: AztecAsyncMap<number, number[]>;
   /** Map from eventCommitmentIndex to boolean indicating if log has been seen. */
   #seenLogs: AztecAsyncMap<number, boolean>;
 
@@ -47,9 +51,10 @@ export class PrivateEventStore {
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
-    this.#eventLogs = this.#store.openArray('private_event_logs');
-    this.#eventLogIndex = this.#store.openMap('private_event_log_index');
+    this.#eventLogs = this.#store.openMap('private_event_logs');
+    this.#eventsByContractScopeSelector = this.#store.openMap('events_by_contract_scope_selector');
     this.#seenLogs = this.#store.openMap('seen_logs');
+    this.#eventsByBlockNumber = this.#store.openMap('events_by_block_number');
   }
 
   #keyFor(contractAddress: AztecAddress, scope: AztecAddress, eventSelector: EventSelector): string {
@@ -87,17 +92,20 @@ export class PrivateEventStore {
 
       this.logger.verbose('storing private event log', { contractAddress, scope, msgContent, l2BlockNumber });
 
-      const index = await this.#eventLogs.lengthAsync();
-      await this.#eventLogs.push({
+      await this.#eventLogs.set(eventCommitmentIndex, {
         msgContent: serializeToBuffer(msgContent),
         l2BlockNumber,
         l2BlockHash: l2BlockHash.toBuffer(),
         eventCommitmentIndex,
         txHash: txHash.toBuffer(),
+        lookupKey: key,
       });
 
-      const existingIndices = (await this.#eventLogIndex.getAsync(key)) || [];
-      await this.#eventLogIndex.set(key, [...existingIndices, index]);
+      const existingIndices = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
+      await this.#eventsByContractScopeSelector.set(key, [...existingIndices, eventCommitmentIndex]);
+
+      const existingBlockIndices = (await this.#eventsByBlockNumber.getAsync(l2BlockNumber)) || [];
+      await this.#eventsByBlockNumber.set(l2BlockNumber, [...existingBlockIndices, eventCommitmentIndex]);
 
       // Mark this log as seen using eventCommitmentIndex
       await this.#seenLogs.set(eventCommitmentIndex, true);
@@ -123,10 +131,10 @@ export class PrivateEventStore {
 
     for (const scope of filter.scopes) {
       const key = this.#keyFor(filter.contractAddress, scope, eventSelector);
-      const indices = (await this.#eventLogIndex.getAsync(key)) || [];
+      const eventCommitmentIndices = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
 
-      for (const index of indices) {
-        const entry = await this.#eventLogs.atAsync(index);
+      for (const eventCommitmentIndex of eventCommitmentIndices) {
+        const entry = await this.#eventLogs.getAsync(eventCommitmentIndex);
         if (!entry || entry.l2BlockNumber < filter.fromBlock || entry.l2BlockNumber >= filter.toBlock) {
           continue;
         }
@@ -158,5 +166,48 @@ export class PrivateEventStore {
     // Sort by eventCommitmentIndex only
     events.sort((a, b) => a.eventCommitmentIndex - b.eventCommitmentIndex);
     return events.map(ev => ev.event);
+  }
+
+  /**
+   * Rolls back private events that were stored after a given `blockNumber` and up to `synchedBlockNumber` (the block
+   * number up to which PXE managed to sync before the reorg happened).
+   */
+  public async rollbackEventsAfterBlock(blockNumber: number, synchedBlockNumber: number): Promise<void> {
+    await this.#store.transactionAsync(async () => {
+      let removedCount = 0;
+
+      for (let block = blockNumber + 1; block <= synchedBlockNumber; block++) {
+        const indices = await this.#eventsByBlockNumber.getAsync(block);
+        if (indices) {
+          await this.#eventsByBlockNumber.delete(block);
+
+          for (const eventCommitmentIndex of indices) {
+            const entry = await this.#eventLogs.getAsync(eventCommitmentIndex);
+            if (!entry) {
+              throw new Error(`Event log not found for eventCommitmentIndex ${eventCommitmentIndex}`);
+            }
+
+            await this.#eventLogs.delete(eventCommitmentIndex);
+            await this.#seenLogs.delete(eventCommitmentIndex);
+
+            // Update #eventsByContractScopeSelector using the stored lookupKey
+            const existingIndices = await this.#eventsByContractScopeSelector.getAsync(entry.lookupKey);
+            if (!existingIndices || existingIndices.length === 0) {
+              throw new Error(`No indices found in #eventsByContractScopeSelector for key ${entry.lookupKey}`);
+            }
+            const filteredIndices = existingIndices.filter(idx => idx !== eventCommitmentIndex);
+            if (filteredIndices.length === 0) {
+              await this.#eventsByContractScopeSelector.delete(entry.lookupKey);
+            } else {
+              await this.#eventsByContractScopeSelector.set(entry.lookupKey, filteredIndices);
+            }
+
+            removedCount++;
+          }
+        }
+      }
+
+      this.logger.verbose(`Rolled back ${removedCount} private events after block ${blockNumber}`);
+    });
   }
 }


### PR DESCRIPTION
Fixes F-115

We have not yet handled reorgs in `PrivateEventStore`. In this PR I tackle that.