### PR TITLE
refactor: move MSM points count division to transpile time

### DIFF
--- a/avm-transpiler/src/procedures/msm.rs
+++ b/avm-transpiler/src/procedures/msm.rs
@@ -2,7 +2,7 @@ pub(crate) const MSM_ASSEMBLY: &str = "
                 ; We are passed three pointers and one usize.
                 ; d0 points to the points. Points are represented by (x: Field, y: Field, is_infinite: bool)
                 ; d1 points to the scalars. Scalars are represented by (lo: Field, hi: Field) both range checked to 128 bits.
-                ; d2 contains the length of the points array. This will be the number of points * 3, since each point is represented by 3 fields.
+                ; d2 contains the number of points.
                 ; d3 points to the result. The result is a point.
                 ADD d3, /*the reserved register 'one_usize'*/ $2, d4; Compute the pointer to the result y.
                 ADD d4, $2, d5; Compute the pointer to the result is_infinite
@@ -20,7 +20,6 @@ pub(crate) const MSM_ASSEMBLY: &str = "
                 SET d12, 0 u1; Initialize a constant false
                 SET d13, 2 u32; Initialize a constant 2
                 SET d14, 3 u32; Initialize a constant 3 for computing pointers to the point components
-                DIV d2, d14, d2; Divide the length of the points array by 3 to get the number of points
                 ; Main loop: iterate over the points/scalars
 OUTER_HEAD:     LT d6, d2, d15 ; Check if we are done with the outer loop
                 JUMPI d15, OUTER_BODY

--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -1145,12 +1145,21 @@ fn generate_mov_to_procedure(source: &MemoryAddress, index: usize) -> AvmInstruc
         Some(
             AddressingModeBuilder::default()
                 .direct_operand(source)
-                .direct_operand(&MemoryAddress::Direct(target_address))
+                .direct_operand(&MemoryAddress::direct(target_address))
                 .build(),
         ),
         source.to_usize() as u32,
         target_address as u32,
     )
+}
+
+fn generate_set_to_procedure(
+    tag: AvmTypeTag,
+    value: &FieldElement,
+    index: usize,
+) -> AvmInstruction {
+    let target_address = SCRATCH_SPACE_START + index;
+    generate_set_instruction(tag, &MemoryAddress::direct(target_address), value, false)
 }
 
 fn generate_procedure_call(
@@ -1313,7 +1322,11 @@ fn handle_black_box_function(
 
             avm_instrs.push(generate_mov_to_procedure(&points.pointer, 0));
             avm_instrs.push(generate_mov_to_procedure(&scalars.pointer, 1));
-            avm_instrs.push(generate_mov_to_procedure(&points.size, 2));
+            avm_instrs.push(generate_set_to_procedure(
+                AvmTypeTag::UINT32,
+                &FieldElement::from(points.size),
+                2,
+            ));
             avm_instrs.push(generate_mov_to_procedure(&outputs.pointer, 3));
             avm_instrs.push(generate_procedure_call(
                 Procedure::MultiScalarMul,
@@ -1363,7 +1376,7 @@ fn handle_debug_log(
     };
     // Message
     let (message_offset, message_size) = match &inputs[1] {
-        ValueOrArray::HeapArray(HeapArray { pointer, size }) => (pointer, *size as u32),
+        ValueOrArray::HeapArray(HeapArray { pointer, size }) => (pointer, *size),
         _ => panic!("Message for ForeignCall::DEBUGLOG should be a HeapArray."),
     };
     // Length and pointer

--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -1319,12 +1319,13 @@ fn handle_black_box_function(
             // decomposition
             // Output array is fixed to 3
             assert_eq!(outputs.size, 3, "Output array size must be equal to 3");
+            assert!(points.size % 3 == 0, "Points array size must be divisible by 3");
 
             avm_instrs.push(generate_mov_to_procedure(&points.pointer, 0));
             avm_instrs.push(generate_mov_to_procedure(&scalars.pointer, 1));
             avm_instrs.push(generate_set_to_procedure(
                 AvmTypeTag::UINT32,
-                &FieldElement::from(points.size),
+                &FieldElement::from(points.size / 3),
                 2,
             ));
             avm_instrs.push(generate_mov_to_procedure(&outputs.pointer, 3));


### PR DESCRIPTION
Instead of passing the points array length to the MSM procedure and dividing by 3 at runtime, compute the number of points at transpile time. This eliminates a DIV instruction from the AVM procedure.