### PR TITLE
refactor: dropping unnecessary indexes from db

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -32,10 +32,10 @@ export interface NoteData {
   noteNonce: Fr;
   /** A hash of the note as it gets stored in the note hash tree. */
   noteHash: Fr;
+  /** True if the note is pending, false if settled. */
+  isPending: boolean;
   /** The corresponding nullifier of the note. Undefined for pending notes. */
   siloedNullifier?: Fr;
-  /** The note's leaf index in the note hash tree. Undefined for pending notes. */
-  index?: bigint;
 }
 
 // These interfaces contain the list of oracles required by aztec-nr in order to simulate and execute transactions, i.e.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/note_packing_utils.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/note_packing_utils.test.ts
@@ -12,7 +12,7 @@ it('packs retrieved note', () => {
     randomness: new Fr(42n),
     storageSlot: new Fr(100n),
     noteNonce: new Fr(2n),
-    index: undefined, // Transient note
+    isPending: true,
     note: new Note([new Fr(3n), new Fr(4n)]),
   };
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/note_packing_utils.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/note_packing_utils.ts
@@ -28,7 +28,7 @@ function fromRawData(nonzeroNoteHashCounter: boolean, maybeNoteNonce: Fr): { sta
  * @param randomness - The randomness injected into the note to get the hiding property of commitments
  * @param storageSlot - The storage slot of the note
  * @param noteNonce - The nonce injected into the note hash preimage by kernels.
- * @param index - Optional index in the note hash tree. If undefined, indicates a transient note
+ * @param isPending - True if the note is pending, false if settled
  * @param note - The note content containing the actual note data
  * @returns The packed note as an array of field elements
  */
@@ -38,7 +38,7 @@ export function packAsRetrievedNote({
   randomness,
   storageSlot,
   noteNonce,
-  index,
+  isPending,
   note,
 }: {
   contractAddress: AztecAddress;
@@ -46,14 +46,14 @@ export function packAsRetrievedNote({
   randomness: Fr;
   storageSlot: Fr;
   noteNonce: Fr;
-  index?: bigint;
+  isPending: boolean;
   note: Note;
 }) {
-  // If index is undefined, the note is transient which implies that the nonzero_note_hash_counter has to be true
-  const nonzeroNoteHashCounter = index === undefined;
+  // If the note is pending it means it has a non-zero note hash counter associated with it.
+  const nonZeroNoteHashCounter = isPending;
 
   // To pack the note as retrieved note we first need to reconstruct the note metadata.
-  const noteMetadata = fromRawData(nonzeroNoteHashCounter, noteNonce);
+  const noteMetadata = fromRawData(nonZeroNoteHashCounter, noteNonce);
 
   // Pack in order: note, contract_address, owner, randomness, storage_slot, metadata (stage, maybe_note_nonce)
   return [

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -286,7 +286,7 @@ export class Oracle {
         randomness: noteData.randomness,
         storageSlot: noteData.storageSlot,
         noteNonce: noteData.noteNonce,
-        index: noteData.index,
+        isPending: noteData.isPending,
         note: noteData.note,
       }),
     );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -500,7 +500,6 @@ describe('Private Execution test suite', () => {
   describe('stateful test contract', () => {
     let contractAddress: AztecAddress;
     const mockFirstNullifier = new Fr(1111);
-    let currentNoteIndex = 0n;
 
     const buildNote = async (amount: bigint, owner: AztecAddress, storageSlot: Fr): Promise<NoteDao> => {
       // WARNING: this is not actually how nonces are computed!
@@ -530,7 +529,8 @@ describe('Private Execution test suite', () => {
         TxHash.random(),
         BlockNumber(Math.abs(randomInt(1000))),
         L2BlockHash.random().toString(),
-        currentNoteIndex++,
+        0,
+        0,
       );
     };
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -428,6 +428,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
         note,
         siloedNullifier: undefined, // Siloed nullifier cannot be known for newly created note.
         noteHash,
+        isPending: true, // This note has just been created and hence is not settled yet.
       },
       counter,
     );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -158,7 +158,7 @@ describe('Utility Execution test suite', () => {
     });
     noteStore.getNotes.mockResolvedValue(
       notes.map(
-        (note, index) =>
+        note =>
           new NoteDao(
             note,
             contractAddress,
@@ -171,7 +171,8 @@ describe('Utility Execution test suite', () => {
             TxHash.random(),
             BlockNumber(42),
             L2BlockHash.random().toString(),
-            BigInt(index),
+            0,
+            0,
           ),
       ),
     );

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -74,22 +74,11 @@ describe('deliverEvent', () => {
 
     /* Happy path context conditions:
      ** - PXE is sync'd to _at least_ block including tx
-     ** - Node knows tx effect
-     ** - Node knows siloed event commitment
+     ** - Node returns the corresponding tx effect and the tx effect includes the event commitment
      */
     await setSyncedBlockNumber(blockNumber);
 
     aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
-
-    aztecNode.findLeavesIndexes.mockImplementation(() =>
-      Promise.resolve([
-        {
-          data: BigInt(0),
-          l2BlockNumber: indexedTxEffect.l2BlockNumber,
-          l2BlockHash: indexedTxEffect.l2BlockHash,
-        },
-      ]),
-    );
 
     eventService = new EventService(anchorBlockStore, aztecNode, privateEventStore);
   });
@@ -125,16 +114,10 @@ describe('deliverEvent', () => {
     await expect(runDeliverEvent).rejects.toThrow(/Could not find tx effect for tx hash .* as of block number/);
   });
 
-  it('should throw if event is not in tx effects', async () => {
+  it('should throw if event commitment is not in the tx effects', async () => {
     await expect(runDeliverEvent({ eventCommitment: Fr.random() })).rejects.toThrow(
       /Event commitment .* is not present in tx/,
     );
-  });
-
-  it('should throw if event is not in nullifiers', async () => {
-    aztecNode.findLeavesIndexes.mockImplementation(() => Promise.resolve([]));
-
-    await expect(runDeliverEvent).rejects.toThrow(/Event commitment .* is not present on the nullifier tree/);
   });
 
   it('should store event for later retrieval', async () => {

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -3,7 +3,6 @@ import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { TxHash } from '@aztec/stdlib/tx';
 
 import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
@@ -45,35 +44,22 @@ export class EventService {
       throw new Error(`Could not find tx effect for tx hash ${txHash} as of block number ${syncedBlockNumber}`);
     }
 
-    const eventInTx = txEffect.data.nullifiers.some(n => n.equals(siloedEventCommitment));
-    if (!eventInTx) {
+    // Find the index of the event commitment in the nullifiers array to determine event ordering within the tx
+    const eventIndexInTx = txEffect.data.nullifiers.findIndex(n => n.equals(siloedEventCommitment));
+    if (eventIndexInTx === -1) {
       throw new Error(
         `Event commitment ${eventCommitment} (siloed as ${siloedEventCommitment}) is not present in tx ${txHash}`,
       );
     }
 
-    const [nullifierIndex] = await this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, [
-      siloedEventCommitment,
-    ]);
-
-    if (nullifierIndex === undefined) {
-      throw new Error(
-        `Event commitment ${eventCommitment} (siloed as ${siloedEventCommitment}) is not present on the nullifier tree at block ${syncedBlockNumber} (from tx ${txHash})`,
-      );
-    }
-
-    return this.privateEventStore.storePrivateEventLog(
-      selector,
-      randomness,
-      content,
-      Number(nullifierIndex.data), // Index of the event commitment in the nullifier tree
-      {
-        contractAddress,
-        scope,
-        txHash,
-        l2BlockNumber: nullifierIndex.l2BlockNumber, // Block number in which the event was emitted
-        l2BlockHash: nullifierIndex.l2BlockHash, // Block hash in which the event was emitted
-      },
-    );
+    return this.privateEventStore.storePrivateEventLog(selector, randomness, content, siloedEventCommitment, {
+      contractAddress,
+      scope,
+      txHash,
+      l2BlockNumber: txEffect.l2BlockNumber,
+      l2BlockHash: txEffect.l2BlockHash,
+      txIndexInBlock: txEffect.txIndexInBlock,
+      eventIndexInTx,
+    });
   }
 }

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -174,14 +174,11 @@ describe('NoteService', () => {
     let noteHash: Fr;
     let uniqueNoteHash: Fr;
     let nullifier: Fr;
-    let siloedNullifier: Fr;
 
     let txHash: TxHash;
     let txEffect: TxEffect;
     let indexedTxEffect: IndexedTxEffect;
     let blockNumber: BlockNumber;
-
-    let nullified = false;
 
     const setSyncedBlockNumber = (blockNumber: BlockNumber) => {
       return anchorBlockStore.setHeader(
@@ -204,7 +201,6 @@ describe('NoteService', () => {
       content = [Fr.random(), Fr.random()];
 
       uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
-      siloedNullifier = await siloNullifier(contractAddress, nullifier);
 
       blockNumber = BlockNumber(42);
 
@@ -231,38 +227,13 @@ describe('NoteService', () => {
         Promise.resolve(queryTxHash == txHash ? indexedTxEffect : undefined),
       );
 
-      aztecNode.findLeavesIndexes.mockImplementation((queryBlockNum, treeId, leaves) => {
-        if (queryBlockNum != blockNumber) {
-          throw new Error(`Got a tree query for block ${queryBlockNum} but synced block is ${blockNumber}`);
-        }
-
-        if (treeId == MerkleTreeId.NOTE_HASH_TREE && leaves[0].equals(uniqueNoteHash)) {
-          return Promise.resolve([
-            {
-              data: BigInt(0),
-              l2BlockNumber: indexedTxEffect.l2BlockNumber,
-              l2BlockHash: indexedTxEffect.l2BlockHash,
-            },
-          ]);
-        } else if (treeId == MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
-          // Note that returning undefined (i.e. the un-nullified case) covers both scenarios where the note has not
-          // been nullified and where the nullifier is in a block past the synced block.
-          return Promise.resolve([
-            nullified
-              ? {
-                  data: BigInt(0),
-                  l2BlockNumber: indexedTxEffect.l2BlockNumber,
-                  l2BlockHash: indexedTxEffect.l2BlockHash,
-                }
-              : undefined,
-          ]);
-        } else {
-          throw new Error();
-        }
+      aztecNode.findLeavesIndexes.mockImplementation((_queryBlockNum, _treeId, _leaves) => {
+        // By default the note is not yet nullified.
+        return Promise.resolve([undefined]);
       });
     });
 
-    it('should store note if it exists in note hash tree and is not nullified', async () => {
+    it('should store note if it exists in a tx effect', async () => {
       await noteService.deliverNote(
         contractAddress,
         owner,
@@ -336,8 +307,17 @@ describe('NoteService', () => {
       ).rejects.toThrow(/as of block number/);
     });
 
-    it('should store and immediately remove note if it is already nullified', async () => {
-      nullified = true;
+    it('should nullify note if nullifier index is found', async () => {
+      const siloedNullifier = await siloNullifier(contractAddress, nullifier);
+      const nullifierIndex = randomDataInBlock(123n);
+
+      // Override the mock to return a nullifier index (indicating the note has been nullified)
+      aztecNode.findLeavesIndexes.mockImplementation((_queryBlockNum, treeId, leaves) => {
+        if (treeId == MerkleTreeId.NULLIFIER_TREE && leaves[0].equals(siloedNullifier)) {
+          return Promise.resolve([nullifierIndex]);
+        }
+        return Promise.resolve([undefined]);
+      });
 
       await noteService.deliverNote(
         contractAddress,
@@ -352,9 +332,22 @@ describe('NoteService', () => {
         recipient.address,
       );
 
-      // Verify note was removed
-      const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] });
-      expect(notes).toHaveLength(0);
+      // Now we verify that the note is stored as nullified by checking it can be retrieved only with
+      // the ACTIVE_OR_NULLIFIED status on the input.
+      const allNotes = await noteStore.getNotes({
+        contractAddress,
+        scopes: [recipient.address],
+        status: NoteStatus.ACTIVE_OR_NULLIFIED,
+      });
+      expect(allNotes).toHaveLength(1);
+      expect(allNotes[0].noteHash.equals(noteHash)).toBe(true);
+
+      const activeNotes = await noteStore.getNotes({
+        contractAddress,
+        scopes: [recipient.address],
+        status: NoteStatus.ACTIVE,
+      });
+      expect(activeNotes).toHaveLength(0);
     });
   });
 });

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -41,7 +41,7 @@ export class NoteService {
       scopes,
     });
     return noteDaos.map(
-      ({ contractAddress, owner, storageSlot, randomness, noteNonce, note, noteHash, siloedNullifier, index }) => ({
+      ({ contractAddress, owner, storageSlot, randomness, noteNonce, note, noteHash, siloedNullifier }) => ({
         contractAddress,
         owner,
         storageSlot,
@@ -49,9 +49,8 @@ export class NoteService {
         noteNonce,
         note,
         noteHash,
+        isPending: false, // Note service deals only with settled notes
         siloedNullifier,
-        // PXE can use this index to get full MembershipWitness
-        index,
       }),
     );
   }
@@ -146,7 +145,10 @@ export class NoteService {
     const uniqueNoteHash = await computeUniqueNoteHash(noteNonce, await siloNoteHash(contractAddress, noteHash));
     const siloedNullifier = await siloNullifier(contractAddress, nullifier);
 
-    const txEffect = await this.aztecNode.getTxEffect(txHash);
+    const [txEffect, [nullifierIndex]] = await Promise.all([
+      this.aztecNode.getTxEffect(txHash),
+      this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, [siloedNullifier]),
+    ]);
     if (!txEffect) {
       throw new Error(`Could not find tx effect for tx hash ${txHash}`);
     }
@@ -155,23 +157,10 @@ export class NoteService {
       throw new Error(`Could not find tx effect for tx hash ${txHash} as of block number ${syncedBlockNumber}`);
     }
 
-    const noteInTx = txEffect.data.noteHashes.some(nh => nh.equals(uniqueNoteHash));
-    if (!noteInTx) {
+    // Find the index of the note hash in the noteHashes array to determine note ordering within the tx
+    const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
+    if (noteIndexInTx === -1) {
       throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
-    }
-
-    // We store notes by their index in the global note hash tree, which has the convenient side effect of validating
-    // note existence in said tree. We concurrently also check if the note's nullifier exists, performing all node
-    // queries in a single round-trip.
-    const [[uniqueNoteHashTreeIndexInBlock], [nullifierIndex]] = await Promise.all([
-      this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NOTE_HASH_TREE, [uniqueNoteHash]),
-      this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, [siloedNullifier]),
-    ]);
-
-    if (uniqueNoteHashTreeIndexInBlock === undefined) {
-      throw new Error(
-        `Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present on the tree at block ${syncedBlockNumber} (from tx ${txHash})`,
-      );
     }
 
     const noteDao = new NoteDao(
@@ -184,15 +173,17 @@ export class NoteService {
       noteHash,
       siloedNullifier,
       txHash,
-      uniqueNoteHashTreeIndexInBlock.l2BlockNumber,
-      uniqueNoteHashTreeIndexInBlock.l2BlockHash.toString(),
-      uniqueNoteHashTreeIndexInBlock.data,
+      txEffect.l2BlockNumber,
+      txEffect.l2BlockHash.toString(),
+      txEffect.txIndexInBlock,
+      noteIndexInTx,
     );
 
     // The note was found by `recipient`, so we use that as the scope when storing the note.
     await this.noteStore.addNotes([noteDao], recipient);
 
     if (nullifierIndex !== undefined) {
+      // We found nullifier index which implies that the note has already been nullified.
       const { data: _, ...blockHashAndNum } = nullifierIndex;
       await this.noteStore.applyNullifiers([{ data: siloedNullifier, ...blockHashAndNum }]);
     }

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -160,7 +160,6 @@ describe('PXE', () => {
     let l2BlockHash: L2BlockHash;
     let scope: AztecAddress;
     let privateEventStore: PrivateEventStore;
-    let eventIndex = 0;
 
     beforeEach(async () => {
       // Set up basic state
@@ -211,6 +210,8 @@ describe('PXE', () => {
       privateEventStore = new PrivateEventStore(kvStore);
     });
 
+    let eventCounter = 0;
+
     async function storeEvent(blockNumber?: number): Promise<PackedPrivateEvent> {
       const event = {
         packedEvent: [Fr.random(), Fr.random()],
@@ -221,14 +222,23 @@ describe('PXE', () => {
       };
 
       const randomness = Fr.random();
+      const siloedEventCommitment = Fr.random();
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, event.packedEvent, eventIndex++, {
-        contractAddress,
-        scope,
-        txHash: event.txHash,
-        l2BlockNumber: event.l2BlockNumber,
-        l2BlockHash: event.l2BlockHash,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        event.packedEvent,
+        siloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash: event.txHash,
+          l2BlockNumber: event.l2BlockNumber,
+          l2BlockHash: event.l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: eventCounter++,
+        },
+      );
 
       return event;
     }

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -18,22 +18,10 @@ const FAKE_ADDRESS = AztecAddress.fromString('0x11111111111111111111111111111111
 const SLOT_X = Fr.fromString('0x01');
 const SLOT_Y = Fr.fromString('0x02');
 const NON_EXISTING_SLOT = Fr.fromString('0xabad1dea');
-const DUMMY_SILOED_NULLIFIER_1 = new Fr(1n);
-const DUMMY_SILOED_NULLIFIER_2 = new Fr(2n);
-const DUMMY_SILOED_NULLIFIER_3 = new Fr(3n);
+const SILOED_NULLIFIER_1 = Fr.random();
+const SILOED_NULLIFIER_2 = Fr.random();
+const SILOED_NULLIFIER_3 = Fr.random();
 // -----------------------------------------------------------------------------
-
-// ─── Test Fixtures Overview ────────────────────────────────────────────────
-//
-// Notes created by `setupProviderWithNotes`:
-//   note1 → CONTRACT_A, SLOT_X, SCOPE_1, index: 1n
-//   note2 → CONTRACT_A, SLOT_Y, SCOPE_1, index: 2n
-//   note3 → CONTRACT_B, SLOT_X, SCOPE_2, index: 3n
-//
-// Each note varies by contractAddress, storageSlot, and recipient (scope).
-// The index (1n, 2n, 3n) is used solely for identification in assertions.
-//
-// ───────────────────────────────────────────────────────────────────────────
 
 describe('NoteStore', () => {
   // Helper to create a deterministic note with sensible defaults, override any field as needed.
@@ -41,7 +29,6 @@ describe('NoteStore', () => {
     return NoteDao.random({
       contractAddress: overrides.contractAddress ?? CONTRACT_A,
       storageSlot: overrides.storageSlot ?? SLOT_X,
-      index: overrides.index ?? 0n,
       l2BlockNumber: overrides.l2BlockNumber ?? BlockNumber(1),
       siloedNullifier: overrides.siloedNullifier ?? Fr.random(),
       ...overrides,
@@ -59,20 +46,17 @@ describe('NoteStore', () => {
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
       storageSlot: SLOT_X,
-      siloedNullifier: DUMMY_SILOED_NULLIFIER_1,
-      index: 1n,
+      siloedNullifier: SILOED_NULLIFIER_1,
     });
     const note2 = await mkNote({
       contractAddress: CONTRACT_A,
       storageSlot: SLOT_Y,
-      siloedNullifier: DUMMY_SILOED_NULLIFIER_2,
-      index: 2n,
+      siloedNullifier: SILOED_NULLIFIER_2,
     });
     const note3 = await mkNote({
       contractAddress: CONTRACT_B,
       storageSlot: SLOT_X,
-      siloedNullifier: DUMMY_SILOED_NULLIFIER_3,
-      index: 3n,
+      siloedNullifier: SILOED_NULLIFIER_3,
     });
 
     await provider.addNotes([note1, note2], SCOPE_1);
@@ -90,12 +74,12 @@ describe('NoteStore', () => {
     };
   }
 
-  // Extracts the `index` field from an array of notes for easy comparison in tests.
-  function getIndexes(notes: NoteDao[]) {
-    return notes.map(n => n.index);
+  // Extracts the `siloedNullifier` field from an array of notes for easy comparison in tests.
+  function getNullifiers(notes: NoteDao[]) {
+    return notes.map(n => n.siloedNullifier.toBigInt());
   }
 
-  // In these tests, we verify the presence/absence of notes by their `index`.
+  // In these tests, we verify the presence/absence of notes by their `siloedNullifier`.
   describe('NoteStore.create', () => {
     it('creates provider on an empty store and confirms getNotes returns an empty array', async () => {
       const store = await openTmpStore('note_store_fresh_store');
@@ -117,8 +101,8 @@ describe('NoteStore', () => {
       await provider1.addScope(SCOPE_1);
       await provider1.addScope(SCOPE_2);
 
-      const noteA = await mkNote({ contractAddress: CONTRACT_A, index: 1n });
-      const noteB = await mkNote({ contractAddress: CONTRACT_B, index: 2n });
+      const noteA = await mkNote({ contractAddress: CONTRACT_A, siloedNullifier: SILOED_NULLIFIER_1 });
+      const noteB = await mkNote({ contractAddress: CONTRACT_B, siloedNullifier: SILOED_NULLIFIER_2 });
       await provider1.addNotes([noteA, noteB], FAKE_ADDRESS);
 
       const provider2 = await NoteStore.create(store);
@@ -126,8 +110,8 @@ describe('NoteStore', () => {
       const notesA = await provider2.getNotes({ contractAddress: CONTRACT_A });
       const notesB = await provider2.getNotes({ contractAddress: CONTRACT_B });
 
-      expect(new Set(getIndexes(notesA))).toEqual(new Set([1n]));
-      expect(new Set(getIndexes(notesB))).toEqual(new Set([2n]));
+      expect(new Set(getNullifiers(notesA))).toEqual(new Set([SILOED_NULLIFIER_1.toBigInt()]));
+      expect(new Set(getNullifiers(notesB))).toEqual(new Set([SILOED_NULLIFIER_2.toBigInt()]));
 
       await store.close();
     });
@@ -150,26 +134,29 @@ describe('NoteStore', () => {
 
     it('filters notes matching only the contractAddress', async () => {
       const res = await provider.getNotes({ contractAddress: CONTRACT_A });
-      // note1 (index 1n) and note2 (index 2n) match CONTRACT_A
-      expect(new Set(getIndexes(res))).toEqual(new Set([1n, 2n]));
+      // note1 and note2 match CONTRACT_A
+      expect(new Set(getNullifiers(res))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
     });
 
     it('filters notes matching contractAddress and storageSlot', async () => {
       const res = await provider.getNotes({ contractAddress: CONTRACT_A, storageSlot: SLOT_Y });
-      expect(new Set(getIndexes(res))).toEqual(new Set([2n])); // note2 (index2n)
+      expect(new Set(getNullifiers(res))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
     });
 
     it('filters notes matching contractAddress in the specified scope', async () => {
       const res = await provider.getNotes({ contractAddress: CONTRACT_B, scopes: [SCOPE_2] });
-      expect(new Set(getIndexes(res))).toEqual(new Set([3n])); // note3 (index 3n)
+      expect(new Set(getNullifiers(res))).toEqual(new Set([note3.siloedNullifier.toBigInt()]));
     });
 
     it('filters notes matching contractAddress across multiple scopes', async () => {
       // Add a note for contractA under scope2 to make the multi-scope filter meaningful.
+      const note4Nullifier = Fr.random();
       const note4 = await mkNote({
         contractAddress: CONTRACT_A,
         storageSlot: SLOT_X,
-        index: 4n,
+        siloedNullifier: note4Nullifier,
       });
       await provider.addNotes([note4], SCOPE_2);
 
@@ -178,7 +165,9 @@ describe('NoteStore', () => {
         scopes: [SCOPE_1, SCOPE_2],
       });
 
-      expect(new Set(getIndexes(res))).toEqual(new Set([1n, 2n, 4n])); // note1, note2, and note4
+      expect(new Set(getNullifiers(res))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt(), note4Nullifier.toBigInt()]),
+      );
     });
 
     it('deduplicates notes that appear in multiple scopes', async () => {
@@ -200,13 +189,15 @@ describe('NoteStore', () => {
       await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
 
       const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(resActive))).toEqual(new Set([1n]));
+      expect(new Set(getNullifiers(resActive))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
 
       const resAll = await provider.getNotes({
         contractAddress: CONTRACT_A,
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(new Set(getIndexes(resAll))).toEqual(new Set([1n, 2n]));
+      expect(new Set(getNullifiers(resAll))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
     });
 
     it('returns only notes that match all provided filters', async () => {
@@ -216,7 +207,7 @@ describe('NoteStore', () => {
         scopes: [SCOPE_1],
       });
 
-      expect(new Set(getIndexes(res))).toEqual(new Set([1n]));
+      expect(new Set(getNullifiers(res))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
     });
 
     it('applies scope filtering to nullified notes', async () => {
@@ -239,7 +230,7 @@ describe('NoteStore', () => {
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
 
-      expect(new Set(getIndexes(res2))).toEqual(new Set([3n]));
+      expect(new Set(getNullifiers(res2))).toEqual(new Set([note3.siloedNullifier.toBigInt()]));
     });
 
     it('filters notes by siloedNullifier', async () => {
@@ -249,14 +240,14 @@ describe('NoteStore', () => {
       };
 
       const res = await provider.getNotes(filter);
-      expect(new Set(getIndexes(res))).toEqual(new Set([1n])); // note1 (index1n)
+      expect(new Set(getNullifiers(res))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
 
       // Test with a different note's siloedNullifier
       const res2 = await provider.getNotes({
         contractAddress: CONTRACT_A,
         siloedNullifier: note2.siloedNullifier,
       });
-      expect(new Set(getIndexes(res2))).toEqual(new Set([2n])); // note2 (index2n)
+      expect(new Set(getNullifiers(res2))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
     });
   });
 
@@ -275,7 +266,7 @@ describe('NoteStore', () => {
 
     it('returns no notes when filtering by non-existing contractAddress', async () => {
       const res = await provider.getNotes({ contractAddress: FAKE_ADDRESS });
-      expect(getIndexes(res)).toHaveLength(0);
+      expect(getNullifiers(res)).toHaveLength(0);
     });
 
     it('returns no notes when filtering by non-existing storageSlot', async () => {
@@ -351,8 +342,10 @@ describe('NoteStore', () => {
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
 
-      expect(new Set(getIndexes(active))).toEqual(new Set([2n]));
-      expect(new Set(getIndexes(all))).toEqual(new Set([1n, 2n]));
+      expect(new Set(getNullifiers(active))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
+      expect(new Set(getNullifiers(all))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
     });
 
     it('nullifies multiple notes and returns them', async () => {
@@ -363,8 +356,8 @@ describe('NoteStore', () => {
       const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
 
       expect(result).toEqual([note1, note3]); // returned nullified notes
-      expect(new Set(getIndexes(activeA))).toEqual(new Set([2n])); // note2 remains active
-      expect(getIndexes(activeB)).toHaveLength(0); // no active notes in contractB
+      expect(new Set(getNullifiers(activeA))).toEqual(new Set([note2.siloedNullifier.toBigInt()])); // note2 remains active
+      expect(getNullifiers(activeB)).toHaveLength(0); // no active notes in contractB
     });
 
     it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
@@ -377,7 +370,7 @@ describe('NoteStore', () => {
       };
 
       const res = await provider.getNotes(filter);
-      expect(new Set(getIndexes(res))).toEqual(new Set([2n]));
+      expect(new Set(getNullifiers(res))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
     });
   });
 
@@ -415,14 +408,14 @@ describe('NoteStore', () => {
         scopes: [SCOPE_2],
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(getIndexes(wrongScopeNotes)).not.toContain(1n);
+      expect(getNullifiers(wrongScopeNotes)).not.toContain(note1.siloedNullifier.toBigInt());
 
       const correctScopeNotes = await provider.getNotes({
         contractAddress: CONTRACT_A,
         scopes: [SCOPE_1],
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(getIndexes(correctScopeNotes)).toContain(1n);
+      expect(getNullifiers(correctScopeNotes)).toContain(note1.siloedNullifier.toBigInt());
     });
 
     it('is atomic - fails entirely if any nullifier is invalid', async () => {
@@ -440,7 +433,9 @@ describe('NoteStore', () => {
 
       // Verify note1 is still active (transaction rolled back)
       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([1n, 2n]));
+      expect(new Set(getNullifiers(activeNotes))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
     });
 
     it('updates all relevant indexes when nullifying notes', async () => {
@@ -452,27 +447,31 @@ describe('NoteStore', () => {
         contractAddress: CONTRACT_A,
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(new Set(getIndexes(byContract))).toEqual(new Set([1n, 2n]));
+      expect(new Set(getNullifiers(byContract))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
 
       const bySlot = await provider.getNotes({
         contractAddress: CONTRACT_A,
         storageSlot: note1.storageSlot,
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(new Set(getIndexes(bySlot))).toEqual(new Set([1n]));
+      expect(new Set(getNullifiers(bySlot))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
 
       const byScope = await provider.getNotes({
         contractAddress: CONTRACT_A,
         scopes: [SCOPE_1],
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       });
-      expect(new Set(getIndexes(byScope))).toEqual(new Set([1n, 2n]));
+      expect(new Set(getNullifiers(byScope))).toEqual(
+        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      );
     });
 
     it('attempts to nullify the same note twice in succession results in error', async () => {
       await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
       const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n]));
+      expect(new Set(getNullifiers(activeNotes))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
 
       // should throw on second attempt as note1 is already nullified
       await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
@@ -504,11 +503,17 @@ describe('NoteStore', () => {
     });
 
     describe('rewind nullifications happy path', () => {
+      let noteBlock1: NoteDao;
+      let noteBlock2: NoteDao;
+      let noteBlock3: NoteDao;
+      let noteBlock5: NoteDao;
+
       async function setupRollbackScenario() {
-        const noteBlock1 = await mkNote({ index: 1n, l2BlockNumber: BlockNumber(1) }); // Nullified at block 2
-        const noteBlock2 = await mkNote({ index: 2n, l2BlockNumber: BlockNumber(2) }); // Never nullified
-        const noteBlock3 = await mkNote({ index: 3n, l2BlockNumber: BlockNumber(3) }); // Nullified at block 4
-        const noteBlock5 = await mkNote({ index: 5n, l2BlockNumber: BlockNumber(5) }); // Created after rollback block 3
+        noteBlock1 = await mkNote({ siloedNullifier: SILOED_NULLIFIER_1, l2BlockNumber: BlockNumber(1) }); // Nullified at block 2
+        noteBlock2 = await mkNote({ siloedNullifier: SILOED_NULLIFIER_2, l2BlockNumber: BlockNumber(2) }); // Never nullified
+        noteBlock3 = await mkNote({ siloedNullifier: SILOED_NULLIFIER_3, l2BlockNumber: BlockNumber(3) }); // Nullified at block 4
+        const noteBlock5Nullifier = Fr.random();
+        noteBlock5 = await mkNote({ siloedNullifier: noteBlock5Nullifier, l2BlockNumber: BlockNumber(5) }); // Created after rollback block 3
 
         await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
 
@@ -531,7 +536,9 @@ describe('NoteStore', () => {
       it('restores notes that were nullified after the rollback block', async () => {
         // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
         const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+        expect(new Set(getNullifiers(activeNotes))).toEqual(
+          new Set([noteBlock2.siloedNullifier.toBigInt(), noteBlock3.siloedNullifier.toBigInt()]),
+        );
       });
 
       it('preserves nullification of notes nullified at or before the rollback block', async () => {
@@ -541,18 +548,26 @@ describe('NoteStore', () => {
         });
 
         // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([1n, 2n, 3n]));
+        expect(new Set(getNullifiers(allNotes))).toEqual(
+          new Set([
+            noteBlock1.siloedNullifier.toBigInt(),
+            noteBlock2.siloedNullifier.toBigInt(),
+            noteBlock3.siloedNullifier.toBigInt(),
+          ]),
+        );
 
         // Verify noteBlock1 is not in active notes
         const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        const activeIndexes = getIndexes(activeNotes);
-        expect(activeIndexes).not.toEqual(expect.arrayContaining([1n]));
+        const activeIndexes = getNullifiers(activeNotes);
+        expect(activeIndexes).not.toEqual(expect.arrayContaining([noteBlock1.siloedNullifier.toBigInt()]));
       });
 
       it('preserves active notes created before the rollback block that were never nullified', async () => {
         // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
         const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([2n, 3n]));
+        expect(new Set(getNullifiers(activeNotes))).toEqual(
+          new Set([noteBlock2.siloedNullifier.toBigInt(), noteBlock3.siloedNullifier.toBigInt()]),
+        );
       });
 
       it('deletes notes created after the rollback block', async () => {
@@ -562,15 +577,22 @@ describe('NoteStore', () => {
         });
 
         // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
-        const indexes = getIndexes(allNotes);
-        expect(new Set(indexes)).toEqual(new Set([1n, 2n, 3n]));
-        expect(indexes).not.toEqual(expect.arrayContaining([5n]));
+        const indexes = getNullifiers(allNotes);
+        expect(new Set(indexes)).toEqual(
+          new Set([
+            noteBlock1.siloedNullifier.toBigInt(),
+            noteBlock2.siloedNullifier.toBigInt(),
+            noteBlock3.siloedNullifier.toBigInt(),
+          ]),
+        );
+        expect(indexes).not.toEqual(expect.arrayContaining([noteBlock5.siloedNullifier.toBigInt()]));
       });
     });
 
     describe('rewind nullifications edge cases', () => {
       it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
-        const note = await mkNote({ index: 10n, l2BlockNumber: BlockNumber(5) });
+        const noteNullifier = Fr.random();
+        const note = await mkNote({ siloedNullifier: noteNullifier, l2BlockNumber: BlockNumber(5) });
         await provider.addNotes([note], SCOPE_1);
 
         const nullifiers = [
@@ -593,11 +615,12 @@ describe('NoteStore', () => {
           contractAddress: CONTRACT_A,
           status: NoteStatus.ACTIVE_OR_NULLIFIED,
         });
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([10n]));
+        expect(new Set(getNullifiers(allNotes))).toEqual(new Set([noteNullifier.toBigInt()]));
       });
 
       it('handles rollback when synchedBlockNumber < blockNumber', async () => {
-        const note = await mkNote({ index: 20n, l2BlockNumber: BlockNumber(3) });
+        const noteNullifier = Fr.random();
+        const note = await mkNote({ siloedNullifier: noteNullifier, l2BlockNumber: BlockNumber(3) });
         await provider.addNotes([note], SCOPE_1);
 
         const nullifiers = [
@@ -619,12 +642,14 @@ describe('NoteStore', () => {
           contractAddress: CONTRACT_A,
           status: NoteStatus.ACTIVE_OR_NULLIFIED,
         });
-        expect(new Set(getIndexes(allNotes))).toEqual(new Set([20n]));
+        expect(new Set(getNullifiers(allNotes))).toEqual(new Set([noteNullifier.toBigInt()]));
       });
 
       it('handles rollback with a large block gap', async () => {
-        const note1 = await mkNote({ index: 30n, l2BlockNumber: BlockNumber(5) });
-        const note2 = await mkNote({ index: 31n, l2BlockNumber: BlockNumber(10) });
+        const note1Nullifier = Fr.random();
+        const note2Nullifier = Fr.random();
+        const note1 = await mkNote({ siloedNullifier: note1Nullifier, l2BlockNumber: BlockNumber(5) });
+        const note2 = await mkNote({ siloedNullifier: note2Nullifier, l2BlockNumber: BlockNumber(10) });
         await provider.addNotes([note1, note2], SCOPE_1);
 
         const nullifiers = [
@@ -640,7 +665,7 @@ describe('NoteStore', () => {
         // note1 should be restored (nullified at block 7 > rollback block 5)
         // note2 should be deleted (created at block 10 > rollback block 5)
         const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getIndexes(activeNotes))).toEqual(new Set([30n]));
+        expect(new Set(getNullifiers(activeNotes))).toEqual(new Set([note1Nullifier.toBigInt()]));
       });
 
       it('handles rollback on empty PXE database gracefully', async () => {

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,4 +1,3 @@
-import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
@@ -15,32 +14,41 @@ import { NoteDao } from '@aztec/stdlib/note';
  **/
 export class NoteStore {
   #store: AztecAsyncKVStore;
+
+  // Note that we use the siloedNullifier as the note id in the store as it's guaranteed to be unique.
+
+  /** noteId (siloedNullifier) -> NoteDao (serialized) */
   #notes: AztecAsyncMap<string, Buffer>;
+  /** noteId (siloedNullifier) -> NoteDao (serialized) */
   #nullifiedNotes: AztecAsyncMap<string, Buffer>;
-  #nullifierToNoteId: AztecAsyncMap<string, string>;
+  /** blockNumber -> siloedNullifier */
   #nullifiersByBlockNumber: AztecAsyncMultiMap<number, string>;
 
+  /** noteId (siloedNullifier) -> scope */
   #nullifiedNotesToScope: AztecAsyncMultiMap<string, string>;
+  /** contractAddress -> noteId (siloedNullifier) */
   #nullifiedNotesByContract: AztecAsyncMultiMap<string, string>;
+  /** storageSlot -> noteId (siloedNullifier) */
   #nullifiedNotesByStorageSlot: AztecAsyncMultiMap<string, string>;
-  #nullifiedNotesByNullifier: AztecAsyncMap<string, string>;
 
+  /** scope (AztecAddress) -> true */
   #scopes: AztecAsyncMap<string, true>;
+  /** noteId (siloedNullifier) -> scope */
   #notesToScope: AztecAsyncMultiMap<string, string>;
+  /** scope -> MultiMap(contractAddress -> noteId) */
   #notesByContractAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
+  /** scope -> MultiMap(storageSlot -> noteId) */
   #notesByStorageSlotAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
 
   private constructor(store: AztecAsyncKVStore) {
     this.#store = store;
     this.#notes = store.openMap('notes');
     this.#nullifiedNotes = store.openMap('nullified_notes');
-    this.#nullifierToNoteId = store.openMap('nullifier_to_note');
     this.#nullifiersByBlockNumber = store.openMultiMap('nullifier_to_block_number');
 
     this.#nullifiedNotesToScope = store.openMultiMap('nullified_notes_to_scope');
     this.#nullifiedNotesByContract = store.openMultiMap('nullified_notes_by_contract');
     this.#nullifiedNotesByStorageSlot = store.openMultiMap('nullified_notes_by_storage_slot');
-    this.#nullifiedNotesByNullifier = store.openMap('nullified_notes_by_nullifier');
 
     this.#scopes = store.openMap('scopes');
     this.#notesToScope = store.openMultiMap('notes_to_scope');
@@ -92,9 +100,8 @@ export class NoteStore {
   /**
    * Adds multiple notes to the data provider under the specified scope.
    *
-   * Notes are stored using their index from the notes hash tree as the key, which provides
-   * uniqueness and maintains creation order. Each note is indexed by multiple criteria
-   * for efficient retrieval.
+   * Notes are stored using their siloedNullifier as the key, which provides uniqueness. Each note is indexed
+   * by multiple criteria for efficient retrieval.
    *
    * @param notes - Notes to store
    * @param scope - The scope (user/account) under which to store the notes
@@ -106,13 +113,12 @@ export class NoteStore {
       }
 
       for (const dao of notes) {
-        const noteIndex = toBufferBE(dao.index, 32).toString('hex');
-        await this.#notes.set(noteIndex, dao.toBuffer());
-        await this.#notesToScope.set(noteIndex, scope.toString());
-        await this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex);
+        const noteId = dao.siloedNullifier.toString();
+        await this.#notes.set(noteId, dao.toBuffer());
+        await this.#notesToScope.set(noteId, scope.toString());
 
-        await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteIndex);
-        await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteIndex);
+        await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteId);
+        await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteId);
       }
     });
   }
@@ -147,14 +153,13 @@ export class NoteStore {
     for (const note of notes) {
       const noteDao = NoteDao.fromBuffer(note);
       if (noteDao.l2BlockNumber > blockNumber) {
-        const noteIndex = toBufferBE(noteDao.index, 32).toString('hex');
-        await this.#notes.delete(noteIndex);
-        await this.#notesToScope.delete(noteIndex);
-        await this.#nullifierToNoteId.delete(noteDao.siloedNullifier.toString());
+        const noteId = noteDao.siloedNullifier.toString();
+        await this.#notes.delete(noteId);
+        await this.#notesToScope.delete(noteId);
         const scopes = await toArray(this.#scopes.keysAsync());
         for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope)!.deleteValue(noteDao.contractAddress.toString(), noteIndex);
-          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(noteDao.storageSlot.toString(), noteIndex);
+          await this.#notesByContractAndScope.get(scope)!.deleteValue(noteDao.contractAddress.toString(), noteId);
+          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(noteDao.storageSlot.toString(), noteId);
         }
       }
     }
@@ -171,50 +176,45 @@ export class NoteStore {
    * @param synchedBlockNumber - Upper bound for the block range to process
    */
   async #rewindNullifiersAfterBlock(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    const nullifiersToUndo: string[] = [];
+    const noteIdsToReinsert: string[] = [];
     const currentBlockNumber = blockNumber + 1;
     for (let i = currentBlockNumber; i <= synchedBlockNumber; i++) {
-      nullifiersToUndo.push(...(await toArray(this.#nullifiersByBlockNumber.getValuesAsync(i))));
+      // noteId === siloedNullifier.toString(), so we can use nullifiers directly as noteIds
+      noteIdsToReinsert.push(...(await toArray(this.#nullifiersByBlockNumber.getValuesAsync(i))));
     }
-    const notesIndexesToReinsert = await Promise.all(
-      nullifiersToUndo.map(nullifier => this.#nullifiedNotesByNullifier.getAsync(nullifier)),
-    );
-    const notNullNoteIndexes = notesIndexesToReinsert.filter(noteIndex => noteIndex != undefined);
     const nullifiedNoteBuffers = await Promise.all(
-      notNullNoteIndexes.map(noteIndex => this.#nullifiedNotes.getAsync(noteIndex!)),
+      noteIdsToReinsert.map(noteId => this.#nullifiedNotes.getAsync(noteId)),
     );
     const noteDaos = nullifiedNoteBuffers
       .filter(buffer => buffer != undefined)
       .map(buffer => NoteDao.fromBuffer(buffer!));
 
     for (const dao of noteDaos) {
-      const noteIndex = toBufferBE(dao.index, 32).toString('hex');
+      const noteId = dao.siloedNullifier.toString();
 
-      const scopes = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteIndex));
+      const scopes = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteId));
 
       if (scopes.length === 0) {
         // We should never run into this error because notes always have a scope assigned to them - either on initial
         // insertion via `addNotes` or when removing their nullifiers.
-        throw new Error(`No scopes found for nullified note with index ${noteIndex}`);
+        throw new Error(`No scopes found for nullified note with nullifier ${noteId}`);
       }
 
       for (const scope of scopes) {
         await Promise.all([
-          this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteIndex),
-          this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteIndex),
-          this.#notesToScope.set(noteIndex, scope),
+          this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteId),
+          this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteId),
+          this.#notesToScope.set(noteId, scope),
         ]);
       }
 
       await Promise.all([
-        this.#notes.set(noteIndex, dao.toBuffer()),
-        this.#nullifierToNoteId.set(dao.siloedNullifier.toString(), noteIndex),
-        this.#nullifiedNotes.delete(noteIndex),
-        this.#nullifiedNotesToScope.delete(noteIndex),
+        this.#notes.set(noteId, dao.toBuffer()),
+        this.#nullifiedNotes.delete(noteId),
+        this.#nullifiedNotesToScope.delete(noteId),
         this.#nullifiersByBlockNumber.deleteValue(dao.l2BlockNumber, dao.siloedNullifier.toString()),
-        this.#nullifiedNotesByContract.deleteValue(dao.contractAddress.toString(), noteIndex),
-        this.#nullifiedNotesByStorageSlot.deleteValue(dao.storageSlot.toString(), noteIndex),
-        this.#nullifiedNotesByNullifier.delete(dao.siloedNullifier.toString()),
+        this.#nullifiedNotesByContract.deleteValue(dao.contractAddress.toString(), noteId),
+        this.#nullifiedNotesByStorageSlot.deleteValue(dao.storageSlot.toString(), noteId),
       ]);
     }
   }
@@ -334,6 +334,17 @@ export class NoteStore {
       }
     }
 
+    // Sort by block number, then by tx index within block, then by note index within tx
+    deduplicated.sort((a, b) => {
+      if (a.l2BlockNumber !== b.l2BlockNumber) {
+        return a.l2BlockNumber - b.l2BlockNumber;
+      }
+      if (a.txIndexInBlock !== b.txIndexInBlock) {
+        return a.txIndexInBlock - b.txIndexInBlock;
+      }
+      return a.noteIndexInTx - b.noteIndexInTx;
+    });
+
     return deduplicated;
   }
 
@@ -358,25 +369,18 @@ export class NoteStore {
 
       for (const blockScopedNullifier of nullifiers) {
         const { data: nullifier, l2BlockNumber: blockNumber } = blockScopedNullifier;
-        const nullifierKey = nullifier.toString();
+        const noteId = nullifier.toString();
 
-        const noteIndex = await this.#nullifierToNoteId.getAsync(nullifierKey);
-        if (!noteIndex) {
-          // Check if already nullified?
-          const alreadyNullified = await this.#nullifiedNotesByNullifier.getAsync(nullifierKey);
-          if (alreadyNullified) {
+        const noteBuffer = await this.#notes.getAsync(noteId);
+        if (!noteBuffer) {
+          // Check if already nullified (noteId === siloedNullifier, so we can check #nullifiedNotes directly)
+          if (await this.#nullifiedNotes.hasAsync(noteId)) {
             throw new Error(`Nullifier already applied in applyNullifiers`);
           }
           throw new Error('Nullifier not found in applyNullifiers');
         }
 
-        const noteBuffer = noteIndex ? await this.#notes.getAsync(noteIndex) : undefined;
-
-        if (!noteBuffer) {
-          throw new Error('Note not found in applyNullifiers');
-        }
-
-        const noteScopes = await toArray(this.#notesToScope.getValuesAsync(noteIndex));
+        const noteScopes = await toArray(this.#notesToScope.getValuesAsync(noteId));
         if (noteScopes.length === 0) {
           // We should never run into this error because notes always have a scope assigned to them - either on initial
           // insertion via `addNotes` or when removing their nullifiers.
@@ -387,26 +391,23 @@ export class NoteStore {
 
         nullifiedNotes.push(note);
 
-        await this.#notes.delete(noteIndex);
-        await this.#notesToScope.delete(noteIndex);
+        await this.#notes.delete(noteId);
+        await this.#notesToScope.delete(noteId);
 
         const scopes = await toArray(this.#scopes.keysAsync());
 
         for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope)!.deleteValue(note.contractAddress.toString(), noteIndex);
-          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(note.storageSlot.toString(), noteIndex);
+          await this.#notesByContractAndScope.get(scope)!.deleteValue(note.contractAddress.toString(), noteId);
+          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(note.storageSlot.toString(), noteId);
         }
 
         for (const scope of noteScopes) {
-          await this.#nullifiedNotesToScope.set(noteIndex, scope);
+          await this.#nullifiedNotesToScope.set(noteId, scope);
         }
-        await this.#nullifiedNotes.set(noteIndex, note.toBuffer());
-        await this.#nullifiersByBlockNumber.set(blockNumber, nullifier.toString());
-        await this.#nullifiedNotesByContract.set(note.contractAddress.toString(), noteIndex);
-        await this.#nullifiedNotesByStorageSlot.set(note.storageSlot.toString(), noteIndex);
-        await this.#nullifiedNotesByNullifier.set(nullifier.toString(), noteIndex);
-
-        await this.#nullifierToNoteId.delete(nullifier.toString());
+        await this.#nullifiedNotes.set(noteId, note.toBuffer());
+        await this.#nullifiersByBlockNumber.set(blockNumber, noteId);
+        await this.#nullifiedNotesByContract.set(note.contractAddress.toString(), noteId);
+        await this.#nullifiedNotesByStorageSlot.set(note.storageSlot.toString(), noteId);
       }
       return nullifiedNotes;
     });

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -1,5 +1,4 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
@@ -24,7 +23,7 @@ describe('PrivateEventStore', () => {
   let eventSelector: EventSelector;
   let randomness: Fr;
   let txHash: TxHash;
-  let eventCommitmentIndex: number;
+  let siloedEventCommitment: Fr;
   let expectedEvent: PackedPrivateEvent;
 
   beforeEach(async () => {
@@ -38,7 +37,7 @@ describe('PrivateEventStore', () => {
     eventSelector = EventSelector.random();
     randomness = Fr.random();
     txHash = TxHash.random();
-    eventCommitmentIndex = randomInt(10);
+    siloedEventCommitment = Fr.random();
 
     expectedEvent = {
       packedEvent: msgContent,
@@ -50,12 +49,14 @@ describe('PrivateEventStore', () => {
   });
 
   it('stores and retrieves private events', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -66,13 +67,15 @@ describe('PrivateEventStore', () => {
     expect(events).toEqual([expectedEvent]);
   });
 
-  it('ignores duplicate events with same eventCommitmentIndex', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
+  it('ignores duplicate events with same siloedEventCommitment', async () => {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -85,22 +88,26 @@ describe('PrivateEventStore', () => {
     expect(events).toEqual([expectedEvent]);
   });
 
-  it('allows multiple events with same content but different eventCommitmentIndex', async () => {
-    const otherEventCommitmentIndex = eventCommitmentIndex + 1;
+  it('allows multiple events with same content but different siloedEventCommitment', async () => {
+    const otherSiloedEventCommitment = Fr.random();
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, otherEventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, otherSiloedEventCommitment, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 1,
     });
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -120,26 +127,32 @@ describe('PrivateEventStore', () => {
       l2BlockNumber: BlockNumber(200),
     };
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), 0, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), Fr.random(), {
       contractAddress,
       scope,
       txHash: TxHash.random(),
       l2BlockNumber: BlockNumber(100),
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, 1, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, Fr.random(), {
       contractAddress,
       scope,
       txHash: expectedEvent.txHash,
       l2BlockNumber: expectedEvent.l2BlockNumber,
       l2BlockHash: expectedEvent.l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), 2, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), Fr.random(), {
       contractAddress,
       scope,
       txHash: TxHash.random(),
       l2BlockNumber: BlockNumber(300),
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -155,19 +168,23 @@ describe('PrivateEventStore', () => {
   it('filters events by recipient', async () => {
     const otherScope = await AztecAddress.random();
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
       contractAddress,
       scope,
       txHash,
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitmentIndex + 1, {
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, Fr.random(), {
       contractAddress,
       scope: otherScope,
       txHash: TxHash.random(),
       l2BlockNumber,
       l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
     });
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -202,35 +219,130 @@ describe('PrivateEventStore', () => {
       msgContent3 = getRandomMsgContent();
     });
 
-    it('returns events in order by eventCommitmentIndex', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, 1, {
+    it('returns events in order by block number', async () => {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(200),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(100),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, 2, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(300),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
         contractAddress,
         fromBlock: 0,
         toBlock: 0 + 1000,
+        scopes: [scope],
+      });
+
+      expect(events.map(e => e.packedEvent)).toEqual([msgContent1, msgContent2, msgContent3]);
+    });
+
+    it('returns events in order by tx index within the same block', async () => {
+      const l2BlockNumber = BlockNumber(100);
+
+      // Store events in the same block but different tx indexes (store them out of order)
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 1,
+        eventIndexInTx: 0,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash: TxHash.random(),
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 2,
+        eventIndexInTx: 0,
+      });
+
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
+        scopes: [scope],
+      });
+
+      expect(events.map(e => e.packedEvent)).toEqual([msgContent1, msgContent2, msgContent3]);
+    });
+
+    it('returns events in order by event index within the same tx', async () => {
+      const txHash = TxHash.random();
+      const l2BlockNumber = BlockNumber(100);
+
+      // Store events in the same block and tx but different event indexes (store them out of order)
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 1,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
+      });
+
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber,
+        l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 2,
+      });
+
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: 0,
+        toBlock: 1000,
         scopes: [scope],
       });
 
@@ -253,36 +365,44 @@ describe('PrivateEventStore', () => {
 
     it('removes events after rollback block', async () => {
       // Store events in blocks 100, 200, 300
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(100),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
       // We add another event in the same block to verify that more events per block work.
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, 1, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(100),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 1,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, 2, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(200),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent4, 3, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent4, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(300),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
       // Rollback to block 150 (should remove events from blocks 200 and 300)
@@ -304,14 +424,17 @@ describe('PrivateEventStore', () => {
       // After a reorg, the same transaction might be re-included in the chain in the same block and at the same
       // position in the block. This test verifies that this scenario works - i.e. that there is no collision in keys.
       const reorgTxHash = TxHash.random();
+      const reorgEventCommitment = Fr.random();
 
       // Store event at block 200
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, reorgEventCommitment, {
         contractAddress,
         scope,
         txHash: reorgTxHash,
         l2BlockNumber: BlockNumber(200),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
       // Rollback to block 100
@@ -326,13 +449,15 @@ describe('PrivateEventStore', () => {
       });
       expect(events.length).toBe(0);
 
-      // Re-add the same event (same eventCommitmentIndex and txHash, as happens after a reorg)
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
+      // Re-add the same event (same siloedEventCommitment and txHash, as happens after a reorg)
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, reorgEventCommitment, {
         contractAddress,
         scope,
         txHash: reorgTxHash,
         l2BlockNumber: BlockNumber(200),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
       // Verify event can be retrieved again
@@ -346,12 +471,14 @@ describe('PrivateEventStore', () => {
     });
 
     it('handles rollback with no events to remove', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, 0, {
+      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
         contractAddress,
         scope,
         txHash: TxHash.random(),
         l2BlockNumber: BlockNumber(100),
         l2BlockHash,
+        txIndexInBlock: 0,
+        eventIndexInTx: 0,
       });
 
       // Rollback after all existing events

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -21,10 +21,13 @@ export type PrivateEventStoreFilter = {
 type PrivateEventEntry = {
   randomness: Fr; // Note that this value is currently not being returned on queries and is therefore temporarily unused
   msgContent: Buffer;
-  eventCommitmentIndex: number;
   l2BlockNumber: number;
   l2BlockHash: Buffer;
   txHash: Buffer;
+  /** The index of the tx within the block, used for ordering events */
+  txIndexInBlock: number;
+  /** The index of the event within the tx (based on nullifier position), used for ordering events */
+  eventIndexInTx: number;
   /** The lookup key for #eventsByContractScopeSelector, used for cleanup during rollback */
   lookupKey: string;
 };
@@ -32,6 +35,10 @@ type PrivateEventEntry = {
 type PrivateEventMetadata = InTx & {
   contractAddress: AztecAddress;
   scope: AztecAddress;
+  /** The index of the tx within the block */
+  txIndexInBlock: number;
+  /** The index of the event within the tx (based on nullifier position) */
+  eventIndexInTx: number;
 };
 
 /**
@@ -39,14 +46,14 @@ type PrivateEventMetadata = InTx & {
  */
 export class PrivateEventStore {
   #store: AztecAsyncKVStore;
-  /** Map storing the actual private event log entries, keyed by eventCommitmentIndex */
-  #eventLogs: AztecAsyncMap<number, PrivateEventEntry>;
-  /** Map from contractAddress_scope_eventSelector to eventCommitmentIndex[] for efficient lookup */
-  #eventsByContractScopeSelector: AztecAsyncMap<string, number[]>;
-  /** Map from block number to eventCommitmentIndex[] for rollback support */
-  #eventsByBlockNumber: AztecAsyncMap<number, number[]>;
-  /** Map from eventCommitmentIndex to boolean indicating if log has been seen. */
-  #seenLogs: AztecAsyncMap<number, boolean>;
+  /** Map storing the actual private event log entries, keyed by siloedEventCommitment */
+  #eventLogs: AztecAsyncMap<string, PrivateEventEntry>;
+  /** Map from contractAddress_scope_eventSelector to siloedEventCommitment[] for efficient lookup */
+  #eventsByContractScopeSelector: AztecAsyncMap<string, string[]>;
+  /** Map from block number to siloedEventCommitment[] for rollback support */
+  #eventsByBlockNumber: AztecAsyncMap<number, string[]>;
+  /** Map from siloedEventCommitment to boolean indicating if log has been seen. */
+  #seenLogs: AztecAsyncMap<string, boolean>;
 
   logger = createLogger('private_event_store');
 
@@ -65,8 +72,9 @@ export class PrivateEventStore {
   /**
    * Store a private event log.
    * @param eventSelector - The event selector of the event.
+   * @param randomness - The randomness used for the event commitment.
    * @param msgContent - The content of the event.
-   * @param eventCommitmentIndex - The index of the event commitment in the nullifier tree.
+   * @param siloedEventCommitment - The siloed event commitment (used as unique identifier).
    * @param metadata
    *  contractAddress - The address of the contract that emitted the event.
    *  scope - The address to which the event is scoped.
@@ -77,41 +85,45 @@ export class PrivateEventStore {
     eventSelector: EventSelector,
     randomness: Fr,
     msgContent: Fr[],
-    eventCommitmentIndex: number,
+    siloedEventCommitment: Fr,
     metadata: PrivateEventMetadata,
   ): Promise<void> {
-    const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash } = metadata;
+    const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
 
     return this.#store.transactionAsync(async () => {
       const key = this.#keyFor(contractAddress, scope, eventSelector);
 
-      // Check if this exact log has already been stored using eventCommitmentIndex as unique identifier
-      const hasBeenSeen = await this.#seenLogs.getAsync(eventCommitmentIndex);
+      // The siloed event commitment is guaranteed to be unique as it's inserted into the nullifier tree. For this
+      // reason we use it as id.
+      const eventId = siloedEventCommitment.toString();
+
+      const hasBeenSeen = await this.#seenLogs.getAsync(eventId);
       if (hasBeenSeen) {
-        this.logger.verbose('Ignoring duplicate event log', { txHash: txHash.toString(), eventCommitmentIndex });
+        this.logger.verbose('Ignoring duplicate event log', { txHash: txHash.toString(), siloedEventCommitment });
         return;
       }
 
       this.logger.verbose('storing private event log', { contractAddress, scope, msgContent, l2BlockNumber });
 
-      await this.#eventLogs.set(eventCommitmentIndex, {
+      await this.#eventLogs.set(eventId, {
         randomness,
         msgContent: serializeToBuffer(msgContent),
         l2BlockNumber,
         l2BlockHash: l2BlockHash.toBuffer(),
-        eventCommitmentIndex,
         txHash: txHash.toBuffer(),
+        txIndexInBlock,
+        eventIndexInTx,
         lookupKey: key,
       });
 
-      const existingIndices = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
-      await this.#eventsByContractScopeSelector.set(key, [...existingIndices, eventCommitmentIndex]);
+      const existingIds = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
+      await this.#eventsByContractScopeSelector.set(key, [...existingIds, eventId]);
 
-      const existingBlockIndices = (await this.#eventsByBlockNumber.getAsync(l2BlockNumber)) || [];
-      await this.#eventsByBlockNumber.set(l2BlockNumber, [...existingBlockIndices, eventCommitmentIndex]);
+      const existingBlockIds = (await this.#eventsByBlockNumber.getAsync(l2BlockNumber)) || [];
+      await this.#eventsByBlockNumber.set(l2BlockNumber, [...existingBlockIds, eventId]);
 
-      // Mark this log as seen using eventCommitmentIndex
-      await this.#seenLogs.set(eventCommitmentIndex, true);
+      // Mark this log as seen
+      await this.#seenLogs.set(eventId, true);
     });
   }
 
@@ -123,21 +135,26 @@ export class PrivateEventStore {
    *  fromBlock: The block number to search from (inclusive).
    *  toBlock: The block number to search upto (exclusive).
    *  scope: - The addresses that decrypted the logs.
-   * @returns - The event log contents, augmented with metadata about
-   *  the transaction and block it the event was included in .
+   * @returns - The event log contents, augmented with metadata about the transaction and block in which the event was
+   * included.
    */
   public async getPrivateEvents(
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
   ): Promise<PackedPrivateEvent[]> {
-    const events: Array<{ eventCommitmentIndex: number; event: PackedPrivateEvent }> = [];
+    const events: Array<{
+      l2BlockNumber: number;
+      txIndexInBlock: number;
+      eventIndexInTx: number;
+      event: PackedPrivateEvent;
+    }> = [];
 
     for (const scope of filter.scopes) {
       const key = this.#keyFor(filter.contractAddress, scope, eventSelector);
-      const eventCommitmentIndices = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
+      const eventIds = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
 
-      for (const eventCommitmentIndex of eventCommitmentIndices) {
-        const entry = await this.#eventLogs.getAsync(eventCommitmentIndex);
+      for (const eventId of eventIds) {
+        const entry = await this.#eventLogs.getAsync(eventId);
         if (!entry || entry.l2BlockNumber < filter.fromBlock || entry.l2BlockNumber >= filter.toBlock) {
           continue;
         }
@@ -154,7 +171,9 @@ export class PrivateEventStore {
         }
 
         events.push({
-          eventCommitmentIndex: entry.eventCommitmentIndex,
+          l2BlockNumber: entry.l2BlockNumber,
+          txIndexInBlock: entry.txIndexInBlock,
+          eventIndexInTx: entry.eventIndexInTx,
           event: {
             packedEvent: msgContent,
             l2BlockNumber: BlockNumber(entry.l2BlockNumber),
@@ -166,8 +185,16 @@ export class PrivateEventStore {
       }
     }
 
-    // Sort by eventCommitmentIndex only
-    events.sort((a, b) => a.eventCommitmentIndex - b.eventCommitmentIndex);
+    // Sort by block number, then by tx index within block, then by event index within tx
+    events.sort((a, b) => {
+      if (a.l2BlockNumber !== b.l2BlockNumber) {
+        return a.l2BlockNumber - b.l2BlockNumber;
+      }
+      if (a.txIndexInBlock !== b.txIndexInBlock) {
+        return a.txIndexInBlock - b.txIndexInBlock;
+      }
+      return a.eventIndexInTx - b.eventIndexInTx;
+    });
     return events.map(ev => ev.event);
   }
 
@@ -181,29 +208,29 @@ export class PrivateEventStore {
     let removedCount = 0;
 
     for (let block = blockNumber + 1; block <= synchedBlockNumber; block++) {
-      const indices = await this.#eventsByBlockNumber.getAsync(block);
-      if (indices) {
+      const eventIds = await this.#eventsByBlockNumber.getAsync(block);
+      if (eventIds) {
         await this.#eventsByBlockNumber.delete(block);
 
-        for (const eventCommitmentIndex of indices) {
-          const entry = await this.#eventLogs.getAsync(eventCommitmentIndex);
+        for (const eventId of eventIds) {
+          const entry = await this.#eventLogs.getAsync(eventId);
           if (!entry) {
-            throw new Error(`Event log not found for eventCommitmentIndex ${eventCommitmentIndex}`);
+            throw new Error(`Event log not found for eventId ${eventId}`);
           }
 
-          await this.#eventLogs.delete(eventCommitmentIndex);
-          await this.#seenLogs.delete(eventCommitmentIndex);
+          await this.#eventLogs.delete(eventId);
+          await this.#seenLogs.delete(eventId);
 
           // Update #eventsByContractScopeSelector using the stored lookupKey
-          const existingIndices = await this.#eventsByContractScopeSelector.getAsync(entry.lookupKey);
-          if (!existingIndices || existingIndices.length === 0) {
-            throw new Error(`No indices found in #eventsByContractScopeSelector for key ${entry.lookupKey}`);
+          const existingIds = await this.#eventsByContractScopeSelector.getAsync(entry.lookupKey);
+          if (!existingIds || existingIds.length === 0) {
+            throw new Error(`No ids found in #eventsByContractScopeSelector for key ${entry.lookupKey}`);
           }
-          const filteredIndices = existingIndices.filter(idx => idx !== eventCommitmentIndex);
-          if (filteredIndices.length === 0) {
+          const filteredIds = existingIds.filter(id => id !== eventId);
+          if (filteredIds.length === 0) {
             await this.#eventsByContractScopeSelector.delete(entry.lookupKey);
           } else {
-            await this.#eventsByContractScopeSelector.set(entry.lookupKey, filteredIndices);
+            await this.#eventsByContractScopeSelector.set(entry.lookupKey, filteredIds);
           }
 
           removedCount++;

--- a/yarn-project/stdlib/src/note/note_dao.ts
+++ b/yarn-project/stdlib/src/note/note_dao.ts
@@ -1,4 +1,3 @@
-import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
@@ -56,8 +55,10 @@ export class NoteDao {
     /** The L2 block hash in which the tx with this note was included. Used for note management while processing
      * reorgs.*/
     public l2BlockHash: string,
-    /** The index of the leaf in the global note hash tree the note is stored at */
-    public index: bigint,
+    /** The index of the tx within the block, used for ordering notes. */
+    public txIndexInBlock: number,
+    /** The index of the note within the tx (based on note hash position), used for ordering notes. */
+    public noteIndexInTx: number,
   ) {}
 
   toBuffer(): Buffer {
@@ -73,7 +74,8 @@ export class NoteDao {
       this.txHash,
       this.l2BlockNumber,
       Fr.fromHexString(this.l2BlockHash),
-      this.index,
+      this.txIndexInBlock,
+      this.noteIndexInTx,
     ]);
   }
 
@@ -91,7 +93,8 @@ export class NoteDao {
     const txHash = reader.readObject(TxHash);
     const l2BlockNumber = BlockNumber(reader.readNumber());
     const l2BlockHash = Fr.fromBuffer(reader).toString();
-    const index = toBigIntBE(reader.readBytes(32));
+    const txIndexInBlock = reader.readNumber();
+    const noteIndexInTx = reader.readNumber();
 
     return new NoteDao(
       note,
@@ -105,7 +108,8 @@ export class NoteDao {
       txHash,
       l2BlockNumber,
       l2BlockHash,
-      index,
+      txIndexInBlock,
+      noteIndexInTx,
     );
   }
 
@@ -134,7 +138,8 @@ export class NoteDao {
       this.txHash.equals(other.txHash) &&
       this.l2BlockNumber === other.l2BlockNumber &&
       this.l2BlockHash === other.l2BlockHash &&
-      this.index === other.index
+      this.txIndexInBlock === other.txIndexInBlock &&
+      this.noteIndexInTx === other.noteIndexInTx
     );
   }
 
@@ -143,11 +148,9 @@ export class NoteDao {
    * @returns - Its size in bytes.
    */
   public getSize() {
-    const indexSize = Math.ceil(Math.log2(Number(this.index)));
     const noteSize = 4 + this.note.items.length * Fr.SIZE_IN_BYTES;
-    return (
-      noteSize + AztecAddress.SIZE_IN_BYTES * 2 + Fr.SIZE_IN_BYTES * 4 + TxHash.SIZE + Point.SIZE_IN_BYTES + indexSize
-    );
+    // 2 numbers for txIndexInBlock and noteIndexInTx (4 bytes each)
+    return noteSize + AztecAddress.SIZE_IN_BYTES * 2 + Fr.SIZE_IN_BYTES * 4 + TxHash.SIZE + Point.SIZE_IN_BYTES + 8;
   }
 
   static async random({
@@ -162,7 +165,8 @@ export class NoteDao {
     txHash = TxHash.random(),
     l2BlockNumber = BlockNumber(Math.floor(Math.random() * 1000)),
     l2BlockHash = Fr.random().toString(),
-    index = Fr.random().toBigInt(),
+    txIndexInBlock = Math.floor(Math.random() * 100),
+    noteIndexInTx = Math.floor(Math.random() * 100),
   }: Partial<NoteDao> = {}) {
     return new NoteDao(
       note,
@@ -176,7 +180,8 @@ export class NoteDao {
       txHash,
       l2BlockNumber,
       l2BlockHash,
-      index,
+      txIndexInBlock,
+      noteIndexInTx,
     );
   }
 }

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -444,7 +444,7 @@ export class RPCTranslator {
         randomness: noteData.randomness,
         storageSlot: noteData.storageSlot,
         noteNonce: noteData.noteNonce,
-        index: noteData.index,
+        isPending: noteData.isPending,
         note: noteData.note,
       }),
     );


### PR DESCRIPTION
We were fetching note hash index and event commitment index to verify that a given note or event exists. This was redundant because we were already fetching tx effect and verifying the corresponding commitment is present in the effect.

For this reason in this PR I drop the indexes. (Note that for notes we still need to fetch nullifier index to verify whether the note has already been nullified or not)

This change forces me to rework how events get ordered (we want them to be returned in the order in which they were emitted). Before the events were ordered by this global event commitment index. With this PR they get ordered by `block_number-tx_index_in_block-commitment_index_in_tx`. We can do this cheaply because we already had all this info returned from node from the `getTxEffect` endpoint.

Fixes https://linear.app/aztec-labs/issue/F-218/remove-note-and-nullif-indexes-from-note-and-event-storage