### PR TITLE
docs(archiver): Expand README with sync process

### DIFF
--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -1,37 +1,154 @@
 # Archiver
 
-Archiver is a service which is used to fetch data onchain data and present them in a nice-to-consume form.
+The archiver fetches onchain data from L1 and stores it locally in a queryable form. It pulls:
+- **Checkpoints** (containing L2 blocks) from `CheckpointProposed` events on the Rollup contract
+- **L1-to-L2 messages** from `MessageSent` events on the Inbox contract
 
-The onchain data specifically are the following events:
+The interfaces `L2BlockSource`, `L2LogsSource`, and `ContractDataSource` define how consumers access this data. Interface `L2BlockSink` allows other subsystems, such as the validator client, to push not-yet-checkpointed blocks into the archiver.
 
-1. `L2BlockProposed` event emitted on Rollup contract,
-2. `MessageAdded` event emitted on Inbox contract,
+## Events
 
-The interfaces defining how the data can be consumed from the archiver are `L2BlockSource`, `L2LogsSource` and `ContractDataSource`.
+The archiver emits events for other subsystems to react to state changes:
 
-## Sync process
+- **`L2PruneDetected`**: Emitted before unwinding checkpoints due to epoch prune. Contains the epoch number and affected blocks. Subscribers (e.g., world-state) use this to prepare for the unwind.
+- **`L2BlockProven`**: Emitted when the proven checkpoint advances. Contains the block number, slot, and epoch.
+- **`InvalidAttestationsCheckpointDetected`**: Emitted when a checkpoint with invalid attestations is encountered during sync.
 
-The archiver sync process periodically checks its current state against the Rollup contract on L1 and updates its local state.
+Note that most subsystems handle these events not by subscribing but by polling the archiver using an `L2BlockStream`. This means that, if the node stops while a subsystem has not yet processed an event, the block stream will detect it and have the subsystem reprocess it.
 
-### Handling invalid blocks
+## Sync Process
 
-After the implementation of [delayed attestation verification](https://github.com/AztecProtocol/engineering-designs/pull/69), the Rollup contract on L1 no longer validates committee attestations. Instead, these are posted in calldata, and L2 nodes are expected to verify them as they download blocks. The archiver handles this validation during its sync process.
+The archiver runs a periodic sync loop with two phases:
 
-Whenever the archiver detects a block with invalid attestations, it skips it. These blocks are not meant to be part of the chain, so the archiver ignores them and continues processing the next blocks. It is expected that an honest proposer will eventually invalidate these blocks, removing them from the chain on L1, and then resume the sequence of valid blocks.
+1. **Process queued blocks**: External subsystems (e.g., sequencer) can push blocks directly via `addBlock()`
+2. **Sync from L1**: Pull checkpoints and messages from L1 contracts
+
+```
+sync()
+├── processQueuedBlocks()       # Handle blocks pushed via addBlock()
+└── syncFromL1()
+    ├── handleL1ToL2Messages()  # Sync messages from Inbox contract
+    ├── handleCheckpoints()     # Sync checkpoints from Rollup contract
+    ├── handleEpochPrune()      # Proactive unwind before proof window expires
+    └── checkForNewCheckpointsBeforeL1SyncPoint()  # Handle L1 reorg edge case
+```
+
+Each sync iteration pins the current L1 block number at the start and uses it as an upper bound for all queries. This ensures consistent data retrieval even if L1 advances during the iteration.
+
+Two independent syncpoints track progress on L1:
+- `blocksSynchedTo`: L1 block number for checkpoint events
+- `messagesSynchedTo`: L1 block ID (number + hash) for messages
+
+### L1-to-L2 Messages
+
+Messages are synced from the Inbox contract via `handleL1ToL2Messages()`:
+
+1. Query Inbox state at the current L1 block (message count + rolling hash)
+2. Compare local vs remote state
+3. If they match, nothing to do
+4. If mismatch, validate the local last message still exists on L1 with the same rolling hash
+   - If not found or hash differs, an L1 reorg occurred: find the last common message, delete everything after, and rollback the syncpoint
+5. Fetch `MessageSent` events in batches and store
+
+### Checkpoints
+
+Checkpoints are synced from the Rollup contract via `handleCheckpoints()`:
+
+1. Query rollup status (proven/pending checkpoint numbers, archive roots)
+2. Update local proven checkpoint if it matches L1 (called early to update as soon as possible)
+3. **Reorg detection**: Compare the local pending checkpoint's archive root against L1
+   - If not in L1 chain, unwind checkpoints until a common ancestor is found
+4. Retrieve `CheckpointProposed` events in batches
+5. For each checkpoint:
+   - Verify archive matches (checkpoint still in chain)
+   - Validate attestations (2/3 + 1 committee signatures required)
+   - Skip invalid checkpoints (see "Invalid Checkpoints" in Edge Cases)
+   - Verify `inHash` matches expected value (see below)
+   - Store valid checkpoints with their blocks
+6. Update proven checkpoint again (may have advanced after storing new checkpoints)
+7. Handle epoch prune if applicable
+8. Check for checkpoints behind syncpoint (L1 reorg case)
+
+The `inHash` is a hash of all L1-to-L2 messages consumed by a checkpoint. The archiver computes the expected `inHash` from locally stored messages and compares it against the checkpoint header. A mismatch indicates a bug (messages out of sync with checkpoints) and causes a fatal error.
+
+The `blocksSynchedTo` syncpoint is updated:
+- When checkpoints are stored: set to the L1 block of the last stored checkpoint
+- When an invalid checkpoint is processed: advanced past it to avoid re-downloading on every iteration
+- When the L2 chain is empty and there are still no checkpoints on L1: set to current L1 block
+- When rolling back due to L1 reorg or missing checkpoints: set to the target L1 block to re-fetch from
+
+Note that the `blocksSynchedTo` pointer is NOT updated during normal sync when there are no new checkpoints. This protects against small L1 reorgs that could add a checkpoint on an L1 block we have flagged as already synced.
+
+### Block Queue
+
+The archiver implements `L2BlockSink`, allowing other subsystems to push blocks before they appear on L1:
+
+```typescript
+archiver.addBlock(block);  // Queues block for processing
+```
+
+Queued blocks are processed at the start of each sync iteration. This allows the sequencer to make blocks available locally before checkpoint publication. This is used to make the `proposed` chain (ie blocks that have been broadcasted via p2p but not checkpointed on L1) available to consumers.
+
+### Edge Cases
+
+#### L1 Reorgs
+
+Both message and checkpoint sync detect L1 reorgs by comparing local state against L1. When detected, they find the last common ancestor and rollback.
+
+**Messages**: Each stored message includes its rolling hash. During sync, if the local last message's rolling hash doesn't match L1, the archiver walks backwards through local messages, querying L1 for each one, until it finds a message with a matching rolling hash. Everything after that message is deleted, and the syncpoint is rolled back.
+
+**Checkpoints**: When the archiver queries the Rollup contract for the archive root at the local pending checkpoint number, and it doesn't match the local archive root, the local checkpoint is no longer in L1's chain. The archiver walks backwards through local checkpoints, querying `archiveAt()` for each, until it finds one that matches. All checkpoints after that are unwound.
+
+**Example**: The archiver has synced up to checkpoint 15. An L1 reorg replaces checkpoint 14 and 15 with different content. On the next sync:
+1. Archiver queries `archiveAt(15)` and gets a different archive root than stored locally
+2. Archiver queries `archiveAt(14)` — still different
+3. Archiver queries `archiveAt(13)` — matches
+4. Archiver unwinds checkpoints 14 and 15
+5. Next sync iteration re-fetches the new checkpoints 14 and 15
+
+#### Epoch Prune
+
+If a prune would occur on the next checkpoint submission (checked via `canPruneAtTime`), the archiver preemptively unwinds to the proven checkpoint.
+
+This handles the case where an epoch's proof submission window has passed without a valid proof being submitted. The Rollup contract will prune all unproven checkpoints on the next submission. Rather than wait for that to happen and then react, the archiver detects this condition and unwinds proactively. This keeps the local state consistent with what L1 will look like after the next checkpoint. It also means that the sequencer or validator client will build the next block with the unwind having already taken place.
+
+**Example**: The proven checkpoint is 10, and pending checkpoints 11-15 exist locally. The proof submission window for the epoch containing checkpoint 11 will expire. On sync:
+1. Archiver calls `canPruneAtTime()` with the next L1 block's timestamp — returns true
+2. Archiver unwinds checkpoints 11-15
+3. Emits `L2PruneDetected` event so subscribed subsystems can react
+4. Local state now shows checkpoint 10 as latest
+
+#### Checkpoints Behind Syncpoint
+
+If after processing all logs the local checkpoint count is less than L1's pending checkpoint count, an L1 reorg may have added checkpoints _behind_ the syncpoint. The archiver rolls back the syncpoint to re-fetch.
+
+This handles a subtle L1 reorg scenario: an L1 reorg doesn't replace existing checkpoints but adds new ones in blocks the archiver already processed. Since the archiver only queries events starting from `blocksSynchedTo`, it would miss these new checkpoints.
+
+> [!NOTE]
+> This scenario only occurs when `blocksSynchedTo` was advanced _without_ storing a checkpoint — specifically when the chain is empty or when an invalid checkpoint was processed (and skipped). In normal operation, `blocksSynchedTo` is set to the L1 block of the last stored checkpoint, so any L1 reorg that adds checkpoints would also change the archive root and be caught by the L1 Reorgs check (step 3 in checkpoint sync).
+
+**Example**: The archiver has synced to L1 block 1000 with checkpoint 10. An L1 reorg at block 950 adds a new checkpoint 11 in block 960 (which was previously empty). On sync:
+1. Archiver queries events from block 1001 onwards — finds nothing
+2. Archiver queries Rollup contract — pending checkpoint is 11
+3. Local checkpoint count (10) < L1 pending (11)
+4. Archiver rolls back `blocksSynchedTo` to the L1 block of checkpoint 10
+5. Next sync iteration re-queries from that point and finds checkpoint 11
+
+#### Invalid Checkpoints
+
+When the archiver encounters a checkpoint with invalid attestations, it skips it and continues processing subsequent checkpoints. It also advances `blocksSynchedTo` past the invalid checkpoint to avoid re-downloading it on every iteration.
+
+This handles [delayed attestation verification](https://github.com/AztecProtocol/engineering-designs/pull/69): the Rollup contract no longer validates committee attestations on L1. Instead, attestations are posted in calldata and L2 nodes verify them during sync. Checkpoints with invalid attestations (insufficient signatures, wrong signers, or invalid signatures) are skipped. An honest proposer will eventually call `invalidate` on the Rollup contract to remove these checkpoints.
+
+The archiver exposes `pendingChainValidationStatus` for the sequencer to know if there's an invalid checkpoint that needs purging before posting a new one. If invalid, this status contains the data needed for the `invalidate` call. When multiple consecutive invalid checkpoints exist, the status references the earliest one (invalidating it automatically purges descendants).
 
 > [!WARNING]
-> If the committee for the epoch is also malicious and attests to a descendant of an invalid block, nodes should also ignore these descendants, unless they become proven. This is currently not implemented. Nodes assume that the majority of the committee is honest.
+> If a malicious committee attests to a descendant of an invalid checkpoint, nodes should ignore these descendants unless proven. This is not yet implemented — nodes assume honest committee majority.
 
-When the current node is elected as proposer, the `sequencer` needs to know whether there is an invalid block in L1 that needs to be purged before posting their own block. To support this, the archiver exposes a `pendingChainValidationStatus`, which is the state of the tip of the pending chain. This status can be valid in the happy path, or invalid if the tip of the pending chain has invalid attestations. If invalid, this status also contains all the data needed for purging the block from L1 via an `invalidate` call to the Rollup contract. Note that, if the head of the chain has more than one invalid consecutive block, this status will reference the earliest one that needs to be purged, since a call to purge an invalid block will automatically purge all descendants. Refer to the [InvalidateLib.sol](`l1-contracts/src/core/libraries/rollup/InvalidateLib.sol`) for more info.
+**Example**: Chain has progressed to checkpoint 10. Then:
+1. Checkpoint 11 posted with invalid attestations → archiver reports 10 as latest, `pendingChainValidationStatus` points to 11
+2. Checkpoint 11 purged, new invalid checkpoint 11 posted → status updates to new checkpoint 11
+3. Checkpoint 12 with invalid attestations posted → no change (status still points to 11)
+4. Checkpoint 11 purged and reposted with valid attestations → archiver syncs checkpoint 11, status becomes valid
 
-> [!TIP]
-> The archiver can be configured to `skipValidateBlockAttestations`, which will make it skip this validation. This cannot be set via environment variables, only via a call to `nodeAdmin_setConfig`. This setting is only meant for testing purposes.
-
-As an example, let's say the chain has been progressing normally up until block 10, and then:
-1. Block 11 is posted with invalid attestations. The archiver will report 10 as the latest block, but the `pendingChainValidationStatus` will point to block 11.
-2. Block 11 is purged, but another block 11 with invalid attestations is posted in its place. The archiver will still report 10 as latest, and the `pendingChainValidationStatus` will point to the new block 11 that needs to be purged.
-3. Block 12 with invalid attestations is posted. No changes in the archiver.
-4. Block 13 is posted with valid attestations, due to a malicious committee. The archiver will try to sync it and fail, since 13 does not follow 10. This scenario is not gracefully handled yet.
-5. Blocks 11 to 13 are purged. The archiver status will not yet be changed: 10 will still be the latest block, and the `pendingChainValidationStatus` will point to 11. This is because the archiver does **not** follow `BlockInvalidated` events.
-6. Block 11 with valid attestations is posted. The archiver pending chain now reports 11 as latest, and its status is valid.
 


### PR DESCRIPTION
Explains the archiver sync process in the README