### PR TITLE
refactor!: cleaning up `msg_sender` functions

### DIFF
--- a/boxes/boxes/vanilla/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/contracts/src/main.nr
@@ -36,10 +36,10 @@ pub contract PrivateVoting {
 
     #[external("private")]
     fn cast_vote(candidate: Field) {
-        let msg_sender_npk_m_hash = get_public_keys(self.msg_sender().unwrap()).npk_m.hash();
+        let msg_sender_npk_m_hash = get_public_keys(self.msg_sender()).npk_m.hash();
 
         let secret = self.context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
-        let nullifier = std::hash::pedersen_hash([self.msg_sender().unwrap().to_field(), secret]); // derive nullifier from sender and secret
+        let nullifier = std::hash::pedersen_hash([self.msg_sender().to_field(), secret]); // derive nullifier from sender and secret
         self.context.push_nullifier(nullifier);
         self.enqueue_self.add_to_tally_public(candidate);
     }
@@ -54,7 +54,7 @@ pub contract PrivateVoting {
 
     #[external("public")]
     fn end_vote() {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "Only admin can end votes"); // assert that caller is admin
+        assert(self.storage.admin.read().eq(self.msg_sender()), "Only admin can end votes"); // assert that caller is admin
         self.storage.vote_ended.write(true);
     }
 

--- a/docs/docs-developers/docs/foundational-topics/call_types.md
+++ b/docs/docs-developers/docs/foundational-topics/call_types.md
@@ -133,7 +133,7 @@ A common pattern is to enqueue public calls to check some validity condition on 
 #include_code enqueueing /noir-projects/noir-contracts/contracts/protocol/router_contract/src/utils.nr rust
 
 Note that this reveals what public function is being called on what contract, and perhaps more importantly which contract enqueued the call during private execution.
-For this reason we've created a canonical router contract which implements some of the checks commonly performed: this conceals the calling contract, as the `context.msg_sender()` in the public function will be the router itself (since it is the router that enqueues the public call).
+To prevent this you can enqueue a call to a public function using `self.enqueue_incognito` that behaves the same as `self.enqueue` but conceals the message sender.
 
 An example of how a deadline can be checked using the router contract follows:
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -69,6 +69,29 @@ The context methods for accessing fee information have been renamed:
 + let da_fee = context.min_fee_per_da_gas();
 ```
 
+### [Aztec.nr] Cleaning up message sender functions
+
+There has been a design decision made to have low-level API exposed on `self.context` and a nicer higher-level API exposed directly on `self`.
+Currently the `msg_sender` function on `self` was a copy of that same function on `self.context`.
+The `msg_sender` function on `self` got modified to return the message sender address directly instead of having it be wrapped in an `Option<...>`.
+In case the underlying message sender is none the function panics.
+
+You need to update your code to no longer trigger the unwrap on the return value:
+
+```diff
+- let message_sender: AztecAddress = self.msg_sender().unwrap();
++ let message_sender: AztecAddress = self.msg_sender();
+```
+
+If you want to handle the `null` case use the lower level API of context:
+
+```diff
+- let maybe_message_sender: Option<AztecAddress> = self.msg_sender();
++ let maybe_message_sender: Option<AztecAddress> = self.context.maybe_msg_sender();
+```
+
+The `self.context.msg_sender_unsafe` method has been dropped as its use can be replaced with the standard `self.context.maybe_msg_sender` function.
+
 ### [Aztec.nr] Renamed message delivery options
 
 The following terms have been renamed:

--- a/docs/examples/contracts/bob_token_contract/src/main.nr
+++ b/docs/examples/contracts/bob_token_contract/src/main.nr
@@ -35,7 +35,7 @@ pub contract BobToken {
     #[external("public")]
     fn setup() {
         // Giggle becomes the owner who can mint mental health tokens
-        self.storage.owner.write(self.msg_sender().unwrap());
+        self.storage.owner.write(self.msg_sender());
     }
     // docs:end:setup
 
@@ -43,7 +43,7 @@ pub contract BobToken {
     #[external("public")]
     fn mint_public(employee: AztecAddress, amount: u64) {
         // Only Giggle can mint tokens
-        assert_eq(self.msg_sender().unwrap(), self.storage.owner.read(), "Only Giggle can mint BOB tokens");
+        assert_eq(self.msg_sender(), self.storage.owner.read(), "Only Giggle can mint BOB tokens");
 
         // Add tokens to employee's public balance
         let current_balance = self.storage.public_balances.at(employee).read();
@@ -54,7 +54,7 @@ pub contract BobToken {
     // docs:start:transfer_public
     #[external("public")]
     fn transfer_public(to: AztecAddress, amount: u64) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
         let sender_balance = self.storage.public_balances.at(sender).read();
         assert(sender_balance >= amount, "Insufficient BOB tokens");
 
@@ -70,7 +70,7 @@ pub contract BobToken {
     // docs:start:transfer_ownership
     #[external("public")]
     fn transfer_ownership(new_owner: AztecAddress) {
-        assert_eq(self.msg_sender().unwrap(), self.storage.owner.read(), "Only current admin can transfer ownership");
+        assert_eq(self.msg_sender(), self.storage.owner.read(), "Only current admin can transfer ownership");
         self.storage.owner.write(new_owner);
     }
     // docs:end:transfer_ownership
@@ -78,7 +78,7 @@ pub contract BobToken {
     // docs:start:public_to_private
     #[external("private")]
     fn public_to_private(amount: u64) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
         // This will enqueue a public function to deduct from public balance
         self.enqueue_self._deduct_public_balance(sender, amount);
         // Add to private balance
@@ -102,7 +102,7 @@ pub contract BobToken {
     // docs:start:transfer_private
     #[external("private")]
     fn transfer_private(to: AztecAddress, amount: u64) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
         // Spend sender's notes (consumes existing notes)
         self.storage.private_balances.at(sender).sub(amount as u128).deliver(
             MessageDelivery.ONCHAIN_CONSTRAINED,
@@ -138,7 +138,7 @@ pub contract BobToken {
     #[external("private")]
     fn mint_private(employee: AztecAddress, amount: u64) {
         // Enqueue ownership check (will revert if not Giggle)
-        self.enqueue_self._assert_is_owner(self.msg_sender().unwrap());
+        self.enqueue_self._assert_is_owner(self.msg_sender());
 
         // If check passes, mint tokens privately
         self.storage.private_balances.at(employee).add(amount as u128).deliver(
@@ -151,7 +151,7 @@ pub contract BobToken {
     // docs:start:private_to_public
     #[external("private")]
     fn private_to_public(amount: u64) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
         // Remove from private balance
         self.storage.private_balances.at(sender).sub(amount as u128).deliver(
             MessageDelivery.ONCHAIN_CONSTRAINED,

--- a/docs/examples/contracts/nft/src/main.nr
+++ b/docs/examples/contracts/nft/src/main.nr
@@ -36,7 +36,7 @@ pub contract NFTPunk {
     // docs:start:set_minter
     #[external("public")]
     fn set_minter(minter: AztecAddress) {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "caller is not admin");
+        assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not admin");
         self.storage.minter.initialize(minter);
     }
     // docs:end:set_minter
@@ -53,7 +53,7 @@ pub contract NFTPunk {
     #[external("private")]
     fn mint(to: AztecAddress, token_id: Field) {
         assert(
-            self.storage.minter.read().eq(self.msg_sender().unwrap()),
+            self.storage.minter.read().eq(self.msg_sender()),
             "caller is not the authorized minter",
         );
 
@@ -78,7 +78,7 @@ pub contract NFTPunk {
     #[external("private")]
     fn burn(from: AztecAddress, token_id: Field) {
         assert(
-            self.storage.minter.read().eq(self.msg_sender().unwrap()),
+            self.storage.minter.read().eq(self.msg_sender()),
             "caller is not the authorized minter",
         );
 

--- a/docs/examples/contracts/nft_bridge/src/main.nr
+++ b/docs/examples/contracts/nft_bridge/src/main.nr
@@ -60,7 +60,7 @@ pub contract NFTBridge {
 
         // Burn the NFT on L2
         let nft: AztecAddress = self.storage.nft.read();
-        self.call(NFTPunk::at(nft).burn(self.context.msg_sender().unwrap(), token_id));
+        self.call(NFTPunk::at(nft).burn(self.msg_sender(), token_id));
     }
     // docs:end:exit
 }

--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -93,7 +93,7 @@ impl AccountActions<&mut PrivateContext> {
         // consume the message.
         // This ensures that contracts cannot consume messages that are not intended for them.
         let message_hash = compute_authwit_message_hash(
-            self.context.msg_sender().unwrap(),
+            self.context.maybe_msg_sender().unwrap(),
             self.context.chain_id(),
             self.context.version(),
             inner_hash,

--- a/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
@@ -261,7 +261,7 @@ pub fn assert_current_call_valid_authwit<let N: u32>(
     let args_hash: Field = context.get_args_hash();
 
     let authorization = CallAuthorization {
-        msg_sender: context.msg_sender().unwrap(),
+        msg_sender: context.maybe_msg_sender().unwrap(),
         selector: context.selector(),
         args_hash,
     };
@@ -318,7 +318,7 @@ pub unconstrained fn assert_current_call_valid_authwit_public(
     on_behalf_of: AztecAddress,
 ) {
     let inner_hash = compute_inner_authwit_hash([
-        context.msg_sender().unwrap().to_field(),
+        context.maybe_msg_sender().unwrap().to_field(),
         context.selector().to_field(),
         context.get_args_hash(),
     ]);

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -242,35 +242,22 @@ impl PrivateContext {
     ///
     /// This is similar to `msg.sender` in Solidity (hence the name).
     ///
-    /// Important Note: Since Aztec doesn't have a concept of an EoA (
-    /// Externally-owned Account), the msg_sender is "null" for the first
-    /// function call of every transaction.
-    /// The first function call of a tx is likely to be a call to the user's
-    /// account contract, so this quirk will most often be handled by account
-    /// contract developers.
+    /// Important Note: Since Aztec doesn't have a concept of an EoA (Externally-owned Account), the msg_sender is
+    /// "none" for the first function call of every transaction. The first function call of a tx is likely to be a call
+    /// to the user's account contract, so this quirk will most often be handled by account contract developers.
     ///
     /// # Returns
-    /// * `Option<AztecAddress>` - The address of the smart contract that called
-    ///   this function (be it an app contract or a user's account contract).
-    ///   Returns `Option<AztecAddress>::none` for the first function call of
-    ///   the tx. No other _private_ function calls in the tx will have a `none`
-    ///   msg_sender, but _public_ function calls might (see the PublicContext).
-    ///
-    pub fn msg_sender(self) -> Option<AztecAddress> {
+    /// * `Option<AztecAddress>` - The address of the smart contract that called this function (be it an app contract
+    ///   or a user's account contract). Returns `Option<AztecAddress>::none` for the first function call of the tx. No
+    ///   other _private_ function calls in the tx will have a `none` msg_sender, but _public_ function calls might
+    ///   (see the PublicContext).
+    pub fn maybe_msg_sender(self) -> Option<AztecAddress> {
         let maybe_msg_sender = self.inputs.call_context.msg_sender;
         if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
             Option::none()
         } else {
             Option::some(maybe_msg_sender)
         }
-    }
-
-    /// "Unsafe" versus calling `context.msg_sender()`, because it doesn't
-    /// translate `NULL_MSG_SENDER_CONTRACT_ADDRESS` as
-    /// `Option<AztecAddress>::none`.
-    /// Used by some internal aztecnr functions.
-    pub fn msg_sender_unsafe(self) -> AztecAddress {
-        self.inputs.call_context.msg_sender
     }
 
     /// Returns the contract address of the current function being executed.

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -448,40 +448,26 @@ impl PublicContext {
     ///
     /// This is similar to `msg.sender` in Solidity (hence the name).
     ///
-    /// Important Note: If the calling function is a _private_ function, then
-    /// it had the option of hiding its address when enqueuing this public
-    /// function call. In such cases, this `context.msg_sender()` method will
-    /// return `Option<AztecAddress>::none`.
-    /// If the calling function is a _public_ function, it will always return
-    /// an `Option<AztecAddress>::some` (i.e. a non-null value).
+    /// Important Note: If the calling function is a _private_ function, then it had the option of hiding its address
+    /// when enqueuing this public function call. In such cases, this method will return `Option<AztecAddress>::none`.
+    /// If the calling function is a _public_ function, it will always return an `Option<AztecAddress>::some` (i.e.
+    /// a non-null value).
     ///
     /// # Returns
-    /// * `Option<AztecAddress>` - The address of the smart contract that called
-    ///   this function (be it an app contract or a user's account contract).
+    /// * `Option<AztecAddress>` - The address of the smart contract that called this function (be it an app contract
+    ///   or a user's account contract).
     ///
     /// # Advanced
     /// * Value is provided by the AVM sender opcode
-    /// * In nested calls, this is the immediate caller, not the original
-    ///   transaction sender
+    /// * In nested calls, this is the immediate caller, not the original transaction sender
     ///
-    pub fn msg_sender(_self: Self) -> Option<AztecAddress> {
+    pub fn maybe_msg_sender(_self: Self) -> Option<AztecAddress> {
         // Safety: AVM opcodes are constrained by the AVM itself
         let maybe_msg_sender = unsafe { sender() };
         if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
             Option::none()
         } else {
             Option::some(maybe_msg_sender)
-        }
-    }
-
-    /// "Unsafe" versus calling `context.msg_sender()`, because it doesn't
-    /// translate `NULL_MSG_SENDER_CONTRACT_ADDRESS` as
-    /// `Option<AztecAddress>::none`.
-    /// Used by some internal aztecnr functions.
-    pub fn msg_sender_unsafe(_self: Self) -> AztecAddress {
-        // Safety: AVM opcodes are constrained by the AVM itself
-        unsafe {
-            sender()
         }
     }
 

--- a/noir-projects/aztec-nr/aztec/src/contract_self.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self.nr
@@ -11,11 +11,7 @@ use crate::{
         event_message::EventMessage,
     },
 };
-use protocol_types::{
-    address::AztecAddress,
-    constants::NULL_MSG_SENDER_CONTRACT_ADDRESS,
-    traits::{Deserialize, Serialize},
-};
+use protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}};
 
 /// `ContractSelf` is the core interface for interacting with an Aztec contract's own state and context.
 ///
@@ -38,7 +34,7 @@ use protocol_types::{
 /// #[external("private")]
 /// fn withdraw(amount: u128, recipient: AztecAddress) {
 ///     // Get the caller of this function
-///     let sender = self.msg_sender().unwrap();
+///     let sender = self.msg_sender();
 ///
 ///     // Access storage
 ///     let token = self.storage.donation_token.get_note().get_address();
@@ -164,19 +160,11 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// "null" for the first function call of every transaction. The first function call of a tx is likely to be a call
     /// to the user's account contract, so this quirk will most often be handled by account contract developers.
     ///
-    /// # Returns
-    /// * `Option<AztecAddress>` - The address of the smart contract that called this function (be it an app contract or
-    ///   a user's account contract). Returns `Option<AztecAddress>::none` for the first function call of the tx. No
-    ///   other _private_ function calls in the tx will have a `none` msg_sender, but _public_ function calls might (see
-    ///   the PublicContext).
-    ///
-    pub fn msg_sender(self) -> Option<AztecAddress> {
-        let maybe_msg_sender = self.context.msg_sender_unsafe();
-        if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
-            Option::none()
-        } else {
-            Option::some(maybe_msg_sender)
-        }
+    /// This function will panic if the msg_sender is "none". This could happen ony for the first function call of a tx.
+    /// No other _private_ function calls in the tx will have a `none` msg_sender, but _public_ function calls might
+    /// (see the PublicContext).
+    pub fn msg_sender(self) -> AztecAddress {
+        self.context.maybe_msg_sender().unwrap()
     }
 
     /// Emits an event privately.
@@ -193,7 +181,7 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///
     /// #[external("private")]
     /// fn transfer(to: AztecAddress, amount: u128) {
-    ///     let from = self.msg_sender().unwrap();
+    ///     let from = self.msg_sender();
     ///
     ///     let message: EventMessage = self.emit(Transfer { from, to, amount });
     ///     message.deliver_to(from, MessageDelivery.OFFCHAIN);
@@ -361,8 +349,8 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// target public function.
     /// This means the origin of the call (msg_sender) will not be publicly
     /// visible to any blockchain observers, nor to the target public function.
-    /// When the target public function reads `context.msg_sender()` it will
-    /// receive an `Option<AztecAddress>::none`.
+    /// If the target public function reads `self.msg_sender()` the call will
+    /// revert.
     ///
     /// NOTES:
     /// - Not all public functions will accept a msg_sender of "none". Many
@@ -501,31 +489,15 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
         }
     }
 
-    /// Returns the contract address that initiated this function call.
-    ///
-    /// This is similar to `msg.sender` in Solidity (hence the name).
+    /// Returns the contract address that initiated this function call. This is similar to `msg.sender` in Solidity
+    /// (hence the name).
     ///
     /// Important Note: If the calling function is a _private_ function, then it had the option of hiding its address
-    /// when enqueuing this public function call. In such cases, this `context.msg_sender()` method will return
-    /// `Option<AztecAddress>::none`. If the calling function is a _public_ function, it will always return an
-    /// `Option<AztecAddress>::some` (i.e. a non-null value).
-    ///
-    /// # Returns
-    /// * `Option<AztecAddress>` - The address of the smart contract that called this function (be it an app contract or
-    ///   a user's account contract).
-    ///
-    /// # Advanced
-    /// * Value is provided by the AVM sender opcode
-    /// * In nested calls, this is the immediate caller, not the original transaction sender
-    ///
-    pub fn msg_sender(self: Self) -> Option<AztecAddress> {
-        // Safety: AVM opcodes are constrained by the AVM itself
-        let maybe_msg_sender = self.context.msg_sender_unsafe();
-        if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
-            Option::none()
-        } else {
-            Option::some(maybe_msg_sender)
-        }
+    /// when enqueuing this public function call. In such cases, call to this method will panic. If you want to
+    /// explicitly handle this case, you can use our low-level API exposed on `context` where the `msg_sender` method
+    /// returns an `Option<AztecAddress>` (e.g. `let msg_sender: Option<AztecAddress> = self.context.msg_sender();`).
+    pub fn msg_sender(self: Self) -> AztecAddress {
+        self.context.maybe_msg_sender().unwrap()
     }
 
     /// Emits an event publicly.

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
@@ -54,7 +54,7 @@ pub fn assert_initialization_matches_address_preimage_public(context: PublicCont
     let expected_init = compute_initialization_hash(context.selector(), context.get_args_hash());
     assert(initialization_hash == expected_init, "Initialization hash does not match");
     assert(
-        (deployer.is_zero()) | (deployer == context.msg_sender().unwrap()),
+        (deployer.is_zero()) | (deployer == context.maybe_msg_sender().unwrap()),
         "Initializer address is not the contract deployer",
     );
 }
@@ -66,7 +66,7 @@ pub fn assert_initialization_matches_address_preimage_private(context: PrivateCo
     let expected_init = compute_initialization_hash(context.selector(), context.get_args_hash());
     assert(instance.initialization_hash == expected_init, "Initialization hash does not match");
     assert(
-        (instance.deployer.is_zero()) | (instance.deployer == context.msg_sender().unwrap()),
+        (instance.deployer.is_zero()) | (instance.deployer == context.maybe_msg_sender().unwrap()),
         "Initializer address is not the contract deployer",
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/helpers.nr
@@ -27,7 +27,7 @@ pub(crate) comptime fn get_abi_relevant_attributes(f: FunctionDefinition) -> Quo
 
 /// Injects an authwit verification check of the form:
 /// ```
-///   if (!from.eq(context.msg_sender().unwrap())) {
+///   if (!from.eq(context.maybe_msg_sender().unwrap())) {
 ///         assert_current_call_valid_authwit::<N>(&mut context, from);
 ///     } else {
 ///         assert(authwit_nonce, "Invalid authwit nonce. When 'from' and 'msg_sender' are the same, authwit_nonce must be zero");
@@ -104,7 +104,7 @@ pub(crate) comptime fn create_authorize_once_check(
         .as_ctstring()
         .as_quoted_str();
     quote {         
-        if (!$from_arg_name_quoted.eq(self.msg_sender().unwrap())) {
+        if (!$from_arg_name_quoted.eq(self.msg_sender())) {
             $fn_call(self.context, $from_arg_name_quoted);
         } else {
             assert($nonce_check_quote, $invalid_nonce_message);

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -70,7 +70,7 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
     let internal_check = if is_fn_only_self(f) {
         let assertion_message =
             f"Function {original_function_name} can only be called by the same contract";
-        quote { assert(self.msg_sender().unwrap() == self.address, $assertion_message); }
+        quote { assert(self.msg_sender() == self.address, $assertion_message); }
     } else {
         quote {}
     };

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
@@ -67,7 +67,7 @@ pub(crate) comptime fn generate_public_external(f: FunctionDefinition) -> Quoted
     let internal_check = if is_fn_only_self(f) {
         let assertion_message =
             f"Function {original_function_name} can only be called by the same contract";
-        quote { assert(self.msg_sender().unwrap() == self.address, $assertion_message); }
+        quote { assert(self.msg_sender() == self.address, $assertion_message); }
     } else {
         quote {}
     };

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
@@ -35,7 +35,7 @@ mod test;
 ///
 /// #[external("private")]
 /// fn cast_vote(election_id: ElectionId, candidate: Field) {
-///     let voter = self.msg_sender().unwrap();
+///     let voter = self.msg_sender();
 ///
 ///     // `claim` will only succeed if `voter` hasn't already claimed for this `election_id` before.
 ///     self.storage.vote_claims.at(election_id).at(voter).claim();

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -99,7 +99,7 @@ pub contract AMM {
         let token1 = Token::at(config.token1);
         let liquidity_token = Token::at(config.liquidity_token);
 
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         // We don't yet know how many tokens the sender will actually supply - that can only be computed during public
         // execution since the amounts supplied must have the same ratio as the live balances. We therefore transfer the
@@ -248,7 +248,7 @@ pub contract AMM {
         let token0 = Token::at(config.token0);
         let token1 = Token::at(config.token1);
 
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         // Liquidity tokens are burned when liquidity is removed in order to reduce the total supply. However, we lack
         // a function to privately burn, so we instead transfer the tokens into the AMM's public balance, and then have
@@ -327,7 +327,7 @@ pub contract AMM {
         assert((token_out == config.token0) | (token_out == config.token1), "TOKEN_OUT_IS_INVALID");
         assert(token_in != token_out, "SAME_TOKEN_SWAP");
 
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         // We transfer the full amount in, since it is an exact amount, and prepare a partial note for the amount out,
         // which will only be known during public execution as it depends on the live balances.
@@ -396,7 +396,7 @@ pub contract AMM {
         assert((token_out == config.token0) | (token_out == config.token1), "TOKEN_OUT_IS_INVALID");
         assert(token_in != token_out, "SAME_TOKEN_SWAP");
 
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         // We don't know how many tokens we'll receive from the user, since the swap amount will only be known during
         // public execution as it depends on the live balances. We therefore transfer the full maximum amount and

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -142,7 +142,7 @@ pub contract AppSubscription {
         let config = self.storage.config.read();
 
         self.call(Token::at(config.subscription_token_address).transfer_in_private(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             config.subscription_recipient_address,
             config.subscription_price,
             authwit_nonce,

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -31,7 +31,7 @@ pub contract Auth {
 
     #[external("public")]
     fn set_authorized(authorized: AztecAddress) {
-        assert_eq(self.storage.admin.read(), self.msg_sender().unwrap(), "caller is not admin");
+        assert_eq(self.storage.admin.read(), self.msg_sender(), "caller is not admin");
         self.storage.authorized.schedule_value_change(authorized);
     }
 
@@ -67,7 +67,7 @@ pub contract Auth {
         // the DelayedPublicMutable, which is as far as the circuit can guarantee the value will not change from some
         // historical value (due to CHANGE_AUTHORIZED_DELAY).
         let authorized = self.storage.authorized.get_current_value();
-        assert_eq(authorized, self.msg_sender().unwrap(), "caller is not authorized");
+        assert_eq(authorized, self.msg_sender(), "caller is not authorized");
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
@@ -27,7 +27,7 @@ pub contract CardGame {
     fn buy_pack(
         seed: Field, // The randomness used to generate the cards. Passed in for now.
     ) {
-        let buyer = self.msg_sender().unwrap();
+        let buyer = self.msg_sender();
         let mut cards = get_pack_cards(seed, buyer, self.context);
 
         let mut collection = self.storage.collections;
@@ -38,7 +38,7 @@ pub contract CardGame {
     fn join_game(game: u32, cards_fields: [Field; 2]) {
         let cards = cards_fields.map(|card_field| Card::from_field(card_field));
 
-        let player = self.msg_sender().unwrap();
+        let player = self.msg_sender();
 
         let mut collection = self.storage.collections;
         collection.remove_cards(cards, player);
@@ -73,7 +73,7 @@ pub contract CardGame {
 
     #[external("private")]
     fn play_card(game: u32, card: Card) {
-        let player = self.msg_sender().unwrap();
+        let player = self.msg_sender();
 
         let mut game_deck = self.storage.game_decks.at(game as Field);
         game_deck.remove_cards([card], player);
@@ -98,7 +98,7 @@ pub contract CardGame {
 
     #[external("private")]
     fn claim_cards(game: u32, cards_fields: [Field; PLAYABLE_CARDS]) {
-        let player = self.msg_sender().unwrap();
+        let player = self.msg_sender();
         let cards = cards_fields.map(|card_field| Card::from_field(card_field));
 
         let mut collection = self.storage.collections;

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -44,7 +44,7 @@ pub contract Claim {
 
         // 2) Check that the note is owned by the msg_sender
         assert(
-            proof_retrieved_note.owner == self.msg_sender().unwrap(),
+            proof_retrieved_note.owner == self.msg_sender(),
             "Note is not owned by the msg_sender",
         );
 

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -53,7 +53,7 @@ pub contract Crowdfunding {
         // docs:end:call-check-deadline
 
         // 2) Transfer the donation tokens from donor to this contract
-        let donor = self.msg_sender().unwrap();
+        let donor = self.msg_sender();
         Token::at(config.donation_token).transfer_in_private(donor, self.address, amount, 0).call(
             self.context,
         );
@@ -76,7 +76,7 @@ pub contract Crowdfunding {
         let operator_address = config.operator;
 
         // 1) Check that msg_sender() is the operator
-        assert(self.msg_sender().unwrap() == operator_address, "Not an operator");
+        assert(self.msg_sender() == operator_address, "Not an operator");
 
         // 2) Transfer the donation tokens from this contract to the operator
         self.call(Token::at(config.donation_token).transfer(operator_address, amount));

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -29,7 +29,7 @@ pub contract Escrow {
     // Withdraws balance. Requires that msg.sender is the owner.
     #[external("private")]
     fn withdraw(token: AztecAddress, amount: u128, recipient: AztecAddress) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         let note = self.storage.owner.get_note();
         assert(note.address == sender);

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
@@ -108,8 +108,7 @@ pub contract Lending {
         on_behalf_of: Field,
         collateral_asset: AztecAddress,
     ) {
-        let on_behalf_of =
-            compute_identifier(secret, on_behalf_of, self.msg_sender().unwrap().to_field());
+        let on_behalf_of = compute_identifier(secret, on_behalf_of, self.msg_sender().to_field());
         let _res = self.call(Token::at(collateral_asset).transfer_to_public(
             from,
             self.address,
@@ -129,7 +128,7 @@ pub contract Lending {
         collateral_asset: AztecAddress,
     ) {
         let _ = self.call(Token::at(collateral_asset).transfer_in_public(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             self.address,
             amount,
             authwit_nonce,
@@ -156,13 +155,13 @@ pub contract Lending {
 
     #[external("private")]
     fn withdraw_private(secret: Field, to: AztecAddress, amount: u128) {
-        let on_behalf_of = compute_identifier(secret, 0, self.msg_sender().unwrap().to_field());
+        let on_behalf_of = compute_identifier(secret, 0, self.msg_sender().to_field());
         self.enqueue_self._withdraw(AztecAddress::from_field(on_behalf_of), to, amount);
     }
 
     #[external("public")]
     fn withdraw_public(to: AztecAddress, amount: u128) {
-        let _ = self.call_self._withdraw(self.msg_sender().unwrap(), to, amount);
+        let _ = self.call_self._withdraw(self.msg_sender(), to, amount);
     }
 
     #[external("public")]
@@ -204,13 +203,13 @@ pub contract Lending {
 
     #[external("private")]
     fn borrow_private(secret: Field, to: AztecAddress, amount: u128) {
-        let on_behalf_of = compute_identifier(secret, 0, self.msg_sender().unwrap().to_field());
+        let on_behalf_of = compute_identifier(secret, 0, self.msg_sender().to_field());
         self.enqueue_self._borrow(AztecAddress::from_field(on_behalf_of), to, amount);
     }
 
     #[external("public")]
     fn borrow_public(to: AztecAddress, amount: u128) {
-        let _ = self.call_self._borrow(self.msg_sender().unwrap(), to, amount);
+        let _ = self.call_self._borrow(self.msg_sender(), to, amount);
     }
 
     #[external("public")]
@@ -245,8 +244,7 @@ pub contract Lending {
         on_behalf_of: Field,
         stable_coin: AztecAddress,
     ) {
-        let on_behalf_of =
-            compute_identifier(secret, on_behalf_of, self.msg_sender().unwrap().to_field());
+        let on_behalf_of = compute_identifier(secret, on_behalf_of, self.msg_sender().to_field());
         // docs:start:private_call
         let _ = self.call(Token::at(stable_coin).burn_private(from, amount, authwit_nonce));
         // docs:end:private_call
@@ -260,11 +258,8 @@ pub contract Lending {
         owner: AztecAddress,
         stable_coin: AztecAddress,
     ) {
-        let _ = self.call(Token::at(stable_coin).burn_public(
-            self.msg_sender().unwrap(),
-            amount,
-            authwit_nonce,
-        ));
+        let _ =
+            self.call(Token::at(stable_coin).burn_public(self.msg_sender(), amount, authwit_nonce));
         let _ = self.call_self._repay(owner, amount, stable_coin);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -71,14 +71,14 @@ pub contract NFT {
 
     #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "caller is not an admin");
+        assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not an admin");
         self.storage.admin.write(new_admin);
     }
 
     // docs:start:set_minter
     #[external("public")]
     fn set_minter(minter: AztecAddress, approve: bool) {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "caller is not an admin");
+        assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not an admin");
         self.storage.minters.at(minter).write(approve);
     }
     // docs:end:set_minter
@@ -86,10 +86,7 @@ pub contract NFT {
     #[external("public")]
     fn mint(to: AztecAddress, token_id: Field) {
         assert(token_id != 0, "zero token ID not supported");
-        assert(
-            self.storage.minters.at(self.msg_sender().unwrap()).read(),
-            "caller is not a minter",
-        );
+        assert(self.storage.minters.at(self.msg_sender()).read(), "caller is not a minter");
         assert(self.storage.nft_exists.at(token_id).read() == false, "token already exists");
 
         self.storage.nft_exists.at(token_id).write(true);
@@ -150,7 +147,7 @@ pub contract NFT {
     // Transfers token with `token_id` from public balance of message sender to a private balance of `to`.
     #[external("private")]
     fn transfer_to_private(to: AztecAddress, token_id: Field) {
-        let from = self.msg_sender().unwrap();
+        let from = self.msg_sender();
 
         // We prepare the private balance increase.
         let partial_note = self.internal._prepare_private_balance_increase(to);
@@ -175,7 +172,7 @@ pub contract NFT {
             self.storage.private_nfts.at(to).storage_slot,
             self.context,
             to,
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
         );
 
         partial_note
@@ -193,7 +190,7 @@ pub contract NFT {
     fn finalize_transfer_to_private(token_id: Field, partial_note: PartialNFTNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the account
         // `from` from whose account the token is being transferred.
-        let from_and_completer = self.msg_sender().unwrap();
+        let from_and_completer = self.msg_sender();
         self.internal._finalize_transfer_to_private(from_and_completer, token_id, partial_note);
     }
 
@@ -234,7 +231,7 @@ pub contract NFT {
      */
     #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
-        let on_behalf_of = self.msg_sender().unwrap();
+        let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
         self.context.push_nullifier(nullifier);
     }

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -81,7 +81,7 @@ pub contract Orderbook {
         // Create the order (this validates the input tokens and amounts).
         let order = Order::new(config, bid_amount, ask_amount, bid_token, ask_token);
 
-        let maker = self.msg_sender().unwrap();
+        let maker = self.msg_sender();
 
         // Transfer tokens from maker to the public balance of this contract.
         self.call(Token::at(bid_token).transfer_to_public(
@@ -123,7 +123,7 @@ pub contract Orderbook {
     fn fulfill_order(order_id: Field, authwit_nonce: Field) {
         let config = self.storage.config.read();
         let order = self.storage.orders.at(order_id).read();
-        let taker = self.msg_sender().unwrap();
+        let taker = self.msg_sender();
 
         // Determine which tokens are being exchanged based on bid_token_is_zero flag
         let (bid_token, ask_token) = config.get_tokens(order.bid_token_is_zero);

--- a/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
@@ -54,7 +54,7 @@ pub contract PrivateToken {
     fn mint(amount: u128, recipient: AztecAddress) {
         let replacement_note_message = self.storage.admin.get_note();
         let admin = replacement_note_message.get_note().address;
-        assert(admin == self.msg_sender().unwrap(), "Only admin can mint");
+        assert(admin == self.msg_sender(), "Only admin can mint");
 
         // We deliver the new note message to the admin using unconstrained delivery, since the admin is motivated to
         // deliver the message to themselves (hence no need to constrain it).
@@ -81,7 +81,7 @@ pub contract PrivateToken {
             .replace(
                 |old| {
                     assert(
-                        old.address == self.msg_sender().unwrap(),
+                        old.address == self.msg_sender(),
                         "Only admin can transfer admin privileges",
                     );
                     AddressNote { address: new_admin }

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
@@ -57,7 +57,7 @@ pub contract PrivateVoting {
 
     #[external("private")]
     fn cast_vote(election_id: ElectionId, candidate: Field) {
-        self.storage.vote_claims.at(election_id).at(self.msg_sender().unwrap()).claim();
+        self.storage.vote_claims.at(election_id).at(self.msg_sender()).claim();
         self.enqueue_self.add_to_tally_public(election_id, candidate);
     }
 
@@ -72,20 +72,14 @@ pub contract PrivateVoting {
 
     #[external("public")]
     fn start_vote(election_id: ElectionId) {
-        assert(
-            self.storage.admin.read().eq(self.msg_sender().unwrap()),
-            "Only admin can start votes",
-        ); // assert that caller is admin
+        assert(self.storage.admin.read().eq(self.msg_sender()), "Only admin can start votes"); // assert that caller is admin
         self.storage.vote_ended.at(election_id).write(false);
         self.storage.active_at_block.at(election_id).initialize(self.context.block_number());
     }
 
     #[external("public")]
     fn end_vote(election_id: ElectionId) {
-        assert(
-            self.storage.admin.read().eq(self.msg_sender().unwrap()),
-            "Only admin can end votes",
-        ); // assert that caller is admin
+        assert(self.storage.admin.read().eq(self.msg_sender()), "Only admin can end votes"); // assert that caller is admin
         self.storage.vote_ended.at(election_id).write(true);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -130,7 +130,7 @@ pub contract SimpleToken {
 
     #[external("private")]
     fn private_transfer(to: AztecAddress, amount: u128) {
-        let from = self.msg_sender().unwrap();
+        let from = self.msg_sender();
 
         let change = self.internal.subtract_balance(from, amount, INITIAL_TRANSFER_CALL_MAX_NOTES);
         self.storage.balances.at(from).add(change).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);
@@ -151,7 +151,7 @@ pub contract SimpleToken {
 
     #[external("private")]
     fn transfer_from_public_to_private(to: AztecAddress, amount: u128) {
-        let from = self.msg_sender().unwrap();
+        let from = self.msg_sender();
 
         let partial_note = self.internal._prepare_private_balance_increase(to);
         self.enqueue_self._finalize_transfer_to_private_unsafe(from, amount, partial_note);
@@ -169,7 +169,7 @@ pub contract SimpleToken {
             self.storage.balances.get_storage_slot(),
             self.context,
             to,
-            self.context.msg_sender().unwrap(),
+            self.msg_sender(),
         );
 
         partial_note
@@ -177,7 +177,7 @@ pub contract SimpleToken {
 
     #[external("public")]
     fn finalize_transfer_to_private(amount: u128, partial_note: PartialUintNote) {
-        let from_and_completer = self.msg_sender().unwrap();
+        let from_and_completer = self.msg_sender();
         self.internal._finalize_transfer_to_private(from_and_completer, amount, partial_note);
     }
 
@@ -208,16 +208,12 @@ pub contract SimpleToken {
     #[external("private")]
     fn mint_privately(from: AztecAddress, to: AztecAddress, amount: u128) {
         let partial_note = self.internal._prepare_private_balance_increase(to);
-        self.enqueue_self._finalize_mint_to_private_unsafe(
-            self.msg_sender().unwrap(),
-            amount,
-            partial_note,
-        );
+        self.enqueue_self._finalize_mint_to_private_unsafe(self.msg_sender(), amount, partial_note);
     }
 
     #[external("public")]
     fn finalize_mint_to_private(amount: u128, partial_note: PartialUintNote) {
-        self.internal._finalize_mint_to_private(self.msg_sender().unwrap(), amount, partial_note);
+        self.internal._finalize_mint_to_private(self.msg_sender(), amount, partial_note);
     }
 
     #[external("public")]
@@ -265,7 +261,7 @@ pub contract SimpleToken {
 
     #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
-        let on_behalf_of = self.msg_sender().unwrap();
+        let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
         self.context.push_nullifier(nullifier);
     }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -88,7 +88,7 @@ pub contract TokenBlacklist {
 
     #[external("public")]
     fn update_roles(user: AztecAddress, roles: UserFlags) {
-        let caller_roles = self.storage.roles.at(self.msg_sender().unwrap()).get_current_value();
+        let caller_roles = self.storage.roles.at(self.msg_sender()).get_current_value();
         assert(caller_roles.is_admin, "caller is not admin");
 
         self.storage.roles.at(user).schedule_value_change(roles);
@@ -99,7 +99,7 @@ pub contract TokenBlacklist {
         let to_roles = self.storage.roles.at(to).get_current_value();
         assert(!to_roles.is_blacklisted, "Blacklisted: Recipient");
 
-        let caller_roles = self.storage.roles.at(self.msg_sender().unwrap()).get_current_value();
+        let caller_roles = self.storage.roles.at(self.msg_sender()).get_current_value();
         assert(caller_roles.is_minter, "caller is not minter");
 
         let new_balance = self.storage.public_balances.at(to).read().add(amount);
@@ -111,7 +111,7 @@ pub contract TokenBlacklist {
 
     #[external("public")]
     fn mint_private(amount: u128, secret_hash: Field) {
-        let caller_roles = self.storage.roles.at(self.msg_sender().unwrap()).get_current_value();
+        let caller_roles = self.storage.roles.at(self.msg_sender()).get_current_value();
         assert(caller_roles.is_minter, "caller is not minter");
 
         let note = TransparentNote { amount, secret_hash };

--- a/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
@@ -88,11 +88,7 @@ pub contract TokenBridge {
         self.context.message_portal(config.portal, content);
 
         // Burn tokens
-        self.call(Token::at(config.token).burn_public(
-            self.msg_sender().unwrap(),
-            amount,
-            authwit_nonce,
-        ));
+        self.call(Token::at(config.token).burn_public(self.msg_sender(), amount, authwit_nonce));
     }
     // docs:end:exit_to_l1_public
 
@@ -142,7 +138,7 @@ pub contract TokenBridge {
         self.context.message_portal(config.portal, content);
 
         // Burn tokens
-        self.call(Token::at(token).burn_private(self.msg_sender().unwrap(), amount, authwit_nonce));
+        self.call(Token::at(token).burn_private(self.msg_sender(), amount, authwit_nonce));
     }
     // docs:end:exit_to_l1_private
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -80,7 +80,7 @@ pub contract Token {
 
     #[external("public")]
     fn set_admin(new_admin: AztecAddress) {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "caller is not admin");
+        assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not admin");
         self.storage.admin.write(new_admin);
     }
 
@@ -147,14 +147,14 @@ pub contract Token {
     // docs:start:set_minter
     #[external("public")]
     fn set_minter(minter: AztecAddress, approve: bool) {
-        assert(self.storage.admin.read().eq(self.msg_sender().unwrap()), "caller is not admin");
+        assert(self.storage.admin.read().eq(self.msg_sender()), "caller is not admin");
         self.storage.minters.at(minter).write(approve);
     }
     // docs:end:set_minter
 
     #[external("public")]
     fn mint_to_public(to: AztecAddress, amount: u128) {
-        assert(self.storage.minters.at(self.msg_sender().unwrap()).read(), "caller is not minter");
+        assert(self.storage.minters.at(self.msg_sender()).read(), "caller is not minter");
         let new_balance = self.storage.public_balances.at(to).read().add(amount);
         let supply = self.storage.total_supply.read().add(amount);
         self.storage.public_balances.at(to).write(new_balance);
@@ -229,7 +229,7 @@ pub contract Token {
 
     #[external("private")]
     fn transfer(to: AztecAddress, amount: u128) {
-        let from = self.msg_sender().unwrap();
+        let from = self.msg_sender();
 
         // We reduce `from`'s balance by amount by recursively removing notes over potentially multiple calls. This
         // method keeps the gate count for each individual call low - reading too many notes at once could result in
@@ -295,7 +295,7 @@ pub contract Token {
     // docs:start:cancel_authwit
     #[external("private")]
     fn cancel_authwit(inner_hash: Field) {
-        let on_behalf_of = self.msg_sender().unwrap();
+        let on_behalf_of = self.msg_sender();
         let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
         self.context.push_nullifier(nullifier);
     }
@@ -328,7 +328,7 @@ pub contract Token {
     #[external("private")]
     fn transfer_to_private(to: AztecAddress, amount: u128) {
         // `from` is the owner of the public balance from which we'll subtract the `amount`.
-        let from = self.msg_sender().unwrap();
+        let from = self.msg_sender();
 
         // We prepare the private balance increase (the partial note).
         let partial_note = self.internal._prepare_private_balance_increase(to);
@@ -358,7 +358,7 @@ pub contract Token {
             self.storage.balances.get_storage_slot(),
             self.context,
             to,
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
         );
 
         partial_note
@@ -377,7 +377,7 @@ pub contract Token {
     fn finalize_transfer_to_private(amount: u128, partial_note: PartialUintNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the account
         // `from` from whose balance we're subtracting the `amount`.
-        let from_and_completer = self.msg_sender().unwrap();
+        let from_and_completer = self.msg_sender();
         self.internal._finalize_transfer_to_private(from_and_completer, amount, partial_note);
     }
 
@@ -400,7 +400,7 @@ pub contract Token {
         // First we subtract the `amount` from the private balance of `from`
         self.storage.balances.at(from).sub(amount).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 
-        partial_note.complete_from_private(self.context, self.msg_sender().unwrap(), amount);
+        partial_note.complete_from_private(self.context, self.msg_sender(), amount);
     }
 
     /// This is a wrapper around `_finalize_transfer_to_private` placed here so that a call
@@ -447,11 +447,7 @@ pub contract Token {
         // At last we finalize the mint. Usage of the `unsafe` method here is safe because we set
         // the `minter_and_completer` function argument to a message sender, guaranteeing that only a message sender
         // with minter permissions can successfully execute the function.
-        self.enqueue_self._finalize_mint_to_private_unsafe(
-            self.msg_sender().unwrap(),
-            amount,
-            partial_note,
-        );
+        self.enqueue_self._finalize_mint_to_private_unsafe(self.msg_sender(), amount, partial_note);
     }
 
     /// Finalizes a mint of token `amount` to a private balance of `to`. The mint must be prepared by calling
@@ -465,7 +461,7 @@ pub contract Token {
     fn finalize_mint_to_private(amount: u128, partial_note: PartialUintNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the minter
         // account.
-        let minter_and_completer = self.msg_sender().unwrap();
+        let minter_and_completer = self.msg_sender();
         assert(self.storage.minters.at(minter_and_completer).read(), "caller is not minter");
 
         self.internal._finalize_mint_to_private(minter_and_completer, amount, partial_note);

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
@@ -57,7 +57,7 @@ pub contract Uniswap {
         // nonce for someone to call swap on sender's behalf
         _nonce_for_swap_approval: Field,
     ) {
-        if (!sender.eq(self.msg_sender().unwrap())) {
+        if (!sender.eq(self.msg_sender())) {
             assert_current_call_valid_authwit_public(self.context, sender);
         }
 
@@ -138,7 +138,7 @@ pub contract Uniswap {
 
         // Transfer funds to this contract
         self.call(Token::at(input_asset).transfer_to_public(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             self.address,
             input_amount,
             nonce_for_transfer_to_public_approval,

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -81,7 +81,7 @@ pub contract FPC {
     fn fee_entrypoint_private(max_fee: u128, authwit_nonce: Field) {
         let accepted_asset = self.storage.config.read().accepted_asset;
 
-        let user = self.msg_sender().unwrap();
+        let user = self.msg_sender();
         let token = Token::at(accepted_asset);
 
         // TODO(#10805): Here we should check that `max_fee` converted to fee juice is enough to cover the tx
@@ -161,7 +161,7 @@ pub contract FPC {
         // We pull the max fee from the user's balance of the accepted asset to this contract.
         // docs:start:public_call
         self.enqueue(Token::at(config.accepted_asset).transfer_in_public(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             self.address,
             max_fee,
             authwit_nonce,
@@ -169,7 +169,7 @@ pub contract FPC {
         // docs:end:public_call
 
         self.set_as_teardown(FPC::at(self.address)._pay_refund(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             max_fee,
             config.accepted_asset,
         ));
@@ -206,7 +206,7 @@ pub contract FPC {
     fn pull_funds(to: AztecAddress) {
         let config = self.storage.config.read();
 
-        assert(self.msg_sender().unwrap() == config.admin, "Only admin can pull funds");
+        assert(self.msg_sender() == config.admin, "Only admin can pull funds");
 
         let token = Token::at(config.accepted_asset);
 

--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
@@ -34,11 +34,7 @@ pub contract AuthRegistry {
      */
     #[external("public")]
     fn set_authorized(message_hash: Field, authorize: bool) {
-        // We use the unsafe method, because for some use cases a "null"
-        // msg_sender might be acceptable (e.g. if it doesn't matter who takes
-        // an action).
-        let msg_sender = self.context.msg_sender_unsafe();
-        self.storage.approved_actions.at(msg_sender).at(message_hash).write(authorize);
+        self.storage.approved_actions.at(self.msg_sender()).at(message_hash).write(authorize);
     }
 
     /**
@@ -50,7 +46,7 @@ pub contract AuthRegistry {
      */
     #[external("public")]
     fn set_reject_all(reject: bool) {
-        self.storage.reject_all.at(self.msg_sender().unwrap()).write(reject);
+        self.storage.reject_all.at(self.msg_sender()).write(reject);
     }
 
     /**
@@ -68,7 +64,7 @@ pub contract AuthRegistry {
         assert_eq(false, self.storage.reject_all.at(on_behalf_of).read(), "rejecting all");
 
         let message_hash = compute_authwit_message_hash(
-            self.context.msg_sender_unsafe(), // we allow "null" msg_sender.
+            self.msg_sender(),
             self.context.chain_id(),
             self.context.version(),
             inner_hash,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
@@ -111,7 +111,7 @@ pub contract ContractInstanceRegistry {
         let deployer = if universal_deploy {
             AztecAddress::zero()
         } else {
-            self.msg_sender().unwrap()
+            self.msg_sender()
         };
 
         let partial_address =
@@ -148,7 +148,7 @@ pub contract ContractInstanceRegistry {
 
     #[external("public")]
     fn update(new_contract_class_id: ContractClassId) {
-        let address = self.msg_sender().unwrap();
+        let address = self.msg_sender();
 
         // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
         // information through publishing, which is safe - we just need this information to be _eventually_ available.
@@ -187,7 +187,7 @@ pub contract ContractInstanceRegistry {
 
     #[external("public")]
     fn set_update_delay(new_update_delay: u64) {
-        let msg_sender = self.msg_sender().unwrap();
+        let msg_sender = self.msg_sender();
 
         // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
         // information through publishing, which is safe - we just need this information to be _eventually_ available.
@@ -204,6 +204,6 @@ pub contract ContractInstanceRegistry {
     #[external("public")]
     #[view]
     fn get_update_delay() -> u64 {
-        self.storage.updated_class_ids.at(self.msg_sender().unwrap()).get_current_delay()
+        self.storage.updated_class_ids.at(self.msg_sender()).get_current_delay()
     }
 }

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
@@ -77,10 +77,7 @@ pub contract FeeJuice {
     #[external("public")]
     #[view]
     fn check_balance(fee_limit: u128) {
-        assert(
-            self.storage.balances.at(self.msg_sender().unwrap()).read() >= fee_limit,
-            "Balance too low",
-        );
+        assert(self.storage.balances.at(self.msg_sender()).read() >= fee_limit, "Balance too low");
     }
 
     // utility function for testing

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -513,7 +513,7 @@ pub contract AvmTest {
 
     #[contract_library_method]
     fn _get_sender(context: PublicContext) -> AztecAddress {
-        context.msg_sender_unsafe()
+        context.maybe_msg_sender().unwrap()
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -16,7 +16,7 @@ contract EventOnly {
 
     #[external("private")]
     fn emit_event_for_msg_sender(value: Field) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
         self.emit(TestEvent { value }).deliver_to(sender, MessageDelivery.ONCHAIN_UNCONSTRAINED);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -28,7 +28,7 @@ pub contract NoConstructor {
     /// no constructor/initializer.
     #[external("private")]
     fn initialize_private_mutable(value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         let note = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(note).deliver(

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -23,7 +23,7 @@ pub contract NoteGetter {
 
     #[external("private")]
     fn insert_note(value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         let note = FieldNote { value };
 
         self.storage.set.at(owner).insert(note).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -50,10 +50,7 @@ contract OffchainEffect {
 
     #[external("private")]
     fn emit_event_as_offchain_message_for_msg_sender(a: u64, b: u64, c: u64) {
-        self.emit(TestEvent { a, b, c }).deliver_to(
-            self.msg_sender().unwrap(),
-            MessageDelivery.OFFCHAIN,
-        );
+        self.emit(TestEvent { a, b, c }).deliver_to(self.msg_sender(), MessageDelivery.OFFCHAIN);
     }
 
     #[external("private")]
@@ -61,7 +58,7 @@ contract OffchainEffect {
         let note = UintNote { value };
 
         self.storage.balances.at(owner).insert(note).deliver_to(
-            self.msg_sender().unwrap(),
+            self.msg_sender(),
             MessageDelivery.OFFCHAIN,
         );
     }

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -26,7 +26,7 @@ pub contract Spam {
 
     #[external("private")]
     fn spam(nullifier_seed: Field, nullifier_count: u32, call_public: bool) {
-        let caller = self.msg_sender().unwrap();
+        let caller = self.msg_sender();
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             self.storage.balances.at(caller).add(1).deliver(MessageDelivery.ONCHAIN_UNCONSTRAINED);

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -41,7 +41,7 @@ pub contract StateVars {
 
     #[external("public")]
     fn initialize_public_immutable(value: u8) {
-        let mut new_mock_struct = MockStruct { account: self.msg_sender().unwrap(), value };
+        let mut new_mock_struct = MockStruct { account: self.msg_sender(), value };
         self.storage.public_immutable.initialize(new_mock_struct);
     }
 
@@ -97,7 +97,7 @@ pub contract StateVars {
 
     #[external("private")]
     fn initialize_private_immutable(randomness: Field, value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         let new_note = FieldNote { value };
 
         self.storage.private_immutable.at(owner).initialize(new_note).deliver(
@@ -107,7 +107,7 @@ pub contract StateVars {
 
     #[external("private")]
     fn initialize_private(randomness: Field, value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         let private_mutable = FieldNote { value };
 
         self.storage.private_mutable.at(owner).initialize(private_mutable).deliver(
@@ -117,7 +117,7 @@ pub contract StateVars {
 
     #[external("private")]
     fn update_private_mutable(randomness: Field, value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         self.storage.private_mutable.at(owner).replace(|_old_note| FieldNote { value }).deliver(
             MessageDelivery.ONCHAIN_CONSTRAINED,
         );
@@ -125,7 +125,7 @@ pub contract StateVars {
 
     #[external("private")]
     fn increase_private_value() {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         // Replace existing note with new note containing incremented value
         self
             .storage

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -63,7 +63,7 @@ pub contract StatefulTest {
     #[external("private")]
     fn destroy_and_create(recipient: AztecAddress) {
         assert_is_initialized_private(self.context);
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         let _ = self.storage.notes.at(sender).pop_notes(NoteGetterOptions::new().set_limit(2));
 
@@ -75,7 +75,7 @@ pub contract StatefulTest {
     #[external("private")]
     #[noinitcheck]
     fn destroy_and_create_no_init_check(recipient: AztecAddress) {
-        let sender = self.msg_sender().unwrap();
+        let sender = self.msg_sender();
 
         let _ = self.storage.notes.at(sender).pop_notes(NoteGetterOptions::new().set_limit(2));
 

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -32,7 +32,7 @@ pub contract TestLog {
     fn emit_encrypted_events(other: AztecAddress, preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
-        self.emit(event0).deliver_to(self.msg_sender().unwrap(), MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.emit(event0).deliver_to(self.msg_sender(), MessageDelivery.ONCHAIN_CONSTRAINED);
 
         // We duplicate the emission, but swapping the sender and recipient:
         self.emit(event0).deliver_to(other, MessageDelivery.ONCHAIN_CONSTRAINED);
@@ -42,7 +42,7 @@ pub contract TestLog {
             value3: preimages[3] as u8,
         };
 
-        self.emit(event1).deliver_to(self.msg_sender().unwrap(), MessageDelivery.ONCHAIN_CONSTRAINED);
+        self.emit(event1).deliver_to(self.msg_sender(), MessageDelivery.ONCHAIN_CONSTRAINED);
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -24,7 +24,7 @@ contract Updatable {
     #[initializer]
     #[external("private")]
     fn initialize(initial_value: Field) {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
         let note = FieldNote { value: initial_value };
         self.storage.private_value.at(owner).initialize(note).deliver(
             MessageDelivery.ONCHAIN_CONSTRAINED,

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -27,7 +27,7 @@ contract Updated {
 
     #[external("private")]
     fn set_private_value() {
-        let owner = self.msg_sender().unwrap();
+        let owner = self.msg_sender();
 
         self.storage.private_value.at(owner).replace(|_old| FieldNote { value: 27 }).deliver(
             MessageDelivery.ONCHAIN_CONSTRAINED,

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -207,7 +207,7 @@ describe('e2e_crowdfunding_and_claim', () => {
     // docs:start:local-tx-fails
     await expect(
       claimContract.methods.claim(anotherDonationNote, donorAddress).send({ from: unrelatedAddress }).wait(),
-    ).rejects.toThrow('proof_retrieved_note.owner == self.msg_sender().unwrap()');
+    ).rejects.toThrow('proof_retrieved_note.owner == self.msg_sender()');
     // docs:end:local-tx-fails
   });
 


### PR DESCRIPTION
Until this PR the `msg_sender` function on `self` was a copy of that same function on `self.context`. The `msg_sender` function on `self` got modified to return the message sender address directly instead of having it be wrapped in an `Option<...>`. In case the underlying message sender is none the function panics. The `self.context.msg_sender_unsafe` method has been dropped as its use can be replaced with the standard `self.context.msg_sender` function.

This PR removed a lot of redundant calls to `unwrap()` which is a sign of this being a good idea.


Fixes https://linear.app/aztec-labs/issue/F-113/consider-what-to-do-with-copied-over-msg-sender-func-from-context-to