### PR TITLE
chore: increase spartan bench time allowance

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -117,7 +117,7 @@ function network_tests {
 }
 
 function network_bench_cmds {
-  echo "$hash:TIMEOUT=3600 BENCH_OUTPUT=bench-out/n_tps.bench.json TPS_TARGET=0.5,1,2 TEST_DURATION=600 $root/yarn-project/end-to-end/scripts/run_test.sh simple n_tps.test.ts"
+  echo "$hash:TIMEOUT=7200 BENCH_OUTPUT=bench-out/n_tps.bench.json TPS_TARGET=0.5,1,2 TEST_DURATION=600 $root/yarn-project/end-to-end/scripts/run_test.sh simple n_tps.test.ts"
 }
 
 function network_bench {


### PR DESCRIPTION
1h is not quite enough when factoring in waiting for the network to become available and the number of individual tests to run.