### PR TITLE
fix(docs): sets version migration notes and fix on next

### DIFF
--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/resources/migration_notes.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/resources/migration_notes.md
@@ -7,7 +7,7 @@ tags: [migration, updating, sandbox, local network]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
-## TBD
+## 3.0.0-devnet.20251212
 
 ### [Aztec node, archiver] Deprecated `getPrivateLogs`
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -50,6 +50,8 @@ do so through the new `debug` sub-module.
 + this.pxe.debug.getNotes(filter);
 ```
 
+## 3.0.0-devnet.20251212
+
 ### [Aztec node, archiver] Deprecated `getPrivateLogs`
 
 Aztec node no longer offers a `getPrivateLogs` method. If you need to process the logs of a block, you can instead use `getBlock` and call `getPrivateLogs` on an `L2BlockNew` instance. See the diff below for before/after equivalent code samples.


### PR DESCRIPTION
We forgot to change the versions on migration notes, both on current and on versioned, so we are fixing that.