### PR TITLE
fix: P2P tests regularly time out validator re-execution

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -282,7 +282,7 @@ tests:
   - regex: "src/e2e_p2p/.*\\.test\\.ts"
     flake_group_id: e2e-p2p-epoch-flakes
     owners:
-      - *palla
+      - *phil
 
   - regex: "src/e2e_epochs/.*\\.test\\.ts"
     flake_group_id: e2e-p2p-epoch-flakes

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -163,7 +163,6 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
       disabledValidators: [],
       attestationPollingIntervalMs: 1000,
       validatorReexecute: true,
-      validatorReexecuteDeadlineMs: 1000,
       disableTransactions: false,
     });
   }

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -43,9 +43,6 @@ export interface ValidatorClientConfig {
   /** Whether to re-execute transactions in a block proposal before attesting */
   validatorReexecute: boolean;
 
-  /** Will re-execute until this many milliseconds are left in the slot */
-  validatorReexecuteDeadlineMs: number;
-
   /** Whether to always reexecute block proposals, even for non-validator nodes or when out of the currnet committee */
   alwaysReexecuteBlockProposals?: boolean;
 
@@ -78,7 +75,6 @@ export const ValidatorClientConfigSchema = zodFor<Omit<ValidatorClientConfig, 'v
     disabledValidators: z.array(schemas.EthAddress),
     attestationPollingIntervalMs: z.number().min(0),
     validatorReexecute: z.boolean(),
-    validatorReexecuteDeadlineMs: z.number().min(0),
     alwaysReexecuteBlockProposals: z.boolean().optional(),
     fishermanMode: z.boolean().optional(),
     skipCheckpointProposalValidation: z.boolean().optional(),

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -414,8 +414,7 @@ export class BlockProposalHandler {
 
   private getReexecutionDeadline(slot: SlotNumber, config: { l1GenesisTime: bigint; slotDuration: number }): Date {
     const nextSlotTimestampSeconds = Number(getTimestampForSlot(SlotNumber(slot + 1), config));
-    const msNeededForPropagationAndPublishing = this.config.validatorReexecuteDeadlineMs;
-    return new Date(nextSlotTimestampSeconds * 1000 - msNeededForPropagationAndPublishing);
+    return new Date(nextSlotTimestampSeconds * 1000);
   }
 
   /**

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -70,7 +70,12 @@ export class CheckpointBuilder {
     const blockBuildingTimer = new Timer();
     const slot = this.checkpointBuilder.constants.slotNumber;
 
-    log.verbose(`Building block ${blockNumber} for slot ${slot} within checkpoint`, { slot, blockNumber, ...opts });
+    log.verbose(`Building block ${blockNumber} for slot ${slot} within checkpoint`, {
+      slot,
+      blockNumber,
+      ...opts,
+      currentTime: new Date(this.dateProvider.now()),
+    });
 
     const constants = this.checkpointBuilder.constants;
     const globalVariables = GlobalVariables.from({

--- a/yarn-project/validator-client/src/config.ts
+++ b/yarn-project/validator-client/src/config.ts
@@ -53,11 +53,6 @@ export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientCo
     description: 'Re-execute transactions before attesting',
     ...booleanConfigHelper(true),
   },
-  validatorReexecuteDeadlineMs: {
-    env: 'VALIDATOR_REEXECUTE_DEADLINE_MS',
-    description: 'Will re-execute until this many milliseconds are left in the slot',
-    ...numberConfigHelper(6000),
-  },
   alwaysReexecuteBlockProposals: {
     env: 'ALWAYS_REEXECUTE_BLOCK_PROPOSALS',
     description:

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -99,7 +99,6 @@ describe('ValidatorClient', () => {
       disableValidator: false,
       disabledValidators: [],
       validatorReexecute: false,
-      validatorReexecuteDeadlineMs: 6000,
       slashBroadcastedInvalidBlockPenalty: 1n,
       disableTransactions: false,
     };


### PR DESCRIPTION
Validator re-execution has a time limit that is currently set as `validatorReexecuteDeadlineMs` time before the end of the next slot. The value of `validatorReexecuteDeadlineMs` is a configuration variable but is not currently updated anywhere from it's default of `6000`. 

This re-execution should actually be deadlined based on the block-building timetable. An issue has been created for this [here](https://linear.app/aztec-labs/issue/A-457/validators-should-use-timetable-to-govern-their-re-execution-deadline). 

The `6000` value is causing problems with the P2P end to end tests as it regularly causes re-execution timeout. This PR removes this value altogether so re-execution can occur all the way up to the end of the slot.
