### PR TITLE
fix: remove unused workflow input

### DIFF
--- a/.github/workflows/deploy-fisherman-network.yaml
+++ b/.github/workflows/deploy-fisherman-network.yaml
@@ -183,7 +183,6 @@ jobs:
       namespace: ignition-fisherman-sepolia
       l1_network: sepolia
       cluster: aztec-gke-private
-      semver: ${{ inputs.semver }}
 
   setup-irm-mainnet:
     needs: deploy-fisherman
@@ -196,4 +195,3 @@ jobs:
       monitoring_namespace: mainnet-irm
       l1_network: mainnet
       cluster: aztec-gke-private
-      semver: ${{ inputs.semver }}


### PR DESCRIPTION
removing unused input variables for `deploy-irm` job