### PR TITLE
feat: Add noir-sync-update skill for Claude Code

### DIFF
--- a/.claude/skills/noir-sync-update/SKILL.md
+++ b/.claude/skills/noir-sync-update/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: noir-sync-update
+description: Perform necessary follow-on updates as a result of updating the noir git submodule.
+---
+
+# Noir Sync Update
+
+## Workflow
+
+Each step has a corresponding script in `scripts/` that handles execution and verification.
+Run each script and commit the results after each step.
+
+```
+Noir Sync Update Progress:
+- [ ] Step 1: ./scripts/step1-bootstrap-noir.sh
+- [ ] Step 2: ./scripts/step2-update-avm-transpiler-cargo-lock.sh
+- [ ] Step 3: ./scripts/step3-update-yarn-lock.sh
+- [ ] Step 4: ./scripts/step4-format-noir-projects.sh
+- [ ] Step 5: ./scripts/step5-check-noir-projects-compile.sh
+```
+
+## Scripts
+
+All scripts are in `.claude/skills/noir-sync-update/scripts/` and can be run from the repository root.
+
+### Step 1: `step1-bootstrap-noir.sh`
+Runs `./bootstrap.sh` in `noir` to ensure the new submodule commit has been pulled.
+No commit should be necessary.
+
+### Step 2: `step2-update-avm-transpiler-cargo-lock.sh`
+Updates the `Cargo.lock` in `avm-transpiler` with only noir-repo packages.
+
+The script:
+1. Reads expected version from `noir/noir-repo/.release-please-manifest.json`
+2. Extracts noir-repo package names from `avm-transpiler/Cargo.toml` (path dependencies pointing to `../noir/noir-repo`)
+3. Shows current version in `Cargo.lock`
+4. Runs `cargo update -p <pkg>` for each noir-repo package (not all dependencies)
+5. Verifies the version matches expected
+6. Runs `cargo check` to ensure it builds
+
+**IMPORTANT:** Do NOT use `cargo update` without `-p` flags—this will update ALL dependencies, not just noir-repo packages.
+
+If `avm-transpiler` no longer builds:
+- If transient dependency mismatches mean changes to the dependency tree are necessary, modify the `Cargo.lock` file. **DO NOT MODIFY `noir/noir-repo`**.
+- If updates are necessary due to changes in exports from `noir/noir-repo` packages, perform the necessary updates to import statements, etc.
+
+### Step 3: `step3-update-yarn-lock.sh`
+Runs `yarn install` in `yarn-project` to update the `yarn.lock` file.
+
+### Step 4: `step4-format-noir-projects.sh`
+Runs `./bootstrap.sh format` in `noir-projects`.
+
+This is necessary as updates to the noir compiler may result in the formatter handling the same code differently. Failing to run the formatter will result in a CI failure.
+
+### Step 5: `step5-check-noir-projects-compile.sh`
+Runs `./bootstrap.sh` in `noir-projects` as a sanity check to ensure it still compiles after the update.

--- a/.claude/skills/noir-sync-update/scripts/step1-bootstrap-noir.sh
+++ b/.claude/skills/noir-sync-update/scripts/step1-bootstrap-noir.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 1: Ensure the noir submodule is bootstrapped
+# This pulls the new submodule commit and builds noir
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "=== Step 1: Bootstrap noir submodule ==="
+cd "$REPO_ROOT/noir"
+
+echo "Running ./bootstrap.sh in noir..."
+./bootstrap.sh
+
+echo ""
+echo "=== Verification ==="
+cd "$REPO_ROOT"
+if git status noir/ --porcelain | grep -q .; then
+    echo "WARNING: Unexpected changes in noir directory:"
+    git status noir/ --short
+    exit 1
+else
+    echo "✓ No unexpected changes in noir directory"
+fi
+
+echo ""
+echo "Step 1 complete. No commit needed."

--- a/.claude/skills/noir-sync-update/scripts/step2-update-avm-transpiler-cargo-lock.sh
+++ b/.claude/skills/noir-sync-update/scripts/step2-update-avm-transpiler-cargo-lock.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 2: Update Cargo.lock in avm-transpiler
+# Only updates noir-repo dependencies, not all dependencies
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "=== Step 2: Update avm-transpiler Cargo.lock ==="
+
+# Get expected version from noir-repo
+MANIFEST="$REPO_ROOT/noir/noir-repo/.release-please-manifest.json"
+if [[ ! -f "$MANIFEST" ]]; then
+    echo "ERROR: Cannot find $MANIFEST"
+    exit 1
+fi
+
+EXPECTED_VERSION=$(grep -o '"\.": "[^"]*"' "$MANIFEST" | head -1 | cut -d'"' -f4)
+echo "Expected noir version from .release-please-manifest.json: $EXPECTED_VERSION"
+
+# Check current version in Cargo.lock (using first noir package we find)
+CARGO_LOCK="$REPO_ROOT/avm-transpiler/Cargo.lock"
+CARGO_TOML="$REPO_ROOT/avm-transpiler/Cargo.toml"
+
+# Extract noir-repo package names from Cargo.toml path dependencies
+# Look for lines like: package_name = { path = "../noir/noir-repo/..." }
+NOIR_PACKAGES=$(grep 'path = "../noir/noir-repo' "$CARGO_TOML" | sed 's/^\([a-zA-Z_-]*\).*/\1/')
+
+if [[ -z "$NOIR_PACKAGES" ]]; then
+    echo "ERROR: No noir-repo dependencies found in $CARGO_TOML"
+    exit 1
+fi
+
+echo ""
+echo "Found noir-repo dependencies in Cargo.toml:"
+echo "$NOIR_PACKAGES" | sed 's/^/  - /'
+
+# Get the first package to check current version
+FIRST_PACKAGE=$(echo "$NOIR_PACKAGES" | head -1)
+CURRENT_VERSION=$(grep -A1 "^name = \"$FIRST_PACKAGE\"$" "$CARGO_LOCK" | grep 'version' | head -1 | cut -d'"' -f2)
+echo ""
+echo "Current $FIRST_PACKAGE version in Cargo.lock: $CURRENT_VERSION"
+
+echo ""
+echo "Updating noir-repo packages..."
+
+# Build cargo update command with -p flags for each package
+cd "$REPO_ROOT/avm-transpiler"
+CARGO_UPDATE_ARGS=""
+for pkg in $NOIR_PACKAGES; do
+    CARGO_UPDATE_ARGS="$CARGO_UPDATE_ARGS -p $pkg"
+done
+
+# shellcheck disable=SC2086
+cargo update $CARGO_UPDATE_ARGS
+
+echo ""
+echo "=== Verification ==="
+
+# Verify the version is correct
+NEW_VERSION=$(grep -A1 "^name = \"$FIRST_PACKAGE\"$" "$CARGO_LOCK" | grep 'version' | head -1 | cut -d'"' -f2)
+echo "New $FIRST_PACKAGE version in Cargo.lock: $NEW_VERSION"
+
+if [[ "$NEW_VERSION" != "$EXPECTED_VERSION" ]]; then
+    echo "ERROR: Version mismatch! Expected $EXPECTED_VERSION but got $NEW_VERSION"
+    exit 1
+fi
+echo "✓ Version matches expected"
+
+# Check git status
+cd "$REPO_ROOT"
+if git status avm-transpiler/Cargo.lock --porcelain | grep -q .; then
+    echo "✓ Cargo.lock was modified"
+else
+    echo "✓ Cargo.lock unchanged (already up to date)"
+fi
+
+# Verify it still builds
+echo ""
+echo "Running cargo check to verify build..."
+cd "$REPO_ROOT/avm-transpiler"
+cargo check
+
+echo ""
+echo "✓ Step 2 complete."
+echo ""
+echo "To commit (if changes): git add avm-transpiler/Cargo.lock && git commit -m 'chore: Update avm-transpiler Cargo.lock for noir sync'"

--- a/.claude/skills/noir-sync-update/scripts/step3-update-yarn-lock.sh
+++ b/.claude/skills/noir-sync-update/scripts/step3-update-yarn-lock.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 3: Update yarn.lock in yarn-project
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "=== Step 3: Update yarn-project yarn.lock ==="
+
+cd "$REPO_ROOT/yarn-project"
+echo "Running yarn install..."
+yarn install
+
+echo ""
+echo "=== Verification ==="
+
+cd "$REPO_ROOT"
+if git status yarn-project/yarn.lock --porcelain | grep -q .; then
+    echo "✓ yarn.lock was modified"
+else
+    echo "✓ yarn.lock unchanged (already up to date)"
+fi
+
+echo ""
+echo "✓ Step 3 complete."
+echo ""
+echo "To commit (if changes): git add yarn-project/yarn.lock && git commit -m 'chore: Update yarn.lock for noir sync'"

--- a/.claude/skills/noir-sync-update/scripts/step4-format-noir-projects.sh
+++ b/.claude/skills/noir-sync-update/scripts/step4-format-noir-projects.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 4: Format noir-projects
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "=== Step 4: Format noir-projects ==="
+
+cd "$REPO_ROOT/noir-projects"
+echo "Running ./bootstrap.sh format..."
+./bootstrap.sh format
+
+echo ""
+echo "=== Verification ==="
+
+cd "$REPO_ROOT"
+if git status noir-projects/ --porcelain | grep -q .; then
+    echo "✓ Formatting changes detected:"
+    git status noir-projects/ --short
+    echo ""
+    echo "To commit: git add noir-projects/ && git commit -m 'chore: Format noir-projects for noir sync'"
+else
+    echo "✓ No formatting changes needed"
+fi
+
+echo ""
+echo "✓ Step 4 complete."

--- a/.claude/skills/noir-sync-update/scripts/step5-check-noir-projects-compile.sh
+++ b/.claude/skills/noir-sync-update/scripts/step5-check-noir-projects-compile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 5: Check noir-projects still compiles
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "=== Step 5: Check noir-projects compilation ==="
+
+cd "$REPO_ROOT/noir-projects"
+echo "Running ./bootstrap.sh..."
+./bootstrap.sh
+
+echo ""
+echo "✓ Step 5 complete. noir-projects compiles successfully."


### PR DESCRIPTION
Adds a skill with scripts to automate the follow-on updates needed after updating the noir git submodule:

1. Bootstrap noir submodule
2. Update avm-transpiler Cargo.lock (noir-repo packages only)
3. Update yarn-project yarn.lock
4. Format noir-projects
5. Check noir-projects compilation

Each step has a corresponding script that handles execution and verification. The step2 script dynamically extracts noir-repo package names from Cargo.toml path dependencies.
