### PR TITLE
fix!: context did not constrain returndata size to 0 at start, and had a misnamed relation

### DIFF
--- a/barretenberg/cpp/pil/vm2/context.pil
+++ b/barretenberg/cpp/pil/vm2/context.pil
@@ -224,7 +224,7 @@ namespace execution;
     #[CD_OFFSET_NEXT_ROW]
     NOT_LAST_EXEC * DEFAULT_CTX_ROW * (parent_calldata_addr' - parent_calldata_addr) = 0;
     NOT_LAST_EXEC * sel_enter_call  * (parent_calldata_addr' - rop[4]) = 0;
-    #[CD_SIZE_ENQUEUED_CALL_IS_ZERO]
+    #[CD_ADDR_ENQUEUED_CALL_IS_ZERO]
     enqueued_call_start * parent_calldata_addr = 0;
 
     // enqueued_call_start = 1 ==> parent_calldata_size is constrained in tx.pil (#[DISPATCH_EXEC_START])
@@ -261,7 +261,7 @@ namespace execution;
     #[NEXT_RD_SIZE_IS_ZERO]
     NOT_LAST_EXEC * (sel_enter_call + sel_error) * last_child_returndata_size' = 0;
     #[RD_SIZE_IS_ZERO]
-    enqueued_call_start * last_child_returndata_addr = 0;
+    enqueued_call_start * last_child_returndata_size = 0;
     #[PROPAGATE_RD_SIZE]
     NOT_LAST_EXEC * DEFAULT_CTX_ROW * (last_child_returndata_size' - last_child_returndata_size) = 0;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context.hpp
@@ -56,7 +56,7 @@ template <typename FF> class context : public Relation<contextImpl<FF>> {
     static constexpr size_t SR_IS_STATIC_IF_STATIC_CALL = 22;
     static constexpr size_t SR_IS_STATIC_IF_CALL_FROM_STATIC_CONTEXT = 23;
     static constexpr size_t SR_CD_OFFSET_NEXT_ROW = 24;
-    static constexpr size_t SR_CD_SIZE_ENQUEUED_CALL_IS_ZERO = 26;
+    static constexpr size_t SR_CD_ADDR_ENQUEUED_CALL_IS_ZERO = 26;
     static constexpr size_t SR_CD_SIZE_NEXT_ROW = 27;
     static constexpr size_t SR_RET_REV_RD_ADDR = 29;
     static constexpr size_t SR_NEXT_RD_ADDR_IS_ZERO = 30;
@@ -145,8 +145,8 @@ template <typename FF> class context : public Relation<contextImpl<FF>> {
             return "IS_STATIC_IF_CALL_FROM_STATIC_CONTEXT";
         case SR_CD_OFFSET_NEXT_ROW:
             return "CD_OFFSET_NEXT_ROW";
-        case SR_CD_SIZE_ENQUEUED_CALL_IS_ZERO:
-            return "CD_SIZE_ENQUEUED_CALL_IS_ZERO";
+        case SR_CD_ADDR_ENQUEUED_CALL_IS_ZERO:
+            return "CD_ADDR_ENQUEUED_CALL_IS_ZERO";
         case SR_CD_SIZE_NEXT_ROW:
             return "CD_SIZE_NEXT_ROW";
         case SR_RET_REV_RD_ADDR:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context_impl.hpp
@@ -214,7 +214,7 @@ void contextImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                     static_cast<View>(in.get(C::execution_rop_4_)));
         std::get<25>(evals) += (tmp * scaling_factor);
     }
-    { // CD_SIZE_ENQUEUED_CALL_IS_ZERO
+    { // CD_ADDR_ENQUEUED_CALL_IS_ZERO
         using View = typename std::tuple_element_t<26, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::execution_enqueued_call_start)) *
                    static_cast<View>(in.get(C::execution_parent_calldata_addr));
@@ -280,7 +280,7 @@ void contextImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     { // RD_SIZE_IS_ZERO
         using View = typename std::tuple_element_t<35, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::execution_enqueued_call_start)) *
-                   static_cast<View>(in.get(C::execution_last_child_returndata_addr));
+                   static_cast<View>(in.get(C::execution_last_child_returndata_size));
         std::get<35>(evals) += (tmp * scaling_factor);
     }
     { // PROPAGATE_RD_SIZE


### PR DESCRIPTION
due to typo where addr was constrained instead of size