### PR TITLE
chore(ci): allow transpiler build to fail in sync PR creation

### DIFF
--- a/.github/workflows/pull-noir.yml
+++ b/.github/workflows/pull-noir.yml
@@ -66,7 +66,8 @@ jobs:
           git fetch --tags
           git checkout ${{ steps.noir_versions.outputs.latest_nightly }}
           cd ../..
-          cargo check --manifest-path avm-transpiler/Cargo.toml
+          # Update Cargo.lock if needed, but don't fail if transpiler no longer builds
+          cargo check --manifest-path avm-transpiler/Cargo.toml || true
           git add noir/noir-repo avm-transpiler/Cargo.lock
 
       - name: Check for existing PR


### PR DESCRIPTION
We ignore a non-zero error code from running `cargo check` on the transpiler now so that we just get the minimal lockfile changes but don't care if the transpiler doesn't build anymore.