### PR TITLE
chore: defensive asserts for map/vector retrievals and optional values in cpp

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bytecode_manager.cpp
@@ -155,7 +155,9 @@ Instruction TxBytecodeManager::read_instruction(const BytecodeId& bytecode_id,
 
 std::shared_ptr<std::vector<uint8_t>> TxBytecodeManager::get_bytecode_data(const BytecodeId& bytecode_id)
 {
-    return bytecodes.at(bytecode_id);
+    auto it = bytecodes.find(bytecode_id);
+    BB_ASSERT(it != bytecodes.end(), "Bytecode not found for the given bytecode_id");
+    return it->second;
 }
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
@@ -17,11 +17,15 @@ std::optional<ContractInstance> ContractDB::get_contract_instance(const AztecAdd
     }
     // If we did get a contract instance, we need to prove that the address is derived from the instance.
     // For protocol contracts the input address is the canonical address, we need to retrieve the derived address.
-    AztecAddress derived_address = is_protocol_contract_address(address)
-                                       ? get_derived_address(protocol_contracts, address)
-                                             .value() /* We can assume that get_derived_address will not return a
-                                                         nullopt, since we have succesfully fetched the instance.*/
-                                       : address;
+    AztecAddress derived_address;
+    if (is_protocol_contract_address(address)) {
+        auto maybe_derived = get_derived_address(protocol_contracts, address);
+        BB_ASSERT(maybe_derived.has_value(),
+                  "Derived address should be found for protocol contract whose instance is found");
+        derived_address = maybe_derived.value();
+    } else {
+        derived_address = address;
+    }
     address_derivation.assert_derivation(derived_address, instance.value());
     return instance;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/hinting_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/hinting_dbs.cpp
@@ -264,6 +264,8 @@ SequentialInsertionResult<PublicDataLeafValue> HintingRawDB::insert_indexed_leav
     AppendOnlyTreeSnapshot state_after = db.get_tree_roots().public_data_tree;
 
     SequentialInsertHintPublicDataTreeKey key = { tree_info, world_state::MerkleTreeId::PUBLIC_DATA_TREE, leaf_value };
+    BB_ASSERT(!result.low_leaf_witness_data.empty(), "Expected non-empty low_leaf_witness_data after insertion");
+    BB_ASSERT(!result.insertion_witness_data.empty(), "Expected non-empty insertion_witness_data after insertion");
     SequentialInsertHint<PublicDataLeafValue> sequential_insert_hint = {
         .hint_key = tree_info,
         .tree_id = world_state::MerkleTreeId::PUBLIC_DATA_TREE,
@@ -286,6 +288,8 @@ SequentialInsertionResult<NullifierLeafValue> HintingRawDB::insert_indexed_leave
     auto state_after = db.get_tree_roots().nullifier_tree;
 
     SequentialInsertHintNullifierTreeKey key = { tree_info, world_state::MerkleTreeId::NULLIFIER_TREE, leaf_value };
+    BB_ASSERT(!result.low_leaf_witness_data.empty(), "Expected non-empty low_leaf_witness_data after insertion");
+    BB_ASSERT(!result.insertion_witness_data.empty(), "Expected non-empty insertion_witness_data after insertion");
     SequentialInsertHint<NullifierLeafValue> sequential_insert_hint = {
         .hint_key = tree_info,
         .tree_id = world_state::MerkleTreeId::NULLIFIER_TREE,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/indexed_memory_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/indexed_memory_tree.hpp
@@ -117,6 +117,7 @@ GetLowIndexedLeafResponse IndexedMemoryTree<LeafType, HashingPolicy>::get_low_in
 template <typename LeafType, typename HashingPolicy>
 IndexedLeaf<LeafType> IndexedMemoryTree<LeafType, HashingPolicy>::get_leaf_preimage(size_t leaf_index) const
 {
+    BB_ASSERT_DEBUG(leaf_index < leaves.size(), "Leaf index out of bounds");
     return leaves.at(leaf_index);
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_bytecode_manager.cpp
@@ -133,7 +133,9 @@ Instruction PureTxBytecodeManager::read_instruction(const BytecodeId&,
 
 std::shared_ptr<std::vector<uint8_t>> PureTxBytecodeManager::get_bytecode_data(const BytecodeId& bytecode_id)
 {
-    return bytecodes.at(bytecode_id);
+    auto it = bytecodes.find(bytecode_id);
+    BB_ASSERT_DEBUG(it != bytecodes.end(), "Bytecode not found for the given bytecode_id");
+    return it->second;
 }
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/sha256_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/sha256_trace.cpp
@@ -434,6 +434,7 @@ void Sha256TraceBuilder::process(
         // If during simulation we encounter an invalid tag, it will have been the last element we retrieved
         // before we threw an error - so it will be the last element in the input vector.
         // Therefore, it is just sufficient to check the tag of the last element
+        BB_ASSERT(!event.input.empty(), "SHA256 input cannot be empty");
         bool invalid_tag_err = event.input.back().get_tag() != MemoryTag::U32;
 
         // Note that if we encountered an invalid tag error, the row that loaded the invalid tag needs to contain


### PR DESCRIPTION
To prevent crashes in worst-case scenarios