### PR TITLE
chore(avm): rename indirect -> addressing mode

### DIFF
--- a/avm-transpiler/src/instructions.rs
+++ b/avm-transpiler/src/instructions.rs
@@ -13,10 +13,10 @@ use crate::opcodes::AvmOpcode;
 pub struct AvmInstruction {
     pub opcode: AvmOpcode,
 
-    /// Any instructions with memory offset operands have the indirect flag
+    /// Any instructions with memory offset operands have the addressing mode
     /// Each bit is a boolean: 0:direct, 1:indirect
     /// The 0th bit corresponds to an instruction's 0th offset arg, 1st to 1st, etc...
-    pub indirect: Option<AvmOperand>,
+    pub addressing_mode: Option<AvmOperand>,
 
     /// Some instructions have a tag, its usage will depend on the instruction.
     /// Its usage will depend on the instruction.
@@ -33,8 +33,8 @@ pub struct AvmInstruction {
 impl Display for AvmInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "opcode {}", self.opcode.name())?;
-        if let Some(indirect) = &self.indirect {
-            write!(f, ", indirect: {}", indirect)?;
+        if let Some(addressing_mode) = &self.addressing_mode {
+            write!(f, ", addressing_mode: {}", addressing_mode)?;
         }
         if !self.operands.is_empty() {
             write!(f, ", operands: [")?;
@@ -60,12 +60,12 @@ impl Display for AvmInstruction {
 
 impl AvmInstruction {
     /// Bytes representation for generating AVM bytecode
-    /// Order: INDIRECT, OPERANDS, TAG, IMMEDIATES
+    /// Order: ADDRESSING_MODE, OPERANDS, TAG, IMMEDIATES
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.push(self.opcode as u8);
-        if let Some(indirect) = &self.indirect {
-            bytes.extend_from_slice(&indirect.to_be_bytes());
+        if let Some(addressing_mode) = &self.addressing_mode {
+            bytes.extend_from_slice(&addressing_mode.to_be_bytes());
         }
         for operand in &self.operands {
             bytes.extend_from_slice(&operand.to_be_bytes());
@@ -95,8 +95,8 @@ impl Default for AvmInstruction {
     fn default() -> Self {
         AvmInstruction {
             opcode: AvmOpcode::ADD_8,
-            // TODO(4266): default to Some(0), since all instructions have indirect flag except jumps
-            indirect: None,
+            // TODO(4266): default to Some(0), since all instructions have addressing mode except jumps
+            addressing_mode: None,
             tag: None,
             operands: vec![],
             immediates: vec![],
@@ -158,34 +158,34 @@ impl AvmOperand {
 
 #[derive(Debug, Default)]
 pub(crate) struct AddressingModeBuilder {
-    indirect: Vec<bool>,
+    addressing_mode: Vec<bool>,
     relative: Vec<bool>,
 }
 
 impl AddressingModeBuilder {
     pub(crate) fn direct_operand(mut self, address: &MemoryAddress) -> Self {
         self.relative.push(address.is_relative());
-        self.indirect.push(false);
+        self.addressing_mode.push(false);
 
         self
     }
 
     pub(crate) fn indirect_operand(mut self, address: &MemoryAddress) -> Self {
         self.relative.push(address.is_relative());
-        self.indirect.push(true);
+        self.addressing_mode.push(true);
 
         self
     }
 
     pub(crate) fn build(self) -> AvmOperand {
-        let num_operands = self.indirect.len();
+        let num_operands = self.addressing_mode.len();
         assert!(num_operands <= 8, "Too many operands for building addressing mode bytes");
 
         let mut result = 0;
-        for (i, (indirect, relative)) in
-            self.indirect.into_iter().zip(self.relative.into_iter()).enumerate()
+        for (i, (is_indirect, relative)) in
+            self.addressing_mode.into_iter().zip(self.relative.into_iter()).enumerate()
         {
-            if indirect {
+            if is_indirect {
                 // Even bits are indirect
                 result |= 1 << (i * 2);
             }

--- a/avm-transpiler/src/procedures/compiler.rs
+++ b/avm-transpiler/src/procedures/compiler.rs
@@ -104,7 +104,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: set_opcode,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: vec![make_operand(bits_needed_mem, &dest_address)],
                     immediates: vec![make_operand(bits_needed_opcode, &immediate_value)],
                     tag: collection.tag,
@@ -133,7 +133,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: AvmOpcode::JUMPI_32,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: vec![make_operand(16, &collection.operands[0])],
                     immediates: vec![make_unresolved_pc()],
                     ..Default::default()
@@ -154,7 +154,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: if bits_needed == 8 { AvmOpcode::NOT_8 } else { AvmOpcode::NOT_16 },
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: collection
                         .operands
                         .iter()
@@ -183,7 +183,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: avm_opcode,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: collection
                         .operands
                         .iter()
@@ -210,7 +210,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: mov_opcode,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: collection
                         .operands
                         .iter()
@@ -242,7 +242,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: AvmOpcode::ECADD,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: collection
                         .operands
                         .into_iter()
@@ -265,7 +265,7 @@ fn compile_opcode(
             result.add_instruction(
                 AvmInstruction {
                     opcode: AvmOpcode::TORADIXBE,
-                    indirect: Some(build_addressing_mode(collection.indirect)),
+                    addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
                     operands: collection
                         .operands
                         .into_iter()
@@ -368,7 +368,7 @@ fn compile_binary_instruction(
     result.add_instruction(
         AvmInstruction {
             opcode: avm_opcode,
-            indirect: Some(build_addressing_mode(collection.indirect)),
+            addressing_mode: Some(build_addressing_mode(collection.addressing_mode)),
             operands: collection
                 .operands
                 .iter()
@@ -381,13 +381,13 @@ fn compile_binary_instruction(
     Ok(())
 }
 
-fn build_addressing_mode(indirect: Vec<bool>) -> AvmOperand {
-    let num_operands = indirect.len();
+fn build_addressing_mode(addressing_mode: Vec<bool>) -> AvmOperand {
+    let num_operands = addressing_mode.len();
     assert!(num_operands <= 8, "Too many operands for building addressing mode bytes");
 
     let mut result = 0;
-    for (i, indirect) in indirect.into_iter().enumerate() {
-        if indirect {
+    for (i, is_indirect) in addressing_mode.into_iter().enumerate() {
+        if is_indirect {
             // No relative, so we only operate on even bits
             result |= 1 << (i * 2);
         }

--- a/avm-transpiler/src/procedures/compiler/operand_collector.rs
+++ b/avm-transpiler/src/procedures/compiler/operand_collector.rs
@@ -33,7 +33,7 @@ impl Immediate {
 
 pub(crate) struct OperandCollectionResult {
     pub(crate) operands: Vec<usize>,
-    pub(crate) indirect: Vec<bool>,
+    pub(crate) addressing_mode: Vec<bool>,
     pub(crate) immediates: Vec<Immediate>,
     pub(crate) tag: Option<AvmTypeTag>,
 }
@@ -42,7 +42,7 @@ pub(crate) struct OperandCollector {
     parsed_opcode: ParsedOpcode,
     extracted_operands: Vec<usize>,
     extracted_immediates: Vec<Immediate>,
-    indirect: Vec<bool>,
+    addressing_mode: Vec<bool>,
 
     operand_index: usize,
     extracted_tag: bool,
@@ -54,7 +54,7 @@ impl OperandCollector {
             parsed_opcode,
             extracted_operands: vec![],
             extracted_immediates: vec![],
-            indirect: vec![],
+            addressing_mode: vec![],
             operand_index: 0,
             extracted_tag: false,
         }
@@ -82,15 +82,15 @@ impl OperandCollector {
         let address = match operand {
             Operand::Symbol(symbol) => match symbol {
                 Symbol::Direct(address) => {
-                    self.indirect.push(false);
+                    self.addressing_mode.push(false);
                     OperandCollector::convert_address(address)
                 }
                 Symbol::Indirect(address) => {
-                    self.indirect.push(true);
+                    self.addressing_mode.push(true);
                     OperandCollector::convert_address(address)
                 }
                 Symbol::Reserved(address) => {
-                    self.indirect.push(false);
+                    self.addressing_mode.push(false);
                     Ok(address)
                 }
                 Symbol::Label(_) => Err("Expected address found label".to_string()),
@@ -148,7 +148,7 @@ impl OperandCollector {
         }
         Ok(OperandCollectionResult {
             operands: self.extracted_operands,
-            indirect: self.indirect,
+            addressing_mode: self.addressing_mode,
             immediates: self.extracted_immediates,
             tag: self.parsed_opcode.tag,
         })

--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -120,7 +120,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
 
                 avm_instrs.push(AvmInstruction {
                     opcode: avm_opcode,
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default()
                             .direct_operand(lhs)
                             .direct_operand(rhs)
@@ -208,7 +208,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
                 };
                 avm_instrs.push(AvmInstruction {
                     opcode: avm_opcode,
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default()
                             .direct_operand(lhs)
                             .direct_operand(rhs)
@@ -234,7 +234,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
 
                 avm_instrs.push(AvmInstruction {
                     opcode: if bits_needed == 8 { AvmOpcode::NOT_8 } else { AvmOpcode::NOT_16 },
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default()
                             .direct_operand(source)
                             .direct_operand(destination)
@@ -250,7 +250,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
             BrilligOpcode::CalldataCopy { destination_address, size_address, offset_address } => {
                 avm_instrs.push(AvmInstruction {
                     opcode: AvmOpcode::CALLDATACOPY,
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default()
                             .direct_operand(size_address)
                             .direct_operand(offset_address)
@@ -296,7 +296,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
 
                 avm_instrs.push(AvmInstruction {
                     opcode: AvmOpcode::JUMPI_32,
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default().direct_operand(condition).build(),
                     ),
                     operands: vec![make_operand(16, &condition.to_usize())],
@@ -345,7 +345,7 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
 
                 avm_instrs.push(AvmInstruction {
                     opcode: AvmOpcode::JUMPI_32,
-                    indirect: Some(
+                    addressing_mode: Some(
                         AddressingModeBuilder::default().direct_operand(condition).build(),
                     ),
                     operands: vec![make_operand(16, &condition.to_usize())],
@@ -625,7 +625,7 @@ fn handle_external_call(
 
     avm_instrs.push(AvmInstruction {
         opcode,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(l2_gas_offset)
                 .direct_operand(da_gas_offset)
@@ -680,7 +680,7 @@ fn handle_note_hash_exists(
     };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::NOTEHASHEXISTS,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(note_hash_offset_operand)
                 .direct_operand(leaf_index_offset_operand)
@@ -717,8 +717,8 @@ fn handle_emit_unencrypted_log(
     };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::EMITUNENCRYPTEDLOG,
-        // The message array from Brillig is indirect.
-        indirect: Some(
+        // The message array from Brillig is indirect (addressing mode).
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&message_size_offset)
                 .indirect_operand(&message_offset)
@@ -760,7 +760,9 @@ fn handle_emit_note_hash_or_nullifier(
     };
     avm_instrs.push(AvmInstruction {
         opcode: if is_nullifier { AvmOpcode::EMITNULLIFIER } else { AvmOpcode::EMITNOTEHASH },
-        indirect: Some(AddressingModeBuilder::default().direct_operand(offset_operand).build()),
+        addressing_mode: Some(
+            AddressingModeBuilder::default().direct_operand(offset_operand).build(),
+        ),
         operands: vec![AvmOperand::U16 { value: offset_operand.to_usize() as u16 }],
         ..Default::default()
     });
@@ -801,7 +803,7 @@ fn handle_nullifier_exists(
     };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::NULLIFIEREXISTS,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(nullifier_offset_operand)
                 .direct_operand(address_offset_operand)
@@ -852,7 +854,7 @@ fn handle_l1_to_l2_msg_exists(
     };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::L1TOL2MSGEXISTS,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(msg_hash_offset_operand)
                 .direct_operand(msg_leaf_index_offset_operand)
@@ -897,7 +899,7 @@ fn handle_send_l2_to_l1_msg(
     };
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::SENDL2TOL1MSG,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(recipient_offset_operand)
                 .direct_operand(content_offset_operand)
@@ -969,7 +971,9 @@ fn handle_getter_instruction(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::GETENVVAR_16,
-        indirect: Some(AddressingModeBuilder::default().direct_operand(&dest_offset).build()),
+        addressing_mode: Some(
+            AddressingModeBuilder::default().direct_operand(&dest_offset).build(),
+        ),
         operands: vec![AvmOperand::U16 { value: dest_offset.to_usize() as u16 }],
         immediates: vec![AvmOperand::U8 { value: var_idx as u8 }],
         ..Default::default()
@@ -1012,7 +1016,7 @@ fn generate_set_instruction(
 
     AvmInstruction {
         opcode: set_opcode,
-        indirect: if indirect {
+        addressing_mode: if indirect {
             Some(AddressingModeBuilder::default().indirect_operand(dest).build())
         } else {
             Some(AddressingModeBuilder::default().direct_operand(dest).build())
@@ -1052,7 +1056,7 @@ fn generate_cast_instruction(
 
     AvmInstruction {
         opcode: avm_opcode,
-        indirect: Some(indirect_flags.build()),
+        addressing_mode: Some(indirect_flags.build()),
         tag: Some(dst_tag),
         operands: vec![
             make_operand(bits_needed, &(source.to_usize())),
@@ -1077,7 +1081,7 @@ fn generate_revert_instruction(
     };
     avm_instrs.push(AvmInstruction {
         opcode: avm_opcode,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(revert_data_size_offset)
                 .indirect_operand(revert_data_pointer)
@@ -1099,7 +1103,7 @@ fn generate_return_instruction(
 ) {
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::RETURN,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(return_data_size_offset)
                 .indirect_operand(return_data_pointer)
@@ -1115,7 +1119,7 @@ fn generate_return_instruction(
 
 /// Generates an AVM MOV instruction.
 fn generate_mov_instruction(
-    indirect: Option<AvmOperand>,
+    addressing_mode: Option<AvmOperand>,
     source: u32,
     dest: u32,
 ) -> AvmInstruction {
@@ -1129,7 +1133,7 @@ fn generate_mov_instruction(
 
     AvmInstruction {
         opcode: mov_opcode,
-        indirect,
+        addressing_mode,
         operands: vec![make_operand(bits_needed, &source), make_operand(bits_needed, &dest)],
         ..Default::default()
     }
@@ -1181,7 +1185,7 @@ fn handle_black_box_function(
 
             avm_instrs.push(AvmInstruction {
                 opcode: AvmOpcode::SHA256COMPRESSION,
-                indirect: Some(
+                addressing_mode: Some(
                     AddressingModeBuilder::default()
                         .indirect_operand(&output.pointer)
                         .indirect_operand(&hash_values.pointer)
@@ -1204,7 +1208,7 @@ fn handle_black_box_function(
 
             avm_instrs.push(AvmInstruction {
                 opcode: AvmOpcode::POSEIDON2,
-                indirect: Some(
+                addressing_mode: Some(
                     AddressingModeBuilder::default()
                         .indirect_operand(&message.pointer)
                         .indirect_operand(&output.pointer)
@@ -1225,7 +1229,7 @@ fn handle_black_box_function(
 
             avm_instrs.push(AvmInstruction {
                 opcode: AvmOpcode::KECCAKF1600,
-                indirect: Some(
+                addressing_mode: Some(
                     AddressingModeBuilder::default()
                         .indirect_operand(&output.pointer)
                         .indirect_operand(&input.pointer)
@@ -1247,7 +1251,7 @@ fn handle_black_box_function(
 
             avm_instrs.push(AvmInstruction {
                 opcode: AvmOpcode::TORADIXBE,
-                indirect: Some(
+                addressing_mode: Some(
                     AddressingModeBuilder::default()
                         .direct_operand(input)
                         .direct_operand(radix)
@@ -1277,8 +1281,8 @@ fn handle_black_box_function(
             result,
         } => avm_instrs.push(AvmInstruction {
             opcode: AvmOpcode::ECADD,
-            // The result (SIXTH operand) is indirect.
-            indirect: Some(
+            // The result (SIXTH operand) is indirect (addressing mode).
+            addressing_mode: Some(
                 AddressingModeBuilder::default()
                     .direct_operand(p1_x_offset)
                     .direct_operand(p1_y_offset)
@@ -1382,7 +1386,7 @@ fn handle_debug_log(
         //  * (N/A) message_size is an immediate
         //  * fields_offset_ptr INDIRECT
         //  * fields_size_offset direct
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(level_offset)
                 .indirect_operand(message_offset)
@@ -1428,7 +1432,7 @@ fn handle_calldata_copy(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::CALLDATACOPY,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&copy_size_offset)
                 .direct_operand(&cd_offset)
@@ -1461,7 +1465,9 @@ fn handle_returndata_size(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::RETURNDATASIZE,
-        indirect: Some(AddressingModeBuilder::default().direct_operand(&dest_offset).build()),
+        addressing_mode: Some(
+            AddressingModeBuilder::default().direct_operand(&dest_offset).build(),
+        ),
         operands: vec![AvmOperand::U16 { value: dest_offset.to_usize() as u16 }],
         ..Default::default()
     });
@@ -1497,7 +1503,7 @@ fn handle_returndata_copy(
         // First we write the return data.
         AvmInstruction {
             opcode: AvmOpcode::RETURNDATACOPY,
-            indirect: Some(
+            addressing_mode: Some(
                 AddressingModeBuilder::default()
                     .direct_operand(&copy_size_offset)
                     .direct_operand(&cd_offset)
@@ -1587,7 +1593,7 @@ fn handle_storage_write(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::SSTORE,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&src_offset)
                 .direct_operand(&slot_offset)
@@ -1644,7 +1650,7 @@ fn handle_get_contract_instance(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::GETCONTRACTINSTANCE,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&address_offset)
                 .indirect_operand(&dest_offset)
@@ -1683,7 +1689,7 @@ fn handle_storage_read(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::SLOAD,
-        indirect: Some(
+        addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&slot_offset)
                 .direct_operand(&dest_offset)
@@ -1759,7 +1765,7 @@ fn handle_success_copy(
 
     avm_instrs.push(AvmInstruction {
         opcode: AvmOpcode::SUCCESSCOPY,
-        indirect: Some(AddressingModeBuilder::default().direct_operand(&dst_offset).build()),
+        addressing_mode: Some(AddressingModeBuilder::default().direct_operand(&dst_offset).build()),
         operands: vec![AvmOperand::U16 { value: dst_offset.to_usize() as u16 }],
         ..Default::default()
     });

--- a/avm-transpiler/src/transpile_contract.rs
+++ b/avm-transpiler/src/transpile_contract.rs
@@ -161,7 +161,7 @@ fn create_revert_dispatch_fn() -> AvmOrAcirContractFunctionArtifact {
         // Set revert data len
         AvmInstruction {
             opcode: AvmOpcode::SET_8,
-            indirect: Some(AvmOperand::U8 { value: 0 }), // All direct
+            addressing_mode: Some(AvmOperand::U8 { value: 0 }), // All direct
             tag: Some(AvmTypeTag::UINT32),
             operands: vec![AvmOperand::U8 { value: 0 }], // Address 0
             immediates: vec![AvmOperand::U8 { value: 1 }], // Value 1
@@ -169,7 +169,7 @@ fn create_revert_dispatch_fn() -> AvmOrAcirContractFunctionArtifact {
         // Set error selector
         AvmInstruction {
             opcode: AvmOpcode::SET_64,
-            indirect: Some(AvmOperand::U8 { value: 0 }), // All direct
+            addressing_mode: Some(AvmOperand::U8 { value: 0 }), // All direct
             tag: Some(AvmTypeTag::UINT64),
             operands: vec![AvmOperand::U16 { value: 1 }], // Address 1
             immediates: vec![AvmOperand::U64 { value: error_selector.as_u64() }], // Value selector
@@ -177,7 +177,7 @@ fn create_revert_dispatch_fn() -> AvmOrAcirContractFunctionArtifact {
         // Revert
         AvmInstruction {
             opcode: AvmOpcode::REVERT_8,
-            indirect: Some(AvmOperand::U8 { value: 0 }), // All direct
+            addressing_mode: Some(AvmOperand::U8 { value: 0 }), // All direct
             operands: vec![
                 AvmOperand::U8 { value: 0 }, // Revert data size address
                 AvmOperand::U8 { value: 1 }, // Revert data start address

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/instr_fetching.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/instr_fetching.test.cpp
@@ -53,7 +53,7 @@ TEST(InstrFetchingConstrainingTest, Add8WithTraceGen)
 
     Instruction add_8_instruction = {
         .opcode = WireOpCode::ADD_8,
-        .indirect = 3,
+        .addressing_mode = 3,
         .operands = { Operand::from<uint8_t>(0x34), Operand::from<uint8_t>(0x35), Operand::from<uint8_t>(0x36) },
     };
 
@@ -80,7 +80,7 @@ TEST(InstrFetchingConstrainingTest, EcaddWithTraceGen)
 
     Instruction ecadd_instruction = {
         .opcode = WireOpCode::ECADD,
-        .indirect = 0x1f1f,
+        .addressing_mode = 0x1f1f,
         .operands = { Operand::from<uint16_t>(0x1279),
                       Operand::from<uint16_t>(0x127a),
                       Operand::from<uint16_t>(0x127b),
@@ -364,7 +364,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOutOfRange)
 {
     Instruction add_8_instruction = {
         .opcode = WireOpCode::ADD_8,
-        .indirect = 3,
+        .addressing_mode = 3,
         .operands = { Operand::from<uint8_t>(0x34), Operand::from<uint8_t>(0x35), Operand::from<uint8_t>(0x36) },
     };
 
@@ -399,7 +399,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOutOfRangeSplitOperand)
 {
     Instruction set_ff_instruction = {
         .opcode = WireOpCode::SET_FF,
-        .indirect = 0x01,
+        .addressing_mode = 0x01,
         .operands = { Operand::from<uint16_t>(0x1279),
                       Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::FF)),
                       Operand::from<FF>(FF::modulus_minus_two) },
@@ -433,7 +433,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionPcOutOfRange)
 {
     Instruction add_8_instruction = {
         .opcode = WireOpCode::SUB_8,
-        .indirect = 3,
+        .addressing_mode = 3,
         .operands = { Operand::from<uint8_t>(0x34), Operand::from<uint8_t>(0x35), Operand::from<uint8_t>(0x36) },
     };
 
@@ -473,7 +473,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionOpcodeOutOfRange)
 {
     Instruction set_128_instruction = {
         .opcode = WireOpCode::SET_128,
-        .indirect = 0,
+        .addressing_mode = 0,
         .operands = { Operand::from<uint16_t>(0x1234),
                       Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U128)),
                       Operand::from<uint128_t>(static_cast<uint128_t>(0xFF) << 120) },
@@ -514,7 +514,7 @@ TEST(InstrFetchingConstrainingTest, SingleInstructionTagOutOfRange)
 {
     Instruction set_16_instruction = {
         .opcode = WireOpCode::SET_16,
-        .indirect = 0,
+        .addressing_mode = 0,
         .operands = { Operand::from<uint16_t>(0x1234), Operand::from<uint8_t>(12), Operand::from<uint16_t>(0x5678) },
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/addressing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/addressing.cpp
@@ -57,7 +57,7 @@ std::vector<Operand> Addressing::resolve(const Instruction& instruction, MemoryI
     // Check if there is any relative address.
     bool has_relative_address = false;
     for (size_t i = 0; i < spec.num_addresses; ++i) {
-        if (is_operand_relative(instruction.indirect, i)) {
+        if (is_operand_relative(instruction.addressing_mode, i)) {
             has_relative_address = true;
             break;
         }
@@ -104,7 +104,7 @@ std::vector<Operand> Addressing::resolve(const Instruction& instruction, MemoryI
             // Note that the operands were stored as is, and then we'll update them if they are relative.
             // Namely, the above initialization guarantees:
             // resolution_info.after_relative = instruction.operands[i].as_ff(); // default value if not relative.
-            if (is_operand_relative(instruction.indirect, i)) {
+            if (is_operand_relative(instruction.addressing_mode, i)) {
                 // We extend the address to uint64_t to avoid overflows.
                 auto offset = static_cast<uint64_t>(resolution_info.after_relative);
                 // Note: Since we know that the offset and the base address are valid, the addition fits in 33 bits.
@@ -133,7 +133,7 @@ std::vector<Operand> Addressing::resolve(const Instruction& instruction, MemoryI
             // We first store the after_relative values as is, and then we'll update them if they are indirect.
             const auto after_relative_address = static_cast<MemoryAddress>(resolution_info.after_relative);
             resolution_info.resolved_operand = Operand::from(after_relative_address);
-            if (is_operand_indirect(instruction.indirect, i)) {
+            if (is_operand_indirect(instruction.addressing_mode, i)) {
                 resolution_info.resolved_operand = memory.get(after_relative_address);
                 // Check the tag of the resolved operand.
                 if (!memory.is_valid_address(resolution_info.resolved_operand)) {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.cpp
@@ -53,7 +53,7 @@ GasTracker::GasTracker(GasEvent& gas_event,
     , greater_than(greater_than)
     , gas_event(gas_event)
 {
-    gas_event.addressing_gas = static_cast<uint32_t>(compute_addressing_gas(instruction.indirect));
+    gas_event.addressing_gas = static_cast<uint32_t>(compute_addressing_gas(instruction.addressing_mode));
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/gas_tracker.test.cpp
@@ -40,7 +40,7 @@ TEST_F(GasTrackerTest, BaseGasConsumption)
     GasTracker tracker(gas_event, instruction, instruction_info_db, context, greater_than);
 
     // Test base gas consumption (no dynamic gas factor).
-    uint32_t l2_gas_used = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_gas_used = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     EXPECT_CALL(context, get_gas_used);
     EXPECT_CALL(context, get_gas_limit);
     EXPECT_CALL(context, set_gas_used(Gas{ l2_gas_used, 0 }));
@@ -65,11 +65,11 @@ TEST_F(GasTrackerTest, AddressingGasConsumption)
 {
     instruction.opcode = WireOpCode::SET_8;
     // Indirect and relative
-    instruction.indirect = 0b11;
+    instruction.addressing_mode = 0b11;
     GasTracker tracker(gas_event, instruction, instruction_info_db, context, greater_than);
 
     // Test base gas consumption
-    uint32_t l2_gas_used = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_gas_used = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     EXPECT_CALL(context, get_gas_used);
     EXPECT_CALL(context, get_gas_limit);
     EXPECT_CALL(context, set_gas_used(Gas{ l2_gas_used, 0 }));
@@ -81,7 +81,7 @@ TEST_F(GasTrackerTest, AddressingGasConsumption)
 
     EXPECT_EQ(gas_event,
               (GasEvent{
-                  .addressing_gas = compute_addressing_gas(instruction.indirect),
+                  .addressing_gas = compute_addressing_gas(instruction.addressing_mode),
                   .dynamic_gas_factor = Gas{ 0, 0 },
                   .total_gas_used_l2 = l2_gas_used,
                   .total_gas_used_da = 0,
@@ -98,7 +98,7 @@ TEST_F(GasTrackerTest, OutOfGasBase)
     // Set up context to be near gas limit
     EXPECT_CALL(context, get_gas_used).WillOnce(Return(Gas{ 999, 450 }));
     EXPECT_CALL(context, get_gas_limit).WillOnce(Return(Gas{ 1000, 500 }));
-    uint32_t opcode_l2_gas = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t opcode_l2_gas = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     // No call to set_gas_used in the tracker.
 
     EXPECT_CALL(greater_than, gt(999 + opcode_l2_gas, 1000)).WillOnce(Return(true));
@@ -124,7 +124,7 @@ TEST_F(GasTrackerTest, DynamicGasConsumption)
 
     EXPECT_CALL(context, get_gas_used);
     EXPECT_CALL(context, get_gas_limit);
-    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     uint32_t l2_dyn_computation = AVM_CALLDATACOPY_DYN_L2_GAS * 10;
     EXPECT_CALL(context, set_gas_used(Gas{ l2_base_gas + l2_dyn_computation, 0 }));
 
@@ -135,7 +135,7 @@ TEST_F(GasTrackerTest, DynamicGasConsumption)
 
     EXPECT_EQ(gas_event,
               (GasEvent{
-                  .addressing_gas = compute_addressing_gas(instruction.indirect),
+                  .addressing_gas = compute_addressing_gas(instruction.addressing_mode),
                   .dynamic_gas_factor = Gas{ 10, 0 },
                   .total_gas_used_l2 = l2_base_gas + l2_dyn_computation,
                   .total_gas_used_da = 0,
@@ -154,7 +154,7 @@ TEST_F(GasTrackerTest, OutOfGasDynamicPhase)
     EXPECT_CALL(context, get_gas_used).WillOnce(Return(Gas{ l2_gas_used_start, 0 }));
     EXPECT_CALL(context, get_gas_limit).WillOnce(Return(Gas{ l2_gas_limit, 500 }));
 
-    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     uint32_t l2_dyn_computation = AVM_CALLDATACOPY_DYN_L2_GAS * 100;
     EXPECT_CALL(greater_than, gt(l2_base_gas + l2_dyn_computation + l2_gas_used_start, l2_gas_limit))
         .WillOnce(Return(true));
@@ -187,7 +187,7 @@ TEST_F(GasTrackerTest, OutOfGasBothPhases)
     EXPECT_CALL(context, get_gas_used).WillOnce(Return(Gas{ l2_gas_used_start, 0 }));
     EXPECT_CALL(context, get_gas_limit).WillOnce(Return(Gas{ l2_gas_limit, 500 }));
 
-    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_base_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     uint32_t l2_dyn_computation = AVM_CALLDATACOPY_DYN_L2_GAS * 100;
     EXPECT_CALL(greater_than, gt(l2_base_gas + l2_dyn_computation + l2_gas_used_start, l2_gas_limit))
         .WillOnce(Return(true));
@@ -220,7 +220,7 @@ TEST_F(GasTrackerTest, OutOfGasBasePhaseWithOverflow)
     EXPECT_CALL(context, get_gas_used).WillOnce(Return(Gas{ prev_gas_used, 0 }));
     EXPECT_CALL(context, get_gas_limit).WillOnce(Return(Gas{ gas_limit, gas_limit }));
 
-    uint32_t l2_opcode_gas = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_opcode_gas = AVM_SET_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     EXPECT_CALL(greater_than,
                 gt(static_cast<uint64_t>(prev_gas_used) + static_cast<uint64_t>(l2_opcode_gas), gas_limit))
         .WillOnce(Return(true));                                         // L2 OOG.
@@ -253,7 +253,7 @@ TEST_F(GasTrackerTest, OutOfGasDynamicPhaseWithOverflow)
     EXPECT_CALL(context, get_gas_used).WillOnce(Return(Gas{ prev_gas_used, 0 }));
     EXPECT_CALL(context, get_gas_limit).WillOnce(Return(Gas{ gas_limit, gas_limit }));
 
-    uint32_t l2_base_opcode_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.indirect);
+    uint32_t l2_base_opcode_gas = AVM_CALLDATACOPY_BASE_L2_GAS + compute_addressing_gas(instruction.addressing_mode);
     uint64_t l2_dyn_computation = static_cast<uint64_t>(AVM_CALLDATACOPY_DYN_L2_GAS) * gas_factor;
     EXPECT_CALL(
         greater_than,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -277,7 +277,7 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
 
     pos++; // move after opcode byte
 
-    uint16_t indirect = 0;
+    uint16_t addressing_mode = 0;
     std::vector<Operand> operands;
     for (const OperandType op_type : inst_format) {
         const auto operand_size = get_operand_type_size_bytes().at(op_type);
@@ -291,14 +291,14 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
             break;
         }
         case OperandType::INDIRECT8: {
-            indirect = bytecode[pos];
+            addressing_mode = bytecode[pos];
             break;
         }
         case OperandType::INDIRECT16: {
             uint16_t operand_u16 = 0;
             uint8_t const* pos_ptr = &bytecode[pos];
             serialize::read(pos_ptr, operand_u16);
-            indirect = operand_u16;
+            addressing_mode = operand_u16;
             break;
         }
         case OperandType::UINT16: {
@@ -341,7 +341,7 @@ Instruction deserialize_instruction(std::span<const uint8_t> bytecode, size_t po
 
     return {
         .opcode = opcode,
-        .indirect = indirect,
+        .addressing_mode = addressing_mode,
         .operands = std::move(operands),
     };
 };
@@ -353,10 +353,10 @@ std::string Instruction::to_string() const
     for (size_t operand_pos = 0; operand_pos < operands.size(); ++operand_pos) {
         const auto& operand = operands[operand_pos];
         oss << std::to_string(operand);
-        if (is_operand_relative(indirect, static_cast<uint8_t>(operand_pos))) {
+        if (is_operand_relative(addressing_mode, static_cast<uint8_t>(operand_pos))) {
             oss << "R";
         }
-        if (is_operand_indirect(indirect, static_cast<uint8_t>(operand_pos))) {
+        if (is_operand_indirect(addressing_mode, static_cast<uint8_t>(operand_pos))) {
             oss << "I";
         }
         oss << " ";
@@ -386,13 +386,13 @@ std::vector<uint8_t> Instruction::serialize() const
     for (const auto& operand_type : get_wire_opcode_wire_format().at(opcode)) {
         switch (operand_type) {
         case OperandType::INDIRECT8:
-            output.emplace_back(static_cast<uint8_t>(indirect));
+            output.emplace_back(static_cast<uint8_t>(addressing_mode));
             break;
         case OperandType::INDIRECT16: {
-            const auto indirect_vec = to_buffer(indirect);
+            const auto addressing_mode_vec = to_buffer(addressing_mode);
             output.insert(output.end(),
-                          std::make_move_iterator(indirect_vec.begin()),
-                          std::make_move_iterator(indirect_vec.end()));
+                          std::make_move_iterator(addressing_mode_vec.begin()),
+                          std::make_move_iterator(addressing_mode_vec.end()));
         } break;
         case OperandType::TAG:
         case OperandType::UINT8:

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.hpp
@@ -31,7 +31,7 @@ using Operand = TaggedValue;
 
 struct Instruction {
     WireOpCode opcode = WireOpCode::LAST_OPCODE_SENTINEL;
-    uint16_t indirect = 0;
+    uint16_t addressing_mode = 0;
     std::vector<Operand> operands;
 
     std::string to_string() const;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.test.cpp
@@ -18,7 +18,7 @@ using simulation::Operand;
 TEST(SerializationTest, Not8RoundTrip)
 {
     const Instruction instr = { .opcode = WireOpCode::NOT_8,
-                                .indirect = 5,
+                                .addressing_mode = 5,
                                 .operands = { Operand::from<uint8_t>(123), Operand::from<uint8_t>(45) } };
     const auto decoded = deserialize_instruction(instr.serialize(), 0);
     EXPECT_EQ(instr, decoded);
@@ -29,7 +29,7 @@ TEST(SerializationTest, Add16RoundTrip)
 {
     const Instruction instr = {
         .opcode = WireOpCode::ADD_16,
-        .indirect = 3,
+        .addressing_mode = 3,
         .operands = { Operand::from<uint16_t>(1000), Operand::from<uint16_t>(1001), Operand::from<uint16_t>(1002) }
     };
     const auto decoded = deserialize_instruction(instr.serialize(), 0);
@@ -40,7 +40,7 @@ TEST(SerializationTest, Add16RoundTrip)
 TEST(SerializationTest, Jumpi32RoundTrip)
 {
     const Instruction instr = { .opcode = WireOpCode::JUMPI_32,
-                                .indirect = 7,
+                                .addressing_mode = 7,
                                 .operands = { Operand::from<uint16_t>(12345), Operand::from<uint32_t>(678901234) } };
     const auto decoded = deserialize_instruction(instr.serialize(), 0);
     EXPECT_EQ(instr, decoded);
@@ -52,7 +52,7 @@ TEST(SerializationTest, Set64RoundTrip)
     const uint64_t value_64 = 0xABCDEF0123456789LLU;
 
     const Instruction instr = { .opcode = WireOpCode::SET_64,
-                                .indirect = 2,
+                                .addressing_mode = 2,
                                 .operands = { Operand::from<uint16_t>(1002),
                                               Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U64)),
                                               Operand::from<uint64_t>(value_64) } };
@@ -66,7 +66,7 @@ TEST(SerializationTest, Set128RoundTrip)
     const uint128_t value_128 = (uint128_t{ 0x123456789ABCDEF0LLU } << 64) + uint128_t{ 0xABCDEF0123456789LLU };
 
     const Instruction instr = { .opcode = WireOpCode::SET_128,
-                                .indirect = 2,
+                                .addressing_mode = 2,
                                 .operands = { Operand::from<uint16_t>(1002),
                                               Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U128)),
                                               Operand::from<uint128_t>(value_128) } };
@@ -80,7 +80,7 @@ TEST(SerializationTest, SetFFRoundTrip)
     const FF large_ff = FF::modulus - 981723;
 
     const Instruction instr = { .opcode = WireOpCode::SET_FF,
-                                .indirect = 2,
+                                .addressing_mode = 2,
                                 .operands = { Operand::from<uint16_t>(1002),
                                               Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::FF)),
                                               Operand::from<FF>(large_ff) } };
@@ -97,7 +97,7 @@ TEST(SerializationTest, DeserializeLargeFF)
 
     // We first serialize a "dummy" instruction and then substitute the immediate value encoded as the last 32 bytes.
     const Instruction instr = { .opcode = WireOpCode::SET_FF,
-                                .indirect = 0,
+                                .addressing_mode = 0,
                                 .operands = { Operand::from<uint16_t>(1002),
                                               Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U8)),
                                               Operand::from<FF>(FF::modulus - 1) } };
@@ -144,7 +144,7 @@ TEST(SerializationTest, InstructionOutOfRange)
 {
     // Create a valid SET_16 instruction
     Instruction instr = { .opcode = WireOpCode::SET_16,
-                          .indirect = 2,
+                          .addressing_mode = 2,
                           .operands = { Operand::from<uint16_t>(1002),
                                         Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U16)),
                                         Operand::from<uint16_t>(12345) } };
@@ -166,7 +166,7 @@ TEST(SerializationTest, InstructionOutOfRange)
 TEST(SerializationTest, CheckTagValid)
 {
     Instruction instr = { .opcode = WireOpCode::SET_128,
-                          .indirect = 2,
+                          .addressing_mode = 2,
                           .operands = { Operand::from<uint16_t>(1002),
                                         Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::U128)),
                                         Operand::from<uint128_t>(12345) } };
@@ -177,7 +177,7 @@ TEST(SerializationTest, CheckTagValid)
 TEST(SerializationTest, CheckTagInvalid)
 {
     Instruction instr = { .opcode = WireOpCode::SET_128,
-                          .indirect = 2,
+                          .addressing_mode = 2,
                           .operands = { Operand::from<uint16_t>(1002),
                                         Operand::from<uint8_t>(static_cast<uint8_t>(MemoryTag::MAX) + 1),
                                         Operand::from<uint128_t>(12345) } };
@@ -187,7 +187,9 @@ TEST(SerializationTest, CheckTagInvalid)
 // Testing check_tag with an invalid instruction for wire opcode SET_128, not enough operands
 TEST(SerializationTest, CheckTagInvalidNotEnoughOperands)
 {
-    Instruction instr = { .opcode = WireOpCode::SET_128, .indirect = 2, .operands = { Operand::from<uint16_t>(1002) } };
+    Instruction instr = { .opcode = WireOpCode::SET_128,
+                          .addressing_mode = 2,
+                          .operands = { Operand::from<uint16_t>(1002) } };
     EXPECT_FALSE(check_tag(instr));
 }
 
@@ -195,7 +197,7 @@ TEST(SerializationTest, CheckTagInvalidNotEnoughOperands)
 TEST(SerializationTest, CheckTagInvalidTagNotByte)
 {
     Instruction instr = { .opcode = WireOpCode::SET_128,
-                          .indirect = 2,
+                          .addressing_mode = 2,
                           .operands = { Operand::from<uint16_t>(1002),
                                         Operand::from<uint16_t>(static_cast<uint8_t>(MemoryTag::U128)),
                                         Operand::from<uint128_t>(12345) } };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_addressing.cpp
@@ -40,7 +40,7 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
         }
 
         // Handle relative addressing
-        if (is_operand_relative(instruction.indirect, i)) {
+        if (is_operand_relative(instruction.addressing_mode, i)) {
             if (!base_address) {
                 MemoryValue maybe_base_address = memory.get(0);
                 if (!memory.is_valid_address(maybe_base_address)) {
@@ -63,7 +63,7 @@ std::vector<Operand> PureAddressing::resolve(const Instruction& instruction, Mem
         }
 
         // Handle indirection
-        if (is_operand_indirect(instruction.indirect, i)) {
+        if (is_operand_indirect(instruction.addressing_mode, i)) {
             const MemoryValue& indirect_value = memory.get(operand.as<MemoryAddress>());
             if (!memory.is_valid_address(indirect_value)) {
                 throw AddressingException(

--- a/barretenberg/cpp/src/barretenberg/vm2/testing/fixtures.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/testing/fixtures.cpp
@@ -126,16 +126,16 @@ Instruction random_instruction(WireOpCode w_opcode)
 {
     const auto format = simulation::testonly::get_instruction_wire_formats().at(w_opcode);
     std::vector<Operand> operands;
-    uint16_t indirect = 0;
-    operands.reserve(format.size()); // Might be a bit larger (due to indirect)
+    uint16_t addressing_mode = 0;
+    operands.reserve(format.size()); // Might be a bit larger (due to addressing_mode)
 
     for (const auto& operand_type : format) {
         switch (operand_type) {
         case OperandType::INDIRECT8:
-            indirect = random_operand(operand_type).as<uint8_t>();
+            addressing_mode = random_operand(operand_type).as<uint8_t>();
             break;
         case OperandType::INDIRECT16:
-            indirect = random_operand(operand_type).as<uint16_t>();
+            addressing_mode = random_operand(operand_type).as<uint16_t>();
             break;
         default:
             operands.emplace_back(random_operand(operand_type));
@@ -145,7 +145,7 @@ Instruction random_instruction(WireOpCode w_opcode)
 
     return Instruction{
         .opcode = w_opcode,
-        .indirect = indirect,
+        .addressing_mode = addressing_mode,
         .operands = std::move(operands),
     };
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/testing/instruction_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/testing/instruction_builder.cpp
@@ -5,13 +5,13 @@ namespace bb::avm2::testing {
 simulation::Instruction InstructionBuilder::build() const
 {
     // First we compute the indirect and relative contributions of each operand.
-    uint16_t indirect = 0;
+    uint16_t addressing_mode = 0;
     for (size_t i = 0; i < operands.size(); ++i) {
         if (operands[i].is_relative) {
-            indirect |= static_cast<uint16_t>(1 << (i * 2 + 1));
+            addressing_mode |= static_cast<uint16_t>(1 << (i * 2 + 1));
         }
         if (operands[i].is_indirect) {
-            indirect |= static_cast<uint16_t>(1 << (i * 2));
+            addressing_mode |= static_cast<uint16_t>(1 << (i * 2));
         }
     }
 
@@ -21,7 +21,7 @@ simulation::Instruction InstructionBuilder::build() const
     for (const auto& operand : operands) {
         operands_vec.push_back(operand.operand);
     }
-    return simulation::Instruction(opcode, indirect, std::move(operands_vec));
+    return simulation::Instruction(opcode, addressing_mode, std::move(operands_vec));
 }
 
 } // namespace bb::avm2::testing

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.cpp
@@ -340,7 +340,7 @@ void BytecodeTraceBuilder::process_instruction_fetching(
                       { C::instr_fetching_bytecode_id, bytecode_id },
                       { C::instr_fetching_pc, event.pc },
                       // indirect + operands.
-                      { C::instr_fetching_indirect, event.instruction.indirect },
+                      { C::instr_fetching_indirect, event.instruction.addressing_mode },
                       { C::instr_fetching_op1, get_operand(0) },
                       { C::instr_fetching_op2, get_operand(1) },
                       { C::instr_fetching_op3, get_operand(2) },

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
@@ -456,7 +456,7 @@ TEST(BytecodeTraceGenTest, InstrDecompositionInBytesEachOpcode)
                   trace.get(C::instr_fetching_exec_opcode, i + 1));
 
         // Check indirect
-        EXPECT_EQ(FF(instr.indirect), trace.get(C::instr_fetching_indirect, i + 1));
+        EXPECT_EQ(FF(instr.addressing_mode), trace.get(C::instr_fetching_indirect, i + 1));
 
         // Check PCs
         EXPECT_EQ(FF(pcs.at(i)), trace.get(C::instr_fetching_pc, i + 1));

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -749,7 +749,7 @@ void ExecutionTraceBuilder::process_instr_fetching(const simulation::Instruction
               { {
                   { C::execution_sel_instruction_fetching_success, 1 },
                   { C::execution_ex_opcode, static_cast<uint8_t>(instruction.get_exec_opcode()) },
-                  { C::execution_indirect, instruction.indirect },
+                  { C::execution_indirect, instruction.addressing_mode },
                   { C::execution_instr_length, instruction.size_in_bytes() },
               } });
 
@@ -881,8 +881,8 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
         bool op_is_address = i < ex_spec.num_addresses;
         relative_oob[i] = resolution_info.error.has_value() &&
                           *resolution_info.error == AddressingEventError::RELATIVE_COMPUTATION_OOB;
-        is_relative[i] = is_operand_relative(instruction.indirect, i);
-        is_indirect[i] = is_operand_indirect(instruction.indirect, i);
+        is_relative[i] = is_operand_relative(instruction.addressing_mode, i);
+        is_indirect[i] = is_operand_indirect(instruction.addressing_mode, i);
         is_relative_effective[i] = op_is_address && is_relative[i];
         is_indirect_effective[i] = op_is_address && is_indirect[i];
         should_apply_indirection[i] = is_indirect_effective[i] && !relative_oob[i] && !base_address_invalid;
@@ -916,8 +916,8 @@ void ExecutionTraceBuilder::process_addressing(const simulation::AddressingEvent
     // We need to compute relative and indirect over the whole 16 bits of the indirect flag.
     // See comment in PIL file about indirect upper bits.
     for (size_t i = AVM_MAX_OPERANDS; i < TOTAL_INDIRECT_BITS / 2; i++) {
-        bool is_relative = is_operand_relative(instruction.indirect, i);
-        bool is_indirect = is_operand_indirect(instruction.indirect, i);
+        bool is_relative = is_operand_relative(instruction.addressing_mode, i);
+        bool is_indirect = is_operand_indirect(instruction.addressing_mode, i);
         trace.set(row,
                   { {
                       { OPERAND_IS_RELATIVE_WIRE_COLUMNS[i], is_relative ? 1 : 0 },

--- a/yarn-project/simulator/src/public/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_gas.test.ts
@@ -11,22 +11,22 @@ import { MAX_OPCODE_VALUE } from './serialization/instruction_serialization.js';
 describe.skip('AVM simulator: dynamic gas costs per instruction', () => {
   it.each([
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
-    [new SetInstruction(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1), [110, 0]],
+    [new SetInstruction(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT8, /*value=*/ 1), [110, 0]],
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
-    [new SetInstruction(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1), [110]],
+    [new SetInstruction(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1), [110]],
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
-    [new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [110]],
+    [new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [110]],
     // BASE_GAS(10) * 5 + MEMORY_WRITE(100) * 5 = 550
-    [new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 5, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [510]],
+    [new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 5, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [510]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 130
-    [new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
+    [new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
     // BASE_GAS(10) * 4 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 160
-    [new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
+    [new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [160]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_INDIRECT_READ_PENALTY(10) * 2 + MEMORY_WRITE(100) = 150
-    [new Add(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Sub(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Mul(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
-    [new Div(/*indirect=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Add(/*addressing_mode=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Sub(/*addressing_mode=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Mul(/*addressing_mode=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
+    [new Div(/*addressing_mode=*/ 3, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [150]],
   ] as const)('computes gas cost for %s', async (instruction, [l2GasCost, daGasCost]) => {
     const bytecode = encodeToBytecode([instruction]);
     const context = initContext();

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -104,10 +104,13 @@ describe('AVM simulator: injected bytecode', () => {
     bytecode = encodeToBytecode([
       new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 0).as(Opcode.SET_8, Set.wireFormat8),
       new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
-      new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0),
-      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
+      new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0),
+      new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.ADD_8,
+        Add.wireFormat8,
+      ),
       new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
-      new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
+      new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
     ]);
   });
 
@@ -138,7 +141,10 @@ describe('AVM simulator: injected bytecode', () => {
 
     // should halt with tag mismatch
     const badBytecode = encodeToBytecode([
-      new Div(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 0).as(Opcode.DIV_8, Div.wireFormat8),
+      new Div(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 0).as(
+        Opcode.DIV_8,
+        Div.wireFormat8,
+      ),
     ]);
     const results = await new AvmSimulator(context).executeBytecode(badBytecode);
     expect(results.reverted).toBe(true);
@@ -1077,13 +1083,16 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const persistableState = initPersistableStateManager({ treesDB, trace });
 
       it.each([
-        ['Public storage writes', () => new SStore(/*indirect=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 0)],
-        ['New note hashes', () => new EmitNoteHash(/*indirect=*/ 0, /*noteHashOffset=*/ 0)],
-        ['New nullifiers', () => new EmitNullifier(/*indirect=*/ 0, /*noteHashOffset=*/ 0)],
-        ['New unencrypted logs', () => new EmitUnencryptedLog(/*indirect=*/ 0, /*logSizeOffest=*/ 1, /*logOffset=*/ 0)],
+        ['Public storage writes', () => new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 0)],
+        ['New note hashes', () => new EmitNoteHash(/*addressing_mode=*/ 0, /*noteHashOffset=*/ 0)],
+        ['New nullifiers', () => new EmitNullifier(/*addressing_mode=*/ 0, /*noteHashOffset=*/ 0)],
+        [
+          'New unencrypted logs',
+          () => new EmitUnencryptedLog(/*addressing_mode=*/ 0, /*logSizeOffest=*/ 1, /*logOffset=*/ 0),
+        ],
         [
           'New L1 to L2 messages',
-          () => new SendL2ToL1Message(/*indirect=*/ 0, /*recipientOffset=*/ 0, /*contentOffest=*/ 0),
+          () => new SendL2ToL1Message(/*addressing_mode=*/ 0, /*recipientOffset=*/ 0, /*contentOffest=*/ 0),
         ],
       ])(`Overrun of %s`, async (_sideEffectType: string, createInstr: () => Instruction) => {
         const bytecode = encodeToBytecode([
@@ -1092,7 +1101,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
           new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
           createInstr(),
           // change value at memory offset 0 so each instr operates on a different value (important for nullifier emission)
-          new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 100, /*dstOffset=*/ 0).as(
+          new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 100, /*dstOffset=*/ 0).as(
             Opcode.ADD_8,
             Add.wireFormat8,
           ),
@@ -1366,20 +1375,23 @@ describe('AVM simulator: shift operations with huge amounts', () => {
   describe('SHL (Shift Left)', () => {
     it('Should handle shift amount greater than bit size (Uint32)', async () => {
       const bytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
           Opcode.SET_8,
           Set.wireFormat8,
         ), // set a constant specifying the "returnSize" (1) to be used by Return
-        new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(Opcode.SHL_8, Shl.wireFormat8),
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
+        new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(
+          Opcode.SHL_8,
+          Shl.wireFormat8,
+        ),
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
       ]);
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -1390,20 +1402,23 @@ describe('AVM simulator: shift operations with huge amounts', () => {
 
     it('Should handle shift amount equal to bit size (Uint128)', async () => {
       const bytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ (1n << 127n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ (1n << 127n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT128, /*value=*/ 128n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT128, /*value=*/ 128n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
           Opcode.SET_8,
           Set.wireFormat8,
         ), // set a constant specifying the "returnSize" (1) to be used by Return
-        new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(Opcode.SHL_8, Shl.wireFormat8),
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
+        new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(
+          Opcode.SHL_8,
+          Shl.wireFormat8,
+        ),
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
       ]);
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -1416,20 +1431,23 @@ describe('AVM simulator: shift operations with huge amounts', () => {
   describe('SHR (Shift Right)', () => {
     it('Should handle shift amount greater than bit size (Uint32)', async () => {
       const bytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
           Opcode.SET_8,
           Set.wireFormat8,
         ), // set a constant specifying the "returnSize" (1) to be used by Return
-        new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(Opcode.SHR_8, Shr.wireFormat8),
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
+        new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(
+          Opcode.SHR_8,
+          Shr.wireFormat8,
+        ),
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
       ]);
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -1440,20 +1458,23 @@ describe('AVM simulator: shift operations with huge amounts', () => {
 
     it('Should handle shift amount equal to bit size (Uint128)', async () => {
       const bytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ (1n << 127n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ (1n << 127n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT128, /*value=*/ 128n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT128, /*value=*/ 128n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
           Opcode.SET_8,
           Set.wireFormat8,
         ), // set a constant specifying the "returnSize" (1) to be used by Return
-        new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(Opcode.SHR_8, Shr.wireFormat8),
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
+        new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(
+          Opcode.SHR_8,
+          Shr.wireFormat8,
+        ),
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
       ]);
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -1464,20 +1485,23 @@ describe('AVM simulator: shift operations with huge amounts', () => {
 
     it('Should handle shift amount equal to bit size (Uint32)', async () => {
       const bytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ (1n << 32n) - 1n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ 32).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ 32).as(
           Opcode.SET_32,
           Set.wireFormat32,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1).as(
           Opcode.SET_8,
           Set.wireFormat8,
         ), // set a constant specifying the "returnSize" (1) to be used by Return
-        new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(Opcode.SHR_8, Shr.wireFormat8),
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
+        new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 3).as(
+          Opcode.SHR_8,
+          Shr.wireFormat8,
+        ),
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 2, /*returnOffset=*/ 3),
       ]);
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
@@ -1495,7 +1519,7 @@ describe('AVM simulator: "unchecked" errors should NOT be caught', () => {
 
   it('Unchecked error during instruction execution NOT be caught', async () => {
     const context = initContext();
-    const instruction = new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+    const instruction = new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
       Opcode.ADD_8,
       Add.wireFormat8,
     );

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
@@ -67,7 +67,7 @@ describe('Accrued Substate', () => {
         ...Buffer.from('4567', 'hex'), // existsOffset
       ]);
       const inst = new NoteHashExists(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*noteHashOffset=*/ 0x1234,
         /*leafIndexOffset=*/ 0x2345,
         /*existsOffset=*/ 0x4567,
@@ -98,7 +98,7 @@ describe('Accrued Substate', () => {
         context.machineState.memory.set(value0Offset, new Field(value0)); // noteHash
         context.machineState.memory.set(leafIndexOffset, new Uint64(leafIndex));
         await new NoteHashExists(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*noteHashOffset=*/ value0Offset,
           leafIndexOffset,
           existsOffset,
@@ -117,7 +117,7 @@ describe('Accrued Substate', () => {
         0x01, // indirect
         ...Buffer.from('1234', 'hex'), // offset
       ]);
-      const inst = new EmitNoteHash(/*indirect=*/ 0x01, /*offset=*/ 0x1234);
+      const inst = new EmitNoteHash(/*addressing_mode=*/ 0x01, /*offset=*/ 0x1234);
 
       expect(EmitNoteHash.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -126,7 +126,7 @@ describe('Accrued Substate', () => {
     it('Should append a new note hash correctly', async () => {
       mockNoteHashCount(trace, 0);
       context.machineState.memory.set(value0Offset, new Field(value0));
-      await new EmitNoteHash(/*indirect=*/ 0, /*offset=*/ value0Offset).execute(context);
+      await new EmitNoteHash(/*addressing_mode=*/ 0, /*offset=*/ value0Offset).execute(context);
       expect(trace.traceNewNoteHash).toHaveBeenCalledTimes(1);
       const siloedNotehash = await siloNoteHash(address, value0);
       const noteNonce = await computeNoteHashNonce(firstNullifier, 0);
@@ -145,7 +145,7 @@ describe('Accrued Substate', () => {
         ...Buffer.from('4567', 'hex'), // existsOffset
       ]);
       const inst = new NullifierExists(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*nullifierOffset=*/ 0x1234,
         /*addressOffset=*/ 0x0234,
         /*existsOffset=*/ 0x4567,
@@ -167,7 +167,7 @@ describe('Accrued Substate', () => {
         context.machineState.memory.set(value0Offset, new Field(value0)); // nullifier
         context.machineState.memory.set(addressOffset, new Field(address.toField()));
         await new NullifierExists(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*nullifierOffset=*/ value0Offset,
           addressOffset,
           existsOffset,
@@ -186,7 +186,7 @@ describe('Accrued Substate', () => {
         0x01, // indirect
         ...Buffer.from('1234', 'hex'), // offset
       ]);
-      const inst = new EmitNullifier(/*indirect=*/ 0x01, /*offset=*/ 0x1234);
+      const inst = new EmitNullifier(/*addressing_mode=*/ 0x01, /*offset=*/ 0x1234);
 
       expect(EmitNullifier.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -194,15 +194,17 @@ describe('Accrued Substate', () => {
 
     it('Should append a new nullifier correctly', async () => {
       context.machineState.memory.set(value0Offset, new Field(value0));
-      await new EmitNullifier(/*indirect=*/ 0, /*offset=*/ value0Offset).execute(context);
+      await new EmitNullifier(/*addressing_mode=*/ 0, /*offset=*/ value0Offset).execute(context);
       expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1);
       expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
     });
 
     it('Nullifier collision reverts (same nullifier emitted twice)', async () => {
       context.machineState.memory.set(value0Offset, new Field(value0));
-      await new EmitNullifier(/*indirect=*/ 0, /*offset=*/ value0Offset).execute(context);
-      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ value0Offset).execute(context)).rejects.toThrow(
+      await new EmitNullifier(/*addressing_mode=*/ 0, /*offset=*/ value0Offset).execute(context);
+      await expect(
+        new EmitNullifier(/*addressing_mode=*/ 0, /*offset=*/ value0Offset).execute(context),
+      ).rejects.toThrow(
         new InstructionExecutionError(
           `Attempted to emit duplicate nullifier ${value0} (contract address: ${address}).`,
         ),
@@ -215,7 +217,9 @@ describe('Accrued Substate', () => {
     it('Nullifier collision reverts (nullifier exists in host state)', async () => {
       mockCheckNullifierExists(treesDB, true, new Fr(leafIndex));
       context.machineState.memory.set(value0Offset, new Field(value0));
-      await expect(new EmitNullifier(/*indirect=*/ 0, /*offset=*/ value0Offset).execute(context)).rejects.toThrow(
+      await expect(
+        new EmitNullifier(/*addressing_mode=*/ 0, /*offset=*/ value0Offset).execute(context),
+      ).rejects.toThrow(
         new InstructionExecutionError(
           `Attempted to emit duplicate nullifier ${value0} (contract address: ${address}).`,
         ),
@@ -235,7 +239,7 @@ describe('Accrued Substate', () => {
         ...Buffer.from('CDEF', 'hex'), // existsOffset
       ]);
       const inst = new L1ToL2MessageExists(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*msgHashOffset=*/ 0x1234,
         /*msgLeafIndexOffset=*/ 0x4567,
         /*existsOffset=*/ 0xcdef,
@@ -267,7 +271,7 @@ describe('Accrued Substate', () => {
         context.machineState.memory.set(value0Offset, new Field(value0)); // msg hash
         context.machineState.memory.set(leafIndexOffset, new Uint64(leafIndex));
         await new L1ToL2MessageExists(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*msgHashOffset=*/ value0Offset,
           leafIndexOffset,
           existsOffset,
@@ -287,7 +291,7 @@ describe('Accrued Substate', () => {
         ...Buffer.from('a234', 'hex'), // length offset
         ...Buffer.from('1234', 'hex'), // log offset
       ]);
-      const inst = new EmitUnencryptedLog(/*indirect=*/ 0x01, /*lengthOffset=*/ 0xa234, /*offset=*/ 0x1234);
+      const inst = new EmitUnencryptedLog(/*addressing_mode=*/ 0x01, /*lengthOffset=*/ 0xa234, /*offset=*/ 0x1234);
 
       expect(EmitUnencryptedLog.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -304,7 +308,7 @@ describe('Accrued Substate', () => {
       );
       context.machineState.memory.set(logSizeOffset, new Uint32(values.length));
 
-      await new EmitUnencryptedLog(/*indirect=*/ 0, logSizeOffset, /*offset=*/ startOffset).execute(context);
+      await new EmitUnencryptedLog(/*addressing_mode=*/ 0, logSizeOffset, /*offset=*/ startOffset).execute(context);
 
       expect(trace.tracePublicLog).toHaveBeenCalledTimes(1);
       expect(trace.tracePublicLog).toHaveBeenCalledWith(address, values);
@@ -323,7 +327,7 @@ describe('Accrued Substate', () => {
 
       const l2GasBefore = context.machineState.l2GasLeft;
       const daGasBefore = context.machineState.daGasLeft;
-      await new EmitUnencryptedLog(/*indirect=*/ 0, logSizeOffset, /*offset=*/ startOffset).execute(context);
+      await new EmitUnencryptedLog(/*addressing_mode=*/ 0, logSizeOffset, /*offset=*/ startOffset).execute(context);
 
       expect(context.machineState.l2GasLeft).toEqual(
         l2GasBefore - AVM_EMITUNENCRYPTEDLOG_BASE_L2_GAS - AVM_EMITUNENCRYPTEDLOG_DYN_L2_GAS * values.length,
@@ -342,7 +346,11 @@ describe('Accrued Substate', () => {
         ...Buffer.from('1234', 'hex'), // recipientOffset
         ...Buffer.from('a234', 'hex'), // contentOffset
       ]);
-      const inst = new SendL2ToL1Message(/*indirect=*/ 0x01, /*recipientOffset=*/ 0x1234, /*contentOffset=*/ 0xa234);
+      const inst = new SendL2ToL1Message(
+        /*addressing_mode=*/ 0x01,
+        /*recipientOffset=*/ 0x1234,
+        /*contentOffset=*/ 0xa234,
+      );
 
       expect(SendL2ToL1Message.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -354,7 +362,7 @@ describe('Accrued Substate', () => {
       context.machineState.memory.set(value0Offset, new Field(value0));
       context.machineState.memory.set(value1Offset, new Field(value1));
       await new SendL2ToL1Message(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*recipientOffset=*/ value0Offset,
         /*contentOffset=*/ value1Offset,
       ).execute(context);
@@ -368,10 +376,10 @@ describe('Accrued Substate', () => {
     context.machineState.memory.set(0, new Field(2020n));
 
     const instructions = [
-      new EmitNoteHash(/*indirect=*/ 0, /*offset=*/ 0),
-      new EmitNullifier(/*indirect=*/ 0, /*offset=*/ 0),
-      new EmitUnencryptedLog(/*indirect=*/ 0, /*logSizeOffset=*/ 0, /*offset=*/ 0),
-      new SendL2ToL1Message(/*indirect=*/ 0, /*recipientOffset=*/ 0, /*contentOffset=*/ 1),
+      new EmitNoteHash(/*addressing_mode=*/ 0, /*offset=*/ 0),
+      new EmitNullifier(/*addressing_mode=*/ 0, /*offset=*/ 0),
+      new EmitUnencryptedLog(/*addressing_mode=*/ 0, /*logSizeOffset=*/ 0, /*offset=*/ 0),
+      new SendL2ToL1Message(/*addressing_mode=*/ 0, /*recipientOffset=*/ 0, /*contentOffset=*/ 1),
     ];
 
     for (const instruction of instructions) {

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
@@ -19,7 +19,7 @@ export class NoteHashExists extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private noteHashOffset: number,
     private leafIndexOffset: number,
     private existsOffset: number,
@@ -29,7 +29,7 @@ export class NoteHashExists extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -55,7 +55,7 @@ export class EmitNoteHash extends Instruction {
   static readonly wireFormat = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private noteHashOffset: number,
   ) {
     super();
@@ -63,7 +63,7 @@ export class EmitNoteHash extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -95,7 +95,7 @@ export class NullifierExists extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private nullifierOffset: number,
     private addressOffset: number,
     private existsOffset: number,
@@ -105,7 +105,7 @@ export class NullifierExists extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -130,7 +130,7 @@ export class EmitNullifier extends Instruction {
   static readonly wireFormat = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private nullifierOffset: number,
   ) {
     super();
@@ -142,7 +142,7 @@ export class EmitNullifier extends Instruction {
     }
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -181,7 +181,7 @@ export class L1ToL2MessageExists extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private msgHashOffset: number,
     private msgLeafIndexOffset: number,
     private existsOffset: number,
@@ -191,7 +191,7 @@ export class L1ToL2MessageExists extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -218,7 +218,7 @@ export class EmitUnencryptedLog extends Instruction {
   static readonly wireFormat = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private logSizeOffset: number,
     private logOffset: number,
   ) {
@@ -231,7 +231,7 @@ export class EmitUnencryptedLog extends Instruction {
     }
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -258,7 +258,7 @@ export class SendL2ToL1Message extends Instruction {
   static readonly wireFormat = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private recipientOffset: number,
     private contentOffset: number,
   ) {
@@ -271,7 +271,7 @@ export class SendL2ToL1Message extends Instruction {
     }
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
@@ -21,10 +21,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Add(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.ADD_16,
-        Add.wireFormat16,
-      );
+      const inst = new Add(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.ADD_16, Add.wireFormat16);
 
       expect(Add.as(Add.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -42,7 +44,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -60,7 +62,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(32, new Uint32(5)); // indirect
 
       await new Add(
-        /*indirect=*/ Addressing.fromModes([
+        /*addressing_mode=*/ Addressing.fromModes([
           /*aOffset*/ AddressingMode.DIRECT,
           /*bOffset*/ AddressingMode.DIRECT,
           /*dstOffset*/ AddressingMode.INDIRECT | AddressingMode.RELATIVE,
@@ -85,7 +87,7 @@ describe('Arithmetic Instructions', () => {
       it(`${TypeTag[tag]}`, async () => {
         context.machineState.memory.set(0, a);
 
-        await new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 2).execute(context);
+        await new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -102,10 +104,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Sub(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.SUB_16,
-        Sub.wireFormat16,
-      );
+      const inst = new Sub(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.SUB_16, Sub.wireFormat16);
 
       expect(Sub.as(Sub.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -123,7 +127,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Sub(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -147,7 +151,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Sub(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -164,10 +168,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Mul(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.MUL_16,
-        Mul.wireFormat16,
-      );
+      const inst = new Mul(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.MUL_16, Mul.wireFormat16);
 
       expect(Mul.as(Mul.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -185,7 +191,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Mul(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Mul(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -204,7 +210,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Mul(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Mul(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -221,10 +227,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Div(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.DIV_16,
-        Div.wireFormat16,
-      );
+      const inst = new Div(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.DIV_16, Div.wireFormat16);
 
       expect(Div.as(Div.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -241,7 +249,7 @@ describe('Arithmetic Instructions', () => {
         context.machineState.memory.set(0, a);
         context.machineState.memory.set(1, b);
 
-        await new Div(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+        await new Div(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
         const actual = context.machineState.memory.get(2);
         expect(actual).toEqual(expected);
@@ -258,10 +266,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new FieldDiv(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.FDIV_16,
-        FieldDiv.wireFormat16,
-      );
+      const inst = new FieldDiv(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.FDIV_16, FieldDiv.wireFormat16);
 
       expect(FieldDiv.as(FieldDiv.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -274,7 +284,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new FieldDiv(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new FieldDiv(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(new Field(2));
@@ -290,10 +300,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Shr(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.SHR_16,
-        Shr.wireFormat16,
-      );
+      const inst = new Shr(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.SHR_16, Shr.wireFormat16);
 
       expect(Shr.as(Shr.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -307,7 +319,8 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () => await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+        async () =>
+          await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/got UINT8, expected UINT32/);
     });
 
@@ -318,7 +331,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = a;
       const actual = context.machineState.memory.get(2);
@@ -332,7 +345,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b00111111100100111001n);
       const actual = context.machineState.memory.get(2);
@@ -346,7 +359,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b01n);
       const actual = context.machineState.memory.get(2);
@@ -363,10 +376,12 @@ describe('Arithmetic Instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Shl(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.SHL_16,
-        Shl.wireFormat16,
-      );
+      const inst = new Shl(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.SHL_16, Shl.wireFormat16);
 
       expect(Shl.as(Shl.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -380,7 +395,8 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () => await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+        async () =>
+          await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/got UINT8, expected UINT32/);
     });
 
@@ -391,7 +407,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = a;
       const actual = context.machineState.memory.get(2);
@@ -405,7 +421,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b1111111001001110010000n);
       const actual = context.machineState.memory.get(2);
@@ -419,7 +435,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint16(0n);
       const actual = context.machineState.memory.get(2);
@@ -433,7 +449,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint16(0b1001001110011100n);
       const actual = context.machineState.memory.get(2);
@@ -447,7 +463,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, hugeShift);
 
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0n);
       const actual = context.machineState.memory.get(2);
@@ -460,7 +476,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift8 = new Uint8((1n << 8n) - 1n); // Max value for Uint8
       context.machineState.memory.set(0, a8);
       context.machineState.memory.set(1, maxShift8);
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
       expect(context.machineState.memory.get(2)).toEqual(new Uint8(0n));
 
       // Test Uint16
@@ -468,7 +484,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift16 = new Uint16((1n << 16n) - 1n); // Max value for Uint16
       context.machineState.memory.set(10, a16);
       context.machineState.memory.set(11, maxShift16);
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 10, /*bOffset=*/ 11, /*dstOffset=*/ 12).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 10, /*bOffset=*/ 11, /*dstOffset=*/ 12).execute(context);
       expect(context.machineState.memory.get(12)).toEqual(new Uint16(0n));
 
       // Test Uint32
@@ -476,7 +492,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift32 = new Uint32((1n << 32n) - 1n); // Max value for Uint32
       context.machineState.memory.set(20, a32);
       context.machineState.memory.set(21, maxShift32);
-      await new Shl(/*indirect=*/ 0, /*aOffset=*/ 20, /*bOffset=*/ 21, /*dstOffset=*/ 22).execute(context);
+      await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 20, /*bOffset=*/ 21, /*dstOffset=*/ 22).execute(context);
       expect(context.machineState.memory.get(22)).toEqual(new Uint32(0n));
     });
 
@@ -488,7 +504,8 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () => await new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+        async () =>
+          await new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/expected integral/i);
     });
   });
@@ -501,7 +518,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, hugeShift);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0n);
       const actual = context.machineState.memory.get(2);
@@ -514,7 +531,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift8 = new Uint8((1n << 8n) - 1n); // Max value for Uint8
       context.machineState.memory.set(0, a8);
       context.machineState.memory.set(1, maxShift8);
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
       expect(context.machineState.memory.get(2)).toEqual(new Uint8(0n));
 
       // Test Uint16
@@ -522,7 +539,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift16 = new Uint16((1n << 16n) - 1n); // Max value for Uint16
       context.machineState.memory.set(10, a16);
       context.machineState.memory.set(11, maxShift16);
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 10, /*bOffset=*/ 11, /*dstOffset=*/ 12).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 10, /*bOffset=*/ 11, /*dstOffset=*/ 12).execute(context);
       expect(context.machineState.memory.get(12)).toEqual(new Uint16(0n));
 
       // Test Uint32
@@ -530,7 +547,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift32 = new Uint32((1n << 32n) - 1n); // Max value for Uint32
       context.machineState.memory.set(20, a32);
       context.machineState.memory.set(21, maxShift32);
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 20, /*bOffset=*/ 21, /*dstOffset=*/ 22).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 20, /*bOffset=*/ 21, /*dstOffset=*/ 22).execute(context);
       expect(context.machineState.memory.get(22)).toEqual(new Uint32(0n));
 
       // Test Uint64
@@ -538,7 +555,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift64 = new Uint64((1n << 64n) - 1n); // Max value for Uint64
       context.machineState.memory.set(30, a64);
       context.machineState.memory.set(31, maxShift64);
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 30, /*bOffset=*/ 31, /*dstOffset=*/ 32).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 30, /*bOffset=*/ 31, /*dstOffset=*/ 32).execute(context);
       expect(context.machineState.memory.get(32)).toEqual(new Uint64(0n));
 
       // Test Uint128
@@ -546,7 +563,7 @@ describe('Arithmetic Instructions', () => {
       const maxShift128 = new Uint128((1n << 128n) - 1n); // Max value for Uint128
       context.machineState.memory.set(40, a128);
       context.machineState.memory.set(41, maxShift128);
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 40, /*bOffset=*/ 41, /*dstOffset=*/ 42).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 40, /*bOffset=*/ 41, /*dstOffset=*/ 42).execute(context);
       expect(context.machineState.memory.get(42)).toEqual(new Uint128(0n));
     });
 
@@ -558,7 +575,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a32);
       context.machineState.memory.set(1, exactBitSize);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0n);
       const actual = context.machineState.memory.get(2);
@@ -573,7 +590,7 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(0, a32);
       context.machineState.memory.set(1, justBelowBitSize);
 
-      await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(1n); // Only the MSB remains
       const actual = context.machineState.memory.get(2);
@@ -588,7 +605,8 @@ describe('Arithmetic Instructions', () => {
       context.machineState.memory.set(1, b);
 
       await expect(
-        async () => await new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
+        async () =>
+          await new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context),
       ).rejects.toThrow(/expected integral/i);
     });
   });

--- a/yarn-project/simulator/src/public/avm/opcodes/arithmetic.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/arithmetic.ts
@@ -15,7 +15,7 @@ import { ThreeOperandInstruction } from './instruction_impl.js';
 export abstract class ThreeOperandArithmeticInstruction extends ThreeOperandInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/bitwise.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/bitwise.test.ts
@@ -23,10 +23,12 @@ describe('Bitwise instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new And(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.AND_16,
-        And.wireFormat16,
-      );
+      const inst = new And(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.AND_16, And.wireFormat16);
 
       expect(And.as(And.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -36,7 +38,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, new Uint32(0b11111110010011100100n));
       context.machineState.memory.set(1, new Uint32(0b11100100111001001111n));
 
-      await new And(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new And(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(new Uint32(0b11100100010001000100n));
@@ -47,7 +49,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(1, new Uint32(0b11100100111001001111n));
 
       const gasBefore = context.machineState.l2GasLeft;
-      await new And(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new And(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       expect(context.machineState.l2GasLeft).toEqual(
         gasBefore - AVM_AND_BASE_L2_GAS - AVM_BITWISE_DYN_L2_GAS * getBitwiseDynamicGasMultiplier(TypeTag.UINT32),
@@ -64,10 +66,12 @@ describe('Bitwise instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Or(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.OR_16,
-        Or.wireFormat16,
-      );
+      const inst = new Or(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.OR_16, Or.wireFormat16);
 
       expect(Or.as(Or.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -80,7 +84,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Or(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Or(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b11111110111011101111n);
       const actual = context.machineState.memory.get(2);
@@ -95,7 +99,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(1, b);
 
       const gasBefore = context.machineState.l2GasLeft;
-      await new Or(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Or(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       expect(context.machineState.l2GasLeft).toEqual(
         gasBefore - AVM_OR_BASE_L2_GAS - AVM_BITWISE_DYN_L2_GAS * getBitwiseDynamicGasMultiplier(TypeTag.UINT32),
@@ -112,10 +116,12 @@ describe('Bitwise instructions', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Xor(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.XOR_16,
-        Xor.wireFormat16,
-      );
+      const inst = new Xor(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.XOR_16, Xor.wireFormat16);
 
       expect(Xor.as(Xor.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -128,7 +134,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new Xor(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Xor(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       const expected = new Uint32(0b00011010101010101011n);
       const actual = context.machineState.memory.get(2);
@@ -143,7 +149,7 @@ describe('Bitwise instructions', () => {
       context.machineState.memory.set(1, b);
 
       const gasBefore = context.machineState.l2GasLeft;
-      await new Xor(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
+      await new Xor(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).execute(context);
 
       expect(context.machineState.l2GasLeft).toEqual(
         gasBefore - AVM_XOR_BASE_L2_GAS - AVM_BITWISE_DYN_L2_GAS * getBitwiseDynamicGasMultiplier(TypeTag.UINT32),
@@ -159,7 +165,7 @@ describe('Bitwise instructions', () => {
         ...Buffer.from('1234', 'hex'), // aOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Not(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*dstOffset=*/ 0x3456).as(
+      const inst = new Not(/*addressing_mode=*/ 0x01, /*aOffset=*/ 0x1234, /*dstOffset=*/ 0x3456).as(
         Opcode.NOT_16,
         Not.wireFormat16,
       );
@@ -173,7 +179,7 @@ describe('Bitwise instructions', () => {
 
       context.machineState.memory.set(0, a);
 
-      await new Not(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+      await new Not(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
 
       const expected = new Uint16(0b1001101100011011n); // high bits!
       const actual = context.machineState.memory.get(1);

--- a/yarn-project/simulator/src/public/avm/opcodes/bitwise.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/bitwise.ts
@@ -9,7 +9,7 @@ import { ThreeOperandInstruction } from './instruction_impl.js';
 abstract class ThreeOperandBitwiseInstruction extends ThreeOperandInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -87,7 +87,7 @@ export class Not extends Instruction {
   static readonly wireFormat16 = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private srcOffset: number,
     private dstOffset: number,
   ) {
@@ -96,7 +96,7 @@ export class Not extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/comparators.test.ts
@@ -21,10 +21,12 @@ describe('Comparators', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Eq(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.EQ_16,
-        Eq.wireFormat16,
-      );
+      const inst = new Eq(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.EQ_16, Eq.wireFormat16);
 
       expect(Eq.as(Eq.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -34,9 +36,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(3), new Uint32(1)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -51,9 +53,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(3), new Field(1)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 11),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 3, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -68,9 +70,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Eq(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -88,10 +90,12 @@ describe('Comparators', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Lt(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.LT_16,
-        Lt.wireFormat16,
-      );
+      const inst = new Lt(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.LT_16, Lt.wireFormat16);
 
       expect(Lt.as(Lt.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -101,9 +105,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -118,9 +122,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -135,9 +139,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lt(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {
@@ -155,10 +159,12 @@ describe('Comparators', () => {
         ...Buffer.from('2345', 'hex'), // bOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new Lte(/*indirect=*/ 0x01, /*aOffset=*/ 0x1234, /*bOffset=*/ 0x2345, /*dstOffset=*/ 0x3456).as(
-        Opcode.LTE_16,
-        Lte.wireFormat16,
-      );
+      const inst = new Lte(
+        /*addressing_mode=*/ 0x01,
+        /*aOffset=*/ 0x1234,
+        /*bOffset=*/ 0x2345,
+        /*dstOffset=*/ 0x3456,
+      ).as(Opcode.LTE_16, Lte.wireFormat16);
 
       expect(Lte.as(Lte.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -168,9 +174,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Uint32(1), new Uint32(2), new Uint32(0)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -185,9 +191,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Field(2), new Field(0)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 0, /*dstOffset=*/ 10),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 11),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 12),
       ];
 
       for (const op of ops) {
@@ -202,9 +208,9 @@ describe('Comparators', () => {
       context.machineState.memory.setSlice(0, [new Field(1), new Uint32(2), new Uint16(3)]);
 
       const ops = [
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
-        new Lte(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 10),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 10),
+        new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 10),
       ];
 
       for (const o of ops) {

--- a/yarn-project/simulator/src/public/avm/opcodes/comparators.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/comparators.ts
@@ -7,7 +7,7 @@ import { ThreeOperandInstruction } from './instruction_impl.js';
 abstract class ComparatorInstruction extends ThreeOperandInstruction {
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/contract.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/contract.test.ts
@@ -40,7 +40,7 @@ describe('Contract opcodes', () => {
         0x02, // memberEnum (immediate)
       ]);
       const inst = new GetContractInstance(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*addressOffset=*/ 0x1234,
         /*dstOffset=*/ 0xa234,
         /*memberEnum=*/ 0x02,
@@ -64,7 +64,9 @@ describe('Contract opcodes', () => {
         const memberValueOffset = dstOffset + 1;
 
         context.machineState.memory.set(0, new Field(address.toField()));
-        await new GetContractInstance(/*indirect=*/ 0, /*addressOffset=*/ 0, dstOffset, memberEnum).execute(context);
+        await new GetContractInstance(/*addressing_mode=*/ 0, /*addressOffset=*/ 0, dstOffset, memberEnum).execute(
+          context,
+        );
 
         expect(persistableState.getContractInstance).toHaveBeenCalledTimes(1);
         expect(persistableState.getContractInstance).toHaveBeenCalledWith(address);
@@ -96,7 +98,9 @@ describe('Contract opcodes', () => {
           const memberValueOffset = dstOffset + 1;
 
           context.machineState.memory.set(0, new Field(address.toField()));
-          await new GetContractInstance(/*indirect=*/ 0, /*addressOffset=*/ 0, dstOffset, memberEnum).execute(context);
+          await new GetContractInstance(/*addressing_mode=*/ 0, /*addressOffset=*/ 0, dstOffset, memberEnum).execute(
+            context,
+          );
 
           // exists should be false
           expect(context.machineState.memory.getTag(existsOffset)).toBe(TypeTag.UINT1);
@@ -114,7 +118,7 @@ describe('Contract opcodes', () => {
     it(`GETCONTRACTINSTANCE reverts for bad enum operand`, async () => {
       const invalidEnum = 255;
       const instruction = new GetContractInstance(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*addressOffset=*/ 0,
         /*dstOffset=*/ 1,
         /*memberEnum=*/ invalidEnum,

--- a/yarn-project/simulator/src/public/avm/opcodes/contract.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/contract.ts
@@ -17,14 +17,14 @@ export class GetContractInstance extends Instruction {
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect bits
+    OperandType.UINT8, // addressing_mode bits
     OperandType.UINT16, // addressOffset
     OperandType.UINT16, // dstOffset
     OperandType.UINT8, // member enum (immediate)
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private addressOffset: number,
     private dstOffset: number,
     private memberEnum: number,
@@ -34,7 +34,7 @@ export class GetContractInstance extends Instruction {
 
   async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/control_flow.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/control_flow.test.ts
@@ -43,7 +43,7 @@ describe('Control Flow Opcodes', () => {
         ...Buffer.from('a234', 'hex'), // condOffset
         ...Buffer.from('12340000', 'hex'), // loc
       ]);
-      const inst = new JumpI(/*indirect=*/ 1, /*condOffset=*/ 0xa234, /*loc=*/ 0x12340000);
+      const inst = new JumpI(/*addressing_mode=*/ 1, /*condOffset=*/ 0xa234, /*loc=*/ 0x12340000);
 
       expect(JumpI.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -56,7 +56,7 @@ describe('Control Flow Opcodes', () => {
 
       context.machineState.memory.set(0, new Uint1(1n));
 
-      const instruction = new JumpI(/*indirect=*/ 0, /*condOffset=*/ 0, jumpLocation);
+      const instruction = new JumpI(/*addressing_mode=*/ 0, /*condOffset=*/ 0, jumpLocation);
       await instruction.execute(context);
       expect(context.machineState.pc).toBe(jumpLocation);
     });
@@ -69,7 +69,7 @@ describe('Control Flow Opcodes', () => {
 
       context.machineState.memory.set(0, new Uint1(0n));
 
-      const instruction = new JumpI(/*indirect=*/ 0, /*condOffset=*/ 0, jumpLocation);
+      const instruction = new JumpI(/*addressing_mode=*/ 0, /*condOffset=*/ 0, jumpLocation);
       await instruction.execute(context);
       expect(context.machineState.pc).toBe(30);
     });
@@ -88,7 +88,7 @@ describe('Control Flow Opcodes', () => {
       // Set the resolved cond to 1.
       context.machineState.memory.set(resolvedCondOffset, new Uint1(1n));
 
-      const instruction = new JumpI(/*indirect=*/ indirect, /*condOffset=*/ condOffset, jumpLocation);
+      const instruction = new JumpI(/*addressing_mode=*/ indirect, /*condOffset=*/ condOffset, jumpLocation);
       await instruction.execute(context);
       expect(context.machineState.pc).toBe(jumpLocation);
     });
@@ -102,7 +102,7 @@ describe('Control Flow Opcodes', () => {
       { type: Field, name: 'Field' },
     ])('Should error if the condition has tag $name', async ({ type }) => {
       context.machineState.memory.set(0, new type(1n));
-      const instruction = new JumpI(/*indirect=*/ 0, /*condOffset=*/ 0, 1);
+      const instruction = new JumpI(/*addressing_mode=*/ 0, /*condOffset=*/ 0, 1);
       await expect(instruction.execute(context)).rejects.toThrow(TagCheckError);
     });
   });

--- a/yarn-project/simulator/src/public/avm/opcodes/control_flow.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/control_flow.ts
@@ -39,7 +39,7 @@ export class JumpI extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private condOffset: number,
     private loc: number,
   ) {
@@ -48,7 +48,7 @@ export class JumpI extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/conversion.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/conversion.test.ts
@@ -27,7 +27,7 @@ describe('Conversion Opcodes', () => {
         ...Buffer.from('5678', 'hex'), // outputStateOffset
       ]);
       const inst = new ToRadixBE(
-        /*indirect=*/ 0x0001,
+        /*addressing_mode=*/ 0x0001,
         /*srcOffset=*/ 0x1234,
         /*radixOffset=*/ 0x2345,
         /*numLimbsOffset=*/ 0x3456,

--- a/yarn-project/simulator/src/public/avm/opcodes/conversion.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/conversion.ts
@@ -12,7 +12,7 @@ export class ToRadixBE extends Instruction {
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [
     OperandType.UINT8, // Opcode
-    OperandType.UINT16, // Indirect
+    OperandType.UINT16, // addressing_mode
     OperandType.UINT16, // src memory address
     OperandType.UINT16, // radix memory address
     OperandType.UINT16, // number of limbs address
@@ -21,7 +21,7 @@ export class ToRadixBE extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private srcOffset: number,
     private radixOffset: number,
     private numLimbsOffset: number,
@@ -33,7 +33,7 @@ export class ToRadixBE extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/ec_add.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/ec_add.test.ts
@@ -31,7 +31,7 @@ describe('EC Instructions', () => {
         ...Buffer.from('1239', 'hex'), // dstOffset
       ]);
       const inst = new EcAdd(
-        /*indirect=*/ 0x1234,
+        /*addressing_mode=*/ 0x1234,
         /*p1X=*/ 0x1235,
         /*p1Y=*/ 0x1236,
         /*p1IsInfinite=*/ 0,
@@ -59,7 +59,7 @@ describe('EC Instructions', () => {
       // context.machineState.memory.set(6, new Uint32(6));
 
       await new EcAdd(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*p1X=*/ 0,
         /*p1Y=*/ 1,
         /*p1IsInfinite=*/ 2,
@@ -98,7 +98,7 @@ describe('EC Instructions', () => {
       context.machineState.memory.set(6, new Uint32(6));
 
       await new EcAdd(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*p1X=*/ 0,
         /*p1Y=*/ 1,
         /*p1IsInfinite=*/ 2,
@@ -138,7 +138,7 @@ describe('EC Instructions', () => {
 
       await expect(
         new EcAdd(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           p1xOffset,
           p1yOffset,
           p1IsInfiniteOffset,
@@ -168,7 +168,7 @@ describe('EC Instructions', () => {
 
       await expect(
         new EcAdd(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           p1xOffset,
           p1yOffset,
           p1IsInfiniteOffset,

--- a/yarn-project/simulator/src/public/avm/opcodes/ec_add.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/ec_add.ts
@@ -26,7 +26,7 @@ export class EcAdd extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private p1XOffset: number,
     private p1YOffset: number,
     private p1IsInfiniteOffset: number,
@@ -40,7 +40,7 @@ export class EcAdd extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
@@ -44,11 +44,11 @@ describe('Environment getters', () => {
   it(`Should (de)serialize correctly`, () => {
     const buf = Buffer.from([
       Opcode.GETENVVAR_16, // opcode
-      0x01, // indirect
+      0x01, // addressing_mode
       ...Buffer.from('1234', 'hex'), // dstOffset
       0x05, // var idx
     ]);
-    const instr = new GetEnvVar(/*indirect=*/ 0x01, /*dstOffset=*/ 0x1234, 5).as(
+    const instr = new GetEnvVar(/*addressing_mode=*/ 0x01, /*dstOffset=*/ 0x1234, 5).as(
       Opcode.GETENVVAR_16,
       GetEnvVar.wireFormat16,
     );
@@ -70,7 +70,7 @@ describe('Environment getters', () => {
     [EnvironmentVariable.ISSTATICCALL, new Fr(isStaticCall ? 1 : 0), TypeTag.UINT1],
   ])('Environment getter instructions', (envVar: EnvironmentVariable, value: Fr, tag: TypeTag = TypeTag.FIELD) => {
     it(`Should read '${EnvironmentVariable[envVar]}' correctly`, async () => {
-      const instruction = new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, envVar);
+      const instruction = new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, envVar);
 
       await instruction.execute(context);
 
@@ -82,13 +82,13 @@ describe('Environment getters', () => {
 
   it(`GETENVVAR reverts for bad enum operand`, async () => {
     const invalidEnum = 255;
-    const instruction = new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, invalidEnum);
+    const instruction = new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, invalidEnum);
     await expect(instruction.execute(context)).rejects.toThrow(`Invalid GETENVVAR var enum ${invalidEnum}`);
   });
 
   describe('Gas left environment variables', () => {
     it('Should read L2GASLEFT correctly', async () => {
-      const instruction = new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, EnvironmentVariable.L2GASLEFT);
+      const instruction = new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, EnvironmentVariable.L2GASLEFT);
 
       await instruction.execute(context);
 
@@ -98,7 +98,7 @@ describe('Environment getters', () => {
     });
 
     it('Should read DAGASLEFT correctly', async () => {
-      const instruction = new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, EnvironmentVariable.DAGASLEFT);
+      const instruction = new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, EnvironmentVariable.DAGASLEFT);
 
       await instruction.execute(context);
 

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
@@ -56,13 +56,13 @@ export class GetEnvVar extends Instruction {
   public static readonly opcode: Opcode = Opcode.GETENVVAR_16;
   static readonly wireFormat16: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.UINT8, // variable enum (immediate)
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private dstOffset: number,
     private varEnum: number,
   ) {
@@ -71,7 +71,7 @@ export class GetEnvVar extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -53,7 +53,7 @@ describe('External Calls', () => {
         ...Buffer.from('b234', 'hex'), // argsOffset
       ]);
       const inst = new Call(
-        /*indirect=*/ 0x1234,
+        /*addressing_mode=*/ 0x1234,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -89,11 +89,18 @@ describe('External Calls', () => {
       context.machineState.memory.set(argsSizeOffset, new Uint32(argsSize));
       context.machineState.memory.setSlice(3, args);
 
-      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsSizeOffset, argsOffset);
+      const instruction = new Call(
+        /*addressing_mode=*/ 0,
+        l2GasOffset,
+        daGasOffset,
+        addrOffset,
+        argsSizeOffset,
+        argsOffset,
+      );
       await instruction.execute(context);
 
       // Use SuccessCopy to get success
-      const successCopyInstruction = new SuccessCopy(/*indirect=*/ 0, successDstOffset);
+      const successCopyInstruction = new SuccessCopy(/*addressing_mode=*/ 0, successDstOffset);
       await successCopyInstruction.execute(context);
 
       const successValue = context.machineState.memory.get(successDstOffset);
@@ -123,11 +130,11 @@ describe('External Calls', () => {
       const successDstOffset = 6;
 
       const otherContextInstructionsBytecode = encodeToBytecode([
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, 0).as(Opcode.SET_8, Set.wireFormat8),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, argsSize).as(Opcode.SET_8, Set.wireFormat8),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, TypeTag.UINT32, 2).as(Opcode.SET_8, Set.wireFormat8),
-        new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*csOffsetAddress=*/ 0, /*dstOffset=*/ 3),
-        new Return(/*indirect=*/ 0, /*sizeOffset=*/ 2, /*retOffset=*/ 3),
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, 0).as(Opcode.SET_8, Set.wireFormat8),
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, argsSize).as(Opcode.SET_8, Set.wireFormat8),
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, TypeTag.UINT32, 2).as(Opcode.SET_8, Set.wireFormat8),
+        new CalldataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 1, /*csOffsetAddress=*/ 0, /*dstOffset=*/ 3),
+        new Return(/*addressing_mode=*/ 0, /*sizeOffset=*/ 2, /*retOffset=*/ 3),
       ]);
       const contractClass = await makeContractClassPublic(0, otherContextInstructionsBytecode);
       mockGetContractClass(contractsDB, contractClass);
@@ -144,11 +151,18 @@ describe('External Calls', () => {
       context.machineState.memory.set(argsSizeOffset, new Uint32(argsSize));
       context.machineState.memory.setSlice(3, args);
 
-      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsSizeOffset, argsOffset);
+      const instruction = new Call(
+        /*addressing_mode=*/ 0,
+        l2GasOffset,
+        daGasOffset,
+        addrOffset,
+        argsSizeOffset,
+        argsOffset,
+      );
       await instruction.execute(context);
 
       // Use SuccessCopy to get success
-      const successCopyInstruction = new SuccessCopy(/*indirect=*/ 0, successDstOffset);
+      const successCopyInstruction = new SuccessCopy(/*addressing_mode=*/ 0, successDstOffset);
       await successCopyInstruction.execute(context);
 
       const successValue = context.machineState.memory.get(successDstOffset);
@@ -174,12 +188,12 @@ describe('External Calls', () => {
       const successDstOffset = 6;
 
       const otherContextInstructionsBytecode = encodeToBytecode([
-        new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, /*envVar=*/ EnvironmentVariable.L2GASLEFT).as(
+        new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*envVar=*/ EnvironmentVariable.L2GASLEFT).as(
           Opcode.GETENVVAR_16,
           GetEnvVar.wireFormat16,
         ),
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, 1).as(Opcode.SET_8, Set.wireFormat8),
-        new Return(/*indirect=*/ 0, /*size=*/ 1, /*retOffset=*/ 0),
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, 1).as(Opcode.SET_8, Set.wireFormat8),
+        new Return(/*addressing_mode=*/ 0, /*size=*/ 1, /*retOffset=*/ 0),
       ]);
       mockCheckNullifierExists(treesDB, true, addr);
 
@@ -198,7 +212,7 @@ describe('External Calls', () => {
       context.machineState.memory.set(argsSizeOffset, new Uint32(argsSize));
 
       const instruction = new Call(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         l2GasOffset,
         daGasOffset,
         addrOffset,
@@ -208,7 +222,7 @@ describe('External Calls', () => {
       await instruction.execute(context);
 
       // Use SuccessCopy to get success
-      const successCopyInstruction = new SuccessCopy(/*indirect=*/ 0, successDstOffset);
+      const successCopyInstruction = new SuccessCopy(/*addressing_mode=*/ 0, successDstOffset);
       await successCopyInstruction.execute(context);
 
       const successValue = context.machineState.memory.get(successDstOffset);
@@ -235,7 +249,7 @@ describe('External Calls', () => {
         ...Buffer.from('b234', 'hex'), // argsOffset
       ]);
       const inst = new StaticCall(
-        /*indirect=*/ 0x1234,
+        /*addressing_mode=*/ 0x1234,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -266,7 +280,7 @@ describe('External Calls', () => {
       context.machineState.memory.setSlice(argsOffset, args);
 
       const otherContextInstructions: Instruction[] = [
-        new SStore(/*indirect=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 0),
+        new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 0),
       ];
 
       const otherContextInstructionsBytecode = encodeToBytecode(otherContextInstructions);
@@ -279,7 +293,7 @@ describe('External Calls', () => {
       mockGetContractInstance(contractsDB, contractInstance);
 
       const instruction = new StaticCall(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         l2GasOffset,
         daGasOffset,
         addrOffset,
@@ -302,7 +316,7 @@ describe('External Calls', () => {
         ...Buffer.from('a234', 'hex'), // copySize
         ...Buffer.from('1234', 'hex'), // returnOffset
       ]);
-      const inst = new Return(/*indirect=*/ 0x10, /*copySize=*/ 0xa234, /*returnOffset=*/ 0x1234);
+      const inst = new Return(/*addressing_mode=*/ 0x10, /*copySize=*/ 0xa234, /*returnOffset=*/ 0x1234);
 
       expect(Return.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -316,7 +330,7 @@ describe('External Calls', () => {
       context.machineState.memory.set(2, new Field(3n));
       context.machineState.memory.set(3, new Uint32(returnData.length));
 
-      const instruction = new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 3, /*returnOffset=*/ 0);
+      const instruction = new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 3, /*returnOffset=*/ 0);
       await instruction.execute(context);
 
       expect(context.machineState.getHalted()).toBe(true);
@@ -333,7 +347,7 @@ describe('External Calls', () => {
         ...Buffer.from('a234', 'hex'), // retSizeOffset
         ...Buffer.from('1234', 'hex'), // returnOffset
       ]);
-      const inst = new Revert(/*indirect=*/ 0x10, /*retSizeOffset=*/ 0xa234, /*returnOffset=*/ 0x1234).as(
+      const inst = new Revert(/*addressing_mode=*/ 0x10, /*retSizeOffset=*/ 0xa234, /*returnOffset=*/ 0x1234).as(
         Opcode.REVERT_16,
         Revert.wireFormat16,
       );
@@ -349,7 +363,7 @@ describe('External Calls', () => {
       context.machineState.memory.set(0, new Uint32(returnData.length));
       context.machineState.memory.setSlice(10, returnData);
 
-      const instruction = new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 0, /*returnOffset=*/ 10);
+      const instruction = new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 0, /*returnOffset=*/ 10);
       await instruction.execute(context);
 
       expect(context.machineState.getHalted()).toBe(true);
@@ -365,7 +379,7 @@ describe('External Calls', () => {
         0x12, // indirect (8-bit)
         ...Buffer.from('5678', 'hex'), // dstOffset (16-bit)
       ]);
-      const inst = new SuccessCopy(/*indirect=*/ 0x12, /*dstOffset=*/ 0x5678);
+      const inst = new SuccessCopy(/*addressing_mode=*/ 0x12, /*dstOffset=*/ 0x5678);
 
       expect(SuccessCopy.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -375,7 +389,7 @@ describe('External Calls', () => {
       context.machineState.nestedCallSuccess = true;
       const dstOffset = 0;
 
-      const instruction = new SuccessCopy(/*indirect=*/ 0, dstOffset);
+      const instruction = new SuccessCopy(/*addressing_mode=*/ 0, dstOffset);
       await instruction.execute(context);
 
       const successValue = context.machineState.memory.get(dstOffset);
@@ -386,7 +400,7 @@ describe('External Calls', () => {
       context.machineState.nestedCallSuccess = false;
       const dstOffset = 0;
 
-      const instruction = new SuccessCopy(/*indirect=*/ 0, dstOffset);
+      const instruction = new SuccessCopy(/*addressing_mode=*/ 0, dstOffset);
       await instruction.execute(context);
 
       const successValue = context.machineState.memory.get(dstOffset);

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
@@ -9,7 +9,7 @@ abstract class ExternalCall extends Instruction {
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [
     OperandType.UINT8,
-    OperandType.UINT16, // Indirect
+    OperandType.UINT16, // addressing_mode
     OperandType.UINT16, // L2 gas offset
     OperandType.UINT16, // DA gas offset
     OperandType.UINT16, // Address offset
@@ -18,7 +18,7 @@ abstract class ExternalCall extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private l2GasOffset: number,
     private daGasOffset: number,
     private addrOffset: number,
@@ -30,7 +30,7 @@ abstract class ExternalCall extends Instruction {
 
   public async execute(context: AvmContext) {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -137,7 +137,7 @@ export class SuccessCopy extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private dstOffset: number,
   ) {
     super();
@@ -145,7 +145,7 @@ export class SuccessCopy extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -174,7 +174,7 @@ export class Return extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private returnSizeOffset: number,
     private returnOffset: number,
   ) {
@@ -183,7 +183,7 @@ export class Return extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -223,7 +223,7 @@ export class Revert extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private retSizeOffset: number,
     private returnOffset: number,
   ) {
@@ -232,7 +232,7 @@ export class Revert extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/hashing.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/hashing.test.ts
@@ -24,7 +24,7 @@ describe('Hashing Opcodes', () => {
         ...Buffer.from('1234', 'hex'), // inputStateOffset
         ...Buffer.from('2345', 'hex'), // outputStateOffset
       ]);
-      const inst = new Poseidon2(/*indirect=*/ 1, /*dstOffset=*/ 0x1234, /*messageOffset=*/ 0x2345);
+      const inst = new Poseidon2(/*addressing_mode=*/ 1, /*dstOffset=*/ 0x1234, /*messageOffset=*/ 0x2345);
 
       expect(Poseidon2.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -98,7 +98,7 @@ describe('Hashing Opcodes', () => {
         ...Buffer.from('1234', 'hex'), // dstOffset
         ...Buffer.from('2345', 'hex'), // inputOffset
       ]);
-      const inst = new KeccakF1600(/*indirect=*/ 1, /*dstOffset=*/ 0x1234, /*inputOffset=*/ 0x2345);
+      const inst = new KeccakF1600(/*addressing_mode=*/ 1, /*dstOffset=*/ 0x1234, /*inputOffset=*/ 0x2345);
 
       expect(KeccakF1600.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -152,7 +152,7 @@ describe('Hashing Opcodes', () => {
         ...Buffer.from('4567', 'hex'), // inputsOffset
       ]);
       const inst = new Sha256Compression(
-        /*indirect=*/ 1,
+        /*addressing_mode=*/ 1,
         /*dstOffset=*/ 0x1234,
         /*stateOffset=*/ 0x2345,
         /*inputsOffset=*/ 0x4567,

--- a/yarn-project/simulator/src/public/avm/opcodes/hashing.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/hashing.ts
@@ -22,7 +22,7 @@ export class Poseidon2 extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private inputStateOffset: number,
     private outputStateOffset: number,
   ) {
@@ -31,7 +31,7 @@ export class Poseidon2 extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -65,7 +65,7 @@ export class KeccakF1600 extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private dstOffset: number,
     private inputOffset: number,
   ) {
@@ -76,7 +76,7 @@ export class KeccakF1600 extends Instruction {
   public async execute(context: AvmContext): Promise<void> {
     const inputSize = 25;
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -109,7 +109,7 @@ export class Sha256Compression extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private outputOffset: number,
     private stateOffset: number,
     private inputsOffset: number,
@@ -122,7 +122,7 @@ export class Sha256Compression extends Instruction {
     const INPUTS_SIZE = 16;
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/instruction_impl.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/instruction_impl.ts
@@ -19,14 +19,14 @@ export const ThreeOperandWireFormat16 = [
 
 /**
  * Covers (de)serialization for an instruction with:
- * indirect, inTag, and three operands.
+ * addressing mode, inTag, and three operands.
  */
 export abstract class ThreeOperandInstruction extends Instruction {
   static readonly wireFormat8: OperandType[] = ThreeOperandWireFormat8;
   static readonly wireFormat16: OperandType[] = ThreeOperandWireFormat16;
 
   constructor(
-    protected indirect: number,
+    protected addressingMode: number,
     protected aOffset: number,
     protected bOffset: number,
     protected dstOffset: number,

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
@@ -30,10 +30,12 @@ describe('Memory instructions', () => {
         TypeTag.UINT8, // inTag
         ...Buffer.from('12', 'hex'),
       ]);
-      const inst = new Set(/*indirect=*/ 0x01, /*dstOffset=*/ 0x56, /*inTag=*/ TypeTag.UINT8, /*value=*/ 0x12).as(
-        Opcode.SET_8,
-        Set.wireFormat8,
-      );
+      const inst = new Set(
+        /*addressing_mode=*/ 0x01,
+        /*dstOffset=*/ 0x56,
+        /*inTag=*/ TypeTag.UINT8,
+        /*value=*/ 0x12,
+      ).as(Opcode.SET_8, Set.wireFormat8);
 
       expect(Set.as(Set.wireFormat8).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -47,10 +49,12 @@ describe('Memory instructions', () => {
         TypeTag.UINT16, // inTag
         ...Buffer.from('1234', 'hex'),
       ]);
-      const inst = new Set(/*indirect=*/ 0x01, /*dstOffset=*/ 0x3456, /*inTag=*/ TypeTag.UINT16, /*value=*/ 0x1234).as(
-        Opcode.SET_16,
-        Set.wireFormat16,
-      );
+      const inst = new Set(
+        /*addressing_mode=*/ 0x01,
+        /*dstOffset=*/ 0x3456,
+        /*inTag=*/ TypeTag.UINT16,
+        /*value=*/ 0x1234,
+      ).as(Opcode.SET_16, Set.wireFormat16);
 
       expect(Set.as(Set.wireFormat16).fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -65,7 +69,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('12345678', 'hex'),
       ]);
       const inst = new Set(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*dstOffset=*/ 0x3456,
         /*inTag=*/ TypeTag.UINT32,
         /*value=*/ 0x12345678,
@@ -84,7 +88,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('1234567812345678', 'hex'),
       ]);
       const inst = new Set(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*dstOffset=*/ 0x3456,
         /*inTag=*/ TypeTag.UINT64,
         /*value=*/ 0x1234567812345678n,
@@ -103,7 +107,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('12345678123456781234567812345678', 'hex'), // const (will be 128 bit)
       ]);
       const inst = new Set(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*dstOffset=*/ 0x3456,
         /*inTag=*/ TypeTag.UINT128,
         /*value=*/ 0x12345678123456781234567812345678n,
@@ -122,7 +126,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', 'hex'), // const (will be 32 bytes)
       ]);
       const inst = new Set(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*dstOffset=*/ 0x3456,
         /*inTag=*/ TypeTag.UINT128,
         /*value=*/ 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdefn,
@@ -133,7 +137,9 @@ describe('Memory instructions', () => {
     });
 
     it('should correctly set value and tag (uninitialized)', async () => {
-      await new Set(/*indirect=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT16, /*value=*/ 1234n).execute(context);
+      await new Set(/*addressing_mode=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT16, /*value=*/ 1234n).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(1);
       const tag = context.machineState.memory.getTag(1);
@@ -145,7 +151,9 @@ describe('Memory instructions', () => {
     it('should correctly set value and tag (overwriting)', async () => {
       context.machineState.memory.set(1, new Field(27));
 
-      await new Set(/*indirect=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1234n).execute(context);
+      await new Set(/*addressing_mode=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1234n).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(1);
       const tag = context.machineState.memory.getTag(1);
@@ -155,7 +163,9 @@ describe('Memory instructions', () => {
     });
 
     it('should correctly set value and tag (truncating)', async () => {
-      await new Set(/*indirect=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT16, /*value=*/ 0x12345678n).execute(context);
+      await new Set(/*addressing_mode=*/ 0, /*offset=*/ 1, /*inTag=*/ TypeTag.UINT16, /*value=*/ 0x12345678n).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(1);
       const tag = context.machineState.memory.getTag(1);
@@ -175,7 +185,7 @@ describe('Memory instructions', () => {
         TypeTag.FIELD, // dstTag
       ]);
       const inst = new Cast(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*aOffset=*/ 0x1234,
         /*dstOffset=*/ 0x3456,
         /*dstTag=*/ TypeTag.FIELD,
@@ -193,11 +203,11 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(4, new Uint128(1n << 100n));
 
       const ops = [
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT16),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT32),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT64),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT128),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT128),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT16),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT32),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT64),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT128),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT128),
       ];
 
       for (const op of ops) {
@@ -224,11 +234,11 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(4, new Uint128((1n << 100n) - 1n));
 
       const ops = [
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT8),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT8),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT16),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT32),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT64),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT8),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT8),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT16),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT32),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT64),
       ];
 
       for (const op of ops) {
@@ -255,11 +265,11 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(4, new Uint128(1n << 100n));
 
       const ops = [
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.FIELD),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.FIELD),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.FIELD),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.FIELD),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.FIELD),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.FIELD),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.FIELD),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.FIELD),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.FIELD),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.FIELD),
       ];
 
       for (const op of ops) {
@@ -286,11 +296,11 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(4, new Field((1n << 200n) - 1n));
 
       const ops = [
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT8),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT16),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT32),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT64),
-        new Cast(/*indirect=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT128),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 10, /*dstTag=*/ TypeTag.UINT8),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*dstOffset=*/ 11, /*dstTag=*/ TypeTag.UINT16),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 2, /*dstOffset=*/ 12, /*dstTag=*/ TypeTag.UINT32),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 3, /*dstOffset=*/ 13, /*dstTag=*/ TypeTag.UINT64),
+        new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 4, /*dstOffset=*/ 14, /*dstTag=*/ TypeTag.UINT128),
       ];
 
       for (const op of ops) {
@@ -312,7 +322,9 @@ describe('Memory instructions', () => {
     it('Should cast between field elements', async () => {
       context.machineState.memory.set(0, new Field(12345678n));
 
-      await new Cast(/*indirect=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 1, /*dstTag=*/ TypeTag.FIELD).execute(context);
+      await new Cast(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*dstOffset=*/ 1, /*dstTag=*/ TypeTag.FIELD).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(1);
       expect(actual).toEqual(new Field(12345678n));
@@ -329,7 +341,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('12', 'hex'), // srcOffset
         ...Buffer.from('34', 'hex'), // dstOffset
       ]);
-      const inst = new Mov(/*indirect=*/ 0x01, /*srcOffset=*/ 0x12, /*dstOffset=*/ 0x34).as(
+      const inst = new Mov(/*addressing_mode=*/ 0x01, /*srcOffset=*/ 0x12, /*dstOffset=*/ 0x34).as(
         Opcode.MOV_8,
         Mov.wireFormat8,
       );
@@ -340,7 +352,7 @@ describe('Memory instructions', () => {
 
     it('Should move integrals on different memory cells', async () => {
       context.machineState.memory.set(0, new Uint16(27));
-      await new Mov(/*indirect=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+      await new Mov(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
 
       const actual = context.machineState.memory.get(1);
       const tag = context.machineState.memory.getTag(1);
@@ -356,7 +368,7 @@ describe('Memory instructions', () => {
         /*srcOffset*/ AddressingMode.DIRECT,
         /*dstOffset*/ AddressingMode.INDIRECT,
       ]);
-      await new Mov(/*indirect=*/ addressing.toWire(), /*srcOffset=*/ 0, /*dstOffset=*/ 10).execute(context);
+      await new Mov(/*addressing_mode=*/ addressing.toWire(), /*srcOffset=*/ 0, /*dstOffset=*/ 10).execute(context);
 
       expect(context.machineState.memory.get(1)).toEqual(new Field(0));
       expect(context.machineState.memory.get(20)).toEqual(new Uint16(55n));
@@ -364,7 +376,7 @@ describe('Memory instructions', () => {
 
     it('Should move field elements on different memory cells', async () => {
       context.machineState.memory.set(0, new Field(27));
-      await new Mov(/*indirect=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+      await new Mov(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
 
       const actual = context.machineState.memory.get(1);
       const tag = context.machineState.memory.getTag(1);
@@ -384,7 +396,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
       const inst = new CalldataCopy(
-        /*indirect=*/ 0x10,
+        /*addressing_mode=*/ 0x10,
         /*copysizeOffset=*/ 0x2345,
         /*cdOffsetAddress=*/ 0x1234,
         /*dstOffset=*/ 0x3456,
@@ -401,7 +413,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(1, new Uint32(0)); // size
       context.machineState.memory.set(3, new Uint16(12)); // not overwritten
 
-      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(3);
       expect(actual).toEqual(new Uint16(12));
@@ -413,7 +427,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(0)); // cdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
 
-      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(1), new Field(2), new Field(3)]);
@@ -425,7 +441,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(1)); // cdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
 
-      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 2);
       expect(actual).toEqual([new Field(2), new Field(3)]);
@@ -439,7 +457,7 @@ describe('Memory instructions', () => {
 
       await expect(
         new CalldataCopy(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*copySizeOffset=*/ 1,
           /*cdStartOffset=*/ 0,
           /*dstOffset=*/ TaggedMemory.MAX_MEMORY_SIZE - 2,
@@ -453,9 +471,12 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(2)); // cdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
 
-      await new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*cdStartOffset=*/ 0, /*dstOffset=*/ 0).execute(
-        context,
-      );
+      await new CalldataCopy(
+        /*addressing_mode=*/ 0,
+        /*copySizeOffset=*/ 1,
+        /*cdStartOffset=*/ 0,
+        /*dstOffset=*/ 0,
+      ).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(3), new Field(0), new Field(0)]);
@@ -469,7 +490,9 @@ describe('Memory instructions', () => {
 
       const gasBefore = context.machineState.l2GasLeft;
 
-      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       expect(context.machineState.l2GasLeft).toEqual(
         gasBefore - AVM_CALLDATACOPY_BASE_L2_GAS - AVM_CALLDATACOPY_DYN_L2_GAS * 3,
@@ -484,7 +507,7 @@ describe('Memory instructions', () => {
         0x01, // indirect
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new ReturndataSize(/*indirect=*/ 0x01, /*dstOffset=*/ 0x3456);
+      const inst = new ReturndataSize(/*addressing_mode=*/ 0x01, /*dstOffset=*/ 0x3456);
 
       expect(ReturndataSize.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -494,7 +517,7 @@ describe('Memory instructions', () => {
       context = initContext();
       context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
 
-      await new ReturndataSize(/*indirect=*/ 0, /*dstOffset=*/ 10).execute(context);
+      await new ReturndataSize(/*addressing_mode=*/ 0, /*dstOffset=*/ 10).execute(context);
 
       const actual = context.machineState.memory.get(10);
       expect(actual).toEqual(new Uint32(3));
@@ -511,7 +534,7 @@ describe('Memory instructions', () => {
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
       const inst = new ReturndataCopy(
-        /*indirect=*/ 0x10,
+        /*addressing_mode=*/ 0x10,
         /*copysizeOffset=*/ 0x2345,
         /*cdOffsetAddress=*/ 0x1234,
         /*dstOffset=*/ 0x3456,
@@ -528,7 +551,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(1, new Uint32(0)); // size
       context.machineState.memory.set(3, new Uint16(12)); // not overwritten
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.get(3);
       expect(actual).toEqual(new Uint16(12));
@@ -540,7 +565,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(0)); // rdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(1), new Field(2), new Field(3)]);
@@ -552,7 +579,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(1)); // rdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 2);
       expect(actual).toEqual([new Field(2), new Field(3)]);
@@ -566,7 +595,7 @@ describe('Memory instructions', () => {
 
       await expect(
         new ReturndataCopy(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*copySizeOffset=*/ 1,
           /*rdStartOffset=*/ 0,
           /*dstOffset=*/ TaggedMemory.MAX_MEMORY_SIZE - 1,
@@ -580,9 +609,12 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(2)); // rdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*rdStartOffset=*/ 0, /*dstOffset=*/ 0).execute(
-        context,
-      );
+      await new ReturndataCopy(
+        /*addressing_mode=*/ 0,
+        /*copySizeOffset=*/ 1,
+        /*rdStartOffset=*/ 0,
+        /*dstOffset=*/ 0,
+      ).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(3), new Field(0), new Field(0)]);
@@ -596,7 +628,9 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(1, new Uint32(size)); // size
 
       const gasBefore = context.machineState.l2GasLeft;
-      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*addressing_mode=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(
+        context,
+      );
       expect(context.machineState.l2GasLeft).toEqual(
         gasBefore - AVM_RETURNDATACOPY_BASE_L2_GAS - AVM_RETURNDATACOPY_DYN_L2_GAS * size,
       );

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.ts
@@ -15,49 +15,49 @@ export class Set extends Instruction {
 
   public static readonly wireFormat8: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT8, // dstOffset
     OperandType.TAG, // tag
     OperandType.UINT8, // const (value)
   ];
   public static readonly wireFormat16: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.TAG, // tag
     OperandType.UINT16, // const (value)
   ];
   public static readonly wireFormat32: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.TAG, // tag
     OperandType.UINT32, // const (value)
   ];
   public static readonly wireFormat64: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.TAG, // tag
     OperandType.UINT64, // const (value)
   ];
   public static readonly wireFormat128: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.TAG, // tag
     OperandType.UINT128, // const (value)
   ];
   public static readonly wireFormatFF: OperandType[] = [
     OperandType.UINT8, // opcode
-    OperandType.UINT8, // indirect
+    OperandType.UINT8, // addressing_mode
     OperandType.UINT16, // dstOffset
     OperandType.TAG, // tag
     OperandType.FF, // const (value)
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private dstOffset: number,
     private inTag: number,
     private value: bigint | number,
@@ -72,7 +72,7 @@ export class Set extends Instruction {
     const res = TaggedMemory.buildFromTagTruncating(this.value, this.inTag);
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -104,7 +104,7 @@ export class Cast extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private srcOffset: number,
     private dstOffset: number,
     private dstTag: number,
@@ -114,7 +114,7 @@ export class Cast extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -150,7 +150,7 @@ export class Mov extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private srcOffset: number,
     private dstOffset: number,
   ) {
@@ -159,7 +159,7 @@ export class Mov extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -185,7 +185,7 @@ export class CalldataCopy extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private copySizeOffset: number,
     private cdStartOffset: number,
     private dstOffset: number,
@@ -195,7 +195,7 @@ export class CalldataCopy extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -225,7 +225,7 @@ export class ReturndataSize extends Instruction {
   static readonly wireFormat: OperandType[] = [OperandType.UINT8, OperandType.UINT8, OperandType.UINT16];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private dstOffset: number,
   ) {
     super();
@@ -233,7 +233,7 @@ export class ReturndataSize extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -259,7 +259,7 @@ export class ReturndataCopy extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private copySizeOffset: number,
     private rdStartOffset: number,
     private dstOffset: number,
@@ -269,7 +269,7 @@ export class ReturndataCopy extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/misc.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/misc.test.ts
@@ -23,7 +23,7 @@ describe('Misc Instructions', () => {
         ...Buffer.from('0010', 'hex'), // messageSize
       ]);
       const inst = new DebugLog(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*level=*/ 0x02,
         /*messageOffset=*/ 0x1234,
         /*fieldsOffset=*/ 0x2345,
@@ -68,7 +68,7 @@ describe('Misc Instructions', () => {
       try {
         // Execute debug log instruction
         await new DebugLog(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*levelOffset=*/ levelOffset,
           /*messageOffset=*/ messageOffset,
           /*fieldsOffset=*/ fieldsOffset,
@@ -107,7 +107,7 @@ describe('Misc Instructions', () => {
       try {
         // Execute debug log instruction
         await new DebugLog(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*level=*/ 0,
           /*messageOffset=*/ messageOffset,
           /*fieldsOffset=*/ fieldsOffset,
@@ -154,7 +154,7 @@ describe('Misc Instructions', () => {
       // Execute debug log instruction
       await expect(
         new DebugLog(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*levelOffset=*/ levelOffset,
           /*messageOffset=*/ messageOffset,
           /*fieldsOffset=*/ fieldsOffset,
@@ -188,7 +188,7 @@ describe('Misc Instructions', () => {
       // Execute debug log instruction
       await expect(
         new DebugLog(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*levelOffset=*/ levelOffset,
           /*messageOffset=*/ messageOffset,
           /*fieldsOffset=*/ fieldsOffset,

--- a/yarn-project/simulator/src/public/avm/opcodes/misc.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/misc.ts
@@ -23,7 +23,7 @@ export class DebugLog extends Instruction {
   ];
 
   constructor(
-    private indirect: number,
+    private addressingMode: number,
     private levelOffset: number,
     private messageOffset: number,
     private fieldsOffset: number,
@@ -35,7 +35,7 @@ export class DebugLog extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
@@ -33,7 +33,7 @@ describe('Storage Instructions', () => {
         ...Buffer.from('1234', 'hex'), // srcOffset
         ...Buffer.from('3456', 'hex'), // slotOffset
       ]);
-      const inst = new SStore(/*indirect=*/ 0x01, /*srcOffset=*/ 0x1234, /*slotOffset=*/ 0x3456);
+      const inst = new SStore(/*addressing_mode=*/ 0x01, /*srcOffset=*/ 0x1234, /*slotOffset=*/ 0x3456);
 
       expect(SStore.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -46,7 +46,7 @@ describe('Storage Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new SStore(/*indirect=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
+      await new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
 
       expect(persistableState.writeStorage).toHaveBeenCalledWith(address, new Fr(a.toBigInt()), new Fr(b.toBigInt()));
     });
@@ -63,7 +63,8 @@ describe('Storage Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      const instruction = () => new SStore(/*indirect=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1).execute(context);
+      const instruction = () =>
+        new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1).execute(context);
       await expect(instruction()).rejects.toThrow(StaticCallAlterationError);
     });
 
@@ -77,7 +78,7 @@ describe('Storage Instructions', () => {
       persistableState.isStorageCold.mockReturnValue(true);
 
       const daGasBefore = context.machineState.daGasLeft;
-      await new SStore(/*indirect=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
+      await new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
 
       expect(context.machineState.daGasLeft).toBe(daGasBefore - AVM_SSTORE_DYN_DA_GAS);
     });
@@ -92,7 +93,7 @@ describe('Storage Instructions', () => {
       persistableState.isStorageCold.mockReturnValue(false);
 
       const daGasBefore = context.machineState.daGasLeft;
-      await new SStore(/*indirect=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
+      await new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0).execute(context);
 
       expect(context.machineState.daGasLeft).toBe(daGasBefore);
     });
@@ -106,7 +107,7 @@ describe('Storage Instructions', () => {
         ...Buffer.from('1234', 'hex'), // slotOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new SLoad(/*indirect=*/ 0x01, /*slotOffset=*/ 0x1234, /*dstOffset=*/ 0x3456);
+      const inst = new SLoad(/*addressing_mode=*/ 0x01, /*slotOffset=*/ 0x1234, /*dstOffset=*/ 0x3456);
 
       expect(SLoad.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -123,7 +124,7 @@ describe('Storage Instructions', () => {
       context.machineState.memory.set(0, a);
       context.machineState.memory.set(1, b);
 
-      await new SLoad(/*indirect=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+      await new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
 
       expect(persistableState.readStorage).toHaveBeenCalledWith(address, new Fr(a.toBigInt()));
 

--- a/yarn-project/simulator/src/public/avm/opcodes/storage.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/storage.ts
@@ -15,7 +15,7 @@ abstract class BaseStorageInstruction extends Instruction {
   ];
 
   constructor(
-    protected indirect: number,
+    protected addressingMode: number,
     protected aOffset: number,
     protected bOffset: number,
   ) {
@@ -27,8 +27,8 @@ export class SStore extends BaseStorageInstruction {
   static readonly type: string = 'SSTORE';
   static readonly opcode = Opcode.SSTORE;
 
-  constructor(indirect: number, srcOffset: number, slotOffset: number) {
-    super(indirect, srcOffset, slotOffset);
+  constructor(addressingMode: number, srcOffset: number, slotOffset: number) {
+    super(addressingMode, srcOffset, slotOffset);
   }
 
   public async execute(context: AvmContext): Promise<void> {
@@ -37,7 +37,7 @@ export class SStore extends BaseStorageInstruction {
     }
 
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
@@ -64,13 +64,13 @@ export class SLoad extends BaseStorageInstruction {
   static readonly type: string = 'SLOAD';
   static readonly opcode = Opcode.SLOAD;
 
-  constructor(indirect: number, slotOffset: number, dstOffset: number) {
-    super(indirect, slotOffset, dstOffset);
+  constructor(addressingMode: number, slotOffset: number, dstOffset: number) {
+    super(addressingMode, slotOffset, dstOffset);
   }
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const addressing = Addressing.fromWire(this.indirect);
+    const addressing = Addressing.fromWire(this.addressingMode);
 
     context.machineState.consumeGas(
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
@@ -76,14 +76,20 @@ describe('Bytecode Serialization', () => {
 
   it('Should deserialize real instructions', () => {
     const instructions = [
-      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
-      new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.SUB_8, Sub.wireFormat8),
-      new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 1, EnvironmentVariable.ADDRESS).as(
+      new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.ADD_8,
+        Add.wireFormat8,
+      ),
+      new Sub(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.SUB_8,
+        Sub.wireFormat8,
+      ),
+      new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, EnvironmentVariable.ADDRESS).as(
         Opcode.GETENVVAR_16,
         GetEnvVar.wireFormat16,
       ),
       new Call(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -91,7 +97,7 @@ describe('Bytecode Serialization', () => {
         /*argsOffset=*/ 0xb234,
       ),
       new StaticCall(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -108,14 +114,20 @@ describe('Bytecode Serialization', () => {
 
   it('Should serialize real instructions', () => {
     const instructions = [
-      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
-      new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.SUB_8, Sub.wireFormat8),
-      new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 1, EnvironmentVariable.ADDRESS).as(
+      new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.ADD_8,
+        Add.wireFormat8,
+      ),
+      new Sub(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.SUB_8,
+        Sub.wireFormat8,
+      ),
+      new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, EnvironmentVariable.ADDRESS).as(
         Opcode.GETENVVAR_16,
         GetEnvVar.wireFormat16,
       ),
       new Call(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -123,7 +135,7 @@ describe('Bytecode Serialization', () => {
         /*argsOffset=*/ 0xb234,
       ),
       new StaticCall(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
@@ -149,7 +161,7 @@ describe('Bytecode Serialization', () => {
 
     const actual = decodeFromBytecode(buf);
     expect(actual).toEqual([
-      new Set(/*indirect=*/ 0x02, /*dstOffset=*/ 0x3456, /*inTag=*/ 0x02, /*value=*/ 245n).as(
+      new Set(/*addressing_mode=*/ 0x02, /*dstOffset=*/ 0x3456, /*inTag=*/ 0x02, /*value=*/ 245n).as(
         Opcode.SET_FF,
         Set.wireFormatFF,
       ),
@@ -188,7 +200,7 @@ describe('Bytecode Serialization', () => {
 
     const instructions = [
       new Call(
-        /*indirect=*/ 0x01,
+        /*addressing_mode=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,

--- a/yarn-project/simulator/src/public/fixtures/custom_bytecode_tests.ts
+++ b/yarn-project/simulator/src/public/fixtures/custom_bytecode_tests.ts
@@ -23,8 +23,8 @@ export async function addressingWithBaseTagIssueTest(isIndirect: boolean, tester
   ]);
 
   const bytecode = encodeToBytecode([
-    new CalldataCopy(/*indirect=*/ addressingMode.toWire(), /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new CalldataCopy(/*addressing_mode=*/ addressingMode.toWire(), /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const txLabel = isIndirect ? 'AddressingWithBaseTagInvalidIndirect' : 'AddressingWithBaseTagInvalidDirect';
@@ -44,11 +44,14 @@ export async function addressingWithIndirectTagIssueTest(tester: PublicTxSimulat
 
   const bytecode = encodeToBytecode([
     // Set a U64 value at offset 0 - this has the wrong tag for an address (should be U32)
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT64, /*value=*/ 100n).as(Opcode.SET_64, Set.wireFormat64),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT64, /*value=*/ 100n).as(
+      Opcode.SET_64,
+      Set.wireFormat64,
+    ),
     // Try to use indirect addressing: read from offset 0, which contains a U64 value
     // This should fail because U64 is not a valid address tag (must be U32)
-    new CalldataCopy(/*indirect=*/ addressingMode.toWire(), /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 1),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new CalldataCopy(/*addressing_mode=*/ addressingMode.toWire(), /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 1),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const txLabel = 'AddressingWithIndirectTagInvalid';
@@ -69,14 +72,17 @@ export async function addressingWithIndirectThenRelativeTagIssueTest(tester: Pub
 
   const bytecode = encodeToBytecode([
     // Set a U32 value 10 at offset 1 - this will be used as an indirect address
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, /*value=*/ 10).as(Opcode.SET_32, Set.wireFormat32),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, /*value=*/ 10).as(
+      Opcode.SET_32,
+      Set.wireFormat32,
+    ),
     // ADD_16: first operand uses indirect addressing (reads from offset 1, gets value 10, uses as address - succeeds)
     //         second operand uses relative addressing (tries to read base from offset 0, but offset 0 has wrong tag - fails)
-    new Add(/*indirect=*/ addressingMode.toWire(), /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3).as(
+    new Add(/*addressing_mode=*/ addressingMode.toWire(), /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3).as(
       Opcode.ADD_16,
       Add.wireFormat16,
     ),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const txLabel = 'AddressingWithIndirectThenRelativeTagInvalid';
@@ -100,15 +106,15 @@ export async function addressingWithRelativeOverflowAndIndirectTagIssueTest(test
 
   const bytecode = encodeToBytecode([
     // Set UINT32_MAX at offset 0 as base address - this will cause overflow when adding relative offset 1
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ UINT32_MAX).as(
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ UINT32_MAX).as(
       Opcode.SET_32,
       Set.wireFormat32,
     ),
-    new Add(/*indirect=*/ addressingMode.toWire(), /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3).as(
+    new Add(/*addressing_mode=*/ addressingMode.toWire(), /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3).as(
       Opcode.ADD_8,
       Add.wireFormat8,
     ),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const txLabel = 'AddressingWithRelativeOverflowAndIndirectTagInvalid';
@@ -118,7 +124,7 @@ export async function addressingWithRelativeOverflowAndIndirectTagIssueTest(test
 export async function pcOutOfRangeTest(tester: PublicTxSimulationTester) {
   const bytecode = encodeToBytecode([
     new Jump(/*jumpOffset=*/ 123), // Jump to out-of-range pc offset.
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const txLabel = 'PcOutOfRange';
@@ -127,14 +133,14 @@ export async function pcOutOfRangeTest(tester: PublicTxSimulationTester) {
 
 export async function invalidOpcodeTest(tester: PublicTxSimulationTester) {
   let bytecode = encodeToBytecode([
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
   ]);
 
   const offsetReturnOpcodeByte = bytecode.length;
 
   bytecode = Buffer.concat([
     bytecode,
-    encodeToBytecode([new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0)]),
+    encodeToBytecode([new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0)]),
   ]);
 
   // Manipulate the Return opcode to make the opcode invalid (out of range).
@@ -157,7 +163,7 @@ export async function invalidByteTest(tester: PublicTxSimulationTester) {
 // Truncate the last instruction in the bytecode.
 export async function instructionTruncatedTest(tester: PublicTxSimulationTester) {
   let bytecode = encodeToBytecode([
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
   ]);
 
   // Truncate the bytecode.
@@ -170,8 +176,8 @@ export async function instructionTruncatedTest(tester: PublicTxSimulationTester)
 // Invalid tag value byte in an instruction.
 export async function invalidTagValueTest(tester: PublicTxSimulationTester) {
   const bytecode = encodeToBytecode([
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, /*value=*/ 0).as(Opcode.SET_8, Set.wireFormat8),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 0),
   ]);
 
   const tagOffset = getTagOffsetInInstruction(Set.wireFormat8);
@@ -186,7 +192,10 @@ export async function invalidTagValueTest(tester: PublicTxSimulationTester) {
 export async function invalidTagValueAndInstructionTruncatedTest(tester: PublicTxSimulationTester) {
   let bytecode = encodeToBytecode([
     // Important: value argument must be a bigint otherwise a type error will be thrown.
-    new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT128, /*value=*/ 0n).as(Opcode.SET_128, Set.wireFormat128),
+    new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT128, /*value=*/ 0n).as(
+      Opcode.SET_128,
+      Set.wireFormat128,
+    ),
   ]);
 
   // Truncate the bytecode.

--- a/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
+++ b/yarn-project/simulator/src/public/fixtures/minimal_public_tx.ts
@@ -12,8 +12,8 @@ export async function executeAvmMinimalPublicTx(tester: PublicTxSimulationTester
   const minimalBytecode = encodeToBytecode([
     new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
     new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
-    new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
-    new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
+    new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
+    new Return(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),
   ]);
 
   const result = await deployAndExecuteCustomBytecode(minimalBytecode, tester, 'MinimalTx', 'AvmMinimalContract');

--- a/yarn-project/simulator/src/public/fixtures/opcode_spammer.ts
+++ b/yarn-project/simulator/src/public/fixtures/opcode_spammer.ts
@@ -449,7 +449,7 @@ export const EXTERNAL_CALL_CONFIG: SpamConfig = {
     { offset: CONST_MAX_U32_OFFSET, value: new Uint32(MAX_U32) }, // l2Gas/daGas - MAX_U32 gets capped to remaining gas
     () => [
       new CalldataCopy(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*copySizeOffset=*/ CALL_COPY_SIZE_OFFSET,
         /*cdStartOffset=*/ CALL_CALLDATA_INDEX_OFFSET,
         /*dstOffset=*/ CALL_ADDR_OFFSET,
@@ -458,7 +458,7 @@ export const EXTERNAL_CALL_CONFIG: SpamConfig = {
   ],
   targetInstructions: () => [
     new Call(
-      /*indirect=*/ 0,
+      /*addressing_mode=*/ 0,
       /*l2GasOffset=*/ CALL_L2_GAS_OFFSET,
       /*daGasOffset=*/ CALL_DA_GAS_OFFSET,
       /*addrOffset=*/ CALL_ADDR_OFFSET,
@@ -477,7 +477,7 @@ const STATIC_CALL_CONFIG: SpamConfig = {
     { offset: CONST_MAX_U32_OFFSET, value: new Uint32(MAX_U32) }, // l2Gas/daGas - MAX_U32 gets capped to remaining gas
     () => [
       new CalldataCopy(
-        /*indirect=*/ 0,
+        /*addressing_mode=*/ 0,
         /*copySizeOffset=*/ CALL_COPY_SIZE_OFFSET,
         /*cdStartOffset=*/ CALL_CALLDATA_INDEX_OFFSET,
         /*dstOffset=*/ CALL_ADDR_OFFSET,
@@ -486,7 +486,7 @@ const STATIC_CALL_CONFIG: SpamConfig = {
   ],
   targetInstructions: () => [
     new StaticCall(
-      /*indirect=*/ 0,
+      /*addressing_mode=*/ 0,
       /*l2GasOffset=*/ CALL_L2_GAS_OFFSET,
       /*daGasOffset=*/ CALL_DA_GAS_OFFSET,
       /*addrOffset=*/ CALL_ADDR_OFFSET,
@@ -517,7 +517,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random addend
     ],
     targetInstructions: () => [
-      new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.ADD_8, Add.wireFormat8),
+      new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.ADD_8,
+        Add.wireFormat8,
+      ),
     ],
   })),
 
@@ -528,7 +531,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random subtrahend
     ],
     targetInstructions: () => [
-      new Sub(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.SUB_8, Sub.wireFormat8),
+      new Sub(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.SUB_8,
+        Sub.wireFormat8,
+      ),
     ],
   })),
 
@@ -539,7 +545,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random multiplier
     ],
     targetInstructions: () => [
-      new Mul(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.MUL_8, Mul.wireFormat8),
+      new Mul(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.MUL_8,
+        Mul.wireFormat8,
+      ),
     ],
   })),
 
@@ -551,7 +560,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomNonZeroWithTag(tag) }, // random non-zero divisor
     ],
     targetInstructions: () => [
-      new Div(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.DIV_8, Div.wireFormat8),
+      new Div(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.DIV_8,
+        Div.wireFormat8,
+      ),
     ],
   })),
 
@@ -563,7 +575,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: randomNonZeroField() }, // random non-zero divisor
       ],
       targetInstructions: () => [
-        new FieldDiv(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        new FieldDiv(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
           Opcode.FDIV_8,
           FieldDiv.wireFormat8,
         ),
@@ -581,7 +593,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new Eq(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.EQ_8, Eq.wireFormat8),
+      new Eq(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.EQ_8, Eq.wireFormat8),
     ],
   })),
 
@@ -592,7 +604,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new Lt(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.LT_8, Lt.wireFormat8),
+      new Lt(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.LT_8, Lt.wireFormat8),
     ],
   })),
 
@@ -603,7 +615,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new Lte(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.LTE_8, Lte.wireFormat8),
+      new Lte(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(
+        Opcode.LTE_8,
+        Lte.wireFormat8,
+      ),
     ],
   })),
 
@@ -617,7 +632,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new And(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.AND_8, And.wireFormat8),
+      new And(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.AND_8,
+        And.wireFormat8,
+      ),
     ],
   })),
 
@@ -628,7 +646,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new Or(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.OR_8, Or.wireFormat8),
+      new Or(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.OR_8, Or.wireFormat8),
     ],
   })),
 
@@ -639,7 +657,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: randomWithTag(tag) }, // random value b
     ],
     targetInstructions: () => [
-      new Xor(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.XOR_8, Xor.wireFormat8),
+      new Xor(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.XOR_8,
+        Xor.wireFormat8,
+      ),
     ],
   })),
 
@@ -647,7 +668,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     label: TypeTag[tag],
     setup: [{ offset: 0, value: randomWithTag(tag) }], // random value
     targetInstructions: () => [
-      new Not(/*indirect=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 0).as(Opcode.NOT_8, Not.wireFormat8),
+      new Not(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 0).as(Opcode.NOT_8, Not.wireFormat8),
     ],
   })),
 
@@ -658,7 +679,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: withTag(1n, tag) }, // shift by 1 (small fixed amount to avoid overflow)
     ],
     targetInstructions: () => [
-      new Shl(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.SHL_8, Shl.wireFormat8),
+      new Shl(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.SHL_8,
+        Shl.wireFormat8,
+      ),
     ],
   })),
 
@@ -669,7 +693,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       { offset: 1, value: withTag(1n, tag) }, // shift by 1 (small fixed amount)
     ],
     targetInstructions: () => [
-      new Shr(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.SHR_8, Shr.wireFormat8),
+      new Shr(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+        Opcode.SHR_8,
+        Shr.wireFormat8,
+      ),
     ],
   })),
 
@@ -680,7 +707,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     label: TypeTag[tag],
     setup: [{ offset: 0, value: randomWithTag(tag) }], // random value to cast
     targetInstructions: () => [
-      new Cast(/*indirect=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1, /*dstTag=*/ TypeTag.UINT32).as(
+      new Cast(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1, /*dstTag=*/ TypeTag.UINT32).as(
         Opcode.CAST_8,
         Cast.wireFormat8,
       ),
@@ -691,7 +718,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     label: TypeTag[tag],
     setup: [{ offset: 0, value: randomWithTag(tag) }], // random value to move
     targetInstructions: () => [
-      new Mov(/*indirect=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).as(Opcode.MOV_8, Mov.wireFormat8),
+      new Mov(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*dstOffset=*/ 1).as(Opcode.MOV_8, Mov.wireFormat8),
     ],
   })),
 
@@ -732,7 +759,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     {
       setup: [],
       targetInstructions: () => [
-        new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ 4242424242424242n).as(
+        new Set(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT128, /*value=*/ 4242424242424242n).as(
           Opcode.SET_128,
           Set.wireFormat128,
         ),
@@ -761,7 +788,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
   [Opcode.JUMPI_32]: [
     {
       setup: [{ offset: 0, value: new Uint1(0n) }], // Always false
-      targetInstructions: () => [new JumpI(/*indirect=*/ 0, /*condOffset=*/ 0, /*loc=*/ 0)],
+      targetInstructions: () => [new JumpI(/*addressing_mode=*/ 0, /*condOffset=*/ 0, /*loc=*/ 0)],
     },
   ],
 
@@ -801,7 +828,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 0, value: new Uint32(0) }, // returnSize = 0
       ],
       targetInstructions: () => [
-        new Return(/*indirect=*/ 0, /*returnSizeOffset=*/ 0, /*returnOffset=*/ 0), // return nothing (size=0)
+        new Return(/*addressing_mode=*/ 0, /*returnSizeOffset=*/ 0, /*returnOffset=*/ 0), // return nothing (size=0)
       ],
       // Use the side-effect-limit pattern (even though it's not a side-effect) as it fits
       // this case (we want to CALL, RETURN, then CALL again back in parent). We omit "cleanup"
@@ -818,7 +845,10 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 0, value: new Uint32(0) }, // retSize = 0
       ],
       targetInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 0, /*returnOffset=*/ 1).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 0, /*returnOffset=*/ 1).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ],
       limit: 1, // REVERT can only execute once per call
     },
@@ -831,7 +861,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     {
       setup: [],
       targetInstructions: () => [
-        new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, /*varEnum=*/ 0).as(
+        new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*varEnum=*/ 0).as(
           Opcode.GETENVVAR_16,
           GetEnvVar.wireFormat16,
         ),
@@ -849,7 +879,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // cdStart = 0
       ],
       targetInstructions: () => [
-        new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new CalldataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
     {
@@ -862,7 +892,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // cdStart = 0
       ],
       targetInstructions: () => [
-        new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new CalldataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
     {
@@ -873,7 +903,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // cdStart = 0
       ],
       targetInstructions: () => [
-        new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new CalldataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*cdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
   ],
@@ -881,14 +911,14 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
   [Opcode.SUCCESSCOPY]: [
     {
       setup: [],
-      targetInstructions: () => [new SuccessCopy(/*indirect=*/ 0, /*dstOffset=*/ 0)],
+      targetInstructions: () => [new SuccessCopy(/*addressing_mode=*/ 0, /*dstOffset=*/ 0)],
     },
   ],
 
   [Opcode.RETURNDATASIZE]: [
     {
       setup: [],
-      targetInstructions: () => [new ReturndataSize(/*indirect=*/ 0, /*dstOffset=*/ 0)],
+      targetInstructions: () => [new ReturndataSize(/*addressing_mode=*/ 0, /*dstOffset=*/ 0)],
     },
   ],
 
@@ -901,7 +931,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // rdOffset
       ],
       targetInstructions: () => [
-        new ReturndataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new ReturndataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
     {
@@ -914,7 +944,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // rdOffset
       ],
       targetInstructions: () => [
-        new ReturndataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new ReturndataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
     {
@@ -925,7 +955,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint32(0n) }, // rdOffset
       ],
       targetInstructions: () => [
-        new ReturndataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
+        new ReturndataCopy(/*addressing_mode=*/ 0, /*copySizeOffset=*/ 0, /*rdStartOffset=*/ 1, /*dstOffset=*/ 2),
       ],
     },
   ],
@@ -937,13 +967,13 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     {
       label: 'Cold read (slot not written)',
       setup: [{ offset: 0, value: new Field(Fr.random()) }], // random slot
-      targetInstructions: () => [new SLoad(/*indirect=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
+      targetInstructions: () => [new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
     },
     {
       label: 'Warm read (from tree)',
       // Uses pre-inserted storage from insertWarmTreeEntries() which is called after contract deployment
       setup: [{ offset: 0, value: new Field(WARM_STORAGE_SLOT) }], // pre-inserted slot
-      targetInstructions: () => [new SLoad(/*indirect=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
+      targetInstructions: () => [new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
     },
     {
       label: 'Warm read (SSTORE first, unique slot per SLOAD)',
@@ -955,12 +985,18 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 3, value: new Uint32(0n) }, // revertSize
       ],
       targetInstructions: () => [
-        new SStore(/*indirect=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0),
-        new SLoad(/*indirect=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 4),
-        new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 0).as(Opcode.ADD_8, Add.wireFormat8), // slot++
+        new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0),
+        new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 4),
+        new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 0).as(
+          Opcode.ADD_8,
+          Add.wireFormat8,
+        ), // slot++
       ],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ],
       limit: MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     },
@@ -976,7 +1012,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: randomWithTag(TypeTag.UINT64) }, // random leafIndex
       ],
       targetInstructions: () => [
-        new NoteHashExists(/*indirect=*/ 0, /*noteHashOffset=*/ 0, /*leafIndexOffset=*/ 1, /*existsOffset=*/ 2),
+        new NoteHashExists(/*addressing_mode=*/ 0, /*noteHashOffset=*/ 0, /*leafIndexOffset=*/ 1, /*existsOffset=*/ 2),
       ],
     },
     {
@@ -987,7 +1023,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint64(WARM_NOTE_HASH_LEAF_INDEX) }, // known leafIndex
       ],
       targetInstructions: () => [
-        new NoteHashExists(/*indirect=*/ 0, /*noteHashOffset=*/ 0, /*leafIndexOffset=*/ 1, /*existsOffset=*/ 2),
+        new NoteHashExists(/*addressing_mode=*/ 0, /*noteHashOffset=*/ 0, /*leafIndexOffset=*/ 1, /*existsOffset=*/ 2),
       ],
     },
   ],
@@ -1000,7 +1036,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Field(Fr.random()) }, // random address
       ],
       targetInstructions: () => [
-        new NullifierExists(/*indirect=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 1, /*existsOffset=*/ 2),
+        new NullifierExists(/*addressing_mode=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 1, /*existsOffset=*/ 2),
       ],
     },
     {
@@ -1011,7 +1047,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Field(WARM_NULLIFIER_ADDRESS.toField()) }, // address it was siloed with
       ],
       targetInstructions: () => [
-        new NullifierExists(/*indirect=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 1, /*existsOffset=*/ 2),
+        new NullifierExists(/*addressing_mode=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 1, /*existsOffset=*/ 2),
       ],
     },
     {
@@ -1022,7 +1058,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Field(1n) }, // constant 1 for ADD
         () => [
           // Get current contract address into offset 2
-          new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 2, /*varEnum=*/ 0).as(
+          new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 2, /*varEnum=*/ 0).as(
             Opcode.GETENVVAR_16,
             GetEnvVar.wireFormat16,
           ),
@@ -1030,12 +1066,18 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 3, value: new Uint32(0n) }, // revertSize
       ],
       targetInstructions: () => [
-        new EmitNullifier(/*indirect=*/ 0, /*nullifierOffset=*/ 0),
-        new NullifierExists(/*indirect=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 2, /*existsOffset=*/ 4),
-        new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.ADD_8, Add.wireFormat8), // nullifier++
+        new EmitNullifier(/*addressing_mode=*/ 0, /*nullifierOffset=*/ 0),
+        new NullifierExists(/*addressing_mode=*/ 0, /*nullifierOffset=*/ 0, /*addressOffset=*/ 2, /*existsOffset=*/ 4),
+        new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+          Opcode.ADD_8,
+          Add.wireFormat8,
+        ), // nullifier++
       ],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ],
       limit: MAX_NULLIFIERS_PER_TX - 1,
     },
@@ -1049,7 +1091,12 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: randomWithTag(TypeTag.UINT64) }, // random msgLeafIndex
       ],
       targetInstructions: () => [
-        new L1ToL2MessageExists(/*indirect=*/ 0, /*msgHashOffset=*/ 0, /*msgLeafIndexOffset=*/ 1, /*existsOffset=*/ 2),
+        new L1ToL2MessageExists(
+          /*addressing_mode=*/ 0,
+          /*msgHashOffset=*/ 0,
+          /*msgLeafIndexOffset=*/ 1,
+          /*existsOffset=*/ 2,
+        ),
       ],
     },
     {
@@ -1060,7 +1107,12 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Uint64(WARM_L1_TO_L2_MSG_LEAF_INDEX) }, // known msgLeafIndex
       ],
       targetInstructions: () => [
-        new L1ToL2MessageExists(/*indirect=*/ 0, /*msgHashOffset=*/ 0, /*msgLeafIndexOffset=*/ 1, /*existsOffset=*/ 2),
+        new L1ToL2MessageExists(
+          /*addressing_mode=*/ 0,
+          /*msgHashOffset=*/ 0,
+          /*msgLeafIndexOffset=*/ 1,
+          /*existsOffset=*/ 2,
+        ),
       ],
     },
   ],
@@ -1071,7 +1123,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       // This ensures we're querying a valid deployed contract
       setup: [
         () => [
-          new GetEnvVar(/*indirect=*/ 0, /*dstOffset=*/ 0, /*varEnum=*/ 0).as(
+          new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*varEnum=*/ 0).as(
             Opcode.GETENVVAR_16,
             GetEnvVar.wireFormat16,
           ),
@@ -1079,7 +1131,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       ],
       // memberEnum 0 = DEPLOYER
       targetInstructions: () => [
-        new GetContractInstance(/*indirect=*/ 0, /*addressOffset=*/ 0, /*dstOffset=*/ 1, /*memberEnum=*/ 0),
+        new GetContractInstance(/*addressing_mode=*/ 0, /*addressOffset=*/ 0, /*dstOffset=*/ 1, /*memberEnum=*/ 0),
       ],
     },
   ],
@@ -1093,9 +1145,12 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 0, value: new Field(Fr.random()) }, // random noteHash
         { offset: 1, value: new Uint32(0n) }, // revertSize
       ],
-      targetInstructions: () => [new EmitNoteHash(/*indirect=*/ 0, /*noteHashOffset=*/ 0)],
+      targetInstructions: () => [new EmitNoteHash(/*addressing_mode=*/ 0, /*noteHashOffset=*/ 0)],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       limit: MAX_NOTE_HASHES_PER_TX,
     },
@@ -1111,11 +1166,17 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 2, value: new Uint32(0n) }, // revertSize
       ],
       targetInstructions: () => [
-        new EmitNullifier(/*indirect=*/ 0, /*nullifierOffset=*/ 0),
-        new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(Opcode.ADD_8, Add.wireFormat8), // nullifier++
+        new EmitNullifier(/*addressing_mode=*/ 0, /*nullifierOffset=*/ 0),
+        new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 0).as(
+          Opcode.ADD_8,
+          Add.wireFormat8,
+        ), // nullifier++
       ],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       limit: MAX_NULLIFIERS_PER_TX - 1, // minus 1 because a TX will always have 1 "TX nullifier" from private
     },
@@ -1128,9 +1189,14 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Field(Fr.random()) }, // random content
         { offset: 2, value: new Uint32(0n) }, // revertSize
       ],
-      targetInstructions: () => [new SendL2ToL1Message(/*indirect=*/ 0, /*recipientOffset=*/ 0, /*contentOffset=*/ 1)],
+      targetInstructions: () => [
+        new SendL2ToL1Message(/*addressing_mode=*/ 0, /*recipientOffset=*/ 0, /*contentOffset=*/ 1),
+      ],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       limit: MAX_L2_TO_L1_MSGS_PER_TX,
     },
@@ -1147,9 +1213,12 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 1, value: new Field(Fr.random()) }, // random slot (same slot each iteration)
         { offset: 2, value: new Uint32(0n) }, // revertSize
       ],
-      targetInstructions: () => [new SStore(/*indirect=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1)],
+      targetInstructions: () => [new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1)],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 2, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
     },
     {
@@ -1161,11 +1230,17 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 3, value: new Uint32(0n) }, // revertSize
       ],
       targetInstructions: () => [
-        new SStore(/*indirect=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1),
-        new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 1).as(Opcode.ADD_8, Add.wireFormat8), // slot++
+        new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 0, /*slotOffset=*/ 1),
+        new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 1).as(
+          Opcode.ADD_8,
+          Add.wireFormat8,
+        ), // slot++
       ],
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       limit: MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     },
@@ -1179,9 +1254,14 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         { offset: 0, value: new Uint32(0n) }, // logSize = 0 fields (minimal)
         { offset: 1, value: new Uint32(0n) }, // revertSize
       ],
-      targetInstructions: () => [new EmitUnencryptedLog(/*indirect=*/ 0, /*logSizeOffset=*/ 0, /*logOffset=*/ 1)], // logOffset doesn't matter when size is 0
+      targetInstructions: () => [
+        new EmitUnencryptedLog(/*addressing_mode=*/ 0, /*logSizeOffset=*/ 0, /*logOffset=*/ 1),
+      ], // logOffset doesn't matter when size is 0
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       // Max logs with 0-field content: floor(4096 / 2) = 2048
       limit: Math.floor(FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH / PUBLIC_LOG_HEADER_LENGTH),
@@ -1200,9 +1280,14 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         //  value: new Field(0n),
         //})),
       ],
-      targetInstructions: () => [new EmitUnencryptedLog(/*indirect=*/ 0, /*logSizeOffset=*/ 0, /*logOffset=*/ 2)], // uses logOffset 2 (uninitialized Field(0))
+      targetInstructions: () => [
+        new EmitUnencryptedLog(/*addressing_mode=*/ 0, /*logSizeOffset=*/ 0, /*logOffset=*/ 2),
+      ], // uses logOffset 2 (uninitialized Field(0))
       cleanupInstructions: () => [
-        new Revert(/*indirect=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(Opcode.REVERT_8, Revert.wireFormat8),
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 1, /*returnOffset=*/ 0).as(
+          Opcode.REVERT_8,
+          Revert.wireFormat8,
+        ),
       ], // revert with empty
       limit: 1, // Only 1 max-size log fits
     },
@@ -1219,7 +1304,9 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         value: new Field(Fr.random()), // random field element
       })),
       // Poseidon hash data at M[0..3], write result to M[0:3] (reuse results as next inputs)
-      targetInstructions: () => [new Poseidon2(/*indirect=*/ 0, /*inputStateOffset=*/ 0, /*outputStateOffset=*/ 0)],
+      targetInstructions: () => [
+        new Poseidon2(/*addressing_mode=*/ 0, /*inputStateOffset=*/ 0, /*outputStateOffset=*/ 0),
+      ],
     },
   ],
 
@@ -1238,7 +1325,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         })),
       ],
       targetInstructions: () => [
-        new Sha256Compression(/*indirect=*/ 0, /*outputOffset=*/ 0, /*stateOffset=*/ 0, /*inputsOffset=*/ 8),
+        new Sha256Compression(/*addressing_mode=*/ 0, /*outputOffset=*/ 0, /*stateOffset=*/ 0, /*inputsOffset=*/ 8),
       ],
     },
   ],
@@ -1250,7 +1337,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
         offset: i,
         value: randomWithTag(TypeTag.UINT64),
       })),
-      targetInstructions: () => [new KeccakF1600(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inputOffset=*/ 0)],
+      targetInstructions: () => [new KeccakF1600(/*addressing_mode=*/ 0, /*dstOffset=*/ 0, /*inputOffset=*/ 0)],
     },
   ],
 
@@ -1267,7 +1354,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       ],
       targetInstructions: () => [
         new EcAdd(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*p1XOffset=*/ 0,
           /*p1YOffset=*/ 1,
           /*p1IsInfiniteOffset=*/ 2,
@@ -1292,7 +1379,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       ],
       targetInstructions: () => [
         new ToRadixBE(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*srcOffset=*/ 0,
           /*radixOffset=*/ 1,
           /*numLimbsOffset=*/ 2,
@@ -1311,7 +1398,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       ],
       targetInstructions: () => [
         new ToRadixBE(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*srcOffset=*/ 0,
           /*radixOffset=*/ 1,
           /*numLimbsOffset=*/ 2,
@@ -1332,7 +1419,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       ],
       targetInstructions: () => [
         new ToRadixBE(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*srcOffset=*/ 0,
           /*radixOffset=*/ 1,
           /*numLimbsOffset=*/ 2,
@@ -1359,7 +1446,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
       // messageSize = 0
       targetInstructions: () => [
         new DebugLog(
-          /*indirect=*/ 0,
+          /*addressing_mode=*/ 0,
           /*levelOffset=*/ 0,
           /*messageOffset=*/ 1,
           /*fieldsOffset=*/ 2,
@@ -1381,7 +1468,7 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
     //   // messageSize = 1000 (large enough to show scaling)
     //   targetInstructions: () => [
     //     new DebugLog(
-    //       /*indirect=*/ 0,
+    //       /*addressing_mode=*/ 0,
     //       /*levelOffset=*/ 0,
     //       /*messageOffset=*/ 1,
     //       /*fieldsOffset=*/ 2,


### PR DESCRIPTION
Part of https://linear.app/aztec-labs/issue/AVM-163/rename-indirect-to-addressing-mode.
PIL code will be done in a follow up.
