### PR TITLE
chore: relation name/tag typos

### DIFF
--- a/barretenberg/cpp/pil/vm2/keccak_memory.pil
+++ b/barretenberg/cpp/pil/vm2/keccak_memory.pil
@@ -208,7 +208,7 @@ val[13] = (1 - last) * val[12]';
 val[14] = (1 - last) * val[13]';
 #[VAL15]
 val[15] = (1 - last) * val[14]';
-#[VAL41]
+#[VAL16]
 val[16] = (1 - last) * val[15]';
 #[VAL17]
 val[17] = (1 - last) * val[16]';

--- a/barretenberg/cpp/pil/vm2/to_radix_mem.pil
+++ b/barretenberg/cpp/pil/vm2/to_radix_mem.pil
@@ -100,7 +100,7 @@ namespace to_radix_mem;
     NOT_LAST * (execution_clk' - execution_clk) = 0;
     #[SPACE_ID_CONTINUITY]
     NOT_LAST * (space_id' - space_id) = 0;
-    #[VALUE_CONTNUITY]
+    #[VALUE_CONTINUITY]
     NOT_LAST * (value_to_decompose' - value_to_decompose) = 0;
     #[RADIX_CONTINUITY]
     NOT_LAST * (radix' - radix) = 0;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory.hpp
@@ -69,7 +69,7 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
     static constexpr size_t SR_VAL13 = 32;
     static constexpr size_t SR_VAL14 = 33;
     static constexpr size_t SR_VAL15 = 34;
-    static constexpr size_t SR_VAL41 = 35;
+    static constexpr size_t SR_VAL16 = 35;
     static constexpr size_t SR_VAL17 = 36;
     static constexpr size_t SR_VAL18 = 37;
     static constexpr size_t SR_VAL19 = 38;
@@ -144,8 +144,8 @@ template <typename FF> class keccak_memory : public Relation<keccak_memoryImpl<F
             return "VAL14";
         case SR_VAL15:
             return "VAL15";
-        case SR_VAL41:
-            return "VAL41";
+        case SR_VAL16:
+            return "VAL16";
         case SR_VAL17:
             return "VAL17";
         case SR_VAL18:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccak_memory_impl.hpp
@@ -269,7 +269,7 @@ void keccak_memoryImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                         static_cast<View>(in.get(C::keccak_memory_val_14__shift)));
         std::get<34>(evals) += (tmp * scaling_factor);
     }
-    { // VAL41
+    { // VAL16
         using View = typename std::tuple_element_t<35, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::keccak_memory_val_16_)) -
                     (FF(1) - static_cast<View>(in.get(C::keccak_memory_last))) *

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix_mem.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix_mem.hpp
@@ -42,7 +42,7 @@ template <typename FF> class to_radix_mem : public Relation<to_radix_memImpl<FF>
     static constexpr size_t SR_SEL_CONTINUITY = 5;
     static constexpr size_t SR_EXEC_CLK_CONTINUITY = 6;
     static constexpr size_t SR_SPACE_ID_CONTINUITY = 7;
-    static constexpr size_t SR_VALUE_CONTNUITY = 8;
+    static constexpr size_t SR_VALUE_CONTINUITY = 8;
     static constexpr size_t SR_RADIX_CONTINUITY = 9;
     static constexpr size_t SR_IS_OUTPUT_BITS_CONTINUITY = 10;
     static constexpr size_t SR_IS_OUTPUT_BITS_IMPLY_RADIX_2 = 16;
@@ -70,8 +70,8 @@ template <typename FF> class to_radix_mem : public Relation<to_radix_memImpl<FF>
             return "EXEC_CLK_CONTINUITY";
         case SR_SPACE_ID_CONTINUITY:
             return "SPACE_ID_CONTINUITY";
-        case SR_VALUE_CONTNUITY:
-            return "VALUE_CONTNUITY";
+        case SR_VALUE_CONTINUITY:
+            return "VALUE_CONTINUITY";
         case SR_RADIX_CONTINUITY:
             return "RADIX_CONTINUITY";
         case SR_IS_OUTPUT_BITS_CONTINUITY:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix_mem_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix_mem_impl.hpp
@@ -75,7 +75,7 @@ void to_radix_memImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                                                    static_cast<View>(in.get(C::to_radix_mem_space_id)));
         std::get<7>(evals) += (tmp * scaling_factor);
     }
-    { // VALUE_CONTNUITY
+    { // VALUE_CONTINUITY
         using View = typename std::tuple_element_t<8, ContainerOverSubrelations>::View;
         auto tmp = CView(to_radix_mem_NOT_LAST) * (static_cast<View>(in.get(C::to_radix_mem_value_to_decompose_shift)) -
                                                    static_cast<View>(in.get(C::to_radix_mem_value_to_decompose)));


### PR DESCRIPTION
Not actual bugs, just naming typos