### PR TITLE
fix(avm): dont catch wide exceptions

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
@@ -12,24 +12,36 @@
 
 namespace bb::avm2 {
 
-class TagMismatchException : public std::runtime_error {
+class TaggedValueException : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error; // Inherit the constructor.
+};
+
+class TagMismatchException : public TaggedValueException {
   public:
     TagMismatchException(const std::string& msg)
-        : std::runtime_error("Mismatched tags: " + msg)
+        : TaggedValueException("Mismatched tags: " + msg)
     {}
 };
 
-class InvalidOperationTag : public std::runtime_error {
+class InvalidOperationTag : public TaggedValueException {
   public:
     InvalidOperationTag(const std::string& msg)
-        : std::runtime_error("InvalidOperationTag: " + msg)
+        : TaggedValueException("InvalidOperationTag: " + msg)
     {}
 };
 
-class DivisionByZero : public std::runtime_error {
+class DivisionByZero : public TaggedValueException {
   public:
     DivisionByZero(const std::string& msg)
-        : std::runtime_error("Division by zero: " + msg)
+        : TaggedValueException("Division by zero: " + msg)
+    {}
+};
+
+class CastException : public TaggedValueException {
+  public:
+    CastException(const std::string& msg)
+        : TaggedValueException("CastException: " + msg)
     {}
 };
 
@@ -118,8 +130,8 @@ class TaggedValue {
         if (std::holds_alternative<T>(value)) {
             return std::get<T>(value);
         }
-        throw std::runtime_error("TaggedValue::as(): type mismatch. Wanted type " +
-                                 std::to_string(static_cast<uint32_t>(tag_for_type<T>())) + " but got " + to_string());
+        throw CastException("TaggedValue::as(): type mismatch. Wanted type " +
+                            std::to_string(static_cast<uint32_t>(tag_for_type<T>())) + " but got " + to_string());
     }
 
     // This method try to do the smallest conversion possible.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.cpp
@@ -14,7 +14,7 @@ MemoryValue Bitwise::and_op(const MemoryValue& a, const MemoryValue& b)
         MemoryValue c = a & b;
         events.emit({ .operation = BitwiseOperation::AND, .a = a, .b = b, .res = static_cast<uint128_t>(c.as_ff()) });
         return c;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::AND, .a = a, .b = b, .res = 0 });
         throw BitwiseException("AND, " + std::string(e.what()));
@@ -27,7 +27,7 @@ MemoryValue Bitwise::or_op(const MemoryValue& a, const MemoryValue& b)
         MemoryValue c = a | b;
         events.emit({ .operation = BitwiseOperation::OR, .a = a, .b = b, .res = static_cast<uint128_t>(c.as_ff()) });
         return c;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::OR, .a = a, .b = b, .res = 0 });
         throw BitwiseException("OR, " + std::string(e.what()));
@@ -45,7 +45,7 @@ MemoryValue Bitwise::xor_op(const MemoryValue& a, const MemoryValue& b)
             .res = static_cast<uint128_t>(c.as_ff()),
         });
         return c;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::XOR, .a = a, .b = b, .res = 0 });
         throw BitwiseException("XOR, " + std::string(e.what()));

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
@@ -6,6 +6,15 @@
 
 namespace bb::avm2::simulation {
 
+namespace {
+
+class InternalEccException : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error; // Inherit the constructor.
+};
+
+} // namespace
+
 // This function assumes that the points p and q are on the curve. You should only
 // use this function internally if you can guarantee this. Otherwise it is called
 // via the opcode ECADD, see the overloaded function Ecc::add (which performs the curve check)
@@ -66,14 +75,15 @@ void Ecc::add(MemoryInterface& memory,
         // Therefore, the maximum address that needs to be written to is dst_address + 2.
         uint64_t max_write_address = static_cast<uint64_t>(dst_address) + 2;
         if (gt.gt(max_write_address, AVM_HIGHEST_MEM_ADDRESS)) {
-            throw std::runtime_error("dst address out of range");
+            throw InternalEccException("dst address out of range");
         }
 
         if (!p.on_curve() || !q.on_curve()) {
-            throw std::runtime_error("One of the points is not on the curve");
+            throw InternalEccException("One of the points is not on the curve");
         }
 
-        EmbeddedCurvePoint result = add(p, q);
+        EmbeddedCurvePoint result = add(p, q); // Cannot throw.
+
         memory.set(dst_address, MemoryValue::from<FF>(result.x()));
         memory.set(dst_address + 1, MemoryValue::from<FF>(result.y()));
         memory.set(dst_address + 2, MemoryValue::from<uint1_t>(result.is_infinity() ? 1 : 0));
@@ -84,7 +94,7 @@ void Ecc::add(MemoryInterface& memory,
                                  .q = q,
                                  .result = result,
                                  .dst_address = dst_address });
-    } catch (const std::exception& e) {
+    } catch (const InternalEccException& e) {
         // Note this point is not on the curve, but corresponds
         // to default values the circuit will assign.
         EmbeddedCurvePoint res = EmbeddedCurvePoint(0, 0, false);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -1810,7 +1810,7 @@ EnqueuedCallResult Execution::execute(std::unique_ptr<ContextInterface> enqueued
             // This is a coding error, we should not get here.
             // All exceptions should fall in the above catch blocks.
             important("An unhandled exception occurred: ", e.what());
-            throw e;
+            throw;
         }
 
         // We always do what follows. "Finally".

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/poseidon2.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/poseidon2.cpp
@@ -14,6 +14,14 @@ using bb::crypto::Poseidon2Permutation;
 
 namespace bb::avm2::simulation {
 
+namespace {
+
+class InternalPoseidon2Exception : public std::runtime_error {
+    using std::runtime_error::runtime_error; // Inherit the constructor.
+};
+
+} // namespace
+
 FF Poseidon2::hash(const std::vector<FF>& input)
 {
     size_t input_size = input.size();
@@ -77,7 +85,7 @@ void Poseidon2::permutation(MemoryInterface& memory, MemoryAddress src_address, 
 
     try {
         if (read_out_of_range || write_out_of_range) {
-            throw std::runtime_error("src or dst address out of range");
+            throw InternalPoseidon2Exception("src or dst address out of range");
         }
 
         // Read 4 elements from memory starting at src_address
@@ -89,7 +97,7 @@ void Poseidon2::permutation(MemoryInterface& memory, MemoryAddress src_address, 
         // are loaded as the circuit expects reading and tagging checking to be different temporality groups
         if (std::ranges::any_of(
                 input.begin(), input.end(), [](const MemoryValue& val) { return val.get_tag() != MemoryTag::FF; })) {
-            throw std::runtime_error("An input tag is not FF");
+            throw InternalPoseidon2Exception("An input tag is not FF");
         }
 
         // This calls the Poseidon2 gadget permutation function and so generates events
@@ -111,7 +119,7 @@ void Poseidon2::permutation(MemoryInterface& memory, MemoryAddress src_address, 
                                .input = input,
                                .output = output });
 
-    } catch (const std::exception& e) {
+    } catch (const InternalPoseidon2Exception& e) {
         perm_mem_events.emit({ .space_id = space_id,
                                .execution_clk = execution_clk,
                                .src_address = src_address,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/interfaces/context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/interfaces/context.hpp
@@ -48,6 +48,7 @@ class ContextInterface {
 
     virtual TransactionPhase get_phase() const = 0;
 
+    // Should not throw.
     virtual std::vector<MemoryValue> get_calldata(uint32_t cd_offset, uint32_t cd_size) const = 0;
     virtual std::vector<MemoryValue> get_returndata(uint32_t rd_addr, uint32_t rd_size) const = 0;
     virtual ContextInterface& get_child_context() = 0;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
@@ -124,51 +124,24 @@ CalldataProvider make_calldata_provider(const ContextInterface& context)
 {
     auto cd_size = context.get_parent_cd_size();
     return [&context, cd_size](uint32_t max_size) -> std::vector<FF> {
-        try {
-            // NOTE: get_calldata will handle offsetting into parent memory for nested contexts
-            // TODO: check if this will pad to size. We don't want that.
-            auto data = context.get_calldata(0, std::min(max_size, cd_size));
-            return std::vector<FF>(data.begin(), data.end());
-        } catch (...) {
-            vinfo("Failed to collect calldata (to:",
-                  context.get_address(),
-                  " pc:",
-                  context.get_pc(),
-                  " cd_size:",
-                  cd_size,
-                  " max_size:",
-                  max_size,
-                  ")");
-            return {};
-        }
+        // NOTE: get_calldata will handle offsetting into parent memory for nested contexts
+        // TODO(AVM-186): check if this will pad to size. We don't want that.
+        auto data = context.get_calldata(0, std::min(max_size, cd_size));
+        return std::vector<FF>(data.begin(), data.end());
     };
 }
 
 ReturnDataProvider make_return_data_provider(const ContextInterface& context, uint32_t rd_offset, uint32_t rd_size)
 {
     return [&context, rd_offset, rd_size](uint32_t max_size) -> std::vector<FF> {
-        try {
-            const auto& memory = context.get_memory();
-            std::vector<FF> data;
-            data.reserve(std::min(max_size, rd_size));
-            for (uint32_t i = 0; i < std::min(max_size, rd_size); i++) {
-                data.push_back(memory.get(rd_offset + i).as_ff());
-            }
-            return data;
-        } catch (...) {
-            vinfo("Failed to collect returndata (to:",
-                  context.get_address(),
-                  " pc:",
-                  context.get_pc(),
-                  " rd_offset:",
-                  rd_offset,
-                  " rd_size:",
-                  rd_size,
-                  " max_size:",
-                  max_size,
-                  ")");
-            return {};
+        // TODO(AVM-187): Consider using get_returndata instead.
+        const auto& memory = context.get_memory();
+        std::vector<FF> data;
+        data.reserve(std::min(max_size, rd_size));
+        for (uint32_t i = 0; i < std::min(max_size, rd_size); i++) {
+            data.push_back(memory.get(rd_offset + i).as_ff());
         }
+        return data;
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.test.cpp
@@ -384,28 +384,6 @@ TEST_F(MakeProviderTest, MakeCalldataProviderRespectsMaxSize)
     ASSERT_EQ(result.size(), max_size);
 }
 
-TEST_F(MakeProviderTest, MakeCalldataProviderHandlesException)
-{
-    static AztecAddress contract_addr(0x1234);
-    uint32_t cd_size = 5;
-
-    // This is called when creating the provider
-    EXPECT_CALL(mock_context, get_parent_cd_size()).WillOnce(Return(cd_size));
-
-    auto provider = make_calldata_provider(mock_context);
-
-    // This is called when invoking the provider, and throws
-    EXPECT_CALL(mock_context, get_calldata(0, _)).WillOnce(::testing::Throw(std::runtime_error("Test exception")));
-    // The exception handler may call get_address() and get_pc() for logging (optional)
-    EXPECT_CALL(mock_context, get_address()).Times(::testing::AnyNumber()).WillRepeatedly(ReturnRef(contract_addr));
-    EXPECT_CALL(mock_context, get_pc()).Times(::testing::AnyNumber()).WillRepeatedly(Return(200));
-
-    auto result = provider(1024);
-
-    // Should return empty vector on exception
-    EXPECT_TRUE(result.empty());
-}
-
 TEST_F(MakeProviderTest, MakeReturnDataProviderSuccess)
 {
     uint32_t rd_addr = 200;
@@ -461,29 +439,6 @@ TEST_F(MakeProviderTest, MakeReturnDataProviderRespectsMaxSize)
     auto result = provider(max_size);
 
     ASSERT_EQ(result.size(), max_size);
-}
-
-TEST_F(MakeProviderTest, MakeReturnDataProviderHandlesException)
-{
-    uint32_t rd_addr = 200;
-    uint32_t rd_size = 3;
-    static AztecAddress contract_addr(0x5678);
-
-    auto provider = make_return_data_provider(mock_context, rd_addr, rd_size);
-
-    // This is called when invoking the provider, and throws
-    StrictMock<MockMemory> memory;
-    EXPECT_CALL(::testing::Const(mock_context), get_memory())
-        .WillOnce(::testing::Throw(std::runtime_error("Test exception")));
-
-    // The exception handler may call get_address() and get_pc() for logging (optional)
-    EXPECT_CALL(mock_context, get_address()).Times(::testing::AnyNumber()).WillRepeatedly(ReturnRef(contract_addr));
-    EXPECT_CALL(mock_context, get_pc()).Times(::testing::AnyNumber()).WillRepeatedly(Return(300));
-
-    auto result = provider(1024);
-
-    // Should return empty vector on exception
-    EXPECT_TRUE(result.empty());
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -438,12 +438,12 @@ bool check_tag(const Instruction& instruction)
 
     size_t pos = 0; // Position in instruction operands
 
-    for (const OperandType& i : wire_format) {
-        if (i == OperandType::INDIRECT8 || i == OperandType::INDIRECT16) {
+    for (const OperandType& operand_type : wire_format) {
+        if (operand_type == OperandType::INDIRECT8 || operand_type == OperandType::INDIRECT16) {
             continue; // No pos increment
         }
 
-        if (i == OperandType::TAG) {
+        if (operand_type == OperandType::TAG) {
             if (pos >= instruction.operands.size()) {
                 vinfo("Instruction operands size is too small. Tag position: ",
                       pos,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -438,12 +438,12 @@ bool check_tag(const Instruction& instruction)
 
     size_t pos = 0; // Position in instruction operands
 
-    for (size_t i = 0; i < wire_format.size(); i++) {
-        if (wire_format[i] == OperandType::INDIRECT8 || wire_format[i] == OperandType::INDIRECT16) {
+    for (const OperandType& i : wire_format) {
+        if (i == OperandType::INDIRECT8 || i == OperandType::INDIRECT16) {
             continue; // No pos increment
         }
 
-        if (wire_format[i] == OperandType::TAG) {
+        if (i == OperandType::TAG) {
             if (pos >= instruction.operands.size()) {
                 vinfo("Instruction operands size is too small. Tag position: ",
                       pos,
@@ -455,7 +455,7 @@ bool check_tag(const Instruction& instruction)
             }
 
             try {
-                uint8_t tag = instruction.operands.at(pos).as<uint8_t>(); // Cast to uint8_t might throw
+                uint8_t tag = instruction.operands.at(pos).as<uint8_t>(); // Cast to uint8_t might throw CastException
 
                 if (tag > static_cast<uint8_t>(MemoryTag::MAX)) {
                     vinfo("Instruction tag operand at position: ",
@@ -467,8 +467,7 @@ bool check_tag(const Instruction& instruction)
                           instruction.opcode);
                     return false;
                 }
-
-            } catch (const std::runtime_error&) {
+            } catch (const CastException&) {
                 vinfo("Instruction operand at position: ",
                       pos,
                       " is longer than a byte.",

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/hybrid_execution.cpp
@@ -88,7 +88,7 @@ EnqueuedCallResult HybridExecution::execute(std::unique_ptr<ContextInterface> en
             // This is a coding error, we should not get here.
             // All exceptions should fall in the above catch blocks.
             important("An unhandled exception occurred: ", e.what());
-            throw e;
+            throw;
         }
 
         // We always do what follows. "Finally".

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bitwise.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bitwise.cpp
@@ -10,7 +10,7 @@ MemoryValue PureBitwise::and_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
         return a & b;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         throw BitwiseException("AND, " + std::string(e.what()));
     }
 }
@@ -18,7 +18,7 @@ MemoryValue PureBitwise::or_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
         return a | b;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         throw BitwiseException("OR, " + std::string(e.what()));
     }
 }
@@ -26,7 +26,7 @@ MemoryValue PureBitwise::xor_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
         return a ^ b;
-    } catch (const std::exception& e) {
+    } catch (const TaggedValueException& e) {
         throw BitwiseException("XOR, " + std::string(e.what()));
     }
 }


### PR DESCRIPTION
Biggest change is that now the calldata providers should never throw. I think this was already the case (an OOB memory access gives you `FF::zero()`). Also, the providers will only be used when callstack collection is on, which shouldnt be in prod.

Related to [AVM-171](https://linear.app/aztec-labs/issue/AVM-171/vm2-move-assert-bb-assert).
