### PR TITLE
feat(avm): contract class mutation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.cpp
@@ -68,15 +68,22 @@ void FuzzerContractDB::add_contracts(const ContractDeploymentData& contract_depl
     }
 }
 
-void FuzzerContractDB::add_contract_class(const ContractClassId& class_id, const ContractClass& contract_class)
+void FuzzerContractDB::add_contract_class(const ContractClassId& class_id,
+                                          const ContractClassWithCommitment& contract_class)
 {
     // todo(ilyas): think of a nicer way without both map and vector
     // Only push to vector if not already present, otherwise we get duplicates sent to the TS simulator
     if (contract_classes.contains(class_id)) {
         return;
     }
-    contract_classes_vector.push_back(contract_class);
-    contract_classes[class_id] = contract_class;
+    auto klass = ContractClass{
+        .id = contract_class.id,
+        .artifact_hash = contract_class.artifact_hash,
+        .private_functions_root = contract_class.private_functions_root,
+        .packed_bytecode = contract_class.packed_bytecode,
+    };
+    contract_classes_vector.push_back(klass);
+    contract_classes[class_id] = klass;
 }
 
 void FuzzerContractDB::add_contract_instance(const AztecAddress& address, const ContractInstance& contract_instance)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/common/interfaces/dbs.hpp
@@ -23,7 +23,7 @@ class FuzzerContractDB : public simulation::ContractDBInterface {
     void add_contracts(const ContractDeploymentData& contract_deployment_data) override;
 
     // Direct methods to add contract class and instance
-    void add_contract_class(const ContractClassId& class_id, const ContractClass& contract_class);
+    void add_contract_class(const ContractClassId& class_id, const ContractClassWithCommitment& contract_class);
     void add_contract_instance(const AztecAddress& address, const ContractInstance& contract_instance);
 
     void create_checkpoint() override;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.cpp
@@ -3,6 +3,7 @@
 #include "barretenberg/avm_fuzzer/common/interfaces/dbs.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 namespace bb::avm2::fuzzer {
@@ -10,18 +11,19 @@ namespace bb::avm2::fuzzer {
 namespace {
 
 // Helper function to create a default contract class from bytecode
-ContractClass create_default_class(const std::vector<uint8_t>& bytecode)
+ContractClassWithCommitment create_default_class(const std::vector<uint8_t>& bytecode)
 {
     // This isn't strictly needed for pure simulation, but if we want to re-use inputs in proving we need valid
     // commitment
     auto bytecode_commitment = simulation::compute_public_bytecode_commitment(bytecode);
     auto class_id =
         simulation::compute_contract_class_id(/*artifact_hash=*/0, /*private_fn_root=*/0, bytecode_commitment);
-    return ContractClass{
+    return ContractClassWithCommitment{
         .id = class_id,
         .artifact_hash = 0,
         .private_functions_root = 0,
         .packed_bytecode = bytecode,
+        .public_bytecode_commitment = bytecode_commitment,
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
@@ -17,6 +17,7 @@
 #include "barretenberg/common/log.hpp"
 #include "barretenberg/vm2/avm_api.hpp"
 #include "barretenberg/vm2/common/avm_io.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 #include "barretenberg/vm2/simulation_helper.hpp"
 #include "barretenberg/vm2/tooling/stats.hpp"
@@ -234,11 +235,12 @@ ContractArtifacts build_bytecode_and_artifacts(FuzzerData& fuzzer_data)
 
     auto bytecode_commitment = compute_public_bytecode_commitment(bytecode);
     auto class_id = compute_contract_class_id(/*artifact_hash=*/0, /*private_fn_root=*/0, bytecode_commitment);
-    ContractClass contract_class{
+    ContractClassWithCommitment contract_class{
         .id = class_id,
         .artifact_hash = 0,
         .private_functions_root = 0,
         .packed_bytecode = bytecode,
+        .public_bytecode_commitment = bytecode_commitment,
     };
     ContractInstance contract_instance{
         .salt = 0,
@@ -333,9 +335,12 @@ size_t mutate_tx_data(FuzzerContext& context,
                         rng);
         break;
     }
-        // case TxDataMutationType::ContractClassMutation:
-        //     // Mutations here are likely to cause immediate failure
-        //     break;
+    case FuzzerTxDataMutationType::ContractClassMutation:
+        mutate_contract_classes(tx_data.contract_classes, tx_data.contract_instances, tx_data.contract_addresses, rng);
+        // The fuzzer (like the AVM) assumes that all triplets of contract classes, instances and addresses are in sync
+        // So when we mutate contract classes, we also need to update the corresponding artifacts
+
+        break;
         // case TxDataMutationType::ContractInstanceMutation:
         //     // Mutations here are likely to cause immediate failure
         //     break;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
@@ -23,7 +23,7 @@ struct FuzzerTxData {
     std::vector<FuzzerData> input_programs;
     // These are the contract classes and instances that will be registered to addresses in the WS
     // The contract addresses may contain duplicates if multiple contracts derive to the same address
-    std::vector<ContractClass> contract_classes;
+    std::vector<ContractClassWithCommitment> contract_classes;
     std::vector<ContractInstance> contract_instances;
     std::vector<AztecAddress> contract_addresses;
 
@@ -54,24 +54,25 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzerTxData& data)
 }
 
 using Bytecode = std::vector<uint8_t>;
-using ContractArtifacts = std::tuple<Bytecode, ContractClass, ContractInstance>;
+using ContractArtifacts = std::tuple<Bytecode, ContractClassWithCommitment, ContractInstance>;
 using FuzzerContext = bb::avm2::fuzzer::FuzzerContext;
 
 // Mutation configuration
 enum class FuzzerTxDataMutationType : uint8_t {
     TxMutation,
     BytecodeMutation,
-    // ContractClassMutation,
+    ContractClassMutation,
     // ContractInstanceMutation,
     // GlobalVariablesMutation,
     // ProtocolContractsMutation
 };
 
-using FuzzerTxDataMutationConfig = WeightedSelectionConfig<FuzzerTxDataMutationType, 2>;
+using FuzzerTxDataMutationConfig = WeightedSelectionConfig<FuzzerTxDataMutationType, 3>;
 
 constexpr FuzzerTxDataMutationConfig FUZZER_TX_DATA_MUTATION_CONFIGURATION = FuzzerTxDataMutationConfig({
     { FuzzerTxDataMutationType::TxMutation, 10 },
     { FuzzerTxDataMutationType::BytecodeMutation, 1 },
+    { FuzzerTxDataMutationType::ContractClassMutation, 1 },
 });
 
 // Build bytecode and contract artifacts from fuzzer data

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/bytecode.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/bytecode.cpp
@@ -1,15 +1,17 @@
 #include "barretenberg/avm_fuzzer/mutations/bytecode.hpp"
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/constants.hpp"
+#include "barretenberg/avm_fuzzer/mutations/basic_types/field.hpp"
 #include "barretenberg/crypto/poseidon2/poseidon2.hpp"
 #include "barretenberg/vm2/common/aztec_constants.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
 #include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 extern "C" size_t LLVMFuzzerMutate(uint8_t* Data, size_t Size, size_t MaxSize);
 
 namespace bb::avm2::fuzzer {
 
-void mutate_bytecode(std::vector<ContractClass>& contract_classes,
+void mutate_bytecode(std::vector<ContractClassWithCommitment>& contract_classes,
                      std::vector<ContractInstance>& contract_instances,
                      const std::vector<AztecAddress>& contract_addresses,
                      std::vector<bb::crypto::merkle_tree::PublicDataLeafValue>& public_data_writes,
@@ -25,7 +27,7 @@ void mutate_bytecode(std::vector<ContractClass>& contract_classes,
     // Select a random contract
     size_t idx = std::uniform_int_distribution<size_t>(0, contract_classes.size() - 1)(rng);
 
-    ContractClass& klass = contract_classes[idx];
+    ContractClassWithCommitment& klass = contract_classes[idx];
     ContractInstance& instance = contract_instances[idx];
     const AztecAddress& address = contract_addresses[idx];
 
@@ -51,9 +53,10 @@ void mutate_bytecode(std::vector<ContractClass>& contract_classes,
 
     // Copy into NEW contract class with updated bytecode and id, we don't modify the existing one in case
     // other instances refer to it
-    ContractClass new_class = klass;
+    ContractClassWithCommitment new_class = klass;
     new_class.id = new_class_id;
     new_class.packed_bytecode = std::move(bytecode);
+    new_class.public_bytecode_commitment = new_bytecode_commitment;
 
     // Update instance's current class ID to point to the newly upgraded-to class
     fuzz_info("Contract at address ", address, ", upgraded from ", original_class_id, " -> ", new_class_id);
@@ -77,6 +80,66 @@ void mutate_bytecode(std::vector<ContractClass>& contract_classes,
             { FF(DOM_SEP__PUBLIC_LEAF_INDEX), FF(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS), storage_slot });
         public_data_writes.push_back(bb::crypto::merkle_tree::PublicDataLeafValue{ leaf_slot, values[i] });
     }
+}
+
+void mutate_contract_classes(std::vector<ContractClassWithCommitment>& contract_classes,
+                             std::vector<ContractInstance>& contract_instances,
+                             std::vector<AztecAddress>& contract_addresses,
+                             std::mt19937_64& rng)
+{
+    // Skip if no contracts to mutate
+    if (contract_classes.empty()) {
+        return;
+    }
+
+    // Select a random contract
+    size_t idx = std::uniform_int_distribution<size_t>(0, contract_classes.size() - 1)(rng);
+
+    ContractClassWithCommitment& klass = contract_classes[idx];
+
+    // We don't mutate the packed bytecode here, only some metadata fields
+    // We also do not mutate the class id directly such that it may fail.
+    // The fuzzer (and AVM) asserts that class IDs are correctly derived in class_id_derivation.cpp
+    auto choice = std::uniform_int_distribution<int>(0, 1)(rng);
+    switch (choice) {
+    case 0:
+        // Mutate artifact hash
+        mutate_field(klass.artifact_hash, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
+        break;
+    case 1:
+        // Mutate private functions root
+        mutate_field(klass.private_functions_root, rng, BASIC_FIELD_MUTATION_CONFIGURATION);
+        break;
+    default:
+        break;
+    }
+
+    auto new_class_id = simulation::compute_contract_class_id(
+        klass.artifact_hash, klass.private_functions_root, klass.public_bytecode_commitment);
+
+    for (size_t i = 0; i < contract_instances.size(); i++) {
+        // Check if an original instance (i.e. it has address nullifier) refers to this class
+        if (contract_instances[i].original_contract_class_id == klass.id) {
+            fuzz_info("Mutated original contract class ", klass.id, " at address ", contract_addresses[i]);
+            // Since this is an original instance, we also need to update the address nullifier
+            auto original_address = simulation::compute_contract_address(contract_instances[i]);
+            // Update instance's current class ID to point to the mutated class
+            contract_instances[i].current_contract_class_id = new_class_id;
+            contract_instances[i].original_contract_class_id = new_class_id;
+            auto contract_addr = std::ranges::find_if(
+                contract_addresses, [&](const AztecAddress& addr) { return addr == original_address; });
+            *contract_addr = simulation::compute_contract_address(contract_instances[i]);
+        }
+        // Check if an upgraded instance refers to this class
+        if (contract_instances[i].current_contract_class_id == klass.id) {
+            fuzz_info("Mutated current contract class ", klass.id, " at address ", contract_addresses[i]);
+            // Update instance's current class ID to point to the mutated class
+            contract_instances[i].current_contract_class_id = new_class_id;
+            // No need to update address as it depends on original class ID only
+        }
+    }
+    // Update class ID
+    klass.id = new_class_id;
 }
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/bytecode.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/bytecode.hpp
@@ -7,10 +7,15 @@
 
 namespace bb::avm2::fuzzer {
 
-void mutate_bytecode(std::vector<ContractClass>& contract_classes,
+void mutate_bytecode(std::vector<ContractClassWithCommitment>& contract_classes,
                      std::vector<ContractInstance>& contract_instances,
                      const std::vector<AztecAddress>& contract_addresses,
                      std::vector<bb::crypto::merkle_tree::PublicDataLeafValue>& public_data_writes,
                      std::mt19937_64& rng);
+
+void mutate_contract_classes(std::vector<ContractClassWithCommitment>& contract_classes,
+                             std::vector<ContractInstance>& contract_instances,
+                             std::vector<AztecAddress>& contract_addresses,
+                             std::mt19937_64& rng);
 
 } // namespace bb::avm2::fuzzer


### PR DESCRIPTION
Adds mutation for contract classses. This requires changing from simple `ContractClass` to `ContractClassWithCommitment` within the fuzzer.

We need the commitment so that when the contract class is mutated, we can re-compute: the class id and the contract address.