### PR TITLE
refactor: improve how randomness and event commitments are handled

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
@@ -1,13 +1,15 @@
-use crate::event::event_selector::EventSelector;
+use crate::{event::event_selector::EventSelector, messages::logs::event::MAX_EVENT_SERIALIZED_LEN};
 use protocol_types::{
-    constants::DOM_SEP__EVENT_COMMITMENT, hash::poseidon2_hash_with_separator, traits::Serialize,
+    constants::DOM_SEP__EVENT_COMMITMENT,
+    hash::{poseidon2_hash_with_separator, poseidon2_hash_with_separator_bounded_vec},
+    traits::{Serialize, ToField},
 };
 
 pub trait EventInterface {
     fn get_event_type_id() -> EventSelector;
 }
 
-/// A private event's commitment is used to validate that an event was indeed emitted.
+/// A private event's commitment is a value stored on-chain which is used to verify that the event was indeed emitted.
 ///
 /// It requires a `randomness` value that must be produced alongside the event in order to perform said validation. This
 /// random value prevents attacks in which someone guesses plausible events (e.g. 'Alice transfers to Bob an amount of
@@ -18,7 +20,50 @@ where
     Event: EventInterface + Serialize,
 {
     poseidon2_hash_with_separator(
-        [randomness].concat(event.serialize()),
+        [randomness, Event::get_event_type_id().to_field()].concat(event.serialize()),
         DOM_SEP__EVENT_COMMITMENT,
     )
+}
+
+/// Unconstrained variant of [compute_private_event_commitment] which takes the event in serialized form.
+///
+/// This function is unconstrained as the mechanism it uses to compute the commitment would be very inefficient in a
+/// constrained environment (due to the hashing of a dynamically sized array). This is not an issue as it is typically
+/// invoked when processing event messages, which is an unconstrained operation.
+pub unconstrained fn compute_private_serialized_event_commitment(
+    serialized_event: BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>,
+    randomness: Field,
+    event_type_id: Field,
+) -> Field {
+    let mut commitment_preimage =
+        BoundedVec::<_, 1 + MAX_EVENT_SERIALIZED_LEN>::from_array([randomness, event_type_id]);
+    commitment_preimage.extend_from_bounded_vec(serialized_event);
+
+    poseidon2_hash_with_separator_bounded_vec(commitment_preimage, DOM_SEP__EVENT_COMMITMENT)
+}
+
+mod test {
+    use crate::event::event_interface::{
+        compute_private_event_commitment, compute_private_serialized_event_commitment,
+        EventInterface,
+    };
+    use crate::test::mocks::mock_event::MockEvent;
+    use protocol_types::traits::{Serialize, ToField};
+
+    global VALUE: Field = 7;
+    global RANDOMNESS: Field = 10;
+
+    #[test]
+    unconstrained fn event_commitment_equivalence() {
+        let event = MockEvent::new(VALUE).build_event();
+
+        assert_eq(
+            compute_private_event_commitment(event, RANDOMNESS),
+            compute_private_serialized_event_commitment(
+                BoundedVec::from_array(event.serialize()),
+                RANDOMNESS,
+                MockEvent::get_event_type_id().to_field(),
+            ),
+        );
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -1,8 +1,11 @@
-use crate::messages::{
-    encoding::MAX_MESSAGE_CONTENT_LEN, logs::event::decode_private_event_message,
-    processing::enqueue_event_for_validation,
+use crate::{
+    event::event_interface::compute_private_serialized_event_commitment,
+    messages::{
+        encoding::MAX_MESSAGE_CONTENT_LEN, logs::event::decode_private_event_message,
+        processing::enqueue_event_for_validation,
+    },
 };
-use protocol_types::address::AztecAddress;
+use protocol_types::{address::AztecAddress, traits::ToField};
 
 pub unconstrained fn process_private_event_msg(
     contract_address: AztecAddress,
@@ -11,8 +14,14 @@ pub unconstrained fn process_private_event_msg(
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
     tx_hash: Field,
 ) {
-    let (event_type_id, serialized_event, event_commitment) =
+    let (event_type_id, randomness, serialized_event) =
         decode_private_event_message(msg_metadata, msg_content);
+
+    let event_commitment = compute_private_serialized_event_commitment(
+        serialized_event,
+        randomness,
+        event_type_id.to_field(),
+    );
 
     enqueue_event_for_validation(
         contract_address,

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -6,11 +6,7 @@ use crate::{
     },
     utils::array,
 };
-use protocol_types::{
-    constants::DOM_SEP__EVENT_COMMITMENT,
-    hash::poseidon2_hash_with_separator_bounded_vec,
-    traits::{FromField, Serialize, ToField},
-};
+use protocol_types::traits::{FromField, Serialize, ToField};
 
 /// The number of fields in a private event message content that are not the event's serialized representation
 /// (1 field for randomness).
@@ -19,7 +15,7 @@ pub(crate) global PRIVATE_EVENT_MSG_PLAINTEXT_RANDOMNESS_INDEX: u32 = 0;
 
 /// The maximum length of the packed representation of an event's contents. This is limited by private log size,
 /// encryption overhead and extra fields in the message (e.g. message type id, randomness, etc.).
-pub(crate) global MAX_EVENT_SERIALIZED_LEN: u32 =
+pub global MAX_EVENT_SERIALIZED_LEN: u32 =
     MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN;
 
 /// Creates the plaintext for a private event message (i.e. one of type [PRIVATE_EVENT_MSG_TYPE_ID]).
@@ -53,7 +49,7 @@ where
         msg_plaintext[PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + i] = serialized_event[i];
     }
 
-    // Private events use the event type id for metadata
+    // The event type id is stored in the message metadata
     encode_message(
         PRIVATE_EVENT_MSG_TYPE_ID,
         Event::get_event_type_id().to_field() as u64,
@@ -71,8 +67,8 @@ where
 pub(crate) unconstrained fn decode_private_event_message(
     msg_metadata: u64,
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
-) -> (EventSelector, BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>, Field) {
-    // In the case of events, the msg metadata is the event selector.
+) -> (EventSelector, Field, BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>) {
+    // Private event messages contain the event type id in the metadata
     let event_type_id = EventSelector::from_field(msg_metadata as Field);
 
     assert(
@@ -87,21 +83,11 @@ pub(crate) unconstrained fn decode_private_event_message(
         "unexpected value for PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
     );
 
-    let serialized_event_with_randomness = msg_content;
+    let randomness = msg_content.get(PRIVATE_EVENT_MSG_PLAINTEXT_RANDOMNESS_INDEX);
+    let serialized_event =
+        array::subbvec(msg_content, PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN);
 
-    let event_commitment = poseidon2_hash_with_separator_bounded_vec(
-        serialized_event_with_randomness,
-        DOM_SEP__EVENT_COMMITMENT,
-    );
-
-    // Randomness was injected into the event payload in `emit_event_in_private` but we have already used it
-    // to compute the event commitment, so we can safely discard it now.
-    let serialized_event = array::subbvec(
-        serialized_event_with_randomness,
-        PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN,
-    );
-
-    (event_type_id, serialized_event, event_commitment)
+    (event_type_id, randomness, serialized_event)
 }
 
 mod test {
@@ -130,10 +116,11 @@ mod test {
 
         assert_eq(msg_type_id, PRIVATE_EVENT_MSG_TYPE_ID);
 
-        let (event_type_id, serialized_event, _) =
+        let (event_type_id, randomness, serialized_event) =
             decode_private_event_message(msg_metadata, msg_content);
 
         assert_eq(event_type_id, MockEvent::get_event_type_id());
+        assert_eq(randomness, RANDOMNESS);
         assert_eq(serialized_event, BoundedVec::from_array(event.serialize()));
     }
 }


### PR DESCRIPTION
We had some duplication in how the commitment was handled, plus some functions made assumptions about the plaintext layout. This makes that more explicit.

With this done, including the event type id in the commitment proved to be trivial.

Closes https://linear.app/aztec-labs/issue/F-201/commit-to-event-selector-in-nullifier.