### PR TITLE
fix!: missing boolean constraints on zero checks targets

### DIFF
--- a/barretenberg/cpp/pil/vm2/keccak_memory.pil
+++ b/barretenberg/cpp/pil/vm2/keccak_memory.pil
@@ -145,6 +145,7 @@ sel * (1 - last) * (ctr' - ctr - 1) = 0;
 pol commit rw; // @boolean (constrained by memory.pil)
 
 pol commit single_tag_error; // @boolean
+#[SINGLE_TAG_ERROR_BOOLEAN]
 single_tag_error * (1 - single_tag_error) = 0;
 
 #[NO_TAG_ERROR_ON_WRITE]
@@ -176,9 +177,6 @@ pol commit tag_min_u64_inv;
 pol TAG_MIN_U64 = tag - constants.MEM_TAG_U64;
 #[SINGLE_TAG_ERROR]
 sel * (TAG_MIN_U64 * ((1 - single_tag_error) * (1 - tag_min_u64_inv) + tag_min_u64_inv) - single_tag_error) = 0;
-
-#[SINGLE_TAG_ERROR_BOOLEAN]
-single_tag_error * (1 - single_tag_error) = 0;
 
 #[VAL01]
 val[1] = (1 - last) * val[0]';

--- a/barretenberg/cpp/pil/vm2/trees/l1_to_l2_message_tree_check.pil
+++ b/barretenberg/cpp/pil/vm2/trees/l1_to_l2_message_tree_check.pil
@@ -17,14 +17,15 @@ include "../constants_gen.pil";
  * };
 **/
 namespace l1_to_l2_message_tree_check;
-    pol commit sel;
+    pol commit sel; // @boolean
     sel * (1 - sel) = 0;
 
     #[skippable_if]
     sel = 0;
 
     // Inputs to the gadget
-    pol commit exists;
+    pol commit exists; // @boolean
+    exists * (1 - exists) = 0;
 
     pol commit msg_hash;
     pol commit leaf_index;

--- a/barretenberg/cpp/pil/vm2/trees/note_hash_tree_check.pil
+++ b/barretenberg/cpp/pil/vm2/trees/note_hash_tree_check.pil
@@ -29,29 +29,30 @@ include "../public_inputs.pil";
  * As write variant usage, we can omit the address column whenever we pass should_silo == 0.
 **/
 namespace note_hash_tree_check;
-    pol commit sel;
+    pol commit sel; // @boolean
     sel * (1 - sel) = 0;
 
     #[skippable_if]
     sel = 0;
 
     // Inputs to the gadget
-    pol commit write;
+    pol commit write; // @boolean
     write * (1 - write) = 0;
     pol READ = 1 - write;
-    pol commit exists;
+    pol commit exists; // @boolean
+    exists * (1 - exists) = 0;
 
     pol commit note_hash;
     pol commit leaf_index;
     pol commit prev_root;
 
     // Write specific inputs
-    pol commit should_silo;
+    pol commit should_silo; // @boolean
     should_silo * (1 - should_silo) = 0;
 
     pol commit address;
 
-    pol commit should_unique;
+    pol commit should_unique; // @boolean
     should_unique * (1 - should_unique) = 0;
 
     pol commit note_hash_index;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory.hpp
@@ -14,10 +14,10 @@ template <typename FF_> class keccak_memoryImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 46> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 4, 3, 5, 3, 4, 3,
-                                                                            3, 3, 3, 4, 3, 3, 3, 5, 3, 3, 3, 3,
-                                                                            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                                            3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
+    static constexpr std::array<size_t, 45> SUBRELATION_PARTIAL_LENGTHS = {
+        3, 3, 3, 3, 3, 3, 4, 3, 5, 3, 4, 3, 3, 3, 3, 4, 3, 3, 3, 5, 3, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+    };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -45,6 +45,7 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
     static constexpr size_t SR_CTR_END = 8;
     static constexpr size_t SR_LAST = 9;
     static constexpr size_t SR_CTR_INCREMENT = 10;
+    static constexpr size_t SR_SINGLE_TAG_ERROR_BOOLEAN = 11;
     static constexpr size_t SR_NO_TAG_ERROR_ON_WRITE = 12;
     static constexpr size_t SR_TAG_ERROR_INIT = 13;
     static constexpr size_t SR_TAG_ERROR_PROPAGATION = 14;
@@ -53,31 +54,30 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
     static constexpr size_t SR_CLK_PROPAGATION = 17;
     static constexpr size_t SR_RW_PROPAGATION = 18;
     static constexpr size_t SR_SINGLE_TAG_ERROR = 19;
-    static constexpr size_t SR_SINGLE_TAG_ERROR_BOOLEAN = 20;
-    static constexpr size_t SR_VAL01 = 21;
-    static constexpr size_t SR_VAL02 = 22;
-    static constexpr size_t SR_VAL03 = 23;
-    static constexpr size_t SR_VAL04 = 24;
-    static constexpr size_t SR_VAL05 = 25;
-    static constexpr size_t SR_VAL06 = 26;
-    static constexpr size_t SR_VAL07 = 27;
-    static constexpr size_t SR_VAL8 = 28;
-    static constexpr size_t SR_VAL09 = 29;
-    static constexpr size_t SR_VAL10 = 30;
-    static constexpr size_t SR_VAL11 = 31;
-    static constexpr size_t SR_VAL12 = 32;
-    static constexpr size_t SR_VAL13 = 33;
-    static constexpr size_t SR_VAL14 = 34;
-    static constexpr size_t SR_VAL15 = 35;
-    static constexpr size_t SR_VAL41 = 36;
-    static constexpr size_t SR_VAL17 = 37;
-    static constexpr size_t SR_VAL18 = 38;
-    static constexpr size_t SR_VAL19 = 39;
-    static constexpr size_t SR_VAL20 = 40;
-    static constexpr size_t SR_VAL21 = 41;
-    static constexpr size_t SR_VAL22 = 42;
-    static constexpr size_t SR_VAL23 = 43;
-    static constexpr size_t SR_VAL24 = 44;
+    static constexpr size_t SR_VAL01 = 20;
+    static constexpr size_t SR_VAL02 = 21;
+    static constexpr size_t SR_VAL03 = 22;
+    static constexpr size_t SR_VAL04 = 23;
+    static constexpr size_t SR_VAL05 = 24;
+    static constexpr size_t SR_VAL06 = 25;
+    static constexpr size_t SR_VAL07 = 26;
+    static constexpr size_t SR_VAL8 = 27;
+    static constexpr size_t SR_VAL09 = 28;
+    static constexpr size_t SR_VAL10 = 29;
+    static constexpr size_t SR_VAL11 = 30;
+    static constexpr size_t SR_VAL12 = 31;
+    static constexpr size_t SR_VAL13 = 32;
+    static constexpr size_t SR_VAL14 = 33;
+    static constexpr size_t SR_VAL15 = 34;
+    static constexpr size_t SR_VAL41 = 35;
+    static constexpr size_t SR_VAL17 = 36;
+    static constexpr size_t SR_VAL18 = 37;
+    static constexpr size_t SR_VAL19 = 38;
+    static constexpr size_t SR_VAL20 = 39;
+    static constexpr size_t SR_VAL21 = 40;
+    static constexpr size_t SR_VAL22 = 41;
+    static constexpr size_t SR_VAL23 = 42;
+    static constexpr size_t SR_VAL24 = 43;
 
     static std::string get_subrelation_label(size_t index)
     {
@@ -96,6 +96,8 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
             return "LAST";
         case SR_CTR_INCREMENT:
             return "CTR_INCREMENT";
+        case SR_SINGLE_TAG_ERROR_BOOLEAN:
+            return "SINGLE_TAG_ERROR_BOOLEAN";
         case SR_NO_TAG_ERROR_ON_WRITE:
             return "NO_TAG_ERROR_ON_WRITE";
         case SR_TAG_ERROR_INIT:
@@ -112,8 +114,6 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
             return "RW_PROPAGATION";
         case SR_SINGLE_TAG_ERROR:
             return "SINGLE_TAG_ERROR";
-        case SR_SINGLE_TAG_ERROR_BOOLEAN:
-            return "SINGLE_TAG_ERROR_BOOLEAN";
         case SR_VAL01:
             return "VAL01";
         case SR_VAL02:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory_impl.hpp
@@ -99,7 +99,7 @@ void keccak_memoryImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
              FF(1));
         std::get<10>(evals) += (tmp * scaling_factor);
     }
-    {
+    { // SINGLE_TAG_ERROR_BOOLEAN
         using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::keccak_memory_single_tag_error)) *
                    (FF(1) - static_cast<View>(in.get(C::keccak_memory_single_tag_error)));
@@ -164,186 +164,180 @@ void keccak_memoryImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                     static_cast<View>(in.get(C::keccak_memory_single_tag_error)));
         std::get<19>(evals) += (tmp * scaling_factor);
     }
-    { // SINGLE_TAG_ERROR_BOOLEAN
-        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::keccak_memory_single_tag_error)) *
-                   (FF(1) - static_cast<View>(in.get(C::keccak_memory_single_tag_error)));
-        std::get<20>(evals) += (tmp * scaling_factor);
-    }
     { // VAL01
-        using View = typename std::tuple_element_t<21, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_1_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_0__shift)));
-        std::get<21>(evals) += (tmp * scaling_factor);
+        std::get<20>(evals) += (tmp * scaling_factor);
     }
     { // VAL02
-        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<21, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_2_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_1__shift)));
-        std::get<22>(evals) += (tmp * scaling_factor);
+        std::get<21>(evals) += (tmp * scaling_factor);
     }
     { // VAL03
-        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<22, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_3_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_2__shift)));
-        std::get<23>(evals) += (tmp * scaling_factor);
+        std::get<22>(evals) += (tmp * scaling_factor);
     }
     { // VAL04
-        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<23, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_4_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_3__shift)));
-        std::get<24>(evals) += (tmp * scaling_factor);
+        std::get<23>(evals) += (tmp * scaling_factor);
     }
     { // VAL05
-        using View = typename std::tuple_element_t<25, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<24, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_5_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_4__shift)));
-        std::get<25>(evals) += (tmp * scaling_factor);
+        std::get<24>(evals) += (tmp * scaling_factor);
     }
     { // VAL06
-        using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<25, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_6_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_5__shift)));
-        std::get<26>(evals) += (tmp * scaling_factor);
+        std::get<25>(evals) += (tmp * scaling_factor);
     }
     { // VAL07
-        using View = typename std::tuple_element_t<27, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_7_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_6__shift)));
-        std::get<27>(evals) += (tmp * scaling_factor);
+        std::get<26>(evals) += (tmp * scaling_factor);
     }
     { // VAL8
-        using View = typename std::tuple_element_t<28, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<27, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_8_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_7__shift)));
-        std::get<28>(evals) += (tmp * scaling_factor);
+        std::get<27>(evals) += (tmp * scaling_factor);
     }
     { // VAL09
-        using View = typename std::tuple_element_t<29, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<28, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_9_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_8__shift)));
-        std::get<29>(evals) += (tmp * scaling_factor);
+        std::get<28>(evals) += (tmp * scaling_factor);
     }
     { // VAL10
-        using View = typename std::tuple_element_t<30, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<29, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_10_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_9__shift)));
-        std::get<30>(evals) += (tmp * scaling_factor);
+        std::get<29>(evals) += (tmp * scaling_factor);
     }
     { // VAL11
-        using View = typename std::tuple_element_t<31, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<30, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_11_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_10__shift)));
-        std::get<31>(evals) += (tmp * scaling_factor);
+        std::get<30>(evals) += (tmp * scaling_factor);
     }
     { // VAL12
-        using View = typename std::tuple_element_t<32, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<31, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_12_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_11__shift)));
-        std::get<32>(evals) += (tmp * scaling_factor);
+        std::get<31>(evals) += (tmp * scaling_factor);
     }
     { // VAL13
-        using View = typename std::tuple_element_t<33, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<32, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_13_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_12__shift)));
-        std::get<33>(evals) += (tmp * scaling_factor);
+        std::get<32>(evals) += (tmp * scaling_factor);
     }
     { // VAL14
-        using View = typename std::tuple_element_t<34, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<33, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_14_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_13__shift)));
-        std::get<34>(evals) += (tmp * scaling_factor);
+        std::get<33>(evals) += (tmp * scaling_factor);
     }
     { // VAL15
-        using View = typename std::tuple_element_t<35, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<34, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_15_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_14__shift)));
-        std::get<35>(evals) += (tmp * scaling_factor);
+        std::get<34>(evals) += (tmp * scaling_factor);
     }
     { // VAL41
-        using View = typename std::tuple_element_t<36, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<35, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_16_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_15__shift)));
-        std::get<36>(evals) += (tmp * scaling_factor);
+        std::get<35>(evals) += (tmp * scaling_factor);
     }
     { // VAL17
-        using View = typename std::tuple_element_t<37, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<36, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_17_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_16__shift)));
-        std::get<37>(evals) += (tmp * scaling_factor);
+        std::get<36>(evals) += (tmp * scaling_factor);
     }
     { // VAL18
-        using View = typename std::tuple_element_t<38, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<37, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_18_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_17__shift)));
-        std::get<38>(evals) += (tmp * scaling_factor);
+        std::get<37>(evals) += (tmp * scaling_factor);
     }
     { // VAL19
-        using View = typename std::tuple_element_t<39, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<38, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_19_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_18__shift)));
-        std::get<39>(evals) += (tmp * scaling_factor);
+        std::get<38>(evals) += (tmp * scaling_factor);
     }
     { // VAL20
-        using View = typename std::tuple_element_t<40, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<39, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_20_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_19__shift)));
-        std::get<40>(evals) += (tmp * scaling_factor);
+        std::get<39>(evals) += (tmp * scaling_factor);
     }
     { // VAL21
-        using View = typename std::tuple_element_t<41, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<40, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_21_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_20__shift)));
-        std::get<41>(evals) += (tmp * scaling_factor);
+        std::get<40>(evals) += (tmp * scaling_factor);
     }
     { // VAL22
-        using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<41, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_22_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_21__shift)));
-        std::get<42>(evals) += (tmp * scaling_factor);
+        std::get<41>(evals) += (tmp * scaling_factor);
     }
     { // VAL23
-        using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<42, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_23_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_22__shift)));
-        std::get<43>(evals) += (tmp * scaling_factor);
+        std::get<42>(evals) += (tmp * scaling_factor);
     }
     { // VAL24
-        using View = typename std::tuple_element_t<44, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<43, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_24_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *
                         static_cast<View>(in.get(C::keccak_memory_val_23__shift)));
-        std::get<44>(evals) += (tmp * scaling_factor);
+        std::get<43>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<45, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<44, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::keccak_memory_sel)) *
             (static_cast<View>(in.get(C::keccak_memory_num_rounds)) - CView(constants_AVM_KECCAKF1600_NUM_ROUNDS));
-        std::get<45>(evals) += (tmp * scaling_factor);
+        std::get<44>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/l1_to_l2_message_tree_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/l1_to_l2_message_tree_check.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class l1_to_l2_message_tree_checkImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 3> SUBRELATION_PARTIAL_LENGTHS = { 3, 5, 3 };
+    static constexpr std::array<size_t, 4> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 5, 3 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/l1_to_l2_message_tree_check_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/l1_to_l2_message_tree_check_impl.hpp
@@ -27,6 +27,12 @@ void l1_to_l2_message_tree_checkImpl<FF_>::accumulate(ContainerOverSubrelations&
     }
     {
         using View = typename std::tuple_element_t<1, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::l1_to_l2_message_tree_check_exists)) *
+                   (FF(1) - static_cast<View>(in.get(C::l1_to_l2_message_tree_check_exists)));
+        std::get<1>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<2, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::l1_to_l2_message_tree_check_sel)) *
                    ((CView(l1_to_l2_message_tree_check_LEAF_VALUE_MSG_HASH_DIFF) *
                          (static_cast<View>(in.get(C::l1_to_l2_message_tree_check_exists)) *
@@ -35,14 +41,14 @@ void l1_to_l2_message_tree_checkImpl<FF_>::accumulate(ContainerOverSubrelations&
                           static_cast<View>(in.get(C::l1_to_l2_message_tree_check_leaf_value_msg_hash_diff_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::l1_to_l2_message_tree_check_exists)));
-        std::get<1>(evals) += (tmp * scaling_factor);
+        std::get<2>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<2, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<3, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::l1_to_l2_message_tree_check_sel)) *
                    (CView(constants_L1_TO_L2_MSG_TREE_HEIGHT) -
                     static_cast<View>(in.get(C::l1_to_l2_message_tree_check_l1_to_l2_message_tree_height)));
-        std::get<2>(evals) += (tmp * scaling_factor);
+        std::get<3>(evals) += (tmp * scaling_factor);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/note_hash_tree_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/note_hash_tree_check.hpp
@@ -14,8 +14,8 @@ template <typename FF_> class note_hash_tree_checkImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 19> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 4, 3, 3,
-                                                                            4, 3, 3, 3, 5, 3, 3, 3, 3 };
+    static constexpr std::array<size_t, 20> SUBRELATION_PARTIAL_LENGTHS = { 3, 3, 3, 3, 3, 3, 3, 3, 4, 3,
+                                                                            3, 4, 3, 3, 3, 5, 3, 3, 3, 3 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -36,10 +36,10 @@ template <typename FF> class note_hash_tree_check : public Relation<note_hash_tr
     static constexpr const std::string_view NAME = "note_hash_tree_check";
 
     // Subrelation indices constants, to be used in tests.
-    static constexpr size_t SR_DISABLE_SILOING_ON_READ = 5;
-    static constexpr size_t SR_PASSTHROUGH_SILOING = 7;
-    static constexpr size_t SR_DISABLE_UNIQUENESS_ON_READ = 9;
-    static constexpr size_t SR_PASSTHROUGH_UNIQUENESS = 10;
+    static constexpr size_t SR_DISABLE_SILOING_ON_READ = 6;
+    static constexpr size_t SR_PASSTHROUGH_SILOING = 8;
+    static constexpr size_t SR_DISABLE_UNIQUENESS_ON_READ = 10;
+    static constexpr size_t SR_PASSTHROUGH_UNIQUENESS = 11;
 
     static std::string get_subrelation_label(size_t index)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/note_hash_tree_check_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/note_hash_tree_check_impl.hpp
@@ -39,84 +39,90 @@ void note_hash_tree_checkImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     {
         using View = typename std::tuple_element_t<2, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_silo)) *
-                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_silo)));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_exists)) *
+                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_exists)));
         std::get<2>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<3, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_unique)) *
-                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_unique)));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_silo)) *
+                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_silo)));
         std::get<3>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<4, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_write)) *
-                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_sel)));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_unique)) *
+                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_unique)));
         std::get<4>(evals) += (tmp * scaling_factor);
     }
-    { // DISABLE_SILOING_ON_READ
+    {
         using View = typename std::tuple_element_t<5, ContainerOverSubrelations>::View;
-        auto tmp = CView(note_hash_tree_check_READ) * static_cast<View>(in.get(C::note_hash_tree_check_should_silo));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_write)) *
+                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_sel)));
         std::get<5>(evals) += (tmp * scaling_factor);
     }
-    {
+    { // DISABLE_SILOING_ON_READ
         using View = typename std::tuple_element_t<6, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_silo)) *
-                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_unique)));
+        auto tmp = CView(note_hash_tree_check_READ) * static_cast<View>(in.get(C::note_hash_tree_check_should_silo));
         std::get<6>(evals) += (tmp * scaling_factor);
     }
-    { // PASSTHROUGH_SILOING
+    {
         using View = typename std::tuple_element_t<7, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_silo)) *
+                   (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_unique)));
+        std::get<7>(evals) += (tmp * scaling_factor);
+    }
+    { // PASSTHROUGH_SILOING
+        using View = typename std::tuple_element_t<8, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
                    (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_silo))) *
                    (static_cast<View>(in.get(C::note_hash_tree_check_note_hash)) -
                     static_cast<View>(in.get(C::note_hash_tree_check_siloed_note_hash)));
-        std::get<7>(evals) += (tmp * scaling_factor);
+        std::get<8>(evals) += (tmp * scaling_factor);
     }
     {
-        using View = typename std::tuple_element_t<8, ContainerOverSubrelations>::View;
+        using View = typename std::tuple_element_t<9, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
                    (CView(constants_DOM_SEP__SILOED_NOTE_HASH) -
                     static_cast<View>(in.get(C::note_hash_tree_check_siloing_separator)));
-        std::get<8>(evals) += (tmp * scaling_factor);
-    }
-    { // DISABLE_UNIQUENESS_ON_READ
-        using View = typename std::tuple_element_t<9, ContainerOverSubrelations>::View;
-        auto tmp = CView(note_hash_tree_check_READ) * static_cast<View>(in.get(C::note_hash_tree_check_should_unique));
         std::get<9>(evals) += (tmp * scaling_factor);
     }
-    { // PASSTHROUGH_UNIQUENESS
+    { // DISABLE_UNIQUENESS_ON_READ
         using View = typename std::tuple_element_t<10, ContainerOverSubrelations>::View;
+        auto tmp = CView(note_hash_tree_check_READ) * static_cast<View>(in.get(C::note_hash_tree_check_should_unique));
+        std::get<10>(evals) += (tmp * scaling_factor);
+    }
+    { // PASSTHROUGH_UNIQUENESS
+        using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
                    (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_should_unique))) *
                    (static_cast<View>(in.get(C::note_hash_tree_check_siloed_note_hash)) -
                     static_cast<View>(in.get(C::note_hash_tree_check_unique_note_hash)));
-        std::get<10>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
-                   (CView(constants_AVM_PUBLIC_INPUTS_PREVIOUS_NON_REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS_ROW_IDX) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_first_nullifier_pi_index)));
         std::get<11>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<12, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
-                   (CView(constants_DOM_SEP__NOTE_HASH_NONCE) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_nonce_separator)));
+                   (CView(constants_AVM_PUBLIC_INPUTS_PREVIOUS_NON_REVERTIBLE_ACCUMULATED_DATA_NULLIFIERS_ROW_IDX) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_first_nullifier_pi_index)));
         std::get<12>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<13, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
-                   (CView(constants_DOM_SEP__UNIQUE_NOTE_HASH) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_unique_note_hash_separator)));
+                   (CView(constants_DOM_SEP__NOTE_HASH_NONCE) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_nonce_separator)));
         std::get<13>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<14, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
+                   (CView(constants_DOM_SEP__UNIQUE_NOTE_HASH) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_unique_note_hash_separator)));
+        std::get<14>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<15, ContainerOverSubrelations>::View;
         auto tmp =
             static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
             ((CView(note_hash_tree_check_PREV_LEAF_VALUE_UNIQUE_NOTE_HASH_DIFF) *
@@ -126,36 +132,36 @@ void note_hash_tree_checkImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                    static_cast<View>(in.get(C::note_hash_tree_check_prev_leaf_value_unique_note_hash_diff_inv))) -
               FF(1)) +
              static_cast<View>(in.get(C::note_hash_tree_check_exists)));
-        std::get<14>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<15, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_write)) *
-                   (static_cast<View>(in.get(C::note_hash_tree_check_unique_note_hash)) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_next_leaf_value)));
         std::get<15>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<16, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
-                   (CView(constants_NOTE_HASH_TREE_HEIGHT) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_note_hash_tree_height)));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_write)) *
+                   (static_cast<View>(in.get(C::note_hash_tree_check_unique_note_hash)) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_next_leaf_value)));
         std::get<16>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<17, ContainerOverSubrelations>::View;
-        auto tmp = (static_cast<View>(in.get(C::note_hash_tree_check_write)) *
-                        (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_discard))) -
-                    static_cast<View>(in.get(C::note_hash_tree_check_should_write_to_public_inputs)));
+        auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_sel)) *
+                   (CView(constants_NOTE_HASH_TREE_HEIGHT) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_note_hash_tree_height)));
         std::get<17>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<18, ContainerOverSubrelations>::View;
+        auto tmp = (static_cast<View>(in.get(C::note_hash_tree_check_write)) *
+                        (FF(1) - static_cast<View>(in.get(C::note_hash_tree_check_discard))) -
+                    static_cast<View>(in.get(C::note_hash_tree_check_should_write_to_public_inputs)));
+        std::get<18>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<19, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::note_hash_tree_check_should_write_to_public_inputs)) *
                    ((CView(constants_AVM_PUBLIC_INPUTS_AVM_ACCUMULATED_DATA_NOTE_HASHES_ROW_IDX) +
                      static_cast<View>(in.get(C::note_hash_tree_check_note_hash_index))) -
                     static_cast<View>(in.get(C::note_hash_tree_check_public_inputs_index)));
-        std::get<18>(evals) += (tmp * scaling_factor);
+        std::get<19>(evals) += (tmp * scaling_factor);
     }
 }
 


### PR DESCRIPTION
And annotated some explicitly constrained booleans in these files while i was at it.

Also we had a duplicated boolean constraint in keccak_mem