### PR TITLE
fix: fixing circular dependency warnings for yarn-project bootstrap lint

### DIFF
--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -6,9 +6,10 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 
 import { DEFAULT_TX_TIMEOUT_S } from '../utils/cli_wallet_and_node_wrapper.js';
+import type { AccountType } from '../utils/constants.js';
 import { CLIFeeArgs } from '../utils/options/fees.js';
 import { printProfileResult } from '../utils/profiling.js';
-import { type AccountType, CLIWallet } from '../utils/wallet.js';
+import { CLIWallet } from '../utils/wallet.js';
 
 export async function createAccount(
   wallet: CLIWallet,

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -18,6 +18,7 @@ import inquirer from 'inquirer';
 
 import type { WalletDB } from '../storage/wallet_db.js';
 import type { CliWalletAndNodeWrapper } from '../utils/cli_wallet_and_node_wrapper.js';
+import type { AccountType } from '../utils/constants.js';
 import {
   ARTIFACT_DESCRIPTION,
   CLIFeeArgs,
@@ -38,7 +39,6 @@ import {
   createVerboseOption,
   integerArgParser,
 } from '../utils/options/index.js';
-import type { AccountType } from '../utils/wallet.js';
 
 // TODO: This function is only used in 1 place so we could just inline this
 export function injectCommands(

--- a/yarn-project/cli-wallet/src/storage/wallet_db.ts
+++ b/yarn-project/cli-wallet/src/storage/wallet_db.ts
@@ -5,8 +5,8 @@ import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { TxHash } from '@aztec/stdlib/tx';
 
+import type { AccountType } from '../utils/constants.js';
 import { extractECDSAPublicKeyFromBase64String } from '../utils/ecdsa.js';
-import type { AccountType } from '../utils/wallet.js';
 
 export const Aliases = ['accounts', 'contracts', 'artifacts', 'secrets', 'transactions', 'authwits'] as const;
 export type AliasType = (typeof Aliases)[number];

--- a/yarn-project/cli-wallet/src/utils/constants.ts
+++ b/yarn-project/cli-wallet/src/utils/constants.ts
@@ -1,0 +1,4 @@
+export const MIN_FEE_PADDING = 0.5;
+
+export const AccountTypes = ['schnorr', 'ecdsasecp256r1', 'ecdsasecp256r1ssh', 'ecdsasecp256k1'] as const;
+export type AccountType = (typeof AccountTypes)[number];

--- a/yarn-project/cli-wallet/src/utils/options/fees.ts
+++ b/yarn-project/cli-wallet/src/utils/options/fees.ts
@@ -11,7 +11,7 @@ import type { FeeOptions } from '@aztec/wallet-sdk/base-wallet';
 import { Option } from 'commander';
 
 import type { WalletDB } from '../../storage/wallet_db.js';
-import { MIN_FEE_PADDING } from '../wallet.js';
+import { MIN_FEE_PADDING } from '../constants.js';
 import { aliasedAddressParser } from './options.js';
 
 export type RawCliFeeArgs = {

--- a/yarn-project/cli-wallet/src/utils/options/options.ts
+++ b/yarn-project/cli-wallet/src/utils/options/options.ts
@@ -7,7 +7,7 @@ import { Option } from 'commander';
 import { readdir, stat } from 'fs/promises';
 
 import type { AliasType, WalletDB } from '../../storage/wallet_db.js';
-import { AccountTypes } from '../wallet.js';
+import { AccountTypes } from '../constants.js';
 
 const TARGET_DIR = 'target';
 

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -25,13 +25,9 @@ import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 import { BaseWallet } from '@aztec/wallet-sdk/base-wallet';
 
 import type { WalletDB } from '../storage/wallet_db.js';
+import type { AccountType } from './constants.js';
 import { extractECDSAPublicKeyFromBase64String } from './ecdsa.js';
 import { printGasEstimates } from './options/fees.js';
-
-export const AccountTypes = ['schnorr', 'ecdsasecp256r1', 'ecdsasecp256r1ssh', 'ecdsasecp256k1'] as const;
-export type AccountType = (typeof AccountTypes)[number];
-
-export const MIN_FEE_PADDING = 0.5;
 
 export class CLIWallet extends BaseWallet {
   private accountCache = new Map<string, Account>();

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -2,6 +2,7 @@ import { Fq, Fr } from '../curves/bn254/field.js';
 import { createConsoleLogger } from '../log/console.js';
 import type { EnvVar } from './env_var.js';
 import { type NetworkNames, getActiveNetworkName } from './network_name.js';
+import { parseBooleanEnv } from './parse-env.js';
 import { SecretValue } from './secret_value.js';
 
 export { SecretValue, getActiveNetworkName };
@@ -231,10 +232,7 @@ export function secretValueConfigHelper<T>(parse: (val: string | undefined) => T
   };
 }
 
-/** Parses an env var as boolean. Returns true only if value is 1, true, or TRUE. */
-export function parseBooleanEnv(val: string | undefined): boolean {
-  return val !== undefined && ['1', 'true', 'TRUE'].includes(val);
-}
+export { parseBooleanEnv } from './parse-env.js';
 
 export function secretStringConfigHelper(): Required<
   Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & {

--- a/yarn-project/foundation/src/config/parse-env.ts
+++ b/yarn-project/foundation/src/config/parse-env.ts
@@ -1,0 +1,4 @@
+/** Parses an env var as boolean. Returns true only if value is 1, true, or TRUE. */
+export function parseBooleanEnv(val: string | undefined): boolean {
+  return val !== undefined && ['1', 'true', 'TRUE'].includes(val);
+}

--- a/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
+++ b/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
@@ -12,11 +12,9 @@ export class RandomnessSingleton {
   private static instance: RandomnessSingleton;
 
   private counter = 0;
+  private readonly log = createLogger('foundation:randomness_singleton');
 
-  private constructor(
-    private readonly seed?: number,
-    private readonly log = createLogger('foundation:randomness_singleton'),
-  ) {
+  private constructor(private readonly seed?: number) {
     if (seed !== undefined) {
       this.log.debug(`Using pseudo-randomness with seed: ${seed}`);
       this.counter = seed;

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -5,7 +5,8 @@ import type { Writable } from 'stream';
 import { inspect } from 'util';
 
 import { compactArray } from '../collection/array.js';
-import { type EnvVar, parseBooleanEnv } from '../config/index.js';
+import type { EnvVar } from '../config/index.js';
+import { parseBooleanEnv } from '../config/parse-env.js';
 import { GoogleCloudLoggerConfig } from './gcloud-logger-config.js';
 import { getLogLevelFromFilters, parseEnv } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';

--- a/yarn-project/kv-store/src/lmdb-v2/array.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/array.ts
@@ -4,8 +4,8 @@ import type { AztecAsyncArray } from '../interfaces/array.js';
 import type { Value } from '../interfaces/common.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { ReadTransaction } from './read_transaction.js';
-// eslint-disable-next-line import/no-cycle
-import { AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
+import type { AztecLMDBStoreV2 } from './store.js';
+import { execInReadTx, execInWriteTx } from './tx-helpers.js';
 import { deserializeKey, serializeKey } from './utils.js';
 
 export class LMDBArray<T extends Value> implements AztecAsyncArray<T> {

--- a/yarn-project/kv-store/src/lmdb-v2/map.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/map.ts
@@ -3,8 +3,8 @@ import { Encoder } from 'msgpackr';
 import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { ReadTransaction } from './read_transaction.js';
-// eslint-disable-next-line import/no-cycle
-import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
+import type { AztecLMDBStoreV2 } from './store.js';
+import { execInReadTx, execInWriteTx } from './tx-helpers.js';
 import { deserializeKey, maxKey, minKey, serializeKey } from './utils.js';
 
 export class LMDBMap<K extends Key, V extends Value> implements AztecAsyncMap<K, V> {

--- a/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
@@ -4,8 +4,8 @@ import { MAXIMUM_KEY, toBufferKey } from 'ordered-binary';
 import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
 import type { ReadTransaction } from './read_transaction.js';
-// eslint-disable-next-line import/no-cycle
-import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
+import type { AztecLMDBStoreV2 } from './store.js';
+import { execInReadTx, execInWriteTx } from './tx-helpers.js';
 import { deserializeKey, maxKey, minKey, serializeKey } from './utils.js';
 
 export class LMDBMultiMap<K extends Key, V extends Value> implements AztecAsyncMultiMap<K, V> {

--- a/yarn-project/kv-store/src/lmdb-v2/singleton.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/singleton.ts
@@ -1,8 +1,8 @@
 import { Encoder } from 'msgpackr';
 
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
-// eslint-disable-next-line import/no-cycle
-import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
+import type { AztecLMDBStoreV2 } from './store.js';
+import { execInReadTx, execInWriteTx } from './tx-helpers.js';
 import { serializeKey } from './utils.js';
 
 export class LMDBSingleValue<T> implements AztecAsyncSingleton<T> {

--- a/yarn-project/kv-store/src/lmdb-v2/store.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.ts
@@ -13,9 +13,7 @@ import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
 import type { AztecAsyncSet } from '../interfaces/set.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { AztecAsyncKVStore } from '../interfaces/store.js';
-// eslint-disable-next-line import/no-cycle
 import { LMDBArray } from './array.js';
-// eslint-disable-next-line import/no-cycle
 import { LMDBMap } from './map.js';
 import {
   Database,
@@ -27,9 +25,10 @@ import {
 import { LMDBMultiMap } from './multi_map.js';
 import { ReadTransaction } from './read_transaction.js';
 import { LMDBSet } from './set.js';
-// eslint-disable-next-line import/no-cycle
 import { LMDBSingleValue } from './singleton.js';
 import { WriteTransaction } from './write_transaction.js';
+
+export { execInReadTx, execInWriteTx } from './tx-helpers.js';
 
 export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
   private open = false;
@@ -215,31 +214,5 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
       actualSize: resp.stats.reduce((s, db) => Number(db.totalUsedSize) + s, 0),
       numItems: resp.stats.reduce((s, db) => Number(db.numDataItems) + s, 0),
     };
-  }
-}
-
-export function execInWriteTx<T>(store: AztecLMDBStoreV2, fn: (tx: WriteTransaction) => Promise<T>): Promise<T> {
-  const currentWrite = store.getCurrentWriteTx();
-  if (currentWrite) {
-    return fn(currentWrite);
-  } else {
-    return store.transactionAsync(fn);
-  }
-}
-
-export async function execInReadTx<T>(
-  store: AztecLMDBStoreV2,
-  fn: (tx: ReadTransaction) => T | Promise<T>,
-): Promise<T> {
-  const currentWrite = store.getCurrentWriteTx();
-  if (currentWrite) {
-    return await fn(currentWrite);
-  } else {
-    const tx = store.getReadTx();
-    try {
-      return await fn(tx);
-    } finally {
-      tx.close();
-    }
   }
 }

--- a/yarn-project/kv-store/src/lmdb-v2/tx-helpers.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/tx-helpers.ts
@@ -1,0 +1,29 @@
+import type { ReadTransaction } from './read_transaction.js';
+import type { AztecLMDBStoreV2 } from './store.js';
+import type { WriteTransaction } from './write_transaction.js';
+
+export function execInWriteTx<T>(store: AztecLMDBStoreV2, fn: (tx: WriteTransaction) => Promise<T>): Promise<T> {
+  const currentWrite = store.getCurrentWriteTx();
+  if (currentWrite) {
+    return fn(currentWrite);
+  } else {
+    return store.transactionAsync(fn);
+  }
+}
+
+export async function execInReadTx<T>(
+  store: AztecLMDBStoreV2,
+  fn: (tx: ReadTransaction) => T | Promise<T>,
+): Promise<T> {
+  const currentWrite = store.getCurrentWriteTx();
+  if (currentWrite) {
+    return await fn(currentWrite);
+  } else {
+    const tx = store.getReadTx();
+    try {
+      return await fn(tx);
+    } finally {
+      tx.close();
+    }
+  }
+}

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.test.ts
@@ -3,7 +3,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { DirectionalAppTaggingSecret, type PreTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
 
-import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../../tagging/index.js';
+import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../../tagging/constants.js';
 import { SenderTaggingStore } from './sender_tagging_store.js';
 
 describe('SenderTaggingStore', () => {

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -3,7 +3,7 @@ import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
 
-import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../../tagging/index.js';
+import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../../tagging/constants.js';
 
 /**
  * Data provider of tagging data used when syncing the sender tagging indexes. The recipient counterpart of this class

--- a/yarn-project/pxe/src/tagging/constants.ts
+++ b/yarn-project/pxe/src/tagging/constants.ts
@@ -1,0 +1,10 @@
+// This window has to be as large as the largest expected number of logs emitted in a tx for a given directional app
+// tagging secret. If we get more tag indexes consumed than this window, an error is thrown in `PXE::proveTx` function.
+// This is set to a larger value than MAX_PRIVATE_LOGS_PER_TX (currently 64) because there could be more than
+// MAX_PRIVATE_LOGS_PER_TX indexes consumed in case the logs are squashed. This happens when the log contains a note
+// and the note is nullified in the same tx.
+//
+// Having a large window significantly slowed down `e2e_l1_with_wall_time` test as there we perform sync for more than
+// 1000 secrets. For this reason we set it to a relatively low value of 20. 20 should be sufficient for all the use
+// cases.
+export const UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN = 20;

--- a/yarn-project/pxe/src/tagging/index.ts
+++ b/yarn-project/pxe/src/tagging/index.ts
@@ -11,17 +11,7 @@
 
 export { loadPrivateLogsForSenderRecipientPair } from './recipient_sync/load_private_logs_for_sender_recipient_pair.js';
 export { syncSenderTaggingIndexes } from './sender_sync/sync_sender_tagging_indexes.js';
-
-// This window has to be as large as the largest expected number of logs emitted in a tx for a given directional app
-// tagging secret. If we get more tag indexes consumed than this window, an error is thrown in `PXE::proveTx` function.
-// This is set to a larger value than MAX_PRIVATE_LOGS_PER_TX (currently 64) because there could be more than
-// MAX_PRIVATE_LOGS_PER_TX indexes consumed in case the logs are squashed. This happens when the log contains a note
-// and the note is nullified in the same tx.
-//
-// Having a large window significantly slowed down `e2e_l1_with_wall_time` test as there we perform sync for more than
-// 1000 secrets. For this reason we set it to a relatively low value of 20. 20 should be sufficient for all the use
-// cases.
-export const UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN = 20;
+export { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from './constants.js';
 
 // Re-export tagging-related types from stdlib
 export { DirectionalAppTaggingSecret, Tag, SiloedTag } from '@aztec/stdlib/logs';

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
@@ -4,7 +4,7 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, TxScopedL2Log } from '@aztec/stdlib/logs';
 
 import type { RecipientTaggingStore } from '../../storage/tagging_store/recipient_tagging_store.js';
-import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../index.js';
+import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../constants.js';
 import { findHighestIndexes } from './utils/find_highest_indexes.js';
 import { loadLogsForRange } from './utils/load_logs_for_range.js';
 

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
@@ -3,7 +3,7 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
 
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
-import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../index.js';
+import { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../constants.js';
 import { getStatusChangeOfPending } from './utils/get_status_change_of_pending.js';
 import { loadAndStoreNewTaggingIndexes } from './utils/load_and_store_new_tagging_indexes.js';
 

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -1,6 +1,15 @@
 import { jsonParseWithSchema, jsonStringify } from '@aztec/foundation/json-rpc';
 
 import {
+  AZTEC_INITIALIZER_ATTRIBUTE,
+  AZTEC_ONLY_SELF_ATTRIBUTE,
+  AZTEC_PRIVATE_ATTRIBUTE,
+  AZTEC_PUBLIC_ATTRIBUTE,
+  AZTEC_UTILITY_ATTRIBUTE,
+  AZTEC_VIEW_ATTRIBUTE,
+  type NoirCompiledContract,
+} from '../noir/index.js';
+import {
   type ABIParameter,
   type ABIParameterVisibility,
   type AbiType,
@@ -14,16 +23,7 @@ import {
   type IntegerValue,
   type StructValue,
   type TypedStructFieldValue,
-} from '../abi/index.js';
-import {
-  AZTEC_INITIALIZER_ATTRIBUTE,
-  AZTEC_ONLY_SELF_ATTRIBUTE,
-  AZTEC_PRIVATE_ATTRIBUTE,
-  AZTEC_PUBLIC_ATTRIBUTE,
-  AZTEC_UTILITY_ATTRIBUTE,
-  AZTEC_VIEW_ATTRIBUTE,
-  type NoirCompiledContract,
-} from '../noir/index.js';
+} from './abi.js';
 
 /**
  * Serializes a contract artifact to a buffer for storage.

--- a/yarn-project/telemetry-client/src/metric-utils.ts
+++ b/yarn-project/telemetry-client/src/metric-utils.ts
@@ -1,0 +1,12 @@
+import type { MetricOptions } from '@opentelemetry/api';
+
+import type { MetricDefinition } from './metrics.js';
+
+/** Extracts OpenTelemetry MetricOptions from a MetricDefinition */
+export function toMetricOptions(def: MetricDefinition): MetricOptions {
+  return {
+    description: def.description,
+    unit: def.unit,
+    valueType: def.valueType,
+  };
+}

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -32,20 +32,20 @@ import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
 import type { TelemetryClientConfig } from './config.js';
+import { toMetricOptions } from './metric-utils.js';
 import type { MetricDefinition } from './metrics.js';
 import { NodejsMetricsMonitor } from './nodejs_metrics_monitor.js';
 import { OtelFilterMetricExporter, PublicOtelFilterMetricExporter } from './otel_filter_metric_exporter.js';
 import { registerOtelLoggerProvider } from './otel_logger_provider.js';
 import { getOtelResource } from './otel_resource.js';
-import {
-  type Gauge,
-  type Histogram,
-  type Meter,
-  type ObservableGauge,
-  type ObservableUpDownCounter,
-  type TelemetryClient,
-  type UpDownCounter,
-  toMetricOptions,
+import type {
+  Gauge,
+  Histogram,
+  Meter,
+  ObservableGauge,
+  ObservableUpDownCounter,
+  TelemetryClient,
+  UpDownCounter,
 } from './telemetry.js';
 
 /** Wraps an OpenTelemetry Meter to implement our custom Meter interface */

--- a/yarn-project/telemetry-client/src/telemetry.ts
+++ b/yarn-project/telemetry-client/src/telemetry.ts
@@ -20,14 +20,7 @@ import type * as Attributes from './attributes.js';
 import type { MetricDefinition } from './metrics.js';
 import { getTelemetryClient } from './start.js';
 
-/** Extracts OpenTelemetry MetricOptions from a MetricDefinition */
-export function toMetricOptions(def: MetricDefinition): MetricOptions {
-  return {
-    description: def.description,
-    unit: def.unit,
-    valueType: def.valueType,
-  };
-}
+export { toMetricOptions } from './metric-utils.js';
 
 export { type Span, SpanStatusCode, ValueType, type Context } from '@opentelemetry/api';
 


### PR DESCRIPTION
# Summary: Fixing Circular Dependency Warnings

All 6 groups of `import/no-cycle` lint warnings have been fixed. Below are the changes made for each.

---

## 1. stdlib/abi

**Cycle:** `contract_artifact.ts` → `index.js` → `contract_artifact.js`

**Fix:** Changed import path from barrel to direct import.

**File modified:** `yarn-project/stdlib/src/abi/contract_artifact.ts`
- Changed `import { ... } from '../abi/index.js'` to `import { ... } from './abi.js'`

---

## 2. pxe/tagging

**Cycle:** `index.ts` exports submodules that import `UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN` back from `index.ts`

**Fix:** Extracted constant to dedicated file.

**New file:** `yarn-project/pxe/src/tagging/constants.ts`

**Files modified:**
- `yarn-project/pxe/src/tagging/index.ts` - Re-exports constant from `./constants.js`
- `yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts` - Imports from `../constants.js`
- `yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts` - Imports from `../constants.js`

---

## 3. cli-wallet

**Cycle:** `wallet.ts` ↔ `fees.ts` (via `MIN_FEE_PADDING` and `AccountType`)

**Fix:** Extracted constants to dedicated file.

**New file:** `yarn-project/cli-wallet/src/utils/constants.ts`

**Files modified:**
- `yarn-project/cli-wallet/src/utils/wallet.ts` - Imports from `./constants.js`
- `yarn-project/cli-wallet/src/utils/options/fees.ts` - Imports from `../constants.js`

---

## 4. foundation

**Cycle:** `pino-logger` → `config` → `field` → `random` → `randomness_singleton` → `pino-logger`

**Fix:** Extracted `parseBooleanEnv` to break the cycle at the `pino-logger` → `config` edge.

**New file:** `yarn-project/foundation/src/config/parse-env.ts`

**Files modified:**
- `yarn-project/foundation/src/log/pino-logger.ts` - Imports `parseBooleanEnv` from `../config/parse-env.js` instead of `../config/index.js`
- `yarn-project/foundation/src/config/index.ts` - Re-exports `parseBooleanEnv` from `./parse-env.js` for backward compatibility

---

## 5. kv-store

**Cycle:** `store.ts` ↔ collection classes (`map.ts`, `array.ts`, `singleton.ts`, `set.ts`)

**Fix:** Extracted `execInReadTx` and `execInWriteTx` to separate file.

**New file:** `yarn-project/kv-store/src/lmdb-v2/tx-helpers.ts`

**Files modified:**
- `yarn-project/kv-store/src/lmdb-v2/store.ts` - Re-exports from `./tx-helpers.js`
- `yarn-project/kv-store/src/lmdb-v2/map.ts` - Imports helpers from `./tx-helpers.js`
- `yarn-project/kv-store/src/lmdb-v2/array.ts` - Imports helpers from `./tx-helpers.js`
- `yarn-project/kv-store/src/lmdb-v2/singleton.ts` - Imports helpers from `./tx-helpers.js`
- `yarn-project/kv-store/src/lmdb-v2/set.ts` - Imports helpers from `./tx-helpers.js`
- Removed `// eslint-disable-next-line import/no-cycle` comments from all files

---

## 6. telemetry-client

**Cycle:** `telemetry.ts` → `start.ts` → `otel.ts` → `telemetry.ts`

**Fix:** Extracted `toMetricOptions` to a separate utility file.

**New file:** `yarn-project/telemetry-client/src/metric-utils.ts`

**Files modified:**
- `yarn-project/telemetry-client/src/otel.ts` - Imports `toMetricOptions` from `./metric-utils.js`
- `yarn-project/telemetry-client/src/telemetry.ts` - Re-exports `toMetricOptions` from `./metric-utils.js`

