### PR TITLE
chore: add TypeScript code style rule for Claude

### DIFF
--- a/yarn-project/.claude/rules/typescript-style.md
+++ b/yarn-project/.claude/rules/typescript-style.md
@@ -1,0 +1,183 @@
+# TypeScript Code Style
+
+## Type Safety
+
+- Avoid `as Type` casts; prefer type guards
+- Never use `as any`
+- Use branded types for common domain types (`SlotNumber`, `BlockNumber`, `EpochNumber`, etc.)
+- Type guard functions follow `is<TypeName>` naming convention:
+  ```typescript
+  function isRevertCodeEnum(value: number): value is RevertCodeEnum { ... }
+  ```
+
+## Data Structures
+
+**Plain types ("structs")** for simple local data with free functions + schema in same file:
+```typescript
+// Example: archiver/src/archiver/structs/inbox_message.ts
+export type InboxMessage = {
+  index: bigint;
+  leaf: Fr;
+  checkpointNumber: CheckpointNumber;
+};
+
+export function serializeInboxMessage(message: InboxMessage): Buffer { ... }
+export function deserializeInboxMessage(buffer: Buffer): InboxMessage { ... }
+```
+
+**Classes** for richer structs with serialization, factory, and utility methods:
+```typescript
+// Example: stdlib/src/tx/block_header.ts
+export class BlockHeader {
+  constructor(public readonly lastArchive: AppendOnlyTreeSnapshot, ...) {}
+
+  static get schema(): ZodFor<BlockHeader> { ... }
+  static from(fields: FieldsOf<BlockHeader>) { ... }
+  static fromBuffer(buffer: Buffer): BlockHeader { ... }
+  static empty(): BlockHeader { ... }
+  static random(): BlockHeader { ... }
+
+  toBuffer(): Buffer { ... }
+  hash(): Promise<Fr> { ... }
+}
+```
+
+Avoid classes with only static methods; use free functions instead.
+
+## Factory Patterns
+
+For classes, use these static factory methods:
+- `from(FieldsOf<T>)` - synchronous construction from plain object
+- `create()` - async construction when validation is needed
+- `fromBuffer()` / `fromString()` - deserialization
+- `empty()` / `random()` - testing helpers
+
+## Schema Patterns (Zod)
+
+Use Zod for validating untrusted input. For classes, define a static schema getter:
+
+```typescript
+static get schema(): ZodFor<BlockHeader> {
+  return z
+    .object({
+      lastArchive: AppendOnlyTreeSnapshot.schema,
+      state: StateReference.schema,
+      // ...
+    })
+    .transform(BlockHeader.from);
+}
+```
+
+Use `zodFor<T>()` helper for type-safe schema definitions on plain types.
+
+## Interfaces
+
+Use interfaces only when:
+- Multiple implementations exist
+- Exposing APIs to the outside world
+- Need to depend on a type without creating a runtime dependency
+
+## Error Handling
+
+- Custom errors extend `Error` and set `this.name`
+- Use error hierarchies with base classes for domains
+- Include `public readonly` properties for error context
+
+```typescript
+export class SequencerTooSlowError extends Error {
+  constructor(
+    public readonly proposedState: SequencerState,
+    public readonly maxAllowedTime: number,
+  ) {
+    super(`Too far into slot for ${proposedState}...`);
+    this.name = 'SequencerTooSlowError';
+  }
+}
+```
+
+## Class Style
+
+- Be explicit with `private`/`public`/`protected`
+- Use `readonly` whenever possible
+- Method organization:
+  1. Static properties/constants
+  2. Instance properties
+  3. Constructor
+  4. Static factory methods (`from`, `create`, `empty`, `random`)
+  5. Lifecycle methods (`start`, `stop`)
+  6. Public API methods
+  7. Protected methods
+  8. Private methods
+
+## Enums vs Union Types
+
+- **Numeric enums** for protocol constants that serialize to numbers
+- **String enums** for status values and event names
+- **`as const` arrays** with derived type for string literal unions:
+  ```typescript
+  const GasDimensions = ['da', 'l2'] as const;
+  type GasDimensions = (typeof GasDimensions)[number];
+  ```
+- **Discriminated unions** with `type` field for variant types
+
+## Optional vs Nullable
+
+- Prefer `undefined` over `null`
+- Use `compactArray()` from foundation to filter undefined values
+
+## General Style
+
+- Prefer `const` over `let`
+- Prefer `async`/`await` over `.then()`/`.catch()` callbacks
+- Named exports only (no default exports)
+- Explicit return types on public API methods; inferred types acceptable on private/internal methods
+
+## Foundation Utilities
+
+- Check `foundation` for existing utilities before reimplementing
+- Extract general (non-domain) utilities to `foundation`
+
+## Collections
+
+Avoid `Set`/`Map` of non-primitive class instances; this leads to errors with `has()` checks. Use primitive keys (strings, numbers) instead.
+
+## Logging
+
+- Be generous with logging, but not excessive
+- Include structured context objects
+- Use appropriate log levels: `trace`, `debug`, `verbose`, `info`, `warn`, `error`
+
+```typescript
+this.log.info(`Preparing checkpoint ${checkpointNumber}`, {
+  slot,
+  checkpointNumber,
+  proposer,
+});
+```
+
+## Import Organization
+
+Order imports as follows:
+1. External `@aztec/*` packages
+2. Foundation utilities (`@aztec/foundation/*`)
+3. Protocol-specific packages
+4. Node.js built-ins (`node:events`, `node:fs`)
+5. Third-party packages (`viem`, `zod`)
+6. Relative imports (with `.js` extension)
+
+Use `import type` for type-only imports.
+
+## Event Handling
+
+Use `TypedEventEmitter<TEventMap>` interface for typed events:
+
+```typescript
+type SequencerEvents = {
+  ['state-changed']: (args: { oldState: SequencerState; newState: SequencerState }) => void;
+  ['block-proposed']: (args: { blockNumber: BlockNumber }) => void;
+};
+
+export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<SequencerEvents>) {
+  // ...
+}
+```

--- a/yarn-project/.claude/skills/unit-test-implementation/SKILL.md
+++ b/yarn-project/.claude/skills/unit-test-implementation/SKILL.md
@@ -96,41 +96,6 @@ export class MockCache {
 }
 ```
 
-## Avoiding Type Casts
-
-### Never Use `as any`
-
-Type casts like `as any` hide type errors and make tests brittle. They indicate either:
-
-1. The test data doesn't match the expected type (fix the test data)
-2. The types are wrong (fix the types)
-3. The test is accessing internals incorrectly (use proper test patterns)
-
-```typescript
-// ❌ Bad: Hiding type mismatches
-const result = someFn() as any;
-mockFn.mockReturnValue({ partial: "data" } as any);
-
-// ✅ Good: Proper typing
-const result: ExpectedType = someFn();
-mockFn.mockReturnValue(createValidMockData());
-```
-
-### Minimize Type Assertions
-
-If you must use type assertions, prefer the most specific type possible:
-
-```typescript
-// ❌ Bad
-const config = {} as any;
-
-// ⚠️ Acceptable when truly needed
-const config = { knownField: "value" } as Partial<Config>;
-
-// ✅ Best: Use factory functions
-const config = createTestConfig({ knownField: "value" });
-```
-
 ## Exposing Internals for Testing
 
 ### Use a Derived Test Class

--- a/yarn-project/.claude/skills/worktree-spawn/SKILL.md
+++ b/yarn-project/.claude/skills/worktree-spawn/SKILL.md
@@ -1,6 +1,24 @@
-# Working in Parallel with Git Worktrees
+---
+name: worktree-spawn
+description: Spawn an independent Claude instance in a git worktree to work on a task in parallel. Use when the user wants to delegate a task to run independently while continuing the current conversation.
+---
 
-When Claude needs to work on a task independently in a separate worktree:
+# Worktree Spawn
+
+Spawn an independent Claude instance in a separate git worktree to work on a task in parallel.
+
+## When to Use
+
+- User wants to delegate a task to run independently
+- Task can be completed without further interaction
+- User wants to continue working on something else in the current session
+
+## Workflow
+
+1. Determine branch name using author initials (from `git config user.initials` or `git config user.name`) and task description
+2. Choose a worktree directory name (typically `../aztec-<feature-name>`)
+3. Create the worktree with a new branch
+4. Spawn Claude in the worktree with a detailed task prompt
 
 ## Command Template
 
@@ -28,6 +46,8 @@ EOF
 
 ## Example
 
+For a task "Fix bug #123 in the sequencer":
+
 ```bash
 cd $(git rev-parse --show-toplevel) && \
 git worktree add -b jd/fix-bug-123 ../aztec-fix-bug && \
@@ -50,8 +70,9 @@ EOF
 ## Key Points
 
 - Always go to git root first before creating worktree
-- Use `-b` flag to create new branch
+- Use `-b` flag to create a new branch
 - Navigate to `yarn-project` within the worktree
 - Always include "Read CLAUDE.md first" in the prompt
 - Worktree directories are typically named `../aztec-<feature-name>`
-- The spawned Claude instance works independently from your current session
+- The spawned Claude instance works independently from the current session
+- PR target is `next` unless specified otherwise


### PR DESCRIPTION
## Summary

- Adds a new Claude rule documenting TypeScript coding conventions for the Aztec monorepo
- Converts git-worktrees rule to a skill (worktree-spawn) for on-demand invocation
- Moves type cast guidelines from unit-test skill to the new code style rule

### New TypeScript Style Rule

The rule covers:
- Type safety (avoid casts, use branded types, type guards)
- Data structures (plain types vs classes)
- Factory patterns (`from()`, `create()`, `fromBuffer()`, `empty()`, `random()`)
- Schema patterns (Zod with `ZodFor<T>`)
- Interface usage guidelines
- Error handling conventions
- Class style and method organization
- Enums vs union types
- Optional vs nullable handling
- Import organization
- Logging and event handling patterns

### Worktree Spawn Skill

Converted from a rule to a skill since it's an action to invoke on demand rather than a passive guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)