### PR TITLE
fix: ci-barretenberg-full mode fixes

### DIFF
--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -205,6 +205,19 @@ add_library(
     ${BARRETENBERG_TARGET_OBJECTS}
 )
 
+# bb-external: A complete static library for external consumers (e.g. barretenberg-rs).
+# Includes everything from libbarretenberg.a plus env and vm2_stub.
+# This provides a single library file that external bindings can link against.
+if(NOT WASM)
+    add_library(
+        bb-external
+        STATIC
+        ${BARRETENBERG_TARGET_OBJECTS}
+        $<TARGET_OBJECTS:env>
+        $<TARGET_OBJECTS:vm2_stub>
+    )
+endif()
+
 if(WASM)
     # When building this wasm "executable", we include the wasi module but exclude the env module.
     # That's because we expect this wasm to be run as a wasi "reactor" and for the host environment

--- a/barretenberg/cpp/src/barretenberg/vm2_stub/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/vm2_stub/CMakeLists.txt
@@ -1,9 +1,13 @@
 # Stub module for AVM functionality when building without vm2
 # This provides the same interface as vm2/dsl but throws runtime errors
-# Using OBJECT library to avoid static library link ordering issues with dsl
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 list(FILTER SOURCE_FILES EXCLUDE REGEX ".*\\.(fuzzer|test|bench)\\.cpp$")
 
+# OBJECT library for internal use (WASM builds, tests that need direct object inclusion)
 add_library(vm2_stub OBJECT ${SOURCE_FILES})
 add_dependencies(vm2_stub msgpack-c)
 target_link_libraries(vm2_stub PUBLIC barretenberg_headers)
+
+# Static library for external consumers (barretenberg-rs) that need a .a file to link against
+add_library(vm2_stub_static STATIC $<TARGET_OBJECTS:vm2_stub>)
+set_target_properties(vm2_stub_static PROPERTIES OUTPUT_NAME "vm2_stub")

--- a/barretenberg/cpp/src/barretenberg/vm2_stub/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/vm2_stub/CMakeLists.txt
@@ -1,13 +1,9 @@
 # Stub module for AVM functionality when building without vm2
 # This provides the same interface as vm2/dsl but throws runtime errors
+# Using OBJECT library to avoid static library link ordering issues with dsl
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 list(FILTER SOURCE_FILES EXCLUDE REGEX ".*\\.(fuzzer|test|bench)\\.cpp$")
 
-# OBJECT library for internal use (WASM builds, tests that need direct object inclusion)
 add_library(vm2_stub OBJECT ${SOURCE_FILES})
 add_dependencies(vm2_stub msgpack-c)
 target_link_libraries(vm2_stub PUBLIC barretenberg_headers)
-
-# Static library for external consumers (barretenberg-rs) that need a .a file to link against
-add_library(vm2_stub_static STATIC $<TARGET_OBJECTS:vm2_stub>)
-set_target_properties(vm2_stub_static PROPERTIES OUTPUT_NAME "vm2_stub")

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -12,12 +12,15 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
         // Use link group to handle circular dependencies between static libraries
-        // libbarretenberg depends on libvm2 for AVM constraints
-        // libvm2 depends on libcommon for utilities
+        // libbarretenberg contains vm2_stub when built without AVM
+        // libvm2 is only present when AVM is enabled
         // libenv provides logstr/throw_or_abort_impl
         println!("cargo:rustc-link-arg=-Wl,--start-group");
         println!("cargo:rustc-link-lib=static=barretenberg");
-        println!("cargo:rustc-link-lib=static=vm2");
+        // Only link vm2 if it exists (AVM enabled builds)
+        if lib_dir.join("libvm2.a").exists() {
+            println!("cargo:rustc-link-lib=static=vm2");
+        }
         println!("cargo:rustc-link-lib=static=common");
         println!("cargo:rustc-link-lib=static=env");
         println!("cargo:rustc-link-arg=-Wl,--end-group");

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    // Only for ffi feature - link libbarretenberg from cpp build
+    // Only for ffi feature - link libbb-external from cpp build
     #[cfg(feature = "ffi")]
     {
         // Find the cpp build lib directory relative to this crate
@@ -11,17 +11,8 @@ fn main() {
 
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
-        // Use --start-group/--end-group to handle circular dependencies between static libraries.
-        // libbarretenberg.a is a mega-library containing most symbols.
-        // env provides logstr, throw_or_abort_impl, env_hardware_concurrency
-        // vm2_stub provides create_avm2_recursion_constraints_goblin stub (throws at runtime)
-        // --allow-multiple-definition is needed because some objects are partially in libbarretenberg.a
-        println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
-        println!("cargo:rustc-link-arg=-Wl,--start-group");
-        println!("cargo:rustc-link-lib=static=barretenberg");
-        println!("cargo:rustc-link-lib=static=env");
-        println!("cargo:rustc-link-lib=static=vm2_stub");
-        println!("cargo:rustc-link-arg=-Wl,--end-group");
+        // libbb-external.a contains everything needed: barretenberg + env + vm2_stub
+        println!("cargo:rustc-link-lib=static=bb-external");
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 }

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -11,18 +11,16 @@ fn main() {
 
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
-        // Use link group to handle circular dependencies between static libraries
-        // libbarretenberg contains vm2_stub when built without AVM
-        // libvm2 is only present when AVM is enabled
-        // libenv provides logstr/throw_or_abort_impl
+        // Use --start-group/--end-group to handle circular dependencies between static libraries.
+        // libbarretenberg.a is a mega-library containing most symbols.
+        // env provides logstr, throw_or_abort_impl, env_hardware_concurrency
+        // vm2_stub provides create_avm2_recursion_constraints_goblin stub (throws at runtime)
+        // --allow-multiple-definition is needed because some objects are partially in libbarretenberg.a
+        println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
         println!("cargo:rustc-link-arg=-Wl,--start-group");
         println!("cargo:rustc-link-lib=static=barretenberg");
-        // Only link vm2 if it exists (AVM enabled builds)
-        if lib_dir.join("libvm2.a").exists() {
-            println!("cargo:rustc-link-lib=static=vm2");
-        }
-        println!("cargo:rustc-link-lib=static=common");
         println!("cargo:rustc-link-lib=static=env");
+        println!("cargo:rustc-link-lib=static=vm2_stub");
         println!("cargo:rustc-link-arg=-Wl,--end-group");
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -13,7 +13,7 @@ function build {
     (cd ../ts && yarn generate)
 
     # Build all targets
-    cargo build --release
+    denoise "cargo build --release"
 
     # Upload build artifacts and generated source files to cache
     cache_upload barretenberg-rs-$hash.tar.gz target/release barretenberg-rs/src/generated_types.rs barretenberg-rs/src/api.rs

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -35,7 +35,7 @@ function test {
   fi
 
   # Run all tests (FFI is enabled by default, links to cpp/build/lib automatically)
-  cargo test --release
+  denoise "cargo test --release"
 }
 
 case "$cmd" in

--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+source $(git rev-parse --show-toplevel)/ci3/source
 
 cd "$(dirname "$0")/.."
 
@@ -9,4 +9,4 @@ if [ -f "$HOME/.cargo/env" ]; then
 fi
 
 # Run all tests (FFI is enabled by default, links to cpp/build/lib automatically)
-cargo test --release
+denoise "cargo test --release"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -694,6 +694,8 @@ case "$cmd" in
     export USE_TEST_CACHE=1
     export AVM=0
     export AVM_TRANSPILER=0
+    pull_submodules
+    noir/bootstrap.sh build_native  # Build nargo for acir_tests
     barretenberg/bootstrap.sh ci
     ;;
 

--- a/ci3/docker_isolate
+++ b/ci3/docker_isolate
@@ -76,6 +76,7 @@ cid=$(docker run -d \
   -e MEM \
   -e TMPFS_SIZE \
   -e USE_HOME_TMP \
+  -e AVM \
   "${arg_env_vars[@]}" \
   aztecprotocol/build:3.0 \
   /bin/bash -c "$cmd")


### PR DESCRIPTION
## Summary
Multiple fixes for `ci-barretenberg-full` mode:

1. **Create libbb-external.a** - Single static library for barretenberg-rs that bundles barretenberg + env + vm2_stub
2. **Propagate AVM env var** - Pass `AVM` environment variable to isolated docker containers so tests use the correct `bb` binary
3. **Denoise barretenberg-rs** - Add `denoise` to build and test commands for cleaner CI output

## Problem
`ci-barretenberg-full` mode was failing with multiple issues:

1. barretenberg-rs build failed with:
   ```
   error: could not find native static library `vm2`, perhaps an -L flag is missing?
   ```
   This happened because `ci-barretenberg-full` builds with `AVM=0`, so libvm2.a is not produced.

2. acir_tests failed with:
   ```
   barretenberg/cpp/build/bin/bb-avm: No such file or directory
   ```
   The `AVM` environment variable wasn't being passed to isolated docker containers, causing `find-bb` to incorrectly select `bb-avm` instead of `bb`.

## Solution
1. Create `libbb-external.a` that includes everything barretenberg-rs needs:
   - All objects from libbarretenberg.a
   - env module (logstr, throw_or_abort_impl, env_hardware_concurrency)
   - vm2_stub (provides stub for create_avm2_recursion_constraints_goblin)
   
   This simplifies linking in barretenberg-rs to just one library and removes the need for `--allow-multiple-definition` and `--start-group/--end-group`.

2. Propagate `AVM` env var to isolated docker containers in `ci3/docker_isolate`

3. Use `denoise` for barretenberg-rs build and test commands

## Caching
`libbb-external.a` is built to `build/lib/` and the native build cache uploads `build/{bin,lib}`, so it will be cached automatically.