### PR TITLE
chore: add sudo wrapper to avm-fuzzing-container

### DIFF
--- a/container-builds/avm-fuzzing-container/src/Dockerfile
+++ b/container-builds/avm-fuzzing-container/src/Dockerfile
@@ -57,6 +57,13 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd -m fuzzer -G sudo
+
+# Create a dummy sudo wrapper that just executes the command
+# (Node.js 24 nodesource script calls sudo which isn't installed)
+RUN mkdir -p /usr/local/bin && \
+    printf '#!/bin/sh\nexec "$@"\n' > /usr/local/bin/sudo && \
+    chmod +x /usr/local/bin/sudo
+
 WORKDIR /home/fuzzer
 
 # Copy fuzzer binary


### PR DESCRIPTION
Updates the avm-fuzzing-container Dockerfile to include a dummy sudo executable in the PATH that wraps and executes commands without requiring actual sudo privileges. This resolves container compatibility issues with Node.js 24 by allowing scripts that call sudo to function within the container environment without elevated permissions.