### PR TITLE
feat: store event randomness in database

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -26,6 +26,7 @@ pub unconstrained fn process_private_event_msg(
     enqueue_event_for_validation(
         contract_address,
         event_type_id,
+        randomness,
         serialized_event,
         event_commitment,
         tx_hash,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
@@ -7,6 +7,7 @@ use protocol_types::{address::AztecAddress, traits::Serialize};
 pub(crate) struct EventValidationRequest {
     pub contract_address: AztecAddress,
     pub event_type_id: EventSelector,
+    pub randomness: Field,
     pub serialized_event: BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>,
     pub event_commitment: Field,
     pub tx_hash: Field,
@@ -23,10 +24,11 @@ mod test {
         let request = EventValidationRequest {
             contract_address: AztecAddress::from_field(1),
             event_type_id: EventSelector::from_field(2),
-            serialized_event: BoundedVec::from_array([3, 4]),
-            event_commitment: 5,
-            tx_hash: 6,
-            recipient: AztecAddress::from_field(7),
+            randomness: 3,
+            serialized_event: BoundedVec::from_array([4, 5]),
+            event_commitment: 6,
+            tx_hash: 7,
+            recipient: AztecAddress::from_field(8),
         };
 
         // We define the serialization in Noir and the deserialization in TS. If the deserialization changes from the
@@ -36,13 +38,14 @@ mod test {
         let expected_serialization = [
             1, // contract_address
             2, // event_type_id
-            3, // serialized_event[0]
-            4, // serialized_event[1]
+            3, // randomness
+            4, // serialized_event[0]
+            5, // serialized_event[1]
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // serialized_event padding
             2, // bounded_vec_len
-            5, // event_commitment
-            6, // tx_hash
-            7, // recipient
+            6, // event_commitment
+            7, // tx_hash
+            8, // recipient
         ];
 
         assert_eq(request.serialize(), expected_serialization);

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -114,6 +114,7 @@ pub(crate) unconstrained fn enqueue_note_for_validation(
 pub(crate) unconstrained fn enqueue_event_for_validation(
     contract_address: AztecAddress,
     event_type_id: EventSelector,
+    randomness: Field,
     serialized_event: BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN>,
     event_commitment: Field,
     tx_hash: Field,
@@ -125,6 +126,7 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
         EventValidationRequest {
             contract_address,
             event_type_id,
+            randomness,
             serialized_event,
             event_commitment,
             tx_hash,

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.test.ts
@@ -10,8 +10,9 @@ describe('EventValidationRequest', () => {
     const serialized = [
       1, // contract_address
       2, // event_type_id
-      3, // serialized_event[0]
-      4, // serialized_event[1]
+      3, // randomness
+      4, // serialized_event[0]
+      5, // serialized_event[1]
       0, // serialized_event padding start
       0,
       0,
@@ -23,18 +24,19 @@ describe('EventValidationRequest', () => {
       0,
       0, // serialized_event padding end
       2, // bounded_vec_len
-      5, // event_commitment
-      6, // tx_hash
-      7, // recipient
+      6, // event_commitment
+      7, // tx_hash
+      8, // recipient
     ].map(n => new Fr(n));
 
     const request = EventValidationRequest.fromFields(serialized);
 
     expect(request.contractAddress).toEqual(AztecAddress.fromBigInt(1n));
     expect(request.eventTypeId).toEqual(new EventSelector(2));
-    expect(request.serializedEvent).toEqual([new Fr(3), new Fr(4)]);
-    expect(request.eventCommitment).toEqual(new Fr(5));
-    expect(request.txHash).toEqual(TxHash.fromBigInt(6n));
-    expect(request.recipient).toEqual(AztecAddress.fromBigInt(7n));
+    expect(request.randomness).toEqual(new Fr(3));
+    expect(request.serializedEvent).toEqual([new Fr(4), new Fr(5)]);
+    expect(request.eventCommitment).toEqual(new Fr(6));
+    expect(request.txHash).toEqual(TxHash.fromBigInt(7n));
+    expect(request.recipient).toEqual(AztecAddress.fromBigInt(8n));
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.ts
@@ -15,6 +15,7 @@ export class EventValidationRequest {
   constructor(
     public contractAddress: AztecAddress,
     public eventTypeId: EventSelector,
+    public randomness: Fr,
     public serializedEvent: Fr[],
     public eventCommitment: Fr,
     public txHash: TxHash,
@@ -27,6 +28,8 @@ export class EventValidationRequest {
     const contractAddress = AztecAddress.fromField(reader.readField());
     const eventTypeId = EventSelector.fromField(reader.readField());
 
+    const randomness = reader.readField();
+
     const eventStorage = reader.readFieldArray(MAX_EVENT_SERIALIZED_LEN);
     const eventLen = reader.readField().toNumber();
     const serializedEvent = eventStorage.slice(0, eventLen);
@@ -38,6 +41,7 @@ export class EventValidationRequest {
     return new EventValidationRequest(
       contractAddress,
       eventTypeId,
+      randomness,
       serializedEvent,
       eventCommitment,
       txHash,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -412,6 +412,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       eventService.deliverEvent(
         request.contractAddress,
         request.eventTypeId,
+        request.randomness,
         request.serializedEvent,
         request.eventCommitment,
         request.txHash,

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -17,6 +17,7 @@ import { EventService } from './event_service.js';
 describe('deliverEvent', () => {
   let blockNumber: BlockNumber;
   let eventSelector: EventSelector;
+  let randomness: Fr;
   let eventContent: Fr[];
   let eventCommitment: Fr;
   let eventNullifier: Fr;
@@ -53,6 +54,7 @@ describe('deliverEvent', () => {
 
     blockNumber = BlockNumber(42);
     eventSelector = EventSelector.random();
+    randomness = Fr.random();
     eventContent = [Fr.random(), Fr.random()];
 
     eventCommitment = Fr.random();
@@ -100,6 +102,7 @@ describe('deliverEvent', () => {
     return eventService.deliverEvent(
       contractAddress,
       eventSelector,
+      randomness,
       eventContent,
       overrides.eventCommitment || eventCommitment,
       txEffect.txHash,

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -19,6 +19,7 @@ export class EventService {
   public async deliverEvent(
     contractAddress: AztecAddress,
     selector: EventSelector,
+    randomness: Fr,
     content: Fr[],
     eventCommitment: Fr,
     txHash: TxHash,
@@ -63,6 +64,7 @@ export class EventService {
 
     return this.privateEventStore.storePrivateEventLog(
       selector,
+      randomness,
       content,
       Number(nullifierIndex.data), // Index of the event commitment in the nullifier tree
       {

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -218,7 +218,9 @@ describe('PXE', () => {
         eventSelector,
       };
 
-      await privateEventStore.storePrivateEventLog(eventSelector, event.packedEvent, eventIndex++, {
+      const randomness = Fr.random();
+
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, event.packedEvent, eventIndex++, {
         contractAddress,
         scope,
         txHash: event.txHash,

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -22,6 +22,7 @@ describe('PrivateEventStore', () => {
   let l2BlockNumber: BlockNumber;
   let l2BlockHash: L2BlockHash;
   let eventSelector: EventSelector;
+  let randomness: Fr;
   let txHash: TxHash;
   let eventCommitmentIndex: number;
   let expectedEvent: PackedPrivateEvent;
@@ -35,6 +36,7 @@ describe('PrivateEventStore', () => {
     l2BlockNumber = BlockNumber(123);
     l2BlockHash = L2BlockHash.random();
     eventSelector = EventSelector.random();
+    randomness = Fr.random();
     txHash = TxHash.random();
     eventCommitmentIndex = randomInt(10);
 
@@ -48,7 +50,7 @@ describe('PrivateEventStore', () => {
   });
 
   it('stores and retrieves private events', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
       contractAddress,
       scope,
       txHash,
@@ -65,7 +67,7 @@ describe('PrivateEventStore', () => {
   });
 
   it('ignores duplicate events with same eventCommitmentIndex', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
       contractAddress,
       scope,
       txHash,
@@ -86,14 +88,14 @@ describe('PrivateEventStore', () => {
   it('allows multiple events with same content but different eventCommitmentIndex', async () => {
     const otherEventCommitmentIndex = eventCommitmentIndex + 1;
 
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, otherEventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, otherEventCommitmentIndex, {
       contractAddress,
       scope,
       txHash,
@@ -118,21 +120,21 @@ describe('PrivateEventStore', () => {
       l2BlockNumber: BlockNumber(200),
     };
 
-    await privateEventStore.storePrivateEventLog(eventSelector, getRandomMsgContent(), 0, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), 0, {
       contractAddress,
       scope,
       txHash: TxHash.random(),
       l2BlockNumber: BlockNumber(100),
       l2BlockHash,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, 1, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, 1, {
       contractAddress,
       scope,
       txHash: expectedEvent.txHash,
       l2BlockNumber: expectedEvent.l2BlockNumber,
       l2BlockHash: expectedEvent.l2BlockHash,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, getRandomMsgContent(), 2, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), 2, {
       contractAddress,
       scope,
       txHash: TxHash.random(),
@@ -153,14 +155,14 @@ describe('PrivateEventStore', () => {
   it('filters events by recipient', async () => {
     const otherScope = await AztecAddress.random();
 
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, msgContent, eventCommitmentIndex + 1, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex + 1, {
       contractAddress,
       scope: otherScope,
       txHash: TxHash.random(),
@@ -201,7 +203,7 @@ describe('PrivateEventStore', () => {
     });
 
     it('returns events in order by eventCommitmentIndex', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent2, 1, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, 1, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -209,7 +211,7 @@ describe('PrivateEventStore', () => {
         l2BlockHash,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -217,7 +219,7 @@ describe('PrivateEventStore', () => {
         l2BlockHash,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent3, 2, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, 2, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -251,7 +253,7 @@ describe('PrivateEventStore', () => {
 
     it('removes events after rollback block', async () => {
       // Store events in blocks 100, 200, 300
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -259,7 +261,7 @@ describe('PrivateEventStore', () => {
         l2BlockHash,
       });
       // We add another event in the same block to verify that more events per block work.
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent2, 1, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, 1, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -267,7 +269,7 @@ describe('PrivateEventStore', () => {
         l2BlockHash,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent3, 2, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, 2, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -275,7 +277,7 @@ describe('PrivateEventStore', () => {
         l2BlockHash,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent4, 3, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent4, 3, {
         contractAddress,
         scope,
         txHash: TxHash.random(),
@@ -304,7 +306,7 @@ describe('PrivateEventStore', () => {
       const reorgTxHash = TxHash.random();
 
       // Store event at block 200
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
         contractAddress,
         scope,
         txHash: reorgTxHash,
@@ -325,7 +327,7 @@ describe('PrivateEventStore', () => {
       expect(events.length).toBe(0);
 
       // Re-add the same event (same eventCommitmentIndex and txHash, as happens after a reorg)
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
         contractAddress,
         scope,
         txHash: reorgTxHash,
@@ -344,7 +346,7 @@ describe('PrivateEventStore', () => {
     });
 
     it('handles rollback with no events to remove', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
         contractAddress,
         scope,
         txHash: TxHash.random(),

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -19,6 +19,7 @@ export type PrivateEventStoreFilter = {
 };
 
 type PrivateEventEntry = {
+  randomness: Fr; // Note that this value is currently not being returned on queries and is therefore temporarily unused
   msgContent: Buffer;
   eventCommitmentIndex: number;
   l2BlockNumber: number;
@@ -74,6 +75,7 @@ export class PrivateEventStore {
    */
   storePrivateEventLog(
     eventSelector: EventSelector,
+    randomness: Fr,
     msgContent: Fr[],
     eventCommitmentIndex: number,
     metadata: PrivateEventMetadata,
@@ -93,6 +95,7 @@ export class PrivateEventStore {
       this.logger.verbose('storing private event log', { contractAddress, scope, msgContent, l2BlockNumber });
 
       await this.#eventLogs.set(eventCommitmentIndex, {
+        randomness,
         msgContent: serializeToBuffer(msgContent),
         l2BlockNumber,
         l2BlockHash: l2BlockHash.toBuffer(),


### PR DESCRIPTION
Merge after https://github.com/AztecProtocol/aztec-packages/pull/19366.

With this we'll be storing the randomness contained in the event, which while currently unused would be required to recompute the commitment and validate that the event exists externally. I didn't add it to the API yet, so the queries don't return it, because the store is in such a poor state that it's better to re-do it entirely.