### PR TITLE
fix(docs): include docs content folders in cache hash

### DIFF
--- a/docs/.rebuild_patterns
+++ b/docs/.rebuild_patterns
@@ -1,6 +1,1 @@
-^docs/src
-^docs/scripts
-^docs/static
-^docs/.*\.js
-^docs/.*\.json
-^docs/bootstrap.sh
+^docs/

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -11,7 +11,7 @@ export BB_HASH=${BB_HASH:-$(../barretenberg/cpp/bootstrap.sh hash)}
 hash=$(
   cache_content_hash \
     .rebuild_patterns \
-    $(find docs versioned_docs -type f -name "*.md*" -exec grep '^#include_code' {} \; | \
+    $(find docs docs-developers docs-network developer_versioned_docs network_versioned_docs -type f -name "*.md*" -exec grep '^#include_code' {} \; | \
       awk '{ gsub("^/", "", $3); print "^" $3 }' | sort -u)
 )
 


### PR DESCRIPTION
## Summary
- Add `docs-network`, `docs-developers`, `developer_versioned_docs`, and `network_versioned_docs` to `.rebuild_patterns` so that changes to markdown files in these directories invalidate the test cache for spellcheck

## Problem
PR #19194 passed spellcheck on the PR but failed on merge queue. This happened because:
1. The spellcheck test cache hash is computed from `.rebuild_patterns`
2. `.rebuild_patterns` didn't include the docs content directories (`docs-network/`, etc.)
3. On PR: hash didn't change → cache hit → spellcheck "passed" using stale cached result
4. On merge queue: `USE_TEST_CACHE=0` → spellcheck ran fresh → found spelling errors

## Solution
Add the missing docs content directories to `.rebuild_patterns` so any markdown changes invalidate the cache and spellcheck runs fresh.

## Test plan
- [x] Verify `.rebuild_patterns` syntax is correct
- [ ] CI should run spellcheck with the new hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)