### PR TITLE
fix!: ecc add predicate completeness bug

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/ecc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/ecc.test.cpp
@@ -161,6 +161,62 @@ TEST(EccAddConstrainingTest, EccDouble)
     check_relation<ecc>(trace);
 }
 
+// Test case for adding two points with different x-coordinates but the same y-coordinate.
+// This edge case exists because cube roots of unity in BN254 Fr allow multiple x values
+// to cube to the same result: if (x, y) is on Grumpkin (y² = x³ - 17), then (ω·x, y)
+// is also on the curve since ω³ = 1.
+//
+// This test uses simulation + tracegen to verify the full pipeline works.
+TEST(EccAddConstrainingTest, EccAddSameYDifferentX)
+{
+    // Point P - known valid point on Grumpkin
+    FF local_p_x("0x04c95d1b26d63d46918a156cae92db1bcbc4072a27ec81dc82ea959abdbcf16a");
+    FF local_p_y("0x035b6dd9e63c1370462c74775765d07fc21fd1093cc988149d3aa763bb3dbb60");
+    EmbeddedCurvePoint local_p(local_p_x, local_p_y, false);
+
+    // Point Q - p_x * omega (cube root of unity), same y-coordinate!
+    // omega = 0x0000000000000000b3c4d79d41a917585bfc41088d8daaa78b17ea66b99c90dd
+    FF local_q_x("0x14dd39aa19e1c8b29e0c530a28106a7d64d2213486baba3c86dce51bdddf75bb");
+    FF local_q_y("0x035b6dd9e63c1370462c74775765d07fc21fd1093cc988149d3aa763bb3dbb60");
+    EmbeddedCurvePoint local_q(local_q_x, local_q_y, false);
+
+    // Verify preconditions: same y, different x
+    ASSERT_NE(local_p.x(), local_q.x());
+    ASSERT_EQ(local_p.y(), local_q.y());
+
+    // Expected result R = P + Q (lambda = 0 since y's are equal)
+    FF local_r_x("0x16bdb7ada0799a3088b9dd3faade12c3f79dbfe9cb1234783a1a7add546398dc");
+    FF local_r_y("0x2d08e098faf58cb97223d13f2a1b87dd6614173f3cefe87ca6a74e3034c244a1");
+    EmbeddedCurvePoint local_r(local_r_x, local_r_y, false);
+
+    // Use simulation to generate events
+    EventEmitter<EccAddEvent> ecc_add_event_emitter;
+    NoopEventEmitter<ScalarMulEvent> scalar_mul_event_emitter;
+    NoopEventEmitter<EccAddMemoryEvent> ecc_add_memory_event_emitter;
+
+    StrictMock<MockExecutionIdManager> execution_id_manager;
+    PureGreaterThan gt;
+    PureToRadix to_radix_simulator;
+    EccSimulator ecc_simulator(execution_id_manager,
+                               gt,
+                               to_radix_simulator,
+                               ecc_add_event_emitter,
+                               scalar_mul_event_emitter,
+                               ecc_add_memory_event_emitter);
+
+    // Perform the addition via simulation
+    EmbeddedCurvePoint result = ecc_simulator.add(local_p, local_q);
+    ASSERT_EQ(result, local_r) << "Simulation produced wrong result";
+
+    // Build trace from simulation events
+    TestTraceContainer trace;
+    EccTraceBuilder builder;
+    builder.process_add(ecc_add_event_emitter.dump_events(), trace);
+
+    // Verify PIL constraints pass
+    check_relation<ecc>(trace);
+}
+
 TEST(EccAddConstrainingTest, EccAddResultingInInfinity)
 {
     // R = P + (-P) = O; , where O is the point at infinity

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.cpp
@@ -62,7 +62,10 @@ void EccTraceBuilder::process_add(const simulation::EventEmitterInterface<simula
         bool y_match = p.y() == q.y();
 
         bool double_predicate = (x_match && y_match);
-        bool add_predicate = (!x_match && !y_match);
+        // add_predicate is true when x-coordinates differ (regardless of y-coordinates).
+        // PIL constraint: sel = double_op + add_op + INFINITY_PRED, where INFINITY_PRED = x_match * (1 - y_match).
+        // When x_match=0: double_op=0, INFINITY_PRED=0, so add_op must be 1.
+        bool add_predicate = !x_match;
         // If x match but the y's don't, the result is the infinity point when adding;
         bool infinity_predicate = (x_match && !y_match);
         // The result is also the infinity point if


### PR DESCRIPTION
## Summary

  - Fix ECC tracegen `add_predicate` bug for points with same y-coordinate but different x-coordinate
  - Add constraining test for this edge case using real Grumpkin points

  ## Description

  The ECC tracegen had a bug where `add_predicate` was set to `(!x_match && !y_match)`, requiring **both** coordinates to differ. However, the PIL constraint `sel = double_op + add_op + INFINITY_PRED` requires `add_op = 1` whenever x-coordinates differ (regardless of y-coordinates).

  This caused constraint failures when adding two points with different x but same y:
  - `x_match = 0`, `y_match = 1`
  - `double_op = 0` (not doubling)
  - `INFINITY_PRED = x_match * (1 - y_match) = 0`
  - PIL requires: `add_op = sel - double_op - INFINITY_PRED = 1`
  - Bug produced: `add_op = 0` → constraint `sel = 0 + 0 + 0 = 0 ≠ 1` fails

  ### Why this edge case exists

  On Grumpkin (y² = x³ - 17), two distinct points can share the same y-coordinate due to cube roots of unity in BN254 Fr. If `(x, y)` is on the curve, then `(ω·x, y)` is also valid since `ω³ = 1`.

  ### Fix

  ```cpp
  // Before (BUG):
  bool add_predicate = (!x_match && !y_match);

  // After:
  bool add_predicate = !x_match;
  ```

  ###  Test plan

  - New constraining test EccAddSameYDifferentX using simulation → tracegen → PIL verification
  - Verified test fails without fix, passes with fix
  - All 26 existing ECC tests pass

  ---
🤖 Generated with https://claude.ai/code

  Co-Authored-By: Claude noreply@anthropic.com


