### PR TITLE
docs: some more comments

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/subbvec.nr
@@ -77,7 +77,7 @@ mod test {
     unconstrained fn subbvec_dst_len_causes_enlarge() {
         let bvec = BoundedVec::<_, 10>::from_array([1, 2, 3, 4, 5]);
 
-        // subbvec does not supprt capacity increases
+        // subbvec does not support capacity increases
         let _: BoundedVec<_, 11> = subbvec(bvec, 0);
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-init/src/main.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-init/src/main.nr
@@ -9,7 +9,10 @@ use dep::types::{
 };
 
 /**
- * @param first_nullifier_hint: 0 if there is no nullifier yet; otherwise it's a claim on whatever has been pushed as the 0th nullifier already by some private call.
+ * @param first_nullifier_hint: a hint to what will be the first nullifier of the transaction. This hint should be 
+ *        set to 0 if no nullifiers will be emitted by any private call. The Init circuit will create a protocol 
+ *        nullifier if the hint is 0. (Note: the 0th nullifier is used to compute note nonces, which are injected
+ *        into notes to prevent Faerie-Gold attacks).
  */
 fn main(
     tx_request: TxRequest,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
@@ -38,6 +38,7 @@ pub fn validate_previous_rollups<let NumPreviousRollups: u32, let NumVkIndices: 
 
     // Check that the block number matches the next available leaf index in the archive, ensuring the hash of the block
     // header will be inserted at the correct position.
+    // We convert with `as Field` instead of converting the other `as u32` to avoid truncating the next_available_leaf_index.
     let constants = previous_rollups[0].public_inputs.constants;
     assert_eq(
         constants.global_variables.block_number as Field,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/utils/merge_checkpoint_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/utils/merge_checkpoint_rollups.nr
@@ -8,8 +8,9 @@ pub fn merge_checkpoint_rollups(
     let num_left_checkpoints = left.num_checkpoints() as u32;
     let num_right_checkpoints = right.num_checkpoints() as u32;
 
-    // Make sure that the total number of checkpoints does not exceed the maximum allowed in an epoch, preventing the
-    // merged arrays (`checkpoint_header_hashes`, `out_hashes`, `fees`) from being truncated.
+    // Make sure that the total number of checkpoints does not exceed the maximum allowed in an epoch, to prevent the
+    // merged arrays (`checkpoint_header_hashes`, `out_hashes`, `fees`) from being truncated within the below calls to
+    // `copy_items_into_array`.
     let num_checkpoints = num_left_checkpoints + num_right_checkpoints;
     assert(
         num_checkpoints <= AZTEC_MAX_EPOCH_DURATION,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
@@ -63,12 +63,18 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
             prover_id: merged_rollup.constants.prover_id,
         };
 
+        // Note: it might seem strange that we only write to the 0th index of an array of length
+        // `AZTEC_MAX_EPOCH_DURATION`. "Why not output a single `Field`?". It's because we want the
+        // layout of the public inputs of this Checkpoint Root circuit to match those of the Checkpoint
+        // Merge circuit. In the Checkpoint Merge circuit, we use more elements of this array: we
+        // progressively merge the arrays from left and right subtrees.
         let mut checkpoint_header_hashes = [0; AZTEC_MAX_EPOCH_DURATION];
         checkpoint_header_hashes[0] = self.create_checkpoint_header().hash();
 
         let mut out_hashes = [0; AZTEC_MAX_EPOCH_DURATION];
         out_hashes[0] = merged_rollup.out_hash;
 
+        // Note: as per the above note.
         let mut fees = [FeeRecipient::empty(); AZTEC_MAX_EPOCH_DURATION];
         fees[0] = FeeRecipient {
             recipient: merged_rollup.constants.coinbase,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_root_inputs_validator.nr
@@ -70,6 +70,8 @@ impl<let NumPreviousRollups: u32, let NumVkIndices: u32> CheckpointRootInputsVal
             "The start blob sponge was not correctly initialized",
         );
 
+        // Note: we validate the correctness of the previous block header at the end of this function.
+
         assert_eq(
             first_rollup.start_state,
             self.previous_block_header.state,
@@ -97,7 +99,7 @@ impl<let NumPreviousRollups: u32, let NumVkIndices: u32> CheckpointRootInputsVal
 
         // `previous_block_header` is provided as a private input and is used to validate the values above.
         // Here we make sure it's indeed the header of the previous block by checking it against the previous archive.
-        // The previous archive will be validated on L1.
+        // The correctness of the claimed previous archive will be validated when this epoch's proof is submitted to L1.
         self.validate_previous_block_header_in_archive();
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/merge_tx_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/merge_tx_rollups.nr
@@ -11,6 +11,9 @@ pub fn accumulate_out_hash(left_out_hash: Field, right_out_hash: Field) -> Field
     }
 }
 
+// Accumulates items that need to be accumulated to the next rollup circuit.
+// Constructs the public inputs of this circuit, taking care to ascribe left and right
+// subtree data to the correct start and end positions.
 pub fn merge_tx_rollups(
     left: TxRollupPublicInputs,
     right: TxRollupPublicInputs,
@@ -25,7 +28,7 @@ pub fn merge_tx_rollups(
 
     TxRollupPublicInputs {
         num_txs,
-        constants: left.constants,
+        constants: left.constants, // Checked to equal the right constants by this circuit's Validator.
         start_tree_snapshots: left.start_tree_snapshots,
         end_tree_snapshots: right.end_tree_snapshots,
         start_sponge_blob: left.start_sponge_blob,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/validate_consecutive_tx_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/validate_consecutive_tx_rollups.nr
@@ -13,6 +13,22 @@ pub fn validate_consecutive_tx_rollups(left: TxRollupPublicInputs, right: TxRoll
 /// When called from the `tx_merge` or `block_root`, it represents the total number of `tx_base` rollups.
 /// When called from the `block_merge` or `checkpoint_root`, it represents the total number of `block_root` rollups.
 /// When called from the `checkpoint_merge` or `root`, it represents the total number of `checkpoint_root` rollups.
+///
+/// Valid configurations:
+///
+///   2         3           4                 5                   6                      7
+///   .         .           .                 .                   .                      .
+///  / \       / \        /   \              / \               /     \               /        \
+/// .   .     .   .     .       .           .   .            .         .          .             .
+///          / \       / \     / \        /   \            /   \      / \       /   \          / \
+///         .   .     .   .   .   .     .       .        .       .   .   .    .       .       .   .
+///                                    / \     / \      / \     / \          / \     / \     / \
+///                                   .   .   .   .    .   .   .   .        .   .   .   .   .   .
+///
+/// etc...
+///
+/// See also: https://hackmd.io/CKdVk7zZS2qWd0vBN7e1SA
+///
 pub fn assert_rollups_filled_greedily(num_left_rollups: u16, num_right_rollups: u16) {
     // The left rollup must be a balanced tree (i.e., `num_left_rollups` is a power of 2).
     assert(


### PR DESCRIPTION
Extracting the comments from that big pr, which can go straight into the code, because they are purely informational and not a question of the form `Q:` / `TODO:` / `AUDIT_COMMENT:`
