### PR TITLE
chore: keccak readme and code cleanup

### DIFF
--- a/barretenberg/cpp/scripts/audit/audit_scopes/blake2s_blake3_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/blake2s_blake3_audit_scope.md
@@ -1,7 +1,7 @@
 # BLAKE2s + BLAKE3 Audit Scope
 
 Repository: https://github.com/AztecProtocol/aztec-packages
-Commit hash: 4a956ceb179c2fe855e4f1fd78f2594e7fc3f5ea
+Commit hash: 8fb8b041d4c9179f62da56a9c7bbf22c40db46cc
 
 ### Files to audit
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/README.md
@@ -1,0 +1,73 @@
+# Keccak Circuit Implementation
+
+## Specification
+- NIST FIPS 202: defines Keccak-f[1600] (as KECCAK-p[1600,24]) and the sponge construction.
+  - https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf
+
+## Overview
+Circuit-friendly implementation of **Keccak-f[1600]** permutation using lookup tables and sparse form arithmetic.
+
+Keccak-f[1600] (`keccakf1600(internal)`) operates on a 1600-bit state arranged as 25 lanes of 64 bits in 24 rounds. Each round applies:
+1. θ (THETA): column parity mixing
+2. ρ (RHO): lane rotations
+3. π (PI): lane permutation
+4. χ (CHI): non-linear step
+5. ι (IOTA): XOR a round constant into lane 0
+
+The implementation uses sparse base-11 representation. Instead of representing a 64-bit lane as a binary integer $\sum_{i=0}^{63} b_i \cdot 2^i$, it is represented in a sparse base-11 form as $\sum_{i=0}^{63} b_i \cdot 11^i$. Here, each digit $b_i$ is ideally a bit (0 or 1), but it may take values between $0-10$ for intermediate computations.
+
+Operations in Keccak's permutation are dominated by bitwise logic and rotations. These operations are expensive in circuit. The sparse base-11 representation allows performing these operations via additions and lookup-based normalization.
+
+### Bitwise operations
+- XOR can be computed by first adding sparse integers, and then normalizing each digit back to $0/1$ using lookups (even maps to $0$, odd maps to $1$).
+
+    IOTA round XORs a round constant into lane 0 using this sparse base-11 representation.
+
+
+- CHI round involves the non-linear operation `A XOR (~B AND C)`. In base-11 representation we can perform an equivalent linear operation `1 + 2A - B + C`. The output values will range between $0-4$, and are mapped back into $0-1$ via the `KECCAK_CHI_OUTPUT` lookup table.
+
+### Rotations
+- RHO round requires rotating each 64-bit lane by a lane-specific offset. The helper `normalize_and_rotate<lane_index>()` does both by
+    - slicing the base-11 integer into chunks,
+    - using a RHO lookup to:
+        - normalize each chunk, and
+        - reorder chunks to get the effect of rotation.
+
+    It also extracts the most significant bit (MSB) of the normalized lane which is used later. This is implemented via the `KECCAK_NORMALIZE_AND_ROTATE` lookup table.
+- THETA round involves performing `XOR(A, ROTL(B,1))`-style operations. Instead of using a rotate-by-1, the implementation uses a twisted representation, where $\text{twisted-limb} = (b_{63}) + \sum_{i=0}^{63} b_i * 11^{i + 1}$. For example, if limb's bit ordering is
+
+    [0, b63, ..., b1, b0 ] then, the twisted limb bit ordering is
+
+    [b63, b62, ..., b0, b63].
+
+    Thus, the equivalent of `XOR(A, ROTL(B,1))` in base-11 world is twisted_A * 2 + twisted_B.
+    The output of this operation resides in bit-slices 1, ..., 63 which can be extracted by removing the least and most significant slices of the output.
+    The THETA round also requires normalization of intermediate values which is performed using the `KECCAK_THETA_OUTPUT` lookup table.
+
+
+PI round is a pure rearrangement of the 25 lanes and does not add any constraints.
+
+
+
+
+## API
+The following is the permutation opcode interface.
+```cpp
+permutation_opcode(
+    std::array<field_ct, NUM_KECCAK_LANES> state, Builder* ctx)
+```
+Inputs:
+- `state`: an array of 25 field elements (`NUM_KECCAK_LANES` = 25), each representing a 64-bit lane of the Keccak state
+- `ctx`: the circuit builder context
+
+Outputs:
+- Returns an array of 25 field elements, representing the Keccak-f[1600] permuted state in the 64-bit-lane representation.
+
+It does the following.
+1. Format input:
+Each 64-bit lane is converted into sparse base-11 representation using the `KECCAK_FORMAT_INPUT` lookup table, also producing its MSB.
+2. Compute twisted state:
+Precompute twisted lanes for THETA.
+3. Run `keccakf1600(internal)`: which applies 24 rounds of THETA, RHO, PI, CHI, IOTA.
+4. Format output:
+Convert sparse lanes back to standard 64-bit-lane values using `KECCAK_FORMAT_OUTPUT`.

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/README.md
@@ -14,9 +14,7 @@ Keccak-f[1600] (`keccakf1600(internal)`) operates on a 1600-bit state arranged a
 4. χ (CHI): non-linear step
 5. ι (IOTA): XOR a round constant into lane 0
 
-The implementation uses sparse base-11 representation. Instead of representing a 64-bit lane as a binary integer $\sum_{i=0}^{63} b_i \cdot 2^i$, it is represented in a sparse base-11 form as $\sum_{i=0}^{63} b_i \cdot 11^i$. Here, each digit $b_i$ is ideally a bit (0 or 1), but it may take values between $0-10$ for intermediate computations.
-
-Operations in Keccak's permutation are dominated by bitwise logic and rotations. These operations are expensive in circuit. The sparse base-11 representation allows performing these operations via additions and lookup-based normalization.
+The implementation uses sparse base-11 representation to implement Keccak’s bitwise logic using cheaper arithmetic operations on digits without generating carries. Instead of representing a 64-bit lane as a binary integer $\sum_{i=0}^{63} b_i \cdot 2^i$, it is represented in a sparse base-11 form as $\sum_{i=0}^{63} b_i \cdot 11^i$. Choosing 11 ensures that when we implement Keccak’s bitwise logic using small arithmetic expressions on digits, the digits don’t produce carries into neighboring positions. During these equivalent sparse form computations, each digit can temporarily take a small value (${0,\dots,10}$), and is then normalized back to ${0,1}$ digitwise using lookup tables.
 
 ### Bitwise operations
 - XOR can be computed by first adding sparse integers, and then normalizing each digit back to $0/1$ using lookups (even maps to $0$, odd maps to $1$).

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.cpp
@@ -317,35 +317,9 @@ template <typename Builder> void keccak<Builder>::theta(keccak_state& internal)
 
         // If number of bits in KECCAK_THETA_OUTPUT table does NOT cleanly divide KECCAK_LANE_SIZE=64,
         // we need an additional range constraint to ensure that mid < 11^64
-        if constexpr (KECCAK_LANE_SIZE % plookup::keccak_tables::Theta::TABLE_BITS == 0) {
-            // N.B. we could optimize out 5 gates per round here but it's very fiddly...
-            // In previous section, D[i] = X + Y (non shifted equiv and shifted equiv)
-            // We also want to validate D[i] == hi' + mid' + lo (where hi', mid' are hi, mid scaled by constants)
-            // We *could* create a big addition gate to validate the previous logic w. following structure:
-            // | w1 | w2  | w3 | w4 |
-            // | -- | --- | -- | -- |
-            // | hi | mid | lo | X  |
-            // | P0 | P1  | P2 | Y  |
-            // To save a gate, we would need to place the wires for the first KECCAK_THETA_OUTPUT plookup gate
-            // at P0, P1, P2. This is fiddly builder logic that is circuit-width-dependent
-            // (this would save 120 gates per hash block... not worth making the code less readable for that)
-            D[i] = plookup_read<Builder>::read_from_1_to_2_table(KECCAK_THETA_OUTPUT, mid);
-        } else {
-            const auto accumulators = plookup_read<Builder>::get_lookup_accumulators(KECCAK_THETA_OUTPUT, D[i]);
-            D[i] = accumulators[ColumnIdx::C2][0];
-
-            // Ensure input to lookup is < 11^{KECCAK_LANE_SIZE},
-            // by validating most significant input slice is < 11^{KECCAK_LANE_SIZE mod slice_bits}
-            const field_ct most_significant_slice = accumulators[ColumnIdx::C1][accumulators[ColumnIdx::C1].size() - 1];
-
-            // N.B. cheaper to validate (11^{KECCAK_LANE_SIZE mod slice_bits} - slice < 2^14) as this
-            // prevents an extra range table from being created
-            constexpr uint256_t maximum = BASE.pow(KECCAK_LANE_SIZE % plookup::keccak_tables::Theta::TABLE_BITS);
-            const field_ct target = -most_significant_slice + maximum;
-            BB_ASSERT_GT((uint256_t(1) << Builder::DEFAULT_PLOOKUP_RANGE_BITNUM) - 1, maximum);
-            target.create_range_constraint(Builder::DEFAULT_PLOOKUP_RANGE_BITNUM,
-                                           "input to KECCAK_THETA_OUTPUT too large!");
-        }
+        static_assert(KECCAK_LANE_SIZE % plookup::keccak_tables::Theta::TABLE_BITS == 0,
+                      "KECCAK_THETA_OUTPUT TABLE_BITS must divide KECCAK_LANE_SIZE.");
+        D[i] = plookup_read<Builder>::read_from_1_to_2_table(KECCAK_THETA_OUTPUT, mid);
     }
 
     // compute state[j * 5 + i] XOR D[i] in base-11 representation

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/keccak/keccak.hpp
@@ -11,9 +11,9 @@
 namespace bb::stdlib {
 
 /**
- * @brief KECCAAAAAAAAAAK
+ * @brief KECCAK
  *
- * Creates constraints that evaluate the Keccak256 hash algorithm.
+ * Creates constraints that evaluate the Keccak-f[1600] permutation.
  *
  * Ultra only due to heavy lookup table use.
  *
@@ -160,17 +160,6 @@ template <typename Builder> class keccak {
     static void iota(keccak_state& state, size_t round);
 
     static void keccakf1600(keccak_state& state);
-
-    static std::vector<uint8_t> hash_native(const std::vector<uint8_t>& data)
-    {
-        auto hash_result = ethash_keccak256(&data[0], data.size());
-
-        std::vector<uint8_t> output;
-        output.resize(32);
-
-        memcpy((void*)&output[0], (void*)&hash_result.word64s[0], 32);
-        return output;
-    }
 
     // exposing keccak f1600 permutation
 


### PR DESCRIPTION
- Add a README for keccak circuit implementation. 
- Remove `hash_native` that is unused. 