### PR TITLE
refactor: renaming deliver event/note to store event/note

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -269,7 +269,7 @@ pub contract TokenBlacklist {
     // "manually" and then pass it to the `process_message` function, but this doesn't seem to be worth the effort
     // given that the TransparentNote flow is deprecated and kept around only for testing purposes.
     #[external("utility")]
-    unconstrained fn deliver_transparent_note(
+    unconstrained fn process_transparent_note(
         contract_address: AztecAddress,
         amount: u128,
         secret_hash: Field,

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -349,7 +349,7 @@ async function addPendingShieldNoteToPXE(
 ) {
   const txEffects = await aztecNode.getTxEffect(txHash);
   await contract.methods
-    .deliver_transparent_note(
+    .process_transparent_note(
       contract.address,
       amount,
       secretHash,

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -154,7 +154,7 @@ export class BlacklistTokenContractTest {
   ) {
     const txEffects = await this.aztecNode.getTxEffect(txHash);
     await contract.methods
-      .deliver_transparent_note(
+      .process_transparent_note(
         contract.address,
         amount,
         secretHash,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -378,7 +378,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     noteValidationRequestsArrayBaseSlot: Fr,
     eventValidationRequestsArrayBaseSlot: Fr,
   ) {
-    // TODO(#10727): allow other contracts to deliver notes
+    // TODO(#10727): allow other contracts to store notes
     if (!this.contractAddress.equals(contractAddress)) {
       throw new Error(`Got a note validation request from ${contractAddress}, expected ${this.contractAddress}`);
     }
@@ -394,8 +394,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     ).map(EventValidationRequest.fromFields);
 
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
-    const noteDeliveries = noteValidationRequests.map(request =>
-      noteService.deliverNote(
+    const noteStorePromises = noteValidationRequests.map(request =>
+      noteService.storeNote(
         request.contractAddress,
         request.owner,
         request.storageSlot,
@@ -410,8 +410,8 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
 
     const eventService = new EventService(this.anchorBlockStore, this.aztecNode, this.privateEventStore);
-    const eventDeliveries = eventValidationRequests.map(request =>
-      eventService.deliverEvent(
+    const eventStorePromises = eventValidationRequests.map(request =>
+      eventService.storeEvent(
         request.contractAddress,
         request.eventTypeId,
         request.randomness,
@@ -422,7 +422,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       ),
     );
 
-    await Promise.all([...noteDeliveries, ...eventDeliveries]);
+    await Promise.all([...noteStorePromises, ...eventStorePromises]);
 
     // Requests are cleared once we're done.
     await this.capsuleStore.setCapsuleArray(contractAddress, noteValidationRequestsArrayBaseSlot, [], this.jobId);

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -14,7 +14,7 @@ import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_sto
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 import { EventService } from './event_service.js';
 
-describe('deliverEvent', () => {
+describe('storeEvent', () => {
   let blockNumber: BlockNumber;
   let eventSelector: EventSelector;
   let randomness: Fr;
@@ -83,12 +83,12 @@ describe('deliverEvent', () => {
     eventService = new EventService(anchorBlockStore, aztecNode, privateEventStore);
   });
 
-  function runDeliverEvent(
+  function runStoreEvent(
     overrides: {
       eventCommitment?: Fr;
     } = {},
   ) {
-    return eventService.deliverEvent(
+    return eventService.storeEvent(
       contractAddress,
       eventSelector,
       randomness,
@@ -101,7 +101,7 @@ describe('deliverEvent', () => {
 
   it('should throw when tx does not exist or has no effects', async () => {
     aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(undefined));
-    await expect(runDeliverEvent).rejects.toThrow(/Could not find tx effect for tx hash/);
+    await expect(runStoreEvent).rejects.toThrow(/Could not find tx effect for tx hash/);
   });
 
   it('should throw when tx block has not yet been synchronized', async () => {
@@ -111,17 +111,17 @@ describe('deliverEvent', () => {
     };
     aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
 
-    await expect(runDeliverEvent).rejects.toThrow(/Could not find tx effect for tx hash .* as of block number/);
+    await expect(runStoreEvent).rejects.toThrow(/Could not find tx effect for tx hash .* as of block number/);
   });
 
   it('should throw if event commitment is not in the tx effects', async () => {
-    await expect(runDeliverEvent({ eventCommitment: Fr.random() })).rejects.toThrow(
+    await expect(runStoreEvent({ eventCommitment: Fr.random() })).rejects.toThrow(
       /Event commitment .* is not present in tx/,
     );
   });
 
   it('should store event for later retrieval', async () => {
-    await runDeliverEvent();
+    await runStoreEvent();
 
     // I should be able to retrieve the private event I just saved using getPrivateEvents
     const result = await privateEventStore.getPrivateEvents(eventSelector, {

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -15,7 +15,7 @@ export class EventService {
     private readonly privateEventStore: PrivateEventStore,
   ) {}
 
-  public async deliverEvent(
+  public async storeEvent(
     contractAddress: AztecAddress,
     selector: EventSelector,
     randomness: Fr,

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -161,7 +161,7 @@ describe('NoteService', () => {
     expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }));
   });
 
-  describe('deliverNote', () => {
+  describe('storeNote', () => {
     // Recipient is different from the owner because recipient refers to the
     // recipient of the message containing the note, while owner refers to the
     // owner of the note.
@@ -234,7 +234,7 @@ describe('NoteService', () => {
     });
 
     it('should store note if it exists in a tx effect', async () => {
-      await noteService.deliverNote(
+      await noteService.storeNote(
         contractAddress,
         owner,
         storageSlot,
@@ -256,7 +256,7 @@ describe('NoteService', () => {
 
     it('should throw if tx hash does not exist', async () => {
       await expect(
-        noteService.deliverNote(
+        noteService.storeNote(
           contractAddress,
           owner,
           storageSlot,
@@ -273,7 +273,7 @@ describe('NoteService', () => {
 
     it('should throw if note was not emitted in the tx', async () => {
       await expect(
-        noteService.deliverNote(
+        noteService.storeNote(
           contractAddress,
           owner,
           storageSlot,
@@ -292,7 +292,7 @@ describe('NoteService', () => {
       await setSyncedBlockNumber(BlockNumber(blockNumber - 1));
 
       await expect(
-        noteService.deliverNote(
+        noteService.storeNote(
           contractAddress,
           owner,
           storageSlot,
@@ -319,7 +319,7 @@ describe('NoteService', () => {
         return Promise.resolve([undefined]);
       });
 
-      await noteService.deliverNote(
+      await noteService.storeNote(
         contractAddress,
         owner,
         storageSlot,

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -107,7 +107,7 @@ export class NoteService {
     await this.noteStore.applyNullifiers(foundNullifiers);
   }
 
-  public async deliverNote(
+  public async storeNote(
     contractAddress: AztecAddress,
     owner: AztecAddress,
     storageSlot: Fr,


### PR DESCRIPTION
We want the term `delivery` to mean the whole process of message traveling to the target PXE. We misused this term in a few places where it was used to name functions that store the final event or note. There was also a `deliver_transparent_note` function which I decided to rename as `process_transparent_note`.

Fixes https://linear.app/aztec-labs/issue/F-206/rename-deliver-eventnote-to-store-eventnote