### PR TITLE
feat(avm): use noop calldata hasher in fast sim

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/noop_calldata_hashing.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/noop_calldata_hashing.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "barretenberg/vm2/simulation/interfaces/calldata_hashing.hpp"
+
+namespace bb::avm2::simulation {
+
+class NoopCalldataHasher : public CalldataHashingInterface {
+  public:
+    void assert_calldata_hash(const FF& /*cd_hash*/, std::span<const FF> /*calldata*/) override {}
+};
+
+class NoopCalldataHashingProvider : public CalldataHashingProviderInterface {
+  public:
+    std::unique_ptr<CalldataHashingInterface> make_calldata_hasher(uint32_t /*context_id*/) override
+    {
+        return std::make_unique<NoopCalldataHasher>();
+    }
+};
+
+} // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation_helper.cpp
@@ -79,6 +79,7 @@
 #include "barretenberg/vm2/simulation/standalone/concrete_dbs.hpp"
 #include "barretenberg/vm2/simulation/standalone/debug_log.hpp"
 #include "barretenberg/vm2/simulation/standalone/hybrid_execution.hpp"
+#include "barretenberg/vm2/simulation/standalone/noop_calldata_hashing.hpp"
 #include "barretenberg/vm2/simulation/standalone/noop_update_check.hpp"
 #include "barretenberg/vm2/simulation/standalone/pure_alu.hpp"
 #include "barretenberg/vm2/simulation/standalone/pure_bitwise.hpp"
@@ -404,7 +405,6 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_internal(ContractDBInterfa
     NoopEventEmitter<RangeCheckEvent> range_check_emitter;
     NoopEventEmitter<ContextStackEvent> context_stack_emitter;
     NoopEventEmitter<TxEvent> tx_event_emitter;
-    NoopEventEmitter<CalldataEvent> calldata_emitter;
     NoopEventEmitter<InternalCallStackEvent> internal_call_stack_emitter;
     NoopEventEmitter<ContractInstanceRetrievalEvent> contract_instance_retrieval_emitter;
     NoopEventEmitter<GetContractInstanceEvent> get_contract_instance_emitter;
@@ -455,7 +455,7 @@ TxSimulationResult AvmSimulationHelper::simulate_fast_internal(ContractDBInterfa
     PureExecutionComponentsProvider execution_components(greater_than, instruction_info_db);
 
     PureMemoryProvider memory_provider;
-    CalldataHashingProvider calldata_hashing_provider(poseidon2, calldata_emitter);
+    NoopCalldataHashingProvider calldata_hashing_provider;
     InternalCallStackManagerProvider internal_call_stack_manager_provider(internal_call_stack_emitter);
     ContextProvider context_provider(tx_bytecode_manager,
                                      memory_provider,


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/AVM-185/consider-using-a-noop-calldata-hasher-in-fast-sim.
