### PR TITLE
fix: node request from `PXE` crossing `MAX_RPC_LIMIT`

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -1017,7 +1017,22 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   // TODO(#12656): Make this a public function on the AztecNode interface and remove the original getLogsByTags. This
   // was not done yet as we were unsure about the API and we didn't want to introduce a breaking change.
   async #getPrivateLogsByTags(tags: Fr[]): Promise<TxScopedL2Log[][]> {
-    const allLogs = await this.aztecNode.getLogsByTags(tags);
+    // Batch tags to avoid exceeding MAX_RPC_LEN
+    const tagBatches = tags.reduce(
+      (acc, tag) => {
+        if (acc[acc.length - 1].length < MAX_RPC_LEN) {
+          acc[acc.length - 1].push(tag);
+        } else {
+          acc.push([tag]);
+        }
+        return acc;
+      },
+      [[]] as Fr[][],
+    );
+
+    const allLogsBatched = await Promise.all(tagBatches.map(batch => this.aztecNode.getLogsByTags(batch)));
+
+    const allLogs = allLogsBatched.flat();
     return allLogs.map(logs => logs.filter(log => !log.isFromPublic));
   }
 


### PR DESCRIPTION
A fix that prevents `PXE` from crossing the `MAX_RPC_LIMIT`. This fix was originally published by @porco-rosso-j
 [here](https://github.com/AztecProtocol/aztec-packages/pull/19181) but it never got to `next` because on `next` the issue went away with the introduction of the new log sync algo.