### PR TITLE
chore: fix rpc node test wiring, bump reorg test time, and disable auto scaler from evicting ethdevnet

### DIFF
--- a/spartan/eth-devnet/templates/eth-beacon.yaml
+++ b/spartan/eth-devnet/templates/eth-beacon.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "eth-devnet.selectorLabels" . | nindent 8 }}
         app: eth-beacon
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       {{- if .Values.ethereum.beacon.nodeSelector }}
       nodeSelector:

--- a/spartan/eth-devnet/templates/eth-execution.yaml
+++ b/spartan/eth-devnet/templates/eth-execution.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "eth-devnet.selectorLabels" . | nindent 8 }}
         app: eth-execution
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       {{- if .Values.ethereum.execution.nodeSelector }}
       nodeSelector:

--- a/spartan/eth-devnet/templates/eth-validator.yaml
+++ b/spartan/eth-devnet/templates/eth-validator.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         {{- include "eth-devnet.selectorLabels" . | nindent 8 }}
         app: eth-validator
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       {{- if .Values.ethereum.validator.nodeSelector }}
       nodeSelector:

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -100,6 +100,7 @@ function test {
 function bench_cmds {
   echo "$hash:ISOLATE=1:NAME=bench_build_block BENCH_OUTPUT=bench-out/build-block.bench.json yarn-project/end-to-end/scripts/run_test.sh simple bench_build_block"
   echo "$hash:ISOLATE=1:CPUS=8:NAME=tx_stats BB_IVC_CONCURRENCY=1 BB_NUM_IVC_VERIFIERS=8 BENCH_OUTPUT=bench-out/tx_stats.bench.json yarn-project/end-to-end/scripts/run_test.sh simple tx_stats_bench"
+  echo "$hash:ISOLATE=1:NAME=node_rpc_perf BENCH_OUTPUT=bench-out/node_rpc_perf.bench.json yarn-project/end-to-end/scripts/run_test.sh simple node_rpc_perf"
 
   for client_flow in client_flows/bridging client_flows/deployments client_flows/amm client_flows/account_deployments client_flows/transfers; do
     echo "$hash:ISOLATE=1:CPUS=8:NAME=$client_flow BENCHMARK_CONFIG=key_flows LOG_LEVEL=error BENCH_OUTPUT=bench-out/ yarn-project/end-to-end/scripts/run_test.sh simple $client_flow"

--- a/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
+++ b/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
@@ -23,7 +23,7 @@ import { mkdir, writeFile } from 'fs/promises';
 import 'jest-extended';
 import * as path from 'path';
 
-import { setup } from './fixtures/utils.js';
+import { setup } from '../fixtures/utils.js';
 
 /** Number of iterations for fast RPC calls */
 const BENCHMARK_ITERATIONS_FAST = 20;

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -44,7 +44,7 @@ async function checkBalances(testAccounts: TestAccounts, mintAmount: bigint, tot
 }
 
 describe('reorg test', () => {
-  jest.setTimeout(150 * 60 * 1000); // 150 minutes
+  jest.setTimeout(210 * 60 * 1000); // 210 minutes
 
   const MINT_AMOUNT = 2_000_000n;
   const SETUP_EPOCHS = 2;


### PR DESCRIPTION
- fix rpc node test wiring
- bump reorg test time
- disable auto scaler from evicting ethdevnet, under some tests (ie. reorg), the prover is essentially killed for some period and autoscaler sees low resource consumption and attempts to move it, killing it in the process, which causes it to go out of sync.