### PR TITLE
refactor!: make bootstrap.sh work on mac (draft)

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -34,6 +34,10 @@ function inject_version {
   # Version starts immediately after the sentinel
   local version_offset=$((sentinel_offset + ${#sentinel}))
   printf "$version\0" | dd of="$binary" bs=1 seek=$version_offset conv=notrunc 2>/dev/null
+  # Re-sign on macOS after modifying the binary (version injection invalidates code signature)
+  if [[ "$(uname)" == "Darwin" ]]; then
+    codesign -s - -f "$binary" 2>/dev/null || true
+  fi
 }
 
 # Define build commands for each preset

--- a/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
@@ -21,6 +21,9 @@ if (NOT(FUZZING))
     # Link avm_transpiler when library is provided
     if(AVM_TRANSPILER_LIB)
         target_link_libraries(bb PRIVATE ${AVM_TRANSPILER_LIB})
+        if(APPLE)
+            target_link_libraries(bb PRIVATE "-framework CoreFoundation")
+        endif()
     endif()
     if(NOT WASM)
         target_link_libraries(bb PRIVATE ipc)
@@ -35,6 +38,14 @@ if (NOT(FUZZING))
             bb
             PRIVATE
             -ldw -lelf
+        )
+    endif()
+
+    # Re-sign on macOS to fix invalid linker-generated adhoc signature
+    if(APPLE)
+        add_custom_command(TARGET bb POST_BUILD
+            COMMAND codesign -s - -f $<TARGET_FILE:bb>
+            COMMENT "Re-signing bb binary for macOS"
         )
     endif()
 
@@ -61,6 +72,9 @@ if (NOT(FUZZING))
         # Link avm_transpiler when library is provided
         if(AVM_TRANSPILER_LIB)
             target_link_libraries(bb-avm PRIVATE ${AVM_TRANSPILER_LIB})
+            if(APPLE)
+                target_link_libraries(bb-avm PRIVATE "-framework CoreFoundation")
+            endif()
         endif()
         if(NOT WASM)
             target_link_libraries(bb-avm PRIVATE ipc)
@@ -75,6 +89,14 @@ if (NOT(FUZZING))
                 bb-avm
                 PRIVATE
                 -ldw -lelf
+            )
+        endif()
+
+        # Re-sign on macOS to fix invalid linker-generated adhoc signature
+        if(APPLE)
+            add_custom_command(TARGET bb-avm POST_BUILD
+                COMMAND codesign -s - -f $<TARGET_FILE:bb-avm>
+                COMMENT "Re-signing bb-avm binary for macOS"
             )
         endif()
     endif()

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.test.cpp
@@ -492,9 +492,9 @@ TEST_F(WorldStateTest, NullifierBatchInsert)
     auto response = ws.batch_insert_indexed_leaves<NullifierLeafValue>(
         MerkleTreeId::NULLIFIER_TREE, { NullifierLeafValue(150), NullifierLeafValue(142), NullifierLeafValue(180) }, 2);
 
-    std::vector<std::pair<NullifierLeafValue, size_t>> expected_sorted_leaves = { { NullifierLeafValue(180), 2 },
-                                                                                  { NullifierLeafValue(150), 0 },
-                                                                                  { NullifierLeafValue(142), 1 } };
+    std::vector<std::pair<NullifierLeafValue, index_t>> expected_sorted_leaves = { { NullifierLeafValue(180), 2 },
+                                                                                   { NullifierLeafValue(150), 0 },
+                                                                                   { NullifierLeafValue(142), 1 } };
     EXPECT_EQ(response.sorted_leaves, expected_sorted_leaves);
 
     {

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -12,7 +12,16 @@ function build {
   crs_size_bytes=$((crs_size*64))
   g1=$crs_path/bn254_g1.dat
   g2=$crs_path/bn254_g2.dat
-  if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
+  # stat -c%s is Linux-only, use stat -f%z on macOS
+  local g1_size=0
+  if [ -f "$g1" ]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      g1_size=$(stat -f%z "$g1")
+    else
+      g1_size=$(stat -c%s "$g1")
+    fi
+  fi
+  if [ ! -f "$g1" ] || [ $g1_size -lt $crs_size_bytes ]; then
     echo "Downloading crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
     mkdir -p $crs_path
     curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $g1 \
@@ -28,7 +37,15 @@ function build {
   crs_size=$((2**18))
   crs_size_bytes=$((crs_size*64))
   gg1=$crs_path/grumpkin_g1.flat.dat
-  if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
+  local gg1_size=0
+  if [ -f "$gg1" ]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      gg1_size=$(stat -f%z "$gg1")
+    else
+      gg1_size=$(stat -c%s "$gg1")
+    fi
+  fi
+  if [ ! -f "$gg1" ] || [ $gg1_size -lt $crs_size_bytes ]; then
     echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
     curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $gg1 \
       https://crs.aztec.network/grumpkin_g1.dat

--- a/ci3/arch
+++ b/ci3/arch
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Returns the standard artifact prefixes for each arch.
 case $(uname -m) in
-  aarch64)
+  aarch64|arm64)
     echo arm64
     ;;
   amd64|x86_64)

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -77,7 +77,13 @@ function publish_log_final {
 
 function live_publish_log {
   while [ -f $outfile ]; do
-    if [ $(( $(date +%s) - $(stat -c %Y "$outfile") )) -le 5 ]; then
+    local file_mtime
+    if [[ "$(uname)" == "Darwin" ]]; then
+      file_mtime=$(stat -f %m "$outfile")
+    else
+      file_mtime=$(stat -c %Y "$outfile")
+    fi
+    if [ $(( $(date +%s) - $file_mtime )) -le 5 ]; then
       publish_log
     fi
     sleep 5
@@ -94,7 +100,13 @@ fi
 set +e
 echo -e "Executing: $cmd ${log_info:-}"
 echo -n "   0 "
-tail --sleep-interval=0.2 -n +1 -f "$outfile" > >(
+# macOS tail doesn't support --sleep-interval
+if [[ "$(uname)" == "Darwin" ]]; then
+  tail_args="-n +1 -f"
+else
+  tail_args="--sleep-interval=0.2 -n +1 -f"
+fi
+tail $tail_args "$outfile" > >(
   while IFS= read -r line; do
     dot_count=$((dot_count+1))
     [ $realtime -eq 1 ] && printf "."

--- a/ci3/source
+++ b/ci3/source
@@ -3,7 +3,10 @@
 # This can be sourced multiple by scripts calling scripts, so it makes sense to only do certain sets through first pass.
 
 # Enter our script directory, allowing usage of scripts from any directory.
-[ -z "${NO_CD:-}" ] && cd "$(dirname $0)"
+# Skip cd if $0 is a shell binary (e.g., /bin/bash or /opt/homebrew/bin/bash)
+if [ -z "${NO_CD:-}" ] && [[ "$0" != */bash ]] && [[ "$0" != */zsh ]] && [[ "$0" != */sh ]]; then
+  cd "$(dirname $0)"
+fi
 
 # We export so we can use from exported functions.
 export root=${root:-$(git rev-parse --show-toplevel)}
@@ -20,6 +23,12 @@ fi
 
 # We are fine using foundry nightly.
 export FOUNDRY_DISABLE_NIGHTLY_WARNING=1
+
+# Fix for parallel setting XDG_CACHE_HOME to empty string, which breaks corepack.
+# If XDG_CACHE_HOME is set but empty, unset it to use the default.
+if [ -n "${XDG_CACHE_HOME+x}" ] && [ -z "$XDG_CACHE_HOME" ]; then
+  unset XDG_CACHE_HOME
+fi
 
 source $ci3/source_options
 source $ci3/source_stdlib

--- a/ci3/source_stdlib
+++ b/ci3/source_stdlib
@@ -33,6 +33,8 @@ function get_num_cpus {
     else
       echo $((cpu_quota / cpu_period))
     fi
+  elif [[ "$(uname)" == "Darwin" ]]; then
+    sysctl -n hw.ncpu
   else
     nproc
   fi


### PR DESCRIPTION
This is the result of tasking Claude Code with getting `bootstrap` to work locally on a MacBook Pro, with M5 and Tahoe 26.1.

I'm posting it as a PR since it seems a handy way of showing all the tweaks and env work in a single place, but I don't work on these scripts myself so I don't expect this to be merged as-is. All credit goes to Claude!

Changes to the codebase itself are easily reviewable here. I dump below a report of out of band changes that were necessary.

##  1. Software Installed

###  Homebrew Packages

  `brew install bash cmake ninja llvm@20 yarn corepack`
  - bash (5.3.9) - Required for bash 4+ features like globstar
  - cmake (3.31+) - Build system
  - ninja - Fast build tool
  - llvm@20 - Clang 20 compiler
  - yarn - Package manager
  - corepack - Node.js package manager manager

###  Clang 20 Symlinks

  Created symlinks in ~/bin/ pointing to Homebrew's LLVM 20:
```
  mkdir -p ~/bin
  ln -sf /opt/homebrew/Cellar/llvm@20/20.1.8/bin/clang ~/bin/clang-20
  ln -sf /opt/homebrew/Cellar/llvm@20/20.1.8/bin/clang++ ~/bin/clang++-20
```

###  Zig Compiler (0.15.1)

```
  sudo mkdir -p /opt/zig
  cd /opt/zig
  sudo curl -L https://ziglang.org/builds/zig-macos-aarch64-0.15.0-dev.10+6362d8c3a.tar.xz | sudo tar xJ --strip-components=1
  Note: Version 0.15.1 wasn't available, used closest dev build.
```

###  Rust Toolchain

```
  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
  rustup target add wasm32-wasip1
```

###  wasi-sdk (for WASM builds)

  cd /opt
  sudo curl -L https://github.com/aspect-build/aspect-cli/releases/download/wasi-sdk-v0.0.5/wasi-sdk-24.0-arm64-macos.tar.gz | sudo tar xz
  sudo mv wasi-sdk-24.0-arm64-macos wasi-sdk
```

###  Foundry 

```
  curl -L https://foundry.paradigm.xyz | bash
  foundryup
```

###  Node.js (via nvm)

```
  nvm install 24
  nvm use 24
```

##  2. Code Changes

###  2.1 ci3/arch - Architecture Detection Fix

  Problem: The script returned "unknown architecture arm64" on macOS.

  Change:
```
  aarch64|arm64)
    echo arm64
    ;;
```

###  2.2 barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt - Code Signing

  Problem: The bb binary was killed by macOS (SIGKILL) due to invalid code signature when linked with libavm_transpiler.a.

  Change: Added post-build signing step for both bb and bb-avm targets:

```
  # After the bb target definition (around line 42-50):
  # Re-sign on macOS to fix invalid linker-generated adhoc signature
  if(APPLE)
      add_custom_command(TARGET bb POST_BUILD
          COMMAND codesign -s - -f $<TARGET_FILE:bb>
          COMMENT "Re-signing bb binary for macOS"
      )
  endif()

  # After the bb-avm target definition (around line 95-101):
  # Re-sign on macOS to fix invalid linker-generated adhoc signature
  if(APPLE)
      add_custom_command(TARGET bb-avm POST_BUILD
          COMMAND codesign -s - -f $<TARGET_FILE:bb-avm>
          COMMENT "Re-signing bb-avm binary for macOS"
      )
  endif()
```

###  2.3 barretenberg/cpp/bootstrap.sh - Version Injection Re-signing

  Problem: The inject_version function modifies the binary with dd after building, which invalidates the code signature.

  Change: Added re-signing after version injection in the inject_version function:
```
  # At the end of the inject_version function (around line 37-40):
    # Re-sign on macOS after modifying the binary (version injection invalidates code signature)
    if [[ "$(uname)" == "Darwin" ]]; then
      codesign -s - -f "$binary" 2>/dev/null || true
    fi
```

##  3. Environment Configuration

  Required PATH

  The following PATH must be set for bootstrap to find all tools:
```
  export PATH="/opt/zig:/opt/homebrew/bin:/opt/homebrew/sbin:$HOME/bin:$HOME/.cargo/bin:$HOME/.foundry/bin:$HOME/.nvm/versions/node/v24.12.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
```

  Running Bootstrap

```
  cd /path/to/aztec-packages

 PATH="/opt/zig:/opt/homebrew/bin:/opt/homebrew/sbin:$HOME/bin:$HOME/.cargo/bin:$HOME/.foundry/bin:$HOME/.nvm/versions/node/v24.12.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
  /opt/homebrew/bin/bash -c 'source ci3/source && ./bootstrap.sh'
```

##  4. Root Cause Analysis

###  The Code Signature Issue

  The main blocker was the bb binary being killed immediately by macOS with SIGKILL (Code Signature Invalid). Investigation revealed:

  1. The crash happened during static initialization before main() even ran
  2. macOS crash reports showed: "termination":{"namespace":"CODESIGNING","indicator":"Invalid Page"}
  3. The linker creates an adhoc signature when linking, but it was invalid for binaries linking libavm_transpiler.a (Rust static library)
  4. The inject_version function in bootstrap.sh further modified the binary, invalidating any existing signature

###  Solution

  Two-part fix:
  1. CMake post-build step to re-sign after linking
  2. Bootstrap script re-sign after version injection

