### PR TITLE
feat: add /fix-pr and /rebase-pr slash commands for Claude

### DIFF
--- a/yarn-project/.claude/commands/fix-pr.md
+++ b/yarn-project/.claude/commands/fix-pr.md
@@ -1,0 +1,122 @@
+---
+description: Fix a failing PR by analyzing CI logs and fixing errors
+argument-hint: <PR number>
+allowed-tools: Bash(gh:*), Bash(git fetch:*), Bash(git rebase:*), Read(/tmp/**), Write(/tmp/**), Bash(curl *ci.aztec-labs.com*)
+---
+
+# Fix Failing PR
+
+Fix the CI failures for PR $ARGUMENTS.
+
+## Phase 1: Identify CI Failures
+
+### Step 1: Get PR info and CI run ID
+```bash
+gh pr view $ARGUMENTS --repo AztecProtocol/aztec-packages --json headRefName,baseRefName,statusCheckRollup
+```
+
+Extract the `ci` job's `detailsUrl` and get the run ID (the number after `runs/`).
+
+### Step 2: Get CI log URL from GitHub Actions
+```bash
+gh run view $RUN_ID --repo AztecProtocol/aztec-packages --log 2>&1 | grep -i "CI run log id"
+```
+
+This returns a URL like `http://ci.aztec-labs.com/$LOG_ID`.
+
+**IMPORTANT**: If GitHub API fails or the log ID is not found, ask the user for the CI log URL directly.
+
+### Step 3: Download and analyze CI log
+```bash
+curl -s "http://ci.aztec-labs.com/$LOG_ID.txt" -u aztec:$CI_PASSWORD -o /tmp/$LOG_ID.log
+```
+
+**IMPORTANT**: Always use the CI log ID as the filename (e.g., `/tmp/1767639787359.log` for `http://ci.aztec-labs.com/1767639787359`). This avoids conflicts when downloading multiple logs.
+
+**Note**: If CI password is not available from local permissions, ask the user for it.
+
+### Step 4: Determine failure type
+
+Search for the failure location:
+```bash
+grep -E "compile_all.*failed|test all" /tmp/$LOG_ID.log
+```
+
+#### If failure is in `compile_all` (build/format/lint):
+1. Find the compile_all log link in the output
+2. Download it and check which sub-step failed:
+   - `format --check` → failed → **FORMAT ERROR**
+   - `yarn tsgo -b --emitDeclarationOnly` → failed → **BUILD ERROR**
+   - `lint --check` → failed → **LINT ERROR**
+3. Download the failed step's log to get specific error messages
+
+#### If failure is in `test all` (tests):
+1. Find the test execution log (grep for `parallel.*run_test_cmd`)
+2. Download and search for `FAILED`:
+   ```bash
+   grep -i "FAILED" /tmp/$TEST_LOG_ID.log
+   ```
+3. Extract the test file path
+4. Classify by path:
+   - Path contains `end-to-end` → **E2E TEST**
+   - Otherwise → **UNIT TEST**
+
+---
+
+## Phase 2: Checkout Branch & Prepare
+
+### Step 1: Check current branch
+```bash
+git branch --show-current
+```
+
+### Step 2: Checkout the PR branch
+```bash
+gh pr checkout $ARGUMENTS
+```
+
+### Step 3: Check for merge conflicts with base
+```bash
+git fetch origin $BASE_BRANCH
+git rebase origin/$BASE_BRANCH
+```
+
+If there are conflicts:
+1. Resolve the conflicts
+2. `git add .`
+3. `git rebase --continue`
+
+**IMPORTANT**: Always REBASE, never merge.
+
+### Step 4: Bootstrap if needed
+See CLAUDE.md "When to Run Bootstrap". Only if changes outside `yarn-project`.
+
+---
+
+## Phase 3: Fix Based on Failure Type
+
+Run all from `yarn-project` folder.
+
+| Failure Type | Fix Action |
+|-------------|------------|
+| **FORMAT** | `./bootstrap.sh format <package-name>` |
+| **LINT** | `./bootstrap.sh lint <package-name>` |
+| **BUILD** | `yarn tsgo -b --emitDeclarationOnly`, fix errors, repeat |
+| **UNIT TEST** | `cd <package> && yarn test <file>`, fix, repeat for each |
+| **E2E TEST** | Same but `yarn test:e2e`. For complex failures use `e2e-test-debugger` agent |
+
+---
+
+## Phase 4: Verify & Push
+
+1. Run quality checklist (see CLAUDE.md "Before Committing")
+2. Amend and push (see CLAUDE.md "Fixing PRs")
+
+---
+
+## Reference
+
+- See `CLAUDE.md` for project conventions
+- See `e2e-test-debugger` agent for complex e2e failure analysis
+- CI logs use basic auth: `-u aztec:$CI_PASSWORD` (place after URL in curl command)
+- If CI password is not available from local permissions, ask the user for it

--- a/yarn-project/.claude/commands/rebase-pr.md
+++ b/yarn-project/.claude/commands/rebase-pr.md
@@ -1,0 +1,68 @@
+---
+description: Rebase a PR on its base branch, fix conflicts, and verify build
+argument-hint: <PR number>
+allowed-tools: Bash(gh:*), Bash(git fetch:*), Bash(git rebase:*)
+---
+
+# Rebase PR
+
+Rebase PR $ARGUMENTS on top of its base branch, fix any conflicts, and verify it builds.
+
+## Phase 1: Checkout & Get PR Info
+
+### Step 1: Get PR info
+```bash
+gh pr view $ARGUMENTS --repo AztecProtocol/aztec-packages --json headRefName,baseRefName
+```
+
+Note the `baseRefName` (usually `master` or `next`).
+
+### Step 2: Checkout the PR branch
+```bash
+gh pr checkout $ARGUMENTS
+```
+
+---
+
+## Phase 2: Rebase on Base Branch
+
+### Step 1: Fetch the latest base branch
+```bash
+git fetch origin $BASE_BRANCH
+```
+
+### Step 2: Rebase
+```bash
+git rebase origin/$BASE_BRANCH
+```
+
+### Step 3: Handle conflicts (if any)
+If there are conflicts:
+1. For each conflicting file, analyze the conflict and resolve it
+2. Stage the resolved files: `git add <file>`
+3. Continue the rebase: `git rebase --continue`
+4. Repeat until rebase completes
+
+**IMPORTANT**: Always REBASE, never merge.
+
+---
+
+## Phase 3: Bootstrap (Only If Needed)
+
+See CLAUDE.md "When to Run Bootstrap". Check if changes outside `yarn-project`:
+```bash
+git diff --name-only HEAD@{1}..HEAD | grep -v "^yarn-project/"
+```
+
+---
+
+## Phase 4: Verify & Push
+
+1. Run quality checklist (see CLAUDE.md "Before Committing") - fix any errors
+2. Amend and push (see CLAUDE.md "Fixing PRs")
+
+---
+
+## Reference
+
+- See `CLAUDE.md` for project conventions

--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -37,12 +37,17 @@ yarn tsc -b                      # Full project (from yarn-project)
 cd <package-name> && yarn tsc -b  # Specific package
 ```
 
-### Before Committing
+### Before Committing (Quality Checklist)
 
-1. **Build**: Ensure project compiles (`yarn tsc -b`)
-2. **Format/Lint**: Run on modified packages
-3. **Test**: Run unit tests for modified files and ensure they pass
-4. **Breaking Changes**: Update `docs/docs/developers/migration_notes.md` if applicable
+Run from `yarn-project`:
+
+1. **Build**: Ensure entire project compiles (`yarn tsgo -b --emitDeclarationOnly`)
+2. **Format**: Run on modified packages (`./bootstrap.sh format <package-name>`)
+3. **Lint**: Run on modified packages (`./bootstrap.sh lint <package-name>`)
+4. **Test**: Run unit tests for modified packages
+5. **Breaking Changes**: Update `docs/docs/developers/migration_notes.md` if applicable
+
+If breaking changes: update `docs/docs/developers/migration_notes.md`
 
 ## Testing
 
@@ -89,7 +94,7 @@ env LOG_LEVEL='info; debug:sequencer,archiver' yarn test src/file.test.ts
 
 ## Format & Lint
 
-All commands run from git root.
+All commands run from `yarn-project`.
 
 ### Single Package (Preferred)
 
@@ -192,11 +197,23 @@ When porting PRs between branches, include reference to original PR(s) in the PR
 
 ### PR Merging
 
-By default, every PR is squashed to a single commit when merged.
+Every PR is required by CI to consist of a single commit in order to be merged.
 
 For PRs with multiple commits that should be preserved (e.g., porting multiple PRs):
 1. Ensure each commit follows conventional commit format
 2. Add label `ci-no-squash` to the PR
+
+### Fixing PRs
+
+When fixing an existing PR (CI failures, review feedback, etc.), always amend the existing commit - never create new commits.
+
+```bash
+git add .
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+This keeps the PR as a single commit. CI enforces PRs have a single commit.
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary
- Adds `/fix-pr <PR>` slash command: Analyzes CI failures, checks out branch, fixes issues (format/lint/build/tests), and pushes
- Adds `/rebase-pr <PR>` slash command: Rebases PR on base branch, resolves conflicts, verifies build, and pushes
- Updates CLAUDE.md with explicit quality checklist commands

## Details
The commands reference CLAUDE.md for common workflows (quality checklist, fixing PRs) to avoid duplication.

## Test plan
- Test `/fix-pr` on a PR with CI failures
- Test `/rebase-pr` on a PR that needs rebasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)