### PR TITLE
refactor: reduce delivery duplication

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -2,12 +2,8 @@ use crate::{
     context::PrivateContext,
     event::{event_emission::NewEvent, event_interface::EventInterface},
     messages::{
-        encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::{event::encode_private_event_message, utils::prefix_with_tag},
-        message_delivery::MessageDelivery,
-        offchain_messages::deliver_offchain_message,
+        logs::event::encode_private_event_message, message_delivery::do_private_message_delivery,
     },
-    utils::remove_constraints::remove_constraints_if,
 };
 use protocol_types::{address::AztecAddress, traits::Serialize};
 
@@ -52,39 +48,18 @@ where
     /// to an invalid recipient) and forced privacy leaks (where an invalid recipient results in a unique transaction
     /// fingerprint, e.g. one lacking the private logs that would correspond to message delivery).
     pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
-        // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when
-        // unconstrained usage is requested. If `delivery_mode` were a runtime value the compiler would be unable to
-        // perform dead-code elimination.
-        assert_constant(delivery_mode);
-
-        // The following maps out the 3 dimensions across which we configure message delivery.
-        let constrained_encryption = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
-        let deliver_as_offchain_message = delivery_mode == MessageDelivery.OFFCHAIN;
-        // TODO(#14565): Add constrained tagging
-        let _constrained_tagging = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
-
-        // Technical note: we're about to call a closure that needs access to `new_event`, but we can't pass `self` to
-        // it because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
+        // Technical note: we're about to call a closure that needs access to `new_event`, but we can't pass `self` to it
+        // because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
         // `context` this would cause for a mutable reference to cross the constrained-unconstrained barrier, which is
         // not allowed. As a workaround, we create a variable without the context and capture that instead.
         let new_event = self.new_event;
 
-        let ciphertext = remove_constraints_if(
-            !constrained_encryption,
-            || AES128::encrypt(
-                encode_private_event_message(new_event.event, new_event.randomness),
-                recipient,
-            ),
+        do_private_message_delivery(
+            self.context,
+            || encode_private_event_message(new_event.event, new_event.randomness),
+            Option::none(),
+            recipient,
+            delivery_mode,
         );
-
-        if deliver_as_offchain_message {
-            deliver_offchain_message(ciphertext, recipient);
-        } else {
-            // Safety: Currently unsafe. See description of ONCHAIN_CONSTRAINED in MessageDeliveryEnum.
-            // TODO(#14565): Implement proper constrained tag prefixing to make this truly ONCHAIN_CONSTRAINED
-            let log_content = prefix_with_tag(ciphertext, recipient);
-
-            self.context.emit_private_log(log_content, log_content.len());
-        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
@@ -1,3 +1,14 @@
+use crate::{
+    context::private_context::PrivateContext,
+    messages::{
+        encryption::{aes128::AES128, message_encryption::MessageEncryption},
+        logs::utils::prefix_with_tag,
+        offchain_messages::deliver_offchain_message,
+    },
+    utils::remove_constraints::remove_constraints_if,
+};
+use protocol_types::address::AztecAddress;
+
 /// Specifies how to deliver a message to a recipient.
 ///
 /// All messages are delivered encrypted to their recipient's public address key, so no other account will be able to
@@ -165,3 +176,68 @@ pub struct MessageDeliveryEnum {
 
 pub global MessageDelivery: MessageDeliveryEnum =
     MessageDeliveryEnum { OFFCHAIN: 1, ONCHAIN_UNCONSTRAINED: 2, ONCHAIN_CONSTRAINED: 3 };
+
+/// Performs private delivery of a message to `recipient` according to `delivery_mode`.
+///
+/// The message is encoded into plaintext and then encrypted for `recipient`. This function takes a _function_ that
+/// returns the plaintext instead of taking the plaintext directly in order to not waste constraints encoding the
+/// message in scenarios where the plaintext will be encrypted with unconstrained encryption.
+///
+/// `maybe_note_hash_counter` is only relevant for on-chain delivery modes (i.e. via protocol logs): if a newly created
+/// note hash's side effect counter is passed, then the log will be squashed alongside the note should its nullifier be
+/// emitted in the current transaction. This is typically only used for note messages: since the note will not actually
+/// be created, there is no point in delivering the message.
+///
+/// `delivery_mode` must be one of [MessageDeliveryEnum].
+pub(crate) fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
+    context: &mut PrivateContext,
+    encode_into_message_plaintext: fn[Env]() -> [Field; MESSAGE_PLAINTEXT_LEN],
+    maybe_note_hash_counter: Option<u32>,
+    recipient: AztecAddress,
+    delivery_mode: u8,
+) {
+    // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when
+    // unconstrained usage is requested. If `delivery_mode` were a runtime value the compiler would be unable to
+    // perform dead-code elimination.
+    assert_constant(delivery_mode);
+
+    // The following maps out the 3 dimensions across which we configure message delivery.
+    let constrained_encryption = delivery_mode == MessageDelivery.ONCHAIN_UNCONSTRAINED;
+    let deliver_as_offchain_message = delivery_mode == MessageDelivery.OFFCHAIN;
+    // TODO(#14565): Add constrained tagging
+    let _constrained_tagging = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
+
+    let ciphertext = remove_constraints_if(
+        !constrained_encryption,
+        || AES128::encrypt(encode_into_message_plaintext(), recipient),
+    );
+
+    if deliver_as_offchain_message {
+        deliver_offchain_message(ciphertext, recipient);
+    } else {
+        // Safety: Currently unsafe. See description of ONCHAIN_CONSTRAINED in MessageDeliveryEnum.
+        // TODO(#14565): Implement proper constrained tag prefixing to make this truly ONCHAIN_CONSTRAINED
+        let log_content = prefix_with_tag(ciphertext, recipient);
+
+        // We forbid this value not being constant to avoid predicating the context calls below, which might result in
+        // the context's arrays having unknown compile time write indices and hence dramatically increasing constraints
+        // when accessing them. In practice this restriction is not a problem as we always know at compile time whether
+        // we're emitting a note or non-note message.
+        assert_constant(maybe_note_hash_counter.is_some());
+
+        if maybe_note_hash_counter.is_some() {
+            // We associate the log with the note's side effect counter, so that if the note ends up being squashed
+            // in the current transaction, the log will be removed as well.
+            //
+            // Note that the log always has the same length regardless of `MESSAGE_PLAINTEXT_LEN`, because all message
+            // ciphertexts also have the same length. This prevents accidental privacy leakage via the log length.
+            context.emit_raw_note_log(
+                log_content,
+                log_content.len(),
+                maybe_note_hash_counter.unwrap(),
+            );
+        } else {
+            context.emit_private_log(log_content, log_content.len());
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/note/note_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_message.nr
@@ -1,13 +1,9 @@
 use crate::{
     context::PrivateContext,
     messages::{
-        encryption::{aes128::AES128, message_encryption::MessageEncryption},
-        logs::{note::encode_private_note_message, utils::prefix_with_tag},
-        message_delivery::MessageDelivery,
-        offchain_messages::deliver_offchain_message,
+        logs::note::encode_private_note_message, message_delivery::do_private_message_delivery,
     },
     note::{lifecycle::NewNote, note_interface::NoteType},
-    utils::remove_constraints::remove_constraints_if,
 };
 use protocol_types::{address::AztecAddress, traits::Packable};
 
@@ -68,57 +64,24 @@ where
     /// low value application like a game might deliver all notes offchain to a centralized server that then serves them
     /// via the app, bypassing the need for contract sync and improving UX.
     pub fn deliver_to(self, recipient: AztecAddress, delivery_mode: u8) {
-        // This function relies on `delivery_mode` being a constant in order to reduce circuit constraints when
-        // unconstrained usage is requested. If `delivery_mode` were a runtime value the compiler would be unable to
-        // perform dead-code elimination.
-        assert_constant(delivery_mode);
-
-        // The following maps out the 3 dimensions across which we configure message delivery.
-        let constrained_encryption = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
-        let deliver_as_offchain_message = delivery_mode == MessageDelivery.OFFCHAIN;
-        // TODO(#14565): Add constrained tagging
-        let _constrained_tagging = delivery_mode == MessageDelivery.ONCHAIN_CONSTRAINED;
-
         // Technical note: we're about to call a closure that needs access to `new_note`, but we can't pass `self` to it
         // because the closure might execute in unconstrained mode, and since `self` contains a mutable reference to
         // `context` this would cause for a mutable reference to cross the constrained-unconstrained barrier, which is
         // not allowed. As a workaround, we create a variable without the context and capture that instead.
         let new_note = self.new_note;
 
-        let ciphertext = remove_constraints_if(
-            !constrained_encryption,
-            || AES128::encrypt(
-                encode_private_note_message(
-                    new_note.note,
-                    new_note.owner,
-                    new_note.storage_slot,
-                    new_note.randomness,
-                ),
-                recipient,
+        do_private_message_delivery(
+            self.context,
+            || encode_private_note_message(
+                new_note.note,
+                new_note.owner,
+                new_note.storage_slot,
+                new_note.randomness,
             ),
+            Option::some(self.new_note.note_hash_counter),
+            recipient,
+            delivery_mode,
         );
-
-        if deliver_as_offchain_message {
-            deliver_offchain_message(ciphertext, recipient);
-        } else {
-            // Onchain messages are delivered via private logs, which must be prefixed with a tag such that the
-            // recipient will know to fetch and decrypt them.
-
-            // Safety: Currently unsafe. See description of ONCHAIN_CONSTRAINED in messages::MessageDeliveryEnum.
-            // TODO(#14565): Implement proper constrained tag prefixing to make this truly ONCHAIN_CONSTRAINED
-            let log_content = prefix_with_tag(ciphertext, recipient);
-
-            // We associate the log with the new note's side effect counter, so that if the note ends up being squashed
-            // in the current transaction, the log will be removed as well.
-            //
-            // Note that the log always has the same length regardless of the [Note] type, because all
-            // message ciphertexts also have the same length. This prevents accidental privacy leakage via the log length.
-            self.context.emit_raw_note_log(
-                log_content,
-                log_content.len(),
-                new_note.note_hash_counter,
-            );
-        }
     }
 
     /// Returns the note contained in the message.


### PR DESCRIPTION
Sharing as a proof of concept, do not merge yet.

This removes the duplication in the `deliver` functions for notes and events by introducing a `Deliverable` trait that represents an object being able to be converted into an array of some length (the message plaintext), plus reporting whether there's an associated note hash counter (yuck) that should result in the message being deleted if said counter is squashed.

I'm not entirely sure this is worth it, as it potentially adds yet another layer of indirection. But I don't hate it, and the `do_private_delivery` function will soon become much more complicated: this nicely shows how different kinds of messages are encoded into plaintext, and that delivery is the same for all.

Perhaps the issue is that the `encode` functions exist as functions that we then invoke here from the trait, so the call stack goes:

```
message ->
  deliver_to ->
    do_private_delivery ->
      trait::encode ->
        encode_message_as_plaintext
```   

while if the encode fn lived as the trait impl and not a standalone fn this would be avoided. On the other hand I like the symmetry in having `encode`/`decode` fns.

Perhaps instead of a trait what we should do is have `do_private_delivery` take closures that do the encoding - that'd remove the trait and its impl entirely.