### PR TITLE
refactor: staged writes on note store

### DIFF
--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -35,7 +35,7 @@ describe('BlockSynchronizer', () => {
     aztecNode = mock<AztecNode>();
     tipsStore = new L2TipsKVStore(store, 'pxe');
     anchorBlockStore = new AnchorBlockStore(store);
-    noteStore = await NoteStore.create(store);
+    noteStore = new NoteStore(store);
     privateEventStore = new PrivateEventStore(store);
     synchronizer = new TestSynchronizer(aztecNode, store, anchorBlockStore, noteStore, privateEventStore, tipsStore);
   });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -356,7 +356,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     const pendingNullifiers = this.noteCache.getNullifiers(this.callContext.contractAddress);
 
-    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
+    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
     const dbNotes = await noteService.getNotes(
       this.callContext.contractAddress,
       owner,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -251,7 +251,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     offset: number,
     status: NoteStatus,
   ): Promise<NoteData[]> {
-    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
+    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
 
     const dbNotes = await noteService.getNotes(this.contractAddress, owner, storageSlot, status, this.scopes);
     return pickNotes<NoteData>(dbNotes, {
@@ -350,7 +350,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.jobId,
     );
 
-    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
+    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
 
     // It is acceptable to run the following operations in parallel for several reasons:
     // 1. syncTaggedLogs does not write to the note store — it only stores the pending tagged logs in a capsule array,
@@ -392,7 +392,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       await this.capsuleStore.readCapsuleArray(contractAddress, eventValidationRequestsArrayBaseSlot, this.jobId)
     ).map(EventValidationRequest.fromFields);
 
-    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
+    const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
     const noteStorePromises = noteValidationRequests.map(request =>
       noteService.storeNote(
         request.contractAddress,

--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from '@aztec/foundation/crypto/random';
 import type { NoteDao, NotesFilter } from '@aztec/stdlib/note';
 
 import type { PXE } from '../pxe.js';
@@ -43,6 +44,6 @@ export class PXEDebugUtils {
     const call = await this.contractStore.getFunctionCall('sync_private_state', [], filter.contractAddress);
     await this.#pxe.simulateUtility(call);
 
-    return this.noteStore.getNotes(filter);
+    return this.noteStore.getNotes(filter, randomBytes(8).toString('hex'));
   }
 }

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -32,8 +32,7 @@ describe('NoteService', () => {
   beforeEach(async () => {
     const store = await openTmpStore('test');
     keyStore = new KeyStore(store);
-    noteStore = await NoteStore.create(store);
-    noteStore = await NoteStore.create(store);
+    noteStore = new NoteStore(store);
     aztecNode = mock<AztecNode>();
     anchorBlockStore = new AnchorBlockStore(store);
     await anchorBlockStore.setHeader(
@@ -44,81 +43,104 @@ describe('NoteService', () => {
 
     contractAddress = await AztecAddress.random();
 
-    // Check that there are no notes in the database
-    const notes = await noteStore.getNotes({ contractAddress });
+    const notes = await noteStore.getNotes({ contractAddress }, 'test');
     expect(notes).toHaveLength(0);
 
-    // Check that the expected number of accounts is present
     const accounts = await keyStore.getAccounts();
     expect(accounts).toHaveLength(0);
 
     recipient = await keyStore.addAccount(new Fr(69), Fr.random());
 
-    noteService = new NoteService(noteStore, aztecNode, anchorBlockStore);
+    noteService = new NoteService(noteStore, aztecNode, anchorBlockStore, 'test');
   });
 
   it('should remove notes that have been nullified', async () => {
-    // Set up initial state with a note
     const noteDao = await NoteDao.random({ contractAddress });
 
     // Spy on the noteStore.applyNullifiers to later on have additional guarantee that we really removed
     // the note.
     jest.spyOn(noteStore, 'applyNullifiers');
 
-    // Add the note to storage
-    await noteStore.addNotes([noteDao], recipient.address);
+    await noteStore.addNotes([noteDao], recipient.address, 'test');
 
     // Set up the nullifier in the merkle tree
     const nullifierIndex = randomDataInBlock(123n);
     aztecNode.findLeavesIndexes.mockResolvedValue([nullifierIndex]);
 
-    // Call the function under test
     await noteService.syncNoteNullifiers(contractAddress);
 
-    // Verify the note was removed by checking storage
-    const remainingNotes = await noteStore.getNotes({
-      contractAddress,
-      status: NoteStatus.ACTIVE,
-      scopes: [recipient.address],
-    });
+    const remainingNotes = await noteStore.getNotes(
+      {
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient.address],
+      },
+      'test',
+    );
     expect(remainingNotes).toHaveLength(0);
 
     // Verify the note was removed by checking the spy
     expect(noteStore.applyNullifiers).toHaveBeenCalledTimes(1);
+
+    // Verify that the changes persist after job completion
+    {
+      await noteStore.commit('test');
+      const remainingNotes = await noteStore.getNotes(
+        {
+          contractAddress,
+          status: NoteStatus.ACTIVE,
+          scopes: [recipient.address],
+        },
+        'fresh-job',
+      );
+      expect(remainingNotes).toHaveLength(0);
+    }
   });
 
   it('should keep notes that have not been nullified', async () => {
-    // Set up initial state with a note
     const noteDao = await NoteDao.random({ contractAddress });
 
-    // Add the note to storage
-    await noteStore.addNotes([noteDao], recipient.address);
+    await noteStore.addNotes([noteDao], recipient.address, 'test');
 
     // No nullifier found in merkle tree
     aztecNode.findLeavesIndexes.mockResolvedValue([undefined]);
 
-    // Call the function under test
     await noteService.syncNoteNullifiers(contractAddress);
 
-    // Verify note still exists
-    const remainingNotes = await noteStore.getNotes({
-      contractAddress,
-      status: NoteStatus.ACTIVE,
-      scopes: [recipient.address],
-    });
+    const remainingNotes = await noteStore.getNotes(
+      {
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient.address],
+      },
+      'test',
+    );
     expect(remainingNotes).toHaveLength(1);
     expect(remainingNotes[0]).toEqual(noteDao);
+
+    // Verify that the changes persist after job completion
+    {
+      await noteStore.commit('test');
+      const remainingNotes = await noteStore.getNotes(
+        {
+          contractAddress,
+          status: NoteStatus.ACTIVE,
+          scopes: [recipient.address],
+        },
+        'fresh-job',
+      );
+      expect(remainingNotes).toHaveLength(1);
+      expect(remainingNotes[0]).toEqual(noteDao);
+    }
   });
 
   // Verifies that notes are not marked as nullified when their nullifier only exists in blocks that haven't been
   // synced yet. We mock the nullifier to only exist in blocks beyond our current sync point, then verify the note
   // is not removed by applyNullifiers.
   it('should not remove notes if nullifier is in unsynced blocks', async () => {
-    // Set up initial state with a note
     const noteDao = await NoteDao.random({ contractAddress });
 
-    // Add the note to storage
-    await noteStore.addNotes([noteDao], recipient.address);
+    await noteStore.addNotes([noteDao], recipient.address, 'test');
 
     // Mock nullifier to only exist after synced block
     aztecNode.findLeavesIndexes.mockImplementation(blockNum => {
@@ -128,37 +150,51 @@ describe('NoteService', () => {
       return Promise.resolve([undefined]);
     });
 
-    // Call the function under test
     await noteService.syncNoteNullifiers(contractAddress);
 
     // Verify note still exists
-    const remainingNotes = await noteStore.getNotes({
-      contractAddress,
-      status: NoteStatus.ACTIVE,
-      scopes: [recipient.address],
-    });
+    const remainingNotes = await noteStore.getNotes(
+      {
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+        scopes: [recipient.address],
+      },
+      'test',
+    );
     expect(remainingNotes).toHaveLength(1);
     expect(remainingNotes[0]).toEqual(noteDao);
+
+    // Verify that the changes persist after job completion
+    {
+      await noteStore.commit('test');
+      const remainingNotes = await noteStore.getNotes(
+        {
+          contractAddress,
+          status: NoteStatus.ACTIVE,
+          scopes: [recipient.address],
+        },
+        'fresh-job',
+      );
+      expect(remainingNotes).toHaveLength(1);
+      expect(remainingNotes[0]).toEqual(noteDao);
+    }
   });
 
   it('should search for notes from all accounts', async () => {
-    // Add multiple accounts to keystore
     await keyStore.addAccount(Fr.random(), Fr.random());
     await keyStore.addAccount(Fr.random(), Fr.random());
 
     expect(await keyStore.getAccounts()).toHaveLength(3);
 
-    // Spy on the noteStore.getNotesSpy
     const getNotesSpy = jest.spyOn(noteStore, 'getNotes');
 
-    // Call the function under test
     await noteService.syncNoteNullifiers(contractAddress);
 
     // Verify applyNullifiers was called once for all accounts
     expect(getNotesSpy).toHaveBeenCalledTimes(1);
 
-    // Verify getNotes was called with the correct contract address
-    expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }));
+    // Verify getNotes was called with the correct contract address and jobId
+    expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }), 'test');
   });
 
   describe('storeNote', () => {
@@ -248,10 +284,20 @@ describe('NoteService', () => {
       );
 
       // Verify note was stored
-      const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] });
+      const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'test');
 
       expect(notes).toHaveLength(1);
       expect(notes[0].noteHash.equals(noteHash)).toBe(true);
+
+      // Verify note is still stored after committing job
+      {
+        await noteStore.commit('test');
+
+        const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'fresh-job');
+
+        expect(notes).toHaveLength(1);
+        expect(notes[0].noteHash.equals(noteHash)).toBe(true);
+      }
     });
 
     it('should throw if tx hash does not exist', async () => {
@@ -332,22 +378,35 @@ describe('NoteService', () => {
         recipient.address,
       );
 
-      // Now we verify that the note is stored as nullified by checking it can be retrieved only with
-      // the ACTIVE_OR_NULLIFIED status on the input.
-      const allNotes = await noteStore.getNotes({
-        contractAddress,
-        scopes: [recipient.address],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(allNotes).toHaveLength(1);
-      expect(allNotes[0].noteHash.equals(noteHash)).toBe(true);
+      const verifyNoteNullifiedInJobContext = async (jobId: string) => {
+        // Now we verify that the note is stored as nullified by checking it can be retrieved only with
+        // the ACTIVE_OR_NULLIFIED status on the input.
+        const allNotes = await noteStore.getNotes(
+          {
+            contractAddress,
+            scopes: [recipient.address],
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          jobId,
+        );
+        expect(allNotes).toHaveLength(1);
+        expect(allNotes[0].noteHash.equals(noteHash)).toBe(true);
 
-      const activeNotes = await noteStore.getNotes({
-        contractAddress,
-        scopes: [recipient.address],
-        status: NoteStatus.ACTIVE,
-      });
-      expect(activeNotes).toHaveLength(0);
+        const activeNotes = await noteStore.getNotes(
+          {
+            contractAddress,
+            scopes: [recipient.address],
+            status: NoteStatus.ACTIVE,
+          },
+          jobId,
+        );
+        expect(activeNotes).toHaveLength(0);
+      };
+
+      // Verify store behaves correctly pre and post commit
+      await verifyNoteNullifiedInJobContext('test');
+      await noteStore.commit('test');
+      await verifyNoteNullifiedInJobContext('fresh-job');
     });
   });
 });

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -16,6 +16,7 @@ export class NoteService {
     private readonly noteStore: NoteStore,
     private readonly aztecNode: AztecNode,
     private readonly anchorBlockStore: AnchorBlockStore,
+    private readonly jobId: string,
   ) {}
 
   /**
@@ -34,13 +35,16 @@ export class NoteService {
     status: NoteStatus,
     scopes?: AztecAddress[],
   ) {
-    const noteDaos = await this.noteStore.getNotes({
-      contractAddress,
-      owner,
-      storageSlot,
-      status,
-      scopes,
-    });
+    const noteDaos = await this.noteStore.getNotes(
+      {
+        contractAddress,
+        owner,
+        storageSlot,
+        status,
+        scopes,
+      },
+      this.jobId,
+    );
     return noteDaos.map(
       ({ contractAddress, owner, storageSlot, randomness, noteNonce, note, noteHash, siloedNullifier }) => ({
         contractAddress,
@@ -71,7 +75,7 @@ export class NoteService {
   public async syncNoteNullifiers(contractAddress: AztecAddress): Promise<void> {
     const anchorBlockHash = L2BlockHash.fromField(await (await this.anchorBlockStore.getBlockHeader()).hash());
 
-    const contractNotes = await this.noteStore.getNotes({ contractAddress });
+    const contractNotes = await this.noteStore.getNotes({ contractAddress }, this.jobId);
 
     if (contractNotes.length === 0) {
       return;
@@ -105,7 +109,7 @@ export class NoteService {
       })
       .filter(nullifier => nullifier !== undefined) as DataInBlock<Fr>[];
 
-    await this.noteStore.applyNullifiers(foundNullifiers);
+    await this.noteStore.applyNullifiers(foundNullifiers, this.jobId);
   }
 
   public async storeNote(
@@ -183,12 +187,12 @@ export class NoteService {
     );
 
     // The note was found by `recipient`, so we use that as the scope when storing the note.
-    await this.noteStore.addNotes([noteDao], recipient);
+    await this.noteStore.addNotes([noteDao], recipient, this.jobId);
 
     if (nullifierIndex !== undefined) {
       // We found nullifier index which implies that the note has already been nullified.
       const { data: _, ...blockHashAndNum } = nullifierIndex;
-      await this.noteStore.applyNullifiers([{ data: siloedNullifier, ...blockHashAndNum }]);
+      await this.noteStore.applyNullifiers([{ data: siloedNullifier, ...blockHashAndNum }], this.jobId);
     }
   }
 }

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -138,7 +138,7 @@ export class PXE {
     const addressStore = new AddressStore(store);
     const privateEventStore = new PrivateEventStore(store);
     const contractStore = new ContractStore(store);
-    const noteStore = await NoteStore.create(store);
+    const noteStore = new NoteStore(store);
     const anchorBlockStore = new AnchorBlockStore(store);
     const senderTaggingStore = new SenderTaggingStore(store);
     const senderAddressBookStore = new SenderAddressBookStore(store);
@@ -158,7 +158,13 @@ export class PXE {
     );
 
     const jobCoordinator = new JobCoordinator(store);
-    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore, privateEventStore]);
+    jobCoordinator.registerStores([
+      capsuleStore,
+      senderTaggingStore,
+      recipientTaggingStore,
+      privateEventStore,
+      noteStore,
+    ]);
 
     const debugUtils = new PXEDebugUtils(contractStore, noteStore);
 
@@ -428,7 +434,6 @@ export class PXE {
     }
 
     await this.addressStore.addCompleteAddress(accountCompleteAddress);
-    await this.noteStore.addScope(accountCompleteAddress.address);
     return accountCompleteAddress;
   }
 

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -36,12 +36,9 @@ describe('NoteStore', () => {
   }
 
   // Sets up a fresh NoteStore with two scopes and three notes.
-  async function setupProviderWithNotes(storeName: string) {
+  async function setupNoteStoreWithNotes(storeName: string) {
     const store = await openTmpStore(storeName);
-    const provider = await NoteStore.create(store);
-
-    await provider.addScope(SCOPE_1);
-    await provider.addScope(SCOPE_2);
+    const noteStore = new NoteStore(store);
 
     const note1 = await mkNote({
       contractAddress: CONTRACT_A,
@@ -59,10 +56,11 @@ describe('NoteStore', () => {
       siloedNullifier: SILOED_NULLIFIER_3,
     });
 
-    await provider.addNotes([note1, note2], SCOPE_1);
-    await provider.addNotes([note3], SCOPE_2);
+    await noteStore.addNotes([note1, note2], SCOPE_1, 'before-each-test-job');
+    await noteStore.addNotes([note3], SCOPE_2, 'before-each-test-job');
+    await noteStore.commit('before-each-test-job');
 
-    return { store, provider, note1, note2, note3 };
+    return { store, noteStore, note1, note2, note3 };
   }
 
   // Helper to create a nullifier object matching a given note.
@@ -74,20 +72,37 @@ describe('NoteStore', () => {
     };
   }
 
-  // Extracts the `siloedNullifier` field from an array of notes for easy comparison in tests.
-  function getNullifiers(notes: NoteDao[]) {
-    return notes.map(n => n.siloedNullifier.toBigInt());
+  // Returns a Set of siloedNullifier bigints from an array of notes or nullifiers expressed as Fr.
+  function nullifierSet(notes: (NoteDao | Fr)[]) {
+    return new Set(notes.map(n => (n instanceof Fr ? n : n.siloedNullifier).toBigInt()));
+  }
+
+  /**
+   * Runs the same function sequentially in the given list of jobId's.
+   * Handy to assert that state is consistent pre and post commit.
+   */
+  async function verifyAndCommitForEachJob(
+    jobIds: string[],
+    noteStore: NoteStore,
+    fn: (jobId: string) => Promise<void>,
+  ) {
+    for (const jobId of jobIds) {
+      await fn(jobId);
+      await noteStore.commit(jobId);
+    }
   }
 
   // In these tests, we verify the presence/absence of notes by their `siloedNullifier`.
   describe('NoteStore.create', () => {
-    it('creates provider on an empty store and confirms getNotes returns an empty array', async () => {
+    it('creates a NoteStore on an empty store and confirms getNotes returns an empty array', async () => {
       const store = await openTmpStore('note_store_fresh_store');
-      const provider = await NoteStore.create(store);
+      const noteStore = new NoteStore(store);
 
-      const res = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(Array.isArray(res)).toBe(true);
-      expect(res).toHaveLength(0);
+      await verifyAndCommitForEachJob(['pre-commit', 'post-commit'], noteStore, async (jobId: string) => {
+        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        expect(Array.isArray(notes)).toBe(true);
+        expect(notes).toHaveLength(0);
+      });
 
       await store.close();
     });
@@ -95,23 +110,25 @@ describe('NoteStore', () => {
     it('re-initializes from an existing store and restores previously added notes', async () => {
       const store = await openTmpStore('note_store_re-init_test');
 
-      // First provider populates the store; second reopens it to verify persistence
-      const provider1 = await NoteStore.create(store);
+      // First note store populates the persistent store; second reopens it to verify persistence
+      {
+        const noteStore1 = new NoteStore(store);
 
-      await provider1.addScope(SCOPE_1);
-      await provider1.addScope(SCOPE_2);
+        const noteA = await mkNote({ contractAddress: CONTRACT_A, siloedNullifier: SILOED_NULLIFIER_1 });
+        const noteB = await mkNote({ contractAddress: CONTRACT_B, siloedNullifier: SILOED_NULLIFIER_2 });
+        await noteStore1.addNotes([noteA, noteB], FAKE_ADDRESS, 'first-store');
+        await noteStore1.commit('first-store');
+      }
 
-      const noteA = await mkNote({ contractAddress: CONTRACT_A, siloedNullifier: SILOED_NULLIFIER_1 });
-      const noteB = await mkNote({ contractAddress: CONTRACT_B, siloedNullifier: SILOED_NULLIFIER_2 });
-      await provider1.addNotes([noteA, noteB], FAKE_ADDRESS);
+      const noteStore2 = new NoteStore(store);
 
-      const provider2 = await NoteStore.create(store);
+      await verifyAndCommitForEachJob(['second-store', 'fresh-job'], noteStore2, async (jobId: string) => {
+        const notesA = await noteStore2.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const notesB = await noteStore2.getNotes({ contractAddress: CONTRACT_B }, jobId);
 
-      const notesA = await provider2.getNotes({ contractAddress: CONTRACT_A });
-      const notesB = await provider2.getNotes({ contractAddress: CONTRACT_B });
-
-      expect(new Set(getNullifiers(notesA))).toEqual(new Set([SILOED_NULLIFIER_1.toBigInt()]));
-      expect(new Set(getNullifiers(notesB))).toEqual(new Set([SILOED_NULLIFIER_2.toBigInt()]));
+        expect(nullifierSet(notesA)).toEqual(nullifierSet([SILOED_NULLIFIER_1]));
+        expect(nullifierSet(notesB)).toEqual(nullifierSet([SILOED_NULLIFIER_2]));
+      });
 
       await store.close();
     });
@@ -119,13 +136,13 @@ describe('NoteStore', () => {
 
   describe('NoteStore.getNotes filtering happy path', () => {
     let store: AztecLMDBStoreV2;
-    let provider: NoteStore;
+    let noteStore: NoteStore;
     let note1: NoteDao;
     let note2: NoteDao;
     let note3: NoteDao;
 
     beforeEach(async () => {
-      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes('note_store_get_notes_happy'));
+      ({ store, noteStore, note1, note2, note3 } = await setupNoteStoreWithNotes('note_store_get_notes_happy'));
     });
 
     afterEach(async () => {
@@ -133,21 +150,19 @@ describe('NoteStore', () => {
     });
 
     it('filters notes matching only the contractAddress', async () => {
-      const res = await provider.getNotes({ contractAddress: CONTRACT_A });
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
       // note1 and note2 match CONTRACT_A
-      expect(new Set(getNullifiers(res))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
-      );
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note1, note2]));
     });
 
     it('filters notes matching contractAddress and storageSlot', async () => {
-      const res = await provider.getNotes({ contractAddress: CONTRACT_A, storageSlot: SLOT_Y });
-      expect(new Set(getNullifiers(res))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, storageSlot: SLOT_Y }, 'test');
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note2]));
     });
 
     it('filters notes matching contractAddress in the specified scope', async () => {
-      const res = await provider.getNotes({ contractAddress: CONTRACT_B, scopes: [SCOPE_2] });
-      expect(new Set(getNullifiers(res))).toEqual(new Set([note3.siloedNullifier.toBigInt()]));
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_B, scopes: [SCOPE_2] }, 'test');
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note3]));
     });
 
     it('filters notes matching contractAddress across multiple scopes', async () => {
@@ -158,79 +173,93 @@ describe('NoteStore', () => {
         storageSlot: SLOT_X,
         siloedNullifier: note4Nullifier,
       });
-      await provider.addNotes([note4], SCOPE_2);
+      await noteStore.addNotes([note4], SCOPE_2, 'test');
 
-      const res = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_1, SCOPE_2],
-      });
-
-      expect(new Set(getNullifiers(res))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt(), note4Nullifier.toBigInt()]),
+      const notes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          scopes: [SCOPE_1, SCOPE_2],
+        },
+        'test',
       );
+
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note1, note2, note4Nullifier]));
     });
 
     it('deduplicates notes that appear in multiple scopes', async () => {
       // note 1 has been added to scope 1 in setup so we add it to scope 2 to then be able to test deduplication
-      await provider.addNotes([note1], SCOPE_2);
+      await noteStore.addNotes([note1], SCOPE_2, 'test');
 
-      const res = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_1, SCOPE_2],
-      });
+      const notes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          scopes: [SCOPE_1, SCOPE_2],
+        },
+        'test',
+      );
 
       // Note 1 should be present exactly once in the result
-      const note1Matches = res.filter(n => n.equals(note1));
+      const note1Matches = notes.filter(n => n.equals(note1));
       expect(note1Matches.length).toBe(1);
     });
 
     it('filters notes by status, returning ACTIVE by default and both ACTIVE and NULLIFIED when requested', async () => {
       const nullifiers = [mkNullifier(note2)];
-      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note2]);
+      await expect(noteStore.applyNullifiers(nullifiers, 'test')).resolves.toEqual([note2]);
 
-      const resActive = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getNullifiers(resActive))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
+      const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1]));
 
-      const resAll = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getNullifiers(resAll))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      const allNotes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        },
+        'test',
       );
+      expect(nullifierSet(allNotes)).toEqual(nullifierSet([note1, note2]));
     });
 
     it('returns only notes that match all provided filters', async () => {
-      const res = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        storageSlot: SLOT_X,
-        scopes: [SCOPE_1],
-      });
+      const notes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          storageSlot: SLOT_X,
+          scopes: [SCOPE_1],
+        },
+        'test',
+      );
 
-      expect(new Set(getNullifiers(res))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note1]));
     });
 
     it('applies scope filtering to nullified notes', async () => {
       const nullifiers = [mkNullifier(note3)];
-      await expect(provider.applyNullifiers(nullifiers)).resolves.toEqual([note3]);
+      await expect(noteStore.applyNullifiers(nullifiers, 'test')).resolves.toEqual([note3]);
 
       // Query for contractB, but with the wrong scope (scope1)
-      const res = await provider.getNotes({
-        contractAddress: CONTRACT_B,
-        scopes: [SCOPE_1],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
+      const wrongScopeNotes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_B,
+          scopes: [SCOPE_1],
+          status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        },
+        'test',
+      );
 
-      expect(res).toHaveLength(0);
+      expect(wrongScopeNotes).toHaveLength(0);
 
       // Query for contractB with the correct scope (scope2)
-      const res2 = await provider.getNotes({
-        contractAddress: CONTRACT_B,
-        scopes: [SCOPE_2],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
+      const correctScopeNotes = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_B,
+          scopes: [SCOPE_2],
+          status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        },
+        'test',
+      );
 
-      expect(new Set(getNullifiers(res2))).toEqual(new Set([note3.siloedNullifier.toBigInt()]));
+      expect(nullifierSet(correctScopeNotes)).toEqual(nullifierSet([note3]));
     });
 
     it('filters notes by siloedNullifier', async () => {
@@ -239,25 +268,28 @@ describe('NoteStore', () => {
         siloedNullifier: note1.siloedNullifier,
       };
 
-      const res = await provider.getNotes(filter);
-      expect(new Set(getNullifiers(res))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
+      const notes = await noteStore.getNotes(filter, 'test');
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note1]));
 
       // Test with a different note's siloedNullifier
-      const res2 = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        siloedNullifier: note2.siloedNullifier,
-      });
-      expect(new Set(getNullifiers(res2))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
+      const notes2 = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          siloedNullifier: note2.siloedNullifier,
+        },
+        'test',
+      );
+      expect(nullifierSet(notes2)).toEqual(nullifierSet([note2]));
     });
   });
 
   describe('NoteStore.getNotes filtering edge cases', () => {
     let store: AztecLMDBStoreV2;
-    let provider: NoteStore;
+    let noteStore: NoteStore;
     let note2: NoteDao;
 
     beforeEach(async () => {
-      ({ store, provider, note2 } = await setupProviderWithNotes('note_store_get_notes_edge'));
+      ({ store, noteStore, note2 } = await setupNoteStoreWithNotes('note_store_get_notes_edge'));
     });
 
     afterEach(async () => {
@@ -265,28 +297,22 @@ describe('NoteStore', () => {
     });
 
     it('returns no notes when filtering by non-existing contractAddress', async () => {
-      const res = await provider.getNotes({ contractAddress: FAKE_ADDRESS });
-      expect(getNullifiers(res)).toHaveLength(0);
+      const notes = await noteStore.getNotes({ contractAddress: FAKE_ADDRESS }, 'test');
+      expect(notes).toHaveLength(0);
     });
 
     it('returns no notes when filtering by non-existing storageSlot', async () => {
-      const res = await provider.getNotes({ contractAddress: CONTRACT_A, storageSlot: NON_EXISTING_SLOT });
-      expect(res).toHaveLength(0);
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, storageSlot: NON_EXISTING_SLOT }, 'test');
+      expect(notes).toHaveLength(0);
     });
 
     it('filters notes matching contractAddress in the specified scope', async () => {
-      const res = await provider.getNotes({ contractAddress: CONTRACT_A, scopes: [SCOPE_2] });
-      expect(res).toHaveLength(0);
-    });
-
-    it('throws when filtering with a scope not present in the PXE database', async () => {
-      await expect(provider.getNotes({ contractAddress: CONTRACT_A, scopes: [FAKE_ADDRESS] })).rejects.toThrow(
-        'Trying to get incoming notes of a scope that is not in the PXE database',
-      );
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: [SCOPE_2] }, 'test');
+      expect(notes).toHaveLength(0);
     });
 
     it('throws when called with an empty scopes array', async () => {
-      await expect(provider.getNotes({ contractAddress: CONTRACT_A, scopes: [] })).rejects.toThrow(
+      await expect(noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: [] }, 'test')).rejects.toThrow(
         'Trying to get notes with an empty scopes array',
       );
     });
@@ -297,8 +323,8 @@ describe('NoteStore', () => {
         siloedNullifier: NON_EXISTING_SLOT,
       };
 
-      const res = await provider.getNotes(filter);
-      expect(res).toHaveLength(0);
+      const notes = await noteStore.getNotes(filter, 'test');
+      expect(notes).toHaveLength(0);
     });
 
     it('returns no notes when siloedNullifier is valid but contractAddress mismatches', async () => {
@@ -307,20 +333,20 @@ describe('NoteStore', () => {
         siloedNullifier: note2.siloedNullifier,
       };
 
-      const res = await provider.getNotes(filter);
-      expect(res).toHaveLength(0);
+      const notes = await noteStore.getNotes(filter, 'test');
+      expect(notes).toHaveLength(0);
     });
   });
 
-  describe('NoteStore.applyNullifiers happy path', () => {
+  describe('applyNullifiers', () => {
     let store: AztecLMDBStoreV2;
-    let provider: NoteStore;
+    let noteStore: NoteStore;
     let note1: NoteDao;
     let note2: NoteDao;
     let note3: NoteDao;
 
     beforeEach(async () => {
-      ({ store, provider, note1, note2, note3 } = await setupProviderWithNotes('note_store_apply_nullifiers_happy'));
+      ({ store, noteStore, note1, note2, note3 } = await setupNoteStoreWithNotes('note_store_apply_nullifiers_happy'));
     });
 
     afterEach(async () => {
@@ -328,40 +354,41 @@ describe('NoteStore', () => {
     });
 
     it('returns empty array when given empty nullifiers array', async () => {
-      const result = await provider.applyNullifiers([]);
+      const result = await noteStore.applyNullifiers([], 'test');
       expect(result).toEqual([]);
     });
 
     it('nullifies a single note and moves it from active to nullified', async () => {
-      const result = await provider.applyNullifiers([mkNullifier(note1)]);
+      const result = await noteStore.applyNullifiers([mkNullifier(note1)], 'test');
       expect(result).toEqual([note1]);
 
-      const active = await provider.getNotes({ contractAddress: CONTRACT_A });
-      const all = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-
-      expect(new Set(getNullifiers(active))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
-      expect(new Set(getNullifiers(all))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
+      const active = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      const all = await noteStore.getNotes(
+        {
+          contractAddress: CONTRACT_A,
+          status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        },
+        'test',
       );
+
+      expect(nullifierSet(active)).toEqual(nullifierSet([note2]));
+      expect(nullifierSet(all)).toEqual(nullifierSet([note1, note2]));
     });
 
     it('nullifies multiple notes and returns them', async () => {
       const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
-      const result = await provider.applyNullifiers(nullifiers);
+      const result = await noteStore.applyNullifiers(nullifiers, 'test');
 
-      const activeA = await provider.getNotes({ contractAddress: CONTRACT_A });
-      const activeB = await provider.getNotes({ contractAddress: CONTRACT_B });
+      const activeA = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      const activeB = await noteStore.getNotes({ contractAddress: CONTRACT_B }, 'test');
 
       expect(result).toEqual([note1, note3]); // returned nullified notes
-      expect(new Set(getNullifiers(activeA))).toEqual(new Set([note2.siloedNullifier.toBigInt()])); // note2 remains active
-      expect(getNullifiers(activeB)).toHaveLength(0); // no active notes in contractB
+      expect(nullifierSet(activeA)).toEqual(nullifierSet([note2])); // note2 remains active
+      expect(activeB).toHaveLength(0); // no active notes in contractB
     });
 
     it('retrieves a nullified note by its siloedNullifier when status is ACTIVE_OR_NULLIFIED', async () => {
-      await provider.applyNullifiers([mkNullifier(note2)]);
+      await noteStore.applyNullifiers([mkNullifier(note2)], 'test');
 
       const filter = {
         contractAddress: CONTRACT_A,
@@ -369,23 +396,8 @@ describe('NoteStore', () => {
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
       };
 
-      const res = await provider.getNotes(filter);
-      expect(new Set(getNullifiers(res))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
-    });
-  });
-
-  describe('NoteStore.applyNullifiers edge cases', () => {
-    let store: AztecLMDBStoreV2;
-    let provider: NoteStore;
-    let note1: NoteDao;
-    let note2: NoteDao;
-
-    beforeEach(async () => {
-      ({ store, provider, note1, note2 } = await setupProviderWithNotes('note_store_apply_nullifiers_edge'));
-    });
-
-    afterEach(async () => {
-      await store.close();
+      const notes = await noteStore.getNotes(filter, 'test');
+      expect(nullifierSet(notes)).toEqual(nullifierSet([note2]));
     });
 
     it('throws error when nullifier is not found', async () => {
@@ -395,27 +407,37 @@ describe('NoteStore', () => {
         l2BlockHash: L2BlockHash.random(),
       };
 
-      await expect(provider.applyNullifiers([fakeNullifier])).rejects.toThrow('Nullifier not found in applyNullifiers');
+      await expect(noteStore.applyNullifiers([fakeNullifier], 'test')).rejects.toThrow(
+        'Attempted to mark a note as nullified which does not exist in PXE DB',
+      );
     });
 
     it('preserves scope information when nullifying notes', async () => {
       const nullifiers = [mkNullifier(note1)];
-      await provider.applyNullifiers(nullifiers);
+      await noteStore.applyNullifiers(nullifiers, 'test');
 
       // Verify nullified note remains visible only within its original scope
-      const wrongScopeNotes = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_2],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(getNullifiers(wrongScopeNotes)).not.toContain(note1.siloedNullifier.toBigInt());
+      await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const wrongScopeNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            scopes: [SCOPE_2],
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          jobId,
+        );
+        expect(nullifierSet(wrongScopeNotes)).not.toContain(note1.siloedNullifier.toBigInt());
 
-      const correctScopeNotes = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_1],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        const correctScopeNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            scopes: [SCOPE_1],
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          jobId,
+        );
+        expect(nullifierSet(correctScopeNotes)).toContain(note1.siloedNullifier.toBigInt());
       });
-      expect(getNullifiers(correctScopeNotes)).toContain(note1.siloedNullifier.toBigInt());
     });
 
     it('is atomic - fails entirely if any nullifier is invalid', async () => {
@@ -429,73 +451,168 @@ describe('NoteStore', () => {
         },
       ];
 
-      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow();
+      await expect(noteStore.applyNullifiers(nullifiers, 'test')).rejects.toThrow();
 
-      // Verify note1 is still active (transaction rolled back)
-      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getNullifiers(activeNotes))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
-      );
+      // Verify notes are still active (transaction rolled back)
+      await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1, note2]));
+      });
     });
 
-    it('updates all relevant indexes when nullifying notes', async () => {
+    // This test ensures applyNullifiers is idempotent: the same nullifier can be applied multiple times
+    // without error. This relaxes constraints on usage of NoteService#storeNote, which can then be
+    // run concurrently in a Promise.all context without risking unnecessarily defensive checks failing.
+    it('applying nullifier a second time is a no-op', async () => {
+      await noteStore.applyNullifiers([mkNullifier(note1)], 'test'); // First application should succeed
+
+      // Second attempt is silently skipped (idempotent behavior)
+      const result = await noteStore.applyNullifiers([mkNullifier(note1)], 'test');
+      expect(result).toEqual([]);
+
+      await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note2]));
+      });
+    });
+
+    it('can nullify a freshly added note in the same job without committing first', async () => {
+      // This test simulates the storeNote flow where a note is added and immediately nullified
+      // without committing first (when the note is discovered to already be nullified on chain)
+      const freshNullifier = Fr.random();
+      const freshNote = await mkNote({
+        contractAddress: CONTRACT_A,
+        storageSlot: SLOT_X,
+        siloedNullifier: freshNullifier,
+      });
+
+      // Add note to stage without committing
+      await noteStore.addNotes([freshNote], SCOPE_1, 'fresh-job');
+
+      // Immediately nullify it in the same job (simulating storeNote when nullifier exists on chain)
+      const nullifiers = [mkNullifier(freshNote)];
+      await expect(noteStore.applyNullifiers(nullifiers, 'fresh-job')).resolves.toEqual([freshNote]);
+
+      // Verify note is now in nullified state
+      await verifyAndCommitForEachJob(['fresh-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        expect(nullifierSet(activeNotes)).not.toContain(freshNullifier.toBigInt());
+
+        const allNotes = await noteStore.getNotes(
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          jobId,
+        );
+        expect(nullifierSet(allNotes)).toContain(freshNullifier.toBigInt());
+      });
+    });
+
+    it('can handle concurrent note additions and nullifications (simulating Promise.all in storeNote)', async () => {
+      // This test simulates the scenario in utilityValidateEnqueuedNotesAndEvents where
+      // multiple storeNote calls run concurrently via Promise.all
+      const NOTE_COUNT = 100;
+      const noteNullifiers = Array.from({ length: NOTE_COUNT }, () => Fr.random());
+      const notes = await Promise.all(
+        noteNullifiers.map(nullifier =>
+          mkNote({ contractAddress: CONTRACT_A, storageSlot: SLOT_X, siloedNullifier: nullifier }),
+        ),
+      );
+
+      // Simulate concurrent storeNote calls where each note is added and immediately nullified
+      const concurrentStoreNoteCalls = notes.map(async note => {
+        await noteStore.addNotes([note], SCOPE_1, 'concurrent-job');
+        const nullifiers = [mkNullifier(note)];
+        await noteStore.applyNullifiers(nullifiers, 'concurrent-job');
+        return note;
+      });
+
+      await expect(Promise.all(concurrentStoreNoteCalls)).resolves.toEqual(notes);
+
+      // Verify all notes are nullified
+      await verifyAndCommitForEachJob(['concurrent-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNullifiers = nullifierSet(activeNotes);
+        for (const nullifier of noteNullifiers) {
+          expect(activeNullifiers).not.toContain(nullifier.toBigInt());
+        }
+
+        const allNotes = await noteStore.getNotes(
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          jobId,
+        );
+        expect(nullifierSet(allNotes)).toEqual(nullifierSet([note1, note2, ...noteNullifiers]));
+      });
+    });
+
+    it('handles nullification of a persisted note in a new job', async () => {
+      // Scenario: A note was persisted in the DB during a previous job, and we want to nullify it in a new job.
+      // This is the syncNoteNullifiers flow where existing notes are checked for nullification.
+
+      // note1 is from setup and committed  (i.e.: it's persisted)
+      // We should be able to nullify it in a new job
       const nullifiers = [mkNullifier(note1)];
-      await provider.applyNullifiers(nullifiers);
+      await expect(noteStore.applyNullifiers(nullifiers, 'new-job')).resolves.toEqual([note1]);
 
-      // Test various filter combinations still work
-      const byContract = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getNullifiers(byContract))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
-      );
+      // Verify the note is in nullified state
+      await verifyAndCommitForEachJob(['new-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        expect(nullifierSet(activeNotes)).not.toContain(note1.siloedNullifier.toBigInt());
 
-      const bySlot = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        storageSlot: note1.storageSlot,
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        const allNotes = await noteStore.getNotes(
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          jobId,
+        );
+        expect(nullifierSet(allNotes)).toContain(note1.siloedNullifier.toBigInt());
       });
-      expect(new Set(getNullifiers(bySlot))).toEqual(new Set([note1.siloedNullifier.toBigInt()]));
-
-      const byScope = await provider.getNotes({
-        contractAddress: CONTRACT_A,
-        scopes: [SCOPE_1],
-        status: NoteStatus.ACTIVE_OR_NULLIFIED,
-      });
-      expect(new Set(getNullifiers(byScope))).toEqual(
-        new Set([note1.siloedNullifier.toBigInt(), note2.siloedNullifier.toBigInt()]),
-      );
     });
 
-    it('attempts to nullify the same note twice in succession results in error', async () => {
-      await provider.applyNullifiers([mkNullifier(note1)]); // First application should succeed
-      const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-      expect(new Set(getNullifiers(activeNotes))).toEqual(new Set([note2.siloedNullifier.toBigInt()]));
+    it('handles duplicate note storage requests gracefully (same note added and nullified twice)', async () => {
+      // This scenario can happen during concurrent note store calls via Promise.all in storeNote
+      // when the same note is somehow processed twice (e.g., duplicate log entries)
+      const duplicateNullifier = new Fr(9999n);
+      const duplicateNote = await mkNote({
+        contractAddress: CONTRACT_A,
+        storageSlot: SLOT_X,
+        siloedNullifier: duplicateNullifier,
+      });
 
-      // should throw on second attempt as note1 is already nullified
-      await expect(provider.applyNullifiers([mkNullifier(note1)])).rejects.toThrow(
-        'Nullifier already applied in applyNullifiers',
-      );
-    });
+      // First attempt to store: add and nullify the note
+      await noteStore.addNotes([duplicateNote], SCOPE_1, 'duplicate-job');
+      await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-job');
 
-    it('attempts to nullify the same note twice in same call results in error', async () => {
-      const nullifiers = [mkNullifier(note1), mkNullifier(note1)];
-      await expect(provider.applyNullifiers(nullifiers)).rejects.toThrow(
-        'Nullifier already applied in applyNullifiers',
+      // Second attempt to store (duplicate): try to add the same note again - should not throw
+      // This simulates what happens in concurrent storeNote calls when the same note is processed twice
+      await noteStore.addNotes([duplicateNote], SCOPE_2, 'duplicate-job');
+      const notesAfterSecondAttempt = await noteStore.getNotes(
+        { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE, scopes: [SCOPE_1, SCOPE_2] },
+        'duplicate-job',
       );
+
+      // Check that the second attempt at calling storeNote didn't accidentally overwrite the first one
+      // (causing the note to be "re-activated")
+      expect(notesAfterSecondAttempt.filter(n => n.siloedNullifier.equals(duplicateNullifier))).toEqual([]);
+
+      // The second applyNullifiers is silently skipped since the note is already nullified (idempotent)
+      const result = await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-job');
+      expect(result).toEqual([]);
+
+      // Verify the note is nullified and has both scopes
+      await verifyAndCommitForEachJob(['duplicate-job', 'after-job-commit'], noteStore, async (jobId: string) => {
+        const allNotes = await noteStore.getNotes(
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          jobId,
+        );
+        expect(nullifierSet(allNotes)).toContain(duplicateNullifier.toBigInt());
+      });
     });
   });
 
   describe('NoteStore.rollback', () => {
-    let provider: NoteStore;
+    let noteStore: NoteStore;
     let store: AztecLMDBStoreV2;
 
     beforeEach(async () => {
       store = await openTmpStore('note_store_rollback_test');
-      provider = await NoteStore.create(store);
-      await provider.addScope(SCOPE_1);
-      await provider.addScope(SCOPE_2);
+      noteStore = new NoteStore(store);
     });
 
     afterEach(async () => {
@@ -515,7 +632,7 @@ describe('NoteStore', () => {
         const noteBlock5Nullifier = Fr.random();
         noteBlock5 = await mkNote({ siloedNullifier: noteBlock5Nullifier, l2BlockNumber: BlockNumber(5) }); // Created after rollback block 3
 
-        await provider.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1);
+        await noteStore.addNotes([noteBlock1, noteBlock2, noteBlock3, noteBlock5], SCOPE_1, 'rollback-scenario-setup');
 
         const nullifiers = [
           mkNullifier(noteBlock1, BlockNumber(2)),
@@ -525,8 +642,10 @@ describe('NoteStore', () => {
 
         // Apply nullifiers and rollback to block 3
         // - should restore noteBlock3 (nullified at block 4) and preserve noteBlock1 (nullified at block 2)
-        await provider.applyNullifiers(nullifiers);
-        await provider.rollback(3, 6);
+        await noteStore.applyNullifiers(nullifiers, 'rollback-scenario-setup');
+        await noteStore.commit('rollback-scenario-setup');
+
+        await noteStore.rollback(3, 6);
       }
 
       beforeEach(async () => {
@@ -535,57 +654,45 @@ describe('NoteStore', () => {
 
       it('restores notes that were nullified after the rollback block', async () => {
         // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getNullifiers(activeNotes))).toEqual(
-          new Set([noteBlock2.siloedNullifier.toBigInt(), noteBlock3.siloedNullifier.toBigInt()]),
-        );
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        expect(nullifierSet(activeNotes)).toEqual(nullifierSet([noteBlock2, noteBlock3]));
       });
 
       it('preserves nullification of notes nullified at or before the rollback block', async () => {
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
-
-        // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
-        expect(new Set(getNullifiers(allNotes))).toEqual(
-          new Set([
-            noteBlock1.siloedNullifier.toBigInt(),
-            noteBlock2.siloedNullifier.toBigInt(),
-            noteBlock3.siloedNullifier.toBigInt(),
-          ]),
+        const allNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          'test',
         );
 
+        // Should contain noteBlock1 (nullified), noteBlock2 (active), and noteBlock3 (restored)
+        expect(nullifierSet(allNotes)).toEqual(nullifierSet([noteBlock1, noteBlock2, noteBlock3]));
+
         // Verify noteBlock1 is not in active notes
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        const activeIndexes = getNullifiers(activeNotes);
-        expect(activeIndexes).not.toEqual(expect.arrayContaining([noteBlock1.siloedNullifier.toBigInt()]));
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        expect(nullifierSet(activeNotes)).not.toContain(noteBlock1.siloedNullifier.toBigInt());
       });
 
       it('preserves active notes created before the rollback block that were never nullified', async () => {
         // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getNullifiers(activeNotes))).toEqual(
-          new Set([noteBlock2.siloedNullifier.toBigInt(), noteBlock3.siloedNullifier.toBigInt()]),
-        );
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        expect(nullifierSet(activeNotes)).toEqual(nullifierSet([noteBlock2, noteBlock3]));
       });
 
       it('deletes notes created after the rollback block', async () => {
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
+        const allNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          'test',
+        );
 
         // noteBlock5 was created at block 5, which is after rollback block 3, should be deleted
-        const indexes = getNullifiers(allNotes);
-        expect(new Set(indexes)).toEqual(
-          new Set([
-            noteBlock1.siloedNullifier.toBigInt(),
-            noteBlock2.siloedNullifier.toBigInt(),
-            noteBlock3.siloedNullifier.toBigInt(),
-          ]),
-        );
-        expect(indexes).not.toEqual(expect.arrayContaining([noteBlock5.siloedNullifier.toBigInt()]));
+        expect(nullifierSet(allNotes)).toEqual(nullifierSet([noteBlock1, noteBlock2, noteBlock3]));
+        expect(nullifierSet(allNotes)).not.toContain(noteBlock5.siloedNullifier.toBigInt());
       });
     });
 
@@ -593,7 +700,7 @@ describe('NoteStore', () => {
       it('handles rollback when blockNumber equals synchedBlockNumber', async () => {
         const noteNullifier = Fr.random();
         const note = await mkNote({ siloedNullifier: noteNullifier, l2BlockNumber: BlockNumber(5) });
-        await provider.addNotes([note], SCOPE_1);
+        await noteStore.addNotes([note], SCOPE_1, 'test');
 
         const nullifiers = [
           {
@@ -602,26 +709,30 @@ describe('NoteStore', () => {
             l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
           },
         ];
-        await provider.applyNullifiers(nullifiers);
+        await noteStore.applyNullifiers(nullifiers, 'test');
 
         // Since nullification happened at block 5 (not after), it should stay nullified
         // The rewind loop processes blocks (blockNumber+1) to synchedBlockNumber = 6 to 5 = no iterations
-        await provider.rollback(5, 5);
+        await noteStore.commit('test');
+        await noteStore.rollback(5, 5);
 
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
         expect(activeNotes).toHaveLength(0);
 
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
-        expect(new Set(getNullifiers(allNotes))).toEqual(new Set([noteNullifier.toBigInt()]));
+        const allNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          'test',
+        );
+        expect(nullifierSet(allNotes)).toEqual(nullifierSet([noteNullifier]));
       });
 
       it('handles rollback when synchedBlockNumber < blockNumber', async () => {
         const noteNullifier = Fr.random();
         const note = await mkNote({ siloedNullifier: noteNullifier, l2BlockNumber: BlockNumber(3) });
-        await provider.addNotes([note], SCOPE_1);
+        await noteStore.addNotes([note], SCOPE_1, 'test');
 
         const nullifiers = [
           {
@@ -630,19 +741,23 @@ describe('NoteStore', () => {
             l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
           },
         ];
-        await provider.applyNullifiers(nullifiers);
+        await noteStore.applyNullifiers(nullifiers, 'test');
 
         // blockNumber=6, synchedBlockNumber=4 therefore no nullifications to rewind
-        await provider.rollback(6, 4);
+        await noteStore.commit('test');
+        await noteStore.rollback(6, 4);
 
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
         expect(activeNotes).toHaveLength(0);
 
-        const allNotes = await provider.getNotes({
-          contractAddress: CONTRACT_A,
-          status: NoteStatus.ACTIVE_OR_NULLIFIED,
-        });
-        expect(new Set(getNullifiers(allNotes))).toEqual(new Set([noteNullifier.toBigInt()]));
+        const allNotes = await noteStore.getNotes(
+          {
+            contractAddress: CONTRACT_A,
+            status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          },
+          'test',
+        );
+        expect(nullifierSet(allNotes)).toEqual(nullifierSet([noteNullifier]));
       });
 
       it('handles rollback with a large block gap', async () => {
@@ -650,7 +765,7 @@ describe('NoteStore', () => {
         const note2Nullifier = Fr.random();
         const note1 = await mkNote({ siloedNullifier: note1Nullifier, l2BlockNumber: BlockNumber(5) });
         const note2 = await mkNote({ siloedNullifier: note2Nullifier, l2BlockNumber: BlockNumber(10) });
-        await provider.addNotes([note1, note2], SCOPE_1);
+        await noteStore.addNotes([note1, note2], SCOPE_1, 'test');
 
         const nullifiers = [
           {
@@ -659,19 +774,58 @@ describe('NoteStore', () => {
             l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
           },
         ];
-        await provider.applyNullifiers(nullifiers);
-        await provider.rollback(5, 100);
+        await noteStore.applyNullifiers(nullifiers, 'test');
+        await noteStore.commit('test');
+        await noteStore.rollback(5, 100);
 
         // note1 should be restored (nullified at block 7 > rollback block 5)
         // note2 should be deleted (created at block 10 > rollback block 5)
-        const activeNotes = await provider.getNotes({ contractAddress: CONTRACT_A });
-        expect(new Set(getNullifiers(activeNotes))).toEqual(new Set([note1Nullifier.toBigInt()]));
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1Nullifier]));
       });
 
       it('handles rollback on empty PXE database gracefully', async () => {
-        await expect(provider.rollback(10, 20)).resolves.not.toThrow();
-        const notes = await provider.getNotes({ contractAddress: CONTRACT_A });
+        await expect(noteStore.rollback(10, 20)).resolves.not.toThrow();
+        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
         expect(notes).toHaveLength(0);
+      });
+
+      it('throws when rollback is called while jobs are running', async () => {
+        const note = await mkNote({ siloedNullifier: Fr.random(), l2BlockNumber: BlockNumber(1) });
+
+        // Add a note but don't commit, i.e., job running
+        await noteStore.addNotes([note], SCOPE_1, 'uncommitted-job');
+
+        await expect(noteStore.rollback(0, 10)).rejects.toThrow(
+          'PXE note store rollback is not allowed while jobs are running',
+        );
+
+        // After discarding the staged data, rollback should succeed
+        await noteStore.discardStaged('uncommitted-job');
+        await expect(noteStore.rollback(0, 10)).resolves.not.toThrow();
+      });
+
+      it('throws integrity error when nullification index references missing note', async () => {
+        const nullifier = Fr.random();
+        const note = await mkNote({ siloedNullifier: nullifier, l2BlockNumber: BlockNumber(1) });
+
+        {
+          await noteStore.addNotes([note], SCOPE_1, 'test');
+          await noteStore.applyNullifiers([mkNullifier(note, BlockNumber(5))], 'test');
+          await noteStore.commit('test');
+        }
+
+        // Corrupt the database by deleting the note but leaving the nullification index.
+        // Arguably overkill, but since we go to the trouble of detecting and throwing the error it's at least useful
+        // to show what case it is defending against.
+        // This condition is only reachable if we mess up the store logic (or data migration).
+        const notesMap = store.openMap<string, Buffer>('notes');
+        await notesMap.delete(nullifier.toString());
+
+        // Rollback should detect the missing note and throw
+        await expect(noteStore.rollback(3, 6)).rejects.toThrow(
+          `PXE DB integrity error: no note found with nullifier ${nullifier.toString()}`,
+        );
       });
     });
   });

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,341 +1,161 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
+import { Semaphore } from '@aztec/foundation/queue';
+import type { Fr } from '@aztec/foundation/schemas';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
-import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { DataInBlock } from '@aztec/stdlib/block';
-import { NoteStatus, type NotesFilter } from '@aztec/stdlib/note';
-import { NoteDao } from '@aztec/stdlib/note';
+import { NoteDao, NoteStatus, type NotesFilter } from '@aztec/stdlib/note';
+
+import type { StagedStore } from '../../job_coordinator/job_coordinator.js';
+import { StoredNote } from './stored_note.js';
 
 /**
  * NoteStore manages the storage and retrieval of notes.
  *
- * Notes can be active or nullified. This class processes new notes, nullifications,
- * and performs rollback handling in the case of a reorg.
+ * Notes can be active or nullified. This class processes new notes, nullifications, and performs rollback handling in
+ * the case of a reorg.
  **/
-export class NoteStore {
+export class NoteStore implements StagedStore {
+  readonly storeName: string = 'note';
+
   #store: AztecAsyncKVStore;
 
   // Note that we use the siloedNullifier as the note id in the store as it's guaranteed to be unique.
 
-  /** noteId (siloedNullifier) -> NoteDao (serialized) */
+  // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
+  // #nullifiersByContractAddress or #nullifiersByNullificationBlockNumber to find relevant note nullifiers that can be
+  // used to read into this map instead.
+  // nullifier => StoredNote (serialized)
   #notes: AztecAsyncMap<string, Buffer>;
-  /** noteId (siloedNullifier) -> NoteDao (serialized) */
-  #nullifiedNotes: AztecAsyncMap<string, Buffer>;
-  /** blockNumber -> siloedNullifier */
-  #nullifiersByBlockNumber: AztecAsyncMultiMap<number, string>;
 
-  /** noteId (siloedNullifier) -> scope */
-  #nullifiedNotesToScope: AztecAsyncMultiMap<string, string>;
-  /** contractAddress -> noteId (siloedNullifier) */
-  #nullifiedNotesByContract: AztecAsyncMultiMap<string, string>;
-  /** storageSlot -> noteId (siloedNullifier) */
-  #nullifiedNotesByStorageSlot: AztecAsyncMultiMap<string, string>;
+  // Indexes which notes (via their nullifiers) belong to a contract. Used in `getNotes` to reduce the amount of notes
+  // checked.
+  // contract address => nullifier
+  #nullifiersByContractAddress: AztecAsyncMultiMap<string, string>;
 
-  /** scope (AztecAddress) -> true */
-  #scopes: AztecAsyncMap<string, true>;
-  /** noteId (siloedNullifier) -> scope */
-  #notesToScope: AztecAsyncMultiMap<string, string>;
-  /** scope -> MultiMap(contractAddress -> noteId) */
-  #notesByContractAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
-  /** scope -> MultiMap(storageSlot -> noteId) */
-  #notesByStorageSlotAndScope: Map<string, AztecAsyncMultiMap<string, string>>;
+  // Groups note nullifiers by the block number they were added to the nullifier tree. Used in `rollback` to handle
+  // re-orgs.
+  // block number => nullifier (block number in which nullifier is included)
+  #nullifiersByNullificationBlockNumber: AztecAsyncMultiMap<number, string>;
 
-  private constructor(store: AztecAsyncKVStore) {
+  // In-memory changes performed during a not-yet committed job. When `commit` is called with said job's id, these
+  // changes are persisted in the DB maps specified above and cleared.
+  // jobId => nullifier => StoredNote (serialized)
+  #notesForJob: Map<string, Map<string, StoredNote>>;
+
+  // Per job locks to prevent multiple concurrent writes to affect each other.
+  // jobId => lock
+  #jobLocks: Map<string, Semaphore>;
+
+  constructor(store: AztecAsyncKVStore) {
     this.#store = store;
     this.#notes = store.openMap('notes');
-    this.#nullifiedNotes = store.openMap('nullified_notes');
-    this.#nullifiersByBlockNumber = store.openMultiMap('nullifier_to_block_number');
+    this.#nullifiersByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
+    this.#nullifiersByNullificationBlockNumber = store.openMultiMap('note_block_number_to_nullifier');
 
-    this.#nullifiedNotesToScope = store.openMultiMap('nullified_notes_to_scope');
-    this.#nullifiedNotesByContract = store.openMultiMap('nullified_notes_by_contract');
-    this.#nullifiedNotesByStorageSlot = store.openMultiMap('nullified_notes_by_storage_slot');
-
-    this.#scopes = store.openMap('scopes');
-    this.#notesToScope = store.openMultiMap('notes_to_scope');
-    this.#notesByContractAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
-    this.#notesByStorageSlotAndScope = new Map<string, AztecAsyncMultiMap<string, string>>();
+    this.#jobLocks = new Map();
+    this.#notesForJob = new Map();
   }
 
   /**
-   * Creates and initializes a new NoteStore instance.
+   * Adds multiple notes to the notes store under the specified scope.
    *
-   * This factory method creates a NoteStore and restores any existing
-   * scope-specific indexes from the database.
-   *
-   * @param store - The key-value store to use for persistence
-   * @returns Promise resolving to a fully initialized NoteStore instance
-   */
-  public static async create(store: AztecAsyncKVStore): Promise<NoteStore> {
-    const pxeDB = new NoteStore(store);
-    for await (const scope of pxeDB.#scopes.keysAsync()) {
-      pxeDB.#notesByContractAndScope.set(scope, store.openMultiMap(`${scope}:notes_by_contract`));
-      pxeDB.#notesByStorageSlotAndScope.set(scope, store.openMultiMap(`${scope}:notes_by_storage_slot`));
-    }
-    return pxeDB;
-  }
-
-  /**
-   * Adds a new scope to the note data provider.
-   *
-   * Scopes provide privacy isolation by creating separate indexes for each user.
-   * Each scope gets its own set of indexes for efficient note retrieval by various criteria.
-   *
-   * @param scope - The AztecAddress representing the scope/user to add
-   * @returns Promise resolving to true if scope was added, false if it already existed
-   */
-  public async addScope(scope: AztecAddress): Promise<boolean> {
-    const scopeString = scope.toString();
-
-    if (await this.#scopes.hasAsync(scopeString)) {
-      return false;
-    }
-
-    await this.#scopes.set(scopeString, true);
-    this.#notesByContractAndScope.set(scopeString, this.#store.openMultiMap(`${scopeString}:notes_by_contract`));
-    this.#notesByStorageSlotAndScope.set(scopeString, this.#store.openMultiMap(`${scopeString}:notes_by_storage_slot`));
-
-    return true;
-  }
-
-  /**
-   * Adds multiple notes to the data provider under the specified scope.
-   *
-   * Notes are stored using their siloedNullifier as the key, which provides uniqueness. Each note is indexed
-   * by multiple criteria for efficient retrieval.
+   * Notes are stored using their siloedNullifier as the key, which provides uniqueness. Each note is indexed by
+   * multiple criteria for efficient retrieval.
    *
    * @param notes - Notes to store
    * @param scope - The scope (user/account) under which to store the notes
+   * @param jobId - The job context for staged writes
    */
-  addNotes(notes: NoteDao[], scope: AztecAddress): Promise<void> {
-    return this.#store.transactionAsync(async () => {
-      if (!(await this.#scopes.hasAsync(scope.toString()))) {
-        await this.addScope(scope);
-      }
-
-      for (const dao of notes) {
-        const noteId = dao.siloedNullifier.toString();
-        await this.#notes.set(noteId, dao.toBuffer());
-        await this.#notesToScope.set(noteId, scope.toString());
-
-        await this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteId);
-        await this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteId);
-      }
-    });
+  public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: string): Promise<void[]> {
+    return this.#withJobLock(jobId, () => Promise.all(notes.map(noteDao => this.#addNote(noteDao, scope, jobId))));
   }
 
-  /**
-   * Synchronizes notes and nullifiers to a specific block number.
-   *
-   * This method ensures that the state of notes and nullifiers is consistent with the
-   * specified block number. It restores any notes that were nullified after the given block
-   * and deletes any active notes created after that block.
-   *
-   * IMPORTANT: This method must be called within a transaction to ensure atomicity.
-   *
-   * @param blockNumber - The new chain tip after a reorg
-   * @param synchedBlockNumber - The block number up to which PXE managed to sync before the reorg happened.
-   */
-  public async rollback(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    await this.#rewindNullifiersAfterBlock(blockNumber, synchedBlockNumber);
-    await this.#deleteActiveNotesAfterBlock(blockNumber);
+  async #addNote(note: NoteDao, scope: AztecAddress, jobId: string) {
+    const noteForJob =
+      (await this.#readNote(note.siloedNullifier.toString(), jobId)) ?? new StoredNote(note, new Set());
+
+    // Make sure the note is linked to the scope and staged for this job
+    noteForJob.addScope(scope.toString());
+    this.#writeNote(noteForJob, jobId);
   }
 
-  /**
-   * Deletes (removes) all active notes created after the specified block number.
-   *
-   * Permanently delete notes from the active notes store, e.g. during a reorg.
-   * Note: This only affects #notes (active notes), not #nullifiedNotes.
-   *
-   * @param blockNumber - Notes created after this block number will be deleted
-   */
-  async #deleteActiveNotesAfterBlock(blockNumber: number): Promise<void> {
-    const notes = await toArray(this.#notes.valuesAsync());
-    for (const note of notes) {
-      const noteDao = NoteDao.fromBuffer(note);
-      if (noteDao.l2BlockNumber > blockNumber) {
-        const noteId = noteDao.siloedNullifier.toString();
-        await this.#notes.delete(noteId);
-        await this.#notesToScope.delete(noteId);
-        const scopes = await toArray(this.#scopes.keysAsync());
-        for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope)!.deleteValue(noteDao.contractAddress.toString(), noteId);
-          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(noteDao.storageSlot.toString(), noteId);
-        }
-      }
+  async #readNote(nullifier: string, jobId: string): Promise<StoredNote | undefined> {
+    // First check staged notes for this job
+    const noteForJob = this.#getNotesForJob(jobId).get(nullifier);
+    if (noteForJob) {
+      return noteForJob;
     }
+
+    // Then check persistent storage
+    const noteBuffer = await this.#notes.getAsync(nullifier);
+    if (noteBuffer) {
+      return StoredNote.fromBuffer(noteBuffer);
+    }
+
+    return undefined;
   }
 
-  /**
-   * Rewinds nullifications after a given block number.
-   *
-   * This operation "unnullifies" notes, rolling back nullifications that occurred
-   * in orphaned blocks, e.g. during a reorg.  The notes are restored to the
-   * active notes store and removed from the nullified store.
-   *
-   * @param blockNumber - Revert nullifications that occurred after this block
-   * @param synchedBlockNumber - Upper bound for the block range to process
-   */
-  async #rewindNullifiersAfterBlock(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    const noteIdsToReinsert: string[] = [];
-    const currentBlockNumber = blockNumber + 1;
-    for (let i = currentBlockNumber; i <= synchedBlockNumber; i++) {
-      // noteId === siloedNullifier.toString(), so we can use nullifiers directly as noteIds
-      noteIdsToReinsert.push(...(await toArray(this.#nullifiersByBlockNumber.getValuesAsync(i))));
-    }
-    const nullifiedNoteBuffers = await Promise.all(
-      noteIdsToReinsert.map(noteId => this.#nullifiedNotes.getAsync(noteId)),
-    );
-    const noteDaos = nullifiedNoteBuffers
-      .filter(buffer => buffer != undefined)
-      .map(buffer => NoteDao.fromBuffer(buffer!));
-
-    for (const dao of noteDaos) {
-      const noteId = dao.siloedNullifier.toString();
-
-      const scopes = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteId));
-
-      if (scopes.length === 0) {
-        // We should never run into this error because notes always have a scope assigned to them - either on initial
-        // insertion via `addNotes` or when removing their nullifiers.
-        throw new Error(`No scopes found for nullified note with nullifier ${noteId}`);
-      }
-
-      for (const scope of scopes) {
-        await Promise.all([
-          this.#notesByContractAndScope.get(scope.toString())!.set(dao.contractAddress.toString(), noteId),
-          this.#notesByStorageSlotAndScope.get(scope.toString())!.set(dao.storageSlot.toString(), noteId),
-          this.#notesToScope.set(noteId, scope),
-        ]);
-      }
-
-      await Promise.all([
-        this.#notes.set(noteId, dao.toBuffer()),
-        this.#nullifiedNotes.delete(noteId),
-        this.#nullifiedNotesToScope.delete(noteId),
-        this.#nullifiersByBlockNumber.deleteValue(dao.l2BlockNumber, dao.siloedNullifier.toString()),
-        this.#nullifiedNotesByContract.deleteValue(dao.contractAddress.toString(), noteId),
-        this.#nullifiedNotesByStorageSlot.deleteValue(dao.storageSlot.toString(), noteId),
-      ]);
-    }
+  #writeNote(note: StoredNote, jobId: string) {
+    this.#getNotesForJob(jobId).set(note.noteDao.siloedNullifier.toString(), note);
   }
 
   /**
    * Retrieves notes based on the provided filter criteria.
    *
-   * This method queries both active and optionally nullified notes based on the filter
-   * parameters.
+   * This method queries both active and optionally nullified notes based on the filter parameters.
    *
-   * @param filter - Filter criteria including contractAddress (required), and optional
-   *                 owner, storageSlot, status, scopes, and siloedNullifier.
+   * @param filter - Filter criteria including contractAddress (required), and optional owner,
+   *                 storageSlot, status, scopes, and siloedNullifier.
+   * @params jobId - the job context to read from.
    * @returns Filtered and deduplicated notes (a note might be present in multiple scopes - we ensure it is only
    * returned once if this is the case)
    * @throws If filtering by an empty scopes array. Scopes have to be set to undefined or to a non-empty array.
    */
-  async getNotes(filter: NotesFilter): Promise<NoteDao[]> {
-    filter.status = filter.status ?? NoteStatus.ACTIVE;
-
-    // throw early if scopes is an empty array
+  async getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
     if (filter.scopes !== undefined && filter.scopes.length === 0) {
-      throw new Error(
-        'Trying to get notes with an empty scopes array. Scopes have to be set to undefined if intending on not filtering by scopes.',
-      );
+      throw new Error('Trying to get notes with an empty scopes array');
     }
 
-    const candidateNoteSources = [];
+    const targetStatus = filter.status ?? NoteStatus.ACTIVE;
 
-    filter.scopes ??= (await toArray(this.#scopes.keysAsync())).map(addressString =>
-      AztecAddress.fromString(addressString),
-    );
+    const foundNotes: Map<string, NoteDao> = new Map();
 
-    const activeNoteIdsPerScope: string[][] = [];
+    const nullifiersOfContract = await this.#nullifiersOfContract(filter.contractAddress, jobId);
+    for (const nullifier of nullifiersOfContract) {
+      const note = await this.#readNote(nullifier, jobId);
 
-    for (const scope of new Set(filter.scopes)) {
-      const formattedScopeString = scope.toString();
-      if (!(await this.#scopes.hasAsync(formattedScopeString))) {
-        throw new Error('Trying to get incoming notes of a scope that is not in the PXE database');
+      // Defensive: hitting this case means we're mishandling contract indices or in-memory job data
+      if (!note) {
+        throw new Error('PXE note database is corrupted.');
       }
 
-      activeNoteIdsPerScope.push(
-        filter.storageSlot
-          ? await toArray(
-              this.#notesByStorageSlotAndScope.get(formattedScopeString)!.getValuesAsync(filter.storageSlot.toString()),
-            )
-          : await toArray(
-              this.#notesByContractAndScope
-                .get(formattedScopeString)!
-                .getValuesAsync(filter.contractAddress.toString()),
-            ),
-      );
-    }
-
-    candidateNoteSources.push({
-      ids: new Set(activeNoteIdsPerScope.flat()),
-      notes: this.#notes,
-    });
-
-    // If status is ACTIVE_OR_NULLIFIED we add nullified notes as candidates on top of the default active ones.
-    if (filter.status === NoteStatus.ACTIVE_OR_NULLIFIED) {
-      const nullifiedIds = filter.storageSlot
-        ? await toArray(this.#nullifiedNotesByStorageSlot.getValuesAsync(filter.storageSlot.toString()))
-        : await toArray(this.#nullifiedNotesByContract.getValuesAsync(filter.contractAddress.toString()));
-
-      const setOfScopes = new Set(filter.scopes.map(s => s.toString() as string));
-      const filteredNullifiedIds = new Set<string>();
-
-      for (const noteId of nullifiedIds) {
-        const scopeList = await toArray(this.#nullifiedNotesToScope.getValuesAsync(noteId));
-        if (scopeList.some(scope => setOfScopes.has(scope))) {
-          filteredNullifiedIds.add(noteId);
-        }
+      // Apply filters
+      if (targetStatus === NoteStatus.ACTIVE && note.isNullified()) {
+        continue;
       }
 
-      if (filteredNullifiedIds.size > 0) {
-        candidateNoteSources.push({
-          ids: filteredNullifiedIds,
-          notes: this.#nullifiedNotes,
-        });
+      if (filter.owner && !note.noteDao.owner.equals(filter.owner)) {
+        continue;
       }
-    }
 
-    const result: NoteDao[] = [];
-    for (const { ids, notes } of candidateNoteSources) {
-      for (const id of ids) {
-        const serializedNote = await notes.getAsync(id);
-        if (!serializedNote) {
-          continue;
-        }
-
-        const note = NoteDao.fromBuffer(serializedNote);
-        if (!note.contractAddress.equals(filter.contractAddress)) {
-          continue;
-        }
-
-        if (filter.owner && !note.owner.equals(filter.owner)) {
-          continue;
-        }
-
-        if (filter.storageSlot && !note.storageSlot.equals(filter.storageSlot!)) {
-          continue;
-        }
-
-        if (filter.siloedNullifier && !note.siloedNullifier.equals(filter.siloedNullifier)) {
-          continue;
-        }
-
-        result.push(note);
+      if (filter.storageSlot && !note.noteDao.storageSlot.equals(filter.storageSlot)) {
+        continue;
       }
-    }
 
-    // A note might be present in multiple scopes - we ensure it is only returned once
-    const deduplicated: NoteDao[] = [];
-    for (const note of result) {
-      if (!deduplicated.some(existing => existing.equals(note))) {
-        deduplicated.push(note);
+      if (filter.siloedNullifier && !note.noteDao.siloedNullifier.equals(filter.siloedNullifier)) {
+        continue;
       }
+
+      if (filter.scopes && note.scopes.intersection(new Set(filter.scopes.map(s => s.toString()))).size === 0) {
+        continue;
+      }
+
+      foundNotes.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
     }
 
     // Sort by block number, then by tx index within block, then by note index within tx
-    deduplicated.sort((a, b) => {
+    return [...foundNotes.values()].sort((a, b) => {
       if (a.l2BlockNumber !== b.l2BlockNumber) {
         return a.l2BlockNumber - b.l2BlockNumber;
       }
@@ -344,72 +164,218 @@ export class NoteStore {
       }
       return a.noteIndexInTx - b.noteIndexInTx;
     });
-
-    return deduplicated;
   }
 
   /**
    * Transitions notes from "active" to "nullified" state.
    *
-   * This operation processes a batch of nullifiers to mark the corresponding notes
-   * as spent/nullified.  The operation is atomic - if any nullifier is not found,
-   * the entire operation fails and no notes are modified.
+   * This operation processes a batch of nullifiers to mark the corresponding notes as spent/nullified.
+   * The operation is atomic - if any nullifier is not found, the entire operation fails and no notes are modified.
+   *
+   * applyNullifiers is idempotent: the same nullifier can be applied multiple times without error.
+   * This relaxes constraints on usage of NoteService#storeNote, which can then be run concurrently in a Promise.all
+   * context without risking unnecessarily defensive checks failing.
    *
    * @param nullifiers - Array of nullifiers with their block numbers to process
-   * @returns Promise resolving to array of nullified NoteDao objects
-   * @throws Error if any nullifier is not found in the active notes
+   * @param jobId - The job context for staged writes
+   * @returns Array of NoteDao objects that were nullified
+   * @throws Error if any nullifier is not found in this notes store
    */
-  applyNullifiers(nullifiers: DataInBlock<Fr>[]): Promise<NoteDao[]> {
-    if (nullifiers.length === 0) {
-      return Promise.resolve([]);
-    }
-
-    return this.#store.transactionAsync(async () => {
-      const nullifiedNotes: NoteDao[] = [];
-
-      for (const blockScopedNullifier of nullifiers) {
-        const { data: nullifier, l2BlockNumber: blockNumber } = blockScopedNullifier;
-        const noteId = nullifier.toString();
-
-        const noteBuffer = await this.#notes.getAsync(noteId);
-        if (!noteBuffer) {
-          // Check if already nullified (noteId === siloedNullifier, so we can check #nullifiedNotes directly)
-          if (await this.#nullifiedNotes.hasAsync(noteId)) {
-            throw new Error(`Nullifier already applied in applyNullifiers`);
-          }
-          throw new Error('Nullifier not found in applyNullifiers');
+  applyNullifiers(nullifiers: DataInBlock<Fr>[], jobId: string): Promise<NoteDao[]> {
+    return this.#withJobLock(jobId, () =>
+      this.#store.transactionAsync(async () => {
+        if (nullifiers.length === 0) {
+          return [];
         }
 
-        const noteScopes = await toArray(this.#notesToScope.getValuesAsync(noteId));
-        if (noteScopes.length === 0) {
+        const notesToNullify = await Promise.all(
+          nullifiers.map(async nullifierInBlock => {
+            const nullifier = nullifierInBlock.data.toString();
+
+            const storedNote = await this.#readNote(nullifier, jobId);
+            if (!storedNote) {
+              throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB`);
+            }
+
+            return { storedNote: await this.#readNote(nullifier, jobId), blockNumber: nullifierInBlock.l2BlockNumber };
+          }),
+        );
+
+        const notesNullifiedInThisCall: Map<string, NoteDao> = new Map();
+        for (const noteToNullify of notesToNullify) {
+          // Safe to coerce (!) because we throw if we find any undefined above
+          const note = noteToNullify.storedNote!;
+
+          // Skip already nullified notes
+          if (note.isNullified()) {
+            continue;
+          }
+
+          note.markAsNullified(noteToNullify.blockNumber);
+          this.#writeNote(note, jobId);
+          notesNullifiedInThisCall.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
+        }
+
+        return [...notesNullifiedInThisCall.values()];
+      }),
+    );
+  }
+
+  /**
+   * Synchronizes notes and nullifiers to a specific block number.
+   *
+   * This method ensures that the state of notes and nullifiers is consistent with the specified block number.
+   * It restores any notes that were nullified after the given block and deletes any active notes created after that
+   * block.
+   *
+   * IMPORTANT: This method must be called within a transaction to ensure atomicity.
+   *
+   * @param blockNumber - The new chain tip after a reorg
+   * @param synchedBlockNumber - The block number up to which PXE managed to sync before the reorg happened.
+   */
+  public async rollback(blockNumber: number, synchedBlockNumber: number): Promise<void> {
+    if (this.#notesForJob.size > 0) {
+      throw new Error('PXE note store rollback is not allowed while jobs are running');
+    }
+    await this.#rewindNullifiedNotesAfterBlock(blockNumber, synchedBlockNumber);
+    await this.#deleteActiveNotesAfterBlock(blockNumber);
+  }
+
+  /**
+   * Deletes (removes) all notes created after the specified block number.
+   *
+   * Permanently delete notes from the notes store, e.g. during a reorg.
+   *
+   * @param blockNumber - Notes created after this block number will be deleted
+   */
+  async #deleteActiveNotesAfterBlock(blockNumber: number): Promise<void> {
+    const notes = await toArray(this.#notes.valuesAsync());
+    for (const noteBuffer of notes) {
+      const storedNote = StoredNote.fromBuffer(noteBuffer);
+      if (storedNote.noteDao.l2BlockNumber > blockNumber) {
+        const noteNullifier = storedNote.noteDao.siloedNullifier.toString();
+        await this.#notes.delete(noteNullifier);
+        await this.#nullifiersByContractAddress.deleteValue(
+          storedNote.noteDao.contractAddress.toString(),
+          noteNullifier,
+        );
+      }
+    }
+  }
+
+  /**
+   * Rewinds nullifications after a given block number.
+   *
+   * This operation "un-nullifies" notes, rolling back nullifications that occurred in orphaned blocks, e.g. during a
+   * reorg.
+   *
+   * @param blockNumber - Revert nullifications that occurred after this block
+   * @param anchorBlockNumber - Upper bound for the block range to process
+   */
+  async #rewindNullifiedNotesAfterBlock(blockNumber: number, anchorBlockNumber: number): Promise<void> {
+    const currentBlockNumber = blockNumber + 1;
+    for (let i = currentBlockNumber; i <= anchorBlockNumber; i++) {
+      const noteNullifiersToReinsert: string[] = await toArray(
+        this.#nullifiersByNullificationBlockNumber.getValuesAsync(i),
+      );
+
+      const nullifiedNoteBuffers = await Promise.all(
+        noteNullifiersToReinsert.map(async noteNullifier => {
+          const note = await this.#notes.getAsync(noteNullifier);
+
+          if (!note) {
+            throw new Error(`PXE DB integrity error: no note found with nullifier ${noteNullifier}`);
+          }
+
+          return note;
+        }),
+      );
+
+      const storedNotes = nullifiedNoteBuffers.map(buffer => StoredNote.fromBuffer(buffer));
+
+      for (const storedNote of storedNotes) {
+        const noteNullifier = storedNote.noteDao.siloedNullifier.toString();
+        const scopes = storedNote.scopes;
+
+        if (scopes.size === 0) {
           // We should never run into this error because notes always have a scope assigned to them - either on initial
           // insertion via `addNotes` or when removing their nullifiers.
-          throw new Error('Note scopes are missing in applyNullifiers');
+          throw new Error(`No scopes found for nullified note with nullifier ${noteNullifier}`);
         }
 
-        const note = NoteDao.fromBuffer(noteBuffer);
+        storedNote.markAsActive();
 
-        nullifiedNotes.push(note);
-
-        await this.#notes.delete(noteId);
-        await this.#notesToScope.delete(noteId);
-
-        const scopes = await toArray(this.#scopes.keysAsync());
-
-        for (const scope of scopes) {
-          await this.#notesByContractAndScope.get(scope)!.deleteValue(note.contractAddress.toString(), noteId);
-          await this.#notesByStorageSlotAndScope.get(scope)!.deleteValue(note.storageSlot.toString(), noteId);
-        }
-
-        for (const scope of noteScopes) {
-          await this.#nullifiedNotesToScope.set(noteId, scope);
-        }
-        await this.#nullifiedNotes.set(noteId, note.toBuffer());
-        await this.#nullifiersByBlockNumber.set(blockNumber, noteId);
-        await this.#nullifiedNotesByContract.set(note.contractAddress.toString(), noteId);
-        await this.#nullifiedNotesByStorageSlot.set(note.storageSlot.toString(), noteId);
+        await Promise.all([
+          this.#notes.set(noteNullifier, storedNote.toBuffer()),
+          this.#nullifiersByNullificationBlockNumber.deleteValue(i, noteNullifier),
+        ]);
       }
-      return nullifiedNotes;
+    }
+  }
+
+  commit(jobId: string): Promise<void> {
+    return this.#withJobLock(jobId, async () => {
+      for (const [nullifier, storedNote] of this.#getNotesForJob(jobId)) {
+        await this.#notes.set(nullifier, storedNote.toBuffer());
+        await this.#nullifiersByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
+        if (storedNote.nullifiedAt !== undefined) {
+          await this.#nullifiersByNullificationBlockNumber.set(storedNote.nullifiedAt, nullifier);
+        }
+      }
+
+      this.#clearJobData(jobId);
     });
+  }
+
+  discardStaged(jobId: string): Promise<void> {
+    return this.#withJobLock(jobId, () => Promise.resolve(this.#clearJobData(jobId)));
+  }
+
+  #clearJobData(jobId: string) {
+    this.#notesForJob.delete(jobId);
+    this.#jobLocks.delete(jobId);
+  }
+
+  /**
+   * Functions run withJobLock are forced to wait for each other, i.e. if they share a `jobId`, they run serially
+   * instead of concurrently. This is needed because staged data is stored in memory, and concurrent async operations
+   * (e.g., Promise.all in `storeNote`) could otherwise interleave and corrupt state.
+   */
+  async #withJobLock<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
+    let lock = this.#jobLocks.get(jobId);
+    if (!lock) {
+      lock = new Semaphore(1);
+      this.#jobLocks.set(jobId, lock);
+    }
+    await lock.acquire();
+    try {
+      return await fn();
+    } finally {
+      lock.release();
+    }
+  }
+
+  #getNotesForJob(jobId: string): Map<string, StoredNote> {
+    let notesForJob = this.#notesForJob.get(jobId);
+    if (!notesForJob) {
+      notesForJob = new Map();
+      this.#notesForJob.set(jobId, notesForJob);
+    }
+    return notesForJob;
+  }
+
+  async #nullifiersOfContract(contractAddress: AztecAddress, jobId: string): Promise<Set<string>> {
+    // Collect persisted nullifiers for this contract
+    const persistedNullifiers: string[] = await toArray(
+      this.#nullifiersByContractAddress.getValuesAsync(contractAddress.toString()),
+    );
+
+    // Collect staged nullifiers from the job where the note's contract matches
+    const stagedNullifiers = this.#getNotesForJob(jobId)
+      .values()
+      .filter(storedNote => storedNote.noteDao.contractAddress.equals(contractAddress))
+      .map(storedNote => storedNote.noteDao.siloedNullifier.toString());
+
+    return new Set([...persistedNullifiers, ...stagedNullifiers]);
   }
 }

--- a/yarn-project/pxe/src/storage/note_store/stored_note.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/stored_note.test.ts
@@ -1,0 +1,202 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { NoteDao } from '@aztec/stdlib/note';
+
+import { StoredNote } from './stored_note.js';
+
+describe('StoredNote', () => {
+  describe('construction', () => {
+    it('creates a StoredNote with default values', async () => {
+      const noteDao = await NoteDao.random();
+      const storedNote = new StoredNote(noteDao, new Set());
+
+      expect(storedNote.noteDao).toBe(noteDao);
+      expect(storedNote.isNullified()).toBe(false);
+      expect(storedNote.scopes.size).toBe(0);
+      expect(storedNote.nullifiedAt).toBeUndefined();
+    });
+  });
+
+  describe('serialization', () => {
+    it('active note with no scopes', async () => {
+      const noteDao = await NoteDao.random();
+      const original = new StoredNote(noteDao, new Set());
+
+      const buffer = original.toBuffer();
+      const restored = StoredNote.fromBuffer(buffer);
+
+      expect(restored.noteDao.equals(original.noteDao)).toBe(true);
+      expect(restored.isNullified()).toBe(false);
+      expect(restored.scopes.size).toBe(0);
+      expect(restored.nullifiedAt).toBeUndefined();
+    });
+
+    it('active note with scopes', async () => {
+      const noteDao = await NoteDao.random();
+      const scopes = new Set(['scope1', 'scope2', 'scope3']);
+      const original = new StoredNote(noteDao, scopes);
+
+      const buffer = original.toBuffer();
+      const restored = StoredNote.fromBuffer(buffer);
+
+      expect(restored.noteDao.equals(original.noteDao)).toBe(true);
+      expect(restored.isNullified()).toBe(false);
+      expect(restored.scopes).toEqual(scopes);
+      expect(restored.nullifiedAt).toBeUndefined();
+    });
+
+    it('nullified note', async () => {
+      const noteDao = await NoteDao.random();
+      const nullifiedAt = BlockNumber(123);
+      const original = new StoredNote(noteDao, new Set(['scope1']), nullifiedAt);
+
+      const buffer = original.toBuffer();
+      const restored = StoredNote.fromBuffer(buffer);
+
+      expect(restored.noteDao.equals(original.noteDao)).toBe(true);
+      expect(restored.isNullified()).toBe(true);
+      expect(restored.scopes).toEqual(new Set(['scope1']));
+      expect(restored.nullifiedAt).toBe(nullifiedAt);
+    });
+
+    it('note with multiple scopes', async () => {
+      const noteDao = await NoteDao.random();
+      const scopes = new Set(Array.from({ length: 100 }, (_, i) => `scope-${i}`));
+      const original = new StoredNote(noteDao, scopes);
+
+      const buffer = original.toBuffer();
+      const restored = StoredNote.fromBuffer(buffer);
+
+      expect(restored.scopes).toEqual(scopes);
+    });
+  });
+
+  describe('addScope', () => {
+    it('adds a scope to an empty set', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+
+      storedNote.addScope('new-scope');
+
+      expect(storedNote.scopes.has('new-scope')).toBe(true);
+      expect(storedNote.scopes.size).toBe(1);
+    });
+
+    it('adds a scope to an existing set', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set(['existing']));
+
+      storedNote.addScope('new-scope');
+
+      expect(storedNote.scopes.has('existing')).toBe(true);
+      expect(storedNote.scopes.has('new-scope')).toBe(true);
+      expect(storedNote.scopes.size).toBe(2);
+    });
+
+    it('is idempotent when adding the same scope twice', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+
+      storedNote.addScope('scope');
+      storedNote.addScope('scope');
+
+      expect(storedNote.scopes.size).toBe(1);
+    });
+  });
+
+  describe('markAsNullified', () => {
+    it('sets nullifiedAt', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+      const blockNumber = BlockNumber(50);
+
+      storedNote.markAsNullified(blockNumber);
+
+      expect(storedNote.isNullified()).toBe(true);
+      expect(storedNote.nullifiedAt).toBe(blockNumber);
+    });
+
+    it('updates nullifiedAt when called multiple times', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+
+      storedNote.markAsNullified(BlockNumber(10));
+      storedNote.markAsNullified(BlockNumber(20));
+
+      expect(storedNote.nullifiedAt).toBe(BlockNumber(20));
+    });
+
+    it('persists nullifiedAt through serialization', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+      storedNote.markAsNullified(BlockNumber(42));
+
+      const restored = StoredNote.fromBuffer(storedNote.toBuffer());
+
+      expect(restored.isNullified()).toBe(true);
+      expect(restored.nullifiedAt).toBe(BlockNumber(42));
+    });
+  });
+
+  describe('markAsActive', () => {
+    it('clears nullifiedAt', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set(), BlockNumber(100));
+
+      storedNote.markAsActive();
+
+      expect(storedNote.isNullified()).toBe(false);
+      expect(storedNote.nullifiedAt).toBeUndefined();
+    });
+
+    it('is idempotent on already active notes', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+
+      storedNote.markAsActive();
+
+      expect(storedNote.isNullified()).toBe(false);
+      expect(storedNote.nullifiedAt).toBeUndefined();
+    });
+
+    it('persists active state through serialization', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set(), BlockNumber(100));
+      storedNote.markAsActive();
+
+      const restored = StoredNote.fromBuffer(storedNote.toBuffer());
+
+      expect(restored.isNullified()).toBe(false);
+      expect(restored.nullifiedAt).toBeUndefined();
+    });
+  });
+
+  describe('state transitions', () => {
+    it('can transition from active to nullified and back', async () => {
+      const storedNote = new StoredNote(await NoteDao.random(), new Set());
+
+      expect(storedNote.isNullified()).toBe(false);
+      expect(storedNote.nullifiedAt).toBeUndefined();
+
+      storedNote.markAsNullified(BlockNumber(10));
+      expect(storedNote.isNullified()).toBe(true);
+      expect(storedNote.nullifiedAt).toBe(BlockNumber(10));
+
+      storedNote.markAsActive();
+      expect(storedNote.isNullified()).toBe(false);
+      expect(storedNote.nullifiedAt).toBeUndefined();
+    });
+
+    it('preserves scopes through state transitions', async () => {
+      const scopes = new Set(['scope1', 'scope2']);
+      const storedNote = new StoredNote(await NoteDao.random(), scopes);
+
+      storedNote.markAsNullified(BlockNumber(10));
+      expect(storedNote.scopes).toEqual(scopes);
+
+      storedNote.markAsActive();
+      expect(storedNote.scopes).toEqual(scopes);
+    });
+
+    it('preserves noteDao through state transitions', async () => {
+      const noteDao = await NoteDao.random();
+      const storedNote = new StoredNote(noteDao, new Set());
+
+      storedNote.markAsNullified(BlockNumber(10));
+      expect(storedNote.noteDao).toBe(noteDao);
+
+      storedNote.markAsActive();
+      expect(storedNote.noteDao).toBe(noteDao);
+    });
+  });
+});

--- a/yarn-project/pxe/src/storage/note_store/stored_note.ts
+++ b/yarn-project/pxe/src/storage/note_store/stored_note.ts
@@ -1,0 +1,48 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+import { NoteDao } from '@aztec/stdlib/note';
+
+export class StoredNote {
+  constructor(
+    readonly noteDao: NoteDao,
+    readonly scopes: Set<string>,
+    private _nullifiedAt: BlockNumber | undefined = undefined,
+  ) {}
+
+  static fromBuffer(buffer: Buffer) {
+    const reader = BufferReader.asReader(buffer);
+
+    const noteDao = NoteDao.fromBuffer(reader);
+    const scopes = reader.readVector({ fromBuffer: (r: BufferReader) => r.readString() });
+
+    const nullifiedAtRaw = reader.readNumber();
+    const nullifiedAt = nullifiedAtRaw === 0 ? undefined : (nullifiedAtRaw as BlockNumber);
+
+    return new StoredNote(noteDao, new Set(scopes), nullifiedAt);
+  }
+
+  toBuffer(): Buffer {
+    const scopesArray = [...this.scopes];
+    return serializeToBuffer(this.noteDao, scopesArray.length, ...scopesArray, this._nullifiedAt ?? 0);
+  }
+
+  addScope(scope: string) {
+    this.scopes.add(scope);
+  }
+
+  markAsNullified(blockNumber: BlockNumber) {
+    this._nullifiedAt = blockNumber;
+  }
+
+  markAsActive() {
+    this._nullifiedAt = undefined;
+  }
+
+  isNullified() {
+    return this._nullifiedAt !== undefined;
+  }
+
+  get nullifiedAt() {
+    return this._nullifiedAt;
+  }
+}

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -152,7 +152,7 @@ export class TXESession implements TXESessionStateHandler {
     const addressStore = new AddressStore(store);
     const privateEventStore = new PrivateEventStore(store);
     const contractStore = new TXEContractStore(store);
-    const noteStore = await NoteStore.create(store);
+    const noteStore = new NoteStore(store);
     const senderTaggingStore = new SenderTaggingStore(store);
     const recipientTaggingStore = new RecipientTaggingStore(store);
     const senderAddressBookStore = new SenderAddressBookStore(store);
@@ -162,7 +162,13 @@ export class TXESession implements TXESessionStateHandler {
 
     // Create job coordinator and register staged stores
     const jobCoordinator = new JobCoordinator(store);
-    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore, privateEventStore]);
+    jobCoordinator.registerStores([
+      capsuleStore,
+      senderTaggingStore,
+      recipientTaggingStore,
+      privateEventStore,
+      noteStore,
+    ]);
 
     // Register protocol contracts.
     for (const { contractClass, instance, artifact } of protocolContracts) {
@@ -310,6 +316,7 @@ export class TXESession implements TXESessionStateHandler {
       this.noteStore,
       this.stateMachine.node,
       this.stateMachine.anchorBlockStore,
+      this.currentJobId,
     ).syncNoteNullifiers(contractAddress);
 
     // Private execution has two associated block numbers: the anchor block (i.e. the historical block that is used to
@@ -403,6 +410,7 @@ export class TXESession implements TXESessionStateHandler {
       this.noteStore,
       this.stateMachine.node,
       this.stateMachine.anchorBlockStore,
+      this.currentJobId,
     ).syncNoteNullifiers(contractAddress);
 
     const anchorBlockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();


### PR DESCRIPTION
Fifth and last part of the series started with https://github.com/AztecProtocol/aztec-packages/pull/19445.

This makes the NoteStore work based on staged writes. With this, notes (and nullifier metadata) aren't written to persistent storage until PXE decides to commit the job.

In the process of getting this reviewed by @benesjan, it became clear that the internal structure of the NoteStore was becoming a maintenance nightmare, so I refactored it to simplify indexing. For that reason I'm also suggesting that this closes the Linear F-94 F-36 issues.

The DB index design is based on the following ideas:

- As few indexes as possible.
- All notes regardless of their state are stored in a `#notes` index. 
- We avoid duplicating indexes to track whether a Note's nullifier is known to be emitted or not.
- Note contents (`NoteDao`) are stored in a single place and augmented with data that this store manages (`StoredNote`). 
- A note is known by PXE to be nullified if we find a `nullifiedAt` block number associated to this note in the store. "Nullifying" and "Un-nullifying" is now achieved by just updating that field. 
- Given the only dimension that grows arbitrarily in this store is the number of notes, we avoid full index scans on it.
- We maintain an index of `contractAddress => nullifier` (`#nullifiersByContractAddress`). Note filters must always provide a contract address, so reading notes works by using this index to read only notes of the given contract. The rest of the filters are applied as notes get read (a la map-reduce).
- We maintain an index of `blockNumber => nullifier` to handle re-orgs efficiently.

Closes F-163
Closes F-94
Closes F-36