### PR TITLE
refactor(avm): Refactor get contract instance fuzzer backfill

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
@@ -1492,12 +1492,23 @@ TEST(fuzz, SendL2ToL1Msg)
 
 TEST(fuzz, EmitUnencryptedLog)
 {
-    auto emitunencryptedlog_instruction =
-        EMITUNENCRYPTEDLOG_Instruction{ .log_size = 1,
-                                        .log_size_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
-                                        .log_values = { 1 },
-                                        .log_values_address_start = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { emitunencryptedlog_instruction } };
+    auto log_size_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct };
+    auto log_values_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct };
+    uint32_t log_size = 1;
+    FF log_value = 42;
+
+    std::vector<FuzzInstruction> instructions;
+
+    instructions.push_back(SET_32_Instruction{
+        .value_tag = bb::avm2::MemoryTag::U32, .result_address = log_size_address, .value = log_size });
+
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = log_values_address, .value = log_value });
+
+    instructions.push_back(EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = log_size_address,
+                                                           .log_values_address = log_values_address });
+
+    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1513,22 +1524,38 @@ namespace external_calls {
 /// ADD8: 1 + 1
 TEST(fuzz, ExternalCallToAdd8)
 {
-    auto call_instruction = CALL_Instruction{ .function_index = 0,
-                                              .address_offset = 1,
-                                              .l2_gas = 10000,
-                                              .l2_gas_address = 2,
-                                              .da_gas = 10000,
-                                              .da_gas_address = 3,
-                                              .arg_size_offset = 4,
-                                              .args_offset = 5,
-                                              .args = {},
-                                              .is_static_call = false };
-    auto returndatasize_with_returndatacopy_instruction = RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction{
-        .copy_size_offset = 6, .dst_address = 7, .rd_start = 0, .rd_start_offset = 8
-    };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { call_instruction,
-                                                     returndatasize_with_returndatacopy_instruction } };
+    std::vector<FuzzInstruction> instructions;
+    auto contract_address = bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(0);
+    AddressRef contract_address_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct };
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = contract_address_address, .value = contract_address });
+
+    uint32_t l2_gas = 10000;
+    AddressRef l2_gas_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = l2_gas_address, .value = l2_gas });
+
+    uint32_t da_gas = 10000;
+    AddressRef da_gas_address = AddressRef{ .address = 3, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = da_gas_address, .value = da_gas });
+
+    uint16_t arg_size = 0;
+    AddressRef arg_size_address = AddressRef{ .address = 4, .mode = AddressingMode::Direct };
+    AddressRef args_address = AddressRef{ .address = 5, .mode = AddressingMode::Direct };
+
+    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
+                                             .da_gas_address = da_gas_address,
+                                             .contract_address_address = contract_address_address,
+                                             .calldata_address = args_address,
+                                             .calldata_size_address = arg_size_address,
+                                             .calldata_size = arg_size,
+                                             .is_static_call = false });
+
+    instructions.push_back(RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction{
+        .copy_size_offset = 6, .dst_address = 7, .rd_start = 0, .rd_start_offset = 8 });
+
+    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1570,20 +1597,37 @@ TEST(fuzz, GetContractInstance)
 // Calls add8, sucesscopy, return
 TEST(fuzz, SuccessCopy)
 {
-    auto call_instruction = CALL_Instruction{ .function_index = 0,
-                                              .address_offset = 1,
-                                              .l2_gas = 10000,
-                                              .l2_gas_address = 2,
-                                              .da_gas = 10000,
-                                              .da_gas_address = 3,
-                                              .arg_size_offset = 4,
-                                              .args_offset = 5,
-                                              .args = {},
-                                              .is_static_call = true };
-    auto successcopy_instruction =
-        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { call_instruction, successcopy_instruction } };
+    std::vector<FuzzInstruction> instructions;
+    auto contract_address = bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(0);
+    AddressRef contract_address_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct };
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = contract_address_address, .value = contract_address });
+
+    uint32_t l2_gas = 10000;
+    AddressRef l2_gas_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = l2_gas_address, .value = l2_gas });
+
+    uint32_t da_gas = 10000;
+    AddressRef da_gas_address = AddressRef{ .address = 3, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = da_gas_address, .value = da_gas });
+
+    uint16_t arg_size = 0;
+    AddressRef arg_size_address = AddressRef{ .address = 4, .mode = AddressingMode::Direct };
+    AddressRef args_address = AddressRef{ .address = 5, .mode = AddressingMode::Direct };
+
+    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
+                                             .da_gas_address = da_gas_address,
+                                             .contract_address_address = contract_address_address,
+                                             .calldata_address = args_address,
+                                             .calldata_size_address = arg_size_address,
+                                             .calldata_size = arg_size,
+                                             .is_static_call = false });
+
+    instructions.push_back(
+        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
+    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1597,20 +1641,36 @@ TEST(fuzz, SuccessCopy)
 // The result should be 0
 TEST(fuzz, CallToZeroDivisionSuccessCopy)
 {
-    auto static_call_instruction = CALL_Instruction{ .function_index = 1,
-                                                     .address_offset = 1,
-                                                     .l2_gas = 10000,
-                                                     .l2_gas_address = 2,
-                                                     .da_gas = 10000,
-                                                     .da_gas_address = 3,
-                                                     .arg_size_offset = 4,
-                                                     .args_offset = 5,
-                                                     .args = {},
-                                                     .is_static_call = true };
-    auto successcopy_instruction =
-        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { static_call_instruction, successcopy_instruction } };
+    std::vector<FuzzInstruction> instructions;
+    auto contract_address = bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(1);
+    AddressRef contract_address_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct };
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = contract_address_address, .value = contract_address });
+
+    uint32_t l2_gas = 10000;
+    AddressRef l2_gas_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = l2_gas_address, .value = l2_gas });
+
+    uint32_t da_gas = 10000;
+    AddressRef da_gas_address = AddressRef{ .address = 3, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = da_gas_address, .value = da_gas });
+
+    uint16_t arg_size = 0;
+    AddressRef arg_size_address = AddressRef{ .address = 4, .mode = AddressingMode::Direct };
+    AddressRef args_address = AddressRef{ .address = 5, .mode = AddressingMode::Direct };
+
+    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
+                                             .da_gas_address = da_gas_address,
+                                             .contract_address_address = contract_address_address,
+                                             .calldata_address = args_address,
+                                             .calldata_size_address = arg_size_address,
+                                             .calldata_size = arg_size,
+                                             .is_static_call = true });
+    instructions.push_back(
+        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
+    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1623,20 +1683,36 @@ TEST(fuzz, CallToZeroDivisionSuccessCopy)
 /// Performs static call to SSTORE_FUNCTION, SUCCESSCOPY, RETURN
 TEST(fuzz, StaticCallToNonStaticFunctionSuccessCopy)
 {
-    auto static_call_instruction = CALL_Instruction{ .function_index = 2,
-                                                     .address_offset = 1,
-                                                     .l2_gas = 10000,
-                                                     .l2_gas_address = 2,
-                                                     .da_gas = 10000,
-                                                     .da_gas_address = 3,
-                                                     .arg_size_offset = 4,
-                                                     .args_offset = 5,
-                                                     .args = {},
-                                                     .is_static_call = true };
-    auto successcopy_instruction =
-        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { static_call_instruction, successcopy_instruction } };
+    std::vector<FuzzInstruction> instructions;
+    auto contract_address = bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(2);
+    AddressRef contract_address_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct };
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = contract_address_address, .value = contract_address });
+
+    uint32_t l2_gas = 10000;
+    AddressRef l2_gas_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = l2_gas_address, .value = l2_gas });
+
+    uint32_t da_gas = 10000;
+    AddressRef da_gas_address = AddressRef{ .address = 3, .mode = AddressingMode::Direct };
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = da_gas_address, .value = da_gas });
+
+    uint16_t arg_size = 0;
+    AddressRef arg_size_address = AddressRef{ .address = 4, .mode = AddressingMode::Direct };
+    AddressRef args_address = AddressRef{ .address = 5, .mode = AddressingMode::Direct };
+
+    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
+                                             .da_gas_address = da_gas_address,
+                                             .contract_address_address = contract_address_address,
+                                             .calldata_address = args_address,
+                                             .calldata_size_address = arg_size_address,
+                                             .calldata_size = arg_size,
+                                             .is_static_call = true });
+    instructions.push_back(
+        SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
+    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -576,11 +576,10 @@ struct RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction {
 };
 
 struct GETCONTRACTINSTANCE_Instruction {
-    uint16_t contract_index;             // index of the contract in the contract db
-    AddressRef contract_address_address; // where the contract address will be stored
+    ParamRef contract_address_address; // where the contract address will be stored
+    uint8_t member_enum;
     AddressRef dst_address;
-    uint8_t member_enum; // taken modulo 3. 0 -> DEPLOYER, 1 -> CLASS_ID, 2 -> INIT_HASH
-    MSGPACK_FIELDS(contract_index, contract_address_address, dst_address, member_enum);
+    MSGPACK_FIELDS(contract_address_address, member_enum, dst_address);
 };
 
 struct SUCCESSCOPY_Instruction {

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
@@ -1291,33 +1291,25 @@ void ProgramBlock::process_getcontractinstance_instruction(GETCONTRACTINSTANCE_I
 #ifdef DISABLE_GETCONTRACTINSTANCE_INSTRUCTION
     return;
 #endif
-    auto contract_address =
-        bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(instruction.contract_index);
-    auto set_function_address_instruction = SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                                                                .result_address = instruction.contract_address_address,
-                                                                .value = contract_address };
-    this->process_set_ff_instruction(set_function_address_instruction);
-    auto contract_address_address_operand =
+    auto contract_address_address =
         memory_manager.get_resolved_address_and_operand_16(instruction.contract_address_address);
-    if (!contract_address_address_operand.has_value()) {
+
+    auto dst_address = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
+    if (!contract_address_address.has_value() || !dst_address.has_value()) {
         return;
     }
-    preprocess_memory_addresses(contract_address_address_operand.value().first);
-    auto dst_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
-    if (!dst_address_operand.has_value()) {
-        return;
-    }
-    preprocess_memory_addresses(dst_address_operand.value().first);
+    preprocess_memory_addresses(contract_address_address.value().first);
+    preprocess_memory_addresses(dst_address.value().first);
+
     auto get_contract_instance_instruction =
         bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::GETCONTRACTINSTANCE)
-            .operand(contract_address_address_operand.value().second)
-            .operand(dst_address_operand.value().second)
-            .operand(
-                static_cast<uint8_t>(instruction.member_enum % 3)) // taking modulo 3 to ensure the member enum is valid
+            .operand(contract_address_address.value().second)
+            .operand(dst_address.value().second)
+            .operand(instruction.member_enum)
             .build();
     instructions.push_back(get_contract_instance_instruction);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, dst_address_operand.value().first.absolute_address);
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, dst_address_operand.value().first.absolute_address + 1);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U1, dst_address.value().first.absolute_address);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, dst_address.value().first.absolute_address + 1);
 }
 
 void ProgramBlock::process_successcopy_instruction(SUCCESSCOPY_Instruction instruction)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -464,12 +464,11 @@ constexpr ReturndatasizeWithReturndatacopyMutationConfig
         { ReturndatasizeWithReturndatacopyMutationOptions::rd_start_offset, 1 },
     });
 
-enum class GetContractInstanceMutationOptions { contract_index, contract_address_address, dst_address, member_enum };
-using GetContractInstanceMutationConfig = WeightedSelectionConfig<GetContractInstanceMutationOptions, 4>;
+enum class GetContractInstanceMutationOptions { contract_address_address, dst_address, member_enum };
+using GetContractInstanceMutationConfig = WeightedSelectionConfig<GetContractInstanceMutationOptions, 3>;
 
 constexpr GetContractInstanceMutationConfig BASIC_GETCONTRACTINSTANCE_MUTATION_CONFIGURATION =
     GetContractInstanceMutationConfig({
-        { GetContractInstanceMutationOptions::contract_index, 1 },
         { GetContractInstanceMutationOptions::contract_address_address, 1 },
         { GetContractInstanceMutationOptions::dst_address, 1 },
         { GetContractInstanceMutationOptions::member_enum, 1 },

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -504,6 +504,37 @@ std::vector<FuzzInstruction> generate_call_instruction(std::mt19937_64& rng)
     return instructions;
 }
 
+std::vector<FuzzInstruction> generate_getcontractinstance_instruction(std::mt19937_64& rng)
+{
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        return { GETCONTRACTINSTANCE_Instruction{
+            .contract_address_address = generate_variable_ref(rng),
+            .member_enum = generate_random_uint8(rng),
+            .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+        } };
+    }
+
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(2);
+
+    auto contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF,
+        .result_address = contract_address_address,
+        .value =
+            bb::avm2::fuzzer::ContractDBProxy::get_instance()->get_function_address(generate_random_uint16(rng)) });
+    uint8_t member_enum = std::uniform_int_distribution<uint8_t>(0, 2)(rng);
+
+    instructions.push_back(GETCONTRACTINSTANCE_Instruction{
+        .contract_address_address = contract_address_address,
+        .member_enum = member_enum,
+        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+    });
+
+    return instructions;
+}
+
 std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
 {
     InstructionGenerationOptions option = BASIC_INSTRUCTION_GENERATION_CONFIGURATION.select(rng);
@@ -680,11 +711,7 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng)
                                                                  .dst_address = generate_random_uint16(rng),
                                                                  .rd_start_offset = generate_random_uint16(rng) } };
     case InstructionGenerationOptions::GETCONTRACTINSTANCE:
-        return { GETCONTRACTINSTANCE_Instruction{ .contract_index = generate_random_uint16(rng),
-                                                  .contract_address_address =
-                                                      generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                                  .member_enum = generate_random_uint8(rng) } };
+        return generate_getcontractinstance_instruction(rng);
     case InstructionGenerationOptions::SUCCESSCOPY:
         return { SUCCESSCOPY_Instruction{ .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
     case InstructionGenerationOptions::ECADD:
@@ -1213,11 +1240,8 @@ void mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& ins
 {
     GetContractInstanceMutationOptions option = BASIC_GETCONTRACTINSTANCE_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
-    case GetContractInstanceMutationOptions::contract_index:
-        mutate_uint16_t(instruction.contract_index, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
-        break;
     case GetContractInstanceMutationOptions::contract_address_address:
-        mutate_address_ref(instruction.contract_address_address, rng, MAX_16BIT_OPERAND);
+        mutate_param_ref(instruction.contract_address_address, rng, MemoryTag::FF, MAX_16BIT_OPERAND);
         break;
     case GetContractInstanceMutationOptions::dst_address:
         mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -1328,8 +1328,9 @@ void Execution::get_contract_instance(ContextInterface& context,
 
     // Execution can still handle address memory read and tag checking
     const auto& address_value = memory.get(address_offset);
-    AztecAddress contract_address = address_value.as<AztecAddress>();
     set_and_validate_inputs(opcode, { address_value });
+
+    AztecAddress contract_address = address_value.as<AztecAddress>();
 
     get_gas_tracker().consume_gas();
 


### PR DESCRIPTION
Finish moving usages of ContractsDbProxy to instruction mutators, ready for removal