### PR TITLE
fix: fixing e2e tests and BlobClient initialization

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1,11 +1,6 @@
 import { Archiver, createArchiver } from '@aztec/archiver';
 import { BBCircuitVerifier, QueuedIVCVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
-import { type BlobClientInterface, createBlobClient } from '@aztec/blob-client/client';
-import {
-  type BlobFileStoreMetadata,
-  createReadOnlyFileStoreBlobClients,
-  createWritableFileStoreBlobClient,
-} from '@aztec/blob-client/filestore';
+import { type BlobClientInterface, createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import {
   ARCHIVE_HEIGHT,
   INITIAL_L2_BLOCK_NUM,
@@ -191,7 +186,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       logger?: Logger;
       publisher?: SequencerPublisher;
       dateProvider?: DateProvider;
-      blobClient?: BlobClientInterface;
       p2pClientDeps?: P2PClientDeps<P2PClientType.Full>;
     } = {},
     options: {
@@ -271,24 +265,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       );
     }
 
-    const blobFileStoreMetadata: BlobFileStoreMetadata = {
-      l1ChainId: config.l1ChainId,
-      rollupVersion: config.rollupVersion,
-      rollupAddress: config.l1Contracts.rollupAddress.toString(),
-    };
-
-    const [fileStoreClients, fileStoreUploadClient] = await Promise.all([
-      createReadOnlyFileStoreBlobClients(config.blobFileStoreUrls, blobFileStoreMetadata, log),
-      createWritableFileStoreBlobClient(config.blobFileStoreUploadUrl, blobFileStoreMetadata, log),
-    ]);
-
-    const blobClient =
-      deps.blobClient ??
-      createBlobClient(config, {
-        logger: createLogger('node:blob-client:client'),
-        fileStoreClients,
-        fileStoreUploadClient,
-      });
+    const blobClient = await createBlobClientWithFileStores(config, createLogger('node:blob-client:client'));
 
     // attempt snapshot sync if possible
     await trySnapshotSync(config, log);
@@ -355,7 +332,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       blockSource: archiver,
       l1ToL2MessageSource: archiver,
       keyStoreManager,
-      fileStoreBlobUploadClient: fileStoreUploadClient,
+      blobClient,
     });
 
     // If we have a validator client, register it as a source of offenses for the slasher,
@@ -786,6 +763,14 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     await tryStop(this.blobClient);
     await tryStop(this.telemetry);
     this.log.info(`Stopped Aztec Node`);
+  }
+
+  /**
+   * Returns the blob client used by this node.
+   * @internal - Exposed for testing purposes only.
+   */
+  public getBlobClient(): BlobClientInterface | undefined {
+    return this.blobClient;
   }
 
   /**

--- a/yarn-project/blob-client/src/client/http.ts
+++ b/yarn-project/blob-client/src/client/http.ts
@@ -548,6 +548,11 @@ export class HttpBlobClient implements BlobClientInterface {
     return this.archiveClient;
   }
 
+  /** Returns true if this client can upload blobs to filestore. */
+  public canUpload(): boolean {
+    return this.fileStoreUploadClient !== undefined;
+  }
+
   /**
    * Start the blob client.
    * Uploads the initial healthcheck file (awaited) and starts periodic uploads.

--- a/yarn-project/blob-client/src/client/interface.ts
+++ b/yarn-project/blob-client/src/client/interface.ts
@@ -24,4 +24,6 @@ export interface BlobClientInterface {
   testSources(): Promise<void>;
   /** Stops the blob client, clearing any periodic tasks. */
   stop?(): void;
+  /** Returns true if this client can upload blobs to filestore. */
+  canUpload(): boolean;
 }

--- a/yarn-project/blob-client/src/client/local.ts
+++ b/yarn-project/blob-client/src/client/local.ts
@@ -22,4 +22,9 @@ export class LocalBlobClient implements BlobClientInterface {
   public getBlobSidecar(_blockId: string, blobHashes: Buffer[], _opts?: GetBlobSidecarOptions): Promise<Blob[]> {
     return this.blobStore.getBlobsByHashes(blobHashes);
   }
+
+  /** Returns true if this client can upload blobs. Always true for local client. */
+  public canUpload(): boolean {
+    return true;
+  }
 }

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.parallel.test.ts
@@ -1,6 +1,7 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { CheatCodes } from '@aztec/aztec/testing';
-import { type BlobClientInterface, HttpBlobClient } from '@aztec/blob-client/client';
+import { HttpBlobClient } from '@aztec/blob-client/client';
 import { GovernanceProposerContract, RollupContract } from '@aztec/ethereum/contracts';
 import type { DeployAztecL1ContractsReturnType } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
@@ -47,7 +48,6 @@ describe('e2e_gov_proposal', () => {
   let deployL1ContractsValues: DeployAztecL1ContractsReturnType;
   let cheatCodes: CheatCodes;
   let dateProvider: TestDateProvider | undefined;
-  let blobClient: BlobClientInterface | undefined;
   let rollup: RollupContract;
   let governanceProposer: GovernanceProposerContract;
   let newGovernanceProposerAddress: EthAddress;
@@ -87,7 +87,6 @@ describe('e2e_gov_proposal', () => {
       deployL1ContractsValues,
       cheatCodes,
       dateProvider,
-      blobClient,
       accounts,
     } = context);
     defaultAccountAddress = accounts[0];
@@ -189,7 +188,7 @@ describe('e2e_gov_proposal', () => {
     const monitor = new ChainMonitor(rollup, dateProvider).start();
 
     // Break the blob client so no new blocks are synced
-    (blobClient as HttpBlobClient).setDisabled(true);
+    ((aztecNodeAdmin as AztecNodeService).getBlobClient() as HttpBlobClient).setDisabled(true);
     await sleep(1000);
     const lastBlockSynced = await aztecNode!.getBlockNumber();
     logger.warn(`blob client is disabled (last block synced is ${lastBlockSynced})`);

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -281,7 +281,6 @@ export class FullProverTest {
       {
         aztecNodeTxProvider: this.aztecNode,
         archiver: archiver as Archiver,
-        blobClient,
       },
       { prefilledPublicData },
     );

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -9,7 +9,6 @@ import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { AnvilTestWatcher, CheatCodes } from '@aztec/aztec/testing';
-import { createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum/config';
 import { deployMulticall3 } from '@aztec/ethereum/contracts';
@@ -410,12 +409,10 @@ async function setupFromFresh(
 
   const telemetry = await getEndToEndTestTelemetryClient(opts.metricsPort);
 
-  const blobClient = await createBlobClientWithFileStores(aztecNodeConfig, createLogger('node:blob-client:client'));
-
   logger.info('Creating and synching an aztec node...');
   const aztecNode = await AztecNodeService.createAndSync(
     aztecNodeConfig,
-    { telemetry, dateProvider, blobClient },
+    { telemetry, dateProvider },
     { prefilledPublicData },
   );
 
@@ -525,12 +522,10 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
 
   const telemetry = await initTelemetryClient(getTelemetryConfig());
 
-  const blobClient = await createBlobClientWithFileStores(aztecNodeConfig, createLogger('node:blob-client:client'));
-
   logger.verbose('Creating aztec node...');
   const aztecNode = await AztecNodeService.createAndSync(
     aztecNodeConfig,
-    { telemetry, dateProvider, blobClient },
+    { telemetry, dateProvider },
     { prefilledPublicData },
   );
 

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -10,7 +10,7 @@ import { type Logger, createLogger } from '@aztec/aztec.js/log';
 import { type AztecNode, createAztecNodeClient, waitForNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { AnvilTestWatcher, CheatCodes } from '@aztec/aztec/testing';
-import { type BlobClientInterface, createBlobClientWithFileStores } from '@aztec/blob-client/client';
+import { createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import { SPONSORED_FPC_SALT } from '@aztec/constants';
 import { isAnvilTestChain } from '@aztec/ethereum/chain';
 import { createExtendedL1Client } from '@aztec/ethereum/client';
@@ -241,7 +241,6 @@ async function setupWithRemoteEnvironment(
     watcher: undefined,
     dateProvider: undefined,
     telemetryClient: undefined,
-    blobClient: undefined,
     teardown,
   };
 }
@@ -326,8 +325,6 @@ export type EndToEndContext = {
   mockGossipSubNetwork: MockGossipSubNetwork | undefined;
   /** Prefilled public data used for setting up nodes. */
   prefilledPublicData: PublicDataTreeLeaf[] | undefined;
-  /** The blob client client used for blob storage (undefined if connected to remote environment) */
-  blobClient: BlobClientInterface | undefined;
   /** Function to stop the started services. */
   teardown: () => Promise<void>;
 };
@@ -513,8 +510,6 @@ export async function setup(
       config.bbWorkingDirectory = bbConfig.bbWorkingDirectory;
     }
 
-    const blobClient = await createBlobClientWithFileStores(config, createLogger('node:blob-client:client'));
-
     let mockGossipSubNetwork: MockGossipSubNetwork | undefined;
     let p2pClientDeps: P2PClientDeps<P2PClientType.Full> | undefined = undefined;
 
@@ -553,7 +548,7 @@ export async function setup(
 
     const aztecNode = await AztecNodeService.createAndSync(
       config, // REFACTOR: createAndSync mutates this config
-      { dateProvider, blobClient, telemetry, p2pClientDeps, logger: createLogger('node:MAIN-aztec-node') },
+      { dateProvider, telemetry, p2pClientDeps, logger: createLogger('node:MAIN-aztec-node') },
       { prefilledPublicData },
     );
     const sequencerClient = aztecNode.getSequencer();
@@ -666,7 +661,6 @@ export async function setup(
       wallet,
       accounts,
       watcher,
-      blobClient,
     };
   } catch (err) {
     // TODO: Just hoisted anvil for now to ensure cleanup. Prob need to hoist the rest.

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -1,6 +1,6 @@
 import { type Archiver, createArchiver } from '@aztec/archiver';
 import { BBCircuitVerifier, QueuedIVCVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
-import { type BlobClientInterface, createBlobClient } from '@aztec/blob-client/client';
+import { createBlobClientWithFileStores } from '@aztec/blob-client/client';
 import { EpochCache } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { RollupContract } from '@aztec/ethereum/contracts';
@@ -36,7 +36,6 @@ export type ProverNodeDeps = {
   aztecNodeTxProvider?: Pick<AztecNode, 'getTxsByHash'>;
   archiver?: Archiver;
   publisherFactory?: ProverPublisherFactory;
-  blobClient?: BlobClientInterface;
   broker?: ProvingJobBroker;
   l1TxUtils?: L1TxUtils;
   dateProvider?: DateProvider;
@@ -53,8 +52,7 @@ export async function createProverNode(
   const config = { ...userConfig };
   const telemetry = deps.telemetry ?? getTelemetryClient();
   const dateProvider = deps.dateProvider ?? new DateProvider();
-  const blobClient =
-    deps.blobClient ?? createBlobClient(config, { logger: createLogger('prover-node:blob-client:client') });
+  const blobClient = await createBlobClientWithFileStores(config, createLogger('prover-node:blob-client:client'));
   const log = deps.log ?? createLogger('prover-node');
 
   // Build a key store from file if given or from environment otherwise

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -1,4 +1,4 @@
-import type { FileStoreBlobClient } from '@aztec/blob-client/filestore';
+import type { BlobClientInterface } from '@aztec/blob-client/client';
 import type { EpochCache } from '@aztec/epoch-cache';
 import type { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
@@ -52,7 +52,7 @@ export function createValidatorClient(
     dateProvider: DateProvider;
     epochCache: EpochCache;
     keyStoreManager: KeystoreManager | undefined;
-    fileStoreBlobUploadClient?: FileStoreBlobClient;
+    blobClient: BlobClientInterface;
   },
 ) {
   if (config.disableValidator || !deps.keyStoreManager) {
@@ -69,7 +69,7 @@ export function createValidatorClient(
     deps.l1ToL2MessageSource,
     txProvider,
     deps.keyStoreManager,
-    deps.fileStoreBlobUploadClient,
+    deps.blobClient,
     deps.dateProvider,
     deps.telemetry,
   );

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -1,4 +1,4 @@
-import type { FileStoreBlobClient } from '@aztec/blob-client/filestore';
+import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -53,6 +53,7 @@ describe('ValidatorClient', () => {
   let dateProvider: TestDateProvider;
   let txProvider: MockProxy<TxProvider>;
   let keyStoreManager: KeystoreManager;
+  let blobClient: MockProxy<BlobClientInterface>;
 
   beforeEach(() => {
     p2pClient = mock<P2P>();
@@ -68,6 +69,9 @@ describe('ValidatorClient', () => {
     txProvider = mock<TxProvider>();
     l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
     dateProvider = new TestDateProvider();
+    blobClient = mock<BlobClientInterface>();
+    blobClient.canUpload.mockReturnValue(false);
+    blobClient.sendBlobsToFilestore.mockResolvedValue(true);
 
     const validatorPrivateKeys = [generatePrivateKey(), generatePrivateKey()];
     validatorAccounts = validatorPrivateKeys.map(privateKey => privateKeyToAccount(privateKey));
@@ -109,7 +113,7 @@ describe('ValidatorClient', () => {
       l1ToL2MessageSource,
       txProvider,
       keyStoreManager,
-      undefined, // fileStoreBlobUploadClient
+      blobClient,
       dateProvider,
     );
   });
@@ -468,11 +472,12 @@ describe('ValidatorClient', () => {
     });
 
     describe('filestore blob upload', () => {
-      let mockFileStoreBlobClient: MockProxy<FileStoreBlobClient>;
+      let mockBlobClient: MockProxy<BlobClientInterface>;
 
       beforeEach(() => {
-        mockFileStoreBlobClient = mock<FileStoreBlobClient>();
-        mockFileStoreBlobClient.saveBlobs.mockResolvedValue();
+        mockBlobClient = mock<BlobClientInterface>();
+        mockBlobClient.canUpload.mockReturnValue(true);
+        mockBlobClient.sendBlobsToFilestore.mockResolvedValue(true);
       });
 
       const createValidatorWithFileStore = () => {
@@ -485,7 +490,7 @@ describe('ValidatorClient', () => {
           l1ToL2MessageSource,
           txProvider,
           keyStoreManager,
-          mockFileStoreBlobClient,
+          mockBlobClient,
           dateProvider,
         );
       };
@@ -507,7 +512,7 @@ describe('ValidatorClient', () => {
         // Wait for fire-and-forget upload (1ms is enough since mock resolves immediately)
         await sleep(1);
 
-        expect(mockFileStoreBlobClient.saveBlobs).toHaveBeenCalledWith(expect.any(Array), true);
+        expect(mockBlobClient.sendBlobsToFilestore).toHaveBeenCalledWith(expect.any(Array));
       });
 
       it('should not attempt upload when fileStoreBlobUploadClient is undefined', async () => {
@@ -519,11 +524,11 @@ describe('ValidatorClient', () => {
 
         expect(attestations).toBeDefined();
         // No upload should happen since there's no filestore client
-        expect(mockFileStoreBlobClient.saveBlobs).not.toHaveBeenCalled();
+        expect(mockBlobClient.sendBlobsToFilestore).not.toHaveBeenCalled();
       });
 
       it('should not fail attestation when blob upload fails', async () => {
-        mockFileStoreBlobClient.saveBlobs.mockRejectedValue(new Error('Upload failed'));
+        mockBlobClient.sendBlobsToFilestore.mockRejectedValue(new Error('Upload failed'));
         const validatorWithFileStore = createValidatorWithFileStore();
         validatorWithFileStore.updateConfig({ validatorReexecute: true });
         blockBuilder.buildBlock.mockImplementation(() => Promise.resolve(blockBuildResult));
@@ -559,7 +564,7 @@ describe('ValidatorClient', () => {
         await sleep(1);
 
         // Upload should still happen because filestore presence triggers re-execution
-        expect(mockFileStoreBlobClient.saveBlobs).toHaveBeenCalled();
+        expect(mockBlobClient.sendBlobsToFilestore).toHaveBeenCalled();
       });
 
       it('should not upload blobs when validation fails', async () => {
@@ -575,7 +580,7 @@ describe('ValidatorClient', () => {
 
         expect(attestations).toBeUndefined();
         // No upload because validation failed
-        expect(mockFileStoreBlobClient.saveBlobs).not.toHaveBeenCalled();
+        expect(mockBlobClient.sendBlobsToFilestore).not.toHaveBeenCalled();
       });
     });
 

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -1,4 +1,4 @@
-import type { FileStoreBlobClient } from '@aztec/blob-client/filestore';
+import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { getBlobsPerL1Block } from '@aztec/blob-lib';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
@@ -67,7 +67,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     private p2pClient: P2P,
     private blockProposalHandler: BlockProposalHandler,
     private config: ValidatorClientFullConfig,
-    private fileStoreBlobUploadClient: FileStoreBlobClient | undefined,
+    private blobClient: BlobClientInterface,
     private dateProvider: DateProvider = new DateProvider(),
     telemetry: TelemetryClient = getTelemetryClient(),
     log = createLogger('validator'),
@@ -150,7 +150,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     l1ToL2MessageSource: L1ToL2MessageSource,
     txProvider: TxProvider,
     keyStoreManager: KeystoreManager,
-    fileStoreBlobUploadClient?: FileStoreBlobClient,
+    blobClient: BlobClientInterface,
     dateProvider: DateProvider = new DateProvider(),
     telemetry: TelemetryClient = getTelemetryClient(),
   ) {
@@ -176,7 +176,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       p2pClient,
       blockProposalHandler,
       config,
-      fileStoreBlobUploadClient,
+      blobClient,
       dateProvider,
       telemetry,
     );
@@ -299,7 +299,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       (slashBroadcastedInvalidBlockPenalty > 0n && validatorReexecute) ||
       (partOfCommittee && validatorReexecute) ||
       alwaysReexecuteBlockProposals ||
-      this.fileStoreBlobUploadClient;
+      this.blobClient.canUpload();
 
     const validationResult = await this.blockProposalHandler.handleBlockProposal(
       proposal,
@@ -356,12 +356,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     this.metrics.incSuccessfulAttestations(inCommittee.length);
 
     // Upload blobs to filestore after successful re-execution (fire-and-forget)
-    if (validationResult.reexecutionResult?.block && this.fileStoreBlobUploadClient) {
+    if (validationResult.reexecutionResult?.block && this.blobClient.canUpload()) {
       void Promise.resolve().then(async () => {
         try {
           const blobFields = validationResult.reexecutionResult!.block.getCheckpointBlobFields();
           const blobs = getBlobsPerL1Block(blobFields);
-          await this.fileStoreBlobUploadClient!.saveBlobs(blobs, true);
+          await this.blobClient.sendBlobsToFilestore(blobs);
           this.log.debug(`Uploaded ${blobs.length} blobs to filestore from re-execution`, proposalInfo);
         } catch (err) {
           this.log.warn(`Failed to upload blobs from re-execution`, err);


### PR DESCRIPTION
Changes the way BlobClient is initialized in AztecNodeService in order to fix [failing e2e tests](http://ci.aztec-labs.com/44e95c377cb31355).

Additional cleanup of BlobClient initialization was introduced:
- AztecNodeService always creates BlobClient - optional parameter was removed
- snapshot_manager does not create BlobClient any more
- validator_client uses BlobClient instead of BlobFileStore to upload blobs after validation

Fixes A-404
