### PR TITLE
fix: add missing json import to chonk-breakdowns dashboard

### DIFF
--- a/ci3/dashboard/rk.py
+++ b/ci3/dashboard/rk.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template_string, request, Response
 from flask_compress import Compress
 from flask_httpauth import HTTPBasicAuth
 import gzip
+import json
 import os
 import re
 import requests


### PR DESCRIPTION
## Summary
- Adds missing `import json` to the chonk-breakdowns dashboard

PR #18987 moved the CI dashboard from iac repo to aztec-packages but the json import was missing, causing 500 errors on the `/api/breakdown/flows` endpoint.