### PR TITLE
fix(avm): fix asan crash during UpdateCheckTracegenTest.HashZeroInteractions test

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/update_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/update_check.hpp
@@ -15,13 +15,13 @@ class UpdateCheck : public UpdateCheckInterface {
                 GreaterThanInterface& gt,
                 HighLevelMerkleDBInterface& merkle_db,
                 EventEmitterInterface<UpdateCheckEvent>& read_event_emitter,
-                const GlobalVariables& globals_)
+                const GlobalVariables& globals)
         : update_check_events(read_event_emitter)
         , poseidon2(poseidon2)
         , range_check(range_check)
         , gt(gt)
         , merkle_db(merkle_db)
-        , globals(globals_)
+        , globals(globals)
     {}
 
     void check_current_class_id(const AztecAddress& address, const ContractInstance& instance) override;
@@ -32,7 +32,7 @@ class UpdateCheck : public UpdateCheckInterface {
     RangeCheckInterface& range_check;
     GreaterThanInterface& gt;
     HighLevelMerkleDBInterface& merkle_db;
-    GlobalVariables globals;
+    const GlobalVariables& globals;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/update_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/update_check.hpp
@@ -15,13 +15,13 @@ class UpdateCheck : public UpdateCheckInterface {
                 GreaterThanInterface& gt,
                 HighLevelMerkleDBInterface& merkle_db,
                 EventEmitterInterface<UpdateCheckEvent>& read_event_emitter,
-                const GlobalVariables& globals)
+                const GlobalVariables& globals_)
         : update_check_events(read_event_emitter)
         , poseidon2(poseidon2)
         , range_check(range_check)
         , gt(gt)
         , merkle_db(merkle_db)
-        , globals(globals)
+        , globals(globals_)
     {}
 
     void check_current_class_id(const AztecAddress& address, const ContractInstance& instance) override;
@@ -32,7 +32,7 @@ class UpdateCheck : public UpdateCheckInterface {
     RangeCheckInterface& range_check;
     GreaterThanInterface& gt;
     HighLevelMerkleDBInterface& merkle_db;
-    const GlobalVariables& globals;
+    GlobalVariables globals;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/update_check_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/update_check_trace.test.cpp
@@ -126,8 +126,8 @@ TEST(UpdateCheckTracegenTest, HashZeroInteractions)
                        mock_l1_to_l2_message_tree_check);
 
     EventEmitter<UpdateCheckEvent> update_check_event_emitter;
-    UpdateCheck update_check(
-        poseidon2, range_check, gt, merkle_db, update_check_event_emitter, { .timestamp = current_timestamp });
+    const GlobalVariables globals = GlobalVariables{ .timestamp = current_timestamp };
+    UpdateCheck update_check(poseidon2, range_check, gt, merkle_db, update_check_event_emitter, globals);
 
     uint32_t leaf_index = 27;
     EXPECT_CALL(mock_low_level_merkle_db, get_tree_roots()).WillRepeatedly(Return(trees));


### PR DESCRIPTION

Found by running vm2_tests with ASAN enabled

