### PR TITLE
chore: create bench-out

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -621,6 +621,8 @@ case "$cmd" in
     spartan/bootstrap.sh network_deploy "${env_file}"
     # Run benchmarks
     spartan/bootstrap.sh network_bench "${env_file}"
+    rm -rf bench-out
+    mkdir -p bench-out
     bench_merge
     cache_upload spartan-bench-$(git rev-parse HEAD^{tree}).tar.gz bench-out/bench.json
     ;;

--- a/yarn-project/bb-prover/src/test/delay_values.ts
+++ b/yarn-project/bb-prover/src/test/delay_values.ts
@@ -43,5 +43,5 @@ export const PROOF_DELAY_MS: Record<ProvingRequestType, number> = {
   [ProvingRequestType.BLOCK_ROOT_SINGLE_TX_ROLLUP]: 15_000,
   [ProvingRequestType.CHECKPOINT_ROOT_ROLLUP]: 35_000,
   [ProvingRequestType.CHECKPOINT_PADDING_ROLLUP]: 0,
-  [ProvingRequestType.PRIVATE_TX_BASE_ROLLUP]: 45_000, // Guess based on public
+  [ProvingRequestType.PRIVATE_TX_BASE_ROLLUP]: 22_000,
 };


### PR DESCRIPTION
This PR creates the bench-out/ folder before calling `bench_merge` after running network benchmarks