### PR TITLE
feat(avm): test avm-bulk with sanitizers CI job

### DIFF
--- a/.github/workflows/avm-test-bulk-with-sanitizers.yml
+++ b/.github/workflows/avm-test-bulk-with-sanitizers.yml
@@ -1,0 +1,30 @@
+name: Build AVM Test Bulk with Sanitizers Container
+
+on:
+  push:
+    branches:
+      - next
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Git commit SHA to build (leave empty for latest)"
+        required: false
+        default: ""
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Free up disk space on runner
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+
+      # It runs bulk test with ASAN and MSAN sanitizers during the build
+      - name: Check build
+        run: |
+          docker build -t avm-asan-container container-builds/avm-asan-container/

--- a/container-builds/avm-asan-container/Dockerfile
+++ b/container-builds/avm-asan-container/Dockerfile
@@ -1,0 +1,44 @@
+FROM aztecprotocol/build:3.0-amd64 AS builder
+
+ARG COMMIT=""
+
+# Install ldid (not included in build image, only in basebox)
+RUN curl -sL https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64 -o /usr/local/bin/ldid \
+    && chmod +x /usr/local/bin/ldid
+
+# Install Node.js 24 (build image has Node 22, but bootstrap requires 24)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y nodejs
+
+WORKDIR /root
+
+# Clone the repository
+RUN git clone https://github.com/AztecProtocol/aztec-packages.git --depth 1 --branch next && \
+    cd aztec-packages && \
+    if [ -n "$COMMIT" ]; then \
+        git fetch origin $COMMIT --depth 1; \
+        git checkout $COMMIT || exit 1; \
+    fi
+
+WORKDIR /root/aztec-packages
+
+# Run bootstrap up to yarn-project (release-image needs docker which isn't available)
+RUN BOOTSTRAP_TO=yarn-project ./bootstrap.sh
+
+WORKDIR /root/aztec-packages/barretenberg/cpp
+
+# Build AVM with ASAN and run AVM proven bulk test
+# If sanitizer reports errors, this will fail and the container will exit with a non-zero status
+RUN cmake . --preset=asan && \
+    cmake --build build-asan --target bb-avm && \
+    mv build-asan/bin/bb-avm build/bin/bb-avm && \
+    cd /root/aztec-packages/yarn-project/bb-prover && \
+    yarn test -t 'AVM proven bulk test' --verbose
+
+# Build AVM with MSAN and run AVM proven bulk test
+# If sanitizer reports errors, this will fail and the container will exit with a non-zero status
+RUN cmake . --preset=msan && \
+    cmake --build build-msan --target bb-avm && \
+    mv build-msan/bin/bb-avm build/bin/bb-avm && \
+    cd /root/aztec-packages/yarn-project/bb-prover && \
+    yarn test -t 'AVM proven bulk test' --verbose

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_bulk.test.ts
@@ -8,7 +8,7 @@ import path from 'path';
 
 import { AvmProvingTester } from './avm_proving_tester.js';
 
-const TIMEOUT = 180_000;
+const TIMEOUT = 1_800_000;
 
 describe('AVM proven bulk test', () => {
   const logger = createLogger('avm-bulk-test');


### PR DESCRIPTION
With https://github.com/AztecProtocol/aztec-packages/pull/19512 https://github.com/AztecProtocol/aztec-packages/pull/19507 we got worried about UBs

This PR introduces CI job which runs avm bulk test (see yarn-project/bb-prover) with ASAN and MSAN sanitizers