### PR TITLE
docs: backport Aztec.js documentation improvements to devnet version

### DIFF
--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_connect_to_local_network.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_connect_to_local_network.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Connect to Local Network
 tags: [local_network, connection, wallet]
 sidebar_position: 1
 description: Connect your application to the Aztec local network and interact with accounts.
@@ -13,71 +13,66 @@ This guide shows you how to connect your application to the Aztec local network 
 - Node.js installed
 - TypeScript project set up
 
-## Install Aztec.js
-
-### Install the Aztec.js package
+## Install dependencies
 
 ```bash
-yarn add @aztec/aztec.js@3.0.0-devnet.20251212
+yarn add @aztec/aztec.js@3.0.0-devnet.20251212 @aztec/test-wallet@3.0.0-devnet.20251212
 ```
 
-## Create a Node Client
+## Connect to the network
 
-The local network is essentially a one-node network. Just like on a real network, you need to interface with it:
+Create a node client and TestWallet to interact with the local network:
 
 ```typescript
-const node = createAztecNodeClient("http://localhost:8080");
-const l1Contracts = await node.getL1ContractAddresses();
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import {
+  TestWallet,
+  registerInitialLocalNetworkAccountsInWallet,
+} from "@aztec/test-wallet/server";
+
+const nodeUrl = "http://localhost:8080";
+const node = createAztecNodeClient(nodeUrl);
+
+// Wait for the network to be ready
+await waitForNode(node);
+
+// Create a TestWallet connected to the node
+const wallet = await TestWallet.create(node);
 ```
 
-As the name implies, we want to know the L1 Contracts addresses for our wallet.
-
-## Create a TestWallet
-
-You will need to create your own TestWallet to connect to local network accounts. Let's create a TestWallet:
-
-```typescript
-import { createAztecNodeClient } from "@aztec/aztec.js/node";
-import { TestWallet } from "@aztec/test-wallet/server";
-
-export async function setupWallet(): Promise<TestWallet> {
-  const nodeUrl = "http://localhost:8080";
-  const node = createAztecNodeClient(nodeUrl);
-  const wallet = await TestWallet.create(node);
-  return wallet;
-}
-```
+`TestWallet` is a development wallet that handles account management and transaction signing locally, suitable for testing and development.
 
 ### Verify the connection
 
 Get node information to confirm your connection:
 
 ```typescript
-const nodeInfo = await pxe.getNodeInfo();
+const nodeInfo = await node.getNodeInfo();
 console.log("Connected to local network version:", nodeInfo.nodeVersion);
 console.log("Chain ID:", nodeInfo.l1ChainId);
 ```
 
-### Get local network accounts
+### Load pre-funded accounts
 
-The local network has some accounts pre-funded with fee-juice to pay for gas. You can import them and create accounts:
+The local network has accounts pre-funded with fee juice to pay for gas. Register them in your wallet:
 
 ```typescript
-import { getInitialTestAccountsData } from "@aztec/accounts/testing";
+const [alice, bob] = await registerInitialLocalNetworkAccountsInWallet(wallet);
 
-const [aliceAccount, bobAccount] = await getInitialTestAccountsData();
-await wallet.createSchnorrAccount(aliceAccount.secret, aliceAccount.salt);
-await wallet.createSchnorrAccount(bobAccount.secret, bobAccount.salt);
+console.log(`Alice's address: ${alice.toString()}`);
+console.log(`Bob's address: ${bob.toString()}`);
 ```
 
-### Check account balances
+These accounts are pre-funded with fee juice (the native gas token) at genesis, so you can immediately send transactions without needing to bridge funds from L1.
 
-Verify that the accounts have fee juice for transactions:
+### Check fee juice balance
+
+Verify that an account has fee juice for transactions:
 
 ```typescript
 import { getFeeJuiceBalance } from "@aztec/aztec.js/utils";
 
-const aliceBalance = await getFeeJuiceBalance(aliceAccount.address, node);
+const aliceBalance = await getFeeJuiceBalance(alice, node);
 console.log(`Alice's fee juice balance: ${aliceBalance}`);
 ```
 

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_create_account.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_create_account.md
@@ -2,105 +2,53 @@
 title: Creating Accounts
 tags: [accounts]
 sidebar_position: 2
-description: Step-by-step guide to creating and deploying user accounts in Aztec.js applications.
+description: Step-by-step guide to creating and deploying new user accounts in Aztec.js applications.
 ---
 
-This guide walks you through creating and deploying a new account contract in Aztec.
+This guide shows you how to create and deploy a new account on Aztec.
 
 ## Prerequisites
 
-- Running Aztec local network or testnet
-- Node.js and TypeScript environment
-- `@aztec/aztec.js` package installed
+- [Connected to a network](./how_to_connect_to_local_network.md) with a `TestWallet` instance
 - Understanding of [account concepts](../foundational-topics/accounts/index.md)
 
 ## Install dependencies
 
 ```bash
-yarn add @aztec/aztec.js@3.0.0-devnet.20251212 @aztec/accounts@3.0.0-devnet.20251212
+yarn add @aztec/aztec.js@3.0.0-devnet.20251212 @aztec/test-wallet@3.0.0-devnet.20251212
 ```
 
-## Create account keys
+## Create a new account
 
-Every account on Aztec requires a secret, a salt, and a signing key.
+Use the wallet's `createSchnorrAccount` method to create a new account with a random secret and salt:
 
 ```typescript
-import { Fr, GrumpkinScalar } from "@aztec/aztec.js";
+import { Fr } from "@aztec/aztec.js/fields";
 
-const secretKey = Fr.random();
-const salt = new Fr(0);
-const signingPrivateKey = GrumpkinScalar.random();
+const secret = Fr.random();
+const salt = Fr.random();
+const newAccount = await wallet.createSchnorrAccount(secret, salt);
+console.log("New account address:", newAccount.address.toString());
 ```
 
-These keys serve the following purposes:
+The secret is used to derive the account's encryption keys, and the salt ensures address uniqueness. The signing key is automatically derived from the secret.
 
-- `secretKey`: Derives encryption keys for private state
-- `signingPrivateKey`: Signs transactions
-
-## Create a wallet
-
-You need a Wallet to hold your account contract. Use `TestWallet` since most third-party wallets implement the same interface:
-
-```typescript
-// for use in the browser
-import { TestWallet } from "@aztec/test-wallet/client/lazy";
-// for use on a server
-import { TestWallet } from "@aztec/test-wallet/server";
-import { createAztecNodeClient } from "@aztec/aztec.js/node";
-
-const nodeUrl = process.env.AZTEC_NODE_URL || "http://localhost:8080";
-const node = createAztecNodeClient(nodeUrl);
-const wallet = await TestWallet.create(node);
-```
+:::warning Store your secret and salt
+Save the `secret` and `salt` values securely. You need both to recover access to your account. If you lose them, you will permanently lose access to the account and any assets it holds.
+:::
 
 ## Deploy the account
 
-### Get Fee Juice
+New accounts must be deployed before they can send transactions. Deployment requires paying fees.
 
-On the local network, all test accounts come pre-funded with Fee Juice. [Import them](./how_to_connect_to_local_network.md) to start using them immediately.
+### Using the Sponsored FPC
 
-On testnet, accounts start without Fee Juice. You can either [use an account that has Fee Juice](./how_to_pay_fees.md#pay-with-fee-juice) or [use the Sponsored Fee Payment Contract](./how_to_pay_fees.md#sponsored-fee-payment-contracts).
-
-### Register and deploy accounts
-
-Test accounts on the local network are already deployed but need to be registered in the wallet:
+If your account doesn't have Fee Juice, use the [Sponsored Fee Payment Contract](./how_to_pay_fees.md#sponsored-fee-payment-contracts):
 
 ```typescript
-// on the local network, you can get the initial test accounts data using getInitialTestAccountsData
-const [initialAccountData] = await getInitialTestAccountsData();
-// add the funded account to the wallet
-const initialAccount = await wallet.createSchnorrAccount(
-  initialAccountData.secret,
-  initialAccountData.salt
-);
-```
+import { AztecAddress } from "@aztec/aztec.js/addresses";
 
-Other accounts require deployment. To deploy an account that already has Fee Juice:
-
-```ts
-const anotherAccount = await wallet.createSchnorrAccount(
-  accountWithFeeJuice.secret,
-  accountWithFeeJuice.salt
-);
-const deployMethod = await anotherAccount.getDeployMethod();
-
-// using the default fee payment method (Fee Juice)
-await deployMethod
-  .send({
-    from: AztecAddress.ZERO, // the zero address is used because there's no account to send from: the transaction itself will create the account!
-  })
-  .wait();
-```
-
-To deploy using the Sponsored FPC:
-
-```typescript
-// deploy an account with random salt and secret
-const anotherAccount = await wallet.createSchnorrAccount(
-  Fr.random(),
-  Fr.random()
-);
-const deployMethod = await anotherAccount.getDeployMethod();
+const deployMethod = await newAccount.getDeployMethod();
 await deployMethod
   .send({
     from: AztecAddress.ZERO,
@@ -110,12 +58,38 @@ await deployMethod
 ```
 
 :::info
-See the [guide on fees](./how_to_pay_fees.md) for setting up `sponsoredPaymentMethod`.
+See the [guide on fees](./how_to_pay_fees.md#sponsored-fee-payment-contracts) for setting up `sponsoredPaymentMethod`.
 :::
+
+### Using Fee Juice
+
+If your account already has Fee Juice (for example, [bridged from L1](./how_to_pay_fees.md#bridge-fee-juice-from-l1)):
+
+```typescript
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+
+const deployMethod = await newAccount.getDeployMethod();
+await deployMethod
+  .send({
+    from: AztecAddress.ZERO,
+  })
+  .wait();
+```
+
+The `from: AztecAddress.ZERO` is required because there's no existing account to send from—the transaction itself creates the account.
+
+## Verify deployment
+
+Confirm the account was deployed successfully:
+
+```typescript
+const metadata = await wallet.getContractMetadata(newAccount.address);
+console.log("Account deployed:", metadata.isContractInitialized);
+```
 
 ## Next steps
 
-- [Deploy contracts](./how_to_deploy_contract.md) with a new account
+- [Deploy contracts](./how_to_deploy_contract.md) with your new account
 - [Send transactions](./how_to_send_transaction.md) from an account
 - Learn about [account abstraction](../foundational-topics/accounts/index.md)
 - Implement [authentication witnesses](./how_to_use_authwit.md)

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_deploy_contract.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_deploy_contract.md
@@ -7,6 +7,10 @@ description: Deploy smart contracts to Aztec using generated TypeScript classes.
 
 This guide shows you how to deploy compiled contracts to Aztec using the generated TypeScript interfaces.
 
+## Overview
+
+Deploying a contract to Aztec involves publishing the contract class (the bytecode) and creating a contract instance at a specific address. The generated TypeScript classes handle this process through an API: you call `deploy()` with constructor arguments, `send()` with transaction options, and `deployed()` to wait for completion. The contract address is deterministically computed from the contract class, constructor arguments, salt, and deployer address.
+
 ## Prerequisites
 
 - Compiled contract artifacts (see [How to Compile](../aztec-nr/how_to_compile_contract.md))
@@ -38,22 +42,26 @@ The codegen command creates a TypeScript class with typed methods for deployment
 import { MyContract } from "./artifacts/MyContract";
 ```
 
+:::note[About wallets and accounts]
+In the examples below, `wallet` refers to a `Wallet` instance that manages keys and signs transactions. The `from` option in `send()` specifies which account pays for the transaction. This account must be registered in the wallet and have sufficient fee juice. On a local network, test accounts are pre-funded; on testnet, you typically use sponsored fees.
+:::
+
 ### Step 2: Deploy the contract
 
-Deploying the contract really depends on how you're paying for it. If paying using an account's fee juice (like a test account on the local network):
+How you deploy depends on how you pay for it. When paying using an account's fee juice (like a test account on the local network):
 
 ```typescript
 // Deploy with constructor arguments
 const contract = await MyContract.deploy(
-  deployer_wallet,
+  wallet,
   constructorArg1,
   constructorArg2
 )
-  .send({ from: testAccount.address }) // testAccount has fee juice and is registered in the deployer_wallet
+  .send({ from: testAccount.address })
   .deployed();
 ```
 
-On the testnet, you'll likely not have funds in `testAccount` to pay for fee Juice. You want to instead pay fees using the [Sponsored Fee Payment Contract method](./how_to_pay_fees.md), for example:
+On testnet, you likely won't have funds in `testAccount` to pay for fee juice. Instead, pay fees using the [Sponsored Fee Payment Contract method](./how_to_pay_fees.md):
 
 ```typescript
 const contract = await MyContract.deploy(
@@ -61,7 +69,16 @@ const contract = await MyContract.deploy(
   constructorArg1,
   constructorArg2
 )
-  .send({ from: alice.address, fee: { paymentMethod: sponsoredPaymentMethod } }) // using the Sponsored FPC
+  .send({ from: alice.address, fee: { paymentMethod: sponsoredPaymentMethod } })
+  .deployed();
+```
+
+Here's a complete example:
+
+```typescript
+const owner = defaultAccountAddress;
+const contract = await StatefulTestContract.deploy(wallet, owner, 42)
+  .send({ from: defaultAccountAddress })
   .deployed();
 ```
 
@@ -86,15 +103,12 @@ const contract = await MyContract.deploy(wallet, arg1, arg2)
 
 ### Deploy universally
 
-Deploy to the same address across networks:
+Deploy to the same address across networks by setting `universalDeploy: true`:
 
 ```typescript
-const contract = await MyContract.deploy(wallet, arg1, arg2)
-  .send({
-    from: testAccount.address,
-    universalDeploy: true,
-    contractAddressSalt: salt,
-  })
+const opts = { universalDeploy: true, from: defaultAccountAddress };
+const contract = await StatefulTestContract.deploy(wallet, owner, 42)
+  .send(opts)
   .deployed();
 ```
 
@@ -129,11 +143,10 @@ await contract.methods
 import { Fr } from "@aztec/aztec.js/fields";
 
 const salt = Fr.random();
-const deployer = testAccount.address;
 
 // Calculate address without deploying
-const deployer = MyContract.deploy(wallet, arg1, arg2);
-const instance = await deployer.getInstance();
+const deployMethod = MyContract.deploy(wallet, arg1, arg2);
+const instance = await deployMethod.getInstance({ contractAddressSalt: salt });
 const address = instance.address;
 
 console.log(`Contract will deploy at: ${address}`);
@@ -167,26 +180,36 @@ console.log(`Contract address: ${contract.address}`);
 
 ## Deploy multiple contracts
 
+### Deploy a token contract
+
+Here's an example deploying a `TokenContract` with constructor arguments for admin, name, symbol, and decimals:
+
+```typescript
+const owner = defaultAccountAddress;
+const token = await TokenContract.deploy(wallet, owner, "TOKEN", "TKN", 18)
+  .send({ from: defaultAccountAddress })
+  .deployed();
+```
+
 ### Deploy contracts with dependencies
+
+When one contract depends on another, deploy them sequentially and pass the first contract's address:
 
 ```typescript
 // Deploy first contract
 const token = await TokenContract.deploy(
   wallet,
-  wallet.address,
+  admin.address,
   "MyToken",
   "MTK",
-  18n
+  18
 )
-  .send({ from: testAccount.address })
+  .send({ from: admin.address })
   .deployed();
 
 // Deploy second contract with reference to first
-const vault = await VaultContract.deploy(
-  wallet,
-  token.address // Pass first contract's address
-)
-  .send({ from: wallet.address })
+const vault = await VaultContract.deploy(wallet, token.address)
+  .send({ from: admin.address })
   .deployed();
 ```
 
@@ -195,9 +218,9 @@ const vault = await VaultContract.deploy(
 ```typescript
 // Start all deployments simultaneously
 const deployments = [
-  Contract1.deploy(wallet, arg1).send({ from: testAccount.address }),
-  Contract2.deploy(wallet, arg2).send({ from: testAccount.address }),
-  Contract3.deploy(wallet, arg3).send({ from: testAccount.address }),
+  Contract1.deploy(wallet, arg1).send({ from: deployer.address }),
+  Contract2.deploy(wallet, arg2).send({ from: deployer.address }),
+  Contract3.deploy(wallet, arg3).send({ from: deployer.address }),
 ];
 
 // Wait for all to complete
@@ -207,23 +230,53 @@ const receipts = await Promise.all(deployments.map((d) => d.wait()));
 const contracts = await Promise.all(deployments.map((d) => d.deployed()));
 ```
 
-:::tip
-Parallel deployment is faster but be aware of nonce management if deploying many contracts from the same account.
+:::tip[Parallel deployment considerations]
+Parallel deployment is faster, but transactions from the same account share a nonce sequence. The wallet handles nonce assignment automatically, but if one deployment fails, subsequent deployments may also fail due to nonce gaps. For reliable parallel deployments:
+
+- Use separate accounts for each deployment, or
+- Handle failures gracefully and retry with fresh nonces
+- Consider using `BatchCall` to bundle multiple operations into a single transaction (see below)
 :::
+
+### Deploy with BatchCall
+
+Use `BatchCall` to bundle a deployment with other calls into a single transaction. This is useful when you need to deploy a contract and immediately call methods on it:
+
+```typescript
+import { BatchCall } from "@aztec/aztec.js";
+
+const owner = defaultAccountAddress;
+// Create a contract instance and make the PXE aware of it
+const deployMethod = StatefulTestContract.deploy(wallet, owner, 42);
+const contract = await deployMethod.register();
+
+// Batch deployment and a public call into the same transaction
+const publicCall = contract.methods.increment_public_value(owner, 84);
+await new BatchCall(wallet, [deployMethod, publicCall])
+  .send({ from: defaultAccountAddress })
+  .wait();
+```
 
 ## Verify deployment
 
 ### Check contract registration
 
-At the moment the easiest way to get contract data is by querying a wallet directly:
+Query the wallet to verify the contract was deployed and its class is published:
 
 ```typescript
-// Get contract metadata
-const metadata = await wallet.getContractMetadata(myContractInstance.address);
-if (metadata) {
-  console.log("Contract metadata found");
-}
+const metadata = await wallet.getContractMetadata(contract.address);
+const isPublished = (
+  await wallet.getContractClassMetadata(
+    metadata.contractInstance!.currentContractClassId
+  )
+).isContractClassPubliclyRegistered;
 ```
+
+The `getContractMetadata` method returns:
+
+- `contractInstance` - The contract instance details (if found)
+- `isContractInitialized` - Whether the constructor has been called
+- `isContractPublished` - Whether the contract class is publicly registered
 
 ### Verify contract is callable
 
@@ -246,38 +299,35 @@ try {
 If a contract was deployed by another account:
 
 ```typescript
-import { loadContractArtifact } from "@aztec/stdlib/abi";
-
-const artifact = loadContractArtifact(MyContract.artifact);
 const contract = await MyContract.at(contractAddress, wallet);
 
-// To register an existing contract instance, you need to know
-// its exact deployment parameters. The registerContract method
-// requires both the artifact and instance details.
-// This is typically handled automatically when deploying.
-await wallet.registerContract({
-  instance: contract.instance,
-  artifact: artifact,
-});
+// Register the contract with the wallet
+// The registerContract method takes positional parameters:
+// - instance: ContractInstanceWithAddress (required)
+// - artifact: ContractArtifact (optional)
+// - secretKey: Fr (optional)
+await wallet.registerContract(contract.instance, MyContract.artifact);
 ```
 
 :::warning
-You need the exact deployment parameters (salt, initialization hash, etc.) to correctly register an externally deployed contract.
-
-For example:
+You need the exact deployment parameters (salt, initialization hash, etc.) to correctly register an externally deployed contract. If you don't have access to the contract instance, you can reconstruct it:
 
 ```typescript
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contracts";
-const contract = await getContractInstanceFromInstantiationParams(
-  contractArtifact,
+import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
+import { PublicKeys } from "@aztec/stdlib/keys";
+
+const instance = await getContractInstanceFromInstantiationParams(
+  MyContract.artifact,
   {
     publicKeys: PublicKeys.default(),
-    constructorArtifact: initializer,
-    constructorArgs: parameters,
-    deployer: from,
-    salt,
+    constructorArtifact: "constructor", // or the initializer function name
+    constructorArgs: [arg1, arg2],
+    deployer: deployerAddress,
+    salt: deploymentSalt,
   }
 );
+
+await wallet.registerContract(instance, MyContract.artifact);
 ```
 
 :::

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_pay_fees.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_pay_fees.md
@@ -19,6 +19,16 @@ This guide walks you through paying transaction fees on Aztec using various paym
 <Fees.FeeAsset_NonTransferrable />
 :::
 
+## Payment methods overview
+
+| Method              | Use Case                      | Privacy | Requirements               |
+| ------------------- | ----------------------------- | ------- | -------------------------- |
+| Fee Juice (default) | Account already has Fee Juice | Public  | Funded account             |
+| Sponsored FPC       | Testing, free transactions    | Public  | None                       |
+| Private FPC         | Pay with tokens privately     | Private | Token balance, FPC address |
+| Public FPC          | Pay with tokens publicly      | Public  | Token balance, FPC address |
+| Bridge + Claim      | Bootstrap from L1             | Public  | L1 ETH for gas             |
+
 ## Pay with Fee Juice
 
 Fee Juice is the native fee token on Aztec.
@@ -49,8 +59,9 @@ You can derive the Sponsored FPC address from its deployment parameters and salt
 
 ```typescript
 import { SponsoredFPCContract } from "@aztec/noir-contracts.js/SponsoredFPC";
-import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contracts";
+import { getContractInstanceFromInstantiationParams } from "@aztec/stdlib/contract";
 import { SponsoredFeePaymentMethod } from "@aztec/aztec.js/fee/testing";
+import { Fr } from "@aztec/aztec.js/fields";
 
 const sponsoredFPCInstance = await getContractInstanceFromInstantiationParams(
   SponsoredFPCContract.artifact,
@@ -60,22 +71,26 @@ const sponsoredFPCInstance = await getContractInstanceFromInstantiationParams(
 );
 ```
 
-Register the contract with your wallet before deploying and using it:
+Register the contract with your wallet before using it:
 
 ```typescript
 await wallet.registerContract(
   sponsoredFPCInstance,
   SponsoredFPCContract.artifact
 );
+```
+
+Then use it to pay for transactions:
+
+```typescript
 const sponsoredPaymentMethod = new SponsoredFeePaymentMethod(
   sponsoredFPCInstance.address
 );
 
-// deploy account for free
-const deployMethod = await yourAccount.getDeployMethod();
-const txHash = await deployMethod
+const tx = await contract.methods
+  .myFunction(param1)
   .send({
-    from: AztecAddress.ZERO,
+    from: sender.address,
     fee: { paymentMethod: sponsoredPaymentMethod },
   })
   .wait();
@@ -99,6 +114,11 @@ Private FPCs enable fee payments without revealing the payer's identity onchain:
 ```typescript
 import { PrivateFeePaymentMethod } from "@aztec/aztec.js/fee";
 
+// The private fee paying method assembled on the app side requires knowledge of the maximum
+// fee the user is willing to pay
+const maxFeesPerGas = (await node.getCurrentBaseFees()).mul(1.5);
+const gasSettings = GasSettings.default({ maxFeesPerGas });
+
 const paymentMethod = new PrivateFeePaymentMethod(
   fpcAddress,
   senderAddress,
@@ -109,10 +129,8 @@ const paymentMethod = new PrivateFeePaymentMethod(
 const tx = await contract.methods
   .myFunction(param1)
   .send({
-    from: wallet.address,
-    fee: {
-      paymentMethod,
-    },
+    from: sender.address,
+    fee: { paymentMethod },
   })
   .wait();
 ```
@@ -175,42 +193,14 @@ After this transaction is minted on L1 and a few blocks pass, you can claim the 
 
 ```typescript
 import { FeeJuicePaymentMethodWithClaim } from "@aztec/aztec.js/fee";
-const feeJuiceWithClaim = new FeeJuicePaymentMethodWithClaim(
-  acc.address,
-  claim
-); // the l2 address and the claim
 
-yourContract.methods
-  .some_method(acc.address)
-  .send({ from: acc.address, fee: { paymentMethod: feeJuiceWithClaim } })
+// Use the claim from bridgeTokensPublic to pay for a transaction
+const paymentMethod = new FeeJuicePaymentMethodWithClaim(acc.address, claim);
+const receipt = await contract.methods
+  .myFunction()
+  .send({ from: acc.address, fee: { gasSettings, paymentMethod } })
   .wait();
 ```
-
-:::tip Creating blocks
-
-To advance time quickly, send a couple of dummy transactions and `.wait()` for them. For example:
-
-```typescript
-// using the `sponsoredFeePaymentMethod` so the network has transactions to build blocks with!
-await contract.methods
-  .some_other_method(acc.address)
-  .send({
-    from: acc.address,
-    fee: { paymentMethod: sponsoredFeePaymentMethod },
-  })
-  .wait();
-await contract.methods
-  .some_other_method(acc.address)
-  .send({
-    from: acc.address,
-    fee: { paymentMethod: sponsoredFeePaymentMethod },
-  })
-  .wait();
-```
-
-This will add a transaction to each block!
-
-:::
 
 ## Configure gas settings
 
@@ -219,19 +209,19 @@ This will add a transaction to each block!
 Set custom gas limits by importing from `stdlib`:
 
 ```typescript
-import { GasSettings, Gas, GasFees } from "@aztec/stdlib/gas";
+import { GasSettings } from "@aztec/stdlib/gas";
 
-const gasSettings = new GasSettings(
-  new Gas(100000, 100000), // gasLimits (DA, L2)
-  new Gas(10000, 10000), // teardownGasLimits
-  new GasFees(10, 10), // maxFeesPerGas
-  new GasFees(1, 1) // maxPriorityFeesPerGas
-);
+const gasSettings = GasSettings.from({
+  gasLimits: { daGas: 100000, l2Gas: 100000 },
+  teardownGasLimits: { daGas: 10000, l2Gas: 10000 },
+  maxFeesPerGas: { daGas: 10, l2Gas: 10 },
+  maxPriorityFeesPerGas: { daGas: 1, l2Gas: 1 },
+});
 
 const tx = await contract.methods
   .myFunction()
   .send({
-    from: wallet.address,
+    from: sender.address,
     fee: {
       paymentMethod,
       gasSettings,
@@ -246,7 +236,7 @@ const tx = await contract.methods
 const tx = await contract.methods
   .myFunction()
   .send({
-    from: wallet.address,
+    from: sender.address,
     fee: {
       paymentMethod,
       estimateGas: true,
@@ -257,7 +247,7 @@ const tx = await contract.methods
 ```
 
 :::tip
-Gas estimation runs a simulation first to determine actual gas usage, then adds padding for safety.
+Gas estimation runs a simulation first to determine actual gas usage, then adds padding for safety. This works with all payment methods, including FPCs.
 :::
 
 ## Next steps

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_send_transaction.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_send_transaction.md
@@ -7,16 +7,20 @@ tags: [transactions, contracts, aztec.js]
 
 This guide shows you how to send transactions to smart contracts on Aztec.
 
+## Overview
+
+Transactions on Aztec execute contract functions that modify state. Unlike simple reads, transactions go through private execution on your device, proving, and then submission to the network for inclusion in a block. You can send single transactions, batch multiple calls atomically, and query transaction status after submission.
+
 ## Prerequisites
 
 - Deployed contract with its address and ABI
-- Funded account wallet
+- Funded account wallet (see [paying fees](./how_to_pay_fees.md))
 - Running Aztec local network or connected to a network
 - Understanding of [contract interactions](../aztec-nr/framework-description/how_to_call_contracts.md)
 
-## Sending a basic transaction
+## Send a transaction
 
-Let's say you've connected to a contract, for example:
+After connecting to a contract:
 
 ```typescript
 import { Contract } from "@aztec/aztec.js";
@@ -24,41 +28,30 @@ import { Contract } from "@aztec/aztec.js";
 const contract = await Contract.at(contractAddress, artifact, wallet);
 ```
 
-or
+Call a function and wait for it to be mined:
 
 ```typescript
-import { MyContract } from "./artifacts/MyContract";
-
-const contract = await MyContract.at(contractAddress, wallet);
-```
-
-You should [choose your fee-paying method](./how_to_pay_fees.md) and just call a function on it:
-
-```typescript
-const withFeeJuice = await contract.methods
+const receipt = await contract.methods
   .transfer(recipientAddress, amount)
-  .send({ from: fundedAccount.address }) // if this account has fee-juice
+  .send({ from: sender.address })
   .wait();
 
-// or using the Sponsored FPC
-
-const sponsored = await contract.methods
-  .transfer(recipientAddress, amount)
-  .send({ fee: { paymentMethod: sponsoredPaymentMethod } })
-  .wait();
+console.log(`Transaction mined in block ${receipt.blockNumber}`);
+console.log(`Transaction fee: ${receipt.transactionFee}`);
 ```
+
+The `from` field specifies which account sends the transaction. If that account has Fee Juice, it pays for the transaction automatically. For other fee payment options, see [paying fees](./how_to_pay_fees.md).
 
 ### Send without waiting
 
 ```typescript
-// Send transaction and get a SentTx object
 const sentTx = contract.methods
   .transfer(recipientAddress, amount)
-  .send({ from: fundedAccount.address });
+  .send({ from: sender.address });
 
 // Get transaction hash immediately
 const txHash = await sentTx.getTxHash();
-console.log(`Transaction sent with hash: ${txHash.toString()}`);
+console.log(`Transaction sent: ${txHash.toString()}`);
 
 // Wait for inclusion later
 const receipt = await sentTx.wait();
@@ -67,7 +60,7 @@ console.log(`Transaction mined in block ${receipt.blockNumber}`);
 
 ## Send batch transactions
 
-### Execute multiple calls atomically
+Execute multiple calls atomically using `BatchCall`:
 
 ```typescript
 import { BatchCall } from "@aztec/aztec.js";
@@ -78,10 +71,8 @@ const batch = new BatchCall(wallet, [
   contract.methods.updateState(),
 ]);
 
-const receipt = await batch.send({ from: fundedAccount.address }).wait();
-console.log(
-  `Batch executed in block ${receipt.blockNumber} with fee ${receipt.transactionFee}`
-);
+const receipt = await batch.send({ from: sender.address }).wait();
+console.log(`Batch executed in block ${receipt.blockNumber}`);
 ```
 
 :::warning
@@ -90,38 +81,27 @@ All calls in a batch must succeed or the entire batch reverts. Use batch transac
 
 ## Query transaction status
 
-### Get transaction receipt
+After sending a transaction, you can query its receipt:
 
 ```typescript
 const txHash = await sentTx.getTxHash();
-const receipt = await wallet.getTxReceipt(txHash); // or node.getTxReceipt(txHash);
+const receipt = await wallet.getTxReceipt(txHash);
+
+console.log(`Status: ${receipt.status}`);
+console.log(`Block number: ${receipt.blockNumber}`);
+console.log(`Transaction fee: ${receipt.transactionFee}`);
 ```
 
-### Check transaction effects
+The receipt includes:
 
-```typescript
-const txHash = await sentTx.getTxHash();
-const effect = await node.getTxEffect(txHash);
-
-// Access public data writes
-effect.data.publicDataWrites.forEach((write) => {
-  console.log(`Wrote ${write.value} to slot ${write.leafSlot}`);
-});
-
-// Check note hashes (private note commitments)
-effect.data.noteHashes.forEach((noteHash) => {
-  console.log(`Created note: ${noteHash.toString()}`);
-});
-
-// Check nullifiers (consumed notes)
-effect.data.nullifiers.forEach((nullifier) => {
-  console.log(`Nullified: ${nullifier.toString()}`);
-});
-```
+- `status` - Transaction status (`success`, `reverted`, `dropped`, or `pending`)
+- `blockNumber` - Block where the transaction was included
+- `transactionFee` - Fee paid for the transaction
+- `error` - Error message if the transaction reverted
 
 ## Next steps
 
 - Learn to [simulate functions](./how_to_simulate_function.md) before sending
 - Understand [authentication witnesses](./how_to_use_authwit.md) for delegated transactions
-- Configure [gas and fees](./how_to_pay_fees.md) for optimal transaction costs
+- Configure [gas and fees](./how_to_pay_fees.md) for transaction costs
 - Set up [transaction testing](./how_to_test.md) in your development workflow

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_simulate_function.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_simulate_function.md
@@ -1,127 +1,87 @@
 ---
 title: Simulating Functions
-tags: [functions, view, simulation]
+tags: [functions, simulation]
 sidebar_position: 5
-description: Step-by-step guide to simulating function calls and reading state from Aztec contracts.
+description: How to simulate function calls and read contract state without creating transactions.
 ---
 
-This guide shows you how to simulate function calls to read contract state.
+This guide shows you how to use `simulate` to execute contract functions and read their return values without creating a transaction.
 
 ## Prerequisites
 
-- Deployed contract address and ABI
-- Wallet connection
-- Understanding of [contract functions](../aztec-nr/framework-description/functions/how_to_define_functions.md)
+- A deployed contract instance (see [How to Deploy a Contract](./how_to_deploy_contract.md))
+- A wallet connection (see [How to Create an Account](./how_to_create_account.md))
 
-## Connect to a contract
+## Overview
 
-Let's say you've connected to a contract, for example:
+The `simulate` method executes a contract function locally and returns its result. It works with private, public, and utility functions. No transaction is created and no gas is spent.
 
 ```typescript
-import { Contract } from "@aztec/aztec.js";
-
-const contract = await Contract.at(contractAddress, artifact, wallet);
+const result = await contract.methods.myFunction(arg1, arg2).simulate({ from: callerAddress });
 ```
 
-or
+The `from` option specifies which address context to use for the simulation. This is required for all simulations.
+
+## Basic simulation
 
 ```typescript
-import { MyContract } from "./artifacts/MyContract";
+const balance = await contract.methods
+  .balance_of_public(newAccountAddress)
+  .simulate({ from: newAccountAddress });
 
-const contract = await MyContract.at(contractAddress, wallet);
+expect(balance).toEqual(1n);
 ```
 
-## Simulate public functions
+## Handling return values
 
-### Step 1: Call a public view function
-
-```typescript
-const result = await contract.methods
-  .get_public_value(param1)
-  .simulate({ from: callerAddress }); // assuming callerAddress is already registered on the wallet, i.e. wallet.createSchnorrAccount(caller.secret, caller.salt)
-
-console.log("Public value:", result);
-```
-
-### Step 2: Handle return values
+For functions returning multiple values, destructure the result:
 
 ```typescript
-const result = await contract.methods
+const [value1, value2] = await contract.methods
   .get_multiple_values()
   .simulate({ from: callerAddress });
-
-// Destructure if returning multiple values
-const [value1, value2] = result;
 ```
 
-## Simulate private functions
+## Including metadata
 
-### Step 1: Call a private view function
+Set `includeMetadata: true` to get additional information about the simulation:
 
 ```typescript
-const privateResult = await contract.methods
-  .get_private_balance(ownerAddress)
-  .simulate({ from: ownerAddress });
+const result = await contract.methods
+  .balance_of_public(address)
+  .simulate({ from: callerAddress, includeMetadata: true });
+
+// Result includes:
+// - result: the function return value
+// - stats: execution statistics (timing, circuit sizes)
+// - offchainEffects: any offchain effects emitted
+// - estimatedGas: gas limit estimates
+console.log("Balance:", result.result);
+console.log("Estimated gas:", result.estimatedGas);
 ```
 
-### Step 2: Access private notes
+## Private function considerations
+
+When simulating private functions, the caller must have access to any private state being read. The PXE only has visibility into notes belonging to registered accounts.
 
 ```typescript
-// Private functions can access the caller's private state
-const notes = await contract.methods
-  .get_my_notes()
-  .simulate({ from: ownerAddress });
+// This works if callerAddress owns the notes
+const balance = await contract.methods
+  .balance_of_private(callerAddress)
+  .simulate({ from: callerAddress });
+
+// This fails if callerAddress doesn't have access to otherAddress's notes
+const otherBalance = await contract.methods
+  .balance_of_private(otherAddress)
+  .simulate({ from: callerAddress }); // Error: cannot access private state
 ```
 
 :::warning
-Private simulations only work if the caller has access to the private state being queried.
+Simulation runs locally without generating proofs. No correctness guarantees are provided on the result. See [Call Types](../foundational-topics/call_types.md#simulate) for more details.
 :::
-
-## Simulate utility functions
-
-### Step 1: Call utility function
-
-```typescript
-const result = await contract.methods
-  .compute_value(input1, input2)
-  .simulate({ from: account.address });
-
-console.log("Computed value:", result);
-```
-
-### Step 2: Use utility functions for complex queries
-
-```typescript
-const aggregatedData = await contract.methods
-  .get_aggregated_stats(startBlock, endBlock)
-  .simulate({ from: account.address });
-
-// Returns structured data based on function signature
-console.log("Stats:", aggregatedData);
-```
-
-## Simulate with different contexts
-
-### Simulate from different addresses
-
-```typescript
-// Simulate as different users to test access control
-const asOwner = await contract.methods
-  .admin_function()
-  .simulate({ from: ownerAddress });
-
-try {
-  const asUser = await contract.methods
-    .admin_function()
-    .simulate({ from: userAddress });
-} catch (error) {
-  console.log("User cannot access admin function");
-}
-```
 
 ## Next steps
 
 - [Send transactions](./how_to_send_transaction.md) to modify contract state
-- Learn about [private and public functions](../aztec-nr/framework-description/functions/how_to_define_functions.md)
-- Explore [testing patterns](./how_to_test.md) for simulations
-- Understand [state management](../aztec-nr/framework-description/how_to_define_storage.md)
+- Learn about [call types](../foundational-topics/call_types.md) and when to use simulation vs transactions
+- Explore [testing patterns](./how_to_test.md) that use simulation

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_test.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_test.md
@@ -1,16 +1,184 @@
 ---
-title: Testing Aztec.nr contracts with TypeScript
+title: Testing Smart Contracts
 tags: [contracts, tests]
 sidebar_position: 8
-description: Learn how to write and run tests for your Aztec.js applications.
+description: Learn how to write and run tests for your Aztec smart contracts using Aztec.js and a local network.
 ---
 
-Note: This section became completely stale so it got removed and will be rewritten.
+This guide covers how to test Aztec smart contracts by connecting to a local network, deploying contracts, and verifying their behavior.
+
+## Prerequisites
+
+- A running [local Aztec network](../../getting_started_on_local_network.md)
+- A compiled contract artifact (see [How to compile a contract](../aztec-nr/how_to_compile_contract.md))
+- Node.js test framework (Jest, Vitest, or similar)
+
+## Setting up the test environment
+
+Connect to your local Aztec network and create a test wallet:
+
+```typescript
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { TestWallet } from "@aztec/test-wallet/server";
+import { createLogger } from "@aztec/aztec.js/log";
+
+const AZTEC_NODE_URL = process.env.AZTEC_NODE_URL || "http://localhost:8080";
+const logger = createLogger("e2e:token");
+
+// Create client connected to the local network
+const node = createAztecNodeClient(AZTEC_NODE_URL);
+
+// Wait for local network to be ready
+await waitForNode(node, logger);
+
+// Create a test wallet
+const wallet = await TestWallet.create(node);
+
+const nodeInfo = await node.getNodeInfo();
+logger.info("Aztec Local Network Info", nodeInfo);
+```
+
+The `TestWallet` manages accounts, tracks deployed contracts, and handles transaction proving. It connects to the Aztec node which provides access to both the Private eXecution Environment (PXE) and the network.
+
+## Loading test accounts
+
+The local network comes with pre-funded accounts. Load them into your wallet:
+
+```typescript
+import { registerInitialLocalNetworkAccountsInWallet } from "@aztec/test-wallet/server";
+
+const [alice, bob] = await registerInitialLocalNetworkAccountsInWallet(wallet);
+```
+
+## Deploying contracts in tests
+
+Deploy contracts using the generated contract class:
+
+```typescript
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
+
+const contract = await TokenContract.deploy(
+  wallet,
+  alice, // admin
+  "TestToken",
+  "TST",
+  18
+)
+  .send({ from: alice })
+  .deployed();
+```
+
+## Verifying contract state
+
+Use `.simulate()` to read contract state without creating a transaction:
+
+```typescript
+const balance = await contract.methods
+  .balance_of_public(newAccountAddress)
+  .simulate({ from: newAccountAddress });
+
+expect(balance).toEqual(1n);
+```
+
+Simulations are free (no gas cost) and return the function's result directly. Use them for:
+
+- Checking balances and state before/after transactions
+- Validating expected outcomes in assertions
+- Debugging contract behavior
+
+## Sending test transactions
+
+Send transactions and wait for confirmation:
+
+```typescript
+await contract.methods
+  .transfer(bob, 100n)
+  .send({ from: alice })
+  .wait();
+```
+
+The `.wait()` method blocks until the transaction is included in a block.
+
+## Example test structure
+
+Here's a complete test example using Jest:
+
+```typescript
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+import {
+  TestWallet,
+  registerInitialLocalNetworkAccountsInWallet,
+} from "@aztec/test-wallet/server";
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
+
+describe("Token contract", () => {
+  let wallet: TestWallet;
+  let alice: AztecAddress;
+  let bob: AztecAddress;
+  let token: TokenContract;
+
+  beforeAll(async () => {
+    const node = createAztecNodeClient("http://localhost:8080");
+    await waitForNode(node);
+    wallet = await TestWallet.create(node);
+    [alice, bob] = await registerInitialLocalNetworkAccountsInWallet(wallet);
+
+    token = await TokenContract.deploy(wallet, alice, "Test", "TST", 18)
+      .send({ from: alice })
+      .deployed();
+  });
+
+  it("mints tokens to an account", async () => {
+    await token.methods.mint_to_public(alice, 1000n).send({ from: alice }).wait();
+
+    const balance = await token.methods
+      .balance_of_public(alice)
+      .simulate({ from: alice });
+
+    expect(balance).toEqual(1000n);
+  });
+
+  it("transfers tokens between accounts", async () => {
+    await token.methods.transfer_in_public(bob, 100n).send({ from: alice }).wait();
+
+    const aliceBalance = await token.methods
+      .balance_of_public(alice)
+      .simulate({ from: alice });
+    const bobBalance = await token.methods
+      .balance_of_public(bob)
+      .simulate({ from: bob });
+
+    expect(aliceBalance).toEqual(900n);
+    expect(bobBalance).toEqual(100n);
+  });
+});
+```
+
+## Testing failure cases
+
+Test that invalid operations revert as expected:
+
+```typescript
+it("reverts when transferring more than balance", async () => {
+  const balance = await token.methods
+    .balance_of_public(alice)
+    .simulate({ from: alice });
+
+  await expect(
+    token.methods
+      .transfer_in_public(bob, balance + 1n)
+      .simulate({ from: alice })
+  ).rejects.toThrow();
+});
+```
+
+Use `.simulate()` to test reverts without spending gas. The simulation will throw if the transaction would fail onchain.
 
 ## Further reading
 
-- [How to simulate functions in Aztec.js](./how_to_simulate_function.md)
-- [How to send transactions in Aztec.js](./how_to_send_transaction.md)
-- [How to deploy a contract in Aztec.js](./how_to_deploy_contract.md)
-- [How to create an account in Aztec.js](./how_to_create_account.md)
-- [How to compile a contract](../aztec-nr/how_to_compile_contract.md).
+- [How to simulate functions](./how_to_simulate_function.md)
+- [How to send transactions](./how_to_send_transaction.md)
+- [How to deploy a contract](./how_to_deploy_contract.md)
+- [How to create an account](./how_to_create_account.md)
+- [How to compile a contract](../aztec-nr/how_to_compile_contract.md)

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_use_authwit.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/how_to_use_authwit.md
@@ -21,99 +21,109 @@ Therefore it is recommended to read the `aztec-nr` [guide on authwitnesses](../a
 - Contract with authwit validation (see [smart contract authwits](../aztec-nr/framework-description/how_to_use_authwit.md))
 - Understanding of [authwit concepts](../foundational-topics/advanced/authwit.md)
 
-## AuthWits
+## Intent types
 
-Let's also assume we have a contract with functions `some_public_function` and `some_private_function` with the macro `#[authorize_once("from", "authwit_nonce")]`, meaning it will check if:
+The authwit system supports different intent types depending on your use case:
 
-- `from` is `msg_sender`, or
-- there's an authwitness allowing `from` to call this function
-
-Regardless of its type, you'll want to define what is being delegated (let's call it "action") and the intent ("who intends to act"). For example:
-
-```typescript
-const nonce = Fr.random()
-
-// bob creates an authwit that authorizes alice to call the function on his behalf
-const action = contract.methods.some_private_function(bob, 10n, nonce)
-const intent = {
-    caller: alice.address, // alice "intends" to call the function on bob's behalf
-    action
-};
-```
-
-:::tip
-
-The nonce is necessary to avoid replay attacks. However, the contract is smart enough to allow bob to call the function himself by setting the nonce to `0`.
-
-:::
+- **`CallIntent`**: Use when authorizing a specific contract function call. Contains `{ caller, action }` where `action` is a `ContractFunctionInteraction`.
+- **`IntentInnerHash`**: Use when authorizing arbitrary data. Contains `{ consumer, innerHash }` where `consumer` is the contract that will verify the authwit.
 
 ## Create private authwits
 
-Private AuthWits mean that some action is authorized in private. No specific transaction is made, the authorization is just sent as part of the actual transaction:
+Private authwits authorize actions in the private domain. The authorization is included directly in the transaction that uses it.
+
+Let's say Alice wants to allow Bob to transfer tokens from her account. Alice is the **authorizer** (she owns the tokens) and Bob is the **caller** (he will execute the transfer):
 
 ```typescript
-const authWit = await wallet.createAuthWit(bob.address, intent);
+import { Fr } from "@aztec/aztec.js/fields";
+
+const nonce = Fr.random();
+
+// Define the action Bob will execute
+const action = tokenContract.methods.transfer_in_private(
+  alice.address, // from
+  bob.address, // to
+  100n, // amount
+  nonce // authwit nonce for replay protection
+);
+
+// Alice creates an authwit authorizing Bob to call this function
+const witness = await wallet.createAuthWit(alice.address, {
+  caller: bob.address,
+  action,
+});
+
+// Bob executes the transfer, providing the authwit
+await action.send({ from: bob.address, authWitnesses: [witness] }).wait();
 ```
 
-Now alice can call the function by providing the authwit:
-
-```typescript
-await action.send({ from: alice.address, authWitnesses: [authWit] }).wait();
-```
+:::tip
+The nonce prevents replay attacks. When `from` and `msg_sender` are the same (self-transfer), set the nonce to `0`.
+:::
 
 ## Create public authwits
 
-Public authwits mean the authorization is public, so it requires a transaction. You create the authwit just as above, but the wallet needs to authorize it in the canonical `AuthRegistry` contract:
+Public authwits require a transaction to store the authorization in the `AuthRegistry` contract before the authorized action can be executed:
 
 ```typescript
-// "true" is specific here... because you may want to revoke it later!
-const authwit = await wallet.setPublicAuthWit(bob.address, intent, true);
-await authwit.send({ from: bob.address }).wait()
-```
+const nonce = Fr.random();
 
-Now that everyone knows about the public authorization, alice can call the function normally:
+// Define the action Bob will execute
+const action = tokenContract.methods.transfer_in_public(
+  alice.address, // from
+  bob.address, // to
+  100n, // amount
+  nonce // authwit nonce
+);
 
-```typescript
-await action.send({ from: alice.address }).wait()
+// Alice sets the public authwit (this requires a transaction)
+const authwit = await wallet.setPublicAuthWit(
+  alice.address,
+  { caller: bob.address, action },
+  true // authorized
+);
+await authwit.send().wait();
+
+// Now Bob can execute the transfer
+await action.send({ from: bob.address }).wait();
 ```
 
 ## Create arbitrary message authwits
 
-This is useful when you need to authorize arbitrary data rather than a specific contract function call. For example, authorizing a signature over a message for offchain verification.
-
-### Step 1: Create inner hash
-
-You can use `computeInnerAuthWitHash` to get yourself a hash of arbitrary hash you can use in an authwit:
+Use this when authorizing arbitrary data rather than a specific contract function call:
 
 ```typescript
-import { computeInnerAuthWitHash, computeAuthWitMessageHash } from "@aztec/aztec.js";
+import { computeInnerAuthWitHash } from "@aztec/aztec.js/authorization";
 
 // Create hash of arbitrary data
-const innerHash = computeInnerAuthWitHash([
-    field1,
-    field2,
-    field3
+const innerHash = await computeInnerAuthWitHash([
+  Fr.fromHexString("0xcafe"),
+  Fr.fromHexString("0xbeef"),
 ]);
 
-// Create full authwit message hash
-const messageHash = computeAuthWitMessageHash(
-    executorAddress,
-    chainId,
-    version,
-    innerHash
-);
+// Create an intent with the consumer contract address
+const intent = {
+  consumer: targetContract.address,
+  innerHash,
+};
+
+// Create the authwit
+const witness = await wallet.createAuthWit(alice.address, intent);
 ```
+
+The `consumer` is the contract address that will verify this authwit.
 
 ## Revoke public authwits
 
-Because public authwits are... well, public, that means you should be able to revoke them. Just set the last parameter to `false` and send the transaction:
+Public authwits can be revoked by setting `authorized` to `false`:
 
 ```typescript
-// Set authorized to false to revoke
-const revoked = await authorizerWallet.setPublicAuthWit({
-    caller: executorAddress,
-    action: action
-}, false).send({ from: account.address });
+const revokeInteraction = await wallet.setPublicAuthWit(
+  alice.address,
+  { caller: bob.address, action },
+  false // revoke authorization
+);
+await revokeInteraction.send().wait();
 ```
 
 ## Next steps
@@ -121,4 +131,3 @@ const revoked = await authorizerWallet.setPublicAuthWit({
 - Learn about [authwits in smart contracts](../aztec-nr/framework-description/how_to_use_authwit.md)
 - Understand [authwit concepts](../foundational-topics/advanced/authwit.md)
 - Explore [account abstraction](../foundational-topics/accounts/index.md)
-- Implement [cross-chain messaging](../aztec-nr/framework-description/how_to_communicate_cross_chain.md)

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/index.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.20251212/docs/aztec-js/index.md
@@ -12,14 +12,9 @@ Aztec.js is a library that provides APIs for managing accounts and interacting w
 ## Installing
 
 ```bash
-npm install @aztec/aztec.js
+npm install @aztec/aztec.js@3.0.0-devnet.20251212
 ```
 
-## Flow
+## Guides
 
-These are some of the important functions you'll need to use in your Aztec.js:
-
-- [Create an account with `@aztec/accounts`](./how_to_create_account.md)
-- [Deploy a contract](./how_to_deploy_contract.md)
-- [Simulate a function call](./how_to_simulate_function.md)
-- [Send a transaction](./how_to_send_transaction.md)
+<DocCardList />


### PR DESCRIPTION
## Summary

Backports relevant changes from PR #19370 to the devnet versioned docs (`v3.0.0-devnet.20251212`).

### Files Updated

All 9 Aztec.js documentation files in the devnet version:
- `how_to_connect_to_local_network.md` - Renamed from "Getting Started", simplified flow
- `how_to_create_account.md` - Simplified with wallet.createSchnorrAccount
- `how_to_deploy_contract.md` - Added overview, BatchCall section, verification
- `how_to_pay_fees.md` - Added payment methods table, fixed imports
- `how_to_send_transaction.md` - Added overview, simplified examples
- `how_to_simulate_function.md` - Complete rewrite for clarity
- `how_to_test.md` - Complete rewrite (was stale)
- `how_to_use_authwit.md` - Clarified intent types
- `index.md` - Simplified with DocCardList

### Key Changes

- Added `registerInitialLocalNetworkAccountsInWallet` helper usage
- Added payment methods overview table comparing Fee Juice, Sponsored FPC, Private FPC, etc.
- Fixed import path to `@aztec/stdlib/contract` (was `contracts`)
- Simplified `GasSettings` with `GasSettings.from()` syntax
- Clarified authwit intent types (`CallIntent` vs `IntentInnerHash`)
- Added overview sections explaining concepts before diving into code
- Updated all version references to `3.0.0-devnet.20251212`

### Adaptations for Devnet Version

- Uses inline code examples instead of `#include_code` macros (which would pull from wrong branch)
- Verified all APIs exist at `v3.0.0-devnet.20251212` tag before using them
- Version-specific package versions throughout

## Test plan

- [ ] Run `yarn start` in docs folder to verify documentation renders correctly
- [ ] Verify links work and point to correct versioned docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)