### PR TITLE
fix: minor bbapi fuzzing results 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.cpp
@@ -62,6 +62,7 @@ ChonkAccumulate::Response ChonkAccumulate::execute(BBApiRequest& request) &&
         precomputed_vk = nullptr;
     } else if (request.vk_policy == VkPolicy::DEFAULT || request.vk_policy == VkPolicy::CHECK) {
         if (!request.loaded_circuit_vk.empty()) {
+            validate_vk_size<Chonk::MegaVerificationKey>(request.loaded_circuit_vk);
             precomputed_vk = from_buffer<std::shared_ptr<Chonk::MegaVerificationKey>>(request.loaded_circuit_vk);
 
             if (request.vk_policy == VkPolicy::CHECK) {
@@ -132,8 +133,20 @@ ChonkProve::Response ChonkProve::execute(BBApiRequest& request) &&
 ChonkVerify::Response ChonkVerify::execute(const BBApiRequest& /*request*/) &&
 {
     BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
+
+    using VerificationKey = Chonk::MegaVerificationKey;
+    validate_vk_size<VerificationKey>(vk);
+
     // Deserialize the hiding kernel verification key directly from buffer
-    auto hiding_kernel_vk = std::make_shared<Chonk::MegaVerificationKey>(from_buffer<Chonk::MegaVerificationKey>(vk));
+    auto hiding_kernel_vk = std::make_shared<VerificationKey>(from_buffer<VerificationKey>(vk));
+
+    // Validate proof size using VK's num_public_inputs before expensive verification
+    const size_t expected_proof_size =
+        static_cast<size_t>(hiding_kernel_vk->num_public_inputs) + ChonkProof::PROOF_LENGTH_WITHOUT_PUB_INPUTS;
+    if (proof.size() != expected_proof_size) {
+        throw_or_abort("proof has wrong size: expected " + std::to_string(expected_proof_size) + ", got " +
+                       std::to_string(proof.size()));
+    }
 
     // Verify the proof using ChonkNativeVerifier
     auto vk_and_hash = std::make_shared<ChonkNativeVerifier::VKAndHash>(hiding_kernel_vk);
@@ -197,6 +210,8 @@ ChonkCheckPrecomputedVk::Response ChonkCheckPrecomputedVk::execute([[maybe_unuse
         info("FAIL: Expected precomputed vk for function ", circuit.name);
         throw_or_abort("Missing precomputed VK");
     }
+
+    validate_vk_size<Chonk::MegaVerificationKey>(circuit.verification_key);
 
     // Deserialize directly from buffer
     auto precomputed_vk = from_buffer<std::shared_ptr<Chonk::MegaVerificationKey>>(circuit.verification_key);

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_shared.hpp
@@ -8,6 +8,7 @@
  */
 
 #include "barretenberg/chonk/chonk.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/dsl/acir_format/acir_format.hpp"
 #include "barretenberg/honk/execution_trace/mega_execution_trace.hpp"
 #include <cstdint>
@@ -15,6 +16,21 @@
 #include <vector>
 
 namespace bb::bbapi {
+
+/**
+ * @brief Validate verification key size before deserialization
+ * @tparam VK The verification key type
+ * @param vk_bytes The serialized verification key bytes
+ * @throws If the size doesn't match the expected size for the VK type
+ */
+template <typename VK> inline void validate_vk_size(const std::vector<uint8_t>& vk_bytes)
+{
+    const size_t expected_size = VK::calc_num_data_types() * sizeof(bb::fr);
+    if (vk_bytes.size() != expected_size) {
+        throw_or_abort("verification key has wrong size: expected " + std::to_string(expected_size) + ", got " +
+                       std::to_string(vk_bytes.size()));
+    }
+}
 
 /**
  * @enum VkPolicy

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -138,6 +138,14 @@ bool _verify(const std::vector<uint8_t>& vk_bytes,
     using Transcript = typename Flavor::Transcript;
     using DataType = typename Transcript::DataType;
 
+    // Validate VK size upfront before deserialization
+    const size_t expected_vk_size = VerificationKey::calc_num_data_types() * sizeof(bb::fr);
+    if (vk_bytes.size() != expected_vk_size) {
+        info(
+            "Proof verification failed: invalid VK size. Expected ", expected_vk_size, " bytes, got ", vk_bytes.size());
+        return false;
+    }
+
     std::shared_ptr<VerificationKey> vk = std::make_shared<VerificationKey>(from_buffer<VerificationKey>(vk_bytes));
     auto vk_and_hash = std::make_shared<VKAndHash>(vk);
 
@@ -335,10 +343,13 @@ CircuitVerify::Response CircuitVerify::execute(BB_UNUSED const BBApiRequest& req
 VkAsFields::Response VkAsFields::execute(BB_UNUSED const BBApiRequest& request) &&
 {
     BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
-    std::vector<bb::fr> fields;
+
+    using VK = UltraFlavor::VerificationKey;
+    validate_vk_size<VK>(verification_key);
 
     // Standard UltraHonk flavors
-    auto vk = from_buffer<UltraFlavor::VerificationKey>(verification_key);
+    auto vk = from_buffer<VK>(verification_key);
+    std::vector<bb::fr> fields;
     fields = vk.to_field_elements();
 
     return { std::move(fields) };
@@ -347,10 +358,13 @@ VkAsFields::Response VkAsFields::execute(BB_UNUSED const BBApiRequest& request) 
 MegaVkAsFields::Response MegaVkAsFields::execute(BB_UNUSED const BBApiRequest& request) &&
 {
     BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
-    std::vector<bb::fr> fields;
+
+    using VK = MegaFlavor::VerificationKey;
+    validate_vk_size<VK>(verification_key);
 
     // MegaFlavor for private function verification keys
-    auto vk = from_buffer<MegaFlavor::VerificationKey>(verification_key);
+    auto vk = from_buffer<VK>(verification_key);
+    std::vector<bb::fr> fields;
     fields = vk.to_field_elements();
 
     return { std::move(fields) };
@@ -360,6 +374,8 @@ CircuitWriteSolidityVerifier::Response CircuitWriteSolidityVerifier::execute(BB_
 {
     BB_BENCH_NAME(MSGPACK_SCHEMA_NAME);
     using VK = UltraKeccakFlavor::VerificationKey;
+    validate_vk_size<VK>(verification_key);
+
     auto vk = std::make_shared<VK>(from_buffer<VK>(verification_key));
 
     std::string contract = settings.disable_zk ? get_honk_solidity_verifier(vk) : get_honk_zk_solidity_verifier(vk);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -456,6 +456,9 @@ struct BitSize {
             value = v;
         } else if (tag == "Integer") {
             Integer v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -532,6 +535,9 @@ struct MemoryAddress {
         }
         if (tag == "Direct") {
             Direct v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -542,6 +548,9 @@ struct MemoryAddress {
             value = v;
         } else if (tag == "Relative") {
             Relative v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -943,6 +952,9 @@ struct BlackBoxOp {
         }
         if (tag == "AES128Encrypt") {
             AES128Encrypt v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -953,6 +965,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Blake2s") {
             Blake2s v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -963,6 +978,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Blake3") {
             Blake3 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -973,6 +991,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Keccakf1600") {
             Keccakf1600 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -983,6 +1004,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EcdsaSecp256k1") {
             EcdsaSecp256k1 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -993,6 +1017,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EcdsaSecp256r1") {
             EcdsaSecp256r1 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1003,6 +1030,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "MultiScalarMul") {
             MultiScalarMul v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1013,6 +1043,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EmbeddedCurveAdd") {
             EmbeddedCurveAdd v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1023,6 +1056,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Poseidon2Permutation") {
             Poseidon2Permutation v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1033,6 +1069,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Sha256Compression") {
             Sha256Compression v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1043,6 +1082,9 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "ToRadix") {
             ToRadix v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1164,6 +1206,9 @@ struct HeapValueType {
         }
         if (tag == "Simple") {
             Simple v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1174,6 +1219,9 @@ struct HeapValueType {
             value = v;
         } else if (tag == "Array") {
             Array v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1184,6 +1232,9 @@ struct HeapValueType {
             value = v;
         } else if (tag == "Vector") {
             Vector v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1299,6 +1350,9 @@ struct ValueOrArray {
         }
         if (tag == "MemoryAddress") {
             MemoryAddress v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1309,6 +1363,9 @@ struct ValueOrArray {
             value = v;
         } else if (tag == "HeapArray") {
             HeapArray v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1319,6 +1376,9 @@ struct ValueOrArray {
             value = v;
         } else if (tag == "HeapVector") {
             HeapVector v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1828,6 +1888,9 @@ struct BrilligOpcode {
         }
         if (tag == "BinaryFieldOp") {
             BinaryFieldOp v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1838,6 +1901,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "BinaryIntOp") {
             BinaryIntOp v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1848,6 +1914,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Not") {
             Not v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1858,6 +1927,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Cast") {
             Cast v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1868,6 +1940,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "JumpIf") {
             JumpIf v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1878,6 +1953,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Jump") {
             Jump v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1888,6 +1966,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "CalldataCopy") {
             CalldataCopy v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1898,6 +1979,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Call") {
             Call v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1908,6 +1992,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Const") {
             Const v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1918,6 +2005,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "IndirectConst") {
             IndirectConst v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1931,6 +2021,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "ForeignCall") {
             ForeignCall v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1941,6 +2034,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Mov") {
             Mov v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1951,6 +2047,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "ConditionalMov") {
             ConditionalMov v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1961,6 +2060,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Load") {
             Load v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1971,6 +2073,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Store") {
             Store v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1981,6 +2086,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "BlackBox") {
             BlackBox v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1991,6 +2099,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Trap") {
             Trap v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2001,6 +2112,9 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Stop") {
             Stop v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2093,6 +2207,9 @@ struct FunctionInput {
         }
         if (tag == "Constant") {
             Constant v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2103,6 +2220,9 @@ struct FunctionInput {
             value = v;
         } else if (tag == "Witness") {
             Witness v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2552,6 +2672,9 @@ struct BlackBoxFuncCall {
         }
         if (tag == "AES128Encrypt") {
             AES128Encrypt v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2562,6 +2685,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "AND") {
             AND v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2572,6 +2698,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "XOR") {
             XOR v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2582,6 +2711,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "RANGE") {
             RANGE v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2592,6 +2724,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Blake2s") {
             Blake2s v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2602,6 +2737,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Blake3") {
             Blake3 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2612,6 +2750,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EcdsaSecp256k1") {
             EcdsaSecp256k1 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2622,6 +2763,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EcdsaSecp256r1") {
             EcdsaSecp256r1 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2632,6 +2776,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "MultiScalarMul") {
             MultiScalarMul v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2642,6 +2789,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EmbeddedCurveAdd") {
             EmbeddedCurveAdd v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2652,6 +2802,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Keccakf1600") {
             Keccakf1600 v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2662,6 +2815,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "RecursiveAggregation") {
             RecursiveAggregation v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2672,6 +2828,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Poseidon2Permutation") {
             Poseidon2Permutation v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2682,6 +2841,9 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Sha256Compression") {
             Sha256Compression v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2773,6 +2935,9 @@ struct BlockType {
             value = v;
         } else if (tag == "CallData") {
             CallData v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2894,6 +3059,9 @@ struct BrilligInputs {
         }
         if (tag == "Single") {
             Single v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2904,6 +3072,9 @@ struct BrilligInputs {
             value = v;
         } else if (tag == "Array") {
             Array v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2914,6 +3085,9 @@ struct BrilligInputs {
             value = v;
         } else if (tag == "MemoryArray") {
             MemoryArray v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2990,6 +3164,9 @@ struct BrilligOutputs {
         }
         if (tag == "Simple") {
             Simple v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3000,6 +3177,9 @@ struct BrilligOutputs {
             value = v;
         } else if (tag == "Array") {
             Array v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3209,6 +3389,9 @@ struct Opcode {
         }
         if (tag == "AssertZero") {
             AssertZero v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3219,6 +3402,9 @@ struct Opcode {
             value = v;
         } else if (tag == "BlackBoxFuncCall") {
             BlackBoxFuncCall v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3229,6 +3415,9 @@ struct Opcode {
             value = v;
         } else if (tag == "MemoryOp") {
             MemoryOp v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3239,6 +3428,9 @@ struct Opcode {
             value = v;
         } else if (tag == "MemoryInit") {
             MemoryInit v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3249,6 +3441,9 @@ struct Opcode {
             value = v;
         } else if (tag == "BrilligCall") {
             BrilligCall v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3259,6 +3454,9 @@ struct Opcode {
             value = v;
         } else if (tag == "Call") {
             Call v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3335,6 +3533,9 @@ struct ExpressionOrMemory {
         }
         if (tag == "Expression") {
             Expression v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3345,6 +3546,9 @@ struct ExpressionOrMemory {
             value = v;
         } else if (tag == "Memory") {
             Memory v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3451,6 +3655,9 @@ struct OpcodeLocation {
         }
         if (tag == "Acir") {
             Acir v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3461,6 +3668,9 @@ struct OpcodeLocation {
             value = v;
         } else if (tag == "Brillig") {
             Brillig v;
+            if (o.type != msgpack::type::MAP) {
+                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
+            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -65,7 +65,8 @@ std::vector<CyclicPermutation> TraceToPolynomials<Flavor>::populate_wires_and_se
             for (uint32_t block_row_idx = 0; block_row_idx < block_size; ++block_row_idx) {
                 for (uint32_t wire_idx = 0; wire_idx < NUM_WIRES; ++wire_idx) {
                     uint32_t var_idx = block.wires[wire_idx][block_row_idx]; // an index into the variables array
-                    uint32_t real_var_idx = builder.real_variable_index[var_idx];
+                    // Use .at() for bounds checking - fuzzer found OOB with malformed ACIR
+                    uint32_t real_var_idx = builder.real_variable_index.at(var_idx);
                     uint32_t trace_row_idx = block_row_idx + offset;
                     // Insert the real witness values from this block into the wire polys at the correct offset
                     wires[wire_idx].at(trace_row_idx) = builder.get_variable(var_idx);


### PR DESCRIPTION
Small cleanliness. Also, a separate requirement from alpha team wanted a fixed proof size to prevent any malleability concerns from adding 0s. It's easier for us to make sure this buffer is the correct size. 

Closes https://linear.app/aztec-labs/issue/A-382 (Investigate issues on malleable tx proofs)