### PR TITLE
chore: Delete outdated test pattern from .test_patterns.yml

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -319,12 +319,6 @@ tests:
     owners:
       - *adam
 
-  # http://ci.aztec-labs.com/b2a907fbce046b94
-  - regex: "src/e2e_simple.test.ts"
-    error_regex: "Failed to send L1 transaction: FormattedViemError: Error: Transaction timed out before sending"
-    owners:
-      - *palla
-
   - regex: "src/e2e_token_bridge_tutorial.test.ts"
     error_regex: "Error: Unable to find low leaf for block"
     owners:


### PR DESCRIPTION
Removed obsolete test pattern for transaction timeout fixed in https://github.com/AztecProtocol/aztec-packages/pull/19393