### PR TITLE
test: remove all webkit tests from test_cmds

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -80,9 +80,6 @@ tests:
     error_regex: "Aborted.*core dumped"
     owners:
       - *adam
-  - regex: "barretenberg/acir_tests/scripts/browser_prove.sh .* webkit"
-    owners:
-      - *luke
   - regex: "barretenberg/cpp/scripts/run_bench.sh wasm bb-micro-bench/wasm/chonk build-wasm-threads/bin/chonk_bench"
     owners:
       - *luke

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -169,8 +169,6 @@ function test_cmds {
   local browser_prefix="$tests_hash:ISOLATE=1:NET=1:CPUS=8"
   echo "$browser_prefix $scripts/browser_prove.sh verify_honk_proof chrome"
   echo "$browser_prefix $scripts/browser_prove.sh a_1_mul chrome"
-  echo "$browser_prefix $scripts/browser_prove.sh verify_honk_proof webkit"
-  echo "$browser_prefix $scripts/browser_prove.sh a_1_mul webkit"
 
   # bb.js tests.
   # ecdsa_secp256r1_3x through bb.js on node to check 256k support.

--- a/playground/bootstrap.sh
+++ b/playground/bootstrap.sh
@@ -19,7 +19,7 @@ function test {
 }
 
 function test_cmds {
-  for browser in chromium webkit firefox; do
+  for browser in chromium firefox; do
     echo "$hash playground/scripts/run_test.sh $browser"
   done
 }


### PR DESCRIPTION
webkit didn't really provide any actionable changes, just annoying investigations due to its bugs. Looking at webkit logs there's a good number of WASM-related bugs. Given our resources and no such reported problems in the wild, WONTFIX