### PR TITLE
fix(docs): Re-order version configuration for build section in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -124,17 +124,17 @@ const config = {
         includeCurrentVersion: process.env.CONTEXT !== "production",
         lastVersion: devnetVersion,
         versions: {
-          ...(nightlyVersion && {
-            [nightlyVersion]: {
-              path: "nightly",
-              banner: "unreleased",
-            },
-          }),
           ...(devnetVersion && {
             [devnetVersion]: {
               label: `Devnet (${devnetVersion})`,
               path: "",
               banner: "none",
+            },
+          }),
+          ...(nightlyVersion && {
+            [nightlyVersion]: {
+              path: "nightly",
+              banner: "unreleased",
             },
           }),
           ...(process.env.CONTEXT !== "production" && {


### PR DESCRIPTION
Currently the build button in the nav bar links to the nightly version of the documentation. This update should make the build button link to the devnet version, which is the default version.
