### PR TITLE
refactor: dropping noteHashLeafIndexMap

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -85,7 +85,6 @@ export async function executePrivateFunction(
 
   const rawReturnValues = await privateExecutionOracle.privateLoadFromExecutionCache(publicInputs.returnsHash);
 
-  const noteHashLeafIndexMap = privateExecutionOracle.getNoteHashLeafIndexMap();
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();
   const offchainEffects = privateExecutionOracle.getOffchainEffects();
@@ -108,7 +107,6 @@ export async function executePrivateFunction(
     Buffer.from(artifact.verificationKey!, 'base64'),
     partialWitness,
     publicInputs,
-    noteHashLeafIndexMap,
     newNotes,
     noteHashNullifierCounterMap,
     rawReturnValues,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -14,7 +14,7 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
+import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
 import { type ContractClassLog, DirectionalAppTaggingSecret, type PreTag } from '@aztec/stdlib/logs';
@@ -64,16 +64,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * Users can also use this to get a clearer idea of what's happened during a simulation.
    */
   private newNotes: NoteAndSlot[] = [];
-  /**
-   * Notes from previous transactions that are returned to the oracle call `getNotes` during this execution.
-   * The mapping maps from the unique siloed note hash to the index for notes created in private executions.
-   * It maps from siloed note hash to the index for notes created by public functions.
-   *
-   * They are not part of the ExecutionNoteCache and being forwarded to nested contexts via `extend()`
-   * because these notes are meant to be maintained on a per-call basis
-   * They should act as references for the read requests output by an app circuit via public inputs.
-   */
-  private noteHashLeafIndexMap: Map<bigint, bigint> = new Map();
   private noteHashNullifierCounterMap: Map<number, number> = new Map();
   private contractClassLogs: CountedContractClassLog[] = [];
   private offchainEffects: { data: Fr[] }[] = [];
@@ -160,14 +150,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     const fields = [...privateContextInputsAsFields, ...args];
     return toACVMWitness(0, fields);
-  }
-
-  /**
-   * The KernelProver will use this to fully populate witnesses and provide hints to the kernel circuit
-   * regarding which note hash each settled read request corresponds to.
-   */
-  public getNoteHashLeafIndexMap() {
-    return this.noteHashLeafIndexMap;
   }
 
   /**
@@ -403,23 +385,6 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
         .map(n => `${n.noteNonce.toString()}:[${n.note.items.map(i => i.toString()).join(',')}]`)
         .join(', ')}`,
     );
-
-    const noteHashesAndIndexes = await Promise.all(
-      notes.map(async n => {
-        if (n.index !== undefined) {
-          const siloedNoteHash = await siloNoteHash(n.contractAddress, n.noteHash);
-          const uniqueNoteHash = await computeUniqueNoteHash(n.noteNonce, siloedNoteHash);
-
-          return { hash: uniqueNoteHash, index: n.index };
-        }
-      }),
-    );
-
-    noteHashesAndIndexes
-      .filter(n => n !== undefined)
-      .forEach(n => {
-        this.noteHashLeafIndexMap.set(n!.hash.toBigInt(), n!.index);
-      });
 
     return notes;
   }

--- a/yarn-project/pxe/src/private_kernel/hints/build_private_kernel_reset_private_inputs.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/build_private_kernel_reset_private_inputs.ts
@@ -138,7 +138,7 @@ export class PrivateKernelResetPrivateInputsBuilder {
     }
   }
 
-  async build(oracle: PrivateKernelOracle, noteHashLeafIndexMap: Map<bigint, bigint>) {
+  async build(oracle: PrivateKernelOracle) {
     if (privateKernelResetDimensionNames.every(name => !this.requestedDimensions[name])) {
       throw new Error('Reset is not required.');
     }
@@ -190,7 +190,6 @@ export class PrivateKernelResetPrivateInputsBuilder {
           this.previousKernel.validationRequests.noteHashReadRequests,
           this.previousKernel.end.noteHashes,
           this.noteHashResetActions,
-          noteHashLeafIndexMap,
         ),
         await buildNullifierReadRequestHintsFromResetActions(
           { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
@@ -84,7 +84,6 @@ describe('Private Kernel Sequencer', () => {
       VerificationKey.makeFakeMegaHonk(),
       new Map(),
       publicInputs,
-      new Map(),
       newNoteIndices.map(idx => notesAndSlots[idx]),
       new Map(),
       [],

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
@@ -28,7 +28,6 @@ import {
   type PrivateCallExecutionResult,
   type PrivateExecutionResult,
   TxRequest,
-  collectNoteHashLeafIndexMap,
   collectNoteHashNullifierCounterMap,
   getFinalMinRevertibleSideEffectCounter,
 } from '@aztec/stdlib/tx';
@@ -101,7 +100,6 @@ export class PrivateKernelExecutionProver {
 
     const executionSteps: PrivateExecutionStep[] = [];
 
-    const noteHashLeafIndexMap = collectNoteHashLeafIndexMap(executionResult);
     const noteHashNullifierCounterMap = collectNoteHashNullifierCounterMap(executionResult);
     const minRevertibleSideEffectCounter = getFinalMinRevertibleSideEffectCounter(executionResult);
     const splitCounter = isPrivateOnlyTx ? 0 : minRevertibleSideEffectCounter;
@@ -116,7 +114,7 @@ export class PrivateKernelExecutionProver {
         );
         while (resetBuilder.needsReset()) {
           const witgenTimer = new Timer();
-          const privateInputs = await resetBuilder.build(this.oracle, noteHashLeafIndexMap);
+          const privateInputs = await resetBuilder.build(this.oracle);
           output = generateWitnesses
             ? await this.proofCreator.generateResetOutput(privateInputs)
             : await this.proofCreator.simulateReset(privateInputs);
@@ -224,7 +222,7 @@ export class PrivateKernelExecutionProver {
     );
     while (resetBuilder.needsReset()) {
       const witgenTimer = new Timer();
-      const privateInputs = await resetBuilder.build(this.oracle, noteHashLeafIndexMap);
+      const privateInputs = await resetBuilder.build(this.oracle);
       output = generateWitnesses
         ? await this.proofCreator.generateResetOutput(privateInputs)
         : await this.proofCreator.simulateReset(privateInputs);

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
@@ -43,7 +43,8 @@ export interface PrivateKernelOracle {
 
   /**
    * Returns a membership witness with the sibling path and leaf index in our private function indexed merkle tree.
-   */ getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+   */
+  getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
 
   /**
    * Returns a membership witness with the sibling path and leaf index in our nullifier indexed merkle tree.

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle_impl.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle_impl.ts
@@ -2,7 +2,6 @@ import { NOTE_HASH_TREE_HEIGHT, PUBLIC_DATA_TREE_HEIGHT, VK_TREE_HEIGHT } from '
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { createLogger } from '@aztec/foundation/log';
-import type { Tuple } from '@aztec/foundation/serialize';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import { getVKIndex, getVKSiblingPath } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -70,13 +69,8 @@ export class PrivateKernelOracleImpl implements PrivateKernelOracle {
     return Promise.resolve(new MembershipWitness(VK_TREE_HEIGHT, BigInt(leafIndex), getVKSiblingPath(leafIndex)));
   }
 
-  async getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>> {
-    const path = await this.node.getNoteHashSiblingPath(this.blockNumber, leafIndex);
-    return new MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>(
-      path.pathSize,
-      leafIndex,
-      path.toFields() as Tuple<Fr, typeof NOTE_HASH_TREE_HEIGHT>,
-    );
+  getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
+    return this.node.getNoteHashMembershipWitness(this.blockNumber, noteHash);
   }
 
   getNullifierMembershipWitness(nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
@@ -30,17 +30,15 @@ describe('buildNoteHashReadRequestHints', () => {
   );
 
   const settledNoteHashes = [111, 222, 333];
-  const settledLeafIndexes = [1010n, 2020n, 3030n];
   const oracle = {
-    getNoteHashMembershipWitness: (leafIndex: bigint) =>
-      settledLeafIndexes.includes(leafIndex) ? ({} as any) : undefined,
+    getNoteHashMembershipWitness: (noteHash: Fr) =>
+      settledNoteHashes.includes(noteHash.toNumber()) ? ({} as any) : undefined,
   };
 
   /**
    * Create initial state.
    */
   let noteHashReadRequests: Tuple<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>;
-  let noteHashLeafIndexMap: Map<bigint, bigint> = new Map();
   let expectedHints: NoteHashReadRequestHints<
     typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
     typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
@@ -66,7 +64,6 @@ describe('buildNoteHashReadRequestHints', () => {
     const readRequestIndex = numReadRequests;
     const hintIndex = numSettledReads;
     const value = settledNoteHashes[noteHashIndex];
-    noteHashLeafIndexMap.set(BigInt(value), settledLeafIndexes[noteHashIndex]);
     noteHashReadRequests[readRequestIndex] = makeReadRequest(settledNoteHashes[noteHashIndex]);
     expectedHints.readRequestActions[readRequestIndex] = ReadRequestAction.readAsSettled(hintIndex);
     expectedHints.settledReadHints[hintIndex] = new SettledReadHint(readRequestIndex, {} as any, new Fr(value));
@@ -85,13 +82,11 @@ describe('buildNoteHashReadRequestHints', () => {
       oracle,
       new ClaimedLengthArray(noteHashReadRequests, numReadRequests),
       new ClaimedLengthArray(noteHashes, MAX_NOTE_HASHES_PER_TX),
-      noteHashLeafIndexMap,
       futureNoteHashes,
     );
 
   beforeEach(() => {
     noteHashReadRequests = makeTuple(MAX_NOTE_HASH_READ_REQUESTS_PER_TX, ScopedReadRequest.empty);
-    noteHashLeafIndexMap = new Map();
     expectedHints = NoteHashReadRequestHintsBuilder.empty(
       MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
       MAX_NOTE_HASH_READ_REQUESTS_PER_TX,

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
@@ -3,6 +3,7 @@ import {
   MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
   type NOTE_HASH_TREE_HEIGHT,
 } from '@aztec/constants';
+import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 
 import type { ClaimedLengthArray } from '../claimed_length_array.js';
@@ -61,12 +62,11 @@ export function getNoteHashReadRequestResetActions(
 
 export async function buildNoteHashReadRequestHintsFromResetActions<PENDING extends number, SETTLED extends number>(
   oracle: {
-    getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+    getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
   },
   noteHashReadRequests: ClaimedLengthArray<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
   noteHashes: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
   resetActions: ReadRequestResetActions<typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
-  noteHashLeafIndexMap: Map<bigint, bigint>,
   maxPending: PENDING = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as SETTLED,
 ) {
@@ -79,11 +79,10 @@ export async function buildNoteHashReadRequestHintsFromResetActions<PENDING exte
   for (let i = 0; i < resetActions.actions.length; i++) {
     if (resetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
       const readRequest = noteHashReadRequests.array[i];
-      const leafIndex = noteHashLeafIndexMap.get(readRequest.value.toBigInt());
-      if (leafIndex === undefined) {
+      const membershipWitness = await oracle.getNoteHashMembershipWitness(readRequest.value);
+      if (!membershipWitness) {
         throw new Error('Read request is reading an unknown note hash.');
       }
-      const membershipWitness = await oracle.getNoteHashMembershipWitness(leafIndex);
       builder.addSettledReadRequest(i, membershipWitness, readRequest.value);
     }
   }
@@ -101,11 +100,10 @@ export async function buildNoteHashReadRequestHintsFromResetActions<PENDING exte
 
 export async function buildNoteHashReadRequestHints<PENDING extends number, SETTLED extends number>(
   oracle: {
-    getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+    getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
   },
   noteHashReadRequests: ClaimedLengthArray<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
   noteHashes: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
-  noteHashLeafIndexMap: Map<bigint, bigint>,
   futureNoteHashes: ScopedNoteHash[],
   maxPending: PENDING = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as SETTLED,
@@ -116,7 +114,6 @@ export async function buildNoteHashReadRequestHints<PENDING extends number, SETT
     noteHashReadRequests,
     noteHashes,
     resetActions,
-    noteHashLeafIndexMap,
     maxPending,
     maxSettled,
   );

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -359,7 +359,6 @@ const emptyPrivateCallExecutionResult = () =>
     Buffer.from(''),
     new Map(),
     PrivateCircuitPublicInputs.empty(),
-    new Map(),
     [],
     new Map(),
     [],

--- a/yarn-project/stdlib/src/tx/private_execution_result.test.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.test.ts
@@ -5,7 +5,6 @@ import { PrivateCircuitPublicInputs } from '../kernel/private_circuit_public_inp
 import {
   PrivateCallExecutionResult,
   PrivateExecutionResult,
-  collectNoteHashLeafIndexMap,
   collectNoteHashNullifierCounterMap,
   getFinalMinRevertibleSideEffectCounter,
 } from './private_execution_result.js';
@@ -16,7 +15,6 @@ function emptyCallExecutionResult(): PrivateCallExecutionResult {
     Buffer.from(''),
     new Map(),
     PrivateCircuitPublicInputs.empty(),
-    new Map(),
     [],
     new Map(),
     [],
@@ -42,42 +40,6 @@ describe('execution_result', () => {
     it('serializes and deserializes correctly', async () => {
       const instance = await PrivateExecutionResult.random();
       expect(jsonParseWithSchema(jsonStringify(instance), PrivateExecutionResult.schema)).toEqual(instance);
-    });
-  });
-
-  describe('collectNoteHashLeafIndexMap', () => {
-    it('returns a map for note hash leaf indexes', () => {
-      executionResult.entrypoint.noteHashLeafIndexMap = new Map();
-      executionResult.entrypoint.noteHashLeafIndexMap.set(12n, 99n);
-      executionResult.entrypoint.noteHashLeafIndexMap.set(34n, 88n);
-      const res = collectNoteHashLeafIndexMap(executionResult);
-      expect(res.size).toBe(2);
-      expect(res.get(12n)).toBe(99n);
-      expect(res.get(34n)).toBe(88n);
-    });
-
-    it('returns a map containing note hash leaf indexes for nested executions', () => {
-      executionResult.entrypoint.noteHashLeafIndexMap.set(12n, 99n);
-      executionResult.entrypoint.noteHashLeafIndexMap.set(34n, 88n);
-
-      const childExecution0 = emptyCallExecutionResult();
-      childExecution0.noteHashLeafIndexMap.set(56n, 77n);
-
-      const childExecution1 = emptyCallExecutionResult();
-      childExecution1.noteHashLeafIndexMap.set(78n, 66n);
-      const grandchildExecution = emptyCallExecutionResult();
-      grandchildExecution.noteHashLeafIndexMap.set(90n, 55n);
-      childExecution1.nestedExecutionResults = [grandchildExecution];
-
-      executionResult.entrypoint.nestedExecutionResults = [childExecution0, childExecution1];
-
-      const res = collectNoteHashLeafIndexMap(executionResult);
-      expect(res.size).toBe(5);
-      expect(res.get(12n)).toBe(99n);
-      expect(res.get(34n)).toBe(88n);
-      expect(res.get(56n)).toBe(77n);
-      expect(res.get(78n)).toBe(66n);
-      expect(res.get(90n)).toBe(55n);
     });
   });
 

--- a/yarn-project/stdlib/src/tx/private_execution_result.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.ts
@@ -129,8 +129,6 @@ export class PrivateCallExecutionResult {
     // Needed for the verifier (kernel)
     /** The call stack item. */
     public publicInputs: PrivateCircuitPublicInputs,
-    /** Mapping of note hash to its index in the note hash tree. Used for building hints for note hash read requests. */
-    public noteHashLeafIndexMap: Map<bigint, bigint>,
     /** The notes created in the executed function. */
     public newNotes: NoteAndSlot[],
     /** Mapping of note hash counter to the counter of its nullifier. */
@@ -159,7 +157,6 @@ export class PrivateCallExecutionResult {
         vk: schemas.Buffer,
         partialWitness: mapSchema(z.coerce.number(), z.string()),
         publicInputs: PrivateCircuitPublicInputs.schema,
-        noteHashLeafIndexMap: mapSchema(schemas.BigInt, schemas.BigInt),
         newNotes: z.array(NoteAndSlot.schema),
         noteHashNullifierCounterMap: mapSchema(z.coerce.number(), z.number()),
         returnValues: z.array(schemas.Fr),
@@ -177,7 +174,6 @@ export class PrivateCallExecutionResult {
       fields.vk,
       fields.partialWitness,
       fields.publicInputs,
-      fields.noteHashLeafIndexMap,
       fields.newNotes,
       fields.noteHashNullifierCounterMap,
       fields.returnValues,
@@ -194,7 +190,6 @@ export class PrivateCallExecutionResult {
       randomBytes(4),
       new Map([[1, 'one']]),
       PrivateCircuitPublicInputs.empty(),
-      new Map([[1n, 1n]]),
       [NoteAndSlot.random()],
       new Map([[0, 0]]),
       [Fr.random()],
@@ -208,16 +203,6 @@ export class PrivateCallExecutionResult {
       [new CountedContractClassLog(await ContractClassLog.random(), randomInt(10))],
     );
   }
-}
-
-export function collectNoteHashLeafIndexMap(execResult: PrivateExecutionResult) {
-  const accum: Map<bigint, bigint> = new Map();
-  const collectNoteHashLeafIndexMapRecursive = (callResult: PrivateCallExecutionResult, accum: Map<bigint, bigint>) => {
-    callResult.noteHashLeafIndexMap.forEach((value, key) => accum.set(key, value));
-    callResult.nestedExecutionResults.forEach(nested => collectNoteHashLeafIndexMapRecursive(nested, accum));
-  };
-  collectNoteHashLeafIndexMapRecursive(execResult.entrypoint, accum);
-  return accum;
 }
 
 export function collectNoteHashNullifierCounterMap(execResult: PrivateExecutionResult) {


### PR DESCRIPTION
Tracking the note hash leaf indexes during execution is unnecessary because when building the kernel hints we are able to obtain the note hash membership witness directly by value instead of by index. I guess the API obtaining the witness by value might be a bit slower since we first need to find where in the tree the it is while index directly points into a tree. But even if this is the case it doesn't seem to be worth the complexity (if the slowness turns out to be a problem we can always store a map from note hash to index in the node given that the note hashes are unique).

Decided to do this when trying to tackle [F-218](https://linear.app/aztec-labs/issue/F-218/remove-note-and-nullif-indexes-from-note-and-event-storage).