### PR TITLE
fix: Prover node correctly cleans up used world state forks

### DIFF
--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -113,6 +113,10 @@ export class ProvingOrchestrator implements EpochProver {
     return this.proverId;
   }
 
+  public getNumActiveForks() {
+    return this.dbs.size;
+  }
+
   public stop(): Promise<void> {
     this.cancel();
     return Promise.resolve();
@@ -486,12 +490,7 @@ export class ProvingOrchestrator implements EpochProver {
     // is aborted and never reaches this point, it will leak the fork. We need to add a global cleanup,
     // but have to make sure it only runs once all operations are completed, otherwise some function here
     // will attempt to access the fork after it was closed.
-    logger.debug(`Cleaning up world state fork for ${blockNumber}`);
-    void this.dbs
-      .get(blockNumber)
-      ?.close()
-      .then(() => this.dbs.delete(blockNumber))
-      .catch(err => logger.error(`Error closing db for block ${blockNumber}`, err));
+    void this.cleanupDBFork(blockNumber);
   }
 
   /**
@@ -532,6 +531,21 @@ export class ProvingOrchestrator implements EpochProver {
     });
 
     return epochProofResult;
+  }
+
+  private async cleanupDBFork(blockNumber: BlockNumber): Promise<void> {
+    logger.debug(`Cleaning up world state fork for ${blockNumber}`);
+    const fork = this.dbs.get(blockNumber);
+    if (!fork) {
+      return;
+    }
+
+    try {
+      await fork.close();
+      this.dbs.delete(blockNumber);
+    } catch (err) {
+      logger.error(`Error closing db for block ${blockNumber}`, err);
+    }
   }
 
   /**
@@ -851,19 +865,22 @@ export class ProvingOrchestrator implements EpochProver {
         },
       ),
       async result => {
-        // If the proofs were slower than the block header building, then we need to try validating the block header hashes here.
-        await this.verifyBuiltBlockAgainstSyncedState(provingState);
-
         logger.debug(`Completed ${rollupType} proof for block ${provingState.blockNumber}`);
 
         const leafLocation = provingState.setBlockRootRollupProof(result);
         const checkpointProvingState = provingState.parentCheckpoint;
+
+        // If the proofs were slower than the block header building, then we need to try validating the block header hashes here.
+        await this.verifyBuiltBlockAgainstSyncedState(provingState);
 
         if (checkpointProvingState.totalNumBlocks === 1) {
           this.checkAndEnqueueCheckpointRootRollup(checkpointProvingState);
         } else {
           this.checkAndEnqueueNextBlockMergeRollup(checkpointProvingState, leafLocation);
         }
+
+        // We are finished with the block at this point, ensure the fork is cleaned up
+        void this.cleanupDBFork(provingState.blockNumber);
       },
     );
   }

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -155,6 +155,40 @@ describe('prover/orchestrator', () => {
         expect(result.proof).toBeDefined();
       });
 
+      it('cleans up all world state forks', async () => {
+        const numBlocks = 1;
+        const {
+          constants,
+          blocks: [{ header, txs }],
+          previousBlockHeader,
+        } = await context.makeCheckpoint(numBlocks);
+
+        const finalBlobChallenges = await context.getFinalBlobChallenges();
+        orchestrator.startNewEpoch(EpochNumber(1), 1, finalBlobChallenges);
+
+        await orchestrator.startNewCheckpoint(
+          0, // checkpointIndex
+          constants,
+          [],
+          numBlocks,
+          previousBlockHeader,
+        );
+
+        const { blockNumber, timestamp } = header.globalVariables;
+        await orchestrator.startNewBlock(blockNumber, timestamp, txs.length);
+
+        // wait for the block root proof to try to be enqueued
+        await sleep(1000);
+
+        // now finish the block
+        await orchestrator.setBlockCompleted(blockNumber);
+
+        const result = await orchestrator.finalizeEpoch();
+        expect(result.proof).toBeDefined();
+        const numForks = orchestrator.getNumActiveForks();
+        expect(numForks).toEqual(0);
+      });
+
       it('can start chonk verifier proofs before adding processed txs', async () => {
         const getChonkVerifierSpy = jest.spyOn(prover, 'getPublicChonkVerifierProof');
 


### PR DESCRIPTION
Previously the prover node would leak every fork created by the `ProvingOrchestrator`. This fixes the issue.

Fork deletion was only taking place insize function `await this.verifyBuiltBlockAgainstSyncedState(provingState);`. But this function returns early where:

```
    const output = provingState.getBlockRootRollupOutput();
    if (!output) {
      logger.debug('Block root rollup proof not built yet, skipping header check.');
      return;
    }
```

As `const leafLocation = provingState.setBlockRootRollupProof(result);` was only being called after this function, it would always return early (and in fact never perform the validation the function was intended for).
