### PR TITLE
fix: fixing getBlockByHash for not published blocks

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1866,6 +1866,72 @@ describe('Archiver', () => {
       expect(checkpointedBlock).toBeDefined();
       expect(checkpointedBlock!.checkpointNumber).toEqual(2);
     }, 10_000);
+
+    describe('getBlockByHash for synced blocks', () => {
+      it('retrieves synced block by hash before checkpoint', async () => {
+        setupMinimalL1Mocks();
+
+        // Create and add synced blocks (not checkpointed)
+        const block1 = await makeBlock(BlockNumber(1), 0, genesisArchive);
+        const block2 = await makeBlock(BlockNumber(2), 1, block1.archive);
+
+        await archiver.addBlock(block1);
+        await archiver.addBlock(block2);
+
+        // Get block header and compute hash
+        const header = await archiver.getBlockHeader(BlockNumber(1));
+        expect(header).toBeDefined();
+        const blockHash = await header!.hash();
+
+        // getPublishedBlockByHash should return undefined before block is checkpointed
+        const publishedBlock = await archiver.getPublishedBlockByHash(blockHash);
+        expect(publishedBlock).toBeUndefined();
+
+        // Store level: getBlockByHash works for synced blocks
+        const storeBlock = await archiverStore.getBlockByHash(blockHash);
+        expect(storeBlock).toBeDefined();
+        expect(storeBlock?.number).toBe(1);
+      });
+
+      it('retrieves block by hash after checkpoint', async () => {
+        setupMinimalL1Mocks();
+
+        // Sync checkpoint 1 from L1
+        const checkpoint1 = checkpoints[0];
+        const rollupTx1 = makeRollupTx(checkpoint1);
+        const blobHashes1 = makeVersionedBlobHashes(checkpoint1);
+        const blobsFromCheckpoint1 = makeBlobsFromCheckpoint(checkpoint1);
+
+        mockL1BlockNumbers(100n);
+        mockRollup.read.status.mockResolvedValue([
+          1n,
+          checkpoint1.archive.root.toString(),
+          1n,
+          checkpoint1.archive.root.toString(),
+          GENESIS_ROOT,
+        ]);
+
+        makeCheckpointProposedEvent(70n, checkpoint1.number, checkpoint1.archive.root.toString(), blobHashes1);
+        makeMessageSentEvents(60n, checkpoint1.number, messagesPerCheckpoint[0]);
+        mockInbox.read.getState.mockResolvedValue(makeInboxStateFromMsgCount(messagesPerCheckpoint[0].length));
+
+        publicClient.getTransaction.mockResolvedValueOnce(rollupTx1);
+        blobClient.getBlobSidecar.mockResolvedValueOnce(blobsFromCheckpoint1);
+
+        await archiver.start(false);
+        await waitUntilArchiverCheckpoint(CheckpointNumber(1));
+
+        // Get block header from the first block in checkpoint 1
+        const header = await archiver.getBlockHeader(BlockNumber(1));
+        expect(header).toBeDefined();
+        const blockHash = await header!.hash();
+
+        // After checkpoint, getPublishedBlockByHash should work
+        const publishedBlock = await archiver.getPublishedBlockByHash(blockHash);
+        expect(publishedBlock).toBeDefined();
+        expect(publishedBlock?.block.number).toBe(1);
+      });
+    });
   });
 
   // TODO(palla/reorg): Add a unit test for the archiver handleEpochPrune

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1663,6 +1663,19 @@ export class Archiver
   }
 
   /**
+   * Gets a block by its hash (including synced blocks that are not yet checkpointed).
+   * @param blockHash - The block hash to retrieve.
+   * @returns The requested L2 block (or undefined if not found).
+   */
+  public async getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+    const block = await this.store.getBlockByHash(blockHash);
+    if (!block) {
+      return undefined;
+    }
+    return L2Block.fromBlockNew(block);
+  }
+
+  /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
    * @param from - Number of the first block to return (inclusive).
    * @param limit - The number of blocks to return.

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -360,6 +360,31 @@ describe('aztec node', () => {
         expect(l2BlockSource.getBlock).toHaveBeenCalledWith(3);
       });
     });
+
+    describe('getBlockByHash', () => {
+      it('returns block for synced but not yet checkpointed block', async () => {
+        const block = L2Block.empty();
+        const blockHash = Fr.random();
+
+        l2BlockSource.getBlockByHash.mockResolvedValue(block);
+
+        const result = await node.getBlockByHash(blockHash);
+
+        expect(l2BlockSource.getBlockByHash).toHaveBeenCalledWith(blockHash);
+        expect(result).toBeDefined();
+        expect(result).toEqual(block);
+      });
+
+      it('returns undefined for non-existent block', async () => {
+        const blockHash = Fr.random();
+        l2BlockSource.getBlockByHash.mockResolvedValue(undefined);
+
+        const result = await node.getBlockByHash(blockHash);
+
+        expect(l2BlockSource.getBlockByHash).toHaveBeenCalledWith(blockHash);
+        expect(result).toBeUndefined();
+      });
+    });
   });
 
   describe('simulatePublicCalls', () => {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -586,8 +586,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block.
    */
   public async getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
-    const publishedBlock = await this.blockSource.getPublishedBlockByHash(blockHash);
-    return publishedBlock?.block;
+    return await this.blockSource.getBlockByHash(blockHash);
   }
 
   /**

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -194,6 +194,13 @@ export interface L2BlockSource {
   getPublishedBlockByHash(blockHash: Fr): Promise<PublishedL2Block | undefined>;
 
   /**
+   * Gets a block by its hash (including synced blocks that are not yet checkpointed).
+   * @param blockHash - The block hash to retrieve.
+   * @returns The requested L2 block (or undefined if not found).
+   */
+  getBlockByHash(blockHash: Fr): Promise<L2Block | undefined>;
+
+  /**
    * Gets a published block by its archive root.
    * @param archive - The archive root to retrieve.
    * @returns The requested block (or undefined if not found).


### PR DESCRIPTION
# Fix: Node Returns undefined for Synced Blocks When Queried by Hash

## Summary

Fixed bug where `getBlockByHash()` returned `undefined` for synced blocks that hadn't been checkpointed on L1 yet. The implementation was only checking checkpointed blocks via `getPublishedBlockByHash()`, while `getBlockHeader('latest')` returns synced blocks. Changed to use store-level `getBlockByHash()` which works for all synced blocks.

## Problem Statement

When getting the latest block header, computing its hash, and requesting the block by that hash, the node returns `undefined`:

```typescript
const blockHeader = await node.getBlockHeader('latest');
const blockHash = await blockHeader?.hash();
const block = await node.getBlockByHash(blockHash); // undefined
```

## Root Cause

- `getBlockHeader('latest')` returns **synced blocks**
- `getBlockByHash()` only returned **checkpointed blocks** via `getPublishedBlockByHash()`
- Synced blocks don't have checkpoint entries until published to L1
- Result: API inconsistency causing undefined for synced blocks

## Solution

Changed `AztecNodeService.getBlockByHash()` to use `blockSource.getBlockByHash()` which queries the store directly and works for all synced blocks, not just checkpointed ones.

## Files Changed

1. **yarn-project/stdlib/src/block/l2_block_source.ts**
   - Added `getBlockByHash()` method to `L2BlockSource` interface

2. **yarn-project/archiver/src/archiver/archiver.ts**
   - Implemented `getBlockByHash()` in `Archiver` class that delegates to store and converts `L2BlockNew` to `L2Block`

3. **yarn-project/aztec-node/src/aztec-node/server.ts**
   - Changed implementation from `getPublishedBlockByHash()` to `getBlockByHash()`

4. **yarn-project/aztec-node/src/aztec-node/server.test.ts**
   - Added unit tests for synced block retrieval and non-existent block cases

5. **yarn-project/archiver/src/archiver/archiver.test.ts**
   - Added integration tests for synced vs checkpointed block scenarios

Fixes A-446
