### PR TITLE
feat: mark non-prerelease versions as releases

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -123,8 +123,9 @@ jobs:
   ci-network-scenario:
     runs-on: ubuntu-latest
     # We either run after a release (tag starting with v), or when the ci-network-scenario label is present in a PR.
+    # We exclude ci-release-pr test tags (v0.0.1-commit.*) which are only for testing the release process.
     needs: ci
-    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
+    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-commit.')) || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/publish-bb-mac.yml
+++ b/.github/workflows/publish-bb-mac.yml
@@ -153,12 +153,23 @@ jobs:
         with:
           name: barretenberg-arm64-darwin-starknet.tar.gz
 
+      - name: Determine if prerelease
+        id: check-prerelease
+        run: |
+          VERSION="${{ inputs.ref_name || inputs.tag || github.ref_name }}"
+          # Check if version has a prerelease tag (e.g., -rc.1, -alpha, -beta)
+          if [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to GitHub
         uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
         with:
           tag_name: ${{ inputs.ref_name || inputs.tag || github.ref_name }}
-          prerelease: true
+          prerelease: ${{ steps.check-prerelease.outputs.is_prerelease == 'true' }}
           files: |
             barretenberg-amd64-darwin.tar.gz
             barretenberg-arm64-darwin.tar.gz
@@ -169,7 +180,7 @@ jobs:
         continue-on-error: true
         with:
           tag_name: ${{ inputs.ref_name || inputs.tag || github.ref_name }}
-          prerelease: true
+          prerelease: ${{ steps.check-prerelease.outputs.is_prerelease == 'true' }}
           files: |
             barretenberg-amd64-darwin-starknet.tar.gz
             barretenberg-arm64-darwin-starknet.tar.gz

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -430,13 +430,25 @@ function release_github {
   if gh release view "aztec-packages-v$CURRENT_VERSION" &>/dev/null; then
     compare_link=$(echo -e "See changes: https://github.com/AztecProtocol/aztec-packages/compare/aztec-packages-v${CURRENT_VERSION}...${COMMIT_HASH}")
   fi
+  # Determine if this is a prerelease (has a prerelease tag like -rc.1, -alpha, etc.)
+  local is_prerelease=false
+  if [ -n "$(semver prerelease $REF_NAME)" ]; then
+    is_prerelease=true
+  fi
   # Ensure we have a commit release.
   if ! gh release view "$REF_NAME" &>/dev/null; then
+    local prerelease_flag=""
+    if $is_prerelease; then
+      prerelease_flag="--prerelease"
+    fi
     do_or_dryrun gh release create "$REF_NAME" \
-      --prerelease \
+      $prerelease_flag \
       --target $COMMIT_HASH \
       --title "$REF_NAME" \
       --notes "$compare_link"
+  elif ! $is_prerelease; then
+    # Release exists but this is not a prerelease version - ensure it's marked as a full release
+    do_or_dryrun gh release edit "$REF_NAME" --prerelease=false
   fi
 }
 


### PR DESCRIPTION
Updates the release process to automatically mark GitHub releases as non-prerelease (final release) when the version has no prerelease tag (e.g., v2.1.8). 

Closes A-367 'Publish released images as "release"'