### PR TITLE
fix: overriding AWS_SHUTDOWN_TIME

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -144,7 +144,7 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
-          AWS_SHUTDOWN_TIME: 360
+          AWS_SHUTDOWN_TIME: 180
           NO_SPOT: 1
         run: |
           # For release tags, use the release image; for PRs, omit to build and push to aztecdev

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -12,12 +12,12 @@ export CI=1
 if [ "$arch" == "arm64" ]; then
   cores=64
   # Allow for 90 minutes as ARM has less cores.
-  export AWS_SHUTDOWN_TIME=90
+  export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-90}
 else
   cores=192,128,64
   if [ "$CI_FULL" -eq 1 ]; then
     # Allow for 75 minutes as ci-full time has crept up.
-    export AWS_SHUTDOWN_TIME=75
+    export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-75}
   fi
 fi
 


### PR DESCRIPTION
it worked more by fluke as CI_FULL wasn't previously set in other configs