### PR TITLE
feat(p2p): (A-430) add nullifier deduplication to transaction pool

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool/README.md
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/README.md
@@ -24,7 +24,7 @@ The lifecycle of transactions in the pool is summarised in the following table:
 
 **Note on why Soft Delete:**
 Mined transactions are soft-deleted rather than permanently removed to support:
-1. Reorg handling — If a chain reorganization occurs, soft-deleted transactions are still available in the mempool 
+1. Reorg handling — If a chain reorganization occurs, soft-deleted transactions are still available in the mempool
 2. Slash condition detection — The epoch prune watcher needs access to transactions from pruned epochs to correctly identify data withholding slash conditions. Without soft-delete, transactions invalidated by reorgs (e.g., built on removed blocks) would be lost, causing false positives for data withholding violations.
 
 Mined transactions are permanently deleted via `cleanupDeletedMinedTxs()` once their original block is finalized on L1, ensuring theyremain available during the uncertainty window.
@@ -34,7 +34,7 @@ Alternatively, mined transactions can be permanently deleted immediately by pass
 
 | Method | Description |
 |--------|-------------|
-| `addTxs(txs, opts?)` | Adds transactions to the pool. Duplicates are ignored. Returns count of newly added txs. |
+| `addTxs(txs, opts?)` | Adds transactions to the pool. Duplicates and nullifier conflicts are handled. Returns count of newly added txs. |
 | `deleteTxs(txHashes, opts?)` | Removes transactions from the pool. Supports soft-delete for mined txs. |
 | `markAsMined(txHashes, blockHeader)` | Marks transactions as included in a block. |
 | `markMinedAsPending(txHashes, blockNumber)` | Reverts mined transactions to pending (used during reorgs). |
@@ -91,6 +91,7 @@ The pool maintains several KV maps and indexes:
 | `#txHashToHistoricalBlockHeaderHash` | Anchor block reference for each tx |
 | `#historicalHeaderToTxHash` | Index from historical block → tx hashes |
 | `#feePayerToTxHash` | Index from fee payer address → tx hashes |
+| `#pendingNullifierToTxHash` | Index from nullifier → tx hash |
 | `#archivedTxs` | Archived transactions for historical lookup |
 
 #### In-Memory Caches
@@ -117,15 +118,17 @@ The priority is stored as a hex string derived from a 32-byte buffer representat
 When `addTxs()` is called:
 
 1. Check for duplicates (skip if tx already exists)
-2. Store the serialized tx in `#txs`
-3. Index the tx by its anchor block hash
-4. If not already mined, add to pending indexes:
+2. Check for nullifier conflicts (see Nullifier Deduplication below)
+3. Store the serialized tx in `#txs`
+4. Index the tx by its anchor block hash
+5. If not already mined, add to pending indexes:
    - Priority-to-hash index (for ordering)
    - Historical header index (for reorg handling)
    - Fee payer index (for balance validation)
-5. Record metrics
-6. Trigger eviction rules for `TXS_ADDED` event
-7. Emit `txs-added` event
+   - Nullifier-to-tx-hash index (for conflict detection)
+6. Record metrics
+7. Trigger eviction rules for `TXS_ADDED` event
+8. Emit `txs-added` event
 
 ### 2. Marking as Mined
 
@@ -151,6 +154,16 @@ The `deleteTxs()` method handles two cases:
 - **Mined transactions**: Soft-deleted by default (moved to `#deletedMinedTxHashes`), with option for permanent deletion
 
 Soft-deleted mined transactions are retained for potential future reference and can be permanently cleaned up later via `cleanupDeletedMinedTxs()`.
+
+### Nullifier Deduplication
+
+The pool prevents nullifier spam attacks by ensuring only one pending transaction can reference each unique nullifier. When an incoming transaction shares nullifiers with existing pending transactions:
+
+- **Higher fee wins**: If the incoming tx has a higher priority fee than ALL conflicting txs, those conflicting txs are replaced
+- **Existing tx wins on tie**: If any conflicting tx has an equal or higher fee, the incoming tx is rejected
+- **Partial overlap counts**: Even a single shared nullifier triggers conflict resolution
+
+This is enforced at entry time via the `#pendingNullifierToTxHash` index, which maps each nullifier to the tx hash that references it. The index is maintained atomically with tx additions and removals.
 
 ## Eviction System
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -427,4 +427,107 @@ describe('KV TX pool', () => {
       expect(await txPool.getLowestPriorityEvictable(1)).toEqual([]);
     });
   });
+
+  /**
+   * Nullifier Index Consistency Tests
+   *
+   * These integration tests verify that the nullifier index is maintained
+   * correctly across all pool operations (add, delete, mine, reorg).
+   */
+  describe('Nullifier index consistency', () => {
+    // Tx type alias for cleaner type annotations
+    type MockTx = Awaited<ReturnType<typeof mockTx>>;
+
+    // Helper to create a public tx (forPublic path) with a specific fee
+    const mockPublicTx = (seed: number, fee: number) =>
+      mockTx(seed, {
+        maxPriorityFeesPerGas: new GasFees(fee, fee),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+    // Helper to set a specific nullifier on a transaction
+    const setNullifier = (tx: MockTx, index: number, value: Fr) => {
+      if (tx.data.forPublic) {
+        tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index] = value;
+      } else if (tx.data.forRollup) {
+        tx.data.forRollup.end.nullifiers[index] = value;
+      }
+    };
+
+    const getNullifier = (tx: MockTx, index: number): Fr => {
+      if (tx.data.forPublic) {
+        return tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index];
+      } else if (tx.data.forRollup) {
+        return tx.data.forRollup.end.nullifiers[index];
+      }
+      throw new Error('Transaction has no nullifiers');
+    };
+
+    it('removes nullifier entries when tx is deleted', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await txPool.addTxs([tx1]);
+      await txPool.deleteTxs([tx1.getTxHash()]);
+
+      // Add a new tx with the same nullifier - should succeed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await txPool.addTxs([tx2]);
+      const pending = await txPool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+    });
+
+    it('removes nullifier entries when tx is mined', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await txPool.addTxs([tx1]);
+      await txPool.markAsMined([tx1.getTxHash()], block1Header);
+
+      // Add a new tx with the same nullifier, it should succeed
+      // (In practice this would fail world state nullifier check,
+      // but we're testing pool index consistency)
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await txPool.addTxs([tx2]);
+      const pending = await txPool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+    });
+
+    it('restores nullifier entries on reorg (markMinedAsPending)', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      await txPool.addTxs([tx1]);
+      await txPool.markAsMined([tx1.getTxHash()], block1Header);
+      await txPool.markMinedAsPending([tx1.getTxHash()], BlockNumber(0));
+
+      // Now tx1 is pending again - nullifier should be claimed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await txPool.addTxs([tx2]);
+      const pending = await txPool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx1.getTxHash());
+      expect(pending).not.toContainEqual(tx2.getTxHash()); // tx2 has lower fee, should be rejected
+    });
+
+    it('cleans up nullifier index when replacement happens', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await txPool.addTxs([tx1]);
+      await txPool.addTxs([tx2]); // Replaces tx1
+
+      // Now add tx3 with the same nullifier as tx2 but lower fee
+      // It should be rejected because tx2 owns that nullifier now
+      const tx3 = await mockPublicTx(3, 3);
+      setNullifier(tx3, 0, getNullifier(tx2, 0));
+
+      await txPool.addTxs([tx3]);
+      const pending = await txPool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+      expect(pending).not.toContainEqual(tx3.getTxHash());
+      expect(pending.length).toBe(1);
+    });
+  });
 });

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -21,6 +21,7 @@ import { EvictionManager } from './eviction/eviction_manager.js';
 import {
   FeePayerTxInfo,
   type PendingTxInfo,
+  type PreAddPoolAccess,
   type TxBlockReference,
   type TxPoolOperations,
 } from './eviction/eviction_strategy.js';
@@ -28,6 +29,7 @@ import { FeePayerBalanceEvictionRule } from './eviction/fee_payer_balance_evicti
 import { InvalidTxsAfterMiningRule } from './eviction/invalid_txs_after_mining_rule.js';
 import { InvalidTxsAfterReorgRule } from './eviction/invalid_txs_after_reorg_rule.js';
 import { LowPriorityEvictionRule } from './eviction/low_priority_eviction_rule.js';
+import { NullifierConflictPreAddRule } from './eviction/nullifier_conflict_pre_add_rule.js';
 import { getPendingTxPriority } from './priority.js';
 import type { TxPool, TxPoolEvents, TxPoolOptions } from './tx_pool.js';
 
@@ -61,6 +63,9 @@ export class AztecKVTxPool
   #historicalHeaderToTxHash: AztecAsyncMultiMap<string, string>;
 
   #feePayerToBalanceEntry: AztecAsyncMultiMap<string, Buffer>;
+
+  /** Index from nullifier to pending tx hash */
+  #pendingNullifierToTxHash: AztecAsyncMap<string, string>;
 
   /** In-memory set of txs that should not be evicted from the pool. */
   #nonEvictableTxs: Set<string>;
@@ -113,6 +118,7 @@ export class AztecKVTxPool
         maxPoolSize: config.maxPendingTxCount ?? 0,
       }),
     );
+    this.#evictionManager.registerPreAddRule(new NullifierConflictPreAddRule());
 
     this.updateConfig(config);
 
@@ -125,6 +131,7 @@ export class AztecKVTxPool
     this.#pendingTxHashToHistoricalBlockHeaderHash = store.openMap('txHistoricalBlock');
     this.#historicalHeaderToTxHash = store.openMultiMap('historicalHeaderToPendingTxHash');
     this.#feePayerToBalanceEntry = store.openMultiMap('feePayerToBalanceEntry');
+    this.#pendingNullifierToTxHash = store.openMap('pendingNullifierToTxHash');
 
     this.#nonEvictableTxs = new Set<string>();
 
@@ -176,7 +183,7 @@ export class AztecKVTxPool
           const key = hash.toString();
           await this.#minedTxHashToBlock.set(key, blockHeader.globalVariables.blockNumber);
 
-          const tx = await this.getPendingTxByHash(hash);
+          const tx = await this.getTxByHash(hash);
           if (tx) {
             const nullifiers = tx.data.getNonEmptyNullifiers();
 
@@ -230,7 +237,7 @@ export class AztecKVTxPool
           }
 
           // Rehydrate the tx in the in-memory pending txs mapping
-          const tx = await this.getPendingTxByHash(hash);
+          const tx = await this.getTxByHash(hash);
           if (tx) {
             await this.addPendingTxIndicesInDbTx(tx, key);
           }
@@ -284,6 +291,8 @@ export class AztecKVTxPool
 
   /**
    * Adds a list of transactions to the pool. Duplicates are ignored.
+   * Handles nullifier deduplication: if an incoming tx has a nullifier conflict with
+   * existing pending txs, it will either replace them (if higher fee) or be rejected.
    * @param txs - An array of txs to be added to the pool.
    * @returns count of added transactions
    */
@@ -294,38 +303,54 @@ export class AztecKVTxPool
 
     const addedTxs: Tx[] = [];
     const uniqueFeePayers: AztecAddress[] = [];
+    const replacedTxHashes: TxHash[] = [];
     const hashesAndStats = txs.map(tx => ({ txHash: tx.getTxHash(), txStats: tx.getStats() }));
     try {
       await this.#store.transactionAsync(async () => {
-        await Promise.all(
-          txs.map(async (tx, i) => {
-            const { txHash, txStats } = hashesAndStats[i];
-            const key = txHash.toString();
-            if (await this.#txs.hasAsync(key)) {
-              this.#log.debug(`Tx ${txHash.toString()} already exists in the pool`);
-              return;
+        for (let i = 0; i < txs.length; i++) {
+          const tx = txs[i];
+          const { txHash, txStats } = hashesAndStats[i];
+          const key = txHash.toString();
+          if (await this.#txs.hasAsync(key)) {
+            this.#log.debug(`Tx ${key} already exists in the pool`);
+            continue;
+          }
+
+          const poolAccess = this.getPreAddPoolAccess();
+          const { shouldReject, txHashesToEvict } = await this.#evictionManager.runPreAddRules(tx, poolAccess);
+          if (shouldReject) {
+            continue;
+          }
+
+          for (const txHashToEvict of txHashesToEvict) {
+            const txToDelete = await this.getTxByHash(txHashToEvict);
+            if (txToDelete) {
+              const evictedKey = txHashToEvict.toString();
+              await this.deletePendingTxInDbTx(txToDelete, evictedKey);
+              replacedTxHashes.push(txHashToEvict);
+              this.#log.verbose(`Evicted tx ${evictedKey} due to higher-fee tx ${key}`);
             }
+          }
 
-            this.#log.verbose(`Adding tx ${txHash.toString()} to pool`, {
-              eventName: 'tx-added-to-pool',
-              ...txStats,
-            } satisfies TxAddedToPoolStats);
+          this.#log.verbose(`Adding tx ${key} to pool`, {
+            eventName: 'tx-added-to-pool',
+            ...txStats,
+          } satisfies TxAddedToPoolStats);
 
-            await this.#txs.set(key, tx.toBuffer());
-            addedTxs.push(tx as Tx);
-            insertIntoSortedArray(uniqueFeePayers, tx.data.feePayer, (a, b) => a.toField().cmp(b.toField()), false);
+          await this.#txs.set(key, tx.toBuffer());
+          addedTxs.push(tx);
+          insertIntoSortedArray(uniqueFeePayers, tx.data.feePayer, (a, b) => a.toField().cmp(b.toField()), false);
 
-            await this.#pendingTxHashToHistoricalBlockHeaderHash.set(
-              key,
-              (await tx.data.constants.anchorBlockHeader.hash()).toString(),
-            );
+          await this.#pendingTxHashToHistoricalBlockHeaderHash.set(
+            key,
+            (await tx.data.constants.anchorBlockHeader.hash()).toString(),
+          );
 
-            if (!(await this.#minedTxHashToBlock.hasAsync(key))) {
-              await this.addPendingTxIndicesInDbTx(tx, key);
-              this.#metrics.recordSize(tx);
-            }
-          }),
-        );
+          if (!(await this.#minedTxHashToBlock.hasAsync(key))) {
+            await this.addPendingTxIndicesInDbTx(tx, key);
+            this.#metrics.recordSize(tx);
+          }
+        }
       });
 
       await this.#evictionManager.evictAfterNewTxs(
@@ -334,6 +359,10 @@ export class AztecKVTxPool
       );
     } catch (err) {
       this.#log.warn('Unexpected error when adding txs', { err });
+    }
+
+    if (replacedTxHashes.length > 0) {
+      this.#metrics.transactionsRemoved(replacedTxHashes.map(hash => hash.toBigInt()));
     }
 
     if (addedTxs.length > 0) {
@@ -367,7 +396,7 @@ export class AztecKVTxPool
         const minedBlockNumber = await this.#minedTxHashToBlock.getAsync(key);
         const txIsPending = minedBlockNumber === undefined;
         if (txIsPending) {
-          await this.deletePendingTx(tx, key);
+          await this.deletePendingTxInDbTx(tx, key);
         } else {
           await this.deleteMinedTx(key, minedBlockNumber!, opts?.permanently ?? false);
           const shouldArchiveTx = this.#archivedTxLimit && !opts?.permanently;
@@ -397,10 +426,11 @@ export class AztecKVTxPool
     await this.#blockToDeletedMinedTxHash.set(minedBlockNumber, txHash);
   }
 
-  private async deletePendingTx(tx: Tx, txHash: `0x${string}`) {
+  // Assumes being called within a DB transaction
+  private async deletePendingTxInDbTx(tx: Tx, txHash: `0x${string}`) {
     // We always permanently delete pending transactions
     this.#log.trace(`Deleting pending tx ${txHash} from pool`);
-    await this.removePendingTxIndices(tx, txHash);
+    await this.removePendingTxIndicesInDbTx(tx, txHash);
     await this.#txs.delete(txHash);
     await this.#pendingTxHashToHistoricalBlockHeaderHash.delete(txHash);
   }
@@ -433,7 +463,7 @@ export class AztecKVTxPool
     let historicalBlockHash = await this.#pendingTxHashToHistoricalBlockHeaderHash.getAsync(txHash.toString());
     // Not all tx might have this index created.
     if (!historicalBlockHash) {
-      const tx = await this.getPendingTxByHash(txHash);
+      const tx = await this.getTxByHash(txHash);
       if (!tx) {
         this.#log.warn(`PendingTxInfo:tx ${txHash} not found`);
         return undefined;
@@ -591,24 +621,6 @@ export class AztecKVTxPool
   }
 
   /**
-   * Checks if a cached transaction exists in the in-memory pending tx pool and returns it.
-   * Otherwise, it checks the tx pool, updates the pending tx pool, and returns the tx.
-   * @param txHash - The generated tx hash.
-   * @returns The transaction, if found, 'undefined' otherwise.
-   */
-  private async getPendingTxByHash(txHash: TxHash | string): Promise<Tx | undefined> {
-    if (typeof txHash === 'string') {
-      txHash = TxHash.fromString(txHash);
-    }
-
-    const tx = await this.getTxByHash(txHash);
-    if (tx) {
-      return tx;
-    }
-    return undefined;
-  }
-
-  /**
    * Archives a list of txs for future reference. The number of archived txs is limited by the specified archivedTxLimit.
    * Note: Pending txs should not be archived, only finalized txs
    * @param txs - The list of transactions to archive.
@@ -666,12 +678,12 @@ export class AztecKVTxPool
     await this.#pendingTxPriorityToHash.set(getPendingTxPriority(tx), txHash);
     await this.#historicalHeaderToTxHash.set((await tx.data.constants.anchorBlockHeader.hash()).toString(), txHash);
     await this.#feePayerToBalanceEntry.set(tx.data.feePayer.toString(), await FeePayerTxInfo.encode(tx, txHash));
-  }
 
-  private async addPendingTxIndices(tx: Tx, txHash: string): Promise<void> {
-    return await this.#store.transactionAsync(async () => {
-      await this.addPendingTxIndicesInDbTx(tx, txHash);
-    });
+    // Add nullifier entries for conflict detection
+    const nullifiers = tx.data.getNonEmptyNullifiers();
+    for (const nullifier of nullifiers) {
+      await this.#pendingNullifierToTxHash.set(nullifier.toString(), txHash);
+    }
   }
 
   // Assumes being called within a DB transaction
@@ -685,12 +697,12 @@ export class AztecKVTxPool
       tx.data.feePayer.toString(),
       await FeePayerTxInfo.encode(tx, txHash),
     );
-  }
 
-  private async removePendingTxIndices(tx: Tx, txHash: string): Promise<void> {
-    return await this.#store.transactionAsync(async () => {
-      await this.removePendingTxIndicesInDbTx(tx, txHash);
-    });
+    // Remove nullifier entries
+    const nullifiers = tx.data.getNonEmptyNullifiers();
+    for (const nullifier of nullifiers) {
+      await this.#pendingNullifierToTxHash.delete(nullifier.toString());
+    }
   }
 
   /**
@@ -715,5 +727,20 @@ export class AztecKVTxPool
     }
 
     return txsToEvict;
+  }
+
+  /**
+   * Creates a PreAddPoolAccess object for use by pre-add eviction rules.
+   * Provides read-only access to pool state during addTxs transaction.
+   */
+  private getPreAddPoolAccess(): PreAddPoolAccess {
+    return {
+      getTxHashByNullifier: async nullifier => {
+        const hashStr = await this.#pendingNullifierToTxHash.getAsync(nullifier.toString());
+        return hashStr ? TxHash.fromString(hashStr) : undefined;
+      },
+      getPendingTxByHash: this.getTxByHash.bind(this),
+      getTxPriority: getPendingTxPriority,
+    };
   }
 }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.ts
@@ -1,13 +1,25 @@
+import { findIndexInSortedArray, insertIntoSortedArray } from '@aztec/foundation/array';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
+import { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
 
 import type { TxPoolOptions } from '../tx_pool.js';
-import { type EvictionContext, EvictionEvent, type EvictionRule, type TxPoolOperations } from './eviction_strategy.js';
+import {
+  type EvictionContext,
+  EvictionEvent,
+  type EvictionRule,
+  type PreAddEvictionResult,
+  type PreAddEvictionRule,
+  type PreAddPoolAccess,
+  type TxPoolOperations,
+} from './eviction_strategy.js';
 
 export class EvictionManager {
   private rules: EvictionRule[] = [];
+
+  /** Pre-add eviction rules (run inside addTxs transaction) */
+  private preAddRules: PreAddEvictionRule[] = [];
 
   constructor(
     private txPool: TxPoolOperations,
@@ -46,13 +58,60 @@ export class EvictionManager {
     await this.runEvictionRules(ctx);
   }
 
+  /**
+   * Runs pre-add eviction rules to determine if an incoming tx should be added
+   * and which existing txs should be evicted.
+   * Called from inside the addTxs database transaction for atomicity.
+   *
+   * @param tx - The incoming transaction
+   * @param poolAccess - Read-only access to pool state
+   * @returns Combined result from all pre-add rules
+   */
+  public async runPreAddRules(tx: Tx, poolAccess: PreAddPoolAccess): Promise<PreAddEvictionResult> {
+    const allTxHashesToEvict: TxHash[] = [];
+    const cmpTxHash = (a: TxHash, b: TxHash) => Fr.cmp(a.hash, b.hash);
+
+    for (const rule of this.preAddRules) {
+      try {
+        const result = await rule.check(tx, poolAccess);
+
+        if (result.shouldReject) {
+          return { shouldReject: true, txHashesToEvict: [], reason: result.reason };
+        }
+
+        for (const txHashToEvict of result.txHashesToEvict) {
+          // Only add if not already present (dedup)
+          if (findIndexInSortedArray(allTxHashesToEvict, txHashToEvict, cmpTxHash) === -1) {
+            insertIntoSortedArray(allTxHashesToEvict, txHashToEvict, cmpTxHash);
+          }
+        }
+      } catch (err) {
+        this.log.warn(`Pre-add eviction rule ${rule.name} unexpected error: ${String(err)}`, {
+          err,
+          preAddRule: rule.name,
+        });
+        // On error, reject the tx to be safe
+        return { shouldReject: true, txHashesToEvict: [], reason: `rule error: ${String(err)}` };
+      }
+    }
+
+    return { shouldReject: false, txHashesToEvict: allTxHashesToEvict };
+  }
+
   public registerRule(rule: EvictionRule) {
     this.rules.push(rule);
+  }
+
+  public registerPreAddRule(rule: PreAddEvictionRule) {
+    this.preAddRules.push(rule);
   }
 
   public updateConfig(config: TxPoolOptions): void {
     for (const rule of this.rules) {
       rule.updateConfig(config);
+    }
+    for (const rule of this.preAddRules) {
+      rule.updateConfig?.(config);
     }
   }
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_strategy.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_strategy.ts
@@ -146,3 +146,62 @@ export class FeePayerTxInfo {
     });
   }
 }
+
+/**
+ * Read-only access to pool state for pre-add eviction checks.
+ * Passed to pre-add rules during the addTxs transaction.
+ */
+export interface PreAddPoolAccess {
+  /**
+   * Get the pending tx hash that uses a specific nullifier, if any.
+   * Returns undefined if no pending tx uses this nullifier.
+   */
+  getTxHashByNullifier(nullifier: Fr): Promise<TxHash | undefined>;
+
+  /**
+   * Get a pending transaction by its hash.
+   */
+  getPendingTxByHash(hash: TxHash): Promise<Tx | undefined>;
+
+  /**
+   * Get the priority string for a transaction (for fee comparison).
+   */
+  getTxPriority(tx: Tx): string;
+}
+
+/**
+ * Result of a pre-add eviction check for a single transaction.
+ */
+export interface PreAddEvictionResult {
+  /** Whether the incoming tx should be rejected */
+  readonly shouldReject: boolean;
+  /** Sorted array of existing tx hashes that should be evicted if this tx is added */
+  readonly txHashesToEvict: TxHash[];
+  /** Optional reason for rejection */
+  readonly reason?: string;
+}
+
+/**
+ * Strategy interface for pre-add eviction rules.
+ * These run inside the addTxs transaction before a tx is added,
+ * deciding whether to evict existing txs or reject the incoming tx.
+ */
+export interface PreAddEvictionRule {
+  readonly name: string;
+
+  /**
+   * Check if incoming tx should be added and which existing txs to evict.
+   * Called inside the addTxs database transaction for atomicity.
+   *
+   * @param tx - The incoming transaction to check
+   * @param poolAccess - Read-only access to current pool state
+   * @returns Result indicating whether to reject and what to evict
+   */
+  check(tx: Tx, poolAccess: PreAddPoolAccess): Promise<PreAddEvictionResult>;
+
+  /**
+   * Updates the configuration for this rule.
+   * Rules should ignore config options that don't apply to them.
+   */
+  updateConfig?(config: TxPoolOptions): void;
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/nullifier_conflict_pre_add_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/nullifier_conflict_pre_add_rule.test.ts
@@ -1,0 +1,382 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { GasFees } from '@aztec/stdlib/gas';
+import { mockTx } from '@aztec/stdlib/testing';
+import { type Tx, TxHash } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { getPendingTxPriority } from '../priority.js';
+import type { PreAddPoolAccess } from './eviction_strategy.js';
+import { NullifierConflictPreAddRule } from './nullifier_conflict_pre_add_rule.js';
+
+describe('NullifierConflictPreAddRule', () => {
+  let poolAccess: MockProxy<PreAddPoolAccess>;
+  let rule: NullifierConflictPreAddRule;
+
+  // Tx type alias for cleaner type annotations
+  type MockTx = Awaited<ReturnType<typeof mockTx>>;
+
+  // Helper to create a public tx (forPublic path) with a specific fee
+  const mockPublicTx = (seed: number, fee: number) =>
+    mockTx(seed, {
+      maxPriorityFeesPerGas: new GasFees(fee, fee),
+      numberOfNonRevertiblePublicCallRequests: 1,
+    });
+
+  // Helper to create a private-only tx (forRollup path) with a specific fee
+  const mockPrivateTx = (seed: number, fee: number) =>
+    mockTx(seed, {
+      maxPriorityFeesPerGas: new GasFees(fee, fee),
+      numberOfNonRevertiblePublicCallRequests: 0,
+      numberOfRevertiblePublicCallRequests: 0,
+    });
+
+  // Helper to set a specific nullifier on a transaction
+  const setNullifier = (tx: MockTx, index: number, value: Fr) => {
+    if (tx.data.forPublic) {
+      tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index] = value;
+    } else if (tx.data.forRollup) {
+      tx.data.forRollup.end.nullifiers[index] = value;
+    }
+  };
+
+  const getNullifier = (tx: MockTx, index: number): Fr => {
+    if (tx.data.forPublic) {
+      return tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index];
+    } else if (tx.data.forRollup) {
+      return tx.data.forRollup.end.nullifiers[index];
+    }
+    throw new Error('Transaction has no nullifiers');
+  };
+
+  beforeEach(() => {
+    poolAccess = mock<PreAddPoolAccess>();
+    poolAccess.getTxHashByNullifier.mockResolvedValue(undefined);
+    poolAccess.getPendingTxByHash.mockResolvedValue(undefined);
+    poolAccess.getTxPriority.mockImplementation((tx: Tx) => getPendingTxPriority(tx));
+
+    rule = new NullifierConflictPreAddRule();
+  });
+
+  describe('check method', () => {
+    describe('no conflicts', () => {
+      it('accepts tx when no nullifier conflicts exist', async () => {
+        const tx = await mockPublicTx(1, 5);
+
+        const result = await rule.check(tx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('accepts tx with different nullifiers than existing txs', async () => {
+        const tx = await mockPublicTx(1, 5);
+
+        // No conflicts - getTxHashesByNullifier returns empty for all nullifiers
+        const result = await rule.check(tx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('basic conflict resolution', () => {
+      it('rejects tx when existing tx has same nullifier with higher fee', async () => {
+        const existingTx = await mockPublicTx(1, 10);
+        const incomingTx = await mockPublicTx(2, 5);
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('evicts existing tx when incoming tx has same nullifier with higher fee', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPublicTx(2, 10);
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash))).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(1);
+      });
+
+      it('rejects tx with equal fee (no replacement on tie)', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPublicTx(2, 5);
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('forPublic vs forRollup paths', () => {
+      it('handles nullifier conflicts for private-only txs (forRollup path)', async () => {
+        const existingTx = await mockPrivateTx(1, 5);
+        const incomingTx = await mockPrivateTx(2, 10);
+
+        expect(existingTx.data.forRollup).toBeDefined();
+        expect(incomingTx.data.forRollup).toBeDefined();
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash))).toBe(true);
+      });
+
+      it('handles nullifier conflicts between forPublic and forRollup txs', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPrivateTx(2, 10);
+
+        expect(existingTx.data.forPublic).toBeDefined();
+        expect(incomingTx.data.forRollup).toBeDefined();
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash))).toBe(true);
+      });
+    });
+
+    describe('partial nullifier overlap', () => {
+      it('detects conflict when txs share only ONE nullifier', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPublicTx(2, 10);
+
+        // Give both txs second nullifiers, share only first
+        setNullifier(existingTx, 1, Fr.random());
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+        setNullifier(incomingTx, 1, Fr.random());
+
+        const existingHash = existingTx.getTxHash();
+
+        // Only return conflict for the shared nullifier
+        poolAccess.getTxHashByNullifier.mockImplementation(nullifier => {
+          if (nullifier.equals(getNullifier(existingTx, 0))) {
+            return Promise.resolve(existingHash);
+          }
+          return Promise.resolve(undefined);
+        });
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash))).toBe(true);
+      });
+
+      it('rejects tx with partial overlap when existing has higher fee', async () => {
+        const existingTx = await mockPublicTx(1, 10);
+        const incomingTx = await mockPublicTx(2, 5);
+
+        setNullifier(existingTx, 1, Fr.random());
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+        setNullifier(incomingTx, 1, Fr.random());
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockImplementation(nullifier => {
+          if (nullifier.equals(getNullifier(existingTx, 0))) {
+            return Promise.resolve(existingHash);
+          }
+          return Promise.resolve(undefined);
+        });
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('multiple conflicts', () => {
+      it('evicts multiple txs when incoming tx beats all of them', async () => {
+        const existingTx1 = await mockPublicTx(1, 3);
+        const existingTx2 = await mockPublicTx(2, 4);
+        const incomingTx = await mockPublicTx(3, 10);
+
+        // incoming tx shares nullifiers with both existing txs
+        setNullifier(incomingTx, 0, getNullifier(existingTx1, 0));
+        setNullifier(incomingTx, 1, getNullifier(existingTx2, 0));
+
+        const existingHash1 = existingTx1.getTxHash();
+        const existingHash2 = existingTx2.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockImplementation(nullifier => {
+          if (nullifier.equals(getNullifier(existingTx1, 0))) {
+            return Promise.resolve(existingHash1);
+          }
+          if (nullifier.equals(getNullifier(existingTx2, 0))) {
+            return Promise.resolve(existingHash2);
+          }
+          return Promise.resolve(undefined);
+        });
+        poolAccess.getPendingTxByHash.mockImplementation(hash => {
+          if (hash.equals(existingHash1)) {
+            return Promise.resolve(existingTx1);
+          }
+          if (hash.equals(existingHash2)) {
+            return Promise.resolve(existingTx2);
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash1))).toBe(true);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash2))).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(2);
+      });
+
+      it('rejects incoming tx if it cannot beat ALL conflicting txs', async () => {
+        const existingTx1 = await mockPublicTx(1, 3);
+        const existingTx2 = await mockPublicTx(2, 100); // Higher fee than incoming
+        const incomingTx = await mockPublicTx(3, 10);
+
+        setNullifier(incomingTx, 0, getNullifier(existingTx1, 0));
+        setNullifier(incomingTx, 1, getNullifier(existingTx2, 0));
+
+        const existingHash1 = existingTx1.getTxHash();
+        const existingHash2 = existingTx2.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockImplementation(nullifier => {
+          if (nullifier.equals(getNullifier(existingTx1, 0))) {
+            return Promise.resolve(existingHash1);
+          }
+          if (nullifier.equals(getNullifier(existingTx2, 0))) {
+            return Promise.resolve(existingHash2);
+          }
+          return Promise.resolve(undefined);
+        });
+        poolAccess.getPendingTxByHash.mockImplementation(hash => {
+          if (hash.equals(existingHash1)) {
+            return Promise.resolve(existingTx1);
+          }
+          if (hash.equals(existingHash2)) {
+            return Promise.resolve(existingTx2);
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0); // Atomic: no partial evictions
+      });
+    });
+
+    describe('same tx with multiple shared nullifiers', () => {
+      it('handles two txs sharing multiple nullifiers', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPublicTx(2, 10);
+
+        // Share both nullifiers
+        setNullifier(existingTx, 1, Fr.random());
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+        setNullifier(incomingTx, 1, getNullifier(existingTx, 1));
+
+        const existingHash = existingTx.getTxHash();
+
+        // Both nullifiers map to the same existing tx
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.some(h => h.equals(existingHash))).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(1); // Only added once, not duplicated
+      });
+
+      it('does not double-count when same tx conflicts on multiple nullifiers', async () => {
+        const existingTx = await mockPublicTx(1, 5);
+        const incomingTx = await mockPublicTx(2, 10);
+
+        // Share 3 nullifiers
+        setNullifier(existingTx, 1, Fr.random());
+        setNullifier(existingTx, 2, Fr.random());
+        setNullifier(incomingTx, 0, getNullifier(existingTx, 0));
+        setNullifier(incomingTx, 1, getNullifier(existingTx, 1));
+        setNullifier(incomingTx, 2, getNullifier(existingTx, 2));
+
+        const existingHash = existingTx.getTxHash();
+
+        poolAccess.getTxHashByNullifier.mockResolvedValue(existingHash);
+        poolAccess.getPendingTxByHash.mockResolvedValue(existingTx);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(1); // Existing tx only in array once
+      });
+    });
+
+    describe('edge cases', () => {
+      it('skips self-reference (incoming tx hash in conflict list)', async () => {
+        const tx = await mockPublicTx(1, 5);
+        const txHash = tx.getTxHash();
+
+        // Simulate edge case where own hash appears in conflict list
+        poolAccess.getTxHashByNullifier.mockResolvedValue(txHash);
+
+        const result = await rule.check(tx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('handles missing conflicting tx gracefully', async () => {
+        const incomingTx = await mockPublicTx(1, 10);
+
+        // Conflict exists in index but tx is not found
+        poolAccess.getTxHashByNullifier.mockResolvedValue(TxHash.random());
+        poolAccess.getPendingTxByHash.mockResolvedValue(undefined);
+
+        const result = await rule.check(incomingTx, poolAccess);
+
+        expect(result.shouldReject).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/nullifier_conflict_pre_add_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/nullifier_conflict_pre_add_rule.ts
@@ -1,0 +1,75 @@
+import { findIndexInSortedArray, insertIntoSortedArray } from '@aztec/foundation/array';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import { type Tx, TxHash } from '@aztec/stdlib/tx';
+
+import type { PreAddEvictionResult, PreAddEvictionRule, PreAddPoolAccess } from './eviction_strategy.js';
+
+const cmpTxHash = (a: TxHash, b: TxHash) => Fr.cmp(a.hash, b.hash);
+
+/**
+ * Pre-add eviction rule that checks for nullifier conflicts between incoming and existing transactions.
+ *
+ * When an incoming tx shares nullifiers with existing pending txs:
+ * - If the incoming tx has strictly higher priority fee, evict all conflicting txs
+ * - If any conflicting tx has equal or higher priority fee, reject the incoming tx
+ *
+ * This prevents nullifier spam attacks where an attacker floods the mempool with
+ * transactions spending the same nullifiers.
+ */
+export class NullifierConflictPreAddRule implements PreAddEvictionRule {
+  public readonly name = 'NullifierConflictPreAdd';
+
+  private log = createLogger('p2p:mempool:tx_pool:nullifier_conflict_pre_add_rule');
+
+  /**
+   * Check if the incoming transaction conflicts with existing transactions via nullifiers.
+   *
+   * @param tx - The incoming transaction
+   * @param poolAccess - Read-only access to pool state
+   * @returns Result with rejection status and txs to evict
+   */
+  async check(tx: Tx, poolAccess: PreAddPoolAccess): Promise<PreAddEvictionResult> {
+    const txHash = tx.getTxHash();
+    const nullifiers = tx.data.getNonEmptyNullifiers();
+    const txHashesToEvict: TxHash[] = [];
+    const incomingPriority = poolAccess.getTxPriority(tx);
+
+    for (const nullifier of nullifiers) {
+      const conflictingHash = await poolAccess.getTxHashByNullifier(nullifier);
+
+      if (
+        !conflictingHash ||
+        conflictingHash.equals(txHash) ||
+        findIndexInSortedArray(txHashesToEvict, conflictingHash, cmpTxHash) !== -1
+      ) {
+        continue;
+      }
+
+      // Get the conflicting tx's priority
+      const conflictingTx = await poolAccess.getPendingTxByHash(conflictingHash);
+      if (!conflictingTx) {
+        continue;
+      }
+
+      const conflictingPriority = poolAccess.getTxPriority(conflictingTx);
+
+      // If incoming tx has strictly higher priority, mark for eviction
+      // Otherwise, reject incoming tx (ties go to existing tx)
+      if (incomingPriority > conflictingPriority) {
+        insertIntoSortedArray(txHashesToEvict, conflictingHash, cmpTxHash);
+      } else {
+        this.log.debug(
+          `Rejecting tx ${txHash.toString()}: nullifier conflict with ${conflictingHash.toString()} which has higher or equal fee`,
+        );
+        return {
+          shouldReject: true,
+          txHashesToEvict: [],
+          reason: `nullifier conflict with ${conflictingHash.toString()}`,
+        };
+      }
+    }
+
+    return { shouldReject: false, txHashesToEvict };
+  }
+}


### PR DESCRIPTION
- Add nullifier -> txHash index for conflict detection
- Implement fee-based replacement for conflicting transactions
- Add canAddTxs() method for P2P layer pre-validation
- Prevent mempool spam via duplicate nullifier attacks
- Add test cases that address normal flow and edge cases

