### PR TITLE
fix: Default CI_USE_BUILD_INSTANCE_KEY to 1 in bootstrap_ec2

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -85,6 +85,8 @@ jobs:
           PR_COMMITS: ${{ github.event.pull_request.commits }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          # Enable build instance key features (disk logging, benchmark uploads, etc.)
+          CI_USE_BUILD_INSTANCE_KEY: "1"
         # NOTE: $CI_MODE is set in the Determine CI Mode step.
         run: ./.github/ci3.sh $CI_MODE
 

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -85,8 +85,6 @@ jobs:
           PR_COMMITS: ${{ github.event.pull_request.commits }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-          # Enable build instance key features (disk logging, benchmark uploads, etc.)
-          CI_USE_BUILD_INSTANCE_KEY: "1"
         # NOTE: $CI_MODE is set in the Determine CI Mode step.
         run: ./.github/ci3.sh $CI_MODE
 

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -8,6 +8,9 @@ NO_TERMINATE=${NO_TERMINATE:-0}
 
 # We're always "in CI" if we're running on a remote instance.
 export CI=1
+# Enable build instance key features (disk logging, benchmark uploads) by default.
+# Set to 0 in ci3-external.yml for external contributors who don't have SSH access.
+export CI_USE_BUILD_INSTANCE_KEY=${CI_USE_BUILD_INSTANCE_KEY:-1}
 
 if [ "$arch" == "arm64" ]; then
   cores=64


### PR DESCRIPTION
## Summary
- Defaults `CI_USE_BUILD_INSTANCE_KEY` to `1` at the top of `bootstrap_ec2`
- This env var was being passed as empty to the docker container (via `${CI_USE_BUILD_INSTANCE_KEY:-}` on line 283), causing benchmark breakdown uploads to be skipped
- External CI (`ci3-external.yml`) explicitly sets it to `"0"` to disable these features for external contributors

## Context
The benchmark breakdown uploads stopped working after b738e8387a because `CI_ENABLE_DISK_LOGS` was renamed to `CI_USE_BUILD_INSTANCE_KEY`, but:
1. The script check was missed (fixed in #19303)
2. The env var was never explicitly defaulted - it relied on an implicit default that doesn't work when passed through docker

## Test plan
- CI should pass
- After merge, benchmark breakdowns should start appearing at `/logs-disk/bench/bb-breakdown/` on the bastion