### PR TITLE
docs: improve docs for nullifier read requests, mark pub fn as unsafe 

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -752,7 +752,7 @@ impl PrivateContext {
     /// revealing which specific note was read.
     ///
     /// This can be used to prove existence of both settled notes (created in
-    /// prior transactions) and transient notes (created in the current
+    /// prior transactions) and pending notes (created in the current
     /// transaction).
     /// If you need to prove existence of a settled note _at a specific block
     /// number_, use `note_inclusion::prove_note_inclusion`.
@@ -833,39 +833,46 @@ impl PrivateContext {
         assert_eq(request.innermost(), note_hash);
     }
 
-    /// Requests to read a specific nullifier from the nullifier tree.
+    /// Requests the private kernel to ensure an `unsiloed_nullifier` has been emitted by `contract_address`, failing
+    /// the transaction otherwise.
     ///
-    /// Nullifier read requests are used to prove that a nullifier exists without
-    /// revealing which specific nullifier preimage was read.
+    /// Note that unsiloed nullifiers are not the actual values stored in the nullifier tree: they are first siloed via
+    /// [crate::hash::compute_siloed_nullifier] with the emitting contract's address.
     ///
-    /// This can be used to prove existence of both settled nullifiers (created in
-    /// prior transactions) and transient nullifiers (created in the current
-    /// transaction).
-    /// If you need to prove existence of a settled nullifier _at a specific block
-    /// number_, use `nullifier_inclusion::prove_nullifier_inclusion`.
+    /// ## Pending Nullifiers
     ///
-    /// Low-level function. Ordinarily, smart contract developers will not need
-    /// to call this directly. Aztec-nr's state variables (see `../state_vars/`)
-    /// are designed to understand when to create and push new nullifier read
-    /// requests.
+    /// Both settled nullifiers (emitted in prior transactions) and pending nullifiers (emitted in the current
+    /// transaction) will be considered by this function. This is the **only** mechanism via which it is possible to
+    /// assert that a pending nullifier exists, since those are otherwise hidden from contracts by the kernels.
     ///
-    /// # Arguments
-    /// * `nullifier` - The nullifier to read and verify
-    /// * `contract_address` - The contract address that emitted the nullifier
+    /// The nullifier must have been emitted **before** this call is made for the transaction to not fail.
     ///
-    /// # Advanced
-    /// This approach improves latency between writes and reads:
-    /// a function can read a nullifier which was created earlier in the tx
-    /// (rather than performing the read in a later tx, after waiting for the
-    /// earlier tx to be included, to ensure the nullifier is included in the tree).
+    /// In order to instead prove existence of a settled nullifier at a specific block number, use
+    /// [crate::history::nullifier_inclusion::ProveNullifierInclusion::prove_nullifier_inclusion].
     ///
+    /// ## Public vs Private
+    ///
+    /// In general, it is unsafe to check for nullifier non-existence in private, as that will not consider the
+    /// possibility of the nullifier having been emitted in any transaction between the anchor block and the inclusion
+    /// block. Private functions instead prove existence via this function and 'prove' non-existence by _emitting_ the
+    /// nullifer, which would cause the transaction to fail if the nullifier existed.
+    ///
+    /// This is not the case in public functions, which do have access to the tip of the blockchain and so can reliably
+    /// prove whether a nullifier exists or not via
+    /// [crate::context::public_context::PublicContext::nullifier_exists_unsafe].
+    ///
+    /// ## Cost
+    ///
+    /// This uses up one of the call's kernel nullifier read requests, which are limited. Like all kernel requests,
+    /// proving time costs are only incurred when the total number of requests exceeds the kernel's capacity, requiring
+    /// an additional invocation of the kernel reset circuit.
     pub fn push_nullifier_read_request(
         &mut self,
-        nullifier: Field,
+        unsiloed_nullifier: Field,
         contract_address: AztecAddress,
     ) {
         let request = Scoped::new(
-            Counted::new(nullifier, self.next_counter()),
+            Counted::new(unsiloed_nullifier, self.next_counter()),
             contract_address,
         );
         self.nullifier_read_requests.push(request);

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -151,37 +151,53 @@ impl PublicContext {
         unsafe { l1_to_l2_msg_exists(msg_hash, msg_leaf_index as u64) } == 1
     }
 
-    /// Checks if a specific nullifier has been emitted by a given contract.
+    /// Returns `true` if an `unsiloed_nullifier` has been emitted by `contract_address`.
     ///
-    /// Whilst nullifiers are primarily intended as a _privacy-preserving_
-    /// record of a one-time action, they can also be used to efficiently
-    /// record _public_ one-time actions too. An example is to check
-    /// whether a contract has been published: we emit a nullifier that is
-    /// deterministic, but whose preimage is _not_ private. This is more
-    /// efficient than using mutable storage, and can be done directly
-    /// from a private function.
+    /// Note that unsiloed nullifiers are not the actual values stored in the nullifier tree: they are first siloed via
+    /// [crate::hash::compute_siloed_nullifier] with the emitting contract's address.
     ///
-    /// Nullifiers can be tested for non-existence in public, which is not the
-    /// case in private. Because private functions do not have access to
-    /// the tip of the blockchain (but only the anchor block they are built
-    /// at) they can only prove nullifier non-existence in the past. But between
-    /// an anchor block and the block in which a tx is included, the nullifier
-    /// might have been inserted into the nullifier tree by some other
-    /// transaction.
-    /// Public functions _do_ have access to the tip of the state, and so
-    /// this pattern is safe.
+    /// ## Use Cases
     ///
-    /// # Arguments
-    /// * `unsiloed_nullifier` - The raw nullifier value (before siloing with
-    ///                          the contract address that emitted it).
-    /// * `address` - The claimed contract address that emitted the nullifier
+    /// Nullifiers are typically used as a _privacy-preserving_ record of a one-time action, but they can also be used
+    /// to efficiently record _public_ one-time actions as well. This is cheaper than using public storage, and has the
+    /// added benefit of the nullifier being emittable from a private function.
     ///
-    /// # Returns
-    /// * `bool` - True if the nullifier has been emitted by the specified contract
+    /// An example is to check whether a contract has been published: we emit a nullifier that is deterministic and
+    /// which has a _public_ preimage.
     ///
-    pub fn nullifier_exists(_self: Self, unsiloed_nullifier: Field, address: AztecAddress) -> bool {
+    /// ## Public vs Private
+    ///
+    /// In general, it is unsafe to check for nullifier non-existence in private, as that will not consider the
+    /// possibility of the nullifier having been emitted in any transaction between the anchor block and the inclusion
+    /// block. Private functions instead prove existence via
+    /// [crate::context::private_context::PrivateContext::push_nullifier_read_request] and 'prove' non-existence by
+    /// _emitting_ the nullifer, which would cause the transaction to fail if the nullifier existed.
+    ///
+    /// This is not the case in public functions, which do have access to the tip of the blockchain and so can reliably
+    /// prove whether a nullifier exists or not.
+    ///
+    /// ## Safety
+    ///
+    /// While it is safe to rely on this function's return value to determine if a nullifier exists or not, it is often
+    /// **not** safe to infer additional information from that. In particular, it is **unsafe** to infer that the
+    /// existence of a nullifier emitted from a private function implies that all other side-effects of said private
+    /// execution have been completed, more concretely that any enqueued public calls have been executed.
+    ///
+    /// This is because all private transaction effects are committed _before_ enqueued public functions are run (in
+    /// order to not reveal detailed timing information about the transaction), so it is possible to observe a nullifier
+    /// that was emitted alongside the enqueuing of a public call **before** said call has been completed.
+    ///
+    /// ## Cost
+    ///
+    /// This emits the `CHECKNULLIFIEREXISTS` opcode, which conceptually performs a merkle inclusion proof on the
+    /// nullifier tree (both when the nullifier exists and when it doesn't).
+    pub fn nullifier_exists_unsafe(
+        _self: Self,
+        unsiloed_nullifier: Field,
+        contract_address: AztecAddress,
+    ) -> bool {
         // Safety: AVM opcodes are constrained by the AVM itself
-        unsafe { nullifier_exists(unsiloed_nullifier, address.to_field()) } == 1
+        unsafe { nullifier_exists(unsiloed_nullifier, contract_address.to_field()) } == 1
     }
 
     /// Consumes a message sent from Ethereum (L1) to Aztec (L2) -- effectively
@@ -234,7 +250,7 @@ impl PublicContext {
         let nullifier = compute_l1_to_l2_message_nullifier(message_hash, secret);
 
         assert(
-            !self.nullifier_exists(nullifier, self.this_address()),
+            !self.nullifier_exists_unsafe(nullifier, self.this_address()),
             "L1-to-L2 message is already nullified",
         );
         assert(

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
@@ -28,7 +28,12 @@ pub fn mark_as_initialized_private(context: &mut PrivateContext) {
 // Used by `create_init_check` (you won't find it through searching)
 pub fn assert_is_initialized_public(context: PublicContext) {
     let init_nullifier = compute_unsiloed_contract_initialization_nullifier(context.this_address());
-    assert(context.nullifier_exists(init_nullifier, context.this_address()), "Not initialized");
+    // Safety: TODO(F-239) - this is currently unsafe, we cannot rely on the nullifier existing to determine that any
+    // public component of contract initialization has been complete.
+    assert(
+        context.nullifier_exists_unsafe(init_nullifier, context.this_address()),
+        "Not initialized",
+    );
 }
 
 // Used by `create_init_check` (you won't find it through searching)

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -174,7 +174,12 @@ impl<T> PublicImmutable<T, PublicContext> {
 
     fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
-        self.context.nullifier_exists(nullifier, self.context.this_address())
+
+        // Safety: it is safe to assume that the state variable has been initialized if the initialization nullifier
+        // exists because the nullifier was emitted in a public function, at the same time the state variable's public
+        // storage was written to. This would only be unsafe if the nullifier was emitted in a private function which
+        // then enqueued the public storage write, which is not the case.
+        self.context.nullifier_exists_unsafe(nullifier, self.context.this_address())
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -121,7 +121,7 @@ unconstrained fn read_nonexistent_nullifier() {
     let env = TestEnvironment::new();
 
     env.public_context(|context| {
-        assert(!context.nullifier_exists(nullifier, context.this_address()));
+        assert(!context.nullifier_exists_unsafe(nullifier, context.this_address()));
     });
 }
 
@@ -131,7 +131,7 @@ unconstrained fn read_public_nullifier_same_context() {
 
     env.public_context(|context| {
         context.push_nullifier(nullifier);
-        assert(context.nullifier_exists(nullifier, context.this_address()));
+        assert(context.nullifier_exists_unsafe(nullifier, context.this_address()));
     });
 }
 
@@ -142,7 +142,7 @@ unconstrained fn read_public_nullifier_other_context() {
     env.public_context(|context| { context.push_nullifier(nullifier); });
 
     env.public_context(|context| {
-        assert(context.nullifier_exists(nullifier, context.this_address()));
+        assert(context.nullifier_exists_unsafe(nullifier, context.this_address()));
     });
 }
 
@@ -153,7 +153,7 @@ unconstrained fn read_private_nullifier() {
     env.private_context(|context| { context.push_nullifier(nullifier); });
 
     env.public_context(|context| {
-        assert(context.nullifier_exists(nullifier, context.this_address()));
+        assert(context.nullifier_exists_unsafe(nullifier, context.this_address()));
     });
 }
 

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -208,8 +208,10 @@ impl PartialUintNote {
         // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
         // state variable's storage slot, and it is internally consistent).
         let validity_commitment = self.compute_validity_commitment(completer);
+        // Safety: we're using the existence of the nullifier as proof of the contract having validated the partial
+        // note's preimage, which is safe.
         assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
+            context.nullifier_exists_unsafe(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -196,8 +196,10 @@ impl PartialNFTNote {
         // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
         // state variable's storage slot, and it is internally consistent).
         let validity_commitment = self.compute_validity_commitment(completer);
+        // Safety: we're using the existence of the nullifier as proof of the contract having validated the partial
+        // note's preimage, which is safe.
         assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
+            context.nullifier_exists_unsafe(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
 

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
@@ -150,13 +150,17 @@ pub contract ContractInstanceRegistry {
     fn update(new_contract_class_id: ContractClassId) {
         let address = self.msg_sender().unwrap();
 
+        // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
+        // information through publishing, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists(address.to_field(), self.address),
+            self.context.nullifier_exists_unsafe(address.to_field(), self.address),
             "msg.sender is not deployed",
         );
 
+        // Safety: we're using the nullifier's existence as a guarantee of the availability of the new contract class'
+        // information through registration, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists(
+            self.context.nullifier_exists_unsafe(
                 new_contract_class_id.to_field(),
                 CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
             ),
@@ -185,8 +189,10 @@ pub contract ContractInstanceRegistry {
     fn set_update_delay(new_update_delay: u64) {
         let msg_sender = self.msg_sender().unwrap();
 
+        // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
+        // information through publishing, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists(msg_sender.to_field(), self.address),
+            self.context.nullifier_exists_unsafe(msg_sender.to_field(), self.address),
             "msg.sender is not deployed",
         );
 

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -704,19 +704,22 @@ pub contract AvmTest {
 
     #[contract_library_method]
     fn _nullifier_exists(context: PublicContext, address: AztecAddress, nullifier: Field) -> bool {
-        context.nullifier_exists(nullifier, address)
+        context.nullifier_exists_unsafe(nullifier, address)
     }
 
     #[external("public")]
     fn assert_nullifier_exists(nullifier: Field) {
-        assert(self.context.nullifier_exists(nullifier, self.address), "Nullifier doesn't exist!");
+        assert(
+            self.context.nullifier_exists_unsafe(nullifier, self.address),
+            "Nullifier doesn't exist!",
+        );
     }
 
     // Use the standard context interface to emit a new nullifier
     #[external("public")]
     fn emit_nullifier_and_check(nullifier: Field) {
         self.context.push_nullifier(nullifier);
-        let exists = self.context.nullifier_exists(nullifier, self.address);
+        let exists = self.context.nullifier_exists_unsafe(nullifier, self.address);
         assert(exists, "Nullifier was just created, but its existence wasn't detected!");
     }
 


### PR DESCRIPTION
This marks the public read nullifier function as unsafe, and explains what is unsafe about it. It clearly points out our own unsafe usage, which we need to address.

I took the opportunity to improve the docs of this and related functions.