### PR TITLE
refactor: staged writes in private events

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -409,7 +409,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       ),
     );
 
-    const eventService = new EventService(this.anchorBlockStore, this.aztecNode, this.privateEventStore);
+    const eventService = new EventService(this.anchorBlockStore, this.aztecNode, this.privateEventStore, this.jobId);
     const eventStorePromises = eventValidationRequests.map(request =>
       eventService.storeEvent(
         request.contractAddress,

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -80,15 +80,15 @@ describe('storeEvent', () => {
 
     aztecNode.getTxEffect.mockImplementation(() => Promise.resolve(indexedTxEffect));
 
-    eventService = new EventService(anchorBlockStore, aztecNode, privateEventStore);
+    eventService = new EventService(anchorBlockStore, aztecNode, privateEventStore, 'test');
   });
 
-  function runStoreEvent(
+  async function runStoreEvent(
     overrides: {
       eventCommitment?: Fr;
     } = {},
   ) {
-    return eventService.storeEvent(
+    await eventService.storeEvent(
       contractAddress,
       eventSelector,
       randomness,
@@ -97,6 +97,8 @@ describe('storeEvent', () => {
       txEffect.txHash,
       recipient,
     );
+
+    await privateEventStore.commit('test');
   }
 
   it('should throw when tx does not exist or has no effects', async () => {

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -13,6 +13,7 @@ export class EventService {
     private readonly anchorBlockStore: AnchorBlockStore,
     private readonly aztecNode: AztecNode,
     private readonly privateEventStore: PrivateEventStore,
+    private readonly jobId: string,
   ) {}
 
   public async storeEvent(
@@ -52,14 +53,21 @@ export class EventService {
       );
     }
 
-    return this.privateEventStore.storePrivateEventLog(selector, randomness, content, siloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber: txEffect.l2BlockNumber,
-      l2BlockHash: txEffect.l2BlockHash,
-      txIndexInBlock: txEffect.txIndexInBlock,
-      eventIndexInTx,
-    });
+    return this.privateEventStore.storePrivateEventLog(
+      selector,
+      randomness,
+      content,
+      siloedEventCommitment,
+      {
+        contractAddress,
+        scope,
+        txHash,
+        l2BlockNumber: txEffect.l2BlockNumber,
+        l2BlockHash: txEffect.l2BlockHash,
+        txIndexInBlock: txEffect.txIndexInBlock,
+        eventIndexInTx,
+      },
+      this.jobId,
+    );
   }
 }

--- a/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.test.ts
@@ -25,17 +25,17 @@ describe('PrivateEventFilterValidator', () => {
     anchorBlockStore = mock<AnchorBlockStore>();
 
     anchorBlockStore.getBlockHeader.mockResolvedValue(lastKnownBlock);
-    validator = new PrivateEventFilterValidator(anchorBlockStore);
+    validator = new PrivateEventFilterValidator(lastKnownBlockNumber);
   });
 
-  it('rejects empty scope', async () => {
-    await expect(validator.validate({ contractAddress, fromBlock: lastKnownBlockNumber, scopes: [] })).rejects.toThrow(
+  it('rejects empty scope', () => {
+    expect(() => validator.validate({ contractAddress, fromBlock: lastKnownBlockNumber, scopes: [] })).toThrow(
       /At least one scope is required to get private events/,
     );
   });
 
-  it('defaults to whole range', async () => {
-    const dataProviderFilter = await validator.validate({ contractAddress, scopes: [scope] });
+  it('defaults to whole range', () => {
+    const dataProviderFilter = validator.validate({ contractAddress, scopes: [scope] });
     expect(dataProviderFilter).toEqual({
       contractAddress,
       scopes: [scope],
@@ -45,8 +45,8 @@ describe('PrivateEventFilterValidator', () => {
     });
   });
 
-  it('toBlock defaults to lastKnownBlock + 1', async () => {
-    const dataProviderFilter = await validator.validate({
+  it('toBlock defaults to lastKnownBlock + 1', () => {
+    const dataProviderFilter = validator.validate({
       contractAddress,
       scopes: [scope],
       fromBlock: INITIAL_L2_BLOCK_NUM,
@@ -59,8 +59,8 @@ describe('PrivateEventFilterValidator', () => {
     });
   });
 
-  it('toBlock without fromBlock defaults to [INITIAL_L2_BLOCK_NUM, toBlock)', async () => {
-    const dataProviderFilter = await validator.validate({
+  it('toBlock without fromBlock defaults to [INITIAL_L2_BLOCK_NUM, toBlock)', () => {
+    const dataProviderFilter = validator.validate({
       contractAddress,
       scopes: [scope],
       toBlock: BlockNumber(lastKnownBlockNumber + 1),
@@ -73,28 +73,28 @@ describe('PrivateEventFilterValidator', () => {
     });
   });
 
-  it('rejects fromBlock >= toBlock', async () => {
-    await expect(
+  it('rejects fromBlock >= toBlock', () => {
+    expect(() =>
       validator.validate({
         contractAddress,
         scopes: [scope],
         fromBlock: lastKnownBlockNumber,
         toBlock: lastKnownBlockNumber,
       }),
-    ).rejects.toThrow(/toBlock must be strictly greater than fromBlock/);
+    ).toThrow(/toBlock must be strictly greater than fromBlock/);
 
-    await expect(
+    expect(() =>
       validator.validate({
         contractAddress,
         scopes: [scope],
         fromBlock: lastKnownBlockNumber,
         toBlock: BlockNumber(lastKnownBlockNumber - 1),
       }),
-    ).rejects.toThrow(/toBlock must be strictly greater than fromBlock/);
+    ).toThrow(/toBlock must be strictly greater than fromBlock/);
   });
 
-  it('preserves txHash', async () => {
-    let dataProviderFilter = await validator.validate({
+  it('preserves txHash', () => {
+    let dataProviderFilter = validator.validate({
       contractAddress,
       scopes: [scope],
       fromBlock: INITIAL_L2_BLOCK_NUM,
@@ -108,7 +108,7 @@ describe('PrivateEventFilterValidator', () => {
     });
 
     const txHash = TxHash.random();
-    dataProviderFilter = await validator.validate({
+    dataProviderFilter = validator.validate({
       contractAddress,
       scopes: [scope],
       fromBlock: INITIAL_L2_BLOCK_NUM,

--- a/yarn-project/pxe/src/events/private_event_filter_validator.ts
+++ b/yarn-project/pxe/src/events/private_event_filter_validator.ts
@@ -2,13 +2,12 @@ import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 
-import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import type { PrivateEventStoreFilter } from '../storage/private_event_store/private_event_store.js';
 
 export class PrivateEventFilterValidator {
-  constructor(private anchorBlockStore: AnchorBlockStore) {}
+  constructor(private lastBlock: BlockNumber) {}
 
-  async validate(filter: PrivateEventFilter): Promise<PrivateEventStoreFilter> {
+  validate(filter: PrivateEventFilter): PrivateEventStoreFilter {
     let { fromBlock, toBlock } = filter;
 
     // Block range filters in Aztec Node are defined as closed-open intervals [fromBlock, toBlock), so
@@ -16,9 +15,8 @@ export class PrivateEventFilterValidator {
     // We then default to [INITIAL_L2_BLOCK_NUM, latestKnownBlock + 1), ie: by default return events from
     // the first block to the latest known block.
     if (!fromBlock || !toBlock) {
-      const lastKnownBlock = (await this.anchorBlockStore.getBlockHeader()).getBlockNumber();
       fromBlock = fromBlock ?? BlockNumber(INITIAL_L2_BLOCK_NUM);
-      toBlock = toBlock ?? BlockNumber(lastKnownBlock + 1);
+      toBlock = toBlock ?? BlockNumber(this.lastBlock + 1);
     }
 
     if (filter.scopes.length === 0) {

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -238,6 +238,7 @@ describe('PXE', () => {
           txIndexInBlock: 0,
           eventIndexInTx: eventCounter++,
         },
+        'test',
       );
 
       return event;
@@ -247,6 +248,7 @@ describe('PXE', () => {
       // Store a couple of events to exercise `getPrivateEvents`
       const event1 = await storeEvent();
       const event2 = await storeEvent();
+      await privateEventStore.commit('test');
 
       const events = await pxe.getPrivateEvents(eventSelector, {
         contractAddress,
@@ -287,6 +289,8 @@ describe('PXE', () => {
           storeEvent(lastKnownBlockNumber + 1),
           storeEvent(lastKnownBlockNumber + 1),
         ]);
+
+        await privateEventStore.commit('test');
       });
 
       it('filters by txHash', async () => {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1,4 +1,5 @@
 import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
@@ -157,7 +158,7 @@ export class PXE {
     );
 
     const jobCoordinator = new JobCoordinator(store);
-    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore]);
+    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore, privateEventStore]);
 
     const debugUtils = new PXEDebugUtils(contractStore, noteStore);
 
@@ -1009,9 +1010,17 @@ export class PXE {
    *    Defaults to the latest known block to PXE + 1.
    * @returns - The packed events with block and tx metadata.
    */
-  public getPrivateEvents(eventSelector: EventSelector, filter: PrivateEventFilter): Promise<PackedPrivateEvent[]> {
-    return this.#putInJobQueue(async jobId => {
+  public async getPrivateEvents(
+    eventSelector: EventSelector,
+    filter: PrivateEventFilter,
+  ): Promise<PackedPrivateEvent[]> {
+    let anchorBlockNumber: BlockNumber;
+
+    await this.#putInJobQueue(async jobId => {
       await this.blockStateSynchronizer.sync();
+
+      anchorBlockNumber = (await this.anchorBlockStore.getBlockHeader()).getBlockNumber();
+
       const contractFunctionSimulator = this.#getSimulatorForTx();
 
       await this.contractStore.syncPrivateState(
@@ -1020,15 +1029,16 @@ export class PXE {
         async privateSyncCall =>
           await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
       );
-
-      const sanitizedFilter = await new PrivateEventFilterValidator(this.anchorBlockStore).validate(filter);
-
-      this.log.debug(
-        `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,
-      );
-
-      return this.privateEventStore.getPrivateEvents(eventSelector, sanitizedFilter);
     });
+
+    // anchorBlockNumber is set during the job and fixed to whatever it is after a block sync
+    const sanitizedFilter = new PrivateEventFilterValidator(anchorBlockNumber!).validate(filter);
+
+    this.log.debug(
+      `Getting private events for ${sanitizedFilter.contractAddress.toString()} from ${sanitizedFilter.fromBlock} to ${sanitizedFilter.toBlock}`,
+    );
+
+    return this.privateEventStore.getPrivateEvents(eventSelector, sanitizedFilter);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -1,4 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
@@ -49,34 +50,56 @@ describe('PrivateEventStore', () => {
   });
 
   it('stores and retrieves private events', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
+    {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        siloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.commit('test');
+    }
+
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
       fromBlock: l2BlockNumber,
       toBlock: l2BlockNumber + 1,
       scopes: [scope],
     });
+
     expect(events).toEqual([expectedEvent]);
   });
 
   it('ignores duplicate events with same siloedEventCommitment', async () => {
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
+    {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        siloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.commit('test');
+    }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -91,24 +114,41 @@ describe('PrivateEventStore', () => {
   it('allows multiple events with same content but different siloedEventCommitment', async () => {
     const otherSiloedEventCommitment = Fr.random();
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, otherSiloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 1,
-    });
+    {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        siloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        otherSiloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 1,
+        },
+        'test',
+      );
+      await privateEventStore.commit('test');
+    }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -127,33 +167,57 @@ describe('PrivateEventStore', () => {
       l2BlockNumber: BlockNumber(200),
     };
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), Fr.random(), {
-      contractAddress,
-      scope,
-      txHash: TxHash.random(),
-      l2BlockNumber: BlockNumber(100),
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, Fr.random(), {
-      contractAddress,
-      scope,
-      txHash: expectedEvent.txHash,
-      l2BlockNumber: expectedEvent.l2BlockNumber,
-      l2BlockHash: expectedEvent.l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, getRandomMsgContent(), Fr.random(), {
-      contractAddress,
-      scope,
-      txHash: TxHash.random(),
-      l2BlockNumber: BlockNumber(300),
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
+    {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        getRandomMsgContent(),
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(100),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: expectedEvent.txHash,
+          l2BlockNumber: expectedEvent.l2BlockNumber,
+          l2BlockHash: expectedEvent.l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        getRandomMsgContent(),
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(300),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.commit('test');
+    }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -168,24 +232,41 @@ describe('PrivateEventStore', () => {
   it('filters events by recipient', async () => {
     const otherScope = await AztecAddress.random();
 
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, siloedEventCommitment, {
-      contractAddress,
-      scope,
-      txHash,
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
-    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, Fr.random(), {
-      contractAddress,
-      scope: otherScope,
-      txHash: TxHash.random(),
-      l2BlockNumber,
-      l2BlockHash,
-      txIndexInBlock: 0,
-      eventIndexInTx: 0,
-    });
+    {
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        siloedEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope: otherScope,
+          txHash: TxHash.random(),
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.commit('test');
+    }
 
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,
@@ -220,35 +301,59 @@ describe('PrivateEventStore', () => {
     });
 
     it('returns events in order by block number', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(200),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      {
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent2,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber: BlockNumber(200),
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(100),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent1,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber: BlockNumber(100),
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(300),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent3,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber: BlockNumber(300),
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
+        await privateEventStore.commit('test');
+      }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
         contractAddress,
@@ -263,36 +368,60 @@ describe('PrivateEventStore', () => {
     it('returns events in order by tx index within the same block', async () => {
       const l2BlockNumber = BlockNumber(100);
 
-      // Store events in the same block but different tx indexes (store them out of order)
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 1,
-        eventIndexInTx: 0,
-      });
+      {
+        // Store events in the same block but different tx indexes (store them out of order)
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent2,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 1,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent1,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 2,
-        eventIndexInTx: 0,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent3,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash: TxHash.random(),
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 2,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
+        await privateEventStore.commit('test');
+      }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
         contractAddress,
@@ -308,36 +437,60 @@ describe('PrivateEventStore', () => {
       const txHash = TxHash.random();
       const l2BlockNumber = BlockNumber(100);
 
-      // Store events in the same block and tx but different event indexes (store them out of order)
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash,
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 1,
-      });
+      {
+        // Store events in the same block and tx but different event indexes (store them out of order)
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent2,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash,
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 1,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash,
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent1,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash,
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 0,
+          },
+          'test',
+        );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash,
-        l2BlockNumber,
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 2,
-      });
+        await privateEventStore.storePrivateEventLog(
+          eventSelector,
+          randomness,
+          msgContent3,
+          Fr.random(),
+          {
+            contractAddress,
+            scope,
+            txHash,
+            l2BlockNumber,
+            l2BlockHash,
+            txIndexInBlock: 0,
+            eventIndexInTx: 2,
+          },
+          'test',
+        );
+        await privateEventStore.commit('test');
+      }
 
       const events = await privateEventStore.getPrivateEvents(eventSelector, {
         contractAddress,
@@ -365,45 +518,75 @@ describe('PrivateEventStore', () => {
 
     it('removes events after rollback block', async () => {
       // Store events in blocks 100, 200, 300
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(100),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent1,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(100),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'before-rollback',
+      );
       // We add another event in the same block to verify that more events per block work.
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent2, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(100),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 1,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent2,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(100),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 1,
+        },
+        'before-rollback',
+      );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent3, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(200),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent3,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(200),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'before-rollback',
+      );
 
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent4, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(300),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent4,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(300),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'before-rollback',
+      );
+
+      await privateEventStore.commit('before-rollback');
 
       // Rollback to block 150 (should remove events from blocks 200 and 300)
       await privateEventStore.rollback(150, 300);
@@ -427,15 +610,23 @@ describe('PrivateEventStore', () => {
       const reorgEventCommitment = Fr.random();
 
       // Store event at block 200
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, reorgEventCommitment, {
-        contractAddress,
-        scope,
-        txHash: reorgTxHash,
-        l2BlockNumber: BlockNumber(200),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent1,
+        reorgEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash: reorgTxHash,
+          l2BlockNumber: BlockNumber(200),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'test',
+      );
+      await privateEventStore.commit('before-rollback');
 
       // Rollback to block 100
       await privateEventStore.rollback(100, 200);
@@ -450,15 +641,24 @@ describe('PrivateEventStore', () => {
       expect(events.length).toBe(0);
 
       // Re-add the same event (same siloedEventCommitment and txHash, as happens after a reorg)
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, reorgEventCommitment, {
-        contractAddress,
-        scope,
-        txHash: reorgTxHash,
-        l2BlockNumber: BlockNumber(200),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent1,
+        reorgEventCommitment,
+        {
+          contractAddress,
+          scope,
+          txHash: reorgTxHash,
+          l2BlockNumber: BlockNumber(200),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        're-add',
+      );
+
+      await privateEventStore.commit('re-add');
 
       // Verify event can be retrieved again
       events = await privateEventStore.getPrivateEvents(eventSelector, {
@@ -471,15 +671,23 @@ describe('PrivateEventStore', () => {
     });
 
     it('handles rollback with no events to remove', async () => {
-      await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent1, Fr.random(), {
-        contractAddress,
-        scope,
-        txHash: TxHash.random(),
-        l2BlockNumber: BlockNumber(100),
-        l2BlockHash,
-        txIndexInBlock: 0,
-        eventIndexInTx: 0,
-      });
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        randomness,
+        msgContent1,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber: BlockNumber(100),
+          l2BlockHash,
+          txIndexInBlock: 0,
+          eventIndexInTx: 0,
+        },
+        'before-rollback',
+      );
+      await privateEventStore.commit('before-rollback');
 
       // Rollback after all existing events
       await privateEventStore.rollback(200, 300);
@@ -493,6 +701,157 @@ describe('PrivateEventStore', () => {
 
       expect(events.length).toBe(1);
       expect(events[0].packedEvent).toEqual(msgContent1);
+    });
+  });
+
+  describe('staging', () => {
+    it('stages events without affecting committed storage', async () => {
+      const commitJobId: string = 'commit-job';
+      const stagingJobId: string = 'staging-job';
+
+      const committedEventRandomness = Fr.random();
+      const stagedEventRandomness = Fr.random();
+
+      // Store committed event
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        committedEventRandomness,
+        msgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: randomInt(100),
+          eventIndexInTx: randomInt(100),
+        },
+        commitJobId,
+      );
+      await privateEventStore.commit(commitJobId);
+
+      // Store staged event (not committed)
+      const stagedMsgContent = getRandomMsgContent();
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        stagedEventRandomness,
+        stagedMsgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: randomInt(100),
+          eventIndexInTx: randomInt(100),
+        },
+        stagingJobId,
+      );
+
+      // With a fresh jobId, should only see committed event
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: l2BlockNumber,
+        toBlock: l2BlockNumber + 1,
+        scopes: [scope],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0].packedEvent).toEqual(msgContent);
+    });
+
+    it('commit promotes staged events to main storage', async () => {
+      const stagingJobId: string = 'staging-job';
+      const stagedEventRandomness = Fr.random();
+      const stagedMsgContent = getRandomMsgContent();
+
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        stagedEventRandomness,
+        stagedMsgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: randomInt(100),
+          eventIndexInTx: randomInt(100),
+        },
+        stagingJobId,
+      );
+
+      await privateEventStore.commit(stagingJobId);
+
+      // Now should see the event with a fresh jobId
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: l2BlockNumber,
+        toBlock: l2BlockNumber + 1,
+        scopes: [scope],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0].packedEvent).toEqual(stagedMsgContent);
+    });
+
+    it('discardStaged removes staged events without affecting main', async () => {
+      const commitJobId: string = 'commit-job';
+      const stagingJobId: string = 'staging-job';
+      const committedEventRandomness = Fr.random();
+      const stagedEventRandomness = Fr.random();
+
+      // Store committed event
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        committedEventRandomness,
+        msgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash,
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: randomInt(100),
+          eventIndexInTx: randomInt(100),
+        },
+        commitJobId,
+      );
+      await privateEventStore.commit(commitJobId);
+
+      // Store staged event (not committed)
+      const stagedMsgContent = getRandomMsgContent();
+      await privateEventStore.storePrivateEventLog(
+        eventSelector,
+        stagedEventRandomness,
+        stagedMsgContent,
+        Fr.random(),
+        {
+          contractAddress,
+          scope,
+          txHash: TxHash.random(),
+          l2BlockNumber,
+          l2BlockHash,
+          txIndexInBlock: randomInt(100),
+          eventIndexInTx: randomInt(100),
+        },
+        stagingJobId,
+      );
+
+      // Discard staging
+      await privateEventStore.discardStaged(stagingJobId);
+
+      // Should only see committed event
+      const events = await privateEventStore.getPrivateEvents(eventSelector, {
+        contractAddress,
+        fromBlock: l2BlockNumber,
+        toBlock: l2BlockNumber + 1,
+        scopes: [scope],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0].packedEvent).toEqual(msgContent);
     });
   });
 });

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -2,12 +2,13 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
-import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash } from '@aztec/stdlib/block';
 import { type InTx, TxHash } from '@aztec/stdlib/tx';
 
+import type { StagedStore } from '../../job_coordinator/job_coordinator.js';
 import type { PackedPrivateEvent } from '../../pxe.js';
 
 export type PrivateEventStoreFilter = {
@@ -44,29 +45,108 @@ type PrivateEventMetadata = InTx & {
 /**
  * Stores decrypted private event logs.
  */
-export class PrivateEventStore {
+export class PrivateEventStore implements StagedStore {
+  readonly storeName: string = 'private_event';
+
   #store: AztecAsyncKVStore;
   /** Map storing the actual private event log entries, keyed by siloedEventCommitment */
   #eventLogs: AztecAsyncMap<string, PrivateEventEntry>;
-  /** Map from contractAddress_scope_eventSelector to siloedEventCommitment[] for efficient lookup */
-  #eventsByContractScopeSelector: AztecAsyncMap<string, string[]>;
-  /** Map from block number to siloedEventCommitment[] for rollback support */
-  #eventsByBlockNumber: AztecAsyncMap<number, string[]>;
+  /** Multi-map from contractAddress_scope_eventSelector to siloedEventCommitment for efficient lookup */
+  #eventsByContractScopeSelector: AztecAsyncMultiMap<string, string>;
+  /** Multi-map from block number to siloedEventCommitment for rollback support */
+  #eventsByBlockNumber: AztecAsyncMultiMap<number, string>;
   /** Map from siloedEventCommitment to boolean indicating if log has been seen. */
   #seenLogs: AztecAsyncMap<string, boolean>;
+
+  /** jobId => eventId (event siloed nullifier)  => PrivateEventEntry */
+  #eventLogsInJobStage: Map<string, Map<string, PrivateEventEntry>>;
 
   logger = createLogger('private_event_store');
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
     this.#eventLogs = this.#store.openMap('private_event_logs');
-    this.#eventsByContractScopeSelector = this.#store.openMap('events_by_contract_scope_selector');
+    this.#eventsByContractScopeSelector = this.#store.openMultiMap('events_by_contract_scope_selector');
     this.#seenLogs = this.#store.openMap('seen_logs');
-    this.#eventsByBlockNumber = this.#store.openMap('events_by_block_number');
+    this.#eventsByBlockNumber = this.#store.openMultiMap('events_by_block_number');
+
+    this.#eventLogsInJobStage = new Map();
   }
 
   #keyFor(contractAddress: AztecAddress, scope: AztecAddress, eventSelector: EventSelector): string {
     return `${contractAddress.toString()}_${scope.toString()}_${eventSelector.toString()}`;
+  }
+
+  async commit(jobId: string): Promise<void> {
+    await Promise.all(
+      [...this.#getEventLogsInJobStage(jobId).entries()].map(async ([eventId, eventEntry]) => {
+        this.logger.verbose('storing private event log (KV store)', eventEntry);
+
+        await Promise.all([
+          this.#eventLogs.set(eventId, eventEntry),
+          this.#eventsByContractScopeSelector.set(eventEntry.lookupKey, eventId),
+          this.#eventsByBlockNumber.set(eventEntry.l2BlockNumber, eventId),
+          this.#seenLogs.set(eventId, true),
+        ]);
+      }),
+    );
+
+    return this.discardStaged(jobId);
+  }
+
+  discardStaged(jobId: string): Promise<void> {
+    this.#eventLogsInJobStage.delete(jobId);
+    return Promise.resolve();
+  }
+
+  #getEventLogsInJobStage(jobId: string): Map<string, PrivateEventEntry> {
+    let jobStage = this.#eventLogsInJobStage.get(jobId);
+    if (jobStage === undefined) {
+      jobStage = new Map();
+      this.#eventLogsInJobStage.set(jobId, jobStage);
+    }
+    return jobStage;
+  }
+
+  async #isSeenLog(jobId: string, eventId: string): Promise<boolean> {
+    const eventLogsInJobStage = this.#getEventLogsInJobStage(jobId).get(eventId);
+    return !!eventLogsInJobStage || !!(await this.#seenLogs.getAsync(eventId));
+  }
+
+  #addEventLogToStage(jobId: string, eventId: string, eventEntry: PrivateEventEntry) {
+    this.#getEventLogsInJobStage(jobId).set(eventId, eventEntry);
+  }
+
+  async #getEventSiloedNullifiers(
+    contractAddress: AztecAddress,
+    scope: AztecAddress,
+    eventSelector: EventSelector,
+    jobId?: string,
+  ): Promise<string[]> {
+    const key = this.#keyFor(contractAddress, scope, eventSelector);
+    const eventSiloedNullifiersInStorage: string[] = [];
+    for await (const eventId of this.#eventsByContractScopeSelector.getValuesAsync(key)) {
+      eventSiloedNullifiersInStorage.push(eventId);
+    }
+
+    if (!jobId) {
+      return eventSiloedNullifiersInStorage;
+    }
+
+    const eventSiloedNullifiersInJobStage = new Set(
+      [...this.#getEventLogsInJobStage(jobId).entries()]
+        .filter(([_, entry]) => entry.lookupKey === key)
+        .map(([idx, _]) => idx),
+    );
+    return [...new Set(eventSiloedNullifiersInStorage).union(eventSiloedNullifiersInJobStage)];
+  }
+
+  async #getEventLogBySiloedNullifier(eventId: string, jobId?: string): Promise<PrivateEventEntry | undefined> {
+    if (jobId) {
+      return this.#getEventLogsInJobStage(jobId).get(eventId) ?? (await this.#eventLogs.getAsync(eventId));
+    } else {
+      return await this.#eventLogs.getAsync(eventId);
+    }
   }
 
   /**
@@ -87,6 +167,7 @@ export class PrivateEventStore {
     msgContent: Fr[],
     siloedEventCommitment: Fr,
     metadata: PrivateEventMetadata,
+    jobId: string,
   ): Promise<void> {
     const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
 
@@ -97,15 +178,20 @@ export class PrivateEventStore {
       // reason we use it as id.
       const eventId = siloedEventCommitment.toString();
 
-      const hasBeenSeen = await this.#seenLogs.getAsync(eventId);
+      const hasBeenSeen = await this.#isSeenLog(jobId, eventId);
       if (hasBeenSeen) {
         this.logger.verbose('Ignoring duplicate event log', { txHash: txHash.toString(), siloedEventCommitment });
         return;
       }
 
-      this.logger.verbose('storing private event log', { contractAddress, scope, msgContent, l2BlockNumber });
+      this.logger.verbose('storing private event log (job stage)', {
+        contractAddress,
+        scope,
+        msgContent,
+        l2BlockNumber,
+      });
 
-      await this.#eventLogs.set(eventId, {
+      this.#addEventLogToStage(jobId, eventId, {
         randomness,
         msgContent: serializeToBuffer(msgContent),
         l2BlockNumber,
@@ -115,15 +201,6 @@ export class PrivateEventStore {
         eventIndexInTx,
         lookupKey: key,
       });
-
-      const existingIds = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
-      await this.#eventsByContractScopeSelector.set(key, [...existingIds, eventId]);
-
-      const existingBlockIds = (await this.#eventsByBlockNumber.getAsync(l2BlockNumber)) || [];
-      await this.#eventsByBlockNumber.set(l2BlockNumber, [...existingBlockIds, eventId]);
-
-      // Mark this log as seen
-      await this.#seenLogs.set(eventId, true);
     });
   }
 
@@ -150,11 +227,11 @@ export class PrivateEventStore {
     }> = [];
 
     for (const scope of filter.scopes) {
-      const key = this.#keyFor(filter.contractAddress, scope, eventSelector);
-      const eventIds = (await this.#eventsByContractScopeSelector.getAsync(key)) || [];
+      const eventIds = await this.#getEventSiloedNullifiers(filter.contractAddress, scope, eventSelector);
 
       for (const eventId of eventIds) {
-        const entry = await this.#eventLogs.getAsync(eventId);
+        const entry = await this.#getEventLogBySiloedNullifier(eventId);
+
         if (!entry || entry.l2BlockNumber < filter.fromBlock || entry.l2BlockNumber >= filter.toBlock) {
           continue;
         }
@@ -202,14 +279,29 @@ export class PrivateEventStore {
    * Rolls back private events that were stored after a given `blockNumber` and up to `synchedBlockNumber` (the block
    * number up to which PXE managed to sync before the reorg happened).
    *
+   * We don't need staged writes for a rollback since it's handled in the context of a blockchain rewind.
+   *
+   * Rollbacks are handled by the BlockSynchronizer, which runs a DB transaction across stores when it detects a
+   * re-org, including setting the new anchor block after rolling back.
+   *
+   * So if anything fails in the process of rolling back any store, all DB changes occurring during rollbacks will be
+   * lost and the anchor block will not be updated; which means this code will eventually need to run again
+   * (i.e.: PXE will detect it's basing it work on an invalid block hash, then which re-triggers rewind).
+   *
+   * For further details, refer to `BlockSynchronizer#handleBlockStreamEvent`.
+   *
    * IMPORTANT: This method must be called within a transaction to ensure atomicity.
    */
   public async rollback(blockNumber: number, synchedBlockNumber: number): Promise<void> {
     let removedCount = 0;
 
     for (let block = blockNumber + 1; block <= synchedBlockNumber; block++) {
-      const eventIds = await this.#eventsByBlockNumber.getAsync(block);
-      if (eventIds) {
+      const eventIds: string[] = [];
+      for await (const eventId of this.#eventsByBlockNumber.getValuesAsync(block)) {
+        eventIds.push(eventId);
+      }
+
+      if (eventIds.length > 0) {
         await this.#eventsByBlockNumber.delete(block);
 
         for (const eventId of eventIds) {
@@ -220,18 +312,7 @@ export class PrivateEventStore {
 
           await this.#eventLogs.delete(eventId);
           await this.#seenLogs.delete(eventId);
-
-          // Update #eventsByContractScopeSelector using the stored lookupKey
-          const existingIds = await this.#eventsByContractScopeSelector.getAsync(entry.lookupKey);
-          if (!existingIds || existingIds.length === 0) {
-            throw new Error(`No ids found in #eventsByContractScopeSelector for key ${entry.lookupKey}`);
-          }
-          const filteredIds = existingIds.filter(id => id !== eventId);
-          if (filteredIds.length === 0) {
-            await this.#eventsByContractScopeSelector.delete(entry.lookupKey);
-          } else {
-            await this.#eventsByContractScopeSelector.set(entry.lookupKey, filteredIds);
-          }
+          await this.#eventsByContractScopeSelector.deleteValue(entry.lookupKey, eventId);
 
           removedCount++;
         }

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -163,7 +163,7 @@ export class TXESession implements TXESessionStateHandler {
 
     // Create job coordinator and register staged stores
     const jobCoordinator = new JobCoordinator(store);
-    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore]);
+    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore, privateEventStore]);
 
     // Register protocol contracts.
     for (const { contractClass, instance, artifact } of protocolContracts) {


### PR DESCRIPTION
Fourth part of the series started with https://github.com/AztecProtocol/aztec-packages/pull/19445.

This makes the PrivateEventStore work based on staged writes. With this, private events aren't written to persistent storage until PXE decides to commit the job.