### PR TITLE
chore(avm): migrate to BB asserts

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -700,9 +700,9 @@ template <class... Ts> struct overloaded : Ts... {
 };
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
-inline std::ostream& operator<<(std::ostream& os, const MemoryTag& tag)
+inline std::ostream& operator<<(std::ostream& os, const MemoryTagWrapper& tag)
 {
-    os << std::to_string(tag);
+    os << tag.value;
     return os;
 }
 

--- a/barretenberg/cpp/src/barretenberg/common/assert.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/assert.hpp
@@ -93,8 +93,8 @@ struct AssertGuard {
 #define BB_ASSERT_EQ(actual, expected, ...)                                                                            \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_EQ" #actual " == " #expected);                                                      \
-        auto _actual = (actual);                                                                                       \
-        auto _expected = (expected);                                                                                   \
+        const auto& _actual = (actual);                                                                                \
+        const auto& _expected = (expected);                                                                            \
         if (!(BB_LIKELY(_actual == _expected))) {                                                                      \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #actual " == " #expected ")\n";                                               \
@@ -108,8 +108,8 @@ struct AssertGuard {
 #define BB_ASSERT_NEQ(actual, expected, ...)                                                                           \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_NEQ" #actual " != " #expected);                                                     \
-        auto _actual = (actual);                                                                                       \
-        auto _expected = (expected);                                                                                   \
+        const auto& _actual = (actual);                                                                                \
+        const auto& _expected = (expected);                                                                            \
         if (!(BB_LIKELY(_actual != _expected))) {                                                                      \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #actual " != " #expected ")\n";                                               \
@@ -123,8 +123,8 @@ struct AssertGuard {
 #define BB_ASSERT_GT(left, right, ...)                                                                                 \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_GT" #left " > " #right);                                                            \
-        auto _left = (left);                                                                                           \
-        auto _right = (right);                                                                                         \
+        const auto& _left = (left);                                                                                    \
+        const auto& _right = (right);                                                                                  \
         if (!(BB_LIKELY(_left > _right))) {                                                                            \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #left " > " #right ")\n";                                                     \
@@ -138,8 +138,8 @@ struct AssertGuard {
 #define BB_ASSERT_GTE(left, right, ...)                                                                                \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_GTE" #left " >= " #right);                                                          \
-        auto _left = (left);                                                                                           \
-        auto _right = (right);                                                                                         \
+        const auto& _left = (left);                                                                                    \
+        const auto& _right = (right);                                                                                  \
         if (!(BB_LIKELY(_left >= _right))) {                                                                           \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #left " >= " #right ")\n";                                                    \
@@ -153,8 +153,8 @@ struct AssertGuard {
 #define BB_ASSERT_LT(left, right, ...)                                                                                 \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_LT" #left " < " #right);                                                            \
-        auto _left = (left);                                                                                           \
-        auto _right = (right);                                                                                         \
+        const auto& _left = (left);                                                                                    \
+        const auto& _right = (right);                                                                                  \
         if (!(BB_LIKELY(_left < _right))) {                                                                            \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #left " < " #right ")\n";                                                     \
@@ -168,8 +168,8 @@ struct AssertGuard {
 #define BB_ASSERT_LTE(left, right, ...)                                                                                \
     do {                                                                                                               \
         BB_BENCH_ASSERT("BB_ASSERT_LTE" #left " <= " #right);                                                          \
-        auto _left = (left);                                                                                           \
-        auto _right = (right);                                                                                         \
+        const auto& _left = (left);                                                                                    \
+        const auto& _right = (right);                                                                                  \
         if (!(BB_LIKELY(_left <= _right))) {                                                                           \
             std::ostringstream oss;                                                                                    \
             oss << "Assertion failed: (" #left " <= " #right ")\n";                                                    \

--- a/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp
@@ -601,7 +601,7 @@ inline bool is_protocol_contract_address(const AztecAddress& address)
 inline std::optional<AztecAddress> get_derived_address(const ProtocolContracts& protocol_contracts,
                                                        const AztecAddress& canonical_address)
 {
-    assert(is_protocol_contract_address(canonical_address) && "Protocol contract canonical address out of bounds");
+    BB_ASSERT(is_protocol_contract_address(canonical_address), "Protocol contract canonical address out of bounds");
     AztecAddress derived_address =
         protocol_contracts.derived_addresses.at(static_cast<uint32_t>(canonical_address) - 1);
     if (derived_address.is_zero()) {

--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
@@ -178,7 +178,7 @@ uint8_t get_tag_bits(ValueTag tag)
         return 0; // It is more useful for this to be 0 in the circuit
     }
 
-    assert(false && "Invalid tag");
+    __builtin_unreachable();
     return 0;
 }
 
@@ -197,7 +197,7 @@ uint8_t get_tag_bytes(ValueTag tag)
         return 0; // It is more useful for this to be 0 in the circuit
     }
 
-    assert(false && "Invalid tag");
+    __builtin_unreachable();
     return 0;
 }
 
@@ -215,7 +215,7 @@ uint256_t get_tag_max_value(ValueTag tag)
         return FF::modulus - 1;
     }
 
-    assert(false && "Invalid tag");
+    __builtin_unreachable();
     return 0;
 }
 
@@ -226,9 +226,9 @@ TaggedValue::TaggedValue(TaggedValue::value_type value_)
 
 TaggedValue TaggedValue::from_tag(ValueTag tag, FF value)
 {
-    auto assert_bounds = [](const FF& value, uint8_t bits) {
+    auto assert_bounds = [tag](const FF& value, uint8_t bits) {
         if (static_cast<uint256_t>(value).get_msb() >= bits) {
-            throw std::runtime_error("Value out of bounds");
+            throw ValueOutOfBounds(format("Value: ", value, " is out of bounds for tag: ", tag));
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <ostream>
 #include <string>
 #include <variant>
 
@@ -38,6 +39,13 @@ class DivisionByZero : public TaggedValueException {
     {}
 };
 
+class ValueOutOfBounds : public TaggedValueException {
+  public:
+    ValueOutOfBounds(const std::string& msg)
+        : TaggedValueException("Value out of bounds: " + msg)
+    {}
+};
+
 class CastException : public TaggedValueException {
   public:
     CastException(const std::string& msg)
@@ -55,6 +63,30 @@ enum class ValueTag {
     U128 = MEM_TAG_U128,
     MAX = U128,
 };
+
+inline std::ostream& operator<<(std::ostream& os, ValueTag tag)
+{
+    switch (tag) {
+    case ValueTag::FF:
+        return os << "FF";
+    case ValueTag::U1:
+        return os << "U1";
+    case ValueTag::U8:
+        return os << "U8";
+    case ValueTag::U16:
+        return os << "U16";
+    case ValueTag::U32:
+        return os << "U32";
+    case ValueTag::U64:
+        return os << "U64";
+    case ValueTag::U128:
+        return os << "U128";
+    default:
+        return os << "Unknown";
+    }
+
+    __builtin_unreachable();
+}
 
 template <typename T> ValueTag tag_for_type()
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/common/to_radix.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/to_radix.cpp
@@ -53,7 +53,7 @@ const std::array<std::vector<uint8_t>, 257>& get_p_limbs_per_radix()
 
 size_t get_p_limbs_per_radix_size(size_t radix)
 {
-    assert(radix <= 256);
+    BB_ASSERT_LTE(radix, static_cast<decltype(radix)>(256), "Radix out of bounds");
     return p_limbs_per_radix_sizes[radix];
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
@@ -17,7 +17,9 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
     // Polynomials that will be shifted need special care.
     AVM_TRACK_TIME("proving/init_polys_to_be_shifted", ({
                        auto to_be_shifted = polys.get_to_be_shifted();
-                       assert(to_be_shifted.size() == TO_BE_SHIFTED_COLUMNS_ARRAY.size());
+                       BB_ASSERT_EQ(to_be_shifted.size(),
+                                    TO_BE_SHIFTED_COLUMNS_ARRAY.size(),
+                                    "To be shifted columns array size mismatch");
 
                        // NOTE: we can't parallelize because Polynomial construction uses parallelism.
                        for (size_t i = 0; i < to_be_shifted.size(); i++) {
@@ -98,7 +100,9 @@ void resize_inverses(AvmFlavor::ProverPolynomials& prover_polynomials,
 
     const size_t num_rows = std::max<size_t>(src_selector.end_index(), dst_selector.end_index());
     inverse_polynomial = AvmProver::Polynomial::create_non_parallel_zero_init(num_rows, MAX_AVM_TRACE_SIZE);
-    assert(prover_polynomials.get(static_cast<ColumnAndShifts>(inverses_col)).size() == num_rows);
+    BB_ASSERT_EQ(prover_polynomials.get(static_cast<ColumnAndShifts>(inverses_col)).size(),
+                 num_rows,
+                 "Inverse polynomial size mismatch");
 }
 
 std::shared_ptr<AvmProver::ProvingKey> proving_key_from_polynomials(AvmProver::ProverPolynomials& polynomials)

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/event_emitter.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/event_emitter.hpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <vector>
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/common/set.hpp"
 
 namespace bb::avm2::simulation {
@@ -76,7 +77,7 @@ template <typename Event> class OneShotEventEmitter : public EventEmitterInterfa
     virtual ~OneShotEventEmitter() = default;
     void emit(Event&& event) override
     {
-        assert(!has_emitted);
+        BB_ASSERT(!has_emitted, "Event already emitted");
         has_emitted = true;
         this->event = event;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/address_derivation.cpp
@@ -37,7 +37,7 @@ void AddressDerivation::assert_derivation(const AztecAddress& address, const Con
     EmbeddedCurvePoint preaddress_public_key = ecc.scalar_mul(EmbeddedCurvePoint::one(), preaddress);
     EmbeddedCurvePoint address_point = ecc.add(preaddress_public_key, instance.public_keys.incoming_viewing_key);
 
-    assert(address == address_point.x());
+    BB_ASSERT_EQ(address, address_point.x(), "Address derivation mismatch");
 
     // Cache this derivation so we don't repeat it
     cached_derivations.insert(address);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/addressing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/addressing.cpp
@@ -52,7 +52,7 @@ std::vector<Operand> Addressing::resolve(const Instruction& instruction, MemoryI
 
     // This represents either: (1) wrong info in the spec, or (2) a wrong witgen deserialization.
     // Therefore, it is not an error the circuit should be able to prove.
-    assert(spec.num_addresses <= instruction.operands.size());
+    BB_ASSERT_LTE(spec.num_addresses, instruction.operands.size(), "Spec num addresses out of bounds");
 
     // Check if there is any relative address.
     bool has_relative_address = false;
@@ -86,7 +86,9 @@ std::vector<Operand> Addressing::resolve(const Instruction& instruction, MemoryI
             // This should be guaranteed by instruction fetching and the wire format.
             // The operand must fit in a MemoryAddress but does not need to be of the right tag.
             // For instance, a 16-bit operand can be cast to a MemoryAddress and fit.
-            assert(FF(static_cast<MemoryAddress>(instruction.operands[i].as_ff())) == instruction.operands[i].as_ff());
+            // NOTE: Only asserting in debug builds because these convertions are in the hot path.
+            BB_ASSERT_DEBUG(FF(static_cast<MemoryAddress>(instruction.operands[i].as_ff())) ==
+                            instruction.operands[i].as_ff());
 
             // Guarantees at this point:
             // - original operand is a valid address IF interpreted as a MemoryAddress.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_hashing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_hashing.cpp
@@ -19,10 +19,8 @@ void BytecodeHasher::assert_public_bytecode_commitment(const BytecodeId& bytecod
     inputs.insert(inputs.end(), bytecode_as_fields.begin(), bytecode_as_fields.end());
 
     FF hash = hasher.hash(inputs);
-    assert(hash == public_bytecode_commitment);
-    // To please the compiler.
-    (void)hash;
-    (void)public_bytecode_commitment;
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(hash, public_bytecode_commitment, "Public bytecode commitment hash mismatch");
 
     events.emit({ .bytecode_id = bytecode_id,
                   .bytecode_length = bytecode_length_in_bytes,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
@@ -66,14 +66,14 @@ BytecodeId TxBytecodeManager::get_bytecode(const AztecAddress& address)
     std::optional<ContractClass> maybe_klass = contract_db.get_contract_class(current_class_id);
     // Note: we don't need to silo and check the class id because the deployer contract guarantees
     // that if a contract instance exists, the class has been registered.
-    assert(maybe_klass.has_value());
+    BB_ASSERT(maybe_klass.has_value(), "Contract class not found");
     auto& klass = maybe_klass.value();
     retrieval_event.contract_class = klass; // WARNING: this class has the whole bytecode.
 
     // Bytecode hashing and decomposition, deduplicated by bytecode_id (commitment)
     std::optional<FF> maybe_bytecode_commitment = contract_db.get_bytecode_commitment(current_class_id);
     // If we reach this point, class ID and instance both exist which means bytecode commitment must exist.
-    assert(maybe_bytecode_commitment.has_value());
+    BB_ASSERT(maybe_bytecode_commitment.has_value(), "Bytecode commitment not found");
     BytecodeId bytecode_id = maybe_bytecode_commitment.value();
     retrieval_event.bytecode_id = bytecode_id;
     debug("Bytecode for ", address, " successfully retrieved!");

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
@@ -21,8 +21,8 @@ void ClassIdDerivation::assert_derivation(const ContractClassWithCommitment& kla
                                             klass.artifact_hash,
                                             klass.private_functions_root,
                                             klass.public_bytecode_commitment });
-    (void)computed_class_id; // Silence unused variable warning when assert is stripped out
-    assert(computed_class_id == klass.id);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(computed_class_id, klass.id, "Computed class ID mismatch");
 
     // Cache this derivation so we don't repeat it
     cached_derivations.insert(klass.id);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
@@ -37,7 +37,7 @@ std::optional<ContractClass> ContractDB::get_contract_class(const ContractClassI
     // Get the bytecode commitment for this class.
     std::optional<FF> maybe_bytecode_commitment = raw_contract_db.get_bytecode_commitment(class_id);
     // If the class exists, the bytecode commitment must also exist.
-    assert(maybe_bytecode_commitment.has_value());
+    BB_ASSERT(maybe_bytecode_commitment.has_value(), "Bytecode commitment not found");
 
     // Perform class ID derivation to verify the class ID is correctly derived from the class data.
     class_id_derivation.assert_derivation(maybe_klass->with_commitment(maybe_bytecode_commitment.value()));
@@ -115,9 +115,9 @@ void MerkleDB::storage_write(const AztecAddress& contract_address,
                                                                          insertion_hint.path,
                                                                          is_protocol_write);
 
-    (void)snapshot_after; // Silence unused variable warning when assert is stripped out
-    // Sanity check.
-    assert(snapshot_after == raw_merkle_db.get_tree_roots().public_data_tree);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(snapshot_after, raw_merkle_db.get_tree_roots().public_data_tree, "Snapshot after mismatch");
+
     if (!is_protocol_write) {
         written_public_data_slots.insert(contract_address, slot);
     }
@@ -209,9 +209,8 @@ void MerkleDB::nullifier_write_internal(std::optional<AztecAddress> contract_add
                                                                        snapshot_before,
                                                                        insertion_path);
 
-    (void)snapshot_after; // Silence unused variable warning when assert is stripped out
-    // Sanity check.
-    assert(snapshot_after == raw_merkle_db.get_tree_roots().nullifier_tree);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(snapshot_after, raw_merkle_db.get_tree_roots().nullifier_tree, "Snapshot after mismatch");
 
     if (!present) {
         tree_counters_stack.top().nullifier_counter++;
@@ -245,9 +244,8 @@ void MerkleDB::note_hash_write(const AztecAddress& contract_address, const FF& n
     AppendOnlyTreeSnapshot snapshot_after =
         note_hash_tree_check.append_note_hash(note_hash, contract_address, note_hash_counter, path, snapshot_before);
 
-    (void)snapshot_after; // Silence unused variable warning when assert is stripped out
-    // Sanity check.
-    assert(snapshot_after == raw_merkle_db.get_tree_roots().note_hash_tree);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(snapshot_after, raw_merkle_db.get_tree_roots().note_hash_tree, "Snapshot after mismatch");
 
     tree_counters_stack.top().note_hash_counter++;
 }
@@ -267,9 +265,8 @@ void MerkleDB::siloed_note_hash_write(const FF& siloed_note_hash)
     AppendOnlyTreeSnapshot snapshot_after =
         note_hash_tree_check.append_siloed_note_hash(siloed_note_hash, note_hash_counter, path, snapshot_before);
 
-    (void)snapshot_after; // Silence unused variable warning when assert is stripped out
-    // Sanity check.
-    assert(snapshot_after == raw_merkle_db.get_tree_roots().note_hash_tree);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(snapshot_after, raw_merkle_db.get_tree_roots().note_hash_tree, "Snapshot after mismatch");
 
     tree_counters_stack.top().note_hash_counter++;
 }
@@ -285,9 +282,8 @@ void MerkleDB::unique_note_hash_write(const FF& unique_note_hash)
     AppendOnlyTreeSnapshot snapshot_after =
         note_hash_tree_check.append_unique_note_hash(unique_note_hash, note_hash_counter, path, snapshot_before);
 
-    (void)snapshot_after; // Silence unused variable warning when assert is stripped out
-    // Sanity check.
-    assert(snapshot_after == raw_merkle_db.get_tree_roots().note_hash_tree);
+    // This will throw an unexpected exception if it fails.
+    BB_ASSERT_EQ(snapshot_after, raw_merkle_db.get_tree_roots().note_hash_tree, "Snapshot after mismatch");
 
     tree_counters_stack.top().note_hash_counter++;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/context_provider.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/context_provider.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<ContextInterface> ContextProvider::make_nested_context(AztecAddr
     merkle_db.create_checkpoint(); // Fork DB just like in TS.
     uint32_t context_id = next_context_id++;
     // Memory assumes that the space id is <= 16 bits.
-    assert(context_id <= std::numeric_limits<uint16_t>::max());
+    BB_ASSERT_LTE(context_id, std::numeric_limits<uint16_t>::max(), "Context ID out of bounds");
     uint16_t space_id = static_cast<uint16_t>(context_id);
     return std::make_unique<NestedContext>(
         context_id,
@@ -53,7 +53,7 @@ std::unique_ptr<ContextInterface> ContextProvider::make_enqueued_context(AztecAd
 
     uint32_t context_id = next_context_id++;
     // Memory assumes that the space id is <= 16 bits.
-    assert(context_id <= std::numeric_limits<uint16_t>::max());
+    BB_ASSERT_LTE(context_id, std::numeric_limits<uint16_t>::max(), "Context ID out of bounds");
     uint16_t space_id = static_cast<uint16_t>(context_id);
 
     cd_hash_provider.make_calldata_hasher(context_id)->compute_calldata_hash(calldata);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/contract_instance_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/contract_instance_manager.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/vm2/simulation/gadgets/contract_instance_manager.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/simulation/interfaces/field_gt.hpp"
 
@@ -50,8 +51,9 @@ std::optional<ContractInstance> ContractInstanceManager::get_contract_instance(c
         std::optional<AztecAddress> derived_address = get_derived_address(protocol_contracts, contract_address);
 
         // Sanity check: if we found a derived address, we should also have the instance, and vice versa.
-        assert(derived_address.has_value() == maybe_instance.has_value() &&
-               "Derived address should be found if the instance was retrieved and vice versa");
+        BB_ASSERT_EQ(derived_address.has_value(),
+                     maybe_instance.has_value(),
+                     "Derived address should be found if the instance was retrieved and vice versa");
 
         event_emitter.emit({
             .address = contract_address,
@@ -78,7 +80,7 @@ std::optional<ContractInstance> ContractInstanceManager::get_contract_instance(c
         return std::nullopt;
     }
 
-    assert(maybe_instance.has_value() && "Contract instance should be found if nullifier exists");
+    BB_ASSERT(maybe_instance.has_value(), "Contract instance should be found if nullifier exists");
     const ContractInstance& instance = maybe_instance.value();
 
     // Validate that the contract instance is the latest if there have been any updates.

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/ecc.cpp
@@ -20,9 +20,9 @@ class InternalEccException : public std::runtime_error {
 // via the opcode ECADD, see the overloaded function Ecc::add (which performs the curve check)
 EmbeddedCurvePoint Ecc::add(const EmbeddedCurvePoint& p, const EmbeddedCurvePoint& q)
 {
-    // Check if points are on the curve.
-    assert(p.on_curve() && "Point p is not on the curve");
-    assert(q.on_curve() && "Point q is not on the curve");
+    // Check if points are on the curve. These will throw an unexpected exception if they fail.
+    BB_ASSERT(p.on_curve(), "Point p is not on the curve");
+    BB_ASSERT(q.on_curve(), "Point q is not on the curve");
 
     EmbeddedCurvePoint result = p + q;
     add_events.emit({ .p = p, .q = q, .result = result });
@@ -34,6 +34,7 @@ EmbeddedCurvePoint Ecc::add(const EmbeddedCurvePoint& p, const EmbeddedCurvePoin
 EmbeddedCurvePoint Ecc::scalar_mul(const EmbeddedCurvePoint& point, const FF& scalar)
 {
     // This is bad - the scalar mul circuit assumes that the point is on the curve.
+    // This will throw an unexpected exception if it fails.
     BB_ASSERT(point.on_curve(), "Point must be on the curve for scalar multiplication");
 
     auto intermediate_states = std::vector<ScalarMulIntermediateState>(254);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -2140,7 +2140,8 @@ inline void Execution::call_with_operands(void (Execution::*f)(ContextInterface&
                                           ContextInterface& context,
                                           const std::vector<Operand>& resolved_operands)
 {
-    assert(resolved_operands.size() == sizeof...(Ts));
+    // NOTE: Only asserting in debug builds because these convertions are in the hot path.
+    BB_ASSERT_DEBUG(resolved_operands.size() == sizeof...(Ts), "Resolved operands size mismatch");
     auto operand_indices = std::make_index_sequence<sizeof...(Ts)>{};
     [f, this, &context, &resolved_operands]<std::size_t... Is>(std::index_sequence<Is...>) {
         (this->*f)(context, resolved_operands.at(Is).to<std::decay_t<Ts>>()...);
@@ -2157,7 +2158,8 @@ inline void Execution::call_with_operands(void (Execution::*f)(ContextInterface&
 void Execution::set_and_validate_inputs(ExecutionOpCode opcode, const std::vector<MemoryValue>& inputs)
 {
     const auto& register_info = instruction_info_db.get(opcode).register_info;
-    assert(inputs.size() == register_info.num_inputs());
+    // NOTE: Only asserting in debug builds because these convertions are in the hot path.
+    BB_ASSERT_DEBUG(inputs.size() == register_info.num_inputs(), "Inputs size mismatch");
     this->inputs = inputs;
     for (size_t i = 0; i < register_info.num_inputs(); i++) {
         if (register_info.expected_tag(i) && register_info.expected_tag(i) != this->inputs.at(i).get_tag()) {
@@ -2180,8 +2182,8 @@ void Execution::set_and_validate_inputs(ExecutionOpCode opcode, const std::vecto
 void Execution::set_output(ExecutionOpCode opcode, const MemoryValue& output)
 {
     const auto& register_info = instruction_info_db.get(opcode).register_info;
-    (void)register_info; // To please GCC.
-    assert(register_info.num_outputs() == 1);
+    // NOTE: Only asserting in debug builds because these convertions are in the hot path.
+    BB_ASSERT_DEBUG(register_info.num_outputs() == 1, "Outputs size mismatch");
     this->output = output;
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.cpp
@@ -24,8 +24,8 @@ struct IntermediateGas {
 
     Gas to_gas() const
     {
-        assert(l2_gas <= std::numeric_limits<uint32_t>::max());
-        assert(da_gas <= std::numeric_limits<uint32_t>::max());
+        BB_ASSERT_LTE(l2_gas, std::numeric_limits<uint32_t>::max(), "L2 gas out of bounds");
+        BB_ASSERT_LTE(da_gas, std::numeric_limits<uint32_t>::max(), "DA gas out of bounds");
         return Gas{ .l2_gas = static_cast<uint32_t>(l2_gas), .da_gas = static_cast<uint32_t>(da_gas) };
     }
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/keccakf1600.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/keccakf1600.cpp
@@ -24,7 +24,7 @@ MemoryValue unconstrained_rotate_left(MemoryValue x, uint8_t len)
     }
 
     const auto x_uint64_t = x.as<uint64_t>();
-    assert(len < 64);
+    BB_ASSERT_LT(len, 64, "Length out of bounds");
     const auto out_uint64_t = (x_uint64_t << len) | x_uint64_t >> (64 - len);
     return MemoryValue::from(out_uint64_t);
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/merkle_check.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/merkle_check.cpp
@@ -25,7 +25,7 @@ void MerkleCheck::assert_membership(const FF& leaf_value,
                                     const FF& root)
 {
     // Gadget breaks if tree_height > 64 (leaf_index is of type uint64_t)
-    assert(sibling_path.size() <= 64 && "Merkle path length must be less than or equal to 64");
+    BB_ASSERT_LTE(sibling_path.size(), static_cast<size_t>(64), "Merkle path length must be less than or equal to 64");
 
     FF curr_value = leaf_value;
     uint64_t curr_index = leaf_index;
@@ -77,7 +77,7 @@ FF MerkleCheck::write(const FF& current_value,
                       const FF& current_root)
 {
     // Gadget breaks if tree_height > 64 (leaf_index is of type uint64_t)
-    assert(sibling_path.size() <= 64 && "Merkle path length must be less than or equal to 64");
+    BB_ASSERT_LTE(sibling_path.size(), static_cast<size_t>(64), "Merkle path length must be less than or equal to 64");
 
     FF read_value = current_value;
     FF write_value = new_value;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/retrieved_bytecodes_tree_check.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/retrieved_bytecodes_tree_check.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/vm2/simulation/gadgets/retrieved_bytecodes_tree_check.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/lib/merkle.hpp"
 
@@ -88,7 +89,8 @@ void RetrievedBytecodesTreeCheck::insert(const FF& class_id)
             .root = write_root,
             .next_available_leaf_index = prev_snapshot.next_available_leaf_index + 1,
         };
-        assert(next_snapshot == tree.get_snapshot());
+        // This will throw an unexpected exception if it fails.
+        BB_ASSERT_EQ(next_snapshot, tree.get_snapshot(), "Next snapshot mismatch");
         append_data = RetrievedBytecodeAppendData{
             .updated_low_leaf_hash = updated_low_leaf_hash,
             .new_leaf_hash = new_leaf_hash,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/sha256.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/sha256.cpp
@@ -37,8 +37,7 @@ MemoryValue Sha256::ror(const MemoryValue& x, uint8_t shift)
 
     // Do this outside of an assert, in case this gets built without assert
     bool lo_in_range = gt.gt(static_cast<uint32_t>(1) << shift, lo); // Ensure the lower bits are in range
-    (void)lo_in_range;                                               // To please GCC.
-    assert(lo_in_range && "Low Value in ROR out of range");
+    BB_ASSERT(lo_in_range, "Low Value in ROR out of range");
     return MemoryValue::from<uint32_t>(result);
 }
 
@@ -52,8 +51,7 @@ MemoryValue Sha256::shr(const MemoryValue& x, uint8_t shift)
 
     // Do this outside of an assert, in case this gets built without assert
     bool lo_in_range = gt.gt(static_cast<uint32_t>(1) << shift, lo); // Ensure the lower bits are in range
-    (void)lo_in_range;                                               // To please GCC.
-    assert(lo_in_range && "Low Value in SHR out of range");
+    BB_ASSERT(lo_in_range, "Low Value in SHR out of range");
 
     return MemoryValue::from<uint32_t>(hi);
 }
@@ -74,9 +72,7 @@ MemoryValue Sha256::modulo_sum(std::span<const MemoryValue> values)
         gt.gt(static_cast<uint64_t>(1) << 32, static_cast<uint64_t>(lo)); // Ensure the lower bits are in range
     bool hi_in_range =
         gt.gt(static_cast<uint64_t>(1) << 32, static_cast<uint64_t>(hi)); // Ensure the upper bits are in range
-    (void)lo_in_range;                                                    // To please GCC.
-    (void)hi_in_range;                                                    // To please GCC.
-    assert(lo_in_range && hi_in_range && "Sum in MODULO_SUM out of range");
+    BB_ASSERT(lo_in_range && hi_in_range, "Sum in MODULO_SUM out of range");
     return MemoryValue::from<uint32_t>(lo);
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/written_public_data_slots_tree_check.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/written_public_data_slots_tree_check.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/vm2/simulation/gadgets/written_public_data_slots_tree_check.hpp"
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/simulation/interfaces/db.hpp"
 #include "barretenberg/vm2/simulation/lib/merkle.hpp"
 
@@ -99,7 +100,8 @@ void WrittenPublicDataSlotsTreeCheck::insert(const AztecAddress& contract_addres
             .root = write_root,
             .next_available_leaf_index = prev_snapshot.next_available_leaf_index + 1,
         };
-        assert(next_snapshot == tree.get_snapshot());
+        // This will throw an unexpected exception if it fails.
+        BB_ASSERT_EQ(next_snapshot, tree.get_snapshot(), "Next snapshot mismatch");
         append_data = SlotAppendData{
             .updated_low_leaf_hash = updated_low_leaf_hash,
             .new_leaf_hash = new_leaf_hash,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
@@ -31,7 +31,7 @@ void CallStackMetadataCollector::notify_enter_call(const AztecAddress& contract_
                                                    bool is_static_call,
                                                    const Gas& gas_limit)
 {
-    assert(!call_stack_metadata.empty());
+    BB_ASSERT(!call_stack_metadata.empty(), "Call stack metadata is empty");
 
     // Check if we should stop collecting due to limits.
     if (should_skip_collection()) {
@@ -86,7 +86,7 @@ void CallStackMetadataCollector::notify_exit_call(bool success,
     top_call_stack_metadata.internal_call_stack_at_exit = std::move(internal_call_stack);
 
     // While exiting, we will move the top call of the stack to the nested vector of the parent call.
-    assert(call_stack_metadata.size() > 1);
+    BB_ASSERT_GT(call_stack_metadata.size(), static_cast<size_t>(1), "Call stack metadata size is not greater than 1");
     call_stack_metadata.pop();
     call_stack_metadata.top().nested.push_back(std::move(top_call_stack_metadata));
 }
@@ -96,7 +96,7 @@ void CallStackMetadataCollector::notify_tx_revert(const std::string& revert_mess
     // Create a synthetic CallStackMetadata entry to capture the revert reason.
     // This is used when a tx-level revert happens outside of an enqueued call
     // (e.g., during revertible insertions from private).
-    assert(call_stack_metadata.size() == 1);
+    BB_ASSERT_EQ(call_stack_metadata.size(), static_cast<size_t>(1), "Call stack metadata size is not equal to 1");
     call_stack_metadata.top().nested.push_back({
         .timestamp = timestamp++,
         .phase = current_phase,
@@ -116,7 +116,7 @@ void CallStackMetadataCollector::notify_tx_revert(const std::string& revert_mess
 
 std::vector<CallStackMetadata> CallStackMetadataCollector::dump_call_stack_metadata()
 {
-    assert(call_stack_metadata.size() == 1);
+    BB_ASSERT_EQ(call_stack_metadata.size(), static_cast<size_t>(1), "Call stack metadata size is not equal to 1");
     return std::move(call_stack_metadata.top().nested);
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/indexed_memory_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/indexed_memory_tree.hpp
@@ -40,7 +40,7 @@ IndexedMemoryTree<LeafType, HashingPolicy>::IndexedMemoryTree(size_t depth, size
     // We need to create the tree inserting the prefill values. Indexed trees need some leaves to exist from the start
     // in order to be able to provide insertion proofs. Users can customize how many default leaves they want the tree
     // to start with, but there must be at least one.
-    assert(num_default_values > 0);
+    BB_ASSERT_GT(num_default_values, static_cast<size_t>(0), "Number of default values is not greater than 0");
 
     std::vector<LeafType> default_leaves;
     default_leaves.reserve(num_default_values);
@@ -79,7 +79,7 @@ IndexedMemoryTree<LeafType, HashingPolicy>::IndexedMemoryTree(size_t depth,
 {
     // It is assumed that you have included any prefill values as part of the initial_leaves. Remember indexed trees
     // need at least 1 prefill leaf (with value 0) in order to work
-    assert(initial_leaves.size() > 0);
+    BB_ASSERT_GT(initial_leaves.size(), static_cast<size_t>(0), "Initial leaves size is not greater than 0");
 
     // Compute the pointers for the prefill leaves and insert them in the tree.
     for (size_t i = 0; i < initial_leaves.size(); ++i) {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/raw_data_dbs.cpp
@@ -172,10 +172,11 @@ void HintedRawContractDB::add_contracts([[maybe_unused]] const ContractDeploymen
 void HintedRawContractDB::create_checkpoint()
 {
     auto hint_it = create_checkpoint_hints.find(action_counter);
-    assert(hint_it != create_checkpoint_hints.end());
+    BB_ASSERT(hint_it != create_checkpoint_hints.end(), "Hint not found for create checkpoint");
 
     const auto& hint = hint_it->second;
-    assert(hint.old_checkpoint_id == checkpoint_stack.top());
+    BB_ASSERT_EQ(
+        hint.old_checkpoint_id, checkpoint_stack.top(), "Old checkpoint id does not match the current checkpoint id");
 
     checkpoint_stack.push(hint.new_checkpoint_id);
     action_counter++;
@@ -184,29 +185,31 @@ void HintedRawContractDB::create_checkpoint()
 void HintedRawContractDB::commit_checkpoint()
 {
     auto hint_it = commit_checkpoint_hints.find(action_counter);
-    assert(hint_it != commit_checkpoint_hints.end());
+    BB_ASSERT(hint_it != commit_checkpoint_hints.end(), "Hint not found for commit checkpoint");
 
     const auto& hint = hint_it->second;
-    assert(hint.old_checkpoint_id == checkpoint_stack.top());
+    BB_ASSERT_EQ(
+        hint.old_checkpoint_id, checkpoint_stack.top(), "Old checkpoint id does not match the current checkpoint id");
 
     checkpoint_stack.pop();
-    assert(hint.new_checkpoint_id == checkpoint_stack.top());
+    BB_ASSERT_EQ(
+        hint.new_checkpoint_id, checkpoint_stack.top(), "New checkpoint id does not match the current checkpoint id");
     action_counter++;
-    (void)hint;
 }
 
 void HintedRawContractDB::revert_checkpoint()
 {
     auto hint_it = revert_checkpoint_hints.find(action_counter);
-    assert(hint_it != revert_checkpoint_hints.end());
+    BB_ASSERT(hint_it != revert_checkpoint_hints.end(), "Hint not found for revert checkpoint");
 
     const auto& hint = hint_it->second;
-    assert(hint.old_checkpoint_id == checkpoint_stack.top());
+    BB_ASSERT_EQ(
+        hint.old_checkpoint_id, checkpoint_stack.top(), "Old checkpoint id does not match the current checkpoint id");
 
     checkpoint_stack.pop();
-    assert(hint.new_checkpoint_id == checkpoint_stack.top());
+    BB_ASSERT_EQ(
+        hint.new_checkpoint_id, checkpoint_stack.top(), "New checkpoint id does not match the current checkpoint id");
     action_counter++;
-    (void)hint;
 }
 
 uint32_t HintedRawContractDB::get_checkpoint_id() const

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -10,6 +10,7 @@
 #include <variant>
 #include <vector>
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/common/log.hpp"
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
@@ -255,7 +256,7 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
 
     const auto opcode = static_cast<WireOpCode>(opcode_byte);
     const auto iter = get_wire_opcode_wire_format().find(opcode);
-    assert(iter != get_wire_opcode_wire_format().end());
+    BB_ASSERT_DEBUG(iter != get_wire_opcode_wire_format().end(), "Wire opcode not found in wire opcode wire format");
     const auto& inst_format = iter->second;
 
     const uint32_t instruction_size = get_wire_instruction_spec().at(opcode).size_in_bytes;
@@ -280,8 +281,8 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
     std::vector<Operand> operands;
     for (const OperandType op_type : inst_format) {
         const auto operand_size = get_operand_type_size_bytes().at(op_type);
-        assert(pos + operand_size <= bytecode_length); // Guaranteed to hold due to
-                                                       //  pos + instruction_size <= bytecode_length
+        // Guaranteed to hold due to pos + instruction_size <= bytecode_length
+        BB_ASSERT_DEBUG(pos + operand_size <= bytecode_length, "Operand size is out of range");
 
         switch (op_type) {
         case OperandType::TAG:
@@ -365,13 +366,13 @@ std::string Instruction::to_string() const
 
 size_t Instruction::size_in_bytes() const
 {
-    assert(get_wire_instruction_spec().contains(opcode));
+    BB_ASSERT_DEBUG(get_wire_instruction_spec().contains(opcode), "Wire instruction spec not found for opcode");
     return get_wire_instruction_spec().at(opcode).size_in_bytes;
 }
 
 ExecutionOpCode Instruction::get_exec_opcode() const
 {
-    assert(get_wire_instruction_spec().contains(opcode));
+    BB_ASSERT_DEBUG(get_wire_instruction_spec().contains(opcode), "Wire instruction spec not found for opcode");
     return get_wire_instruction_spec().at(opcode).exec_opcode;
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
@@ -22,7 +22,7 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
     ExecutionOpCode exec_opcode = instruction_info_db.get(instruction.opcode).exec_opcode;
     const ExecInstructionSpec& spec = instruction_info_db.get(exec_opcode);
 
-    assert(spec.num_addresses <= instruction.operands.size());
+    BB_ASSERT_DEBUG(spec.num_addresses <= instruction.operands.size(), "Number of addresses is out of range");
 
     std::optional<MemoryAddress> base_address;
     std::vector<Operand> resolved_operands = instruction.operands;
@@ -33,7 +33,7 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
 
         // We assume from serialization that the operand is <= the bits of a memory address.
         // We assert this here as it is a precondition.
-        assert(get_tag_bits(tag) <= get_tag_bits(MemoryAddressTag));
+        BB_ASSERT_DEBUG(get_tag_bits(tag) <= get_tag_bits(MemoryAddressTag), "Tag bits are out of range");
         // Normalize possibly smaller sizes to MemoryAddress.
         if (tag != MemoryAddressTag) {
             operand = Operand::from(static_cast<MemoryAddress>(operand.to<MemoryAddress>()));

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
@@ -77,7 +77,7 @@ BytecodeId PureTxBytecodeManager::get_bytecode(const AztecAddress& address)
     std::optional<ContractClass> maybe_klass = contract_db.get_contract_class(current_class_id);
     // Note: we don't need to silo and check the class id because the deployer contract guarantees
     // that if a contract instance exists, the class has been registered.
-    assert(maybe_klass.has_value());
+    BB_ASSERT(maybe_klass.has_value(), "Contract class not found");
     auto& klass = maybe_klass.value();
     debug("Bytecode for ", address, " successfully retrieved!");
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -306,8 +306,8 @@ void BytecodeTraceBuilder::process_instruction_fetching(
 
             if (wire_instr_spec.tag_operand_idx.has_value()) {
                 const auto tag_value_idx = wire_instr_spec.tag_operand_idx.value();
-                assert((tag_value_idx == 2 || tag_value_idx == 3) &&
-                       "Current constraints support only tag for operand index equal to 2 or 3");
+                BB_ASSERT((tag_value_idx == 2 || tag_value_idx == 3),
+                          "Current constraints support only tag for operand index equal to 2 or 3");
                 has_tag = 1;
 
                 if (tag_value_idx == 2) {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/data_copy_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/data_copy_trace.cpp
@@ -121,7 +121,7 @@ void DataCopyTraceBuilder::process(
 
         // If there is an error, the copying data is empty. Therefore, we have to perform this
         // assertion after the error check.
-        assert(event.copying_data.size() == copy_size);
+        BB_ASSERT_EQ(event.copying_data.size(), copy_size, "Copying data size is not equal to copy size");
 
         /////////////////////////////
         // Check for Zero Sized Copy

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.cpp
@@ -73,7 +73,7 @@ void EccTraceBuilder::process_add(const simulation::EventEmitterInterface<simula
 
         bool use_computed_result = !infinity_predicate && (!p.is_infinity() && !q.is_infinity());
 
-        assert(result_is_infinity == result.is_infinity() && "Inconsistent infinity result assumption");
+        BB_ASSERT_EQ(result_is_infinity, result.is_infinity(), "Inconsistent infinity result assumption");
 
         FF lambda = compute_lambda(double_predicate, add_predicate, result_is_infinity, p, q);
 
@@ -145,7 +145,7 @@ void EccTraceBuilder::process_scalar_mul(
 
             simulation::ScalarMulIntermediateState state = event.intermediate_states[intermediate_state_idx];
             if (is_start) {
-                assert(state.res == event.result);
+                BB_ASSERT_EQ(state.res, event.result, "Inconsistent result assumption");
             }
             EmbeddedCurvePoint res = state.res;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -7,6 +7,7 @@
 #include <ranges>
 #include <stdexcept>
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/common/addressing.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/common/field.hpp"
@@ -265,8 +266,8 @@ bool is_phase_discarded(TransactionPhase phase, const FailingContexts& failures)
  */
 uint32_t dying_context_for_phase(TransactionPhase phase, const FailingContexts& failures)
 {
-    assert((phase == TransactionPhase::APP_LOGIC || phase == TransactionPhase::TEARDOWN) &&
-           "Execution events must have app logic or teardown phase");
+    BB_ASSERT((phase == TransactionPhase::APP_LOGIC || phase == TransactionPhase::TEARDOWN),
+              "Execution events must have app logic or teardown phase");
 
     switch (phase) {
     case TransactionPhase::APP_LOGIC: {
@@ -572,8 +573,9 @@ void ExecutionTraceBuilder::process(
                 sel_exit_call = true;
                 should_execute_revert = true;
             } else if (exec_opcode == ExecutionOpCode::GETENVVAR) {
-                assert(ex_event.addressing_event.resolution_info.size() == 2 &&
-                       "GETENVVAR should have exactly two resolved operands (envvar enum and output)");
+                BB_ASSERT_EQ(ex_event.addressing_event.resolution_info.size(),
+                             static_cast<size_t>(2),
+                             "GETENVVAR should have exactly two resolved operands (envvar enum and output)");
                 // rop[1] is the envvar enum
                 Operand envvar_enum = ex_event.addressing_event.resolution_info[1].resolved_operand;
                 process_get_env_var_opcode(envvar_enum, ex_event.output, trace, row);
@@ -751,7 +753,7 @@ void ExecutionTraceBuilder::process_instr_fetching(const simulation::Instruction
 
     // At this point we can assume instruction fetching succeeded.
     auto operands = instruction.operands;
-    assert(operands.size() <= AVM_MAX_OPERANDS);
+    BB_ASSERT_LTE(operands.size(), static_cast<size_t>(AVM_MAX_OPERANDS), "Operands size is out of range");
     operands.resize(AVM_MAX_OPERANDS, Operand::from<FF>(0));
 
     for (size_t i = 0; i < AVM_MAX_OPERANDS; i++) {
@@ -843,7 +845,8 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
     const ExecInstructionSpec& ex_spec = get_exec_instruction_spec().at(exec_opcode);
 
     auto resolution_info_vec = addr_event.resolution_info;
-    assert(resolution_info_vec.size() <= AVM_MAX_OPERANDS);
+    BB_ASSERT_LTE(
+        resolution_info_vec.size(), static_cast<size_t>(AVM_MAX_OPERANDS), "Resolution info size is out of range");
     // Pad with default values for the missing operands.
     resolution_info_vec.resize(AVM_MAX_OPERANDS,
                                {
@@ -1013,7 +1016,7 @@ void ExecutionTraceBuilder::process_registers(ExecutionOpCode exec_opcode,
                                               TraceContainer& trace,
                                               uint32_t row)
 {
-    assert(registers.size() == AVM_MAX_REGISTERS);
+    BB_ASSERT_EQ(registers.size(), static_cast<size_t>(AVM_MAX_REGISTERS), "Registers size is out of range");
     // At this point we can assume instruction fetching succeeded, so this should never fail.
     const auto& register_info = get_exec_instruction_spec().at(exec_opcode).register_info;
 
@@ -1087,7 +1090,7 @@ void ExecutionTraceBuilder::process_get_env_var_opcode(Operand envvar_enum,
                                                        TraceContainer& trace,
                                                        uint32_t row)
 {
-    assert(envvar_enum.get_tag() == ValueTag::U8);
+    BB_ASSERT_EQ(envvar_enum.get_tag(), ValueTag::U8, "Envvar enum tag is not U8");
     const auto& envvar_spec = GetEnvVarSpec::get_table(envvar_enum.as<uint8_t>());
 
     trace.set(row,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/discard_reconstruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/discard_reconstruction.hpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <vector>
 
+#include "barretenberg/common/assert.hpp"
 #include "barretenberg/vm2/simulation/events/checkpoint_event_type.hpp"
 
 namespace bb::avm2::tracegen {
@@ -33,11 +34,11 @@ std::unordered_map<size_t, size_t> compute_reverted_in_map(const std::vector<Eve
                 checkpoint_stack.push(i);
                 break;
             case simulation::CheckPointEventType::COMMIT_CHECKPOINT:
-                assert(!checkpoint_stack.empty());
+                BB_ASSERT(!checkpoint_stack.empty());
                 checkpoint_stack.pop();
                 break;
             case simulation::CheckPointEventType::REVERT_CHECKPOINT:
-                assert(!checkpoint_stack.empty());
+                BB_ASSERT(!checkpoint_stack.empty());
                 reverted_in[checkpoint_stack.top()] = i;
                 checkpoint_stack.pop();
                 break;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/instruction_spec.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/instruction_spec.cpp
@@ -201,7 +201,7 @@ Column get_dyn_gas_selector(uint32_t dyn_gas_id)
     case AVM_DYN_GAS_ID_SSTORE:
         return C::execution_sel_gas_sstore;
     default:
-        assert(false && "Invalid dynamic gas id");
+        BB_ASSERT(false, "Invalid dynamic gas id");
     }
 
     // This is just to please gcc.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.cpp
@@ -45,7 +45,7 @@ void MerkleCheckTraceBuilder::process(
         // to complete the merkle check.
 
         const bool write = event.new_leaf_value.has_value();
-        assert(write == event.new_root.has_value());
+        BB_ASSERT_EQ(write, event.new_root.has_value(), "Write and new root have different values");
 
         FF read_node = event.leaf_value;
         FF write_node = event.new_leaf_value.value_or(FF(0));
@@ -111,9 +111,11 @@ void MerkleCheckTraceBuilder::process(
             row++;
         }
 
-        assert(current_index_in_layer == 0);
-        assert(read_node == root);
-        assert(write_node == new_root);
+        BB_ASSERT_EQ(current_index_in_layer,
+                     static_cast<decltype(current_index_in_layer)>(0),
+                     "Current index in layer is not 0");
+        BB_ASSERT_EQ(read_node, root, "Read node is not equal to root");
+        BB_ASSERT_EQ(write_node, new_root, "Write node is not equal to new root");
     }
 
     // Batch invert the columns.

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/precomputed_trace.cpp
@@ -62,8 +62,8 @@ void PrecomputedTraceBuilder::process_bitwise(TraceContainer& trace)
             return a ^ b;
         }
 
-        assert(false && "This should not happen");
-        return 0; // Should never happen. To please the compiler.
+        BB_ASSERT(false, "This should not happen");
+        __builtin_unreachable();
     };
 
     for (const auto op_id : { BitwiseOperation::AND, BitwiseOperation::OR, BitwiseOperation::XOR }) {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/public_data_tree_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/public_data_tree_trace.cpp
@@ -162,11 +162,14 @@ void process_squashing_trace(const std::vector<PublicDataTreeReadWriteEvent>& no
             const auto& next_event = nondiscarded_writes[i + 1];
 
             if (event.leaf_slot == next_event.leaf_slot) {
-                assert(event.execution_id < next_event.execution_id);
+                BB_ASSERT_LT(
+                    event.execution_id, next_event.execution_id, "Execution id is not less than next execution id");
                 clk_diff = next_event.execution_id - event.execution_id;
                 check_clock = true;
             } else {
-                assert(static_cast<uint256_t>(event.leaf_slot) < static_cast<uint256_t>(next_event.leaf_slot));
+                BB_ASSERT_LT(static_cast<uint256_t>(event.leaf_slot),
+                             static_cast<uint256_t>(next_event.leaf_slot),
+                             "Leaf slot is not less than next leaf slot");
                 leaf_slot_increase = true;
             }
         }


### PR DESCRIPTION
`BB_ASSERT` or `BB_ASSERT_DEBUG` was used depending on whether the code was in the hot path.

The biggest semantic change is that `assert` crashes, and `BB_ASSERT*` throws.

I made a change in the assertion macros because the previous implementation was potentially making copies of the input objects. The original implementation was (probably) chosen so that when the inputs where expressions (e.g., `obj + 7`) they were only evaluated once. This is reasonable. But... when the input is not an expression a copy might be made. The chosen solution was to use `const auto&`, which would in general be dangerous but it works for temporary values (like the expression) thanks to the C++ feature called "lifetime extension" for this very particular case (`const&`). The change was discussed with Adam.
* https://en.cppreference.com/w/cpp/language/reference_initialization.html#Lifetime_of_a_temporary
* https://stackoverflow.com/questions/39718268/why-do-const-references-extend-the-lifetime-of-rvalues

Fixes [AVM-171](https://linear.app/aztec-labs/issue/AVM-171/vm2-move-assert-bb-assert).