### PR TITLE
chore: reintroduce reorg test and temporarily bump up CI timeout for network tests

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -145,7 +145,7 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
-          AWS_SHUTDOWN_TIME: 180
+          AWS_SHUTDOWN_TIME: 540 # temporarily increased to 9 hours, todo(revert to 360)
           NO_SPOT: 1
         run: |
           # For release tags, use the release image; for PRs, omit to build and push to aztecdev

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -81,12 +81,12 @@ function network_test_cmds {
   echo $prefix $run_test_script simple src/spartan/proving.test.ts
   echo $prefix $run_test_script simple src/spartan/prover-node.test.ts #needs partial epoch proved first
   echo $prefix $run_test_script simple src/spartan/invalidate_blocks.test.ts
-  # echo $prefix $run_test_script simple src/spartan/4epochs.test.ts #takes too long ~4 epochs
+  # echo $prefix $run_test_script simple src/spartan/4epochs.test.ts #runs >~4 epochs
   echo $prefix $run_test_script simple src/spartan/gating-passive.test.ts
   echo $prefix $run_test_script simple src/spartan/mempool_limit.test.ts
   echo $prefix $run_test_script simple src/spartan/upgrade_governance_proposer.test.ts
-  # echo $prefix $run_test_script simple src/spartan/reorg.test.ts #takes too long >~5 epochs
   echo $prefix $run_test_script simple src/spartan/validator_nuke_and_suppression.test.ts
+  echo $prefix $run_test_script simple src/spartan/reorg.test.ts #runs >~5 epochs
 }
 
 function single_test {


### PR DESCRIPTION
This PR re-introduces the nightly re-org test with a longer timeout.