### PR TITLE
feat!: backport single use claims to devnet

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/mod.nr
@@ -8,6 +8,7 @@ pub mod public_immutable;
 pub mod public_mutable;
 pub mod private_set;
 pub mod delayed_public_mutable;
+pub mod single_use_claim;
 pub mod state_variable;
 pub mod storage;
 
@@ -21,4 +22,5 @@ pub use crate::state_vars::private_set::PrivateSet;
 pub use crate::state_vars::public_immutable::PublicImmutable;
 pub use crate::state_vars::public_mutable::PublicMutable;
 pub use crate::state_vars::single_private_immutable::SinglePrivateImmutable;
+pub use crate::state_vars::single_use_claim::SingleUseClaim;
 pub use crate::state_vars::state_variable::StateVariable;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
@@ -1,0 +1,140 @@
+use dep::protocol_types::{
+    address::AztecAddress, constants::GENERATOR_INDEX__NOTE_HASH,
+    hash::poseidon2_hash_with_separator, traits::Hash,
+};
+
+use crate::{
+    context::{PrivateContext, UtilityContext},
+    keys::getters::{get_nsk_app, get_public_keys},
+    oracle::notes::check_nullifier_exists,
+    state_vars::owned_state_variable::OwnedStateVariable,
+};
+
+mod test;
+
+/// A private state variable type that represents a right each user can exercise at most once.
+///
+/// Because it is _owned_, you must wrap a [SingleUseClaim] inside an [crate::state_vars::owned::Owned] state variable
+/// when using it in storage.
+///
+/// ## Example
+///
+/// The right to vote at most once can be implemented using [SingleUseClaim] as a primitive.
+///
+/// ```noir
+/// #[derive(Serialize, Deserialize)]
+/// struct ElectionId { id: Field }
+///
+/// #[storage]
+/// struct Storage<Context> {
+///     // election => candidate => number of votes
+///     tally: Map<ElectionId, Map<Field, PublicMutable<Field, Context>, Context>, Context>,
+///     // track right to vote at most once per election
+///     vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
+/// }
+///
+/// #[external("private")]
+/// fn cast_vote(election_id: ElectionId, candidate: Field) {
+///     let voter = self.msg_sender().unwrap();
+///
+///     // `claim` will only succeed if `voter` hasn't already claimed for this `election_id` before.
+///     self.storage.vote_claims.at(election_id).at(voter).claim();
+///
+///     // Now that we checked that the voter is entitled to vote,
+///     // we can enqueue the corresponding public effect
+///     self.enqueue_self.add_to_tally_public(election_id, candidate);
+/// }
+/// ```
+///
+/// For more details on what _owned_ means, see the documentation for the [OwnedStateVariable] trait.
+///
+/// ## Cost
+///
+/// Exercising a claim (via the [SingleUseClaim::claim] function) emits one nullifier.
+///
+/// ## Privacy considerations
+///
+/// The [SingleUseClaim::claim] function emits a public nullifier per owner: it's fully private,
+/// hidden behind the owner's app-siloed nullifier secret key (aka `nsk`).
+///
+/// Public effects you emit alongside a claim (e.g. a  public function call to update a tally)
+/// may still let observers infer who likely exercised the claim, so consider that when designing flows.
+/// ```
+pub struct SingleUseClaim<Context> {
+    context: Context,
+    storage_slot: Field,
+    owner: AztecAddress,
+}
+
+impl<Context> OwnedStateVariable<Context> for SingleUseClaim<Context> {
+    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+        Self { context, storage_slot, owner }
+    }
+}
+
+impl<Context> SingleUseClaim<Context> {
+    /// Computes the nullifier that will be created when the single use claim is claimed
+    /// by the owner (denoted by the app-siloed nullifier secret key `owner_nsk_app`).
+    ///
+    /// This function is primarily used internally by functions [SingleUseClaim::claim], [SingleUseClaim::assert_claimed] and
+    /// [SingleUseClaim::has_claimed] to coherently write and read state.
+    fn compute_nullifier(self, owner_nsk_app: Field) -> Field {
+        // TODO(F-180): make sure we follow the nullifier convention
+        poseidon2_hash_with_separator(
+            [owner_nsk_app, self.storage_slot],
+            GENERATOR_INDEX__NOTE_HASH,
+        )
+    }
+}
+
+impl SingleUseClaim<&mut PrivateContext> {
+    /// Records the fact that the owner in scope has claimed this single use claim.
+    ///
+    /// This function succeeds at most once for a given `owner`. Any subsequent calls with same owner are
+    /// guaranteed to fail.
+    ///
+    /// Note that, by itself, calling this function doesn't do anything other than prevent it being called again
+    /// with the same owner. Its invocation is typically accompanied by other contract actions, e.g. minting tokens,
+    /// casting a vote, etc.
+    ///
+    /// ## Advanced
+    ///
+    /// The implementation of this function emits a nullifier derived from
+    /// the `owner`'s nullifier secret key and the storage slot of the underlying state variable.
+    pub fn claim(self) {
+        let owner_nsk_app = self.context.request_nsk_app(get_public_keys(self.owner).npk_m.hash());
+        self.context.push_nullifier(self.compute_nullifier(owner_nsk_app));
+    }
+
+    /// Asserts that the owner has already claimed this single use claim
+    /// (i.e. that [SingleUseClaim::claim] has been called).
+    ///
+    /// ## Advanced
+    ///
+    /// This function generates a kernel nullifier read request, so it can even assert the existence of
+    /// pending claims, i.e. when [SingleUseClaim::claim] was called in the same transaction as
+    /// [SingleUseClaim::assert_claimed].
+    pub fn assert_claimed(self) {
+        let owner_nsk_app = self.context.request_nsk_app(get_public_keys(self.owner).npk_m.hash());
+        let nullifier = self.compute_nullifier(owner_nsk_app);
+
+        // Safety: `check_nullifier_exists` is an unconstrained function - we can constrain a true value
+        // by providing an inclusion proof of the nullifier, but cannot constrain a false value since
+        // a non-inclusion proof would only be valid if done in public.
+        // We use this check to be able to test this function works properly on synthetic envs
+        // like TXE, but we still need to use `push_nullifier_read_request` to ensure this
+        // existence check is also performed by the kernel.
+        let has_been_claimed = unsafe { check_nullifier_exists(nullifier) };
+        assert(has_been_claimed, "cannot prove claim exists");
+
+        self.context.push_nullifier_read_request(nullifier, self.context.this_address())
+    }
+}
+
+impl SingleUseClaim<UtilityContext> {
+    /// Returns whether an owner has claimed this single use claim.
+    pub unconstrained fn has_claimed(self) -> bool {
+        let owner_nsk_app = get_nsk_app(get_public_keys(self.owner).npk_m.hash());
+        check_nullifier_exists(self.compute_nullifier(owner_nsk_app))
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim/test.nr
@@ -1,0 +1,150 @@
+use crate::{
+    context::{private_context::PrivateContext, UtilityContext},
+    oracle::random::random,
+    state_vars::{owned_state_variable::OwnedStateVariable, single_use_claim::SingleUseClaim},
+};
+use crate::test::helpers::test_environment::TestEnvironment;
+use dep::protocol_types::{address::AztecAddress, traits::FromField};
+
+global STORAGE_SLOT: Field = 17;
+
+unconstrained fn in_private(
+    context: &mut PrivateContext,
+    owner: AztecAddress,
+) -> SingleUseClaim<&mut PrivateContext> {
+    SingleUseClaim::new(context, STORAGE_SLOT, owner)
+}
+
+unconstrained fn in_utility(
+    context: UtilityContext,
+    storage_slot: Field,
+    owner: AztecAddress,
+) -> SingleUseClaim<UtilityContext> {
+    SingleUseClaim::new(context, storage_slot, owner)
+}
+
+#[test(should_fail_with = "Duplicate siloed nullifier")]
+unconstrained fn claim_twice_same_tx() {
+    let mut env = TestEnvironment::new();
+
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.claim();
+        state_var.assert_claimed();
+
+        state_var.claim();
+    });
+}
+
+#[test]
+unconstrained fn has_not_yet_claimed() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, STORAGE_SLOT, owner);
+        assert(!state_var.has_claimed());
+    });
+}
+
+#[test(should_fail_with = "cannot prove claim exists")]
+unconstrained fn assert_claimed_fails() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+        state_var.assert_claimed();
+    });
+}
+
+#[test(should_fail_with = "already present")]
+unconstrained fn claim_twice_separate_tx() {
+    let mut env = TestEnvironment::new();
+
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.claim();
+        state_var.assert_claimed();
+    });
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, STORAGE_SLOT, owner);
+        assert(state_var.has_claimed());
+    });
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+        state_var.claim();
+    });
+}
+
+#[test]
+unconstrained fn claim_twice_different_owner() {
+    let mut env = TestEnvironment::new();
+
+    let owner_a = env.create_light_account();
+    let owner_b = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var_a = in_private(context, owner_a);
+        let state_var_b = in_private(context, owner_b);
+
+        state_var_a.claim();
+        state_var_b.claim();
+
+        state_var_a.assert_claimed();
+        state_var_b.assert_claimed();
+    });
+
+    env.utility_context(|context| {
+        let state_var_a = in_utility(context, STORAGE_SLOT, owner_a);
+        let state_var_b = in_utility(context, STORAGE_SLOT, owner_b);
+
+        assert(state_var_a.has_claimed());
+        assert(state_var_b.has_claimed());
+    });
+}
+
+#[test]
+unconstrained fn claim_two_claim_ids_different_state_vars() {
+    let mut env = TestEnvironment::new();
+
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var_a = SingleUseClaim::new(context, STORAGE_SLOT, owner);
+        state_var_a.claim();
+        state_var_a.assert_claimed();
+
+        let state_var_b = SingleUseClaim::new(context, STORAGE_SLOT + 1, owner);
+        state_var_b.claim();
+        state_var_b.assert_claimed();
+    });
+
+    env.utility_context(|context| {
+        let state_var_0 = in_utility(context, STORAGE_SLOT, owner);
+        assert(state_var_0.has_claimed());
+
+        let state_var_1 = in_utility(context, STORAGE_SLOT + 1, owner);
+        assert(state_var_1.has_claimed());
+    });
+}
+
+#[test(should_fail_with = "No public key registered")]
+unconstrained fn claim_owner_unknown_public_keys() {
+    let mut env = TestEnvironment::new();
+
+    let owner = AztecAddress::from_field(random());
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+        state_var.claim();
+    });
+}

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
@@ -1,80 +1,96 @@
 mod test;
 use dep::aztec::macros::aztec;
 
-/**
- * WARNING: this is no-longer considered a good example of an Aztec contract,
- * because it touches low-level functions and concepts that oughtn't be 
- * seen by a typical user.
- * The syntax and user-experience of Aztec contracts has since improved, so you
- * should seek alternative examples, please.
- */
-
 #[aztec]
 pub contract PrivateVoting {
     // docs:start:imports
-    use dep::aztec::{
-        keys::getters::get_public_keys,
-        macros::{functions::{external, initializer, only_self}, storage::storage},
-    };
+    use dep::aztec::macros::{functions::{external, initializer, only_self}, storage::storage};
     use dep::aztec::protocol_types::{
         address::AztecAddress,
-        hash::poseidon2_hash,
-        traits::{Hash, ToField},
+        traits::{Deserialize, Serialize, ToField},
     };
-    use dep::aztec::state_vars::{Map, PublicImmutable, PublicMutable};
+    use dep::aztec::state_vars::{
+        Map, Owned, PublicImmutable, PublicMutable, single_use_claim::SingleUseClaim,
+    };
+
+    #[derive(Serialize, Deserialize)]
+    pub struct ElectionId {
+        id: Field,
+    }
+
+    impl ElectionId {
+        pub fn new(id: Field) -> Self {
+            Self { id }
+        }
+    }
+
+    impl ToField for ElectionId {
+        fn to_field(self) -> Field {
+            self.id
+        }
+    }
 
     // docs:end:imports
     // docs:start:storage_struct
     #[storage]
     struct Storage<Context> {
-        admin: PublicMutable<AztecAddress, Context>, // admin can end vote
-        tally: Map<Field, PublicMutable<Field, Context>, Context>, // we will store candidate as key and number of votes as value
-        vote_ended: PublicMutable<bool, Context>, // vote_ended is boolean
-        active_at_block: PublicImmutable<u32, Context>, // when people can start voting
+        // admin can start and end elections
+        admin: PublicMutable<AztecAddress, Context>,
+        // election => candidate => number of votes
+        tally: Map<ElectionId, Map<Field, PublicMutable<Field, Context>, Context>, Context>,
+        // election => election ended
+        vote_ended: Map<ElectionId, PublicMutable<bool, Context>, Context>,
+        // election => election started at
+        active_at_block: Map<ElectionId, PublicImmutable<u32, Context>, Context>,
+        // election => voter => single use claim that ensures voter can at most vote once per election
+        vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
     }
     // docs:end:storage_struct
 
     // docs:start:constructor
     #[external("public")]
     #[initializer]
-    // annotation to mark function as a constructor
     fn constructor(admin: AztecAddress) {
         self.storage.admin.write(admin);
-        self.storage.vote_ended.write(false);
-        self.storage.active_at_block.initialize(self.context.block_number());
     }
     // docs:end:constructor
 
     #[external("private")]
-    // annotation to mark function as private and expose private context
-    fn cast_vote(candidate: Field) {
-        let msg_sender_nullifier_public_key_message_hash =
-            get_public_keys(self.msg_sender().unwrap()).npk_m.hash();
-
-        let secret = self.context.request_nsk_app(msg_sender_nullifier_public_key_message_hash); // get secret key of caller of function
-        let nullifier = poseidon2_hash([self.msg_sender().unwrap().to_field(), secret]); // derive nullifier from sender and secret
-        self.context.push_nullifier(nullifier);
-        self.enqueue_self.add_to_tally_public(candidate);
+    fn cast_vote(election_id: ElectionId, candidate: Field) {
+        self.storage.vote_claims.at(election_id).at(self.msg_sender().unwrap()).claim();
+        self.enqueue_self.add_to_tally_public(election_id, candidate);
     }
 
     #[external("public")]
     #[only_self]
-    fn add_to_tally_public(candidate: Field) {
-        assert(self.storage.vote_ended.read() == false, "Vote has ended"); // assert that vote has not ended
-        let new_tally = self.storage.tally.at(candidate).read() + 1;
-        self.storage.tally.at(candidate).write(new_tally);
+    fn add_to_tally_public(election_id: ElectionId, candidate: Field) {
+        assert(self.storage.active_at_block.at(election_id).read() <= self.context.block_number());
+        assert(self.storage.vote_ended.at(election_id).read() == false, "Vote has ended"); // assert that vote has not ended
+        let new_tally = self.storage.tally.at(election_id).at(candidate).read() + 1;
+        self.storage.tally.at(election_id).at(candidate).write(new_tally);
     }
 
     #[external("public")]
-    fn end_vote() {
+    fn start_vote(election_id: ElectionId) {
+        assert(
+            self.storage.admin.read().eq(self.msg_sender().unwrap()),
+            "Only admin can start votes",
+        ); // assert that caller is admin
+        self.storage.vote_ended.at(election_id).write(false);
+        self.storage.active_at_block.at(election_id).initialize(self.context.block_number());
+    }
+
+    #[external("public")]
+    fn end_vote(election_id: ElectionId) {
         assert(
             self.storage.admin.read().eq(self.msg_sender().unwrap()),
             "Only admin can end votes",
         ); // assert that caller is admin
-        self.storage.vote_ended.write(true);
+        self.storage.vote_ended.at(election_id).write(true);
     }
+
     #[external("utility")]
-    unconstrained fn get_vote(candidate: Field) -> Field {
-        self.storage.tally.at(candidate).read()
+    unconstrained fn get_tally(election_id: ElectionId, candidate: Field) -> Field {
+        self.storage.tally.at(election_id).at(candidate).read()
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/first.nr
@@ -2,6 +2,7 @@ use crate::test::utils;
 use dep::aztec::protocol_types::storage::map::derive_storage_slot_in_map;
 
 use crate::PrivateVoting;
+use crate::PrivateVoting::ElectionId;
 
 #[test]
 unconstrained fn test_initializer() {
@@ -27,10 +28,14 @@ unconstrained fn test_check_vote_status() {
 unconstrained fn test_end_vote() {
     let (env, voting_contract_address, admin) = utils::setup();
 
-    env.call_public(admin, PrivateVoting::at(voting_contract_address).end_vote());
+    let election_id = ElectionId::new(Field::from(42));
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).end_vote(election_id));
 
     env.public_context_at(voting_contract_address, |context| {
-        let vote_ended = context.storage_read(PrivateVoting::storage_layout().vote_ended.slot);
+        let vote_ended = context.storage_read(derive_storage_slot_in_map(
+            PrivateVoting::storage_layout().vote_ended.slot,
+            election_id,
+        ));
         assert_eq(vote_ended, true);
     });
 }
@@ -39,56 +44,110 @@ unconstrained fn test_end_vote() {
 unconstrained fn test_fail_end_vote_by_non_admin() {
     let (mut env, voting_contract_address, _) = utils::setup();
     let alice = env.create_light_account();
+    let election_id = ElectionId::new(Field::from(42));
 
-    env.call_public(alice, PrivateVoting::at(voting_contract_address).end_vote());
+    env.call_public(alice, PrivateVoting::at(voting_contract_address).end_vote(election_id));
 }
 
 #[test]
 unconstrained fn test_cast_vote() {
-    let (mut env, voting_contract_address, _) = utils::setup();
+    let (mut env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_light_account();
 
-    let candidate = 1;
-    env.call_private(alice, PrivateVoting::at(voting_contract_address).cast_vote(candidate));
+    let election_id = ElectionId::new(Field::from(42));
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).start_vote(election_id));
 
-    env.public_context_at(voting_contract_address, |context| {
-        let vote_count = context.storage_read(derive_storage_slot_in_map(
-            PrivateVoting::storage_layout().tally.slot,
-            candidate,
-        ));
-        assert_eq(vote_count, 1);
-    });
+    let candidate = 1;
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
+    );
+
+    let tally = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+        election_id,
+        candidate,
+    ));
+    assert_eq(tally, 1);
 }
 
 #[test]
 unconstrained fn test_cast_vote_with_separate_accounts() {
-    let (mut env, voting_contract_address, _) = utils::setup();
+    let (mut env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_light_account();
     let bob = env.create_light_account();
 
+    let election_id = ElectionId::new(Field::from(42));
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).start_vote(election_id));
+
     let candidate = 101;
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
+    );
 
-    env.call_private(alice, PrivateVoting::at(voting_contract_address).cast_vote(candidate));
+    let _ = env.call_private(
+        bob,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
+    );
 
-    let _ = env.call_private(bob, PrivateVoting::at(voting_contract_address).cast_vote(candidate));
-
-    env.public_context_at(voting_contract_address, |context| {
-        let vote_count = context.storage_read(derive_storage_slot_in_map(
-            PrivateVoting::storage_layout().tally.slot,
-            candidate,
-        ));
-        assert_eq(vote_count, 2);
-    });
+    let tally = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+        election_id,
+        candidate,
+    ));
+    assert_eq(tally, 2);
 }
 
 #[test(should_fail_with = "duplicate siloed nullifier")]
 unconstrained fn test_fail_vote_twice() {
-    let (mut env, voting_contract_address, _) = utils::setup();
+    let (mut env, voting_contract_address, admin) = utils::setup();
     let alice = env.create_light_account();
+
+    let election_id = ElectionId::new(Field::from(42));
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).start_vote(election_id));
 
     let candidate = 101;
 
-    env.call_private(alice, PrivateVoting::at(voting_contract_address).cast_vote(candidate));
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
+    );
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
+    );
+}
 
-    env.call_private(alice, PrivateVoting::at(voting_contract_address).cast_vote(candidate));
+#[test]
+unconstrained fn test_vote_in_two_different_elections() {
+    let (mut env, voting_contract_address, admin) = utils::setup();
+    let alice = env.create_light_account();
+
+    let election_id_42 = ElectionId::new(Field::from(42));
+    let election_id_54 = ElectionId::new(Field::from(54));
+
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).start_vote(election_id_42));
+    env.call_public(admin, PrivateVoting::at(voting_contract_address).start_vote(election_id_54));
+
+    let candidate = 101;
+
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id_42, candidate),
+    );
+    env.call_private(
+        alice,
+        PrivateVoting::at(voting_contract_address).cast_vote(election_id_54, candidate),
+    );
+
+    let vote_count_42 = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+        election_id_42,
+        candidate,
+    ));
+    let vote_count_54 = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+        election_id_54,
+        candidate,
+    ));
+
+    assert_eq(vote_count_42, 1);
+    assert_eq(vote_count_54, 1);
 }

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -35,18 +35,22 @@ describe('e2e_voting_contract', () => {
   describe('votes', () => {
     it('votes, then tries to vote again', async () => {
       const candidate = new Fr(1);
-      await votingContract.methods.cast_vote(candidate).send({ from: owner }).wait();
-      expect(await votingContract.methods.get_vote(candidate).simulate({ from: owner })).toBe(1n);
+      const electionId = { id: Fr.random() };
+
+      await votingContract.methods.start_vote(electionId).send({ from: owner }).wait();
+
+      await votingContract.methods.cast_vote(electionId, candidate).send({ from: owner }).wait();
+      expect(await votingContract.methods.get_tally(electionId, candidate).simulate({ from: owner })).toBe(1n);
 
       // We try voting again, but our TX is dropped due to trying to emit duplicate nullifiers
       // first confirm that it fails simulation
-      await expect(votingContract.methods.cast_vote(candidate).simulate({ from: owner })).rejects.toThrow(
+      await expect(votingContract.methods.cast_vote(electionId, candidate).simulate({ from: owner })).rejects.toThrow(
         /Nullifier collision|duplicate.*nullifier/,
       );
       // if we skip simulation, tx fails
-      await expect(votingContract.methods.cast_vote(candidate).send({ from: owner }).wait()).rejects.toThrow(
-        TX_ERROR_EXISTING_NULLIFIER,
-      );
+      await expect(
+        votingContract.methods.cast_vote(electionId, candidate).send({ from: owner }).wait(),
+      ).rejects.toThrow(TX_ERROR_EXISTING_NULLIFIER);
     });
   });
 });


### PR DESCRIPTION
Adds a state var type: `SingleUseClaim`, which is a useful primitive to build semaphore protocols (see [#1590](https://github.com/AztecProtocol/aztec-packages/issues/15901) for a detailed discussion of semaphores and alternative implementations of this primitive).

It also ports the `PrivateVoting` contract example to rely on it, which shows that the primitive helps abstract contract devs from low-level details.

Closes F-132
Closes https://github.com/AztecProtocol/aztec-packages/issues/15901