### PR TITLE
chore: fix simple flaking, specify ethereum slot duration

### DIFF
--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -43,6 +43,7 @@ describe('e2e_simple', () => {
         minTxsPerBlock: 1,
         aztecEpochDuration: 4,
         aztecSlotDuration: 12,
+        ethereumSlotDuration: 4,
         aztecTargetCommitteeSize: 0,
         startProverNode: true,
       }));


### PR DESCRIPTION
Need to specify ethereum slot duration for anvil to not start in automine, which might cause it to flake.