### PR TITLE
chore: check input num_bytes are within limit early-on in blake constraint generation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
@@ -28,7 +28,7 @@ template <typename Builder> void create_blake2s_constraints(Builder& builder, co
 
         // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
         auto num_bytes = round_to_nearest_byte(num_bits);
-        BB_ASSERT_LTE(num_bytes, 32U, "Input num_bytes exceeds 32");
+        BB_ASSERT_LTE(num_bytes, 32U, "Input num_bytes exceeds 32 per element in blake2s");
 
         field_ct element = to_field_ct(witness_index, builder);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
@@ -5,6 +5,7 @@
 // =====================
 
 #include "blake2s_constraint.hpp"
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/stdlib/hash/blake2s/blake2s.hpp"
 #include "barretenberg/stdlib/primitives/byte_array/byte_array.hpp"
 #include "round.hpp"
@@ -27,6 +28,7 @@ template <typename Builder> void create_blake2s_constraints(Builder& builder, co
 
         // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
         auto num_bytes = round_to_nearest_byte(num_bits);
+        BB_ASSERT_LTE(num_bytes, 32U, "Input num_bytes exceeds 32");
 
         field_ct element = to_field_ct(witness_index, builder);
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
@@ -26,7 +26,6 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
 
         // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
         auto num_bytes = round_to_nearest_byte(num_bits);
-        BB_ASSERT_LTE(num_bytes, 1024U, "barretenberg does not support blake3 inputs with more than 1024 bytes");
         field_ct element = to_field_ct(witness_index, builder);
 
         // byte_array_ct(field, num_bytes) constructor adds range constraints for each byte
@@ -35,7 +34,7 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
         // Safe write: both arr and element_bytes are constrained
         arr.write(element_bytes);
     }
-
+    BB_ASSERT_LTE(arr.size(), 1024U, "Barretenberg does not support blake3 inputs with more than 1024 bytes");
     byte_array_ct output_bytes = bb::stdlib::Blake3s<Builder>::hash(arr);
 
     for (const auto& [output_byte, result_byte_idx] : zip_view(output_bytes.bytes(), constraint.result)) {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
@@ -26,6 +26,7 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
 
         // XXX: The implementation requires us to truncate the element to the nearest byte and not bit
         auto num_bytes = round_to_nearest_byte(num_bits);
+        BB_ASSERT_LTE(num_bytes, 32U, "Input num_bytes exceeds 32 per element in blake3s");
         field_ct element = to_field_ct(witness_index, builder);
 
         // byte_array_ct(field, num_bytes) constructor adds range constraints for each byte


### PR DESCRIPTION
`num_bytes<=32` was implicitly enforced by `byte_array` constructor when generating ACIR constraints for blake. The current PR adds an assertion to check `num_bytes<=32` in `create_blake2s_constraints` and `create_blake3_constraints` to catch any issues early-on. The following are the changes. 
- In blake2s, add an assertion to check `num_bytes<=32`
- In blake3s, move the existing assertion to the right position 