### PR TITLE
refactor(telemetry): co-locate metric names, descriptions, and units

### DIFF
--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -10,7 +10,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 export class ArchiverInstrumentation {
@@ -45,81 +44,33 @@ export class ArchiverInstrumentation {
     this.tracer = telemetry.getTracer('Archiver');
     const meter = telemetry.getMeter('Archiver');
 
-    this.blockHeight = meter.createGauge(Metrics.ARCHIVER_BLOCK_HEIGHT, {
-      description: 'The height of the latest block processed by the archiver',
-      valueType: ValueType.INT,
-    });
+    this.blockHeight = meter.createGauge(Metrics.ARCHIVER_BLOCK_HEIGHT);
 
-    this.l1BlockHeight = meter.createGauge(Metrics.ARCHIVER_L1_BLOCK_HEIGHT, {
-      description: 'The height of the latest L1 block processed by the archiver',
-      valueType: ValueType.INT,
-    });
+    this.l1BlockHeight = meter.createGauge(Metrics.ARCHIVER_L1_BLOCK_HEIGHT);
 
-    this.txCount = meter.createUpDownCounter(Metrics.ARCHIVER_TOTAL_TXS, {
-      description: 'The total number of transactions',
-      valueType: ValueType.INT,
-    });
+    this.txCount = meter.createUpDownCounter(Metrics.ARCHIVER_TOTAL_TXS);
 
-    this.proofsSubmittedCount = meter.createUpDownCounter(Metrics.ARCHIVER_ROLLUP_PROOF_COUNT, {
-      description: 'Number of proofs submitted',
-      valueType: ValueType.INT,
-    });
+    this.proofsSubmittedCount = meter.createUpDownCounter(Metrics.ARCHIVER_ROLLUP_PROOF_COUNT);
 
-    this.proofsSubmittedDelay = meter.createHistogram(Metrics.ARCHIVER_ROLLUP_PROOF_DELAY, {
-      unit: 'ms',
-      description: 'Time after a block is submitted until its proof is published',
-      valueType: ValueType.INT,
-    });
+    this.proofsSubmittedDelay = meter.createHistogram(Metrics.ARCHIVER_ROLLUP_PROOF_DELAY);
 
-    this.syncDurationPerBlock = meter.createHistogram(Metrics.ARCHIVER_SYNC_PER_BLOCK, {
-      unit: 'ms',
-      description: 'Duration to sync a block',
-      valueType: ValueType.INT,
-    });
+    this.syncDurationPerBlock = meter.createHistogram(Metrics.ARCHIVER_SYNC_PER_BLOCK);
 
-    this.syncBlockCount = meter.createUpDownCounter(Metrics.ARCHIVER_SYNC_BLOCK_COUNT, {
-      description: 'Number of blocks synced from L1',
-      valueType: ValueType.INT,
-    });
+    this.syncBlockCount = meter.createUpDownCounter(Metrics.ARCHIVER_SYNC_BLOCK_COUNT);
 
-    this.manaPerBlock = meter.createHistogram(Metrics.ARCHIVER_MANA_PER_BLOCK, {
-      description: 'The mana consumed by blocks',
-      valueType: ValueType.DOUBLE,
-      unit: 'Mmana',
-    });
+    this.manaPerBlock = meter.createHistogram(Metrics.ARCHIVER_MANA_PER_BLOCK);
 
-    this.txsPerBlock = meter.createHistogram(Metrics.ARCHIVER_TXS_PER_BLOCK, {
-      description: 'The block tx count',
-      valueType: ValueType.INT,
-      unit: 'tx',
-    });
+    this.txsPerBlock = meter.createHistogram(Metrics.ARCHIVER_TXS_PER_BLOCK);
 
-    this.syncDurationPerMessage = meter.createHistogram(Metrics.ARCHIVER_SYNC_PER_MESSAGE, {
-      unit: 'ms',
-      description: 'Duration to sync a message',
-      valueType: ValueType.INT,
-    });
+    this.syncDurationPerMessage = meter.createHistogram(Metrics.ARCHIVER_SYNC_PER_MESSAGE);
 
-    this.syncMessageCount = meter.createUpDownCounter(Metrics.ARCHIVER_SYNC_MESSAGE_COUNT, {
-      description: 'Number of L1 to L2 messages synced',
-      valueType: ValueType.INT,
-    });
+    this.syncMessageCount = meter.createUpDownCounter(Metrics.ARCHIVER_SYNC_MESSAGE_COUNT);
 
-    this.pruneDuration = meter.createHistogram(Metrics.ARCHIVER_PRUNE_DURATION, {
-      unit: 'ms',
-      description: 'Duration to sync a message',
-      valueType: ValueType.INT,
-    });
+    this.pruneDuration = meter.createHistogram(Metrics.ARCHIVER_PRUNE_DURATION);
 
-    this.pruneCount = meter.createUpDownCounter(Metrics.ARCHIVER_PRUNE_COUNT, {
-      description: 'Number of prunes detected',
-      valueType: ValueType.INT,
-    });
+    this.pruneCount = meter.createUpDownCounter(Metrics.ARCHIVER_PRUNE_COUNT);
 
-    this.blockProposalTxTargetCount = meter.createUpDownCounter(Metrics.ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT, {
-      description: 'Number of block proposals by tx target',
-      valueType: ValueType.INT,
-    });
+    this.blockProposalTxTargetCount = meter.createUpDownCounter(Metrics.ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT);
 
     this.dbMetrics = new LmdbMetrics(
       meter,

--- a/yarn-project/aztec-node/src/aztec-node/node_metrics.ts
+++ b/yarn-project/aztec-node/src/aztec-node/node_metrics.ts
@@ -1,11 +1,4 @@
-import {
-  Attributes,
-  type Histogram,
-  Metrics,
-  type TelemetryClient,
-  type UpDownCounter,
-  ValueType,
-} from '@aztec/telemetry-client';
+import { Attributes, type Histogram, Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
 
 export class NodeMetrics {
   private receiveTxCount: UpDownCounter;
@@ -16,23 +9,12 @@ export class NodeMetrics {
 
   constructor(client: TelemetryClient, name = 'AztecNode') {
     const meter = client.getMeter(name);
-    this.receiveTxCount = meter.createUpDownCounter(Metrics.NODE_RECEIVE_TX_COUNT, {});
-    this.receiveTxDuration = meter.createHistogram(Metrics.NODE_RECEIVE_TX_DURATION, {
-      description: 'The duration of the receiveTx method',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.receiveTxCount = meter.createUpDownCounter(Metrics.NODE_RECEIVE_TX_COUNT);
+    this.receiveTxDuration = meter.createHistogram(Metrics.NODE_RECEIVE_TX_DURATION);
 
-    this.snapshotDuration = meter.createHistogram(Metrics.NODE_SNAPSHOT_DURATION, {
-      description: 'How long taking a snapshot takes',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.snapshotDuration = meter.createHistogram(Metrics.NODE_SNAPSHOT_DURATION);
 
-    this.snapshotErrorCount = meter.createUpDownCounter(Metrics.NODE_SNAPSHOT_ERROR_COUNT, {
-      description: 'How many snapshot errors have happened',
-      valueType: ValueType.INT,
-    });
+    this.snapshotErrorCount = meter.createUpDownCounter(Metrics.NODE_SNAPSHOT_ERROR_COUNT);
 
     this.snapshotErrorCount.add(0);
   }

--- a/yarn-project/bb-prover/src/instrumentation.ts
+++ b/yarn-project/bb-prover/src/instrumentation.ts
@@ -7,7 +7,6 @@ import {
   Metrics,
   type TelemetryClient,
   type Tracer,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 /**
@@ -31,51 +30,21 @@ export class ProverInstrumentation {
     this.tracer = telemetry.getTracer(name);
     const meter = telemetry.getMeter(name);
 
-    this.simulationDuration = meter.createHistogram(Metrics.CIRCUIT_SIMULATION_DURATION, {
-      description: 'Records how long it takes to simulate a circuit',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.simulationDuration = meter.createHistogram(Metrics.CIRCUIT_SIMULATION_DURATION);
 
-    this.witGenDuration = meter.createHistogram(Metrics.CIRCUIT_WITNESS_GEN_DURATION, {
-      description: 'Records how long it takes to generate the partial witness for a circuit',
-      unit: 's',
-      valueType: ValueType.DOUBLE,
-    });
+    this.witGenDuration = meter.createHistogram(Metrics.CIRCUIT_WITNESS_GEN_DURATION);
 
-    this.provingDuration = meter.createHistogram(Metrics.CIRCUIT_PROVING_DURATION, {
-      unit: 's',
-      description: 'Records how long it takes to prove a circuit',
-      valueType: ValueType.DOUBLE,
-    });
+    this.provingDuration = meter.createHistogram(Metrics.CIRCUIT_PROVING_DURATION);
 
-    this.witGenInputSize = meter.createGauge(Metrics.CIRCUIT_WITNESS_GEN_INPUT_SIZE, {
-      unit: 'By',
-      description: 'Records the size of the input to the witness generation',
-      valueType: ValueType.INT,
-    });
+    this.witGenInputSize = meter.createGauge(Metrics.CIRCUIT_WITNESS_GEN_INPUT_SIZE);
 
-    this.witGenOutputSize = meter.createGauge(Metrics.CIRCUIT_WITNESS_GEN_OUTPUT_SIZE, {
-      unit: 'By',
-      description: 'Records the size of the output of the witness generation',
-      valueType: ValueType.INT,
-    });
+    this.witGenOutputSize = meter.createGauge(Metrics.CIRCUIT_WITNESS_GEN_OUTPUT_SIZE);
 
-    this.proofSize = meter.createGauge(Metrics.CIRCUIT_PROVING_PROOF_SIZE, {
-      unit: 'By',
-      description: 'Records the size of the proof generated for a circuit',
-      valueType: ValueType.INT,
-    });
+    this.proofSize = meter.createGauge(Metrics.CIRCUIT_PROVING_PROOF_SIZE);
 
-    this.circuitPublicInputCount = meter.createGauge(Metrics.CIRCUIT_PUBLIC_INPUTS_COUNT, {
-      description: 'Records the number of public inputs in a circuit',
-      valueType: ValueType.INT,
-    });
+    this.circuitPublicInputCount = meter.createGauge(Metrics.CIRCUIT_PUBLIC_INPUTS_COUNT);
 
-    this.circuitSize = meter.createGauge(Metrics.CIRCUIT_SIZE, {
-      description: 'Records the size of the circuit in gates',
-      valueType: ValueType.INT,
-    });
+    this.circuitSize = meter.createGauge(Metrics.CIRCUIT_SIZE);
   }
 
   /**

--- a/yarn-project/bb-prover/src/verifier/queued_chonk_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/queued_chonk_verifier.ts
@@ -10,7 +10,6 @@ import {
   type ObservableGauge,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
   getTelemetryClient,
 } from '@aztec/telemetry-client';
 
@@ -36,49 +35,18 @@ class IVCVerifierMetrics {
   constructor(client: TelemetryClient, name = 'QueuedIVCVerifier') {
     const meter = client.getMeter(name);
 
-    this.ivcVerificationHistogram = meter.createHistogram(Metrics.IVC_VERIFIER_TIME, {
-      unit: 'ms',
-      description: 'Duration to verify chonk proofs',
-      valueType: ValueType.INT,
-    });
+    this.ivcVerificationHistogram = meter.createHistogram(Metrics.IVC_VERIFIER_TIME);
 
-    this.ivcTotalVerificationHistogram = meter.createHistogram(Metrics.IVC_VERIFIER_TOTAL_TIME, {
-      unit: 'ms',
-      description: 'Total duration to verify chonk proofs, including serde',
-      valueType: ValueType.INT,
-    });
+    this.ivcTotalVerificationHistogram = meter.createHistogram(Metrics.IVC_VERIFIER_TOTAL_TIME);
 
-    this.ivcFailureCount = meter.createUpDownCounter(Metrics.IVC_VERIFIER_FAILURE_COUNT, {
-      description: 'Count of failed IVC proof verifications',
-      valueType: ValueType.INT,
-    });
+    this.ivcFailureCount = meter.createUpDownCounter(Metrics.IVC_VERIFIER_FAILURE_COUNT);
 
     this.aggDurationMetrics = {
-      avg: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_AVG, {
-        valueType: ValueType.DOUBLE,
-        description: 'AVG ivc verification',
-        unit: 'ms',
-      }),
-      max: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_MAX, {
-        valueType: ValueType.DOUBLE,
-        description: 'MAX ivc verification',
-        unit: 'ms',
-      }),
-      min: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_MIN, {
-        valueType: ValueType.DOUBLE,
-        description: 'MIN ivc verification',
-        unit: 'ms',
-      }),
-      p50: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_P50, {
-        valueType: ValueType.DOUBLE,
-        description: 'P50 ivc verification',
-        unit: 'ms',
-      }),
-      p90: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_P90, {
-        valueType: ValueType.DOUBLE,
-        description: 'P90 ivc verification',
-        unit: 'ms',
-      }),
+      avg: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_AVG),
+      max: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_MAX),
+      min: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_MIN),
+      p50: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_P50),
+      p90: meter.createObservableGauge(Metrics.IVC_VERIFIER_AGG_DURATION_P90),
     };
 
     meter.addBatchObservableCallback(this.aggregate, Object.values(this.aggDurationMetrics));

--- a/yarn-project/blob-client/src/archive/instrumentation.ts
+++ b/yarn-project/blob-client/src/archive/instrumentation.ts
@@ -1,4 +1,4 @@
-import { Attributes, Metrics, type TelemetryClient, type UpDownCounter, ValueType } from '@aztec/telemetry-client';
+import { Attributes, Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
 
 export class BlobArchiveClientInstrumentation {
   private blockRequestCounter: UpDownCounter;
@@ -11,20 +11,11 @@ export class BlobArchiveClientInstrumentation {
     name: string,
   ) {
     const meter = client.getMeter(name);
-    this.blockRequestCounter = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOCK_REQUEST_COUNT, {
-      description: 'Number of requests made to retrieve blocks from the blob archive',
-      valueType: ValueType.INT,
-    });
+    this.blockRequestCounter = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOCK_REQUEST_COUNT);
 
-    this.blobRequestCounter = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOB_REQUEST_COUNT, {
-      description: 'Number of requests made to retrieve blobs from the blob archive',
-      valueType: ValueType.INT,
-    });
+    this.blobRequestCounter = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOB_REQUEST_COUNT);
 
-    this.retrievedBlobs = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOB_COUNT, {
-      description: 'Number of blobs retrieved from the blob archive',
-      valueType: ValueType.INT,
-    });
+    this.retrievedBlobs = meter.createUpDownCounter(Metrics.BLOB_SINK_ARCHIVE_BLOB_COUNT);
   }
 
   incRequest(type: 'blocks' | 'blobs', status: number) {

--- a/yarn-project/end-to-end/src/bench/utils.ts
+++ b/yarn-project/end-to-end/src/bench/utils.ts
@@ -3,7 +3,7 @@ import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { BatchCall, type SentTx, type WaitOpts } from '@aztec/aztec.js/contracts';
 import { mean, stdDev, times } from '@aztec/foundation/collection';
 import { BenchmarkingContract } from '@aztec/noir-test-contracts.js/Benchmarking';
-import type { MetricsType } from '@aztec/telemetry-client';
+import type { MetricDefinition } from '@aztec/telemetry-client';
 import type { BenchmarkDataPoint, BenchmarkMetricsType, BenchmarkTelemetryClient } from '@aztec/telemetry-client/bench';
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -16,7 +16,7 @@ import { type EndToEndContext, type SetupOptions, setup } from '../fixtures/util
  */
 export async function benchmarkSetup(
   opts: Partial<SetupOptions> & {
-    /** What metrics to export */ metrics: (MetricsType | MetricFilter)[];
+    /** What metrics to export */ metrics: (MetricDefinition | MetricFilter)[];
     /** Where to output the benchmark data (defaults to BENCH_OUTPUT or bench.json) */
     benchOutput?: string;
   },
@@ -47,7 +47,7 @@ export async function benchmarkSetup(
 }
 
 type MetricFilter = {
-  source: MetricsType;
+  source: MetricDefinition;
   transform: (value: number) => number;
   name: string;
   unit?: string;
@@ -62,17 +62,21 @@ export type GithubActionBenchmarkResult = {
   extra?: string;
 };
 
+function isMetricDefinition(f: MetricDefinition | MetricFilter): f is MetricDefinition {
+  return 'description' in f;
+}
+
 function formatMetricsForGithubBenchmarkAction(
   data: BenchmarkMetricsType,
-  filter: (MetricsType | MetricFilter)[],
+  filter: (MetricDefinition | MetricFilter)[],
 ): GithubActionBenchmarkResult[] {
   const allFilters: MetricFilter[] = filter.map(f =>
-    typeof f === 'string' ? { name: f, source: f, transform: (x: number) => x, unit: undefined } : f,
+    isMetricDefinition(f) ? { name: f.name, source: f, transform: (x: number) => x, unit: f.unit } : f,
   );
   return data.flatMap(meter => {
     return meter.metrics
-      .filter(metric => allFilters.map(f => f.source).includes(metric.name as MetricsType))
-      .map(metric => [metric, allFilters.find(f => f.source === metric.name)!] as const)
+      .filter(metric => allFilters.map(f => f.source.name).includes(metric.name))
+      .map(metric => [metric, allFilters.find(f => f.source.name === metric.name)!] as const)
       .map(([metric, filter]) => ({
         name: `${meter.name}/${filter.name}`,
         unit: filter.unit ?? metric.unit ?? 'unknown',

--- a/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
+++ b/yarn-project/node-lib/src/metrics/l1_tx_metrics.ts
@@ -1,14 +1,7 @@
 import type { IL1TxMetrics, L1TxState } from '@aztec/ethereum/l1-tx-utils';
 import { TxUtilsState } from '@aztec/ethereum/l1-tx-utils';
 import { createLogger } from '@aztec/foundation/log';
-import {
-  Attributes,
-  type Histogram,
-  type Meter,
-  Metrics,
-  type UpDownCounter,
-  ValueType,
-} from '@aztec/telemetry-client';
+import { Attributes, type Histogram, type Meter, Metrics, type UpDownCounter } from '@aztec/telemetry-client';
 
 export type L1TxScope = 'sequencer' | 'prover' | 'other';
 
@@ -38,55 +31,23 @@ export class L1TxMetrics implements IL1TxMetrics {
     private scope: L1TxScope = 'other',
     private logger = createLogger('l1-tx-utils:metrics'),
   ) {
-    this.txMinedDuration = this.meter.createHistogram(Metrics.L1_TX_MINED_DURATION, {
-      description: 'Time from initial tx send until mined',
-      unit: 's',
-      valueType: ValueType.INT,
-    });
+    this.txMinedDuration = this.meter.createHistogram(Metrics.L1_TX_MINED_DURATION);
 
-    this.txAttemptsUntilMined = this.meter.createHistogram(Metrics.L1_TX_ATTEMPTS_UNTIL_MINED, {
-      description: 'Number of tx attempts (including speed-ups) until mined',
-      unit: 'attempts',
-      valueType: ValueType.INT,
-    });
+    this.txAttemptsUntilMined = this.meter.createHistogram(Metrics.L1_TX_ATTEMPTS_UNTIL_MINED);
 
-    this.txMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_MINED_COUNT, {
-      description: 'Count of transactions successfully mined',
-      valueType: ValueType.INT,
-    });
+    this.txMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_MINED_COUNT);
 
-    this.txRevertedCount = this.meter.createUpDownCounter(Metrics.L1_TX_REVERTED_COUNT, {
-      description: 'Count of transactions that reverted',
-      valueType: ValueType.INT,
-    });
+    this.txRevertedCount = this.meter.createUpDownCounter(Metrics.L1_TX_REVERTED_COUNT);
 
-    this.txCancelledCount = this.meter.createUpDownCounter(Metrics.L1_TX_CANCELLED_COUNT, {
-      description: 'Count of transactions cancelled',
-      valueType: ValueType.INT,
-    });
+    this.txCancelledCount = this.meter.createUpDownCounter(Metrics.L1_TX_CANCELLED_COUNT);
 
-    this.txNotMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_NOT_MINED_COUNT, {
-      description: 'Count of transactions not mined (timed out)',
-      valueType: ValueType.INT,
-    });
+    this.txNotMinedCount = this.meter.createUpDownCounter(Metrics.L1_TX_NOT_MINED_COUNT);
 
-    this.maxPriorityFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_PRIORITY_FEE, {
-      description: 'Max priority fee per gas at tx end state (in wei)',
-      unit: 'wei',
-      valueType: ValueType.INT,
-    });
+    this.maxPriorityFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_PRIORITY_FEE);
 
-    this.maxFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_FEE, {
-      description: 'Max fee per gas at tx end state (in wei)',
-      unit: 'wei',
-      valueType: ValueType.INT,
-    });
+    this.maxFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_MAX_FEE);
 
-    this.blobFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_BLOB_FEE, {
-      description: 'Max fee per blob gas at tx end state (in wei)',
-      unit: 'wei',
-      valueType: ValueType.INT,
-    });
+    this.blobFeeHistogram = this.meter.createHistogram(Metrics.L1_TX_BLOB_FEE);
   }
 
   /**

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_status_handshake.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_status_handshake.test.ts
@@ -161,12 +161,8 @@ describe('p2p client integration status handshake', () => {
     const c1PeerManager = (c1 as any).p2pService.peerManager;
     const realSend = c1PeerManager.reqresp.sendRequestToPeer;
 
-    // @ts-expect-error arguments not expected
-    jest.spyOn(c1PeerManager.reqresp, 'sendRequestToPeer').mockImplementation(async function (
-      peerId: PeerId,
-      protocol: ReqRespSubProtocol,
-      ...rest
-    ) {
+    jest.spyOn(c1PeerManager.reqresp, 'sendRequestToPeer').mockImplementation(async function (...args: unknown[]) {
+      const [peerId, protocol, ...rest] = args as [PeerId, ReqRespSubProtocol, ...unknown[]];
       if (peerId.toString() === badPeerId.toString() && protocol === ReqRespSubProtocol.STATUS) {
         return Promise.resolve({ status: ReqRespStatus.SUCCESS, data: Buffer.from('invalid status') });
       }

--- a/yarn-project/p2p/src/mem_pools/instrumentation.ts
+++ b/yarn-project/p2p/src/mem_pools/instrumentation.ts
@@ -7,8 +7,8 @@ import {
   LmdbMetrics,
   type LmdbStatsCallback,
   type Meter,
+  type MetricDefinition,
   Metrics,
-  type MetricsType,
   type ObservableGauge,
   type TelemetryClient,
   type UpDownCounter,
@@ -20,10 +20,10 @@ export enum PoolName {
 }
 
 type MetricsLabels = {
-  objectInMempool: MetricsType;
-  objectSize: MetricsType;
-  itemsAdded: MetricsType;
-  itemMinedDelay: MetricsType;
+  objectInMempool: MetricDefinition;
+  objectSize: MetricDefinition;
+  itemsAdded: MetricDefinition;
+  itemMinedDelay: MetricDefinition;
 };
 
 /**
@@ -85,14 +85,9 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
 
     const metricsLabels = getMetricsLabels(name);
 
-    this.objectsInMempool = this.meter.createObservableGauge(metricsLabels.objectInMempool, {
-      description: 'The current number of transactions in the mempool',
-    });
+    this.objectsInMempool = this.meter.createObservableGauge(metricsLabels.objectInMempool);
 
-    this.objectSize = this.meter.createHistogram(metricsLabels.objectSize, {
-      unit: 'By',
-      description: 'The size of transactions in the mempool',
-    });
+    this.objectSize = this.meter.createHistogram(metricsLabels.objectSize);
 
     this.dbMetrics = new LmdbMetrics(
       this.meter,
@@ -102,13 +97,9 @@ export class PoolInstrumentation<PoolObject extends Gossipable> {
       dbStats,
     );
 
-    this.addObjectCounter = this.meter.createUpDownCounter(metricsLabels.itemsAdded, {
-      description: 'The number of transactions added to the mempool',
-    });
+    this.addObjectCounter = this.meter.createUpDownCounter(metricsLabels.itemsAdded);
 
-    this.minedDelay = this.meter.createHistogram(metricsLabels.itemMinedDelay, {
-      description: 'Delay between transaction added and evicted from the mempool',
-    });
+    this.minedDelay = this.meter.createHistogram(metricsLabels.itemMinedDelay);
 
     this.meter.addBatchObservableCallback(this.observeStats, [this.objectsInMempool]);
   }

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -1,6 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { type BlockAttestation, PeerErrorSeverity } from '@aztec/stdlib/p2p';
-import { Attributes, Metrics, type TelemetryClient, ValueType } from '@aztec/telemetry-client';
+import { Attributes, Metrics, type TelemetryClient } from '@aztec/telemetry-client';
 
 import type { AttestationPool } from '../../mem_pools/attestation_pool/attestation_pool.js';
 import { AttestationValidator } from './attestation_validator.js';
@@ -25,10 +25,7 @@ export class FishermanAttestationValidator extends AttestationValidator {
     this.logger = this.logger.createChild('[FISHERMAN]');
 
     const meter = telemetryClient.getMeter('FishermanAttestationValidator');
-    this.invalidAttestationCounter = meter.createUpDownCounter(Metrics.VALIDATOR_INVALID_ATTESTATION_RECEIVED_COUNT, {
-      description: 'The number of invalid attestations received',
-      valueType: ValueType.INT,
-    });
+    this.invalidAttestationCounter = meter.createUpDownCounter(Metrics.VALIDATOR_INVALID_ATTESTATION_RECEIVED_COUNT);
   }
 
   override async validate(message: BlockAttestation): Promise<PeerErrorSeverity | undefined> {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
@@ -31,7 +31,9 @@ export class DataTxValidator implements TxValidator<Tx> {
     if (!tx.getTxHash().equals(expected)) {
       const reason = TX_ERROR_INCORRECT_HASH;
       this.#log.verbose(
-        `Rejecting tx ${tx.getTxHash().toString()}. Reason: ${reason}. Expected hash ${expected.toString()}. Got ${tx.getTxHash().toString()}.`,
+        `Rejecting tx ${tx.getTxHash().toString()}. Reason: ${reason}. Expected hash ${expected.toString()}. Got ${tx
+          .getTxHash()
+          .toString()}.`,
       );
       return reason;
     }
@@ -52,7 +54,9 @@ export class DataTxValidator implements TxValidator<Tx> {
     if (tx.getTotalPublicCalldataCount() > MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS) {
       const reason = TX_ERROR_CALLDATA_COUNT_TOO_LARGE;
       this.#log.verbose(
-        `Rejecting tx ${tx.getTxHash().toString()}. Reason: ${reason}. Expected no greater than ${MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS} fields. Got ${tx.getTotalPublicCalldataCount()}.`,
+        `Rejecting tx ${tx
+          .getTxHash()
+          .toString()}. Reason: ${reason}. Expected no greater than ${MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS} fields. Got ${tx.getTotalPublicCalldataCount()}.`,
       );
       return reason;
     }
@@ -89,7 +93,9 @@ export class DataTxValidator implements TxValidator<Tx> {
         if (expectedHashes.some(h => logHash.value.equals(h))) {
           const matchingLogIndex = expectedHashes.findIndex(l => logHash.value.equals(l));
           this.#log.verbose(
-            `Rejecting tx ${tx.getTxHash().toString()} because of mismatched contract class logs indices. Expected ${i} from the kernel's log hashes. Got ${matchingLogIndex} in the tx.`,
+            `Rejecting tx ${tx
+              .getTxHash()
+              .toString()} because of mismatched contract class logs indices. Expected ${i} from the kernel's log hashes. Got ${matchingLogIndex} in the tx.`,
           );
           return TX_ERROR_CONTRACT_CLASS_LOG_SORTING;
         } else {
@@ -105,7 +111,9 @@ export class DataTxValidator implements TxValidator<Tx> {
       const expectedMinLength = 1 + tx.contractClassLogFields[i].fields.findLastIndex(f => !f.isZero());
       if (logHash.logHash.length < expectedMinLength) {
         this.#log.verbose(
-          `Rejecting tx ${tx.getTxHash().toString()} because of incorrect contract class log length. Expected the length to be at least ${expectedMinLength}. Got ${
+          `Rejecting tx ${tx
+            .getTxHash()
+            .toString()} because of incorrect contract class log length. Expected the length to be at least ${expectedMinLength}. Got ${
             logHash.logHash.length
           }.`,
         );

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
@@ -43,7 +43,9 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
     // This gets implicitly tested in the proof validator, but we can get a much cheaper check here by looking early at the vk.
     if (!tx.data.constants.vkTreeRoot.equals(this.values.vkTreeRoot)) {
       this.#log.verbose(
-        `Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} because of incorrect vk tree root ${tx.data.constants.vkTreeRoot.toString()} != ${this.values.vkTreeRoot.toString()}`,
+        `Rejecting tx ${
+          'txHash' in tx ? tx.txHash : tx.hash
+        } because of incorrect vk tree root ${tx.data.constants.vkTreeRoot.toString()} != ${this.values.vkTreeRoot.toString()}`,
       );
       return false;
     } else {
@@ -54,7 +56,9 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
   #hasCorrectprotocolContractsHash(tx: T): boolean {
     if (!tx.data.constants.protocolContractsHash.equals(this.values.protocolContractsHash)) {
       this.#log.verbose(
-        `Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} because of incorrect protocol contracts hash ${tx.data.constants.protocolContractsHash.toString()} != ${this.values.protocolContractsHash.toString()}`,
+        `Rejecting tx ${
+          'txHash' in tx ? tx.txHash : tx.hash
+        } because of incorrect protocol contracts hash ${tx.data.constants.protocolContractsHash.toString()} != ${this.values.protocolContractsHash.toString()}`,
       );
       return false;
     }
@@ -64,7 +68,9 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
   #hasCorrectL1ChainId(tx: T): boolean {
     if (!tx.data.constants.txContext.chainId.equals(this.values.l1ChainId)) {
       this.#log.verbose(
-        `Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} because of incorrect L1 chain ${tx.data.constants.txContext.chainId.toNumber()} != ${this.values.l1ChainId.toNumber()}`,
+        `Rejecting tx ${
+          'txHash' in tx ? tx.txHash : tx.hash
+        } because of incorrect L1 chain ${tx.data.constants.txContext.chainId.toNumber()} != ${this.values.l1ChainId.toNumber()}`,
       );
       return false;
     } else {
@@ -75,7 +81,9 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
   #hasCorrectRollupVersion(tx: T): boolean {
     if (!tx.data.constants.txContext.version.equals(this.values.rollupVersion)) {
       this.#log.verbose(
-        `Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} because of incorrect rollup version ${tx.data.constants.txContext.version.toNumber()} != ${this.values.rollupVersion.toNumber()}`,
+        `Rejecting tx ${
+          'txHash' in tx ? tx.txHash : tx.hash
+        } because of incorrect rollup version ${tx.data.constants.txContext.version.toNumber()} != ${this.values.rollupVersion.toNumber()}`,
       );
       return false;
     } else {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
@@ -35,7 +35,9 @@ export class TimestampTxValidator<T extends AnyTx> implements TxValidator<T> {
         );
       }
       this.#log.verbose(
-        `Rejecting tx ${getTxHash(tx)} for low expiration timestamp. Tx expiration timestamp: ${includeByTimestamp}, timestamp: ${
+        `Rejecting tx ${getTxHash(
+          tx,
+        )} for low expiration timestamp. Tx expiration timestamp: ${includeByTimestamp}, timestamp: ${
           this.values.timestamp
         }.`,
       );

--- a/yarn-project/p2p/src/services/libp2p/instrumentation.ts
+++ b/yarn-project/p2p/src/services/libp2p/instrumentation.ts
@@ -8,7 +8,6 @@ import {
   type ObservableGauge,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import { type RecordableHistogram, createHistogram } from 'node:perf_hooks';
@@ -28,81 +27,28 @@ export class P2PInstrumentation {
   constructor(client: TelemetryClient, name: string) {
     const meter = client.getMeter(name);
 
-    this.messageValidationDuration = meter.createHistogram(Metrics.P2P_GOSSIP_MESSAGE_VALIDATION_DURATION, {
-      unit: 'ms',
-      description: 'How long validating a gossiped message takes',
-      valueType: ValueType.INT,
-    });
+    this.messageValidationDuration = meter.createHistogram(Metrics.P2P_GOSSIP_MESSAGE_VALIDATION_DURATION);
 
-    this.messagePrevalidationCount = meter.createUpDownCounter(Metrics.P2P_GOSSIP_MESSAGE_PREVALIDATION_COUNT, {
-      description: 'How many message pass/fail prevalidation',
-      valueType: ValueType.INT,
-    });
+    this.messagePrevalidationCount = meter.createUpDownCounter(Metrics.P2P_GOSSIP_MESSAGE_PREVALIDATION_COUNT);
 
-    this.messageLatency = meter.createHistogram(Metrics.P2P_GOSSIP_MESSAGE_LATENCY, {
-      unit: 'ms',
-      description: 'P2P message latency',
-      valueType: ValueType.INT,
-    });
+    this.messageLatency = meter.createHistogram(Metrics.P2P_GOSSIP_MESSAGE_LATENCY);
 
-    this.txReceivedCount = meter.createUpDownCounter(Metrics.P2P_GOSSIP_TX_RECEIVED_COUNT, {
-      description: 'The number of txs received from the p2p network',
-    });
+    this.txReceivedCount = meter.createUpDownCounter(Metrics.P2P_GOSSIP_TX_RECEIVED_COUNT);
 
     this.aggLatencyMetrics = {
-      avg: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_AVG, {
-        valueType: ValueType.DOUBLE,
-        description: 'AVG msg latency',
-        unit: 'ms',
-      }),
-      max: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_MAX, {
-        valueType: ValueType.DOUBLE,
-        description: 'MAX msg latency',
-        unit: 'ms',
-      }),
-      min: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_MIN, {
-        valueType: ValueType.DOUBLE,
-        description: 'MIN msg latency',
-        unit: 'ms',
-      }),
-      p50: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_P50, {
-        valueType: ValueType.DOUBLE,
-        description: 'P50 msg latency',
-        unit: 'ms',
-      }),
-      p90: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_P90, {
-        valueType: ValueType.DOUBLE,
-        description: 'P90 msg latency',
-        unit: 'ms',
-      }),
+      avg: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_AVG),
+      max: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_MAX),
+      min: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_MIN),
+      p50: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_P50),
+      p90: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_LATENCY_P90),
     };
 
     this.aggValidationMetrics = {
-      avg: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_AVG, {
-        valueType: ValueType.DOUBLE,
-        description: 'AVG msg validation',
-        unit: 'ms',
-      }),
-      max: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MAX, {
-        valueType: ValueType.DOUBLE,
-        description: 'MAX msg validation',
-        unit: 'ms',
-      }),
-      min: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MIN, {
-        valueType: ValueType.DOUBLE,
-        description: 'MIN msg validation',
-        unit: 'ms',
-      }),
-      p50: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P50, {
-        valueType: ValueType.DOUBLE,
-        description: 'P50 msg validation',
-        unit: 'ms',
-      }),
-      p90: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P90, {
-        valueType: ValueType.DOUBLE,
-        description: 'P90 msg validation',
-        unit: 'ms',
-      }),
+      avg: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_AVG),
+      max: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MAX),
+      min: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MIN),
+      p50: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P50),
+      p90: meter.createObservableGauge(Metrics.P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P90),
     };
 
     meter.addBatchObservableCallback(this.aggregate, [

--- a/yarn-project/p2p/src/services/peer-manager/metrics.ts
+++ b/yarn-project/p2p/src/services/peer-manager/metrics.ts
@@ -6,7 +6,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
   getTelemetryClient,
 } from '@aztec/telemetry-client';
 
@@ -32,31 +31,11 @@ export class PeerManagerMetrics {
     this.tracer = telemetryClient.getTracer(name);
 
     const meter = telemetryClient.getMeter(name);
-    this.sentGoodbyes = meter.createUpDownCounter(Metrics.PEER_MANAGER_GOODBYES_SENT, {
-      description: 'Number of goodbyes sent to peers',
-      unit: 'peers',
-      valueType: ValueType.INT,
-    });
-    this.receivedGoodbyes = meter.createUpDownCounter(Metrics.PEER_MANAGER_GOODBYES_RECEIVED, {
-      description: 'Number of goodbyes received from peers',
-      unit: 'peers',
-      valueType: ValueType.INT,
-    });
-    this.peerCount = meter.createGauge(Metrics.PEER_MANAGER_PEER_COUNT, {
-      description: 'Number of peers',
-      unit: 'peers',
-      valueType: ValueType.INT,
-    });
-    this.lowScoreDisconnects = meter.createUpDownCounter(Metrics.PEER_MANAGER_LOW_SCORE_DISCONNECTS, {
-      description: 'Number of peers disconnected due to low score',
-      unit: 'peers',
-      valueType: ValueType.INT,
-    });
-    this.peerConnectionDuration = meter.createHistogram(Metrics.PEER_MANAGER_PEER_CONNECTION_DURATION, {
-      description: 'Time duration between peer connection and disconnection',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.sentGoodbyes = meter.createUpDownCounter(Metrics.PEER_MANAGER_GOODBYES_SENT);
+    this.receivedGoodbyes = meter.createUpDownCounter(Metrics.PEER_MANAGER_GOODBYES_RECEIVED);
+    this.peerCount = meter.createGauge(Metrics.PEER_MANAGER_PEER_COUNT);
+    this.lowScoreDisconnects = meter.createUpDownCounter(Metrics.PEER_MANAGER_LOW_SCORE_DISCONNECTS);
+    this.peerConnectionDuration = meter.createHistogram(Metrics.PEER_MANAGER_PEER_CONNECTION_DURATION);
   }
 
   public recordGoodbyeSent(reason: GoodByeReason) {

--- a/yarn-project/p2p/src/services/peer-manager/peer_scoring.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_scoring.ts
@@ -6,7 +6,6 @@ import {
   Metrics,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
   getTelemetryClient,
 } from '@aztec/telemetry-client';
 
@@ -53,10 +52,7 @@ export class PeerScoring {
 
     const meter = telemetry.getMeter('PeerScoring');
 
-    this.peerStateCounter = meter.createUpDownCounter(Metrics.P2P_PEER_STATE_COUNT, {
-      description: 'Count of peers by state (Healthy, Disconnect, Banned)',
-      valueType: ValueType.INT,
-    });
+    this.peerStateCounter = meter.createUpDownCounter(Metrics.P2P_PEER_STATE_COUNT);
   }
 
   public penalizePeer(peerId: PeerId, penalty: PeerErrorSeverity) {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
@@ -261,7 +261,9 @@ export class ConnectionSampler {
         }
       } catch (error) {
         this.logger.error(
-          `Error cleaning up stale connection to peer ${stream.metadata.peerId?.toString() ?? 'unknown'} stream ${stream.id}`,
+          `Error cleaning up stale connection to peer ${stream.metadata.peerId?.toString() ?? 'unknown'} stream ${
+            stream.id
+          }`,
           { error },
         );
       }

--- a/yarn-project/p2p/src/services/reqresp/metrics.ts
+++ b/yarn-project/p2p/src/services/reqresp/metrics.ts
@@ -1,5 +1,5 @@
 // Request response metrics
-import { Attributes, Metrics, ValueType } from '@aztec/telemetry-client';
+import { Attributes, Metrics } from '@aztec/telemetry-client';
 import type { TelemetryClient, Tracer, UpDownCounter } from '@aztec/telemetry-client';
 
 export class ReqRespMetrics {
@@ -18,28 +18,12 @@ export class ReqRespMetrics {
     this.tracer = telemetryClient.getTracer(name);
 
     const meter = telemetryClient.getMeter(name);
-    this.sentRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_SENT_REQUESTS, {
-      description: 'Number of requests sent to peers',
-      unit: 'requests',
-      valueType: ValueType.INT,
-    });
-    this.receivedRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_RECEIVED_REQUESTS, {
-      description: 'Number of requests received from peers',
-      unit: 'requests',
-      valueType: ValueType.INT,
-    });
+    this.sentRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_SENT_REQUESTS);
+    this.receivedRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_RECEIVED_REQUESTS);
 
-    this.failedOutboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS, {
-      description: 'Number of failed outbound requests - nodes not getting valid responses',
-      unit: 'requests',
-      valueType: ValueType.INT,
-    });
+    this.failedOutboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS);
 
-    this.failedInboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_INBOUND_REQUESTS, {
-      description: 'Number of failed inbound requests - node failing to respond to requests',
-      unit: 'requests',
-      valueType: ValueType.INT,
-    });
+    this.failedInboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_INBOUND_REQUESTS);
   }
 
   public recordRequestSent(protocol: string) {

--- a/yarn-project/p2p/src/services/reqresp/protocols/status.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/status.ts
@@ -19,9 +19,10 @@ export class StatusMessage {
     readonly latestBlockNumber: BlockNumber,
     readonly latestBlockHash: string,
     readonly finalizedBlockNumber: BlockNumber,
+  ) {
     //TODO: add finalizedBlockHash
     //readonly finalizedBlockHash: string,
-  ) {}
+  }
 
   /**
    * Deserializes the StatusMessage object from a Buffer.

--- a/yarn-project/p2p/src/services/tx_collection/instrumentation.ts
+++ b/yarn-project/p2p/src/services/tx_collection/instrumentation.ts
@@ -1,11 +1,4 @@
-import {
-  Attributes,
-  type Histogram,
-  Metrics,
-  type TelemetryClient,
-  type UpDownCounter,
-  ValueType,
-} from '@aztec/telemetry-client';
+import { Attributes, type Histogram, Metrics, type TelemetryClient, type UpDownCounter } from '@aztec/telemetry-client';
 
 import type { CollectionMethod } from './tx_collection.js';
 
@@ -17,21 +10,11 @@ export class TxCollectionInstrumentation {
   constructor(client: TelemetryClient, name: string) {
     const meter = client.getMeter(name);
 
-    this.txsCollected = meter.createUpDownCounter(Metrics.TX_COLLECTOR_COUNT, {
-      description: 'The number of txs collected',
-    });
+    this.txsCollected = meter.createUpDownCounter(Metrics.TX_COLLECTOR_COUNT);
 
-    this.collectionDurationPerTx = meter.createHistogram(Metrics.TX_COLLECTOR_DURATION_PER_TX, {
-      unit: 'ms',
-      description: 'Average duration per tx of an individual tx collection request',
-      valueType: ValueType.INT,
-    });
+    this.collectionDurationPerTx = meter.createHistogram(Metrics.TX_COLLECTOR_DURATION_PER_TX);
 
-    this.collectionDurationPerRequest = meter.createHistogram(Metrics.TX_COLLECTOR_DURATION_PER_REQUEST, {
-      unit: 'ms',
-      description: 'Total duration of an individual tx collection request',
-      valueType: ValueType.INT,
-    });
+    this.collectionDurationPerRequest = meter.createHistogram(Metrics.TX_COLLECTOR_DURATION_PER_REQUEST);
   }
 
   increaseTxsFor(what: CollectionMethod, count: number, duration: number) {

--- a/yarn-project/p2p/src/services/tx_provider_instrumentation.ts
+++ b/yarn-project/p2p/src/services/tx_provider_instrumentation.ts
@@ -12,30 +12,17 @@ export class TxProviderInstrumentation {
   constructor(client: TelemetryClient, name: string) {
     const meter = client.getMeter(name);
 
-    this.txFromProposalCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_PROPOSALS_COUNT, {
-      description: 'The number of txs taken from block proposals',
-    });
+    this.txFromProposalCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_PROPOSALS_COUNT);
 
-    this.txFromMempoolCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_MEMPOOL_COUNT, {
-      description: 'The number of txs taken from the local mempool',
-    });
+    this.txFromMempoolCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_MEMPOOL_COUNT);
 
-    this.txFromP2PCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_P2P_COUNT, {
-      description: 'The number of txs taken from the p2p network',
-    });
+    this.txFromP2PCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_TXS_FROM_P2P_COUNT);
 
-    this.missingTxsCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_MISSING_TXS_COUNT, {
-      description: 'The number of txs not found anywhere',
-    });
+    this.missingTxsCount = meter.createUpDownCounter(Metrics.TX_PROVIDER_MISSING_TXS_COUNT);
 
-    this.fractionOfTxsRequestedFromP2P = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION, {
-      description: 'The fraction of transaction requested from peers',
-    });
+    this.fractionOfTxsRequestedFromP2P = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION);
 
-    this.txsRequestDelay = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUEST_DELAY, {
-      unit: 'ms',
-      description: 'The time it took to request missing transactions from p2p',
-    });
+    this.txsRequestDelay = meter.createHistogram(Metrics.TX_PROVIDER_P2P_TXS_REQUEST_DELAY);
   }
 
   incTxsFromProposals(count: number) {

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_metrics.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_metrics.ts
@@ -1,4 +1,4 @@
-import { type Histogram, Metrics, type TelemetryClient, type Tracer, ValueType } from '@aztec/telemetry-client';
+import { type Histogram, Metrics, type TelemetryClient, type Tracer } from '@aztec/telemetry-client';
 
 export class ProvingOrchestratorMetrics {
   public readonly tracer: Tracer;
@@ -9,11 +9,7 @@ export class ProvingOrchestratorMetrics {
     this.tracer = client.getTracer(name);
     const meter = client.getMeter(name);
 
-    this.baseRollupInputsDuration = meter.createHistogram(Metrics.PROVING_ORCHESTRATOR_BASE_ROLLUP_INPUTS_DURATION, {
-      unit: 'ms',
-      description: 'Duration to build base rollup inputs',
-      valueType: ValueType.INT,
-    });
+    this.baseRollupInputsDuration = meter.createHistogram(Metrics.PROVING_ORCHESTRATOR_BASE_ROLLUP_INPUTS_DURATION);
   }
 
   recordBaseRollupInputs(durationMs: number) {

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_instrumentation.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_instrumentation.ts
@@ -8,7 +8,6 @@ import {
   type ObservableResult,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 export type MonitorCallback = (proofType: ProvingRequestType) => number;
@@ -28,49 +27,25 @@ export class ProvingBrokerInstrumentation {
   constructor(client: TelemetryClient, name = 'ProvingBroker') {
     const meter = client.getMeter(name);
 
-    this.queueSize = meter.createObservableGauge(Metrics.PROVING_QUEUE_SIZE, {
-      valueType: ValueType.INT,
-    });
+    this.queueSize = meter.createObservableGauge(Metrics.PROVING_QUEUE_SIZE);
 
-    this.activeJobs = meter.createObservableGauge(Metrics.PROVING_QUEUE_ACTIVE_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.activeJobs = meter.createObservableGauge(Metrics.PROVING_QUEUE_ACTIVE_JOBS);
 
-    this.resolvedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_RESOLVED_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.resolvedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_RESOLVED_JOBS);
 
-    this.rejectedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_REJECTED_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.rejectedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_REJECTED_JOBS);
 
-    this.retriedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_RETRIED_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.retriedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_RETRIED_JOBS);
 
-    this.timedOutJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_TIMED_OUT_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.timedOutJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_TIMED_OUT_JOBS);
 
-    this.cachedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_CACHED_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.cachedJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_CACHED_JOBS);
 
-    this.totalJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_TOTAL_JOBS, {
-      valueType: ValueType.INT,
-    });
+    this.totalJobs = meter.createUpDownCounter(Metrics.PROVING_QUEUE_TOTAL_JOBS);
 
-    this.jobWait = meter.createHistogram(Metrics.PROVING_QUEUE_JOB_WAIT, {
-      description: 'Records how long a job sits in the queue',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.jobWait = meter.createHistogram(Metrics.PROVING_QUEUE_JOB_WAIT);
 
-    this.jobDuration = meter.createHistogram(Metrics.PROVING_QUEUE_JOB_DURATION, {
-      description: 'Records how long a job takes to complete',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.jobDuration = meter.createHistogram(Metrics.PROVING_QUEUE_JOB_DURATION);
   }
 
   monitorQueueDepth(fn: MonitorCallback) {

--- a/yarn-project/prover-node/src/metrics.ts
+++ b/yarn-project/prover-node/src/metrics.ts
@@ -13,7 +13,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import { formatEther, formatUnits } from 'viem';
@@ -30,28 +29,11 @@ export class ProverNodeJobMetrics {
     public readonly tracer: Tracer,
     private logger = createLogger('prover-node:publisher:metrics'),
   ) {
-    this.proverEpochExecutionDuration = this.meter.createHistogram(Metrics.PROVER_NODE_EXECUTION_DURATION, {
-      description: 'Duration of execution of an epoch by the prover',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
-    this.provingJobDuration = this.meter.createHistogram(Metrics.PROVER_NODE_JOB_DURATION, {
-      description: 'Duration of proving job',
-      unit: 's',
-      valueType: ValueType.DOUBLE,
-    });
-    this.provingJobCheckpoints = this.meter.createGauge(Metrics.PROVER_NODE_JOB_CHECKPOINTS, {
-      description: 'Number of checkpoints in a proven epoch',
-      valueType: ValueType.INT,
-    });
-    this.provingJobBlocks = this.meter.createGauge(Metrics.PROVER_NODE_JOB_BLOCKS, {
-      description: 'Number of blocks in a proven epoch',
-      valueType: ValueType.INT,
-    });
-    this.provingJobTransactions = this.meter.createGauge(Metrics.PROVER_NODE_JOB_TRANSACTIONS, {
-      description: 'Number of transactions in a proven epoch',
-      valueType: ValueType.INT,
-    });
+    this.proverEpochExecutionDuration = this.meter.createHistogram(Metrics.PROVER_NODE_EXECUTION_DURATION);
+    this.provingJobDuration = this.meter.createHistogram(Metrics.PROVER_NODE_JOB_DURATION);
+    this.provingJobCheckpoints = this.meter.createGauge(Metrics.PROVER_NODE_JOB_CHECKPOINTS);
+    this.provingJobBlocks = this.meter.createGauge(Metrics.PROVER_NODE_JOB_BLOCKS);
+    this.provingJobTransactions = this.meter.createGauge(Metrics.PROVER_NODE_JOB_TRANSACTIONS);
   }
 
   public recordProvingJob(
@@ -81,15 +63,9 @@ export class ProverNodeRewardsMetrics {
     private rollup: RollupContract,
     private logger = createLogger('prover-node:publisher:metrics'),
   ) {
-    this.rewards = this.meter.createObservableGauge(Metrics.PROVER_NODE_REWARDS_PER_EPOCH, {
-      valueType: ValueType.DOUBLE,
-      description: 'The rewards earned',
-    });
+    this.rewards = this.meter.createObservableGauge(Metrics.PROVER_NODE_REWARDS_PER_EPOCH);
 
-    this.accumulatedRewards = this.meter.createUpDownCounter(Metrics.PROVER_NODE_REWARDS_TOTAL, {
-      valueType: ValueType.DOUBLE,
-      description: 'The rewards earned (total)',
-    });
+    this.accumulatedRewards = this.meter.createUpDownCounter(Metrics.PROVER_NODE_REWARDS_TOTAL);
   }
 
   public async start() {
@@ -150,68 +126,25 @@ export class ProverNodePublisherMetrics {
   ) {
     this.meter = client.getMeter(name);
 
-    this.gasPrice = this.meter.createHistogram(Metrics.L1_PUBLISHER_GAS_PRICE, {
-      description: 'The gas price used for transactions',
-      unit: 'gwei',
-      valueType: ValueType.DOUBLE,
-    });
+    this.gasPrice = this.meter.createHistogram(Metrics.L1_PUBLISHER_GAS_PRICE);
 
-    this.txCount = this.meter.createUpDownCounter(Metrics.L1_PUBLISHER_TX_COUNT, {
-      description: 'The number of transactions processed',
-    });
+    this.txCount = this.meter.createUpDownCounter(Metrics.L1_PUBLISHER_TX_COUNT);
 
-    this.txDuration = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_DURATION, {
-      description: 'The duration of transaction processing',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.txDuration = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_DURATION);
 
-    this.txGas = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_GAS, {
-      description: 'The gas consumed by transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txGas = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_GAS);
 
-    this.txCalldataSize = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_SIZE, {
-      description: 'The size of the calldata in transactions',
-      unit: 'By',
-      valueType: ValueType.INT,
-    });
+    this.txCalldataSize = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_SIZE);
 
-    this.txCalldataGas = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_GAS, {
-      description: 'The gas consumed by the calldata in transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txCalldataGas = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_GAS);
 
-    this.txBlobDataGasUsed = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_USED, {
-      description: 'The amount of blob gas used in transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txBlobDataGasUsed = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_USED);
 
-    this.txBlobDataGasCost = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_COST, {
-      description: 'The gas cost of blobs in transactions',
-      unit: 'gwei',
-      valueType: ValueType.INT,
-    });
+    this.txBlobDataGasCost = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_COST);
 
-    this.txTotalFee = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_TOTAL_FEE, {
-      description: 'How much L1 tx costs',
-      unit: 'gwei',
-      valueType: ValueType.DOUBLE,
-      advice: {
-        explicitBucketBoundaries: [
-          0.001, 0.002, 0.004, 0.008, 0.01, 0.02, 0.04, 0.08, 0.1, 0.2, 0.4, 0.8, 1, 1.2, 1.4, 1.8, 2,
-        ],
-      },
-    });
+    this.txTotalFee = this.meter.createHistogram(Metrics.L1_PUBLISHER_TX_TOTAL_FEE);
 
-    this.senderBalance = this.meter.createGauge(Metrics.L1_PUBLISHER_BALANCE, {
-      unit: 'eth',
-      description: 'The balance of the sender address',
-      valueType: ValueType.DOUBLE,
-    });
+    this.senderBalance = this.meter.createGauge(Metrics.L1_PUBLISHER_BALANCE);
   }
 
   recordFailedTx() {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher-metrics.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher-metrics.ts
@@ -7,7 +7,6 @@ import {
   Metrics,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import { formatEther } from 'viem/utils';
@@ -40,88 +39,33 @@ export class SequencerPublisherMetrics {
   ) {
     const meter = client.getMeter(name);
 
-    this.gasPrice = meter.createHistogram(Metrics.L1_PUBLISHER_GAS_PRICE, {
-      description: 'The gas price used for transactions',
-      unit: 'gwei',
-      valueType: ValueType.DOUBLE,
-    });
+    this.gasPrice = meter.createHistogram(Metrics.L1_PUBLISHER_GAS_PRICE);
 
-    this.txCount = meter.createUpDownCounter(Metrics.L1_PUBLISHER_TX_COUNT, {
-      description: 'The number of transactions processed',
-    });
+    this.txCount = meter.createUpDownCounter(Metrics.L1_PUBLISHER_TX_COUNT);
 
-    this.txDuration = meter.createHistogram(Metrics.L1_PUBLISHER_TX_DURATION, {
-      description: 'The duration of transaction processing',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.txDuration = meter.createHistogram(Metrics.L1_PUBLISHER_TX_DURATION);
 
-    this.txGas = meter.createHistogram(Metrics.L1_PUBLISHER_TX_GAS, {
-      description: 'The gas consumed by transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txGas = meter.createHistogram(Metrics.L1_PUBLISHER_TX_GAS);
 
-    this.txCalldataSize = meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_SIZE, {
-      description: 'The size of the calldata in transactions',
-      unit: 'By',
-      valueType: ValueType.INT,
-    });
+    this.txCalldataSize = meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_SIZE);
 
-    this.txCalldataGas = meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_GAS, {
-      description: 'The gas consumed by the calldata in transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txCalldataGas = meter.createHistogram(Metrics.L1_PUBLISHER_TX_CALLDATA_GAS);
 
-    this.txBlobDataGasUsed = meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_USED, {
-      description: 'The amount of blob gas used in transactions',
-      unit: 'gas',
-      valueType: ValueType.INT,
-    });
+    this.txBlobDataGasUsed = meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_USED);
 
-    this.txBlobDataGasCost = meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_COST, {
-      description: 'The gas cost of blobs in transactions',
-      unit: 'gwei',
-      valueType: ValueType.INT,
-    });
+    this.txBlobDataGasCost = meter.createHistogram(Metrics.L1_PUBLISHER_TX_BLOBDATA_GAS_COST);
 
-    this.blobCountHistogram = meter.createHistogram(Metrics.L1_PUBLISHER_BLOB_COUNT, {
-      description: 'Number of blobs in L1 transactions',
-      unit: 'blobs',
-      valueType: ValueType.INT,
-    });
+    this.blobCountHistogram = meter.createHistogram(Metrics.L1_PUBLISHER_BLOB_COUNT);
 
-    this.blobInclusionBlocksHistogram = meter.createHistogram(Metrics.L1_PUBLISHER_BLOB_INCLUSION_BLOCKS, {
-      description: 'Number of L1 blocks between blob tx submission and inclusion',
-      unit: 'blocks',
-      valueType: ValueType.INT,
-    });
+    this.blobInclusionBlocksHistogram = meter.createHistogram(Metrics.L1_PUBLISHER_BLOB_INCLUSION_BLOCKS);
 
-    this.blobTxSuccessCounter = meter.createUpDownCounter(Metrics.L1_PUBLISHER_BLOB_TX_SUCCESS, {
-      description: 'Number of successful L1 transactions with blobs',
-    });
+    this.blobTxSuccessCounter = meter.createUpDownCounter(Metrics.L1_PUBLISHER_BLOB_TX_SUCCESS);
 
-    this.blobTxFailureCounter = meter.createUpDownCounter(Metrics.L1_PUBLISHER_BLOB_TX_FAILURE, {
-      description: 'Number of failed L1 transactions with blobs',
-    });
+    this.blobTxFailureCounter = meter.createUpDownCounter(Metrics.L1_PUBLISHER_BLOB_TX_FAILURE);
 
-    this.txTotalFee = meter.createHistogram(Metrics.L1_PUBLISHER_TX_TOTAL_FEE, {
-      description: 'How much L1 tx costs',
-      unit: 'eth',
-      valueType: ValueType.DOUBLE,
-      advice: {
-        explicitBucketBoundaries: [
-          0.001, 0.002, 0.004, 0.008, 0.01, 0.02, 0.04, 0.08, 0.1, 0.2, 0.4, 0.8, 1, 1.2, 1.4, 1.8, 2,
-        ],
-      },
-    });
+    this.txTotalFee = meter.createHistogram(Metrics.L1_PUBLISHER_TX_TOTAL_FEE);
 
-    this.senderBalance = meter.createGauge(Metrics.L1_PUBLISHER_BALANCE, {
-      unit: 'eth',
-      description: 'The balance of the sender address',
-      valueType: ValueType.DOUBLE,
-    });
+    this.senderBalance = meter.createGauge(Metrics.L1_PUBLISHER_BALANCE);
   }
 
   recordFailedTx(txType: L1TxType) {

--- a/yarn-project/sequencer-client/src/sequencer/metrics.ts
+++ b/yarn-project/sequencer-client/src/sequencer/metrics.ts
@@ -11,7 +11,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import { type Hex, formatUnits } from 'viem';
@@ -70,33 +69,13 @@ export class SequencerMetrics {
 
     this.blockCounter = this.meter.createUpDownCounter(Metrics.SEQUENCER_BLOCK_COUNT);
 
-    this.blockBuildDuration = this.meter.createHistogram(Metrics.SEQUENCER_BLOCK_BUILD_DURATION, {
-      unit: 'ms',
-      description: 'Duration to build a block',
-      valueType: ValueType.INT,
-    });
+    this.blockBuildDuration = this.meter.createHistogram(Metrics.SEQUENCER_BLOCK_BUILD_DURATION);
 
-    this.blockBuildManaPerSecond = this.meter.createGauge(Metrics.SEQUENCER_BLOCK_BUILD_MANA_PER_SECOND, {
-      unit: 'mana/s',
-      description: 'Mana per second when building a block',
-      valueType: ValueType.INT,
-    });
+    this.blockBuildManaPerSecond = this.meter.createGauge(Metrics.SEQUENCER_BLOCK_BUILD_MANA_PER_SECOND);
 
-    this.stateTransitionBufferDuration = this.meter.createHistogram(
-      Metrics.SEQUENCER_STATE_TRANSITION_BUFFER_DURATION,
-      {
-        unit: 'ms',
-        description:
-          'The time difference between when the sequencer needed to transition to a new state and when it actually did.',
-        valueType: ValueType.INT,
-      },
-    );
+    this.stateTransitionBufferDuration = this.meter.createHistogram(Metrics.SEQUENCER_STATE_TRANSITION_BUFFER_DURATION);
 
-    this.blockAttestationDelay = this.meter.createHistogram(Metrics.SEQUENCER_BLOCK_ATTESTATION_DELAY, {
-      unit: 'ms',
-      description: 'The time difference between block proposal and minimal attestation count reached,',
-      valueType: ValueType.INT,
-    });
+    this.blockAttestationDelay = this.meter.createHistogram(Metrics.SEQUENCER_BLOCK_ATTESTATION_DELAY);
 
     // Init gauges and counters
     this.blockCounter.add(0, {
@@ -106,152 +85,65 @@ export class SequencerMetrics {
       [Attributes.STATUS]: 'built',
     });
 
-    this.rewards = this.meter.createGauge(Metrics.SEQUENCER_CURRENT_BLOCK_REWARDS, {
-      valueType: ValueType.DOUBLE,
-      description: 'The rewards earned',
-    });
+    this.rewards = this.meter.createGauge(Metrics.SEQUENCER_CURRENT_BLOCK_REWARDS);
 
-    this.slots = this.meter.createUpDownCounter(Metrics.SEQUENCER_SLOT_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of slots this sequencer was selected for',
-    });
+    this.slots = this.meter.createUpDownCounter(Metrics.SEQUENCER_SLOT_COUNT);
 
     /**
      * NOTE: we do not track missed slots as a separate metric. That would be difficult to determine
      * Instead, use a computed metric, `slots - filledSlots` to get the number of slots a sequencer has missed.
      */
-    this.filledSlots = this.meter.createUpDownCounter(Metrics.SEQUENCER_FILLED_SLOT_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of slots this sequencer has filled',
-    });
+    this.filledSlots = this.meter.createUpDownCounter(Metrics.SEQUENCER_FILLED_SLOT_COUNT);
 
-    this.timeToCollectAttestations = this.meter.createGauge(Metrics.SEQUENCER_COLLECT_ATTESTATIONS_DURATION, {
-      description: 'The time spent collecting attestations from committee members',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.timeToCollectAttestations = this.meter.createGauge(Metrics.SEQUENCER_COLLECT_ATTESTATIONS_DURATION);
 
-    this.allowanceToCollectAttestations = this.meter.createGauge(
-      Metrics.SEQUENCER_COLLECT_ATTESTATIONS_TIME_ALLOWANCE,
-      {
-        description: 'Maximum amount of time to collect attestations',
-        unit: 'ms',
-        valueType: ValueType.INT,
-      },
-    );
+    this.allowanceToCollectAttestations = this.meter.createGauge(Metrics.SEQUENCER_COLLECT_ATTESTATIONS_TIME_ALLOWANCE);
 
-    this.requiredAttestions = this.meter.createGauge(Metrics.SEQUENCER_REQUIRED_ATTESTATIONS_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The minimum number of attestations required to publish a block',
-    });
+    this.requiredAttestions = this.meter.createGauge(Metrics.SEQUENCER_REQUIRED_ATTESTATIONS_COUNT);
 
-    this.collectedAttestions = this.meter.createGauge(Metrics.SEQUENCER_COLLECTED_ATTESTATIONS_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The minimum number of attestations required to publish a block',
-    });
+    this.collectedAttestions = this.meter.createGauge(Metrics.SEQUENCER_COLLECTED_ATTESTATIONS_COUNT);
 
-    this.blockProposalFailed = this.meter.createUpDownCounter(Metrics.SEQUENCER_BLOCK_PROPOSAL_FAILED_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of times block proposal failed (including validation builds)',
-    });
+    this.blockProposalFailed = this.meter.createUpDownCounter(Metrics.SEQUENCER_BLOCK_PROPOSAL_FAILED_COUNT);
 
-    this.blockProposalSuccess = this.meter.createUpDownCounter(Metrics.SEQUENCER_BLOCK_PROPOSAL_SUCCESS_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of times block proposal succeeded (including validation builds)',
-    });
+    this.blockProposalSuccess = this.meter.createUpDownCounter(Metrics.SEQUENCER_BLOCK_PROPOSAL_SUCCESS_COUNT);
 
-    this.checkpointSuccess = this.meter.createUpDownCounter(Metrics.SEQUENCER_CHECKPOINT_SUCCESS_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of times checkpoint publishing succeeded',
-    });
+    this.checkpointSuccess = this.meter.createUpDownCounter(Metrics.SEQUENCER_CHECKPOINT_SUCCESS_COUNT);
 
     this.blockProposalPrecheckFailed = this.meter.createUpDownCounter(
       Metrics.SEQUENCER_BLOCK_PROPOSAL_PRECHECK_FAILED_COUNT,
-      {
-        valueType: ValueType.INT,
-        description: 'The number of times block proposal pre-build checks failed',
-      },
     );
 
-    this.slashingAttempts = this.meter.createUpDownCounter(Metrics.SEQUENCER_SLASHING_ATTEMPTS_COUNT, {
-      valueType: ValueType.INT,
-      description: 'The number of slashing action attempts',
-    });
+    this.slashingAttempts = this.meter.createUpDownCounter(Metrics.SEQUENCER_SLASHING_ATTEMPTS_COUNT);
 
     // Fisherman fee analysis metrics
-    this.fishermanWouldBeIncluded = this.meter.createUpDownCounter(Metrics.FISHERMAN_FEE_ANALYSIS_WOULD_BE_INCLUDED, {
-      valueType: ValueType.INT,
-      description: 'Whether the transaction would have been included in the block',
-    });
+    this.fishermanWouldBeIncluded = this.meter.createUpDownCounter(Metrics.FISHERMAN_FEE_ANALYSIS_WOULD_BE_INCLUDED);
 
-    this.fishermanTimeBeforeBlock = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_TIME_BEFORE_BLOCK, {
-      unit: 'ms',
-      description: 'Time in ms between fee analysis and block being mined',
-      valueType: ValueType.INT,
-    });
+    this.fishermanTimeBeforeBlock = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_TIME_BEFORE_BLOCK);
 
-    this.fishermanPendingBlobTxCount = this.meter.createHistogram(
-      Metrics.FISHERMAN_FEE_ANALYSIS_PENDING_BLOB_TX_COUNT,
-      {
-        description: 'Number of blob transactions seen in the pending block',
-        valueType: ValueType.INT,
-      },
-    );
+    this.fishermanPendingBlobTxCount = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_PENDING_BLOB_TX_COUNT);
 
     this.fishermanIncludedBlobTxCount = this.meter.createHistogram(
       Metrics.FISHERMAN_FEE_ANALYSIS_INCLUDED_BLOB_TX_COUNT,
-      {
-        description: 'Number of blob transactions that got included in the mined block',
-        valueType: ValueType.INT,
-      },
     );
 
     this.fishermanCalculatedPriorityFee = this.meter.createHistogram(
       Metrics.FISHERMAN_FEE_ANALYSIS_CALCULATED_PRIORITY_FEE,
-      {
-        unit: 'gwei',
-        description: 'Priority fee calculated by each strategy',
-        valueType: ValueType.DOUBLE,
-      },
     );
 
-    this.fishermanPriorityFeeDelta = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_PRIORITY_FEE_DELTA, {
-      unit: 'gwei',
-      description: 'Difference between our priority fee and minimum included priority fee',
-      valueType: ValueType.DOUBLE,
-    });
+    this.fishermanPriorityFeeDelta = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_PRIORITY_FEE_DELTA);
 
-    this.fishermanEstimatedCost = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_ESTIMATED_COST, {
-      unit: 'eth',
-      description: 'Estimated total cost in ETH for the transaction with this strategy',
-      valueType: ValueType.DOUBLE,
-    });
+    this.fishermanEstimatedCost = this.meter.createHistogram(Metrics.FISHERMAN_FEE_ANALYSIS_ESTIMATED_COST);
 
     this.fishermanEstimatedOverpayment = this.meter.createHistogram(
       Metrics.FISHERMAN_FEE_ANALYSIS_ESTIMATED_OVERPAYMENT,
-      {
-        unit: 'eth',
-        description: 'Estimated overpayment in ETH vs minimum required for inclusion',
-        valueType: ValueType.DOUBLE,
-      },
     );
 
     this.fishermanMinedBlobTxPriorityFee = this.meter.createHistogram(
       Metrics.FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_PRIORITY_FEE,
-      {
-        unit: 'gwei',
-        description: 'Priority fee per gas for blob transactions in mined blocks',
-        valueType: ValueType.DOUBLE,
-      },
     );
 
     this.fishermanMinedBlobTxTotalCost = this.meter.createHistogram(
       Metrics.FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_TOTAL_COST,
-      {
-        unit: 'eth',
-        description: 'Total cost in ETH for blob transactions in mined blocks',
-        valueType: ValueType.DOUBLE,
-      },
     );
   }
 

--- a/yarn-project/simulator/src/public/executor_metrics.ts
+++ b/yarn-project/simulator/src/public/executor_metrics.ts
@@ -7,7 +7,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import type { ExecutorMetricsInterface } from './executor_metrics_interface.js';
@@ -26,45 +25,19 @@ export class ExecutorMetrics implements ExecutorMetricsInterface {
     this.tracer = client.getTracer(name);
     const meter = client.getMeter(name);
 
-    this.fnCount = meter.createUpDownCounter(Metrics.PUBLIC_EXECUTOR_SIMULATION_COUNT, {
-      description: 'Number of functions executed',
-    });
+    this.fnCount = meter.createUpDownCounter(Metrics.PUBLIC_EXECUTOR_SIMULATION_COUNT);
 
-    this.fnDuration = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_DURATION, {
-      description: 'How long it takes to execute a function',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.fnDuration = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_DURATION);
 
-    this.manaPerSecond = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_MANA_PER_SECOND, {
-      description: 'Mana used per second',
-      unit: 'mana/s',
-      valueType: ValueType.INT,
-    });
+    this.manaPerSecond = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_MANA_PER_SECOND);
 
-    this.manaUsed = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_MANA_USED, {
-      description: 'Total mana used',
-      unit: 'mana',
-      valueType: ValueType.INT,
-    });
+    this.manaUsed = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_MANA_USED);
 
-    this.totalInstructionsExecuted = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_TOTAL_INSTRUCTIONS, {
-      description: 'Total number of instructions executed',
-      unit: '#instructions',
-      valueType: ValueType.INT,
-    });
+    this.totalInstructionsExecuted = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_SIMULATION_TOTAL_INSTRUCTIONS);
 
-    this.txHashing = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_TX_HASHING, {
-      description: 'Tx hashing time',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.txHashing = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_TX_HASHING);
 
-    this.privateEffectsInsertions = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_PRIVATE_EFFECTS_INSERTION, {
-      description: 'Private effects insertion time',
-      unit: 'us',
-      valueType: ValueType.INT,
-    });
+    this.privateEffectsInsertions = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_PRIVATE_EFFECTS_INSERTION);
   }
 
   startRecordingTxSimulation(_txLabel: string) {

--- a/yarn-project/simulator/src/public/public_processor/public_processor_metrics.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor_metrics.ts
@@ -9,7 +9,6 @@ import {
   type TelemetryClient,
   type Tracer,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 export class PublicProcessorMetrics {
@@ -34,60 +33,27 @@ export class PublicProcessorMetrics {
     this.tracer = client.getTracer(name);
     const meter = client.getMeter(name);
 
-    this.txDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TX_DURATION, {
-      description: 'How long it takes to process a transaction',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.txDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TX_DURATION);
 
-    this.txCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_TX_COUNT, {
-      description: 'Number of transactions processed',
-    });
+    this.txCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_TX_COUNT);
 
-    this.txPhaseCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_TX_PHASE_COUNT, {
-      description: 'Number of phases processed',
-    });
+    this.txPhaseCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_TX_PHASE_COUNT);
 
-    this.phaseDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_PHASE_DURATION, {
-      description: 'How long it takes to process a phase',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.phaseDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_PHASE_DURATION);
 
-    this.phaseCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_PHASE_COUNT, {
-      description: 'Number of failed phases',
-    });
+    this.phaseCount = meter.createUpDownCounter(Metrics.PUBLIC_PROCESSOR_PHASE_COUNT);
 
-    this.bytecodeDeployed = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_DEPLOY_BYTECODE_SIZE, {
-      description: 'Size of deployed bytecode',
-      unit: 'By',
-    });
+    this.bytecodeDeployed = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_DEPLOY_BYTECODE_SIZE);
 
-    this.totalGas = meter.createGauge(Metrics.PUBLIC_PROCESSOR_TOTAL_GAS, {
-      description: 'Total gas used in block',
-      unit: 'gas',
-    });
+    this.totalGas = meter.createGauge(Metrics.PUBLIC_PROCESSOR_TOTAL_GAS);
 
-    this.totalGasHistogram = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TOTAL_GAS_HISTOGRAM, {
-      description: 'Total gas used in block as histogram',
-      unit: 'gas/block',
-    });
+    this.totalGasHistogram = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TOTAL_GAS_HISTOGRAM);
 
-    this.txGas = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TX_GAS, {
-      description: 'Gas used in transaction',
-      unit: 'gas/tx',
-    });
+    this.txGas = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TX_GAS);
 
-    this.gasRate = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_GAS_RATE, {
-      description: 'L2 gas per second for complete block',
-      unit: 'gas/s',
-    });
+    this.gasRate = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_GAS_RATE);
 
-    this.treeInsertionDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TREE_INSERTION, {
-      description: 'How long it takes for tree insertion',
-      unit: 'us',
-      valueType: ValueType.INT,
-    });
+    this.treeInsertionDuration = meter.createHistogram(Metrics.PUBLIC_PROCESSOR_TREE_INSERTION);
   }
 
   recordPhaseDuration(phaseName: TxExecutionPhase, durationMs: number) {

--- a/yarn-project/telemetry-client/src/bench.ts
+++ b/yarn-project/telemetry-client/src/bench.ts
@@ -2,13 +2,13 @@ import { createLogger } from '@aztec/foundation/log';
 
 import type { BatchObservableCallback, Context, MetricOptions, Observable, ValueType } from '@opentelemetry/api';
 
+import type { MetricDefinition } from './metrics.js';
 import { NoopTracer } from './noop.js';
 import type {
   AttributesType,
   Gauge,
   Histogram,
   Meter,
-  MetricsType,
   ObservableGauge,
   ObservableUpDownCounter,
   TelemetryClient,
@@ -87,30 +87,34 @@ class InMemoryPlainMeter implements Meter {
     this.metrics.forEach(metric => metric.clear());
   }
 
-  createGauge(name: MetricsType, options?: MetricOptions): Gauge {
-    return this.createMetric('gauge', name, options);
+  createGauge(metric: MetricDefinition): Gauge {
+    return this.createMetric('gauge', metric);
   }
 
-  createObservableGauge(name: MetricsType, options?: MetricOptions): ObservableGauge {
-    return this.createMetric('gauge', name, options);
+  createObservableGauge(metric: MetricDefinition): ObservableGauge {
+    return this.createMetric('gauge', metric);
   }
 
-  createHistogram(name: MetricsType, options?: MetricOptions): Histogram {
-    return this.createMetric('histogram', name, options);
+  createHistogram(metric: MetricDefinition, _extraOptions?: Partial<MetricOptions>): Histogram {
+    return this.createMetric('histogram', metric);
   }
 
-  createUpDownCounter(name: MetricsType, options?: MetricOptions): UpDownCounter {
-    return this.createMetric('counter', name, options);
+  createUpDownCounter(metric: MetricDefinition): UpDownCounter {
+    return this.createMetric('counter', metric);
   }
 
-  createObservableUpDownCounter(name: MetricsType, options?: MetricOptions): ObservableUpDownCounter {
-    return this.createMetric('counter', name, options);
+  createObservableUpDownCounter(metric: MetricDefinition): ObservableUpDownCounter {
+    return this.createMetric('counter', metric);
   }
 
-  private createMetric(type: 'gauge' | 'counter' | 'histogram', name: string, options?: MetricOptions) {
-    const metric = new InMemoryPlainMetric(type, name, options);
-    this.metrics.push(metric);
-    return metric;
+  private createMetric(type: 'gauge' | 'counter' | 'histogram', metric: MetricDefinition) {
+    const m = new InMemoryPlainMetric(type, metric.name, {
+      description: metric.description,
+      unit: metric.unit,
+      valueType: metric.valueType,
+    });
+    this.metrics.push(m);
+    return m;
   }
 
   addBatchObservableCallback(

--- a/yarn-project/telemetry-client/src/l1_metrics.ts
+++ b/yarn-project/telemetry-client/src/l1_metrics.ts
@@ -4,7 +4,7 @@ import { type Chain, type FallbackTransport, type Hex, type HttpTransport, type 
 
 import { L1_SENDER } from './attributes.js';
 import { L1_BALANCE_ETH, L1_BLOB_BASE_FEE_WEI, L1_BLOCK_HEIGHT, L1_GAS_PRICE_WEI } from './metrics.js';
-import { type BatchObservableResult, type Meter, type ObservableGauge, ValueType } from './telemetry.js';
+import type { BatchObservableResult, Meter, ObservableGauge } from './telemetry.js';
 
 export class L1Metrics {
   private l1BlockHeight: ObservableGauge;
@@ -18,25 +18,10 @@ export class L1Metrics {
     private client: PublicClient<FallbackTransport<HttpTransport[]>, Chain>,
     addresses: EthAddress[],
   ) {
-    this.l1BlockHeight = meter.createObservableGauge(L1_BLOCK_HEIGHT, {
-      description: 'The latest L1 block seen',
-      valueType: ValueType.INT,
-    });
-    this.l1BalanceEth = meter.createObservableGauge(L1_BALANCE_ETH, {
-      description: 'Eth balance of an address',
-      unit: 'eth',
-      valueType: ValueType.DOUBLE,
-    });
-    this.gasPriceWei = meter.createObservableGauge(L1_GAS_PRICE_WEI, {
-      description: 'L1 gas price',
-      unit: 'wei',
-      valueType: ValueType.DOUBLE,
-    });
-    this.blobBaseFeeWei = meter.createObservableGauge(L1_BLOB_BASE_FEE_WEI, {
-      description: 'L1 blob fee',
-      unit: 'wei',
-      valueType: ValueType.DOUBLE,
-    });
+    this.l1BlockHeight = meter.createObservableGauge(L1_BLOCK_HEIGHT);
+    this.l1BalanceEth = meter.createObservableGauge(L1_BALANCE_ETH);
+    this.gasPriceWei = meter.createObservableGauge(L1_GAS_PRICE_WEI);
+    this.blobBaseFeeWei = meter.createObservableGauge(L1_BLOB_BASE_FEE_WEI);
 
     this.addresses = addresses.map(addr => addr.toString());
   }

--- a/yarn-project/telemetry-client/src/lmdb_metrics.ts
+++ b/yarn-project/telemetry-client/src/lmdb_metrics.ts
@@ -1,11 +1,5 @@
 import * as Metrics from './metrics.js';
-import {
-  type AttributesType,
-  type BatchObservableResult,
-  type Meter,
-  type ObservableGauge,
-  ValueType,
-} from './telemetry.js';
+import type { AttributesType, BatchObservableResult, Meter, ObservableGauge } from './telemetry.js';
 
 export type LmdbStatsCallback = () => Promise<{
   mappingSize: number;
@@ -25,25 +19,10 @@ export class LmdbMetrics {
     private attributes?: AttributesType,
     private getStats?: LmdbStatsCallback,
   ) {
-    this.dbMapSize = meter.createObservableGauge(Metrics.DB_MAP_SIZE, {
-      description: 'LMDB Map Size',
-      valueType: ValueType.INT,
-      unit: 'By',
-    });
-    this.dbPhysicalFileSize = meter.createObservableGauge(Metrics.DB_PHYSICAL_FILE_SIZE, {
-      description: 'LMDB Physical File Size',
-      valueType: ValueType.INT,
-      unit: 'By',
-    });
-    this.dbUsedSize = meter.createObservableGauge(Metrics.DB_USED_SIZE, {
-      description: 'LMDB Used Size',
-      valueType: ValueType.INT,
-      unit: 'By',
-    });
-    this.dbNumItems = meter.createObservableGauge(Metrics.DB_NUM_ITEMS, {
-      description: 'LMDB Num Items',
-      valueType: ValueType.INT,
-    });
+    this.dbMapSize = meter.createObservableGauge(Metrics.DB_MAP_SIZE);
+    this.dbPhysicalFileSize = meter.createObservableGauge(Metrics.DB_PHYSICAL_FILE_SIZE);
+    this.dbUsedSize = meter.createObservableGauge(Metrics.DB_USED_SIZE);
+    this.dbNumItems = meter.createObservableGauge(Metrics.DB_NUM_ITEMS);
 
     meter.addBatchObservableCallback(this.recordDBMetrics, [
       this.dbMapSize,

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -5,278 +5,1317 @@
  *
  * @see {@link https://opentelemetry.io/docs/specs/semconv/general/metrics/ | OpenTelemetry Metrics} for naming conventions.
  */
+import { ValueType } from '@opentelemetry/api';
 
-export const BLOB_SINK_STORE_REQUESTS = 'aztec.blob_sink.store_request_count';
-export const BLOB_SINK_RETRIEVE_REQUESTS = 'aztec.blob_sink.retrieve_request_count';
-export const BLOB_SINK_OBJECTS_IN_BLOB_STORE = 'aztec.blob_sink.objects_in_blob_store';
-export const BLOB_SINK_BLOB_SIZE = 'aztec.blob_sink.blob_size';
+/**
+ * Defines the complete metadata for a metric.
+ * Co-locates name, description, unit, and value type in a single definition.
+ */
+export interface MetricDefinition {
+  /** The metric name (e.g., 'aztec.sequencer.block.build_duration') */
+  readonly name: string;
 
-export const BLOB_SINK_ARCHIVE_BLOB_REQUEST_COUNT = 'aztec.blob_sink.archive.block_request_count';
-export const BLOB_SINK_ARCHIVE_BLOCK_REQUEST_COUNT = 'aztec.blob_sink.archive.blob_request_count';
-export const BLOB_SINK_ARCHIVE_BLOB_COUNT = 'aztec.blob_sink.archive.blob_count';
+  /** Human-readable description of what this metric measures */
+  readonly description: string;
 
-/** How long it takes to simulate a circuit */
-export const CIRCUIT_SIMULATION_DURATION = 'aztec.circuit.simulation.duration';
-export const CIRCUIT_SIMULATION_INPUT_SIZE = 'aztec.circuit.simulation.input_size';
-export const CIRCUIT_SIMULATION_OUTPUT_SIZE = 'aztec.circuit.simulation.output_size';
+  /**
+   * The unit of measurement.
+   * Common units: 'ms', 's', 'By', 'gas', 'mana', 'mana/s', 'gwei', 'eth', 'peers', 'requests', 'tx', 'blobs', 'blocks'
+   * @see https://opentelemetry.io/docs/specs/semconv/general/metrics/ for conventions
+   */
+  readonly unit?: string;
 
-export const CIRCUIT_WITNESS_GEN_DURATION = 'aztec.circuit.witness_generation.duration';
-export const CIRCUIT_WITNESS_GEN_INPUT_SIZE = 'aztec.circuit.witness_generation.input_size';
-export const CIRCUIT_WITNESS_GEN_OUTPUT_SIZE = 'aztec.circuit.witness_generation.output_size';
+  /**
+   * The type of value reported.
+   * INT for counts/integers, DOUBLE for fractional values.
+   * @default ValueType.DOUBLE (OpenTelemetry default)
+   */
+  readonly valueType?: ValueType;
+}
 
-export const CIRCUIT_PROVING_DURATION = 'aztec.circuit.proving.duration';
-export const CIRCUIT_PROVING_INPUT_SIZE = 'aztec.circuit.proving.input_size';
-export const CIRCUIT_PROVING_PROOF_SIZE = 'aztec.circuit.proving.proof_size';
+export const BLOB_SINK_STORE_REQUESTS: MetricDefinition = {
+  name: 'aztec.blob_sink.store_request_count',
+  description: 'Number of blob store requests',
+  valueType: ValueType.INT,
+};
+export const BLOB_SINK_RETRIEVE_REQUESTS: MetricDefinition = {
+  name: 'aztec.blob_sink.retrieve_request_count',
+  description: 'Number of blob retrieve requests',
+  valueType: ValueType.INT,
+};
+export const BLOB_SINK_OBJECTS_IN_BLOB_STORE: MetricDefinition = {
+  name: 'aztec.blob_sink.objects_in_blob_store',
+  description: 'Number of objects in the blob store',
+  valueType: ValueType.INT,
+};
+export const BLOB_SINK_BLOB_SIZE: MetricDefinition = {
+  name: 'aztec.blob_sink.blob_size',
+  description: 'Size of blobs',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const CIRCUIT_PUBLIC_INPUTS_COUNT = 'aztec.circuit.public_inputs_count';
-export const CIRCUIT_GATE_COUNT = 'aztec.circuit.gate_count';
-export const CIRCUIT_SIZE = 'aztec.circuit.size';
+export const BLOB_SINK_ARCHIVE_BLOB_REQUEST_COUNT: MetricDefinition = {
+  name: 'aztec.blob_sink.archive.block_request_count',
+  description: 'Number of archive blob requests',
+  valueType: ValueType.INT,
+};
+export const BLOB_SINK_ARCHIVE_BLOCK_REQUEST_COUNT: MetricDefinition = {
+  name: 'aztec.blob_sink.archive.blob_request_count',
+  description: 'Number of archive block requests',
+  valueType: ValueType.INT,
+};
+export const BLOB_SINK_ARCHIVE_BLOB_COUNT: MetricDefinition = {
+  name: 'aztec.blob_sink.archive.blob_count',
+  description: 'Number of blobs in archive',
+  valueType: ValueType.INT,
+};
 
-export const MEMPOOL_TX_COUNT = 'aztec.mempool.tx_count';
-export const MEMPOOL_TX_SIZE = 'aztec.mempool.tx_size';
-export const MEMPOOL_TX_ADDED_COUNT = 'aztec.mempool.tx_added_count';
-export const MEMPOOL_TX_MINED_DELAY = 'aztec.mempool.tx_mined_delay';
+export const CIRCUIT_SIMULATION_DURATION: MetricDefinition = {
+  name: 'aztec.circuit.simulation.duration',
+  description: 'Records how long it takes to simulate a circuit',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_SIMULATION_INPUT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.simulation.input_size',
+  description: 'Size of the input to the circuit simulation',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_SIMULATION_OUTPUT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.simulation.output_size',
+  description: 'Size of the output of the circuit simulation',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const DB_NUM_ITEMS = 'aztec.db.num_items';
-export const DB_MAP_SIZE = 'aztec.db.map_size';
-export const DB_PHYSICAL_FILE_SIZE = 'aztec.db.physical_file_size';
-export const DB_USED_SIZE = 'aztec.db.used_size';
+export const CIRCUIT_WITNESS_GEN_DURATION: MetricDefinition = {
+  name: 'aztec.circuit.witness_generation.duration',
+  description: 'Records how long it takes to generate the partial witness for a circuit',
+  unit: 's',
+  valueType: ValueType.DOUBLE,
+};
+export const CIRCUIT_WITNESS_GEN_INPUT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.witness_generation.input_size',
+  description: 'Records the size of the input to the witness generation',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_WITNESS_GEN_OUTPUT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.witness_generation.output_size',
+  description: 'Records the size of the output of the witness generation',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const MEMPOOL_ATTESTATIONS_COUNT = 'aztec.mempool.attestations_count';
-export const MEMPOOL_ATTESTATIONS_SIZE = 'aztec.mempool.attestations_size';
-export const MEMPOOL_ATTESTATIONS_ADDED_COUNT = 'aztec.mempool.attestations_added_count';
-export const MEMPOOL_ATTESTATIONS_MINED_DELAY = 'aztec.mempool.attestations_mined_delay';
+export const CIRCUIT_PROVING_DURATION: MetricDefinition = {
+  name: 'aztec.circuit.proving.duration',
+  description: 'Records how long it takes to prove a circuit',
+  unit: 's',
+  valueType: ValueType.DOUBLE,
+};
+export const CIRCUIT_PROVING_INPUT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.proving.input_size',
+  description: 'Size of the input to the circuit proving',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_PROVING_PROOF_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.proving.proof_size',
+  description: 'Records the size of the proof generated for a circuit',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_L1_BLOCK_HEIGHT = 'aztec.archiver.l1_block_height';
-export const ARCHIVER_BLOCK_HEIGHT = 'aztec.archiver.block_height';
-export const ARCHIVER_ROLLUP_PROOF_DELAY = 'aztec.archiver.rollup_proof_delay';
-export const ARCHIVER_ROLLUP_PROOF_COUNT = 'aztec.archiver.rollup_proof_count';
+export const CIRCUIT_PUBLIC_INPUTS_COUNT: MetricDefinition = {
+  name: 'aztec.circuit.public_inputs_count',
+  description: 'Records the number of public inputs in a circuit',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_GATE_COUNT: MetricDefinition = {
+  name: 'aztec.circuit.gate_count',
+  description: 'Records the gate count of a circuit',
+  valueType: ValueType.INT,
+};
+export const CIRCUIT_SIZE: MetricDefinition = {
+  name: 'aztec.circuit.size',
+  description: 'Records the size of the circuit in gates',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_MANA_PER_BLOCK = 'aztec.archiver.block.mana_count';
-export const ARCHIVER_TXS_PER_BLOCK = 'aztec.archiver.block.tx_count';
-export const ARCHIVER_SYNC_PER_BLOCK = 'aztec.archiver.block.sync_per_item_duration';
-export const ARCHIVER_SYNC_BLOCK_COUNT = 'aztec.archiver.block.sync_count';
+export const MEMPOOL_TX_COUNT: MetricDefinition = {
+  name: 'aztec.mempool.tx_count',
+  description: 'The current number of transactions in the mempool',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_TX_SIZE: MetricDefinition = {
+  name: 'aztec.mempool.tx_size',
+  description: 'The size of transactions in the mempool',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_TX_ADDED_COUNT: MetricDefinition = {
+  name: 'aztec.mempool.tx_added_count',
+  description: 'The number of transactions added to the mempool',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_TX_MINED_DELAY: MetricDefinition = {
+  name: 'aztec.mempool.tx_mined_delay',
+  description: 'Delay between transaction added and evicted from the mempool',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_SYNC_PER_MESSAGE = 'aztec.archiver.message.sync_per_item_duration';
-export const ARCHIVER_SYNC_MESSAGE_COUNT = 'aztec.archiver.message.sync_count';
+export const DB_NUM_ITEMS: MetricDefinition = {
+  name: 'aztec.db.num_items',
+  description: 'LMDB Num Items',
+  valueType: ValueType.INT,
+};
+export const DB_MAP_SIZE: MetricDefinition = {
+  name: 'aztec.db.map_size',
+  description: 'LMDB Map Size',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const DB_PHYSICAL_FILE_SIZE: MetricDefinition = {
+  name: 'aztec.db.physical_file_size',
+  description: 'LMDB Physical File Size',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const DB_USED_SIZE: MetricDefinition = {
+  name: 'aztec.db.used_size',
+  description: 'LMDB Used Size',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_PRUNE_DURATION = 'aztec.archiver.prune_duration';
-export const ARCHIVER_PRUNE_COUNT = 'aztec.archiver.prune_count';
+export const MEMPOOL_ATTESTATIONS_COUNT: MetricDefinition = {
+  name: 'aztec.mempool.attestations_count',
+  description: 'The current number of attestations in the mempool',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_ATTESTATIONS_SIZE: MetricDefinition = {
+  name: 'aztec.mempool.attestations_size',
+  description: 'The size of attestations in the mempool',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_ATTESTATIONS_ADDED_COUNT: MetricDefinition = {
+  name: 'aztec.mempool.attestations_added_count',
+  description: 'The number of attestations added to the mempool',
+  valueType: ValueType.INT,
+};
+export const MEMPOOL_ATTESTATIONS_MINED_DELAY: MetricDefinition = {
+  name: 'aztec.mempool.attestations_mined_delay',
+  description: 'Delay between attestation added and evicted from the mempool',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_TOTAL_TXS = 'aztec.archiver.tx_count';
+export const ARCHIVER_L1_BLOCK_HEIGHT: MetricDefinition = {
+  name: 'aztec.archiver.l1_block_height',
+  description: 'The height of the latest L1 block processed by the archiver',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_BLOCK_HEIGHT: MetricDefinition = {
+  name: 'aztec.archiver.block_height',
+  description: 'The height of the latest block processed by the archiver',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_ROLLUP_PROOF_DELAY: MetricDefinition = {
+  name: 'aztec.archiver.rollup_proof_delay',
+  description: 'Time after a block is submitted until its proof is published',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_ROLLUP_PROOF_COUNT: MetricDefinition = {
+  name: 'aztec.archiver.rollup_proof_count',
+  description: 'Number of proofs submitted',
+  valueType: ValueType.INT,
+};
 
-export const ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT = 'aztec.archiver.block_proposal_tx_target_count';
+export const ARCHIVER_MANA_PER_BLOCK: MetricDefinition = {
+  name: 'aztec.archiver.block.mana_count',
+  description: 'The mana consumed by blocks',
+  unit: 'Mmana',
+  valueType: ValueType.DOUBLE,
+};
+export const ARCHIVER_TXS_PER_BLOCK: MetricDefinition = {
+  name: 'aztec.archiver.block.tx_count',
+  description: 'The block tx count',
+  unit: 'tx',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_SYNC_PER_BLOCK: MetricDefinition = {
+  name: 'aztec.archiver.block.sync_per_item_duration',
+  description: 'Duration to sync a block',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_SYNC_BLOCK_COUNT: MetricDefinition = {
+  name: 'aztec.archiver.block.sync_count',
+  description: 'Number of blocks synced from L1',
+  valueType: ValueType.INT,
+};
 
-export const NODE_RECEIVE_TX_DURATION = 'aztec.node.receive_tx.duration';
-export const NODE_RECEIVE_TX_COUNT = 'aztec.node.receive_tx.count';
+export const ARCHIVER_SYNC_PER_MESSAGE: MetricDefinition = {
+  name: 'aztec.archiver.message.sync_per_item_duration',
+  description: 'Duration to sync a message',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_SYNC_MESSAGE_COUNT: MetricDefinition = {
+  name: 'aztec.archiver.message.sync_count',
+  description: 'Number of L1 to L2 messages synced',
+  valueType: ValueType.INT,
+};
 
-export const NODE_SNAPSHOT_DURATION = 'aztec.node.snapshot_duration';
-export const NODE_SNAPSHOT_ERROR_COUNT = 'aztec.node.snapshot_error_count';
+export const ARCHIVER_PRUNE_DURATION: MetricDefinition = {
+  name: 'aztec.archiver.prune_duration',
+  description: 'Duration of a prune operation',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const ARCHIVER_PRUNE_COUNT: MetricDefinition = {
+  name: 'aztec.archiver.prune_count',
+  description: 'Number of prunes detected',
+  valueType: ValueType.INT,
+};
 
-export const SEQUENCER_STATE_TRANSITION_BUFFER_DURATION = 'aztec.sequencer.state_transition_buffer.duration';
-export const SEQUENCER_BLOCK_BUILD_DURATION = 'aztec.sequencer.block.build_duration';
-export const SEQUENCER_BLOCK_BUILD_MANA_PER_SECOND = 'aztec.sequencer.block.build_mana_per_second';
-export const SEQUENCER_BLOCK_COUNT = 'aztec.sequencer.block.count';
-export const SEQUENCER_CURRENT_BLOCK_REWARDS = 'aztec.sequencer.current_block_rewards';
-export const SEQUENCER_SLOT_COUNT = 'aztec.sequencer.slot.total_count';
-export const SEQUENCER_FILLED_SLOT_COUNT = 'aztec.sequencer.slot.filled_count';
+export const ARCHIVER_TOTAL_TXS: MetricDefinition = {
+  name: 'aztec.archiver.tx_count',
+  description: 'The total number of transactions',
+  valueType: ValueType.INT,
+};
 
-export const SEQUENCER_BLOCK_ATTESTATION_DELAY = 'aztec.sequencer.block.attestation_delay';
+export const ARCHIVER_BLOCK_PROPOSAL_TX_TARGET_COUNT: MetricDefinition = {
+  name: 'aztec.archiver.block_proposal_tx_target_count',
+  description: 'Number of block proposals by tx target',
+  valueType: ValueType.INT,
+};
 
-export const SEQUENCER_COLLECTED_ATTESTATIONS_COUNT = 'aztec.sequencer.attestations.collected_count';
-export const SEQUENCER_REQUIRED_ATTESTATIONS_COUNT = 'aztec.sequencer.attestations.required_count';
-export const SEQUENCER_COLLECT_ATTESTATIONS_DURATION = 'aztec.sequencer.attestations.collect_duration';
-export const SEQUENCER_COLLECT_ATTESTATIONS_TIME_ALLOWANCE = 'aztec.sequencer.attestations.collect_allowance';
+export const NODE_RECEIVE_TX_DURATION: MetricDefinition = {
+  name: 'aztec.node.receive_tx.duration',
+  description: 'The duration of the receiveTx method',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const NODE_RECEIVE_TX_COUNT: MetricDefinition = {
+  name: 'aztec.node.receive_tx.count',
+  description: 'Number of transactions received',
+  valueType: ValueType.INT,
+};
 
-export const SEQUENCER_BLOCK_PROPOSAL_FAILED_COUNT = 'aztec.sequencer.block.proposal_failed_count';
-export const SEQUENCER_BLOCK_PROPOSAL_SUCCESS_COUNT = 'aztec.sequencer.block.proposal_success_count';
-export const SEQUENCER_BLOCK_PROPOSAL_PRECHECK_FAILED_COUNT = 'aztec.sequencer.block.proposal_precheck_failed_count';
-export const SEQUENCER_SLASHING_ATTEMPTS_COUNT = 'aztec.sequencer.slashing.attempts_count';
-export const SEQUENCER_CHECKPOINT_SUCCESS_COUNT = 'aztec.sequencer.checkpoint.success_count';
+export const NODE_SNAPSHOT_DURATION: MetricDefinition = {
+  name: 'aztec.node.snapshot_duration',
+  description: 'How long taking a snapshot takes',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const NODE_SNAPSHOT_ERROR_COUNT: MetricDefinition = {
+  name: 'aztec.node.snapshot_error_count',
+  description: 'How many snapshot errors have happened',
+  valueType: ValueType.INT,
+};
+
+export const SEQUENCER_STATE_TRANSITION_BUFFER_DURATION: MetricDefinition = {
+  name: 'aztec.sequencer.state_transition_buffer.duration',
+  description:
+    'The time difference between when the sequencer needed to transition to a new state and when it actually did',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_BLOCK_BUILD_DURATION: MetricDefinition = {
+  name: 'aztec.sequencer.block.build_duration',
+  description: 'Duration to build a block',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_BLOCK_BUILD_MANA_PER_SECOND: MetricDefinition = {
+  name: 'aztec.sequencer.block.build_mana_per_second',
+  description: 'Mana per second when building a block',
+  unit: 'mana/s',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_BLOCK_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.block.count',
+  description: 'Number of blocks built by this sequencer',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_CURRENT_BLOCK_REWARDS: MetricDefinition = {
+  name: 'aztec.sequencer.current_block_rewards',
+  description: 'The rewards earned',
+  valueType: ValueType.DOUBLE,
+};
+export const SEQUENCER_SLOT_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.slot.total_count',
+  description: 'The number of slots this sequencer was selected for',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_FILLED_SLOT_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.slot.filled_count',
+  description: 'The number of slots this sequencer has filled',
+  valueType: ValueType.INT,
+};
+
+export const SEQUENCER_BLOCK_ATTESTATION_DELAY: MetricDefinition = {
+  name: 'aztec.sequencer.block.attestation_delay',
+  description: 'The time difference between block proposal and minimal attestation count reached',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+
+export const SEQUENCER_COLLECTED_ATTESTATIONS_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.attestations.collected_count',
+  description: 'The number of attestations collected for a block proposal',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_REQUIRED_ATTESTATIONS_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.attestations.required_count',
+  description: 'The minimum number of attestations required to publish a block',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_COLLECT_ATTESTATIONS_DURATION: MetricDefinition = {
+  name: 'aztec.sequencer.attestations.collect_duration',
+  description: 'The time spent collecting attestations from committee members',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_COLLECT_ATTESTATIONS_TIME_ALLOWANCE: MetricDefinition = {
+  name: 'aztec.sequencer.attestations.collect_allowance',
+  description: 'Maximum amount of time to collect attestations',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+
+export const SEQUENCER_BLOCK_PROPOSAL_FAILED_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.block.proposal_failed_count',
+  description: 'The number of times block proposal failed (including validation builds)',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_BLOCK_PROPOSAL_SUCCESS_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.block.proposal_success_count',
+  description: 'The number of times block proposal succeeded (including validation builds)',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_BLOCK_PROPOSAL_PRECHECK_FAILED_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.block.proposal_precheck_failed_count',
+  description: 'The number of times block proposal pre-build checks failed',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_SLASHING_ATTEMPTS_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.slashing.attempts_count',
+  description: 'The number of slashing action attempts',
+  valueType: ValueType.INT,
+};
+export const SEQUENCER_CHECKPOINT_SUCCESS_COUNT: MetricDefinition = {
+  name: 'aztec.sequencer.checkpoint.success_count',
+  description: 'The number of times checkpoint publishing succeeded',
+  valueType: ValueType.INT,
+};
 
 // Fisherman fee analysis metrics
-export const FISHERMAN_FEE_ANALYSIS_WOULD_BE_INCLUDED = 'aztec.fisherman.fee_analysis.would_be_included';
-export const FISHERMAN_FEE_ANALYSIS_TIME_BEFORE_BLOCK = 'aztec.fisherman.fee_analysis.time_before_block';
-export const FISHERMAN_FEE_ANALYSIS_PENDING_BLOB_TX_COUNT = 'aztec.fisherman.fee_analysis.pending_blob_tx_count';
-export const FISHERMAN_FEE_ANALYSIS_INCLUDED_BLOB_TX_COUNT = 'aztec.fisherman.fee_analysis.included_blob_tx_count';
-export const FISHERMAN_FEE_ANALYSIS_CALCULATED_PRIORITY_FEE = 'aztec.fisherman.fee_analysis.calculated_priority_fee';
-export const FISHERMAN_FEE_ANALYSIS_PRIORITY_FEE_DELTA = 'aztec.fisherman.fee_analysis.priority_fee_delta';
-export const FISHERMAN_FEE_ANALYSIS_ESTIMATED_COST = 'aztec.fisherman.fee_analysis.estimated_cost';
-export const FISHERMAN_FEE_ANALYSIS_ESTIMATED_OVERPAYMENT = 'aztec.fisherman.fee_analysis.estimated_overpayment';
-export const FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_PRIORITY_FEE =
-  'aztec.fisherman.fee_analysis.mined_blob_tx_priority_fee';
-export const FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_TOTAL_COST = 'aztec.fisherman.fee_analysis.mined_blob_tx_total_cost';
+export const FISHERMAN_FEE_ANALYSIS_WOULD_BE_INCLUDED: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.would_be_included',
+  description: 'Whether the transaction would have been included in the block',
+  valueType: ValueType.INT,
+};
+export const FISHERMAN_FEE_ANALYSIS_TIME_BEFORE_BLOCK: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.time_before_block',
+  description: 'Time in ms between fee analysis and block being mined',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const FISHERMAN_FEE_ANALYSIS_PENDING_BLOB_TX_COUNT: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.pending_blob_tx_count',
+  description: 'Number of blob transactions seen in the pending block',
+  valueType: ValueType.INT,
+};
+export const FISHERMAN_FEE_ANALYSIS_INCLUDED_BLOB_TX_COUNT: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.included_blob_tx_count',
+  description: 'Number of blob transactions that got included in the mined block',
+  valueType: ValueType.INT,
+};
+export const FISHERMAN_FEE_ANALYSIS_CALCULATED_PRIORITY_FEE: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.calculated_priority_fee',
+  description: 'Priority fee calculated by each strategy',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const FISHERMAN_FEE_ANALYSIS_PRIORITY_FEE_DELTA: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.priority_fee_delta',
+  description: 'Difference between our priority fee and minimum included priority fee',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const FISHERMAN_FEE_ANALYSIS_ESTIMATED_COST: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.estimated_cost',
+  description: 'Estimated total cost in ETH for the transaction with this strategy',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
+export const FISHERMAN_FEE_ANALYSIS_ESTIMATED_OVERPAYMENT: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.estimated_overpayment',
+  description: 'Estimated overpayment in ETH vs minimum required for inclusion',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
+export const FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_PRIORITY_FEE: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.mined_blob_tx_priority_fee',
+  description: 'Priority fee per gas for blob transactions in mined blocks',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const FISHERMAN_FEE_ANALYSIS_MINED_BLOB_TX_TOTAL_COST: MetricDefinition = {
+  name: 'aztec.fisherman.fee_analysis.mined_blob_tx_total_cost',
+  description: 'Total cost in ETH for blob transactions in mined blocks',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
 
-export const VALIDATOR_INVALID_ATTESTATION_RECEIVED_COUNT = 'aztec.validator.invalid_attestation_received_count';
+export const VALIDATOR_INVALID_ATTESTATION_RECEIVED_COUNT: MetricDefinition = {
+  name: 'aztec.validator.invalid_attestation_received_count',
+  description: 'Number of invalid attestations received',
+  valueType: ValueType.INT,
+};
 
-export const L1_PUBLISHER_GAS_PRICE = 'aztec.l1_publisher.gas_price';
-export const L1_PUBLISHER_TX_COUNT = 'aztec.l1_publisher.tx_count';
-export const L1_PUBLISHER_TX_DURATION = 'aztec.l1_publisher.tx_duration';
-export const L1_PUBLISHER_TX_GAS = 'aztec.l1_publisher.tx_gas';
-export const L1_PUBLISHER_TX_CALLDATA_SIZE = 'aztec.l1_publisher.tx_calldata_size';
-export const L1_PUBLISHER_TX_CALLDATA_GAS = 'aztec.l1_publisher.tx_calldata_gas';
-export const L1_PUBLISHER_TX_BLOBDATA_GAS_USED = 'aztec.l1_publisher.tx_blobdata_gas_used';
-export const L1_PUBLISHER_TX_BLOBDATA_GAS_COST = 'aztec.l1_publisher.tx_blobdata_gas_cost';
-export const L1_PUBLISHER_BLOB_COUNT = 'aztec.l1_publisher.blob_count';
-export const L1_PUBLISHER_BLOB_INCLUSION_BLOCKS = 'aztec.l1_publisher.blob_inclusion_blocks';
-export const L1_PUBLISHER_BLOB_TX_SUCCESS = 'aztec.l1_publisher.blob_tx_success';
-export const L1_PUBLISHER_BLOB_TX_FAILURE = 'aztec.l1_publisher.blob_tx_failure';
-export const L1_PUBLISHER_BALANCE = 'aztec.l1_publisher.balance';
-export const L1_PUBLISHER_TX_TOTAL_FEE = 'aztec.l1_publisher.tx_total_fee';
+export const L1_PUBLISHER_GAS_PRICE: MetricDefinition = {
+  name: 'aztec.l1_publisher.gas_price',
+  description: 'The gas price used for transactions',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const L1_PUBLISHER_TX_COUNT: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_count',
+  description: 'The number of transactions processed',
+};
+export const L1_PUBLISHER_TX_DURATION: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_duration',
+  description: 'The duration of transaction processing',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_TX_GAS: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_gas',
+  description: 'The gas consumed by transactions',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_TX_CALLDATA_SIZE: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_calldata_size',
+  description: 'The size of the calldata in transactions',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_TX_CALLDATA_GAS: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_calldata_gas',
+  description: 'The gas consumed by the calldata in transactions',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_TX_BLOBDATA_GAS_USED: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_blobdata_gas_used',
+  description: 'The amount of blob gas used in transactions',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_TX_BLOBDATA_GAS_COST: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_blobdata_gas_cost',
+  description: 'The gas cost of blobs in transactions',
+  unit: 'gwei',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_BLOB_COUNT: MetricDefinition = {
+  name: 'aztec.l1_publisher.blob_count',
+  description: 'Number of blobs in L1 transactions',
+  unit: 'blobs',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_BLOB_INCLUSION_BLOCKS: MetricDefinition = {
+  name: 'aztec.l1_publisher.blob_inclusion_blocks',
+  description: 'Number of L1 blocks between blob tx submission and inclusion',
+  unit: 'blocks',
+  valueType: ValueType.INT,
+};
+export const L1_PUBLISHER_BLOB_TX_SUCCESS: MetricDefinition = {
+  name: 'aztec.l1_publisher.blob_tx_success',
+  description: 'Number of successful L1 transactions with blobs',
+};
+export const L1_PUBLISHER_BLOB_TX_FAILURE: MetricDefinition = {
+  name: 'aztec.l1_publisher.blob_tx_failure',
+  description: 'Number of failed L1 transactions with blobs',
+};
+export const L1_PUBLISHER_BALANCE: MetricDefinition = {
+  name: 'aztec.l1_publisher.balance',
+  description: 'The balance of the sender address',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
+export const L1_PUBLISHER_TX_TOTAL_FEE: MetricDefinition = {
+  name: 'aztec.l1_publisher.tx_total_fee',
+  description: 'How much L1 tx costs',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
 
-export const L1_BLOCK_HEIGHT = 'aztec.l1.block_height';
-export const L1_BALANCE_ETH = 'aztec.l1.balance';
-export const L1_GAS_PRICE_WEI = 'aztec.l1.gas_price';
-export const L1_BLOB_BASE_FEE_WEI = 'aztec.l1.blob_base_fee';
+export const L1_BLOCK_HEIGHT: MetricDefinition = {
+  name: 'aztec.l1.block_height',
+  description: 'The current L1 block height',
+  valueType: ValueType.INT,
+};
+export const L1_BALANCE_ETH: MetricDefinition = {
+  name: 'aztec.l1.balance',
+  description: 'ETH balance of an address',
+  unit: 'eth',
+  valueType: ValueType.DOUBLE,
+};
+export const L1_GAS_PRICE_WEI: MetricDefinition = {
+  name: 'aztec.l1.gas_price',
+  description: 'Current L1 gas price',
+  unit: 'wei',
+  valueType: ValueType.INT,
+};
+export const L1_BLOB_BASE_FEE_WEI: MetricDefinition = {
+  name: 'aztec.l1.blob_base_fee',
+  description: 'Current L1 blob base fee',
+  unit: 'wei',
+  valueType: ValueType.INT,
+};
 
-export const L1_TX_MINED_DURATION = 'aztec.l1_tx.mined_duration';
-export const L1_TX_MINED_COUNT = 'aztec.l1_tx.mined_count';
-export const L1_TX_REVERTED_COUNT = 'aztec.l1_tx.reverted_count';
-export const L1_TX_CANCELLED_COUNT = 'aztec.l1_tx.cancelled_count';
-export const L1_TX_NOT_MINED_COUNT = 'aztec.l1_tx.not_mined_count';
-export const L1_TX_ATTEMPTS_UNTIL_MINED = 'aztec.l1_tx.attempts_until_mined';
-export const L1_TX_MAX_PRIORITY_FEE = 'aztec.l1_tx.max_priority_fee';
-export const L1_TX_MAX_FEE = 'aztec.l1_tx.max_fee';
-export const L1_TX_BLOB_FEE = 'aztec.l1_tx.blob_fee';
+export const L1_TX_MINED_DURATION: MetricDefinition = {
+  name: 'aztec.l1_tx.mined_duration',
+  description: 'Duration from L1 tx submission to mining',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const L1_TX_MINED_COUNT: MetricDefinition = {
+  name: 'aztec.l1_tx.mined_count',
+  description: 'Number of L1 transactions mined',
+  valueType: ValueType.INT,
+};
+export const L1_TX_REVERTED_COUNT: MetricDefinition = {
+  name: 'aztec.l1_tx.reverted_count',
+  description: 'Number of L1 transactions reverted',
+  valueType: ValueType.INT,
+};
+export const L1_TX_CANCELLED_COUNT: MetricDefinition = {
+  name: 'aztec.l1_tx.cancelled_count',
+  description: 'Number of L1 transactions cancelled',
+  valueType: ValueType.INT,
+};
+export const L1_TX_NOT_MINED_COUNT: MetricDefinition = {
+  name: 'aztec.l1_tx.not_mined_count',
+  description: 'Number of L1 transactions not mined',
+  valueType: ValueType.INT,
+};
+export const L1_TX_ATTEMPTS_UNTIL_MINED: MetricDefinition = {
+  name: 'aztec.l1_tx.attempts_until_mined',
+  description: 'Number of attempts until L1 tx was mined',
+  valueType: ValueType.INT,
+};
+export const L1_TX_MAX_PRIORITY_FEE: MetricDefinition = {
+  name: 'aztec.l1_tx.max_priority_fee',
+  description: 'Max priority fee used for L1 tx',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const L1_TX_MAX_FEE: MetricDefinition = {
+  name: 'aztec.l1_tx.max_fee',
+  description: 'Max fee used for L1 tx',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
+export const L1_TX_BLOB_FEE: MetricDefinition = {
+  name: 'aztec.l1_tx.blob_fee',
+  description: 'Blob fee used for L1 tx',
+  unit: 'gwei',
+  valueType: ValueType.DOUBLE,
+};
 
-export const PEER_MANAGER_GOODBYES_SENT = 'aztec.peer_manager.goodbyes_sent';
-export const PEER_MANAGER_GOODBYES_RECEIVED = 'aztec.peer_manager.goodbyes_received';
-export const PEER_MANAGER_PEER_COUNT = 'aztec.peer_manager.peer_count';
-export const PEER_MANAGER_LOW_SCORE_DISCONNECTS = 'aztec.peer_manager.low_score_disconnects';
-export const PEER_MANAGER_PEER_CONNECTION_DURATION = 'aztec.peer_manager.peer_connection_duration';
-export const P2P_PEER_STATE_COUNT = 'aztec.p2p.peer_state_count';
+export const PEER_MANAGER_GOODBYES_SENT: MetricDefinition = {
+  name: 'aztec.peer_manager.goodbyes_sent',
+  description: 'Number of goodbyes sent to peers',
+  unit: 'peers',
+  valueType: ValueType.INT,
+};
+export const PEER_MANAGER_GOODBYES_RECEIVED: MetricDefinition = {
+  name: 'aztec.peer_manager.goodbyes_received',
+  description: 'Number of goodbyes received from peers',
+  unit: 'peers',
+  valueType: ValueType.INT,
+};
+export const PEER_MANAGER_PEER_COUNT: MetricDefinition = {
+  name: 'aztec.peer_manager.peer_count',
+  description: 'Number of peers',
+  unit: 'peers',
+  valueType: ValueType.INT,
+};
+export const PEER_MANAGER_LOW_SCORE_DISCONNECTS: MetricDefinition = {
+  name: 'aztec.peer_manager.low_score_disconnects',
+  description: 'Number of peers disconnected due to low score',
+  unit: 'peers',
+  valueType: ValueType.INT,
+};
+export const PEER_MANAGER_PEER_CONNECTION_DURATION: MetricDefinition = {
+  name: 'aztec.peer_manager.peer_connection_duration',
+  description: 'Time duration between peer connection and disconnection',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_PEER_STATE_COUNT: MetricDefinition = {
+  name: 'aztec.p2p.peer_state_count',
+  description: 'Number of peers in each state',
+  unit: 'peers',
+  valueType: ValueType.INT,
+};
 
-export const P2P_REQ_RESP_SENT_REQUESTS = 'aztec.p2p.req_resp.sent_requests';
-export const P2P_REQ_RESP_RECEIVED_REQUESTS = 'aztec.p2p.req_resp.received_requests';
-export const P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS = 'aztec.p2p.req_resp.failed_outbound_requests';
-export const P2P_REQ_RESP_FAILED_INBOUND_REQUESTS = 'aztec.p2p.req_resp.failed_inbound_requests';
+export const P2P_REQ_RESP_SENT_REQUESTS: MetricDefinition = {
+  name: 'aztec.p2p.req_resp.sent_requests',
+  description: 'Number of requests sent to peers',
+  unit: 'requests',
+  valueType: ValueType.INT,
+};
+export const P2P_REQ_RESP_RECEIVED_REQUESTS: MetricDefinition = {
+  name: 'aztec.p2p.req_resp.received_requests',
+  description: 'Number of requests received from peers',
+  unit: 'requests',
+  valueType: ValueType.INT,
+};
+export const P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS: MetricDefinition = {
+  name: 'aztec.p2p.req_resp.failed_outbound_requests',
+  description: 'Number of failed outbound requests - nodes not getting valid responses',
+  unit: 'requests',
+  valueType: ValueType.INT,
+};
+export const P2P_REQ_RESP_FAILED_INBOUND_REQUESTS: MetricDefinition = {
+  name: 'aztec.p2p.req_resp.failed_inbound_requests',
+  description: 'Number of failed inbound requests - node failing to respond to requests',
+  unit: 'requests',
+  valueType: ValueType.INT,
+};
 
-export const P2P_GOSSIP_MESSAGE_VALIDATION_DURATION = 'aztec.p2p.gossip.message_validation_duration';
-export const P2P_GOSSIP_MESSAGE_PREVALIDATION_COUNT = 'aztec.p2p.gossip.message_validation_count';
-export const P2P_GOSSIP_MESSAGE_LATENCY = 'aztec.p2p.gossip.message_latency';
-export const P2P_GOSSIP_TX_RECEIVED_COUNT = 'aztec.p2p.gossip.tx_received_count';
+export const P2P_GOSSIP_MESSAGE_VALIDATION_DURATION: MetricDefinition = {
+  name: 'aztec.p2p.gossip.message_validation_duration',
+  description: 'Duration to validate a gossip message',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_MESSAGE_PREVALIDATION_COUNT: MetricDefinition = {
+  name: 'aztec.p2p.gossip.message_validation_count',
+  description: 'Number of gossip messages validated',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_MESSAGE_LATENCY: MetricDefinition = {
+  name: 'aztec.p2p.gossip.message_latency',
+  description: 'Latency of gossip messages',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_TX_RECEIVED_COUNT: MetricDefinition = {
+  name: 'aztec.p2p.gossip.tx_received_count',
+  description: 'Number of transactions received via gossip',
+  valueType: ValueType.INT,
+};
 
-export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_MIN = 'aztec.p2p.gossip.agg_message_latency_min';
-export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_MAX = 'aztec.p2p.gossip.agg_message_latency_max';
-export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_P50 = 'aztec.p2p.gossip.agg_message_latency_p50';
-export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_P90 = 'aztec.p2p.gossip.agg_message_latency_p90';
-export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_AVG = 'aztec.p2p.gossip.agg_message_latency_avg';
+export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_MIN: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_latency_min',
+  description: 'Minimum aggregated gossip message latency',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_MAX: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_latency_max',
+  description: 'Maximum aggregated gossip message latency',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_P50: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_latency_p50',
+  description: 'P50 aggregated gossip message latency',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_P90: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_latency_p90',
+  description: 'P90 aggregated gossip message latency',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_LATENCY_AVG: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_latency_avg',
+  description: 'Average aggregated gossip message latency',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MIN = 'aztec.p2p.gossip.agg_message_validation_duration_min';
-export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MAX = 'aztec.p2p.gossip.agg_message_validation_duration_max';
-export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P50 = 'aztec.p2p.gossip.agg_message_validation_duration_p50';
-export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P90 = 'aztec.p2p.gossip.agg_message_validation_duration_p90';
-export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_AVG = 'aztec.p2p.gossip.agg_message_validation_duration_avg';
+export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MIN: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_validation_duration_min',
+  description: 'Minimum aggregated gossip message validation duration',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_MAX: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_validation_duration_max',
+  description: 'Maximum aggregated gossip message validation duration',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P50: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_validation_duration_p50',
+  description: 'P50 aggregated gossip message validation duration',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_P90: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_validation_duration_p90',
+  description: 'P90 aggregated gossip message validation duration',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const P2P_GOSSIP_AGG_MESSAGE_VALIDATION_DURATION_AVG: MetricDefinition = {
+  name: 'aztec.p2p.gossip.agg_message_validation_duration_avg',
+  description: 'Average aggregated gossip message validation duration',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const PUBLIC_PROCESSOR_TX_DURATION = 'aztec.public_processor.tx_duration';
-export const PUBLIC_PROCESSOR_TX_COUNT = 'aztec.public_processor.tx_count';
-export const PUBLIC_PROCESSOR_TX_PHASE_COUNT = 'aztec.public_processor.tx_phase_count';
-export const PUBLIC_PROCESSOR_TX_GAS = 'aztec.public_processor.tx_gas';
-export const PUBLIC_PROCESSOR_PHASE_DURATION = 'aztec.public_processor.phase_duration';
-export const PUBLIC_PROCESSOR_PHASE_COUNT = 'aztec.public_processor.phase_count';
-export const PUBLIC_PROCESSOR_DEPLOY_BYTECODE_SIZE = 'aztec.public_processor.deploy_bytecode_size';
-export const PUBLIC_PROCESSOR_TOTAL_GAS = 'aztec.public_processor.total_gas';
-export const PUBLIC_PROCESSOR_TOTAL_GAS_HISTOGRAM = 'aztec.public_processor.total_gas_histogram';
-export const PUBLIC_PROCESSOR_GAS_RATE = 'aztec.public_processor.gas_rate';
-export const PUBLIC_PROCESSOR_TREE_INSERTION = 'aztec.public_processor.tree_insertion';
+export const PUBLIC_PROCESSOR_TX_DURATION: MetricDefinition = {
+  name: 'aztec.public_processor.tx_duration',
+  description: 'Duration to process a public transaction',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TX_COUNT: MetricDefinition = {
+  name: 'aztec.public_processor.tx_count',
+  description: 'Number of public transactions processed',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TX_PHASE_COUNT: MetricDefinition = {
+  name: 'aztec.public_processor.tx_phase_count',
+  description: 'Number of phases in public transaction processing',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TX_GAS: MetricDefinition = {
+  name: 'aztec.public_processor.tx_gas',
+  description: 'Gas consumed by public transaction',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_PHASE_DURATION: MetricDefinition = {
+  name: 'aztec.public_processor.phase_duration',
+  description: 'Duration of public processing phase',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_PHASE_COUNT: MetricDefinition = {
+  name: 'aztec.public_processor.phase_count',
+  description: 'Number of public processing phases',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_DEPLOY_BYTECODE_SIZE: MetricDefinition = {
+  name: 'aztec.public_processor.deploy_bytecode_size',
+  description: 'Size of deployed bytecode',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TOTAL_GAS: MetricDefinition = {
+  name: 'aztec.public_processor.total_gas',
+  description: 'Total gas consumed by public processor',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TOTAL_GAS_HISTOGRAM: MetricDefinition = {
+  name: 'aztec.public_processor.total_gas_histogram',
+  description: 'Histogram of total gas consumed by public processor',
+  unit: 'gas',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_GAS_RATE: MetricDefinition = {
+  name: 'aztec.public_processor.gas_rate',
+  description: 'Gas rate in public processor',
+  unit: 'gas/s',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_PROCESSOR_TREE_INSERTION: MetricDefinition = {
+  name: 'aztec.public_processor.tree_insertion',
+  description: 'Duration of tree insertion in public processor',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
 export const PUBLIC_EXECUTOR_PREFIX = 'aztec.public_executor.';
-export const PUBLIC_EXECUTOR_SIMULATION_COUNT = 'aztec.public_executor.simulation_count';
-export const PUBLIC_EXECUTOR_SIMULATION_DURATION = 'aztec.public_executor.simulation_duration';
-export const PUBLIC_EXECUTOR_SIMULATION_MANA_PER_SECOND = 'aztec.public_executor.simulation_mana_per_second';
-export const PUBLIC_EXECUTOR_SIMULATION_MANA_USED = 'aztec.public_executor.simulation_mana_used';
-export const PUBLIC_EXECUTOR_SIMULATION_TOTAL_INSTRUCTIONS = 'aztec.public_executor.simulation_total_instructions';
-export const PUBLIC_EXECUTOR_TX_HASHING = 'aztec.public_executor.tx_hashing';
-export const PUBLIC_EXECUTOR_PRIVATE_EFFECTS_INSERTION = 'aztec.public_executor.private_effects_insertion';
-export const PUBLIC_EXECUTOR_SIMULATION_BYTECODE_SIZE = 'aztec.public_executor.simulation_bytecode_size';
+export const PUBLIC_EXECUTOR_SIMULATION_COUNT: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_count',
+  description: 'Number of functions executed',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_SIMULATION_DURATION: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_duration',
+  description: 'How long it takes to execute a function',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_SIMULATION_MANA_PER_SECOND: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_mana_per_second',
+  description: 'Mana used per second',
+  unit: 'mana/s',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_SIMULATION_MANA_USED: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_mana_used',
+  description: 'Total mana used',
+  unit: 'mana',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_SIMULATION_TOTAL_INSTRUCTIONS: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_total_instructions',
+  description: 'Total number of instructions executed',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_TX_HASHING: MetricDefinition = {
+  name: 'aztec.public_executor.tx_hashing',
+  description: 'Tx hashing time',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_PRIVATE_EFFECTS_INSERTION: MetricDefinition = {
+  name: 'aztec.public_executor.private_effects_insertion',
+  description: 'Private effects insertion time',
+  unit: 'us',
+  valueType: ValueType.INT,
+};
+export const PUBLIC_EXECUTOR_SIMULATION_BYTECODE_SIZE: MetricDefinition = {
+  name: 'aztec.public_executor.simulation_bytecode_size',
+  description: 'Size of bytecode being executed',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const PROVING_ORCHESTRATOR_BASE_ROLLUP_INPUTS_DURATION =
-  'aztec.proving_orchestrator.base_rollup.inputs_duration';
+export const PROVING_ORCHESTRATOR_BASE_ROLLUP_INPUTS_DURATION: MetricDefinition = {
+  name: 'aztec.proving_orchestrator.base_rollup.inputs_duration',
+  description: 'Duration to build base rollup inputs',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const PROVING_QUEUE_JOB_SIZE = 'aztec.proving_queue.job_size';
-export const PROVING_QUEUE_SIZE = 'aztec.proving_queue.size';
-export const PROVING_QUEUE_TOTAL_JOBS = 'aztec.proving_queue.enqueued_jobs_count';
-export const PROVING_QUEUE_CACHED_JOBS = 'aztec.proving_queue.cached_jobs_count';
-export const PROVING_QUEUE_ACTIVE_JOBS = 'aztec.proving_queue.active_jobs_count';
-export const PROVING_QUEUE_RESOLVED_JOBS = 'aztec.proving_queue.resolved_jobs_count';
-export const PROVING_QUEUE_REJECTED_JOBS = 'aztec.proving_queue.rejected_jobs_count';
-export const PROVING_QUEUE_RETRIED_JOBS = 'aztec.proving_queue.retried_jobs_count';
-export const PROVING_QUEUE_TIMED_OUT_JOBS = 'aztec.proving_queue.timed_out_jobs_count';
-export const PROVING_QUEUE_JOB_WAIT = 'aztec.proving_queue.job_wait';
-export const PROVING_QUEUE_JOB_DURATION = 'aztec.proving_queue.job_duration';
-export const PROVING_QUEUE_DB_NUM_ITEMS = 'aztec.proving_queue.db.num_items';
-export const PROVING_QUEUE_DB_MAP_SIZE = 'aztec.proving_queue.db.map_size';
-export const PROVING_QUEUE_DB_USED_SIZE = 'aztec.proving_queue.db.used_size';
+export const PROVING_QUEUE_JOB_SIZE: MetricDefinition = {
+  name: 'aztec.proving_queue.job_size',
+  description: 'Size of proving jobs',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_SIZE: MetricDefinition = {
+  name: 'aztec.proving_queue.size',
+  description: 'Number of jobs in the proving queue',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_TOTAL_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.enqueued_jobs_count',
+  description: 'Total number of jobs enqueued',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_CACHED_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.cached_jobs_count',
+  description: 'Number of cached proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_ACTIVE_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.active_jobs_count',
+  description: 'Number of active proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_RESOLVED_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.resolved_jobs_count',
+  description: 'Number of resolved proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_REJECTED_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.rejected_jobs_count',
+  description: 'Number of rejected proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_RETRIED_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.retried_jobs_count',
+  description: 'Number of retried proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_TIMED_OUT_JOBS: MetricDefinition = {
+  name: 'aztec.proving_queue.timed_out_jobs_count',
+  description: 'Number of timed out proving jobs',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_JOB_WAIT: MetricDefinition = {
+  name: 'aztec.proving_queue.job_wait',
+  description: 'Records how long a job sits in the queue',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_JOB_DURATION: MetricDefinition = {
+  name: 'aztec.proving_queue.job_duration',
+  description: 'Records how long a job takes to complete',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_DB_NUM_ITEMS: MetricDefinition = {
+  name: 'aztec.proving_queue.db.num_items',
+  description: 'Number of items in the proving queue database',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_DB_MAP_SIZE: MetricDefinition = {
+  name: 'aztec.proving_queue.db.map_size',
+  description: 'Map size of the proving queue database',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const PROVING_QUEUE_DB_USED_SIZE: MetricDefinition = {
+  name: 'aztec.proving_queue.db.used_size',
+  description: 'Used size of the proving queue database',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
 
-export const PROVING_AGENT_IDLE = 'aztec.proving_queue.agent.idle';
+export const PROVING_AGENT_IDLE: MetricDefinition = {
+  name: 'aztec.proving_queue.agent.idle',
+  description: 'Records how long an agent was idle',
+  unit: 's',
+  valueType: ValueType.DOUBLE,
+};
 
-export const PROVER_NODE_EXECUTION_DURATION = 'aztec.prover_node.execution.duration';
-export const PROVER_NODE_JOB_DURATION = 'aztec.prover_node.job_duration';
-export const PROVER_NODE_JOB_CHECKPOINTS = 'aztec.prover_node.job_checkpoints';
-export const PROVER_NODE_JOB_BLOCKS = 'aztec.prover_node.job_blocks';
-export const PROVER_NODE_JOB_TRANSACTIONS = 'aztec.prover_node.job_transactions';
-export const PROVER_NODE_REWARDS_TOTAL = 'aztec.prover_node.rewards_total';
-export const PROVER_NODE_REWARDS_PER_EPOCH = 'aztec.prover_node.rewards_per_epoch';
+export const PROVER_NODE_EXECUTION_DURATION: MetricDefinition = {
+  name: 'aztec.prover_node.execution.duration',
+  description: 'Duration of execution of an epoch by the prover',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_JOB_DURATION: MetricDefinition = {
+  name: 'aztec.prover_node.job_duration',
+  description: 'Duration of proving job',
+  unit: 's',
+  valueType: ValueType.DOUBLE,
+};
+export const PROVER_NODE_JOB_CHECKPOINTS: MetricDefinition = {
+  name: 'aztec.prover_node.job_checkpoints',
+  description: 'Number of checkpoints in a proven epoch',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_JOB_BLOCKS: MetricDefinition = {
+  name: 'aztec.prover_node.job_blocks',
+  description: 'Number of blocks in a proven epoch',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_JOB_TRANSACTIONS: MetricDefinition = {
+  name: 'aztec.prover_node.job_transactions',
+  description: 'Number of transactions in a proven epoch',
+  valueType: ValueType.INT,
+};
+export const PROVER_NODE_REWARDS_TOTAL: MetricDefinition = {
+  name: 'aztec.prover_node.rewards_total',
+  description: 'The rewards earned (total)',
+  valueType: ValueType.DOUBLE,
+};
+export const PROVER_NODE_REWARDS_PER_EPOCH: MetricDefinition = {
+  name: 'aztec.prover_node.rewards_per_epoch',
+  description: 'The rewards earned',
+  valueType: ValueType.DOUBLE,
+};
 
-export const WORLD_STATE_FORK_DURATION = 'aztec.world_state.fork.duration';
-export const WORLD_STATE_SYNC_DURATION = 'aztec.world_state.sync.duration';
-export const WORLD_STATE_MERKLE_TREE_SIZE = 'aztec.world_state.merkle_tree_size';
-export const WORLD_STATE_DB_SIZE = 'aztec.world_state.db_size';
-export const WORLD_STATE_DB_MAP_SIZE = 'aztec.world_state.db_map_size';
-export const WORLD_STATE_DB_PHYSICAL_SIZE = 'aztec.world_state.db_physical_size';
-export const WORLD_STATE_TREE_SIZE = 'aztec.world_state.tree_size';
-export const WORLD_STATE_UNFINALIZED_HEIGHT = 'aztec.world_state.unfinalized_height';
-export const WORLD_STATE_FINALIZED_HEIGHT = 'aztec.world_state.finalized_height';
-export const WORLD_STATE_OLDEST_BLOCK = 'aztec.world_state.oldest_block';
-export const WORLD_STATE_DB_USED_SIZE = 'aztec.world_state.db_used_size';
-export const WORLD_STATE_DB_NUM_ITEMS = 'aztec.world_state.db_num_items';
-export const WORLD_STATE_REQUEST_TIME = 'aztec.world_state.request_time';
-export const WORLD_STATE_CRITICAL_ERROR_COUNT = 'aztec.world_state.critical_error_count';
+export const WORLD_STATE_FORK_DURATION: MetricDefinition = {
+  name: 'aztec.world_state.fork.duration',
+  description: 'Duration to fork world state',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_SYNC_DURATION: MetricDefinition = {
+  name: 'aztec.world_state.sync.duration',
+  description: 'Duration to sync world state',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_MERKLE_TREE_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.merkle_tree_size',
+  description: 'Size of the merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_DB_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.db_size',
+  description: 'Size of the world state database',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_DB_MAP_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.db_map_size',
+  description: 'The current configured map size for each merkle tree',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_DB_PHYSICAL_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.db_physical_size',
+  description: 'The current physical disk space used for each database',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_TREE_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.tree_size',
+  description: 'The current number of leaves in each merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_UNFINALIZED_HEIGHT: MetricDefinition = {
+  name: 'aztec.world_state.unfinalized_height',
+  description: 'The unfinalized block height of each merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_FINALIZED_HEIGHT: MetricDefinition = {
+  name: 'aztec.world_state.finalized_height',
+  description: 'The finalized block height of each merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_OLDEST_BLOCK: MetricDefinition = {
+  name: 'aztec.world_state.oldest_block',
+  description: 'The oldest historical block of each merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_DB_USED_SIZE: MetricDefinition = {
+  name: 'aztec.world_state.db_used_size',
+  description: 'The current used database size for each db of each merkle tree',
+  unit: 'By',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_DB_NUM_ITEMS: MetricDefinition = {
+  name: 'aztec.world_state.db_num_items',
+  description: 'The current number of items in each database of each merkle tree',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_REQUEST_TIME: MetricDefinition = {
+  name: 'aztec.world_state.request_time',
+  description: 'The round trip time of world state requests',
+  unit: 'us',
+  valueType: ValueType.INT,
+};
+export const WORLD_STATE_CRITICAL_ERROR_COUNT: MetricDefinition = {
+  name: 'aztec.world_state.critical_error_count',
+  description: 'The number of critical errors in the world state',
+  valueType: ValueType.INT,
+};
 
-export const PROOF_VERIFIER_COUNT = 'aztec.proof_verifier.count';
+export const PROOF_VERIFIER_COUNT: MetricDefinition = {
+  name: 'aztec.proof_verifier.count',
+  description: 'Number of proofs verified',
+  valueType: ValueType.INT,
+};
 
-export const VALIDATOR_RE_EXECUTION_TIME = 'aztec.validator.re_execution_time';
-export const VALIDATOR_RE_EXECUTION_MANA = 'aztec.validator.re_execution_mana';
-export const VALIDATOR_RE_EXECUTION_TX_COUNT = 'aztec.validator.re_execution_tx_count';
+export const VALIDATOR_RE_EXECUTION_TIME: MetricDefinition = {
+  name: 'aztec.validator.re_execution_time',
+  description: 'The time taken to re-execute a transaction',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const VALIDATOR_RE_EXECUTION_MANA: MetricDefinition = {
+  name: 'aztec.validator.re_execution_mana',
+  description: 'The mana consumed by blocks',
+  unit: 'Mmana',
+  valueType: ValueType.DOUBLE,
+};
+export const VALIDATOR_RE_EXECUTION_TX_COUNT: MetricDefinition = {
+  name: 'aztec.validator.re_execution_tx_count',
+  description: 'The number of txs in a block proposal',
+  unit: 'tx',
+  valueType: ValueType.INT,
+};
 
-export const VALIDATOR_FAILED_REEXECUTION_COUNT = 'aztec.validator.failed_reexecution_count';
-export const VALIDATOR_ATTESTATION_SUCCESS_COUNT = 'aztec.validator.attestation_success_count';
-export const VALIDATOR_ATTESTATION_FAILED_BAD_PROPOSAL_COUNT = 'aztec.validator.attestation_failed_bad_proposal_count';
-export const VALIDATOR_ATTESTATION_FAILED_NODE_ISSUE_COUNT = 'aztec.validator.attestation_failed_node_issue_count';
+export const VALIDATOR_FAILED_REEXECUTION_COUNT: MetricDefinition = {
+  name: 'aztec.validator.failed_reexecution_count',
+  description: 'The number of failed re-executions',
+  valueType: ValueType.INT,
+};
+export const VALIDATOR_ATTESTATION_SUCCESS_COUNT: MetricDefinition = {
+  name: 'aztec.validator.attestation_success_count',
+  description: 'The number of successful attestations',
+  valueType: ValueType.INT,
+};
+export const VALIDATOR_ATTESTATION_FAILED_BAD_PROPOSAL_COUNT: MetricDefinition = {
+  name: 'aztec.validator.attestation_failed_bad_proposal_count',
+  description: 'The number of failed attestations due to invalid block proposals',
+  valueType: ValueType.INT,
+};
+export const VALIDATOR_ATTESTATION_FAILED_NODE_ISSUE_COUNT: MetricDefinition = {
+  name: 'aztec.validator.attestation_failed_node_issue_count',
+  description: 'The number of failed attestations due to node issues (timeout, missing data, etc.)',
+  valueType: ValueType.INT,
+};
 
-export const NODEJS_EVENT_LOOP_DELAY_MIN = 'nodejs.eventloop.delay.min';
-export const NODEJS_EVENT_LOOP_DELAY_MEAN = 'nodejs.eventloop.delay.mean';
-export const NODEJS_EVENT_LOOP_DELAY_MAX = 'nodejs.eventloop.delay.max';
-export const NODEJS_EVENT_LOOP_DELAY_STDDEV = 'nodejs.eventloop.delay.stddev';
-export const NODEJS_EVENT_LOOP_DELAY_P50 = 'nodejs.eventloop.delay.p50';
-export const NODEJS_EVENT_LOOP_DELAY_P90 = 'nodejs.eventloop.delay.p90';
-export const NODEJS_EVENT_LOOP_DELAY_P99 = 'nodejs.eventloop.delay.p99';
+export const NODEJS_EVENT_LOOP_DELAY_MIN: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.min',
+  description: 'Minimum delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_MEAN: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.mean',
+  description: 'Mean delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_MAX: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.max',
+  description: 'Max delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_STDDEV: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.stddev',
+  description: 'Stddev delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_P50: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.p50',
+  description: 'P50 delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_P90: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.p90',
+  description: 'P90 delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
+export const NODEJS_EVENT_LOOP_DELAY_P99: MetricDefinition = {
+  name: 'nodejs.eventloop.delay.p99',
+  description: 'P99 delay of the event loop',
+  unit: 'ns',
+  valueType: ValueType.INT,
+};
 
-export const NODEJS_EVENT_LOOP_UTILIZATION = 'nodejs.eventloop.utilization';
-export const NODEJS_EVENT_LOOP_TIME = 'nodejs.eventloop.time';
+export const NODEJS_EVENT_LOOP_UTILIZATION: MetricDefinition = {
+  name: 'nodejs.eventloop.utilization',
+  description: 'How busy is the event loop',
+  valueType: ValueType.DOUBLE,
+};
+export const NODEJS_EVENT_LOOP_TIME: MetricDefinition = {
+  name: 'nodejs.eventloop.time',
+  description: 'How much time the event loop has spent in a given state',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const NODEJS_MEMORY_HEAP_USAGE = 'nodejs.memory.v8_heap.usage';
-export const NODEJS_MEMORY_HEAP_TOTAL = 'nodejs.memory.v8_heap.total';
-export const NODEJS_MEMORY_NATIVE_USAGE = 'nodejs.memory.native.usage';
-export const NODEJS_MEMORY_BUFFER_USAGE = 'nodejs.memory.array_buffer.usage';
+export const NODEJS_MEMORY_HEAP_USAGE: MetricDefinition = {
+  name: 'nodejs.memory.v8_heap.usage',
+  description: 'Memory used by the V8 heap',
+  unit: 'By',
+};
+export const NODEJS_MEMORY_HEAP_TOTAL: MetricDefinition = {
+  name: 'nodejs.memory.v8_heap.total',
+  description: 'The max size the V8 heap can grow to',
+  unit: 'By',
+};
+export const NODEJS_MEMORY_NATIVE_USAGE: MetricDefinition = {
+  name: 'nodejs.memory.native.usage',
+  description: 'Memory allocated for native C++ objects',
+  unit: 'By',
+};
+export const NODEJS_MEMORY_BUFFER_USAGE: MetricDefinition = {
+  name: 'nodejs.memory.array_buffer.usage',
+  description: 'Memory allocated for buffers (includes native memory used)',
+  unit: 'By',
+};
 
-export const TX_PROVIDER_TXS_FROM_PROPOSALS_COUNT = 'aztec.tx_collector.txs_from_proposal_count';
-export const TX_PROVIDER_TXS_FROM_MEMPOOL_COUNT = 'aztec.tx_collector.txs_from_mempool_count';
-export const TX_PROVIDER_TXS_FROM_P2P_COUNT = 'aztec.tx_collector.txs_from_p2p_count';
-export const TX_PROVIDER_MISSING_TXS_COUNT = 'aztec.tx_collector.missing_txs_count';
-export const TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION = 'aztec.tx_collector.txs_requested_fraction';
-export const TX_PROVIDER_P2P_TXS_REQUEST_DELAY = 'aztec.tx_collector.txs_requested_delay';
+export const TX_PROVIDER_TXS_FROM_PROPOSALS_COUNT: MetricDefinition = {
+  name: 'aztec.tx_collector.txs_from_proposal_count',
+  description: 'The number of txs taken from block proposals',
+  valueType: ValueType.INT,
+};
+export const TX_PROVIDER_TXS_FROM_MEMPOOL_COUNT: MetricDefinition = {
+  name: 'aztec.tx_collector.txs_from_mempool_count',
+  description: 'The number of txs taken from the local mempool',
+  valueType: ValueType.INT,
+};
+export const TX_PROVIDER_TXS_FROM_P2P_COUNT: MetricDefinition = {
+  name: 'aztec.tx_collector.txs_from_p2p_count',
+  description: 'The number of txs taken from the p2p network',
+  valueType: ValueType.INT,
+};
+export const TX_PROVIDER_MISSING_TXS_COUNT: MetricDefinition = {
+  name: 'aztec.tx_collector.missing_txs_count',
+  description: 'The number of txs not found anywhere',
+  valueType: ValueType.INT,
+};
+export const TX_PROVIDER_P2P_TXS_REQUESTED_FRACTION: MetricDefinition = {
+  name: 'aztec.tx_collector.txs_requested_fraction',
+  description: 'The fraction of transaction requested from peers',
+  valueType: ValueType.DOUBLE,
+};
+export const TX_PROVIDER_P2P_TXS_REQUEST_DELAY: MetricDefinition = {
+  name: 'aztec.tx_collector.txs_requested_delay',
+  description: 'The time it took to request missing transactions from p2p',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const TX_COLLECTOR_COUNT = 'aztec.tx_collector.tx_count';
-export const TX_COLLECTOR_DURATION_PER_REQUEST = 'aztec.tx_collector.duration_per_request';
-export const TX_COLLECTOR_DURATION_PER_TX = 'aztec.tx_collector.duration_per_tx';
+export const TX_COLLECTOR_COUNT: MetricDefinition = {
+  name: 'aztec.tx_collector.tx_count',
+  description: 'The number of txs collected',
+  valueType: ValueType.INT,
+};
+export const TX_COLLECTOR_DURATION_PER_REQUEST: MetricDefinition = {
+  name: 'aztec.tx_collector.duration_per_request',
+  description: 'Total duration of an individual tx collection request',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const TX_COLLECTOR_DURATION_PER_TX: MetricDefinition = {
+  name: 'aztec.tx_collector.duration_per_tx',
+  description: 'Average duration per tx of an individual tx collection request',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
 
-export const IVC_VERIFIER_TIME = 'aztec.ivc_verifier.time';
-export const IVC_VERIFIER_TOTAL_TIME = 'aztec.ivc_verifier.total_time';
-export const IVC_VERIFIER_FAILURE_COUNT = 'aztec.ivc_verifier.failure_count';
+export const IVC_VERIFIER_TIME: MetricDefinition = {
+  name: 'aztec.ivc_verifier.time',
+  description: 'Duration to verify chonk proofs',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const IVC_VERIFIER_TOTAL_TIME: MetricDefinition = {
+  name: 'aztec.ivc_verifier.total_time',
+  description: 'Total duration to verify chonk proofs, including serde',
+  unit: 'ms',
+  valueType: ValueType.INT,
+};
+export const IVC_VERIFIER_FAILURE_COUNT: MetricDefinition = {
+  name: 'aztec.ivc_verifier.failure_count',
+  description: 'Count of failed IVC proof verifications',
+  valueType: ValueType.INT,
+};
 
-export const IVC_VERIFIER_AGG_DURATION_MIN = 'aztec.ivc_verifier.agg_duration_min';
-export const IVC_VERIFIER_AGG_DURATION_MAX = 'aztec.ivc_verifier.agg_duration_max';
-export const IVC_VERIFIER_AGG_DURATION_P50 = 'aztec.ivc_verifier.agg_duration_p50';
-export const IVC_VERIFIER_AGG_DURATION_P90 = 'aztec.ivc_verifier.agg_duration_p90';
-export const IVC_VERIFIER_AGG_DURATION_AVG = 'aztec.ivc_verifier.agg_duration_avg';
+export const IVC_VERIFIER_AGG_DURATION_MIN: MetricDefinition = {
+  name: 'aztec.ivc_verifier.agg_duration_min',
+  description: 'MIN ivc verification',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+};
+export const IVC_VERIFIER_AGG_DURATION_MAX: MetricDefinition = {
+  name: 'aztec.ivc_verifier.agg_duration_max',
+  description: 'MAX ivc verification',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+};
+export const IVC_VERIFIER_AGG_DURATION_P50: MetricDefinition = {
+  name: 'aztec.ivc_verifier.agg_duration_p50',
+  description: 'P50 ivc verification',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+};
+export const IVC_VERIFIER_AGG_DURATION_P90: MetricDefinition = {
+  name: 'aztec.ivc_verifier.agg_duration_p90',
+  description: 'P90 ivc verification',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+};
+export const IVC_VERIFIER_AGG_DURATION_AVG: MetricDefinition = {
+  name: 'aztec.ivc_verifier.agg_duration_avg',
+  description: 'AVG ivc verification',
+  unit: 'ms',
+  valueType: ValueType.DOUBLE,
+};

--- a/yarn-project/telemetry-client/src/nodejs_metrics_monitor.ts
+++ b/yarn-project/telemetry-client/src/nodejs_metrics_monitor.ts
@@ -3,17 +3,9 @@ import { type EventLoopUtilization, type IntervalHistogram, monitorEventLoopDela
 
 import * as Attributes from './attributes.js';
 import * as Metrics from './metrics.js';
-import {
-  type BatchObservableResult,
-  type Meter,
-  type ObservableGauge,
-  type UpDownCounter,
-  ValueType,
-} from './telemetry.js';
+import type { BatchObservableResult, Meter, ObservableGauge, UpDownCounter } from './telemetry.js';
 
-/**
- * Detector for custom Aztec attributes
- */
+/** Monitors Node.js runtime metrics */
 export class NodejsMetricsMonitor {
   private eventLoopDelayGauges: {
     min: ObservableGauge;
@@ -38,53 +30,25 @@ export class NodejsMetricsMonitor {
   private eventLoopDelay: IntervalHistogram;
 
   constructor(private meter: Meter) {
-    const nsObsGauge = (name: (typeof Metrics)[keyof typeof Metrics], description: string) =>
-      meter.createObservableGauge(name, {
-        unit: 'ns',
-        valueType: ValueType.INT,
-        description,
-      });
-
     this.eventLoopDelayGauges = {
-      min: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MIN, 'Minimum delay of the event loop'),
-      mean: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MEAN, 'Mean delay of the event loop'),
-      max: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MAX, 'Max delay of the event loop'),
-      stddev: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_STDDEV, 'Stddev delay of the event loop'),
-      p50: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P50, 'P50 delay of the event loop'),
-      p90: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P90, 'P90 delay of the event loop'),
-      p99: nsObsGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P99, 'P99 delay of the event loop'),
+      min: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MIN),
+      mean: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MEAN),
+      max: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_MAX),
+      stddev: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_STDDEV),
+      p50: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P50),
+      p90: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P90),
+      p99: meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_DELAY_P99),
     };
 
-    this.eventLoopUilization = meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_UTILIZATION, {
-      valueType: ValueType.DOUBLE,
-      description: 'How busy is the event loop',
-    });
-
-    this.eventLoopTime = meter.createUpDownCounter(Metrics.NODEJS_EVENT_LOOP_TIME, {
-      unit: 'ms',
-      valueType: ValueType.INT,
-      description: 'How much time the event loop has spent in a given state',
-    });
-
+    this.eventLoopUilization = meter.createObservableGauge(Metrics.NODEJS_EVENT_LOOP_UTILIZATION);
+    this.eventLoopTime = meter.createUpDownCounter(Metrics.NODEJS_EVENT_LOOP_TIME);
     this.eventLoopDelay = monitorEventLoopDelay();
 
     this.memoryGauges = {
-      heapUsed: meter.createObservableGauge(Metrics.NODEJS_MEMORY_HEAP_USAGE, {
-        unit: 'By',
-        description: 'Memory used by the V8 heap',
-      }),
-      heapTotal: meter.createObservableGauge(Metrics.NODEJS_MEMORY_HEAP_TOTAL, {
-        unit: 'By',
-        description: 'The max size the V8 heap can grow to',
-      }),
-      arrayBuffers: meter.createObservableGauge(Metrics.NODEJS_MEMORY_BUFFER_USAGE, {
-        unit: 'By',
-        description: 'Memory allocated for buffers (includes native memory used)',
-      }),
-      external: meter.createObservableGauge(Metrics.NODEJS_MEMORY_NATIVE_USAGE, {
-        unit: 'By',
-        description: 'Memory allocated for native C++ objects',
-      }),
+      heapUsed: meter.createObservableGauge(Metrics.NODEJS_MEMORY_HEAP_USAGE),
+      heapTotal: meter.createObservableGauge(Metrics.NODEJS_MEMORY_HEAP_TOTAL),
+      arrayBuffers: meter.createObservableGauge(Metrics.NODEJS_MEMORY_BUFFER_USAGE),
+      external: meter.createObservableGauge(Metrics.NODEJS_MEMORY_NATIVE_USAGE),
     };
   }
 

--- a/yarn-project/telemetry-client/src/noop.ts
+++ b/yarn-project/telemetry-client/src/noop.ts
@@ -1,20 +1,63 @@
-import {
-  type Context,
-  type Meter,
-  type Span,
-  type SpanContext,
-  type Tracer,
-  createNoopMeter,
-} from '@opentelemetry/api';
+import { type Context, type Span, type SpanContext, type Tracer, createNoopMeter } from '@opentelemetry/api';
 
-import type { TelemetryClient } from './telemetry.js';
+import type { MetricDefinition } from './metrics.js';
+import type {
+  Gauge,
+  Histogram,
+  Meter,
+  ObservableGauge,
+  ObservableUpDownCounter,
+  TelemetryClient,
+  UpDownCounter,
+} from './telemetry.js';
+
+/** A no-op meter that implements our custom Meter interface */
+class NoopMeter implements Meter {
+  private otelMeter = createNoopMeter();
+
+  createGauge(_metric: MetricDefinition): Gauge {
+    return this.otelMeter.createGauge('');
+  }
+
+  createObservableGauge(_metric: MetricDefinition): ObservableGauge {
+    return this.otelMeter.createObservableGauge('');
+  }
+
+  createHistogram(_metric: MetricDefinition, _extraOptions?: Parameters<Meter['createHistogram']>[1]): Histogram {
+    return this.otelMeter.createHistogram('');
+  }
+
+  createUpDownCounter(_metric: MetricDefinition): UpDownCounter {
+    return this.otelMeter.createUpDownCounter('');
+  }
+
+  createObservableUpDownCounter(_metric: MetricDefinition): ObservableUpDownCounter {
+    return this.otelMeter.createObservableUpDownCounter('');
+  }
+
+  addBatchObservableCallback(
+    callback: Parameters<Meter['addBatchObservableCallback']>[0],
+    observables: Parameters<Meter['addBatchObservableCallback']>[1],
+  ): void {
+    this.otelMeter.addBatchObservableCallback(callback, observables);
+  }
+
+  removeBatchObservableCallback(
+    callback: Parameters<Meter['removeBatchObservableCallback']>[0],
+    observables: Parameters<Meter['removeBatchObservableCallback']>[1],
+  ): void {
+    this.otelMeter.removeBatchObservableCallback(callback, observables);
+  }
+}
 
 export class NoopTelemetryClient implements TelemetryClient {
+  private meter = new NoopMeter();
+
   setExportedPublicTelemetry(_prefixes: string[]): void {}
   setPublicTelemetryCollectFrom(_roles: string[]): void {}
 
   getMeter(): Meter {
-    return createNoopMeter();
+    return this.meter;
   }
 
   getTracer(): Tracer {

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -4,7 +4,7 @@ import {
   type Context,
   DiagConsoleLogger,
   DiagLogLevel,
-  type Meter,
+  type Meter as OtelMeter,
   ROOT_CONTEXT,
   type Tracer,
   type TracerProvider,
@@ -32,18 +32,67 @@ import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import type { TelemetryClientConfig } from './config.js';
+import type { MetricDefinition } from './metrics.js';
 import { NodejsMetricsMonitor } from './nodejs_metrics_monitor.js';
 import { OtelFilterMetricExporter, PublicOtelFilterMetricExporter } from './otel_filter_metric_exporter.js';
 import { registerOtelLoggerProvider } from './otel_logger_provider.js';
 import { getOtelResource } from './otel_resource.js';
-import type { TelemetryClient } from './telemetry.js';
+import {
+  type Gauge,
+  type Histogram,
+  type Meter,
+  type ObservableGauge,
+  type ObservableUpDownCounter,
+  type TelemetryClient,
+  type UpDownCounter,
+  toMetricOptions,
+} from './telemetry.js';
+
+/** Wraps an OpenTelemetry Meter to implement our custom Meter interface */
+class WrappedMeter implements Meter {
+  constructor(private otelMeter: OtelMeter) {}
+
+  createGauge(metric: MetricDefinition): Gauge {
+    return this.otelMeter.createGauge(metric.name, toMetricOptions(metric));
+  }
+
+  createObservableGauge(metric: MetricDefinition): ObservableGauge {
+    return this.otelMeter.createObservableGauge(metric.name, toMetricOptions(metric));
+  }
+
+  createHistogram(metric: MetricDefinition, extraOptions?: Parameters<Meter['createHistogram']>[1]): Histogram {
+    return this.otelMeter.createHistogram(metric.name, { ...toMetricOptions(metric), ...extraOptions });
+  }
+
+  createUpDownCounter(metric: MetricDefinition): UpDownCounter {
+    return this.otelMeter.createUpDownCounter(metric.name, toMetricOptions(metric));
+  }
+
+  createObservableUpDownCounter(metric: MetricDefinition): ObservableUpDownCounter {
+    return this.otelMeter.createObservableUpDownCounter(metric.name, toMetricOptions(metric));
+  }
+
+  addBatchObservableCallback(
+    callback: Parameters<Meter['addBatchObservableCallback']>[0],
+    observables: Parameters<Meter['addBatchObservableCallback']>[1],
+  ): void {
+    this.otelMeter.addBatchObservableCallback(callback, observables);
+  }
+
+  removeBatchObservableCallback(
+    callback: Parameters<Meter['removeBatchObservableCallback']>[0],
+    observables: Parameters<Meter['removeBatchObservableCallback']>[1],
+  ): void {
+    this.otelMeter.removeBatchObservableCallback(callback, observables);
+  }
+}
 
 export type OpenTelemetryClientFactory = (resource: IResource, log: Logger) => OpenTelemetryClient;
 
 export class OpenTelemetryClient implements TelemetryClient {
   hostMetrics: HostMetrics | undefined;
   nodejsMetricsMonitor: NodejsMetricsMonitor | undefined;
-  private meters: Map<string, Meter> = new Map<string, Meter>();
+  private meters: Map<string, WrappedMeter> = new Map<string, WrappedMeter>();
   private tracers: Map<string, Tracer> = new Map<string, Tracer>();
 
   protected constructor(
@@ -66,7 +115,8 @@ export class OpenTelemetryClient implements TelemetryClient {
   getMeter(name: string): Meter {
     let meter = this.meters.get(name);
     if (!meter) {
-      meter = this.meterProvider.getMeter(name, this.resource.attributes[ATTR_SERVICE_VERSION] as string);
+      const otelMeter = this.meterProvider.getMeter(name, this.resource.attributes[ATTR_SERVICE_VERSION] as string);
+      meter = new WrappedMeter(otelMeter);
       this.meters.set(name, meter);
     }
     return meter;
@@ -104,9 +154,10 @@ export class OpenTelemetryClient implements TelemetryClient {
       meterProvider: this.meterProvider,
     });
 
-    this.nodejsMetricsMonitor = new NodejsMetricsMonitor(
+    const nodejsMeter = new WrappedMeter(
       this.meterProvider.getMeter(this.resource.attributes[ATTR_SERVICE_NAME] as string),
     );
+    this.nodejsMetricsMonitor = new NodejsMetricsMonitor(nodejsMeter);
 
     this.hostMetrics.start();
     this.nodejsMetricsMonitor.start();

--- a/yarn-project/telemetry-client/src/prom_otel_adapter.test.ts
+++ b/yarn-project/telemetry-client/src/prom_otel_adapter.test.ts
@@ -223,13 +223,16 @@ describe('OtelAvgMinMax', () => {
 
   test('creates three gauges with correct names and descriptions', () => {
     otelAvgMinMax = new OtelAvgMinMax(mockLogger, mockMeter, 'test_avgminmax', 'Test AvgMinMax');
-    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith('test_avgminmax_avg', {
+    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith({
+      name: 'test_avgminmax_avg',
       description: 'Test AvgMinMax (average)',
     });
-    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith('test_avgminmax_min', {
+    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith({
+      name: 'test_avgminmax_min',
       description: 'Test AvgMinMax (minimum)',
     });
-    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith('test_avgminmax_max', {
+    expect(mockMeter.createObservableGauge).toHaveBeenCalledWith({
+      name: 'test_avgminmax_max',
       description: 'Test AvgMinMax (maximum)',
     });
   });

--- a/yarn-project/telemetry-client/src/prom_otel_adapter.ts
+++ b/yarn-project/telemetry-client/src/prom_otel_adapter.ts
@@ -3,7 +3,8 @@ import { Timer } from '@aztec/foundation/timer';
 
 import { Registry } from 'prom-client';
 
-import type { Histogram, Meter, MetricsType, ObservableGauge, TelemetryClient } from './telemetry.js';
+import type { MetricDefinition } from './metrics.js';
+import type { Histogram, Meter, ObservableGauge, TelemetryClient } from './telemetry.js';
 
 /**
  * Types matching the gossipsub and libp2p services
@@ -94,9 +95,8 @@ export class OtelGauge<Labels extends LabelsGeneric = NoLabels> implements IGaug
     help: string,
     private labelNames: Array<keyof Labels> = [],
   ) {
-    this.gauge = meter.createObservableGauge(name as MetricsType, {
-      description: help,
-    });
+    const metricDef: MetricDefinition = { name, description: help };
+    this.gauge = meter.createObservableGauge(metricDef);
 
     // Only observe in the callback when collect() is called
     this.gauge.addCallback(this.handleObservation.bind(this));
@@ -214,8 +214,8 @@ export class OtelHistogram<Labels extends LabelsGeneric = NoLabels> implements I
     buckets: number[] = [],
     private labelNames: Array<keyof Labels> = [],
   ) {
-    this.histogram = meter.createHistogram(name as MetricsType, {
-      description: help,
+    const metricDef: MetricDefinition = { name, description: help };
+    this.histogram = meter.createHistogram(metricDef, {
       advice: buckets.length ? { explicitBucketBoundaries: buckets } : undefined,
     });
   }
@@ -289,15 +289,9 @@ export class OtelAvgMinMax<Labels extends LabelsGeneric = NoLabels> implements I
   ) {
     // Create three separate gauges for avg, min, and max
     this.gauges = {
-      avg: meter.createObservableGauge(`${name}_avg` as MetricsType, {
-        description: `${help} (average)`,
-      }),
-      min: meter.createObservableGauge(`${name}_min` as MetricsType, {
-        description: `${help} (minimum)`,
-      }),
-      max: meter.createObservableGauge(`${name}_max` as MetricsType, {
-        description: `${help} (maximum)`,
-      }),
+      avg: meter.createObservableGauge({ name: `${name}_avg`, description: `${help} (average)` }),
+      min: meter.createObservableGauge({ name: `${name}_min`, description: `${help} (minimum)` }),
+      max: meter.createObservableGauge({ name: `${name}_max`, description: `${help} (maximum)` }),
     };
 
     // Register callbacks for each gauge
@@ -429,7 +423,7 @@ export class OtelMetricsAdapter extends Registry implements MetricsRegister {
     return new OtelGauge<Labels>(
       this.logger,
       this.meter,
-      configuration.name as MetricsType,
+      configuration.name,
       configuration.help,
       configuration.labelNames,
     );
@@ -439,7 +433,7 @@ export class OtelMetricsAdapter extends Registry implements MetricsRegister {
     return new OtelHistogram<Labels>(
       this.logger,
       this.meter,
-      configuration.name as MetricsType,
+      configuration.name,
       configuration.help,
       configuration.buckets,
       configuration.labelNames,
@@ -450,7 +444,7 @@ export class OtelMetricsAdapter extends Registry implements MetricsRegister {
     return new OtelAvgMinMax<Labels>(
       this.logger,
       this.meter,
-      configuration.name as MetricsType,
+      configuration.name,
       configuration.help,
       configuration.labelNames,
     );

--- a/yarn-project/telemetry-client/src/telemetry.ts
+++ b/yarn-project/telemetry-client/src/telemetry.ts
@@ -17,8 +17,17 @@ import {
 } from '@opentelemetry/api';
 
 import type * as Attributes from './attributes.js';
-import type * as Metrics from './metrics.js';
+import type { MetricDefinition } from './metrics.js';
 import { getTelemetryClient } from './start.js';
+
+/** Extracts OpenTelemetry MetricOptions from a MetricDefinition */
+export function toMetricOptions(def: MetricDefinition): MetricOptions {
+  return {
+    description: def.description,
+    unit: def.unit,
+    valueType: def.valueType,
+  };
+}
 
 export { type Span, SpanStatusCode, ValueType, type Context } from '@opentelemetry/api';
 
@@ -57,8 +66,8 @@ export type AttributesType = Partial<Record<AttributeNames, AttributeValue>>;
 /** Subset of attributes allowed to be added to metrics */
 export type MetricAttributesType = Partial<Record<Exclude<AttributeNames, BannedMetricAttributeNames>, AttributeValue>>;
 
-/** Global registry of metrics */
-export type MetricsType = (typeof Metrics)[keyof typeof Metrics];
+/** Re-export MetricDefinition for convenience */
+export type { MetricDefinition } from './metrics.js';
 
 export type Gauge = OtelGauge<MetricAttributesType>;
 export type Histogram = OtelHistogram<MetricAttributesType>;
@@ -77,17 +86,15 @@ export type { Tracer };
 export interface Meter {
   /**
    * Creates a new gauge instrument. A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
-   * @param name - The name of the gauge
-   * @param options - The options for the gauge
+   * @param metric - The metric definition
    */
-  createGauge(name: MetricsType, options?: MetricOptions): Gauge;
+  createGauge(metric: MetricDefinition): Gauge;
 
   /**
-   * Creates a new gauge instrument. A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
-   * @param name - The name of the gauge
-   * @param options - The options for the gauge
+   * Creates a new observable gauge instrument. A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
+   * @param metric - The metric definition
    */
-  createObservableGauge(name: MetricsType, options?: MetricOptions): ObservableGauge;
+  createObservableGauge(metric: MetricDefinition): ObservableGauge;
 
   addBatchObservableCallback(
     callback: BatchObservableCallback<AttributesType>,
@@ -101,24 +108,22 @@ export interface Meter {
 
   /**
    * Creates a new histogram instrument. A histogram is a metric that samples observations (usually things like request durations or response sizes) and counts them in configurable buckets.
-   * @param name - The name of the histogram
-   * @param options - The options for the histogram
+   * @param metric - The metric definition
+   * @param extraOptions - Optional extra options (e.g., advice for bucket boundaries)
    */
-  createHistogram(name: MetricsType, options?: MetricOptions): Histogram;
+  createHistogram(metric: MetricDefinition, extraOptions?: Partial<MetricOptions>): Histogram;
 
   /**
    * Creates a new counter instrument. A counter can go up or down with a delta from the previous value.
-   * @param name - The name of the counter
-   * @param options - The options for the counter
+   * @param metric - The metric definition
    */
-  createUpDownCounter(name: MetricsType, options?: MetricOptions): UpDownCounter;
+  createUpDownCounter(metric: MetricDefinition): UpDownCounter;
 
   /**
-   * Creates a new gauge instrument. A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
-   * @param name - The name of the gauge
-   * @param options - The options for the gauge
+   * Creates a new observable up/down counter instrument.
+   * @param metric - The metric definition
    */
-  createObservableUpDownCounter(name: MetricsType, options?: MetricOptions): ObservableUpDownCounter;
+  createObservableUpDownCounter(metric: MetricDefinition): ObservableUpDownCounter;
 }
 
 /**

--- a/yarn-project/validator-client/src/metrics.ts
+++ b/yarn-project/validator-client/src/metrics.ts
@@ -1,11 +1,11 @@
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import {
   Attributes,
+  type Gauge,
   type Histogram,
   Metrics,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 export class ValidatorMetrics {
@@ -16,55 +16,28 @@ export class ValidatorMetrics {
 
   private reexMana: Histogram;
   private reexTx: Histogram;
-  private reexDuration: Histogram;
+  private reexDuration: Gauge;
 
   constructor(telemetryClient: TelemetryClient) {
     const meter = telemetryClient.getMeter('Validator');
 
-    this.failedReexecutionCounter = meter.createUpDownCounter(Metrics.VALIDATOR_FAILED_REEXECUTION_COUNT, {
-      description: 'The number of failed re-executions',
-      unit: 'count',
-      valueType: ValueType.INT,
-    });
+    this.failedReexecutionCounter = meter.createUpDownCounter(Metrics.VALIDATOR_FAILED_REEXECUTION_COUNT);
 
-    this.successfulAttestationsCount = meter.createUpDownCounter(Metrics.VALIDATOR_ATTESTATION_SUCCESS_COUNT, {
-      description: 'The number of successful attestations',
-      valueType: ValueType.INT,
-    });
+    this.successfulAttestationsCount = meter.createUpDownCounter(Metrics.VALIDATOR_ATTESTATION_SUCCESS_COUNT);
 
     this.failedAttestationsBadProposalCount = meter.createUpDownCounter(
       Metrics.VALIDATOR_ATTESTATION_FAILED_BAD_PROPOSAL_COUNT,
-      {
-        description: 'The number of failed attestations due to invalid block proposals',
-        valueType: ValueType.INT,
-      },
     );
 
     this.failedAttestationsNodeIssueCount = meter.createUpDownCounter(
       Metrics.VALIDATOR_ATTESTATION_FAILED_NODE_ISSUE_COUNT,
-      {
-        description: 'The number of failed attestations due to node issues (timeout, missing data, etc.)',
-        valueType: ValueType.INT,
-      },
     );
 
-    this.reexMana = meter.createHistogram(Metrics.VALIDATOR_RE_EXECUTION_MANA, {
-      description: 'The mana consumed by blocks',
-      valueType: ValueType.DOUBLE,
-      unit: 'Mmana',
-    });
+    this.reexMana = meter.createHistogram(Metrics.VALIDATOR_RE_EXECUTION_MANA);
 
-    this.reexTx = meter.createHistogram(Metrics.VALIDATOR_RE_EXECUTION_TX_COUNT, {
-      description: 'The number of txs in a block proposal',
-      valueType: ValueType.INT,
-      unit: 'tx',
-    });
+    this.reexTx = meter.createHistogram(Metrics.VALIDATOR_RE_EXECUTION_TX_COUNT);
 
-    this.reexDuration = meter.createGauge(Metrics.VALIDATOR_RE_EXECUTION_TIME, {
-      description: 'The time taken to re-execute a transaction',
-      unit: 'ms',
-      valueType: ValueType.INT,
-    });
+    this.reexDuration = meter.createGauge(Metrics.VALIDATOR_RE_EXECUTION_TIME);
   }
 
   public recordReex(time: number, txs: number, mManaTotal: number) {

--- a/yarn-project/world-state/src/instrumentation/instrumentation.ts
+++ b/yarn-project/world-state/src/instrumentation/instrumentation.ts
@@ -7,7 +7,6 @@ import {
   Metrics,
   type TelemetryClient,
   type UpDownCounter,
-  ValueType,
 } from '@aztec/telemetry-client';
 
 import {
@@ -46,56 +45,25 @@ export class WorldStateInstrumentation {
     private log: Logger = createLogger('world-state:instrumentation'),
   ) {
     const meter = telemetry.getMeter('World State');
-    this.dbMapSize = meter.createGauge(Metrics.WORLD_STATE_DB_MAP_SIZE, {
-      description: `The current configured map size for each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.dbMapSize = meter.createGauge(Metrics.WORLD_STATE_DB_MAP_SIZE);
 
-    this.dbPhysicalSize = meter.createGauge(Metrics.WORLD_STATE_DB_PHYSICAL_SIZE, {
-      description: `The current physical disk space used for each database`,
-      valueType: ValueType.INT,
-    });
+    this.dbPhysicalSize = meter.createGauge(Metrics.WORLD_STATE_DB_PHYSICAL_SIZE);
 
-    this.treeSize = meter.createGauge(Metrics.WORLD_STATE_TREE_SIZE, {
-      description: `The current number of leaves in each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.treeSize = meter.createGauge(Metrics.WORLD_STATE_TREE_SIZE);
 
-    this.unfinalizedHeight = meter.createGauge(Metrics.WORLD_STATE_UNFINALIZED_HEIGHT, {
-      description: `The unfinalized block height of each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.unfinalizedHeight = meter.createGauge(Metrics.WORLD_STATE_UNFINALIZED_HEIGHT);
 
-    this.finalizedHeight = meter.createGauge(Metrics.WORLD_STATE_FINALIZED_HEIGHT, {
-      description: `The finalized block height of each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.finalizedHeight = meter.createGauge(Metrics.WORLD_STATE_FINALIZED_HEIGHT);
 
-    this.oldestBlock = meter.createGauge(Metrics.WORLD_STATE_OLDEST_BLOCK, {
-      description: `The oldest historical block of each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.oldestBlock = meter.createGauge(Metrics.WORLD_STATE_OLDEST_BLOCK);
 
-    this.dbUsedSize = meter.createGauge(Metrics.WORLD_STATE_DB_USED_SIZE, {
-      description: `The current used database size for each db of each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.dbUsedSize = meter.createGauge(Metrics.WORLD_STATE_DB_USED_SIZE);
 
-    this.dbNumItems = meter.createGauge(Metrics.WORLD_STATE_DB_NUM_ITEMS, {
-      description: `The current number of items in each database of each merkle tree`,
-      valueType: ValueType.INT,
-    });
+    this.dbNumItems = meter.createGauge(Metrics.WORLD_STATE_DB_NUM_ITEMS);
 
-    this.requestHistogram = meter.createHistogram(Metrics.WORLD_STATE_REQUEST_TIME, {
-      description: 'The round trip time of world state requests',
-      unit: 'us',
-      valueType: ValueType.INT,
-    });
+    this.requestHistogram = meter.createHistogram(Metrics.WORLD_STATE_REQUEST_TIME);
 
-    this.criticalErrors = meter.createUpDownCounter(Metrics.WORLD_STATE_CRITICAL_ERROR_COUNT, {
-      description: 'The number of critical errors in the world state',
-      valueType: ValueType.INT,
-    });
+    this.criticalErrors = meter.createUpDownCounter(Metrics.WORLD_STATE_CRITICAL_ERROR_COUNT);
   }
 
   private updateTreeStats(treeDbStats: TreeDBStats, treeMeta: TreeMeta, tree: MerkleTreeId) {


### PR DESCRIPTION

## Summary
Moves metric descriptions and units into the central `metrics.ts` file so node operators can see full documentation for each metric in one place.

- Add `MetricDefinition` interface with `name`, `description`, `unit`, and `valueType` fields
- Convert all ~200 metric constants from strings to `MetricDefinition` objects
- Update `Meter` interface to accept `MetricDefinition` instead of name + options
- Create `WrappedMeter` and `NoopMeter` classes to adapt implementations
- Remove inline descriptions/units from all service metric files
- Update tests to match new interface
## Test Plan
 - Ran `yarn test` in telemetry-client package - all 18 tests pass
 - Ran `./bootstrap.sh` successfully
 - TypeScript compilation passes with no errors
