### PR TITLE
feat: pull timeseries data from prometheus at the end of bench

### DIFF
--- a/yarn-project/end-to-end/src/quality_of_service/prometheus_client.ts
+++ b/yarn-project/end-to-end/src/quality_of_service/prometheus_client.ts
@@ -1,0 +1,113 @@
+export type PromteheusClientOptions = {
+  server: URL;
+};
+
+export class PrometheusClient {
+  constructor(
+    private config: PromteheusClientOptions,
+    private httpClient: typeof fetch = fetch,
+  ) {}
+
+  public async querySingleValue(query: string, time = new Date()): Promise<number> {
+    const resp = await this.queryRaw(query, time);
+    if (resp.status === 'success') {
+      if (resp.data.resultType === 'vector') {
+        if (resp.data.result.length === 0) {
+          return 0;
+        }
+        const [_, value] = resp.data.result[0].value;
+        return parseFloat(value);
+      }
+    }
+
+    throw new TypeError('Unsupported response body', { cause: JSON.stringify(resp) });
+  }
+
+  public queryRaw(query: string, time = new Date()): Promise<PrometheusResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('query', query);
+    searchParams.set('time', String(Math.trunc(time.getTime() / 1000)));
+    searchParams.set('limit', '10');
+
+    return this.callPrometheus('query', searchParams);
+  }
+
+  public queryRangeRaw(
+    query: string,
+    step: PrometheusDuration,
+    start: Date,
+    end = new Date(),
+  ): Promise<PrometheusResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('query', query);
+    searchParams.set('step', step);
+    searchParams.set('start', String(Math.trunc(start.getTime() / 1000)));
+    searchParams.set('end', String(Math.trunc(end.getTime() / 1000)));
+    searchParams.set('limit', '10');
+
+    return this.callPrometheus('query_range', searchParams);
+  }
+
+  private async callPrometheus(api: string, searchParams: URLSearchParams): Promise<PrometheusResponse> {
+    const url = new URL('api/v1/' + api, this.config.server);
+    for (const [name, value] of searchParams) {
+      url.searchParams.append(name, value);
+    }
+
+    const resp = await this.httpClient(url, { method: 'GET' });
+    if (!resp.ok || resp.status !== 200) {
+      throw new Error('Invalid HTTP response from Prometheus', {
+        cause: {
+          url,
+          status: resp.status,
+          statusText: resp.statusText,
+        },
+      });
+    }
+
+    const body = await resp.json();
+    if ('status' in body && (body.status === 'error' || body.status === 'success')) {
+      return body;
+    }
+
+    throw new Error('Invalid response from Prometheus', {
+      cause: {
+        url,
+        body,
+      },
+    });
+  }
+}
+
+export type PrometheusDuration = `${number}s` | `${number}m` | `${number}h`;
+
+export type PrometheusData =
+  | {
+      resultType: 'vector';
+      result: Array<{
+        metric: unknown;
+        value: [unixTimestamp: number, value: string];
+      }>;
+    }
+  | {
+      resultType: 'matrix';
+      result: Array<{
+        metric: unknown;
+        values: [unixTimestamp: number, value: string];
+      }>;
+    }
+  | {
+      resultType: 'scalar' | 'string';
+      result: unknown;
+    };
+
+export type PrometheusResponse =
+  | {
+      status: 'error';
+      errorType: string;
+      error: string;
+    }
+  | {
+      status: 'success';
+      data: PrometheusData;
+    };

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -10,14 +10,17 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { BenchmarkingContract } from '@aztec/noir-test-contracts.js/Benchmarking';
 import { GasFees } from '@aztec/stdlib/gas';
+import { TopicType } from '@aztec/stdlib/p2p';
 import { Tx } from '@aztec/stdlib/tx';
 import { ProvenTx, TestWallet, proveInteraction } from '@aztec/test-wallet/server';
 
 import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { dirname } from 'path';
 
 import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+import { PrometheusClient } from '../quality_of_service/prometheus_client.js';
 import {
   type WalletWrapper,
   createWalletAndAztecNodeClient,
@@ -30,6 +33,7 @@ import {
   getGitProjectRoot,
   installChaosMeshChart,
   setupEnvironment,
+  startPortForwardForPrometeheus,
   uninstallChaosMesh,
 } from './utils.js';
 
@@ -55,6 +59,9 @@ if (lowValueAccounts + highValueAccounts <= 0) {
 
 const CHAOS_MESH_NAME = 'network-shaping';
 
+const p2pLatencyQuery = (perc: string, topicName: TopicType) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_p2p_gossip_message_latency_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}", aztec_gossip_topic_name="${topicName}"}[1m])) by (le))`;
+
 describe('sustained N TPS test', () => {
   jest.setTimeout(60 * 60 * 1000 * 10); // 10 hours
 
@@ -69,24 +76,42 @@ describe('sustained N TPS test', () => {
   let benchmarkContract: BenchmarkingContract;
 
   let metrics: TxInclusionMetrics;
+  let prometheusClient: PrometheusClient;
+  let childProcesses: ChildProcess[];
 
   afterAll(async () => {
+    if (process.env.BENCH_OUTPUT) {
+      for (const topic of Object.values(TopicType)) {
+        try {
+          const [p50, p95] = await Promise.all([
+            prometheusClient.querySingleValue(p2pLatencyQuery('0.50', topic)),
+            prometheusClient.querySingleValue(p2pLatencyQuery('0.95', topic)),
+          ]);
+
+          metrics.recordP2PGossipLatency(topic, p50, p95);
+        } catch (err) {
+          logger.warn(`Failed to scrape prometheus data: ${err}`, { err });
+        }
+      }
+
+      await mkdir(dirname(process.env.BENCH_OUTPUT), { recursive: true });
+      await writeFile(process.env.BENCH_OUTPUT, JSON.stringify(metrics.toGithubActionBenchmarkJSON()));
+    }
+
     for (const { cleanup } of testWallets!) {
       await cleanup();
     }
 
-    if (process.env.BENCH_OUTPUT) {
-      await mkdir(dirname(process.env.BENCH_OUTPUT), { recursive: true });
-      await writeFile(process.env.BENCH_OUTPUT, JSON.stringify(metrics.toGithubActionBenchmarkJSON()));
+    for (const proc of childProcesses) {
+      proc.kill();
     }
-  });
 
-  afterAll(async () => {
     await uninstallChaosMesh(CHAOS_MESH_NAME, config.NAMESPACE, logger);
   });
 
   beforeAll(async () => {
     logger.info(`Starting test setup for sustained TPS tests over ${TEST_DURATION_SECONDS} seconds...`);
+    childProcesses = [];
 
     const spartanDir = `${getGitProjectRoot()}/spartan`;
     const chaosMeshInstallation = installChaosMeshChart({
@@ -100,6 +125,14 @@ describe('sustained N TPS test', () => {
     const rpcIP = await getExternalIP(config.NAMESPACE, 'rpc-aztec-node');
     const rpcUrl = `http://${rpcIP}:8080`;
     aztecNode = createAztecNodeClient(rpcUrl);
+
+    const promPortForward = await startPortForwardForPrometeheus('metrics');
+    childProcesses.push(promPortForward.process);
+
+    prometheusClient = new PrometheusClient({
+      server: new URL(`http://127.0.0.1:${promPortForward.port}`),
+    });
+
     metrics = new TxInclusionMetrics(aztecNode);
 
     await retryUntil(
@@ -132,7 +165,7 @@ describe('sustained N TPS test', () => {
     logger.info('Deploying benchmark contract...');
     const sponsor = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
     benchmarkContract = await BenchmarkingContract.deploy(localTestAccounts[0].wallet)
-      .send({ from: localTestAccounts[0].accounts[0], fee: { paymentMethod: sponsor } })
+      .send({ from: localTestAccounts[0].recipientAddress, fee: { paymentMethod: sponsor } })
       .deployed();
 
     logger.info(`Awaiting chaos mesh installation`);

--- a/yarn-project/end-to-end/src/spartan/tx_metrics.ts
+++ b/yarn-project/end-to-end/src/spartan/tx_metrics.ts
@@ -1,5 +1,6 @@
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { L2Block } from '@aztec/stdlib/block';
+import type { TopicType } from '@aztec/stdlib/p2p';
 import { Tx, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { createHistogram } from 'perf_hooks';
@@ -20,6 +21,8 @@ export class TxInclusionMetrics {
   private data = new Map<string, TxInclusionData>();
   private groups = new Set<string>();
   private blocks = new Map<number, Promise<L2Block>>();
+
+  private p2pGossipLatencyByTopic: Partial<Record<TopicType, { p50: number; p95: number }>> = {};
 
   constructor(private aztecNode: AztecNode) {}
 
@@ -71,7 +74,7 @@ export class TxInclusionMetrics {
   } {
     const histogram = createHistogram({});
     for (const tx of this.data.values()) {
-      if (!tx.blocknumber || tx.group !== group) {
+      if (!tx.blocknumber || tx.group !== group || tx.minedAt === -1) {
         continue;
       }
 
@@ -101,6 +104,10 @@ export class TxInclusionMetrics {
     };
   }
 
+  public recordP2PGossipLatency(topicName: TopicType, p50: number, p95: number): void {
+    this.p2pGossipLatencyByTopic[topicName] = { p50, p95 };
+  }
+
   toGithubActionBenchmarkJSON(): Array<{ name: string; unit: string; value: number; range?: number; extra?: string }> {
     const data: Array<{ name: string; unit: string; value: number; range?: number; extra?: string }> = [];
     for (const group of this.groups) {
@@ -123,6 +130,19 @@ export class TxInclusionMetrics {
           value: stats.p99,
         },
       );
+    }
+
+    for (const [topic, { p50, p95 }] of Object.entries(this.p2pGossipLatencyByTopic)) {
+      data.push({
+        name: `p2p_gossip_latency/${topic}/p50`,
+        unit: 'ms',
+        value: p50,
+      });
+      data.push({
+        name: `p2p_gossip_latency/${topic}/p95`,
+        unit: 'ms',
+        value: p95,
+      });
     }
 
     return data;

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -117,7 +117,7 @@ export async function startPortForward({
   );
 
   let isResolved = false;
-  const connected = new Promise<number>(resolve => {
+  const connected = new Promise<number>((resolve, reject) => {
     process.stdout?.on('data', data => {
       const str = data.toString() as string;
       if (!isResolved && str.includes('Forwarding from')) {
@@ -125,7 +125,8 @@ export async function startPortForward({
         logger.debug(`Port forward for ${resource}: ${str}`);
         const port = str.search(/:\d+/);
         if (port === -1) {
-          throw new Error('Port not found in port forward output');
+          reject(new Error('Port not found in port forward output'));
+          return;
         }
         const portNumber = parseInt(str.slice(port + 1));
         logger.verbose(`Port forwarded for ${resource} at ${portNumber}:${containerPort}`);
@@ -145,17 +146,26 @@ export async function startPortForward({
     process.on('close', () => {
       if (!isResolved) {
         isResolved = true;
-        logger.warn(`Port forward for ${resource} closed before connection established`);
-        resolve(0);
+        const msg = `Port forward for ${resource} closed before connection established`;
+        logger.warn(msg);
+        reject(new Error(msg));
       }
     });
     process.on('error', error => {
-      logger.error(`Port forward for ${resource} error: ${error}`);
-      resolve(0);
+      if (!isResolved) {
+        isResolved = true;
+        const msg = `Port forward for ${resource} error: ${error}`;
+        logger.error(msg);
+        reject(new Error(msg));
+      }
     });
     process.on('exit', code => {
-      logger.verbose(`Port forward for ${resource} exited with code ${code}`);
-      resolve(0);
+      if (!isResolved) {
+        isResolved = true;
+        const msg = `Port forward for ${resource} exited with code ${code}`;
+        logger.verbose(msg);
+        reject(new Error(msg));
+      }
     });
   });
 
@@ -195,6 +205,14 @@ export function getExternalIP(namespace: string, serviceName: string): Promise<s
   });
 
   return promise;
+}
+
+export function startPortForwardForPrometeheus(namespace: string) {
+  return startPortForward({
+    resource: `svc/${namespace}-prometheus-server`,
+    namespace,
+    containerPort: 80,
+  });
 }
 
 export function startPortForwardForRPC(namespace: string, index = 0) {


### PR DESCRIPTION
This PR adds a client that's able to pull timeseries data from prometheus. This can be used in spartan benchmarks to run PromQL queries.