### PR TITLE
test: use WASM backend for bbjs-test acir tests

### DIFF
--- a/barretenberg/acir_tests/bbjs-test/src/index.ts
+++ b/barretenberg/acir_tests/bbjs-test/src/index.ts
@@ -24,12 +24,12 @@ async function generateProof({
   oracleHash?: string;
   multiThreaded?: boolean;
 }) {
-  const { UltraHonkBackend, Barretenberg } = await import('@aztec/bb.js');
+  const { UltraHonkBackend, Barretenberg, BackendType } = await import('@aztec/bb.js');
 
   logger.debug(`Generating proof for ${bytecodePath}...`);
   const circuitArtifact = await fs.readFile(bytecodePath);
   const bytecode = JSON.parse(circuitArtifact.toString()).bytecode;
-  const bb = await Barretenberg.new({ threads: multiThreaded ? 8 : 1 });
+  const bb = await Barretenberg.new({ threads: multiThreaded ? 8 : 1, backend: BackendType.Wasm });
   const backend = new UltraHonkBackend(bytecode, bb);
 
   const witness = await fs.readFile(witnessPath);
@@ -62,9 +62,9 @@ async function generateProof({
 }
 
 async function verifyProof({ directory }: { directory: string }) {
-  const { UltraHonkVerifierBackend, Barretenberg } = await import('@aztec/bb.js');
+  const { UltraHonkVerifierBackend, Barretenberg, BackendType } = await import('@aztec/bb.js');
 
-  const bb = await Barretenberg.new({ threads: 1 });
+  const bb = await Barretenberg.new({ threads: 1, backend: BackendType.Wasm });
   const verifier = new UltraHonkVerifierBackend(bb);
 
   const proof = await fs.readFile(proofPath(directory));


### PR DESCRIPTION
There's a testing gap if we don't use WASM. We already use bb directly.

Updates bbjs-test to use the WASM backend for acir tests instead of bb binary