### PR TITLE
chore: add safety to derive_generators and tweak pedersen scope

### DIFF
--- a/barretenberg/cpp/scripts/audit/audit_scopes/pedersen_hash_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/pedersen_hash_audit_scope.md
@@ -8,14 +8,7 @@ Commit hash: 4a956ceb179c2fe855e4f1fd78f2594e7fc3f5ea
 #### Native implementation
 1. ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.hpp```
 2. ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.cpp```
-3. ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.hpp```
-4. ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/c_bind.cpp```
-
-#### Tests
-5. ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp```
-    - Test vectors for Pedersen hash implementation
-
-
+3. ```barretenberg/cpp/src/barretenberg/crypto/generators/generator_data.hpp```
 
 ### Summary of the module
 
@@ -38,6 +31,9 @@ Key features:
 - Ensures output is never the point at infinity
 - Uses precomputed generator points for efficiency
 - Based on the hardness of the discrete logarithm problem
+
+#### Tests
+- ```barretenberg/cpp/src/barretenberg/crypto/pedersen_hash/pedersen.test.cpp```
 
 ### Documentation
 

--- a/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/group.hpp
@@ -88,6 +88,18 @@ template <typename Fq_, typename Fr_, typename Params> class group {
                                                                 const size_t num_generators,
                                                                 const size_t starting_index = 0)
     {
+        // Safety: domain_separator_bytes is indexed via &domain_separator_bytes[0] below.
+        // An empty domain separator would be UB and also defeats domain separation.
+        BB_ASSERT(!domain_separator_bytes.empty(), "derive_generators: domain_separator_bytes must be non-empty");
+
+        // We serialize the generator index into 4 bytes (uint32_t). Ensure we never silently truncate.
+        if (num_generators > 0) {
+            BB_ASSERT(starting_index <= static_cast<size_t>(UINT32_MAX),
+                      "derive_generators: starting_index exceeds uint32 range");
+            BB_ASSERT(num_generators <= (static_cast<size_t>(UINT32_MAX) - starting_index + 1),
+                      "derive_generators: starting_index + num_generators exceeds uint32 range");
+        }
+
         std::vector<affine_element> result;
         const auto domain_hash = blake3::blake3s_constexpr(&domain_separator_bytes[0], domain_separator_bytes.size());
         std::vector<uint8_t> generator_preimage;


### PR DESCRIPTION
Adds some asserts in derive_generators to protect against undefined behavior and adds generator_data.hpp to pedersen hash scope for additional scrutiny