### PR TITLE
chore(avm): callstackmetadatacollector clarifications

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.cpp
@@ -41,9 +41,7 @@ void CallStackMetadataCollector::notify_enter_call(const AztecAddress& contract_
     call_stack_metadata.top().num_nested_calls++;
     total_call_stack_items++;
 
-    // Use configured limit or default.
-    uint32_t max_calldata_size = limits.max_calldata_size_in_fields > 0 ? limits.max_calldata_size_in_fields : 1024;
-    std::vector<FF> calldata = calldata_provider(max_calldata_size);
+    std::vector<FF> calldata = calldata_provider(limits.max_calldata_size_in_fields);
 
     call_stack_metadata.push({
         .timestamp = timestamp++,
@@ -72,10 +70,7 @@ void CallStackMetadataCollector::notify_exit_call(bool success,
         return;
     }
 
-    // Use configured limit or default.
-    uint32_t max_return_data_size =
-        limits.max_returndata_size_in_fields > 0 ? limits.max_returndata_size_in_fields : 1024;
-    std::vector<FF> return_data = return_data_provider(max_return_data_size);
+    std::vector<FF> return_data = return_data_provider(limits.max_returndata_size_in_fields);
     std::vector<PC> internal_call_stack = internal_call_stack_provider();
     internal_call_stack.push_back(pc);
 
@@ -125,21 +120,27 @@ CalldataProvider make_calldata_provider(const ContextInterface& context)
     auto cd_size = context.get_parent_cd_size();
     return [&context, cd_size](uint32_t max_size) -> std::vector<FF> {
         // NOTE: get_calldata will handle offsetting into parent memory for nested contexts
-        // TODO(AVM-186): check if this will pad to size. We don't want that.
+        // In principle, get_calldata would pad, but this shouldn't happen since we always ask for less than cd_size.
         auto data = context.get_calldata(0, std::min(max_size, cd_size));
+        // Convert MemoryValue to FF.
         return std::vector<FF>(data.begin(), data.end());
     };
 }
 
-ReturnDataProvider make_return_data_provider(const ContextInterface& context, uint32_t rd_offset, uint32_t rd_size)
+ReturnDataProvider make_return_data_provider(const ContextInterface& context,
+                                             uint32_t rd_mem_offset_in_child,
+                                             uint32_t rd_size)
 {
-    return [&context, rd_offset, rd_size](uint32_t max_size) -> std::vector<FF> {
-        // TODO(AVM-187): Consider using get_returndata instead.
+    return [&context, rd_mem_offset_in_child, rd_size](uint32_t max_size) -> std::vector<FF> {
+        // NOTE: We can't use get_returndata here because that needs the parent and not the child context.
+        // Passing the parent context to this method gives other problems like handling top-level returns.
         const auto& memory = context.get_memory();
         std::vector<FF> data;
-        data.reserve(std::min(max_size, rd_size));
-        for (uint32_t i = 0; i < std::min(max_size, rd_size); i++) {
-            data.push_back(memory.get(rd_offset + i).as_ff());
+        uint32_t effective_rd_size = std::min(max_size, rd_size);
+        data.reserve(effective_rd_size);
+        // This will copy effective_rd_size elements from returndata and will not pad.
+        for (uint32_t i = 0; i < effective_rd_size; i++) {
+            data.push_back(memory.get(rd_mem_offset_in_child + i).as_ff());
         }
         return data;
     };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/call_stack_metadata_collector.test.cpp
@@ -18,9 +18,14 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 using ::testing::StrictMock;
 
+CollectionLimitsConfig limits = {
+    .max_calldata_size_in_fields = 1024,
+    .max_returndata_size_in_fields = 1024,
+};
+
 TEST(CallStackMetadataCollectorTest, SingleCallEnterAndExit)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract_addr(0x1234);
     uint32_t caller_pc = 100;
     uint32_t exit_pc = 200;
@@ -70,7 +75,7 @@ TEST(CallStackMetadataCollectorTest, SingleCallEnterAndExit)
 
 TEST(CallStackMetadataCollectorTest, NestedCalls)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract1(0x1111);
     AztecAddress contract2(0x2222);
     AztecAddress contract3(0x3333);
@@ -158,7 +163,7 @@ TEST(CallStackMetadataCollectorTest, NestedCalls)
 
 TEST(CallStackMetadataCollectorTest, MultipleSiblingCalls)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract0(0x0000);
     AztecAddress contract1(0xaaaa);
     AztecAddress contract2(0xbbbb);
@@ -216,7 +221,7 @@ TEST(CallStackMetadataCollectorTest, MultipleSiblingCalls)
 
 TEST(CallStackMetadataCollectorTest, CalldataSizeLimit)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract_addr(0x1234);
     std::vector<FF> large_calldata(2000, FF(0xabcd)); // Larger than max_calldata_size (1024)
 
@@ -246,7 +251,7 @@ TEST(CallStackMetadataCollectorTest, CalldataSizeLimit)
 
 TEST(CallStackMetadataCollectorTest, ReturnDataSizeLimit)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract_addr(0x5678);
     std::vector<FF> calldata = { FF(0x1234) };
 
@@ -277,7 +282,7 @@ TEST(CallStackMetadataCollectorTest, ReturnDataSizeLimit)
 
 TEST(CallStackMetadataCollectorTest, PhaseTracking)
 {
-    CallStackMetadataCollector collector;
+    CallStackMetadataCollector collector(limits);
     AztecAddress contract1(0x1111);
     AztecAddress contract2(0x2222);
     AztecAddress contract3(0x3333);


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/AVM-186/check-callstack-metadata-collector-and-padding-in-get-calldata.
Closes https://linear.app/aztec-labs/issue/AVM-187/check-if-make-return-data-provider-makes-sense.
