### PR TITLE
chore(fix): fix validator stalling on deployment by ensuring namespace is completely wiped before continuing

### DIFF
--- a/spartan/scripts/deploy_network.sh
+++ b/spartan/scripts/deploy_network.sh
@@ -195,7 +195,7 @@ fi
 K8S_CLUSTER_CONTEXT=$(kubectl config current-context)
 
 if [[ "${DESTROY_NAMESPACE:-}" == "true" ]]; then
-  kubectl delete namespace "${NAMESPACE}" --ignore-not-found=true
+  "${SCRIPT_DIR}/network_teardown.sh"
 fi
 
 # Create the namespace if it doesn't exist


### PR DESCRIPTION
Should fix the validator stall on deployment. Seems like the occurrence rate increases when deploying to a namespace that already exists.