### PR TITLE
chore: add ignore not found flag to avoid ci error

### DIFF
--- a/spartan/scripts/network_teardown.sh
+++ b/spartan/scripts/network_teardown.sh
@@ -78,6 +78,6 @@ fi
 
 # Delete the namespace
 echo "Deleting namespace $NAMESPACE..."
-kubectl delete namespace "$NAMESPACE"
+kubectl delete namespace "$NAMESPACE" --ignore-not-found
 
 echo "Destroyed network $NAMESPACE"


### PR DESCRIPTION
Fixes an error caused by #19426 when namespace does not exist. 
