### PR TITLE
fix: enable testnet txs

### DIFF
--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -308,7 +308,7 @@ export const testnetL2ChainConfig: L2ChainConfig = {
   testAccounts: false,
   sponsoredFPC: true,
   p2pEnabled: true,
-  disableTransactions: true,
+  disableTransactions: false,
   bootstrapNodes: [],
   minTxsPerBlock: 0,
   maxTxsPerBlock: 20,


### PR DESCRIPTION
Txs on testnet should be accepted. This PR flips the disable flag.