### PR TITLE
fix: check ci-barretenberg-full label before branch-based ci-barretenberg

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -51,10 +51,10 @@ function main {
   #   ci_mode="full-no-test-cache"
   elif has_label "ci-docs" || [ "$target_branch" == "merge-train/docs" ]; then
     ci_mode="docs"
-  elif has_label "ci-barretenberg" || [ "$target_branch" == "merge-train/barretenberg" ]; then
-    ci_mode="barretenberg"
   elif has_label "ci-barretenberg-full"; then
     ci_mode="barretenberg-full"
+  elif has_label "ci-barretenberg" || [ "$target_branch" == "merge-train/barretenberg" ]; then
+    ci_mode="barretenberg"
   elif [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
     ci_mode="release"
   elif has_label "ci-skip"; then


### PR DESCRIPTION
## Summary
- Fixes a bug where the `ci-barretenberg-full` label was being ignored for PRs targeting `merge-train/barretenberg`
- The branch-based check for `ci-barretenberg` was evaluated first, causing the explicit label to be skipped
- This reorders the conditions so explicit labels take precedence over branch defaults

## Context
Discovered on PR #19461 where setting `ci-barretenberg-full` label resulted in only 13 seconds of CI because the target branch (`merge-train/barretenberg`) matched `ci-barretenberg` mode first, causing a cache hit.