### PR TITLE
fix(docs): add references frontmatter to documentation files

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -302,6 +302,7 @@ Approved external documentation sources:
 - Consider the user's journey through the entire documentation site
 - Flag any content that might need subject matter expert review
 - Suggest improvements even if they go beyond pure editing
+- When making changes to documentation processes or tooling, remember to check and update READMEs, project documentation (like this file), and code comments
 
-Last updated: 2025-12-24
-Version: 1.2
+Last updated: 2026-01-09
+Version: 1.3

--- a/docs/README.md
+++ b/docs/README.md
@@ -448,7 +448,7 @@ When documentation references source code files, the CI system can automatically
 
 **How it works:**
 
-1. **Mark Referenced Files**: Add a `references` field to your documentation frontmatter with paths to source files (from repository root):
+1. **Mark Referenced Files**: Add a `references` field to your documentation frontmatter with paths to source files or directories (from repository root):
 
    ```yaml
    ---
@@ -457,10 +457,19 @@ When documentation references source code files, the CI system can automatically
    ---
    ```
 
+   To reference all files in a directory, use `/*` suffix:
+
+   ```yaml
+   ---
+   title: Function Context
+   references: ["noir-projects/aztec-nr/aztec/src/context/*"]
+   ---
+   ```
+
 2. **Automatic Detection**: During CI builds (`bootstrap.sh`), the system:
 
-   - Extracts all referenced files from documentation frontmatter
-   - Checks if any referenced files changed in the current PR
+   - Extracts all referenced paths from documentation frontmatter
+   - Checks if any referenced files (or files within referenced directories) changed in the current PR
    - Automatically requests `@AztecProtocol/devrel` as reviewers if:
      - The PR is not a draft
      - DevRel team is not already requested
@@ -473,7 +482,10 @@ When documentation references source code files, the CI system can automatically
 
 **Implementation**: The automation is handled by `scripts/check_doc_references.sh`, which runs as part of the docs CI pipeline.
 
-**Path Format**: Reference paths must be absolute from the repository root (e.g., `yarn-project/...`, not `../../../../yarn-project/...`).
+**Path Format**:
+- Paths must be absolute from the repository root (e.g., `yarn-project/...`, not `../../../../yarn-project/...`)
+- For individual files: `"path/to/file.ts"`
+- For directories (all files within): `"path/to/directory/*"`
 
 ## Contributing
 

--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_prove_history.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_prove_history.md
@@ -3,6 +3,7 @@ title: Proving Historic State
 sidebar_position: 15
 tags: [contracts]
 description: Prove historical state and note inclusion in your Aztec smart contracts using the Archive tree.
+references: ["noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr"]
 ---
 
 This guide shows you how to prove historical state transitions and note inclusion using Aztec's Archive tree.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_retrieve_filter_notes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/how_to_retrieve_filter_notes.md
@@ -3,6 +3,7 @@ title: Retrieving and Filtering Notes
 sidebar_position: 0
 tags: [private-state, smart-contracts, notes]
 description: Step-by-step guide to retrieving, filtering, and sorting notes from private storage in Aztec contracts.
+references: ["noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr", "noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/filter.nr"]
 ---
 
 This guide shows you how to retrieve and filter notes from private storage using `NoteGetterOptions`.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/partial_notes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/partial_notes.md
@@ -3,6 +3,7 @@ title: Partial Notes
 sidebar_position: 1
 tags: [Developers, Contracts, Notes]
 description: How partial notes work and how they can be used.
+references: ["noir-projects/aztec-nr/uint-note/src/uint_note.nr", "noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr"]
 ---
 
 import Image from "@theme/IdealImage";

--- a/docs/docs-developers/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/advanced/protocol_oracles.md
@@ -3,6 +3,7 @@ title: Oracle Functions
 sidebar_position: 18
 tags: [functions, oracles]
 description: Learn about oracles in Aztec, which provide external data to smart contracts during execution.
+references: ["noir-projects/aztec-nr/aztec/src/oracle/*"]
 ---
 
 This page goes over what oracles are in Aztec and how they work.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/contract_structure.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/contract_structure.md
@@ -3,6 +3,7 @@ title: Contract Structure
 sidebar_position: 1
 tags: [contracts]
 description: Learn the fundamental structure of Aztec smart contracts including the contract keyword, directory layout, and how contracts manage state and functions.
+references: ["docs/examples/contracts/counter_contract/src/main.nr"]
 ---
 
 A contract is a collection of persistent [state variables](./how_to_define_storage.md) and [functions](./functions/index.md) which may manipulate these variables. Functions and state variables within a contract's scope are said to belong to that contract.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/data_structures.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/data_structures.md
@@ -1,6 +1,7 @@
 ---
 title: Data Structures
 description: Learn about the data structures used in Aztec portals for L1-L2 communication.
+references: ["l1-contracts/src/core/libraries/DataStructures.sol"]
 ---
 
 This page documents the Solidity structs used for L1-L2 message passing in the Aztec protocol.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/inbox.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/inbox.md
@@ -2,6 +2,7 @@
 title: Inbox
 description: Learn about the inbox mechanism in Aztec portals for receiving messages from L1.
 tags: [portals, contracts]
+references: ["l1-contracts/src/core/interfaces/messagebridge/IInbox.sol"]
 ---
 
 The `Inbox` is a contract deployed on L1 that handles message passing from L1 to L2.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/outbox.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/outbox.md
@@ -2,6 +2,7 @@
 title: Outbox
 description: Learn about the outbox mechanism in Aztec portals for sending messages to L1.
 tags: [portals, contracts]
+references: ["l1-contracts/src/core/interfaces/messagebridge/IOutbox.sol"]
 ---
 
 The `Outbox` is a contract deployed on L1 that handles message passing from L2 to L1. Portal contracts call `consume()` to receive and process messages that were sent from L2 contracts. The Rollup contract inserts message roots via `insert()` when epochs are proven.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/registry.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/ethereum-aztec-messaging/registry.md
@@ -2,6 +2,7 @@
 title: Registry
 description: Learn about the portal registry and how it manages L1-L2 contract mappings.
 tags: [portals, contracts]
+references: ["l1-contracts/src/governance/interfaces/IRegistry.sol"]
 ---
 
 The registry is a contract deployed on L1, that contains addresses for the `Rollup`. It also keeps track of the different versions that have been deployed and let you query prior deployments easily.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/attributes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/attributes.md
@@ -3,6 +3,7 @@ title: Attributes and Macros
 sidebar_position: 6
 tags: [functions]
 description: Reference for Aztec contract attributes that control function visibility, execution context, storage, and notes.
+references: ["noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr"]
 ---
 
 This page documents the attributes (macros) available in Aztec.nr for defining contract functions, storage, and notes.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/context.md
@@ -3,6 +3,7 @@ title: Understanding Function Context
 sidebar_position: 3
 tags: [functions, context]
 description: Learn about the execution context available to Aztec contract functions, including caller information and block data.
+references: ["noir-projects/aztec-nr/aztec/src/context/*", "noir-projects/noir-protocol-circuits/crates/types/src/abis/*"]
 ---
 
 import Image from '@theme/IdealImage';

--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/how_to_define_functions.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/how_to_define_functions.md
@@ -3,6 +3,7 @@ title: How to Define Functions
 sidebar_position: 1
 tags: [functions, smart-contracts]
 description: Define different types of functions in your Aztec contracts for private, public, and utility execution.
+references: ["docs/examples/contracts/bob_token_contract/src/main.nr", "docs/examples/contracts/counter_contract/src/main.nr"]
 ---
 
 ## Overview

--- a/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/globals.md
@@ -2,6 +2,7 @@
 title: Global Variables
 description: Access chain ID, block number, timestamps, and gas information in your Aztec contracts
 sidebar_position: 9
+references: ["noir-projects/noir-protocol-circuits/crates/types/src/abis/*"]
 ---
 
 # Global Variables

--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_call_contracts.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_call_contracts.md
@@ -3,6 +3,7 @@ title: Calling Other Contracts
 sidebar_position: 5
 tags: [functions, contracts, composability]
 description: Call functions in other contracts from your Aztec smart contracts to enable composability.
+references: ["noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr"]
 ---
 
 This guide shows you how to call functions in other contracts from your Aztec smart contracts.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_communicate_cross_chain.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_communicate_cross_chain.md
@@ -3,6 +3,7 @@ title: Communicating Cross-Chain
 tags: [contracts, portals]
 sidebar_position: 12
 description: Send messages and data between L1 and L2 contracts using portal contracts and cross-chain messaging.
+references: ["l1-contracts/test/portals/TokenPortal.sol", "noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr"]
 ---
 
 This guide covers cross-chain communication between Ethereum (L1) and Aztec (L2) using portal contracts.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_implement_custom_notes.md
@@ -4,6 +4,7 @@ description: Learn how to create and use custom note types for specialized priva
 sidebar_position: 6
 tags: [smart contracts, notes, privacy]
 keywords: [implementing note, note, custom note]
+references: ["docs/examples/tutorials/token_bridge_contract/contracts/aztec/nft/*", "noir-projects/noir-contracts/contracts/app/nft_contract/*"]
 ---
 
 This guide shows you how to create custom note types for storing specialized private data in your Aztec contracts.

--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_use_authwit.md
@@ -3,6 +3,7 @@ title: Enabling Authentication Witnesses
 description: Enable contracts to execute actions on behalf of user accounts using authentication witnesses.
 tags: [accounts, authwit]
 sidebar_position: 11
+references: ["noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr", "noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr"]
 ---
 
 Authentication witnesses (authwit) allow other contracts to execute actions on behalf of your account. This guide shows you how to implement and use authwits in your Aztec smart contracts.

--- a/docs/docs-developers/docs/aztec-nr/index.md
+++ b/docs/docs-developers/docs/aztec-nr/index.md
@@ -3,6 +3,7 @@ title: Developing Smart Contracts
 sidebar_position: 0
 tags: [aztec.nr, smart contracts]
 description: Comprehensive guide to writing smart contracts for the Aztec network using Noir.
+references: ["docs/examples/contracts/counter_contract/src/main.nr"]
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/docs/docs-developers/docs/foundational-topics/accounts/keys.md
+++ b/docs/docs-developers/docs/foundational-topics/accounts/keys.md
@@ -2,6 +2,7 @@
 title: Keys
 tags: [accounts, keys]
 description: Understand the specialized key pairs used in Aztec accounts - nullifier keys, incoming viewing keys, and signing keys - and how they enable privacy, security, and flexible authentication.
+references: ["noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr"]
 ---
 
 import Image from "@theme/IdealImage";

--- a/docs/docs-developers/docs/foundational-topics/call_types.md
+++ b/docs/docs-developers/docs/foundational-topics/call_types.md
@@ -3,6 +3,7 @@ title: Call Types
 sidebar_position: 6
 tags: [calls, contracts, execution]
 description: Understand the different types of contract calls in Aztec, including private and public execution modes, and how they compare to Ethereum's call types.
+references: ["noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr", "noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr", "noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr", "noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr", "noir-projects/noir-contracts/contracts/protocol/router_contract/src/main.nr", "noir-projects/noir-contracts/contracts/protocol/router_contract/src/utils.nr", "yarn-project/end-to-end/src/composed/docs_examples.test.ts", "yarn-project/end-to-end/src/e2e_card_game.test.ts", "yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts"]
 ---
 
 ## What is a Call

--- a/docs/docs-developers/docs/foundational-topics/fees.md
+++ b/docs/docs-developers/docs/foundational-topics/fees.md
@@ -3,6 +3,7 @@ title: Fees
 sidebar_position: 4
 tags: [fees]
 description: Understand Aztec's fee system including mana-based transaction pricing, Aztec token payments, and how L1 and L2 costs are transparently calculated for users.
+references: ["yarn-project/stdlib/src/gas/gas_settings.ts"]
 ---
 
 import { Why_Fees } from '@site/src/components/Snippets/general_snippets';

--- a/docs/docs-developers/docs/foundational-topics/state_management.md
+++ b/docs/docs-developers/docs/foundational-topics/state_management.md
@@ -3,6 +3,7 @@ title: State Management
 description: How public and private state work in Aztec, including storage slots, notes, and the UTXO model
 sidebar_position: 0
 tags: [protocol, storage]
+references: ["noir-projects/aztec-nr/uint-note/src/uint_note.nr"]
 ---
 
 import Image from "@theme/IdealImage";

--- a/docs/docs-developers/docs/foundational-topics/transactions.md
+++ b/docs/docs-developers/docs/foundational-topics/transactions.md
@@ -3,6 +3,7 @@ title: Transactions
 sidebar_position: 3
 tags: [protocol]
 description: Comprehensive guide to the Aztec transaction lifecycle, covering private execution, PXE interactions, kernel circuits, and the step-by-step process from user request to L1 settlement.
+references: ["noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/*", "yarn-project/aztec.js/src/contract/*", "yarn-project/stdlib/src/tx/*"]
 ---
 
 import Image from '@theme/IdealImage';

--- a/docs/docs-developers/docs/foundational-topics/wallets.md
+++ b/docs/docs-developers/docs/foundational-topics/wallets.md
@@ -3,6 +3,7 @@ title: Wallets
 sidebar_position: 2
 tags: [accounts]
 description: Overview of wallet responsibilities in Aztec including account management, private state tracking, transaction execution, key management, and authorization handling.
+references: ["yarn-project/aztec.js/src/account/interface.ts"]
 ---
 
 This page covers the main responsibilities of a wallet in the Aztec network.

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -2,6 +2,7 @@
 title: Counter Contract
 description: Code-along tutorial for creating a simple counter contract on Aztec.
 sidebar_position: 0
+references: ["docs/examples/contracts/counter_contract/src/main.nr"]
 ---
 
 import Image from "@theme/IdealImage";

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
@@ -3,6 +3,7 @@ title: Private Token Contract
 sidebar_position: 1
 tags: [privacy, tokens, intermediate]
 description: Build a privacy-preserving token for employee mental health benefits that keeps spending habits confidential.
+references: ["docs/examples/contracts/bob_token_contract/src/main.nr", "docs/examples/ts/bob_token_contract/index.ts"]
 ---
 
 ## The Privacy Challenge: Mental Health Benefits at Giggle

--- a/docs/docs-developers/docs/tutorials/js_tutorials/aztecjs-getting-started.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/aztecjs-getting-started.md
@@ -2,6 +2,7 @@
 title: Deploying a Token Contract
 sidebar_position: 0
 description: A tutorial going through how to deploy a token contract to the local network using typescript.
+references: ["docs/examples/ts/aztecjs_getting_started/index.ts"]
 ---
 
 import Image from "@theme/IdealImage";

--- a/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
+++ b/docs/docs-developers/docs/tutorials/js_tutorials/token_bridge.md
@@ -2,6 +2,7 @@
 title: "Bridge Your NFT to Aztec"
 sidebar_position: 1
 description: "Build a private NFT bridge between Ethereum and Aztec using custom notes, PrivateSet, and cross-chain messaging portals."
+references: ["docs/examples/tutorials/token_bridge_contract/*"]
 ---
 
 ## Why Bridge an NFT?

--- a/docs/scripts/check_doc_references.sh
+++ b/docs/scripts/check_doc_references.sh
@@ -16,6 +16,10 @@ set -euo pipefail
 #   pr_number - (Optional) PR number. If not provided, will attempt auto-detection
 #   docs_dir  - (Optional) Documentation directory. Default: docs
 #
+# Reference Format:
+#   - Individual files: "yarn-project/stdlib/src/interfaces/aztec-node.ts"
+#   - Directories (all files within): "noir-projects/aztec-nr/aztec/src/context/*"
+#
 # Environment:
 #   GITHUB_REF - May contain PR number in format refs/pull/123/merge
 #   GITHUB_BASE_REF - Base branch name (set by GitHub Actions)
@@ -153,19 +157,22 @@ find "$DOCS_DIR/docs" -type f -name "*.md" -print0 | while IFS= read -r -d '' do
     }
   ' "$doc_file"
 done > "$MAPPING_FILE"
-# Validate all referenced files exist
-echo "Validating referenced files exist..."
-MISSING_FILES=""
-while IFS='|' read -r ref_file doc_file; do
-  if [[ ! -f "$ref_file" ]]; then
-    MISSING_FILES="${MISSING_FILES}  - ${ref_file} (referenced in ${doc_file})\n"
+# Validate all referenced paths exist (can be files or directories)
+# Directory references use /* suffix (e.g., "src/context/*" means all files in that directory)
+echo "Validating referenced paths exist..."
+MISSING_PATHS=""
+while IFS='|' read -r ref_path doc_file; do
+  # Strip /* suffix for directory references before checking existence
+  check_path="${ref_path%/\*}"
+  if [[ ! -e "$check_path" ]]; then
+    MISSING_PATHS="${MISSING_PATHS}  - ${ref_path} (referenced in ${doc_file})\n"
   fi
 done < "$MAPPING_FILE"
 
-if [[ -n "$MISSING_FILES" ]]; then
+if [[ -n "$MISSING_PATHS" ]]; then
   echo ""
-  echo "ERROR: The following referenced files do not exist:"
-  echo -e "$MISSING_FILES"
+  echo "ERROR: The following referenced paths do not exist:"
+  echo -e "$MISSING_PATHS"
   echo "Please update the 'references' frontmatter in the affected documentation files."
   exit 1
 fi
@@ -225,11 +232,14 @@ echo "Found $(echo "$CHANGED_FILES" | wc -l) changed file(s) in PR."
 
 # Check if any referenced files were changed and build mapping
 # Reference paths are absolute from repo root, so we can compare directly
+# Directory references use /* suffix - strip it for matching (e.g., "src/context/*" matches "src/context/file.nr")
 CHANGED_REFERENCES=""
 declare -A FILE_TO_DOCS_MAP
 
 while IFS= read -r ref_file; do
-  if echo "$CHANGED_FILES" | grep -qF "$ref_file"; then
+  # Strip /* suffix for directory references before matching
+  match_pattern="${ref_file%/\*}"
+  if echo "$CHANGED_FILES" | grep -qF "$match_pattern"; then
     CHANGED_REFERENCES="${CHANGED_REFERENCES}${ref_file}\n"
 
     # Find all docs that reference this changed file

--- a/docs/scripts/extract_references.sh
+++ b/docs/scripts/extract_references.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Extract references from #include_code macros in a doc file
+#
+# Outputs individual file paths. To reference entire directories, manually
+# consolidate paths and use the /* suffix (e.g., "path/to/dir/*").
+#
+# Usage: extract_references.sh <doc_file.md>
+
+DOC_FILE="$1"
+
+if [[ ! -f "$DOC_FILE" ]]; then
+  echo "Usage: $0 <doc_file.md>"
+  exit 1
+fi
+
+echo "references:"
+grep "#include_code" "$DOC_FILE" | while read -r line; do
+  path=$(echo "$line" | awk '{print $3}')
+  path="${path#/}"  # Remove leading slash
+  echo "  - \"$path\""
+done | sort -u


### PR DESCRIPTION
## Summary

- Adds `references` frontmatter to 28 documentation files that include code snippets via `#include_code` macros
- Creates helper script `docs/scripts/extract_references.sh` to extract references from documentation files
- Updates `check_doc_references.sh` to support directory references with `/*` suffix
- Updates `docs/README.md` with documentation about the references format
- Updates `docs/CLAUDE.md` with reminder about updating docs when changing processes
- Enables automatic DevRel review notifications when referenced source files change in PRs

## Files Updated

| Category | Count | Files |
|----------|-------|-------|
| Contract Tutorials | 2 | `counter_contract.md`, `token_contract.md` |
| JS Tutorials | 2 | `aztecjs-getting-started.md`, `token_bridge.md` |
| Framework Documentation | 18 | Various `aztec-nr/` files |
| Foundational Topics | 6 | `transactions.md`, `state_management.md`, `wallets.md`, `fees.md`, `call_types.md`, `keys.md` |

## How It Works

Documentation files can now declare source code dependencies via frontmatter:

```yaml
---
title: Counter Contract
references: ["docs/examples/contracts/counter_contract/src/main.nr"]
---
```

**Directory references use `/*` suffix** to indicate all files within that directory:

```yaml
references: ["noir-projects/aztec-nr/aztec/src/context/*"]
```

When any file within that directory changes, the documentation will be flagged for review.

When referenced paths change in a PR, `docs/scripts/check_doc_references.sh`:
1. Requests `@AztecProtocol/devrel` as reviewers
2. Posts a PR comment listing affected documentation

## Reference Format

- **Individual files**: `"path/to/file.ts"`
- **Directories (all files within)**: `"path/to/directory/*"`

## Test Plan

- All 28 documentation files have `references` frontmatter
- All referenced paths (files and directories) verified to exist
- Script logic tested for both file and directory matching
- Documentation updated in README.md and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)