### PR TITLE
fix(avm): constraint when unwinding empty call stack

### DIFF
--- a/barretenberg/cpp/pil/vm2/opcodes/internal_call.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/internal_call.pil
@@ -35,9 +35,10 @@ namespace execution;
     // If we encounter a sel_execute_internal_call, the next internal_call_id is the current next_internal_call_id
     #[NEW_CALL_ID_ON_CALL]
     sel_execute_internal_call * (internal_call_id' - next_internal_call_id) = 0;
-    // If we encounter a sel_return_call, the next internal_call_id is the current internal_call_return_id
+    // If we unwind the call stack (i.e. sel_internal_return_call that does not error), the next internal_call_id is the current internal_call_return_id
+    // This is gated by (1 - sel_opcode_error) so we don't enforce the constraint when the callstack is empty
     #[RESTORE_INTERNAL_ID_ON_RETURN]
-    sel_execute_internal_return * (internal_call_id' - internal_call_return_id) = 0;
+    sel_read_unwind_call_stack * (internal_call_id' - internal_call_return_id) = 0;
     // Otherwise it's propagated down
     #[DEFAULT_PROPAGATE_CALL_ID]
     NOT_LAST_EXEC * PROPAGATE_CALL_ID * (internal_call_id' - internal_call_id) = 0;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/internal_call_impl.hpp
@@ -41,7 +41,7 @@ void internal_callImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     }
     { // RESTORE_INTERNAL_ID_ON_RETURN
         using View = typename std::tuple_element_t<2, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::execution_sel_execute_internal_return)) *
+        auto tmp = static_cast<View>(in.get(C::execution_sel_read_unwind_call_stack)) *
                    (static_cast<View>(in.get(C::execution_internal_call_id_shift)) -
                     static_cast<View>(in.get(C::execution_internal_call_return_id)));
         std::get<2>(evals) += (tmp * scaling_factor);


### PR DESCRIPTION
`internal_call_return` forces `internal_call_id' = return_id`. However, during an error (when the call stack is empty) `return_id = 0` which forces `internal_call_id' = 0`. When there is another enqueued call after an error row (specifically this only happens when there is a teardown), there are constraints that enforce `internal_call_id' = 1`.

These are contradictory constraints and the solution is to only enforce `internal_call_id' = return_id` if there are no errors.

This didnt get detected via other fuzzers or tests because in the single enqueued call variant, the next row is defaulted to zero which enables the buggy relation to pass.