### PR TITLE
fix(avm): Fix relative addressing in fuzzer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.cpp
@@ -38,9 +38,7 @@ void ControlFlow::process_insert_simple_instruction_block(InsertSimpleInstructio
         return;
     }
     auto instruction_block = instruction_blocks->at(instruction.instruction_block_idx % instruction_blocks->size());
-    for (const auto& instr : instruction_block) {
-        current_block->process_instruction(instr);
-    }
+    current_block->process_instruction_block(instruction_block);
 }
 
 void ControlFlow::process_jump_to_new_block(JumpToNewBlock instruction)
@@ -55,9 +53,7 @@ void ControlFlow::process_jump_to_new_block(JumpToNewBlock instruction)
         instruction_blocks->at(instruction.target_program_block_instruction_block_idx % instruction_blocks->size());
     ProgramBlock* target_block = new ProgramBlock();
     current_block->finalize_with_jump(target_block);
-    for (const auto& instr : target_instruction_block) {
-        target_block->process_instruction(instr);
-    }
+    target_block->process_instruction_block(target_instruction_block);
     current_block = target_block;
 }
 
@@ -76,12 +72,8 @@ void ControlFlow::process_jump_if_to_new_block(JumpIfToNewBlock instruction)
     ProgramBlock* target_then_block = new ProgramBlock();
     ProgramBlock* target_else_block = new ProgramBlock();
     current_block->finalize_with_jump_if(target_then_block, target_else_block, instruction.condition_offset_index);
-    for (const auto& instr : target_then_instruction_block) {
-        target_then_block->process_instruction(instr);
-    }
-    for (const auto& instr : target_else_instruction_block) {
-        target_else_block->process_instruction(instr);
-    }
+    target_then_block->process_instruction_block(target_then_instruction_block);
+    target_else_block->process_instruction_block(target_else_instruction_block);
     current_block = target_then_block;
 }
 
@@ -178,9 +170,7 @@ void ControlFlow::process_insert_internal_call(InsertInternalCall instruction)
         instruction_blocks->at(instruction.target_program_block_instruction_block_idx % instruction_blocks->size());
     ProgramBlock* target_block = new ProgramBlock();
     current_block->insert_internal_call(target_block);
-    for (const auto& instr : target_instruction_block) {
-        target_block->process_instruction(instr);
-    }
+    target_block->process_instruction_block(target_instruction_block);
     target_block->caller = current_block;
     current_block = target_block;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp
@@ -2,9 +2,12 @@
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp"
+#include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/vm2/testing/instruction_builder.hpp"
 #include <vector>
+
+using InstructionBlock = bb::avm2::fuzzer::InstructionBlock;
 
 struct ReturnOptions {
     uint8_t return_size;
@@ -139,7 +142,7 @@ class ControlFlow {
     ProgramBlock* current_block;
     /// @brief the entry block of the program
     ProgramBlock* start_block;
-    std::vector<std::vector<FuzzInstruction>>* instruction_blocks;
+    std::vector<InstructionBlock>* instruction_blocks;
 
     /// @brief add instructions to the current block from the instruction block at the given index
     /// taken modulo length of the instruction blocks vector
@@ -200,7 +203,7 @@ class ControlFlow {
     std::vector<ProgramBlock*> get_reachable_blocks(ProgramBlock* block);
 
   public:
-    ControlFlow(std::vector<std::vector<FuzzInstruction>>& instruction_blocks)
+    ControlFlow(std::vector<InstructionBlock>& instruction_blocks)
         : current_block(new ProgramBlock())
         , start_block(current_block)
         , instruction_blocks(&instruction_blocks)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzz.test.cpp
@@ -81,7 +81,7 @@ class ArithmeticFuzzTest : public FuzzTest {
         auto instructions = std::vector<FuzzInstruction>{ set_instruction_1, set_instruction_2, instruction };
         auto return_options =
             ReturnOptions{ .return_size = 1, .return_value_tag = return_value_tag, .return_value_offset_index = 2 };
-        auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+        auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
         auto control_flow = ControlFlow(instruction_blocks);
         control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
         auto bytecode = control_flow.build_bytecode(return_options);
@@ -107,7 +107,7 @@ class ArithmeticFuzzTest : public FuzzTest {
 
         auto return_options =
             ReturnOptions{ .return_size = 1, .return_value_tag = return_value_tag, .return_value_offset_index = 2 };
-        auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+        auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
         auto control_flow = ControlFlow(instruction_blocks);
         control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
         auto bytecode = control_flow.build_bytecode(return_options);
@@ -274,7 +274,7 @@ TEST_F(ArithmeticFuzzTest, FDIV8)
 
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 2 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -297,7 +297,7 @@ TEST_F(ArithmeticFuzzTest, NOT8)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -463,7 +463,7 @@ TEST_F(ArithmeticFuzzTest, FDIV16)
 
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 2 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -486,7 +486,7 @@ TEST_F(ArithmeticFuzzTest, NOT16)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, not_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -517,7 +517,7 @@ TEST_F(FuzzTest, CAST8)
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U16, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -545,7 +545,7 @@ TEST_F(FuzzTest, CAST16)
     auto instructions = std::vector<FuzzInstruction>{ set_u16, set_u8, cast_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U16, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -567,7 +567,7 @@ TEST_F(FuzzTest, SET16)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U16, .return_value_offset_index = 0 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -586,7 +586,7 @@ TEST_F(FuzzTest, SET32)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U32, .return_value_offset_index = 0 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -606,7 +606,7 @@ TEST_F(FuzzTest, SET64)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U64, .return_value_offset_index = 0 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -631,7 +631,7 @@ TEST_F(FuzzTest, SET128)
     auto return_options = ReturnOptions{ .return_size = 1,
                                          .return_value_tag = bb::avm2::MemoryTag::U128,
                                          .return_value_offset_index = 0 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -651,7 +651,7 @@ TEST_F(FuzzTest, SETFF)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::FF, .return_value_offset_index = 0 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -679,7 +679,7 @@ TEST_F(FuzzTest, MOV8)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -708,7 +708,7 @@ TEST_F(FuzzTest, MOV16)
     auto instructions = std::vector<FuzzInstruction>{ set_instruction, set_instruction2, mov_instruction };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U16, .return_value_offset_index = 1 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(return_options);
@@ -733,18 +733,18 @@ class ControlFlowFuzzTest : public FuzzTest {
         auto set_instruction_block_1 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
                                                           .result_address = AddressRef{ .address = 1 },
                                                           .value = first_boolean_value };
-        auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
+        auto instruction_block_1 = InstructionBlock{ .instructions = { set_instruction_block_1 } };
         auto set_instruction_block_2 = SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
                                                           .result_address = AddressRef{ .address = 2 },
                                                           .value = second_boolean_value };
-        auto instruction_block_2 = std::vector<FuzzInstruction>{ set_instruction_block_2 };
-        auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instruction_block_1, instruction_block_2 };
+        auto instruction_block_2 = InstructionBlock{ .instructions = { set_instruction_block_2 } };
+        auto instruction_blocks = std::vector<InstructionBlock>{ instruction_block_1, instruction_block_2 };
         for (uint8_t i = 2; i < 5; i++) {
             auto set_instruction =
                 SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U8,
                                    .result_address = AddressRef{ .address = i, .mode = AddressingMode::Direct },
                                    .value = i };
-            instruction_blocks.push_back({ set_instruction });
+            instruction_blocks.push_back(InstructionBlock{ .instructions = { set_instruction } });
         }
         auto return_options = ReturnOptions{ .return_size = 1,
                                              .return_value_tag = bb::avm2::MemoryTag::U8,
@@ -769,17 +769,18 @@ class ControlFlowFuzzTest : public FuzzTest {
     //    nop  ----→  return 2
     FF simulate_jump_to_block_helper(uint8_t condition_value)
     {
-        auto set_instruction_block_1 =
-            SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                               .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
-                               .value = condition_value };
-        auto set_return_value_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
-            .value_tag = bb::avm2::MemoryTag::U8,
-            .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-            .value = 2 } };
-        auto instruction_block_1 = std::vector<FuzzInstruction>{ set_instruction_block_1 };
+        auto set_return_value_block =
+            InstructionBlock{ .instructions = { SET_8_Instruction{
+                                  .value_tag = bb::avm2::MemoryTag::U8,
+                                  .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                                  .value = 2 } } };
+        auto instruction_block_1 =
+            InstructionBlock{ .instructions = { SET_8_Instruction{
+                                  .value_tag = bb::avm2::MemoryTag::U1,
+                                  .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                                  .value = condition_value } } };
         auto instruction_blocks =
-            std::vector<std::vector<FuzzInstruction>>{ instruction_block_1, {}, set_return_value_block };
+            std::vector<InstructionBlock>{ instruction_block_1, InstructionBlock(), set_return_value_block };
         auto return_options = ReturnOptions{ .return_size = 1,
                                              .return_value_tag = bb::avm2::MemoryTag::U8,
                                              .return_value_offset_index = 1 };
@@ -802,15 +803,17 @@ class ControlFlowFuzzTest : public FuzzTest {
 // block2 set return value 11 and return return value
 TEST_F(ControlFlowFuzzTest, JumpToNewBlockSmoke)
 {
-    auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 10 } };
-    auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 11 } };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions };
+    auto block1_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 10 } } };
+    auto block2_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 11 } } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ block1_instructions, block2_instructions };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -829,20 +832,23 @@ TEST_F(ControlFlowFuzzTest, JumpToNewBlockSmoke)
 // block3 set return value 12 and return return value
 TEST_F(ControlFlowFuzzTest, JumpToNewBlockSmoke2)
 {
-    auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 10 } };
-    auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 11 } };
-    auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 12 } };
+    auto block1_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 10 } } };
+    auto block2_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 11 } } };
+    auto block3_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 12 } } };
     auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ block1_instructions, block2_instructions, block3_instructions };
+        std::vector<InstructionBlock>{ block1_instructions, block2_instructions, block3_instructions };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -861,12 +867,12 @@ TEST_F(ControlFlowFuzzTest, JumpToNewBlockSmoke2)
 // if blocks does not share defined variables, block2 will return 0
 TEST_F(ControlFlowFuzzTest, JumpToNewBlockSharesVariables)
 {
-    auto block1_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 10 } };
+    auto block1 = InstructionBlock{ .instructions = { SET_8_Instruction{
+                                        .value_tag = bb::avm2::MemoryTag::U8,
+                                        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                                        .value = 10 } } };
 
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ block1_instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ block1 };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -883,25 +889,28 @@ TEST_F(ControlFlowFuzzTest, JumpToNewBlockSharesVariables)
 // return 11    return 12
 TEST_F(ControlFlowFuzzTest, JumpIfToNewBlockSmoke)
 {
-    auto set_true_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
-        .value = 1 } };
-    auto set_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
-        .value = 0 } };
-    auto block2_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 11 } };
-    auto block3_instructions = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U8,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = 12 } };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
-        set_true_block, set_false_block, block2_instructions, block3_instructions
-    };
+    auto set_true_block =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U1,
+                              .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                              .value = 1 } } };
+    auto set_false_block =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U1,
+                              .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
+                              .value = 0 } } };
+    auto block2_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 11 } } };
+    auto block3_instructions =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U8,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = 12 } } };
+    auto instruction_blocks =
+        std::vector<InstructionBlock>{ set_true_block, set_false_block, block2_instructions, block3_instructions };
     auto return_options =
         ReturnOptions{ .return_size = 1, .return_value_tag = bb::avm2::MemoryTag::U8, .return_value_offset_index = 1 };
     auto control_flow = ControlFlow(instruction_blocks);
@@ -947,29 +956,31 @@ TEST_F(ControlFlowFuzzTest, JumpToBlockSmoke)
 TEST_F(ControlFlowFuzzTest, JumpIfToNewBlockWithReturn)
 {
     // Block 0: Set condition (U1)
-    auto set_condition_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
-        .value = 1 } };
+    auto set_condition_block =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U1,
+                              .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                              .value = 1 } } };
 
     // Block 1: Set FF value
     const bb::avm2::FF ff_value = bb::avm2::FF(123456789);
-    auto set_ff_block = std::vector<FuzzInstruction>{ SET_FF_Instruction{
-        .value_tag = bb::avm2::MemoryTag::FF,
-        .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
-        .value = ff_value } };
+    auto set_ff_block =
+        InstructionBlock{ .instructions = { SET_FF_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::FF,
+                              .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
+                              .value = ff_value } } };
 
     // Block 2: Set U128 value
     const uint64_t u128_value_low = 0xFEDCBA9876543210ULL;
     const uint64_t u128_value_high = 0x123456789ABCDEF0ULL;
-    auto set_u128_block = std::vector<FuzzInstruction>{ SET_128_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U128,
-        .result_address = AddressRef{ .address = 20, .mode = AddressingMode::Direct },
-        .value_low = u128_value_low,
-        .value_high = u128_value_high } };
+    auto set_u128_block =
+        InstructionBlock{ .instructions = { SET_128_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U128,
+                              .result_address = AddressRef{ .address = 20, .mode = AddressingMode::Direct },
+                              .value_low = u128_value_low,
+                              .value_high = u128_value_high } } };
 
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ set_condition_block, set_ff_block, set_u128_block };
+    auto instruction_blocks = std::vector<InstructionBlock>{ set_condition_block, set_ff_block, set_u128_block };
 
     auto control_flow = ControlFlow(instruction_blocks);
 
@@ -1011,12 +1022,13 @@ TEST_F(ControlFlowFuzzTest, JumpIfToNewBlockWithReturn)
     EXPECT_EQ(result_true.output.at(0), ff_value);
 
     // Test with condition = false (should return U128 value)
-    auto set_condition_false_block = std::vector<FuzzInstruction>{ SET_8_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U1,
-        .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
-        .value = 0 } };
+    auto set_condition_false_block =
+        InstructionBlock{ .instructions = { SET_8_Instruction{
+                              .value_tag = bb::avm2::MemoryTag::U1,
+                              .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                              .value = 0 } } };
     auto instruction_blocks_false =
-        std::vector<std::vector<FuzzInstruction>>{ set_condition_false_block, set_ff_block, set_u128_block };
+        std::vector<InstructionBlock>{ set_condition_false_block, set_ff_block, set_u128_block };
 
     auto control_flow_false = ControlFlow(instruction_blocks_false);
     control_flow_false.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
@@ -1065,11 +1077,11 @@ TEST_F(FuzzTest, SstoreThenSload)
                            .result_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
                            .value = 11 };
 
-    auto set_sstore_sload_block = std::vector<FuzzInstruction>{
-        set_value_instruction, sstore_instruction, sload_instruction, set_value_instruction2
+    auto set_sstore_sload_block = InstructionBlock{
+        .instructions = { set_value_instruction, sstore_instruction, sload_instruction, set_value_instruction2 }
     };
 
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ set_sstore_sload_block };
+    auto instruction_blocks = std::vector<InstructionBlock>{ set_sstore_sload_block };
     // FF should be set via sload instruction
     auto return_options = ReturnOptions{ .return_size = 1,
                                          .return_value_tag = bb::avm2::MemoryTag::FF,
@@ -1092,7 +1104,8 @@ class ExecutionEnvironmentFuzzTest : public FuzzTest {
         auto getenvvar_instruction =
             GETENVVAR_Instruction{ .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                    .type = type };
-        auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { getenvvar_instruction } };
+        auto instruction_blocks =
+            std::vector<InstructionBlock>{ InstructionBlock{ .instructions = { getenvvar_instruction } } };
         auto control_flow = ControlFlow(instruction_blocks);
         control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
         auto return_options =
@@ -1107,7 +1120,7 @@ class ExecutionEnvironmentFuzzTest : public FuzzTest {
 TEST_F(ExecutionEnvironmentFuzzTest, GetEnvVarSmoke)
 {
     EXPECT_EQ(getenvvar_helper(0),
-              FF("0x02fea672ef18fe4b8d13dcfd8943797c99b9885da7b338d224dd5136a0cc8a6f")); // address with bytecode
+              FF("0x0dcd235d388105fa4154fc2d1c0143686d5da4d4aa9826d8f6609a02dc2d7c56")); // address with bytecode
     EXPECT_EQ(getenvvar_helper(1), MSG_SENDER);                                          // sender, see simulator.cpp
     EXPECT_EQ(getenvvar_helper(2), TRANSACTION_FEE);                   // transaction fee, see simulator.cpp
     EXPECT_EQ(getenvvar_helper(3), CHAIN_ID);                          // chain id, see simulator.cpp globals
@@ -1117,8 +1130,9 @@ TEST_F(ExecutionEnvironmentFuzzTest, GetEnvVarSmoke)
     EXPECT_EQ(getenvvar_helper(7), FEE_PER_L2_GAS);                    // FEEPERL2GAS = 1, see simulator.cpp gas_fees
     EXPECT_EQ(getenvvar_helper(8), FEE_PER_DA_GAS);                    // FEEPERDAGAS = 1, see simulator.cpp gas_fees
     EXPECT_EQ(getenvvar_helper(9), 0);                                 // is static call is always false
-    EXPECT_EQ(getenvvar_helper(10), GAS_LIMIT.l2_gas - 2 * 6);         // L2GASLEFT, gas spent on getenvvar + return
-    EXPECT_EQ(getenvvar_helper(11), GAS_LIMIT.da_gas);                 // DAGASLEFT, see simulator.cpp
+    EXPECT_EQ(getenvvar_helper(10),
+              GAS_LIMIT.l2_gas - AVM_SET_BASE_L2_GAS - 2 * 6); // L2GASLEFT, gas spent on set + getenvvar + return
+    EXPECT_EQ(getenvvar_helper(11), GAS_LIMIT.da_gas);         // DAGASLEFT, see simulator.cpp
 }
 } // namespace execution_environment
 
@@ -1137,9 +1151,8 @@ TEST_F(FuzzTest, EmitNullifierThenNullifierExists)
         .contract_address_address = AddressRef{ .address = 10, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 20, .mode = AddressingMode::Direct }
     };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
-        { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
-    };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(ReturnOptions{
@@ -1162,9 +1175,8 @@ TEST_F(FuzzTest, EmitNullifierThenNullifierExistsOverwritingPreviousNullifier)
         .contract_address_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct }
     }; // GETENVVAR overwrites previous nullifier
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
-        { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction }
-    };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, emit_nullifier_instruction, nullifier_exists_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1183,8 +1195,8 @@ TEST_F(FuzzTest, EmitNoteHashThenNoteHashExists)
                                     .notehash_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                     .leaf_index_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                                     .result_address = AddressRef{ .address = 2, .mode = AddressingMode::Direct } };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { emit_note_hash_instruction, note_hash_exists_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { emit_note_hash_instruction, note_hash_exists_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1208,7 +1220,8 @@ TEST_F(FuzzTest, CopyCalldataThenReturnData)
                                                               .copy_size_address = AddressRef{ .address = 1 },
                                                               .cd_start = 0,
                                                               .cd_start_address = AddressRef{ .address = 2 } };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { calldatacopy_instruction } };
+    auto instruction_blocks =
+        std::vector<InstructionBlock>{ InstructionBlock{ .instructions = { calldatacopy_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1230,8 +1243,8 @@ TEST_F(FuzzTest, InternalCall)
                             .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2 } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_field_instruction2 } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     control_flow.process_cfg_instruction(internal_call_instruction);
@@ -1256,8 +1269,8 @@ TEST_F(FuzzTest, InternalCalledBlockUsesInternalReturn)
                            .result_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct },
                            .value = 1 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_boolean_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_boolean_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 1 });
     control_flow.process_cfg_instruction(internal_call_instruction);
@@ -1291,9 +1304,8 @@ TEST_F(FuzzTest, SeveralInternalCalls)
                             .value = 313373 };
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
-        { set_field_instruction, set_field_instruction2, set_field_instruction3 }
-    };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_field_instruction2, set_field_instruction3 } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     control_flow.process_cfg_instruction(internal_call_instruction);
@@ -1342,9 +1354,8 @@ TEST_F(FuzzTest, Reentrancy)
     auto internal_call_instruction = InsertInternalCall{ .target_program_block_instruction_block_idx = 1 };
     auto internal_call_instruction2 = InsertInternalCall{ .target_program_block_instruction_block_idx = 2 };
     auto internal_call_instruction3 = InsertInternalCall{ .target_program_block_instruction_block_idx = 3 };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{
-        { set_field_instruction0, set_field_instruction1, set_field_instruction2, set_field_instruction3 }
-    };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        { set_field_instruction0, set_field_instruction1, set_field_instruction2, set_field_instruction3 } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     // call f1
@@ -1393,8 +1404,8 @@ TEST_F(FuzzTest, DirectWithIndirect)
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
     };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_field_instruction2, add_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1417,13 +1428,12 @@ TEST_F(FuzzTest, DirectWithIndirectRelative)
         .a_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF,
                                   .index = 1,
                                   .pointer_address_seed = 100,
-                                  .base_offset_seed = 100,
                                   .mode = AddressingMode::IndirectRelative },
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 0, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 130, .mode = AddressingMode::Direct }
     };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_field_instruction2, add_instruction }, .base_offset = 100 } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1448,8 +1458,8 @@ TEST_F(FuzzTest, IndirectResultCanBeUsedInNextInstruction)
         .b_address = VariableRef{ .tag = bb::avm2::MemoryTag::FF, .index = 1, .mode = AddressingMode::Direct },
         .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct }
     };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, add_instruction, mul_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, add_instruction, mul_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1477,8 +1487,8 @@ TEST_F(FuzzTest, Memoryaddressing32BitWidth)
                                   .mode = AddressingMode::Indirect },
         .result_address = AddressRef{ .address = 150, .mode = AddressingMode::Direct }
     };
-    auto instruction_blocks =
-        std::vector<std::vector<FuzzInstruction>>{ { set_field_instruction, set_field_instruction2, add_instruction } };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{
+        .instructions = { set_field_instruction, set_field_instruction2, add_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1497,7 +1507,8 @@ TEST_F(FuzzTest, SendL2ToL1Msg)
                                    .recipient_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
                                    .content = 200,
                                    .content_address = AddressRef{ .address = 1, .mode = AddressingMode::Direct } };
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ { sendl2tol1msg_instruction } };
+    auto instruction_blocks =
+        std::vector<InstructionBlock>{ InstructionBlock{ .instructions = { sendl2tol1msg_instruction } } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1524,7 +1535,7 @@ TEST_F(FuzzTest, EmitUnencryptedLog)
     instructions.push_back(EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = log_size_address,
                                                            .log_values_address = log_values_address });
 
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1551,7 +1562,7 @@ class ExternalCallsFuzzTest : public FuzzTest {
             .member_enum = member_enum,
             .dst_address = AddressRef{ .address = 124, .mode = AddressingMode::Direct } });
 
-        auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+        auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
         auto control_flow = ControlFlow(instruction_blocks);
         control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
         auto bytecode = control_flow.build_bytecode(
@@ -1596,7 +1607,7 @@ TEST_F(ExternalCallsFuzzTest, ExternalCallToAdd8)
     instructions.push_back(RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction{
         .copy_size_offset = 6, .dst_address = 7, .rd_start = 0, .rd_start_offset = 8 });
 
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1650,7 +1661,7 @@ TEST_F(ExternalCallsFuzzTest, SuccessCopy)
 
     instructions.push_back(
         SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1693,7 +1704,7 @@ TEST_F(ExternalCallsFuzzTest, CallToZeroDivisionSuccessCopy)
                                              .is_static_call = true });
     instructions.push_back(
         SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(
@@ -1735,7 +1746,7 @@ TEST_F(ExternalCallsFuzzTest, StaticCallToNonStaticFunctionSuccessCopy)
                                              .is_static_call = true });
     instructions.push_back(
         SUCCESSCOPY_Instruction{ .dst_address = AddressRef{ .address = 6, .mode = AddressingMode::Direct } });
-    auto instruction_blocks = std::vector<std::vector<FuzzInstruction>>{ instructions };
+    auto instruction_blocks = std::vector<InstructionBlock>{ InstructionBlock{ instructions } };
     auto control_flow = ControlFlow(instruction_blocks);
     control_flow.process_cfg_instruction(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     auto bytecode = control_flow.build_bytecode(

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_data.hpp
@@ -1,34 +1,30 @@
 #pragma once
 
 #include <cstdint>
+#include <iostream>
 #include <vector>
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/control_flow.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
+#include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 
 /// @brief describes the data which will be used for fuzzing
 /// Should contain instructions, calldata, CFG instructions, options to disable/enable instructions, etc
 struct FuzzerData {
-    std::vector<std::vector<FuzzInstruction>> instruction_blocks;
+    std::vector<InstructionBlock> instruction_blocks;
     std::vector<CFGInstruction> cfg_instructions;
     std::vector<bb::avm2::FF> calldata;
     ReturnOptions return_options;
     MSGPACK_FIELDS(instruction_blocks, cfg_instructions, calldata, return_options);
 };
 
-#include <iostream>
-
 inline std::ostream& operator<<(std::ostream& os, const FuzzerData& data)
 {
     os << "FuzzerData {\n";
     os << "  instructions: [\n";
     for (const auto& block : data.instruction_blocks) {
-        os << "    [\n";
-        for (const auto& instr : block) {
-            os << "      " << instr << ",\n";
-        }
-        os << "    ],\n";
+        os << "    " << block << ",\n";
     }
     os << "  ],\n";
     os << "  cfg_instructions: [\n";

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -105,13 +105,9 @@ struct VariableRef {
     /// Used for Indirect/IndirectRelative modes only
     uint16_t pointer_address_seed = 0;
 
-    /// @brief A seed for the generation of the base offset
-    /// Used for Relative/IndirectRelative modes only
-    /// Sets M[0] = base_offset
-    uint32_t base_offset_seed = 0;
     AddressingModeWrapper mode = AddressingMode::Direct;
 
-    MSGPACK_FIELDS(tag, index, pointer_address_seed, base_offset_seed, mode);
+    MSGPACK_FIELDS(tag, index, pointer_address_seed, mode);
 };
 
 struct AddressRef {
@@ -121,12 +117,8 @@ struct AddressRef {
     /// Used for Indirect/IndirectRelative modes only
     uint16_t pointer_address_seed = 0;
 
-    /// @brief A seed for the generation of the base offset
-    /// Used for Relative/IndirectRelative modes only
-    /// Sets M[0] = base_offset
-    uint32_t base_offset_seed = 0;
     AddressingModeWrapper mode = AddressingMode::Direct;
-    MSGPACK_FIELDS(address, pointer_address_seed, base_offset_seed, mode);
+    MSGPACK_FIELDS(address, pointer_address_seed, mode);
 };
 
 using ParamRef = std::variant<VariableRef, AddressRef>;
@@ -138,9 +130,20 @@ using ParamRef = std::variant<VariableRef, AddressRef>;
 struct ResolvedAddress {
     uint32_t absolute_address = 0;
     uint32_t operand_address = 0;
-    std::optional<uint32_t> base_pointer = std::nullopt;
     std::optional<uint32_t> pointer_address = std::nullopt;
+    bool via_relative = false;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const ResolvedAddress& address)
+{
+    os << "ResolvedAddress {\n";
+    os << "  absolute_address: " << address.absolute_address << ",\n";
+    os << "  operand_address: " << address.operand_address << ",\n";
+    os << "  pointer_address: " << address.pointer_address.value() << ",\n";
+    os << "  via_relative: " << address.via_relative << ",\n";
+    os << "}";
+    return os;
+}
 
 /// @brief mem[result_offset] = mem[a_address] + mem[b_address]
 struct ADD_8_Instruction {
@@ -715,7 +718,7 @@ inline std::ostream& operator<<(std::ostream& os, const MemoryTagWrapper& tag)
 
 inline std::ostream& operator<<(std::ostream& os, const VariableRef& variable)
 {
-    os << "VariableRef " << variable.tag << " " << variable.index << " " << variable.base_offset_seed << " "
+    os << "VariableRef " << variable.tag << " " << variable.index << " "
        << static_cast<int>(static_cast<AddressingMode>(variable.mode));
     return os;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
@@ -30,13 +30,29 @@ std::optional<std::ranges::range_value_t<Range>> get_nth_filtered(Range&& range,
     return *std::ranges::next(filtered.begin(), static_cast<long>(index % static_cast<size_t>(count)));
 }
 
-uint32_t get_max_variable_address(AddressingMode mode, uint32_t literal_max_value)
+uint32_t get_max_variable_address(AddressingMode mode, uint32_t base_offset, uint32_t max_operand_address)
 {
-    if (mode == AddressingMode::Direct) {
-        return literal_max_value;
+    switch (mode) {
+    case AddressingMode::Direct:
+        return max_operand_address;
+    case AddressingMode::Relative:
+        return base_offset + max_operand_address;
+    case AddressingMode::Indirect:
+    case AddressingMode::IndirectRelative:
+        return AVM_HIGHEST_MEM_ADDRESS;
     }
-    // In relative addressing, and indirect addressing, we can reach any variable address.
-    return AVM_HIGHEST_MEM_ADDRESS;
+}
+
+uint32_t get_min_variable_address(AddressingMode mode, uint32_t base_offset)
+{
+    switch (mode) {
+    case AddressingMode::Relative:
+        return base_offset;
+    case AddressingMode::Direct:
+    case AddressingMode::Indirect:
+    case AddressingMode::IndirectRelative:
+        return 0;
+    }
 }
 
 uint32_t trimmed_pointer_address(uint32_t pointer_address_seed, uint32_t max_operand_address)
@@ -44,17 +60,11 @@ uint32_t trimmed_pointer_address(uint32_t pointer_address_seed, uint32_t max_ope
     return pointer_address_seed % (max_operand_address + 1);
 }
 
-uint32_t trimmed_relative_operand_address(uint32_t base_offset_seed,
-                                          uint32_t relative_target,
+uint32_t trimmed_relative_pointer_address(uint32_t pointer_address_seed,
+                                          uint32_t base_offset,
                                           uint32_t max_operand_address)
 {
-    uint32_t max_operand = std::min(relative_target, max_operand_address);
-    return (base_offset_seed % (max_operand + 1));
-}
-
-uint32_t trimmed_base_pointer(uint32_t base_offset_seed, uint32_t relative_target, uint32_t max_operand_address)
-{
-    return relative_target - trimmed_relative_operand_address(base_offset_seed, relative_target, max_operand_address);
+    return base_offset + (pointer_address_seed % (max_operand_address + 1));
 }
 
 } // namespace
@@ -107,19 +117,20 @@ ResolvedAddress MemoryManager::resolve_address(VariableRef variable,
         break;
     }
     case AddressingMode::Relative:
-        resolved_address.base_pointer =
-            trimmed_base_pointer(variable.base_offset_seed, absolute_address, max_operand_address);
-        resolved_address.operand_address =
-            trimmed_relative_operand_address(variable.base_offset_seed, absolute_address, max_operand_address);
+        // TODO(Alvaro): Maybe delete this or prevent wraparound
+        BB_ASSERT_LTE(absolute_address, base_offset + max_operand_address);
+        resolved_address.operand_address = absolute_address - base_offset;
+        resolved_address.via_relative = true;
         break;
-    case AddressingMode::IndirectRelative:
-        resolved_address.pointer_address = variable.pointer_address_seed;
+    case AddressingMode::IndirectRelative: {
+        uint32_t trimmed_pointer_address_value =
+            trimmed_relative_pointer_address(variable.pointer_address_seed, base_offset, max_operand_address);
+        resolved_address.pointer_address = trimmed_pointer_address_value;
         // Relative addressing target is the pointer
-        resolved_address.base_pointer =
-            trimmed_base_pointer(variable.base_offset_seed, variable.pointer_address_seed, max_operand_address);
-        resolved_address.operand_address = trimmed_relative_operand_address(
-            variable.base_offset_seed, variable.pointer_address_seed, max_operand_address);
+        resolved_address.operand_address = trimmed_pointer_address_value - base_offset;
+        resolved_address.via_relative = true;
         break;
+    }
     case AddressingMode::Direct:
         // We can't change the absolute address, or it won't find anything useful there.
         resolved_address.operand_address = absolute_address;
@@ -136,7 +147,7 @@ ResolvedAddress MemoryManager::resolve_address(AddressRef address, uint32_t max_
     };
     switch (address.mode) {
     case AddressingMode::Indirect: {
-        // Trim the pointer to 16 bits for it to be writable by SET_32
+        // Trim the pointer to max_operand_address bits for it to be reachable by the instruction
         uint32_t trimmed_pointer_address_value =
             trimmed_pointer_address(address.pointer_address_seed, max_operand_address);
         resolved_address.pointer_address = trimmed_pointer_address_value;
@@ -144,22 +155,24 @@ ResolvedAddress MemoryManager::resolve_address(AddressRef address, uint32_t max_
         break;
     }
     case AddressingMode::Relative:
-        resolved_address.base_pointer =
-            trimmed_base_pointer(address.base_offset_seed, resolved_address.absolute_address, max_operand_address);
-        resolved_address.operand_address = trimmed_relative_operand_address(
-            address.base_offset_seed, resolved_address.absolute_address, max_operand_address);
+        // TODO(Alvaro): Maybe delete this or prevent wraparound
+        BB_ASSERT_LTE(address.address, base_offset + max_operand_address);
+        resolved_address.operand_address = address.address - base_offset;
+        resolved_address.via_relative = true;
         break;
-    case AddressingMode::IndirectRelative:
-        resolved_address.pointer_address = address.pointer_address_seed;
+    case AddressingMode::IndirectRelative: {
         // Relative addressing target is the pointer
-        resolved_address.base_pointer =
-            trimmed_base_pointer(address.base_offset_seed, address.pointer_address_seed, max_operand_address);
-        resolved_address.operand_address = trimmed_relative_operand_address(
-            address.base_offset_seed, address.pointer_address_seed, max_operand_address);
+        uint32_t trimmed_pointer_address_value =
+            trimmed_relative_pointer_address(address.pointer_address_seed, base_offset, max_operand_address);
+        resolved_address.pointer_address = trimmed_pointer_address_value;
+
+        resolved_address.operand_address = trimmed_pointer_address_value - base_offset;
+        resolved_address.via_relative = true;
         break;
+    }
     case AddressingMode::Direct:
         // Do not delete this assert, if it fails, it means that some address was generated / mutated incorrectly in
-        // instruction.cpp. Check all the `max_operand` parameters that you're passing to generate_address_ref.
+        // instruction_block.cpp. Check all the `max_operand` parameters that you're passing to generate_address_ref.
         BB_ASSERT_LTE(address.address, max_operand_address);
         resolved_address.operand_address = resolved_address.absolute_address;
         break;
@@ -197,7 +210,10 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
 std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
     get_resolved_address_and_operand_8(VariableRef address)
 {
-    auto actual_address = get_variable_address(address.tag, address.index, get_max_variable_address(address.mode, 255));
+    auto actual_address = get_variable_address(address.tag,
+                                               address.index,
+                                               get_min_variable_address(address.mode, base_offset),
+                                               get_max_variable_address(address.mode, base_offset, 255));
     if (!actual_address.has_value()) {
         return std::nullopt;
     }
@@ -214,6 +230,9 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
     get_resolved_address_and_operand_8(AddressRef address)
 {
     auto resolved_address = resolve_address(address, 255);
+
+    BB_ASSERT_LTE(resolved_address.operand_address, uint32_t{ 255 });
+
     auto operand = OperandBuilder::from<uint8_t>(static_cast<uint8_t>(resolved_address.operand_address));
     return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
@@ -229,8 +248,10 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
 std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> MemoryManager::
     get_resolved_address_and_operand_16(VariableRef address)
 {
-    auto actual_address =
-        get_variable_address(address.tag, address.index, get_max_variable_address(address.mode, 65535));
+    auto actual_address = get_variable_address(address.tag,
+                                               address.index,
+                                               get_min_variable_address(address.mode, base_offset),
+                                               get_max_variable_address(address.mode, base_offset, 65535));
     if (!actual_address.has_value()) {
         return std::nullopt;
     }
@@ -246,18 +267,26 @@ std::optional<std::pair<ResolvedAddress, bb::avm2::testing::OperandBuilder>> Mem
     get_resolved_address_and_operand_16(AddressRef address)
 {
     auto resolved_address = resolve_address(address, 65535);
+    BB_ASSERT_LTE(resolved_address.operand_address, uint32_t{ 65535 });
+
     auto operand = OperandBuilder::from<uint16_t>(static_cast<uint16_t>(resolved_address.operand_address));
     return std::make_pair(resolved_address, get_memory_address_operand(operand, address.mode));
 }
 
-std::optional<uint32_t> MemoryManager::get_variable_address(bb::avm2::MemoryTag tag, uint32_t index, uint32_t max_value)
+std::optional<uint32_t> MemoryManager::get_variable_address(bb::avm2::MemoryTag tag,
+                                                            uint32_t index,
+                                                            uint32_t min_value,
+                                                            uint32_t max_value)
 {
-    return get_nth_filtered(this->stored_variables[tag], [max_value](uint32_t val) { return val <= max_value; }, index);
+    return get_nth_filtered(
+        this->stored_variables[tag],
+        [min_value, max_value](uint32_t val) { return val >= min_value && val <= max_value; },
+        index);
 }
 
 std::optional<uint8_t> MemoryManager::get_memory_offset_8(bb::avm2::MemoryTag tag, uint32_t index)
 {
-    auto value = get_variable_address(tag, index, 255);
+    auto value = get_variable_address(tag, index, 0, 255);
     if (!value.has_value()) {
         return std::nullopt;
     }
@@ -267,7 +296,7 @@ std::optional<uint8_t> MemoryManager::get_memory_offset_8(bb::avm2::MemoryTag ta
 
 std::optional<uint16_t> MemoryManager::get_memory_offset_16(bb::avm2::MemoryTag tag, uint32_t index)
 {
-    auto value = get_variable_address(tag, index, 65535);
+    auto value = get_variable_address(tag, index, 0, 65535);
     if (!value.has_value()) {
         return std::nullopt;
     }
@@ -307,4 +336,9 @@ std::optional<uint16_t> MemoryManager::get_leaf_index(uint16_t note_hash_index)
         return std::nullopt;
     }
     return note_hash_index % emitted_note_hashes.size();
+}
+
+void MemoryManager::set_base_offset(uint32_t base_offset)
+{
+    this->base_offset = base_offset;
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.cpp
@@ -117,7 +117,6 @@ ResolvedAddress MemoryManager::resolve_address(VariableRef variable,
         break;
     }
     case AddressingMode::Relative:
-        // TODO(Alvaro): Maybe delete this or prevent wraparound
         BB_ASSERT_LTE(absolute_address, base_offset + max_operand_address);
         resolved_address.operand_address = absolute_address - base_offset;
         resolved_address.via_relative = true;
@@ -155,7 +154,6 @@ ResolvedAddress MemoryManager::resolve_address(AddressRef address, uint32_t max_
         break;
     }
     case AddressingMode::Relative:
-        // TODO(Alvaro): Maybe delete this or prevent wraparound
         BB_ASSERT_LTE(address.address, base_offset + max_operand_address);
         resolved_address.operand_address = address.address - base_offset;
         resolved_address.via_relative = true;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
@@ -25,7 +25,12 @@ class MemoryManager {
                                                                  AddressingMode mode);
     ResolvedAddress resolve_address(VariableRef address, uint32_t absolute_address, uint32_t max_operand_address);
     ResolvedAddress resolve_address(AddressRef address, uint32_t max_operand_address);
-    std::optional<uint32_t> get_variable_address(bb::avm2::MemoryTag tag, uint32_t index, uint32_t max_value);
+    std::optional<uint32_t> get_variable_address(bb::avm2::MemoryTag tag,
+                                                 uint32_t index,
+                                                 uint32_t min_value,
+                                                 uint32_t max_value);
+
+    uint32_t base_offset = 0;
 
   public:
     MemoryManager() = default;
@@ -57,11 +62,13 @@ class MemoryManager {
     // Get slot from storage_addresses
     std::optional<bb::avm2::FF> get_slot(uint16_t slot_offset_index);
 
-    // Append emitted note hash to emitted_note_hashes
+    // Append emitted note hash to emitted_note_hashesget_variable_address
     void append_emitted_note_hash(bb::avm2::FF note_hash);
     // Get emitted note hash from emitted_note_hashes
     std::optional<bb::avm2::FF> get_emitted_note_hash(uint16_t note_hash_index);
     // Get leaf index from emitted_note_hashes, nullopt if emitted_note_hashes is empty
     // note_hash_index % length(emitted_note_hashes)
     std::optional<uint16_t> get_leaf_index(uint16_t note_hash_index);
+
+    void set_base_offset(uint32_t base_offset);
 };

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp
@@ -62,7 +62,7 @@ class MemoryManager {
     // Get slot from storage_addresses
     std::optional<bb::avm2::FF> get_slot(uint16_t slot_offset_index);
 
-    // Append emitted note hash to emitted_note_hashesget_variable_address
+    // Append emitted note hash to emitted_note_hashes
     void append_emitted_note_hash(bb::avm2::FF note_hash);
     // Get emitted note hash from emitted_note_hashes
     std::optional<bb::avm2::FF> get_emitted_note_hash(uint16_t note_hash_index);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
@@ -11,21 +11,11 @@
 
 void ProgramBlock::preprocess_memory_addresses(ResolvedAddress resolved_address)
 {
-    if (resolved_address.base_pointer.has_value()) {
-        auto set_base_offset_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
-                                               .operand(static_cast<uint16_t>(0))
-                                               .operand(bb::avm2::MemoryTag::U32)
-                                               .operand(resolved_address.base_pointer.value())
-                                               .build();
-        instructions.push_back(set_base_offset_instruction);
-        memory_manager.set_memory_address(bb::avm2::ValueTag::U32, 0U);
-    }
     if (resolved_address.pointer_address.has_value()) {
-        if (resolved_address.base_pointer.has_value()) {
+        if (resolved_address.via_relative) {
             // Indirect relative: Write the pointer in a relative manner
             auto set_pointer_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::SET_32)
-                                               .operand(static_cast<uint16_t>(resolved_address.pointer_address.value() -
-                                                                              resolved_address.base_pointer.value()))
+                                               .operand(static_cast<uint16_t>(resolved_address.operand_address))
                                                .relative()
                                                .operand(bb::avm2::MemoryTag::U32)
                                                .operand(resolved_address.absolute_address)
@@ -1670,6 +1660,18 @@ std::optional<uint16_t> ProgramBlock::get_terminating_condition_value()
 bool ProgramBlock::is_memory_address_set(uint16_t address)
 {
     return memory_manager.is_memory_address_set(address);
+}
+
+void ProgramBlock::process_instruction_block(InstructionBlock& instruction_block)
+{
+    memory_manager.set_base_offset(instruction_block.base_offset);
+    process_set_32_instruction(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                            .result_address = AddressRef{ .address = 0, .mode = AddressingMode::Direct },
+                            .value = instruction_block.base_offset });
+    for (const auto& instr : instruction_block.instructions) {
+        process_instruction(instr);
+    }
 }
 
 void ProgramBlock::process_instruction(FuzzInstruction instruction)

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
@@ -24,8 +24,11 @@
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/memory_manager.hpp"
+#include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/simulation/lib/serialization.hpp"
+
+using InstructionBlock = bb::avm2::fuzzer::InstructionBlock;
 
 enum class TerminatorType {
     RETURN,
@@ -126,6 +129,11 @@ class ProgramBlock {
     int offset = -1;
 
     ProgramBlock() = default;
+
+    /// @brief process the instruction block
+    /// @param instruction_block the instruction block to process
+    void process_instruction_block(InstructionBlock& instruction_block);
+
     /// @brief process the instruction
     /// @param instruction the instruction to process
     /// Updates `stored_variables` if the instruction writes to memory

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -105,22 +105,20 @@ constexpr MemoryTagMutationConfig BASIC_MEMORY_TAG_MUTATION_CONFIGURATION = Memo
     { MemoryTagOptions::FF, 1 },
 });
 
-enum class VariableRefMutationOptions { tag, index, pointer_address, base_offset, mode };
-using VariableRefMutationConfig = WeightedSelectionConfig<VariableRefMutationOptions, 5>;
+enum class VariableRefMutationOptions { tag, index, pointer_address, mode };
+using VariableRefMutationConfig = WeightedSelectionConfig<VariableRefMutationOptions, 4>;
 constexpr VariableRefMutationConfig BASIC_VARIABLE_REF_MUTATION_CONFIGURATION = VariableRefMutationConfig({
     { VariableRefMutationOptions::tag, 3 },
     { VariableRefMutationOptions::index, 4 },
     { VariableRefMutationOptions::pointer_address, 1 },
-    { VariableRefMutationOptions::base_offset, 1 },
     { VariableRefMutationOptions::mode, 2 },
 });
 
-enum class AddressRefMutationOptions { address, pointer_address, base_offset, mode };
-using AddressRefMutationConfig = WeightedSelectionConfig<AddressRefMutationOptions, 5>;
+enum class AddressRefMutationOptions { address, pointer_address, mode };
+using AddressRefMutationConfig = WeightedSelectionConfig<AddressRefMutationOptions, 3>;
 constexpr AddressRefMutationConfig BASIC_ADDRESS_REF_MUTATION_CONFIGURATION = AddressRefMutationConfig({
     { AddressRefMutationOptions::address, 1 },
     { AddressRefMutationOptions::pointer_address, 1 },
-    { AddressRefMutationOptions::base_offset, 1 },
     { AddressRefMutationOptions::mode, 1 },
 });
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/fuzzer_data.cpp
@@ -22,10 +22,10 @@ void mutate_fuzzer_data(FuzzerData& fuzzer_data, std::mt19937_64& rng, const Fuz
         auto mutation_config = BASIC_FUZZER_DATA_MUTATION_CONFIGURATION.select(rng);
         switch (mutation_config) {
         case FuzzerDataMutationOptions::InstructionMutation:
-            mutate_vec<std::vector<FuzzInstruction>>(
+            mutate_vec<InstructionBlock>(
                 fuzzer_data.instruction_blocks,
                 rng,
-                [&context](std::vector<FuzzInstruction>& block, std::mt19937_64& r) {
+                [&context](InstructionBlock& block, std::mt19937_64& r) {
                     mutate_instruction_block(block, r, context);
                 },
                 [&context](std::mt19937_64& r) { return generate_instruction_block(r, context); },
@@ -52,14 +52,15 @@ void mutate_fuzzer_data(FuzzerData& fuzzer_data, std::mt19937_64& rng, const Fuz
 void add_default_instruction_block_if_empty(FuzzerData& fuzzer_data, std::mt19937_64& rng, const FuzzerContext& context)
 {
     if (fuzzer_data.instruction_blocks.empty()) {
-        std::vector<FuzzInstruction> instruction_block;
+        InstructionBlock instruction_block = generate_instruction_block(rng, context);
+        std::vector<FuzzInstruction> preamble;
         uint32_t num_tags = static_cast<uint32_t>(ValueTag::MAX);
-        instruction_block.reserve(num_tags);
+        preamble.reserve(num_tags);
         // Add one set per memory tag type
         for (uint32_t i = 0; i < num_tags; i++) {
             // TODO: Randomize address, value. Keep address < 255 so it can be used anywhere.
             auto tag = static_cast<ValueTag>(i);
-            instruction_block.push_back(SET_8_Instruction{
+            preamble.push_back(SET_8_Instruction{
                 .value_tag = tag,
                 .result_address =
                     AddressRef{
@@ -68,8 +69,7 @@ void add_default_instruction_block_if_empty(FuzzerData& fuzzer_data, std::mt1993
                 .value = 1,
             });
         }
-        auto preamble = generate_instruction_block(rng, context);
-        instruction_block.insert(instruction_block.end(), preamble.begin(), preamble.end());
+        instruction_block.instructions.insert(instruction_block.instructions.begin(), preamble.begin(), preamble.end());
         fuzzer_data.instruction_blocks.push_back(instruction_block);
         fuzzer_data.cfg_instructions.push_back(InsertSimpleInstructionBlock{ .instruction_block_idx = 0 });
     }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -1,120 +1,27 @@
-#include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
+#include "barretenberg/avm_fuzzer/mutations/instructions/instruction.hpp"
+
+#include <optional>
+#include <random>
+#include <vector>
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.hpp"
+#include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/field.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/memory_tag.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/uint16_t.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/uint32_t.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/uint64_t.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/uint8_t.hpp"
+#include "barretenberg/avm_fuzzer/mutations/basic_types/uint_mutations.hpp"
 #include "barretenberg/avm_fuzzer/mutations/basic_types/vector.hpp"
 #include "barretenberg/avm_fuzzer/mutations/configuration.hpp"
 #include "barretenberg/vm2/common/field.hpp"
-#include <optional>
 
-AddressingMode generate_addressing_mode(std::mt19937_64& rng)
-{
-    return static_cast<AddressingMode>(generate_random_uint8(rng) % 4);
-}
-
-VariableRef generate_variable_ref(std::mt19937_64& rng)
-{
-    auto tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION);
-    auto index = generate_random_uint32(rng);
-    auto pointer_address = generate_random_uint16(rng);
-    auto base_offset = generate_random_uint32(rng);
-    auto mode = generate_addressing_mode(rng);
-    return VariableRef{ .tag = tag,
-                        .index = index,
-                        .pointer_address_seed = pointer_address,
-                        .base_offset_seed = base_offset,
-                        .mode = mode };
-}
+namespace {
 
 // Maximum operand values based on instruction operand size
 constexpr uint32_t MAX_8BIT_OPERAND = 255;
 constexpr uint32_t MAX_16BIT_OPERAND = 65535;
-
-AddressRef generate_address_ref(std::mt19937_64& rng, uint32_t max_operand_value)
-{
-    auto address = generate_random_uint32(rng);
-    auto pointer_address = generate_random_uint16(rng);
-    auto base_offset = generate_random_uint32(rng);
-    auto mode = generate_addressing_mode(rng);
-    // For Direct mode, constrain address to fit in the operand
-    if (mode == AddressingMode::Direct) {
-        address = address % (max_operand_value + 1);
-    }
-    return AddressRef{
-        .address = address, .pointer_address_seed = pointer_address, .base_offset_seed = base_offset, .mode = mode
-    };
-}
-
-std::vector<FuzzInstruction> generate_ecadd_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        // Random mode: use existing memory values (may fail if not valid points on curve)
-        return { ECADD_Instruction{ .p1_x = generate_variable_ref(rng),
-                                    .p1_y = generate_variable_ref(rng),
-                                    .p1_infinite = generate_variable_ref(rng),
-                                    .p2_x = generate_variable_ref(rng),
-                                    .p2_y = generate_variable_ref(rng),
-                                    .p2_infinite = generate_variable_ref(rng),
-                                    .result = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
-    }
-
-    // Backfill mode: generate valid points on the Grumpkin curve and SET them
-    // 6 SET instructions (2 points * 3 fields each) + 1 ECADD = 7 instructions
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(7);
-
-    // Generate a valid point via scalar multiplication of the generator (always on curve)
-    auto generate_point = [&rng]() {
-        bb::avm2::Fq scalar(generate_random_field(rng));
-        return bb::avm2::EmbeddedCurvePoint::one() * scalar;
-    };
-
-    // Generate SET instructions to backfill a point at the given addresses
-    auto backfill_point = [&instructions](const bb::avm2::EmbeddedCurvePoint& point,
-                                          AddressRef x_addr,
-                                          AddressRef y_addr,
-                                          AddressRef inf_addr) {
-        instructions.push_back(
-            SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = x_addr, .value = point.x() });
-        instructions.push_back(
-            SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = y_addr, .value = point.y() });
-        instructions.push_back(SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                                  .result_address = inf_addr,
-                                                  .value = static_cast<uint8_t>(point.is_infinity() ? 1 : 0) });
-    };
-
-    auto p1 = generate_point();
-    auto p2 = generate_point();
-
-    // Generate addresses (SET_FF uses 16-bit, SET_8 uses 8-bit operands)
-    AddressRef p1_x_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef p1_y_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef p1_inf_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
-    AddressRef p2_x_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef p2_y_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef p2_inf_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
-
-    backfill_point(p1, p1_x_addr, p1_y_addr, p1_inf_addr);
-    backfill_point(p2, p2_x_addr, p2_y_addr, p2_inf_addr);
-
-    instructions.push_back(ECADD_Instruction{ .p1_x = p1_x_addr,
-                                              .p1_y = p1_y_addr,
-                                              .p1_infinite = p1_inf_addr,
-                                              .p2_x = p2_x_addr,
-                                              .p2_y = p2_y_addr,
-                                              .p2_infinite = p2_inf_addr,
-                                              .result = generate_address_ref(rng, MAX_16BIT_OPERAND) });
-
-    return instructions;
-}
 
 // Helper to generate a SET instruction for a given tag at a given address
 FuzzInstruction generate_set_for_tag(bb::avm2::MemoryTag tag, AddressRef addr, std::mt19937_64& rng)
@@ -142,397 +49,6 @@ FuzzInstruction generate_set_for_tag(bb::avm2::MemoryTag tag, AddressRef addr, s
     }
 }
 
-// Generate binary ALU instruction with optional backfill for matching tagged operands
-template <typename InstructionType>
-std::vector<FuzzInstruction> generate_alu_with_matching_tags(std::mt19937_64& rng, uint32_t max_operand)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        return { InstructionType{ .a_address = generate_variable_ref(rng),
-                                  .b_address = generate_variable_ref(rng),
-                                  .result_address = generate_address_ref(rng, max_operand) } };
-    }
-
-    auto tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION);
-    AddressRef a_addr = generate_address_ref(rng, max_operand);
-    AddressRef b_addr = generate_address_ref(rng, max_operand);
-
-    std::vector<FuzzInstruction> instructions;
-    instructions.push_back(generate_set_for_tag(tag, a_addr, rng));
-    instructions.push_back(generate_set_for_tag(tag, b_addr, rng));
-    instructions.push_back(InstructionType{
-        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
-    return instructions;
-}
-
-// Generate binary ALU instruction with optional backfill for matching non-FF tagged operands
-// Used for bitwise operations (AND, OR, XOR) and integer DIV which don't support FF
-template <typename InstructionType>
-std::vector<FuzzInstruction> generate_alu_with_matching_tags_not_ff(std::mt19937_64& rng, uint32_t max_operand)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        return { InstructionType{ .a_address = generate_variable_ref(rng),
-                                  .b_address = generate_variable_ref(rng),
-                                  .result_address = generate_address_ref(rng, max_operand) } };
-    }
-
-    // Pick a random non-FF tag (U1, U8, U16, U32, U64, U128)
-    static constexpr std::array<bb::avm2::MemoryTag, 6> int_tags = {
-        bb::avm2::MemoryTag::U1,  bb::avm2::MemoryTag::U8,  bb::avm2::MemoryTag::U16,
-        bb::avm2::MemoryTag::U32, bb::avm2::MemoryTag::U64, bb::avm2::MemoryTag::U128
-    };
-    auto tag = int_tags[std::uniform_int_distribution<size_t>(0, int_tags.size() - 1)(rng)];
-
-    AddressRef a_addr = generate_address_ref(rng, max_operand);
-    AddressRef b_addr = generate_address_ref(rng, max_operand);
-
-    std::vector<FuzzInstruction> instructions;
-    instructions.push_back(generate_set_for_tag(tag, a_addr, rng));
-    instructions.push_back(generate_set_for_tag(tag, b_addr, rng));
-    instructions.push_back(InstructionType{
-        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_fdiv_instruction(std::mt19937_64& rng, uint32_t max_operand)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        // Random mode: use existing memory values
-        return { FDIV_8_Instruction{ .a_address = generate_variable_ref(rng),
-                                     .b_address = generate_variable_ref(rng),
-                                     .result_address = generate_address_ref(rng, max_operand) } };
-    }
-
-    // Backfill mode: generate two non-zero FF values
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(3);
-
-    // Generate non-zero field values (avoid division by zero)
-    auto generate_nonzero_field = [&rng]() {
-        bb::avm2::FF value;
-        do {
-            value = generate_random_field(rng);
-        } while (value.is_zero());
-        return value;
-    };
-
-    AddressRef a_addr = generate_address_ref(rng, max_operand);
-    AddressRef b_addr = generate_address_ref(rng, max_operand);
-
-    // SET the dividend (a)
-    instructions.push_back(SET_FF_Instruction{
-        .value_tag = bb::avm2::MemoryTag::FF, .result_address = a_addr, .value = generate_nonzero_field() });
-
-    // SET the divisor (b) - must be non-zero
-    instructions.push_back(SET_FF_Instruction{
-        .value_tag = bb::avm2::MemoryTag::FF, .result_address = b_addr, .value = generate_nonzero_field() });
-
-    // FDIV instruction
-    instructions.push_back(FDIV_8_Instruction{
-        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
-
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_keccakf_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-    if (!use_backfill) {
-        // Random mode
-        return { KECCAKF1600_Instruction{ .src_address = generate_variable_ref(rng),
-                                          .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
-    }
-    // Backfill mode
-    std::vector<FuzzInstruction> instructions;
-
-    // Keccak needs to backfill 25 U64 values, these need be contiguous in memory
-    AddressRef src_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 24);
-    for (size_t i = 0; i < 25; i++) {
-        AddressRef item_address = src_address;
-        item_address.address += static_cast<uint32_t>(i);
-        instructions.push_back(SET_64_Instruction{ .value_tag = bb::avm2::MemoryTag::U64,
-                                                   .result_address = item_address,
-                                                   .value = generate_random_uint64(rng) });
-    }
-    instructions.push_back(KECCAKF1600_Instruction{ .src_address = src_address,
-                                                    .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_sha256compression_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-    if (!use_backfill) {
-        // Random mode
-        return { SHA256COMPRESSION_Instruction{ .state_address = generate_variable_ref(rng),
-                                                .input_address = generate_variable_ref(rng),
-                                                .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
-    }
-    // Backfill mode
-    // SHA256 compression needs 8 U32 values for state and 16 U32 values for input (contiguous)
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(8 + 16 + 1);
-
-    // Generate state address (8 contiguous U32 values)
-    AddressRef state_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 7);
-
-    for (size_t i = 0; i < 8; i++) {
-        AddressRef item_address = state_address;
-        item_address.address += static_cast<uint32_t>(i);
-        instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                                   .result_address = item_address,
-                                                   .value = generate_random_uint32(rng) });
-    }
-
-    // Generate input address (16 contiguous U32 values)
-    AddressRef input_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 15);
-
-    for (size_t i = 0; i < 16; i++) {
-        AddressRef item_address = input_address;
-        item_address.address += static_cast<uint32_t>(i);
-        instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                                   .result_address = item_address,
-                                                   .value = generate_random_uint32(rng) });
-    }
-
-    instructions.push_back(
-        SHA256COMPRESSION_Instruction{ .state_address = state_address,
-                                       .input_address = input_address,
-                                       .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_toradixbe_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-    if (!use_backfill) {
-        // Random mode
-        return { TORADIXBE_Instruction{ .value_address = generate_variable_ref(rng),
-                                        .radix_address = generate_variable_ref(rng),
-                                        .num_limbs_address = generate_variable_ref(rng),
-                                        .output_bits_address = generate_variable_ref(rng),
-                                        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                        .is_output_bits = std::uniform_int_distribution<int>(0, 1)(rng) == 0 } };
-    }
-    // Backfill mode: set up proper typed values
-    // value: FF, radix: U32, num_limbs: U32, output_bits: U1
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(5);
-
-    AddressRef value_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef radix_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef num_limbs_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    AddressRef output_bits_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
-
-    // SET the radix (U32) - pick radix between 2 and 256
-    uint32_t radix = std::uniform_int_distribution<uint32_t>(2, 256)(rng);
-    instructions.push_back(
-        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = radix_addr, .value = radix });
-
-    // SET the output_bits (U1)
-    bool is_output_bits = radix == 2;
-    instructions.push_back(SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
-                                              .result_address = output_bits_addr,
-                                              .value = static_cast<uint8_t>(is_output_bits ? 1 : 0) });
-
-    // Generate value with num_limbs digits
-    uint32_t num_limbs = std::uniform_int_distribution<uint32_t>(1, 256)(rng);
-    bb::avm2::FF value = 0;
-    bb::avm2::FF exponent = 1;
-    for (uint32_t i = 0; i < num_limbs; i++) {
-        uint32_t digit = std::uniform_int_distribution<uint32_t>(0, radix - 1)(rng);
-        value += bb::avm2::FF(digit) * exponent;
-        exponent *= radix;
-    }
-
-    // 20% chance to truncate - reduce the number of limbs we request
-    if (std::uniform_int_distribution<int>(0, 4)(rng) == 0) {
-        num_limbs--;
-    }
-
-    // SET the num_limbs (U32)
-    instructions.push_back(SET_32_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U32, .result_address = num_limbs_addr, .value = num_limbs });
-
-    // SET the value (FF)
-    instructions.push_back(
-        SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = value_addr, .value = value });
-
-    // TORADIXBE instruction
-    instructions.push_back(TORADIXBE_Instruction{ .value_address = value_addr,
-                                                  .radix_address = radix_addr,
-                                                  .num_limbs_address = num_limbs_addr,
-                                                  .output_bits_address = output_bits_addr,
-                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                                  .is_output_bits = is_output_bits });
-    return instructions;
-}
-
-// A better way in the future is to pass in a vector of possible slots that have been written to,
-// this would allow us to supply external world state info.
-std::vector<FuzzInstruction> generate_sload_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        // Random mode: requires at least one prior SSTORE to have been processed
-        return { SLOAD_Instruction{ .slot_index = generate_random_uint16(rng),
-                                    .slot_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                    .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
-    }
-
-    // Backfill mode: generate SSTORE first to ensure storage_addresses is non-empty
-    // This guarantees SLOAD will find a valid slot (get_slot uses modulo on non-empty vector)
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(3);
-
-    AddressRef sstore_src = generate_address_ref(rng, MAX_16BIT_OPERAND);
-
-    // SET a value to store
-    instructions.push_back(SET_FF_Instruction{
-        .value_tag = bb::avm2::MemoryTag::FF, .result_address = sstore_src, .value = generate_random_field(rng) });
-
-    // SSTORE - appends to storage_addresses in memory_manager
-    instructions.push_back(SSTORE_Instruction{ .src_address = sstore_src,
-                                               .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                               .slot = generate_random_field(rng) });
-
-    // SLOAD - now guaranteed to succeed (storage_addresses not empty, get_slot uses modulo)
-    instructions.push_back(SLOAD_Instruction{ .slot_index = generate_random_uint16(rng),
-                                              .slot_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                              .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
-
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_emitunencryptedlog_instruction(std::mt19937_64& rng)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-        return { EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = generate_variable_ref(rng),
-                                                 .log_values_address = generate_variable_ref(rng) } };
-    }
-
-    uint32_t log_size = std::uniform_int_distribution<uint32_t>(0, FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH)(rng);
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(3);
-
-    auto log_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    auto log_values_address = generate_address_ref(rng, MAX_16BIT_OPERAND - log_size);
-
-    instructions.push_back(SET_32_Instruction{
-        .value_tag = bb::avm2::MemoryTag::U32, .result_address = log_size_address, .value = log_size });
-
-    // Write one random FF in the log
-    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                                               .result_address = log_values_address,
-                                               .value = generate_random_field(rng) });
-
-    instructions.push_back(EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = log_size_address,
-                                                           .log_values_address = log_values_address });
-
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_call_instruction(std::mt19937_64& rng,
-                                                       const bb::avm2::fuzzer::FuzzerContext& context)
-{
-    // 80% chance to use backfill (4 out of 5) to increase success rate
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-
-    if (!use_backfill) {
-
-        return { CALL_Instruction{ .l2_gas_address = generate_variable_ref(rng),
-                                   .da_gas_address = generate_variable_ref(rng),
-                                   .contract_address_address = generate_variable_ref(rng),
-                                   .calldata_address = generate_variable_ref(rng),
-                                   .calldata_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                   .calldata_size = generate_random_uint16(rng),
-                                   .is_static_call = rng() % 2 == 0 } };
-    }
-
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(5);
-
-    auto contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                                               .result_address = contract_address_address,
-                                               .value = context.get_contract_address(generate_random_uint16(rng)) });
-
-    auto l2_gas_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                               .result_address = l2_gas_address,
-                                               .value = generate_random_uint32(rng) });
-
-    auto da_gas_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                               .result_address = da_gas_address,
-                                               .value = generate_random_uint32(rng) });
-
-    auto calldata_size = generate_random_uint16(rng);
-    auto calldata_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-
-    auto calldata_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    // Write one random FF in the calldata
-    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                                               .result_address = calldata_address,
-                                               .value = generate_random_field(rng) });
-
-    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
-                                             .da_gas_address = da_gas_address,
-                                             .contract_address_address = contract_address_address,
-                                             .calldata_address = calldata_address,
-                                             .calldata_size_address = calldata_size_address,
-                                             .calldata_size = calldata_size,
-                                             .is_static_call = rng() % 2 == 0 });
-
-    return instructions;
-}
-
-std::vector<FuzzInstruction> generate_getcontractinstance_instruction(std::mt19937_64& rng,
-                                                                      const bb::avm2::fuzzer::FuzzerContext& context)
-{
-    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
-    if (!use_backfill) {
-        return { GETCONTRACTINSTANCE_Instruction{
-            .contract_address_address = generate_variable_ref(rng),
-            .member_enum = generate_random_uint8(rng),
-            .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-        } };
-    }
-
-    std::vector<FuzzInstruction> instructions;
-    instructions.reserve(2);
-
-    auto contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
-    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
-                                               .result_address = contract_address_address,
-                                               .value = context.get_contract_address(generate_random_uint16(rng)) });
-    uint8_t member_enum = std::uniform_int_distribution<uint8_t>(0, 2)(rng);
-
-    instructions.push_back(GETCONTRACTINSTANCE_Instruction{
-        .contract_address_address = contract_address_address,
-        .member_enum = member_enum,
-        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-    });
-
-    return instructions;
-}
-
 uint8_t generate_envvar_type(std::mt19937_64& rng)
 {
     bool valid_type = std::uniform_int_distribution<int>(0, 9)(rng) != 0;
@@ -546,8 +62,31 @@ uint8_t generate_envvar_type(std::mt19937_64& rng)
     }
 }
 
+std::optional<MemoryTag> get_param_ref_tag(const ParamRef& param)
+{
+    return std::visit(overloaded{ [](const VariableRef& var) -> std::optional<MemoryTag> { return var.tag.value; },
+                                  [](const AddressRef&) -> std::optional<MemoryTag> { return std::nullopt; } },
+                      param);
+}
+
+void sanitize_address_ref(AddressRef& address_ref, uint32_t base_offset, uint32_t max_operand_value)
+{
+
+    // For Direct mode, constrain address to fit in the operand
+    if (address_ref.mode == AddressingMode::Direct) {
+        address_ref.address = address_ref.address % (max_operand_value + 1);
+    }
+    // For Relative mode, we can reach from base_pointer to base_pointer + max_operand_value
+    if (address_ref.mode == AddressingMode::Relative) {
+        address_ref.address = base_offset + (address_ref.address % (max_operand_value + 1));
+    }
+}
+
+} // namespace
+
 namespace bb::avm2::fuzzer {
-std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng, const FuzzerContext& context)
+
+std::vector<FuzzInstruction> InstructionMutator::generate_instruction(std::mt19937_64& rng)
 {
     InstructionGenerationOptions option = BASIC_INSTRUCTION_GENERATION_CONFIGURATION.select(rng);
     // forgive me
@@ -717,13 +256,13 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng, const Fu
     case InstructionGenerationOptions::EMITUNENCRYPTEDLOG:
         return generate_emitunencryptedlog_instruction(rng);
     case InstructionGenerationOptions::CALL:
-        return generate_call_instruction(rng, context);
+        return generate_call_instruction(rng);
     case InstructionGenerationOptions::RETURNDATASIZE_WITH_RETURNDATACOPY:
         return { RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction{ .copy_size_offset = generate_random_uint16(rng),
                                                                  .dst_address = generate_random_uint16(rng),
                                                                  .rd_start_offset = generate_random_uint16(rng) } };
     case InstructionGenerationOptions::GETCONTRACTINSTANCE:
-        return generate_getcontractinstance_instruction(rng, context);
+        return generate_getcontractinstance_instruction(rng);
     case InstructionGenerationOptions::SUCCESSCOPY:
         return { SUCCESSCOPY_Instruction{ .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
     case InstructionGenerationOptions::ECADD:
@@ -745,8 +284,122 @@ std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng, const Fu
                                          .message_size = generate_random_uint16(rng) } } };
     }
 }
+
+void InstructionMutator::mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng)
+{
+    std::visit(
+        overloaded{
+            [&rng, this](ADD_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](SUB_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](MUL_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](DIV_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](EQ_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](LT_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](LTE_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](AND_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](OR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](XOR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](SHL_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](SHR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](SET_8_Instruction& instr) { mutate_set_8_instruction(instr, rng); },
+            [&rng, this](SET_16_Instruction& instr) { mutate_set_16_instruction(instr, rng); },
+            [&rng, this](SET_32_Instruction& instr) { mutate_set_32_instruction(instr, rng); },
+            [&rng, this](SET_64_Instruction& instr) { mutate_set_64_instruction(instr, rng); },
+            [&rng, this](SET_128_Instruction& instr) { mutate_set_128_instruction(instr, rng); },
+            [&rng, this](SET_FF_Instruction& instr) { mutate_set_ff_instruction(instr, rng); },
+            [&rng, this](MOV_8_Instruction& instr) { mutate_mov_8_instruction(instr, rng); },
+            [&rng, this](MOV_16_Instruction& instr) { mutate_mov_16_instruction(instr, rng); },
+            [&rng, this](FDIV_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
+            [&rng, this](NOT_8_Instruction& instr) { mutate_not_8_instruction(instr, rng); },
+            [&rng, this](ADD_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](SUB_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](MUL_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](DIV_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](FDIV_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](EQ_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](LT_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](LTE_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](AND_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](OR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](XOR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](NOT_16_Instruction& instr) { mutate_not_16_instruction(instr, rng); },
+            [&rng, this](SHL_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](SHR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
+            [&rng, this](CAST_8_Instruction& instr) { mutate_cast_8_instruction(instr, rng); },
+            [&rng, this](CAST_16_Instruction& instr) { mutate_cast_16_instruction(instr, rng); },
+            [&rng, this](SSTORE_Instruction& instr) { mutate_sstore_instruction(instr, rng); },
+            [&rng, this](SLOAD_Instruction& instr) { mutate_sload_instruction(instr, rng); },
+            [&rng, this](GETENVVAR_Instruction& instr) { mutate_getenvvar_instruction(instr, rng); },
+            [&rng, this](EMITNULLIFIER_Instruction& instr) { mutate_emit_nullifier_instruction(instr, rng); },
+            [&rng, this](NULLIFIEREXISTS_Instruction& instr) { mutate_nullifier_exists_instruction(instr, rng); },
+            [&rng, this](L1TOL2MSGEXISTS_Instruction& instr) { mutate_l1tol2msgexists_instruction(instr, rng); },
+            [&rng, this](EMITNOTEHASH_Instruction& instr) { mutate_emit_note_hash_instruction(instr, rng); },
+            [&rng, this](NOTEHASHEXISTS_Instruction& instr) { mutate_note_hash_exists_instruction(instr, rng); },
+            [&rng, this](CALLDATACOPY_Instruction& instr) { mutate_calldatacopy_instruction(instr, rng); },
+            [&rng, this](SENDL2TOL1MSG_Instruction& instr) { mutate_sendl2tol1msg_instruction(instr, rng); },
+            [&rng, this](EMITUNENCRYPTEDLOG_Instruction& instr) { mutate_emitunencryptedlog_instruction(instr, rng); },
+            [&rng, this](CALL_Instruction& instr) { mutate_call_instruction(instr, rng); },
+            [&rng, this](RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instr) {
+                mutate_returndatasize_with_returndatacopy_instruction(instr, rng);
+            },
+            [&rng, this](GETCONTRACTINSTANCE_Instruction& instr) {
+                mutate_getcontractinstance_instruction(instr, rng);
+            },
+            [&rng, this](SUCCESSCOPY_Instruction& instr) { mutate_successcopy_instruction(instr, rng); },
+            [&rng, this](ECADD_Instruction& instr) { mutate_ecadd_instruction(instr, rng); },
+            [&rng, this](POSEIDON2PERM_Instruction& instr) { mutate_poseidon2perm_instruction(instr, rng); },
+            [&rng, this](KECCAKF1600_Instruction& instr) { mutate_keccakf1600_instruction(instr, rng); },
+            [&rng, this](SHA256COMPRESSION_Instruction& instr) { mutate_sha256compression_instruction(instr, rng); },
+            [&rng, this](TORADIXBE_Instruction& instr) { mutate_toradixbe_instruction(instr, rng); },
+            [&rng, this](DEBUGLOG_Instruction& instr) { mutate_debuglog_instruction(instr, rng); },
+            [](auto&) { throw std::runtime_error("Unknown instruction"); } },
+        instruction);
+}
+
+AddressingMode InstructionMutator::generate_addressing_mode(std::mt19937_64& rng)
+{
+    return static_cast<AddressingMode>(generate_random_uint8(rng) % 4);
+}
+
+AddressRef InstructionMutator::generate_address_ref(std::mt19937_64& rng, uint32_t max_operand_value)
+{
+    AddressRef address_ref = AddressRef{ .address = generate_random_uint32(rng),
+                                         .pointer_address_seed = generate_random_uint16(rng),
+                                         .mode = generate_addressing_mode(rng) };
+    sanitize_address_ref(address_ref, base_offset, max_operand_value);
+    return address_ref;
+}
+
+void InstructionMutator::mutate_address_ref(AddressRef& address, std::mt19937_64& rng, uint32_t max_operand_value)
+{
+    AddressRefMutationOptions option = BASIC_ADDRESS_REF_MUTATION_CONFIGURATION.select(rng);
+    switch (option) {
+    case AddressRefMutationOptions::address:
+        mutate_uint32_t(address.address, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
+        break;
+    case AddressRefMutationOptions::pointer_address:
+        mutate_uint16_t(address.pointer_address_seed, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+        break;
+    case AddressRefMutationOptions::mode:
+        address.mode = generate_addressing_mode(rng);
+        break;
+    }
+    sanitize_address_ref(address, base_offset, max_operand_value);
+}
+
+VariableRef InstructionMutator::generate_variable_ref(std::mt19937_64& rng)
+{
+    auto tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION);
+    auto index = generate_random_uint32(rng);
+    auto pointer_address = generate_random_uint16(rng);
+    auto mode = generate_addressing_mode(rng);
+    return VariableRef{ .tag = tag, .index = index, .pointer_address_seed = pointer_address, .mode = mode };
+}
+
 /// Most of the tags will be equal to the default tag
-void mutate_variable_ref(VariableRef& variable, std::mt19937_64& rng, std::optional<MemoryTag> default_tag)
+void InstructionMutator::mutate_variable_ref(VariableRef& variable,
+                                             std::mt19937_64& rng,
+                                             std::optional<MemoryTag> default_tag)
 {
     VariableRefMutationOptions option = BASIC_VARIABLE_REF_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -763,61 +416,481 @@ void mutate_variable_ref(VariableRef& variable, std::mt19937_64& rng, std::optio
     case VariableRefMutationOptions::pointer_address:
         mutate_uint16_t(variable.pointer_address_seed, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
-    case VariableRefMutationOptions::base_offset:
-        mutate_uint32_t(variable.base_offset_seed, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
-        break;
     case VariableRefMutationOptions::mode:
         variable.mode = generate_addressing_mode(rng);
         break;
     }
 }
 
-void mutate_address_ref(AddressRef& address, std::mt19937_64& rng, uint32_t max_operand_value)
+std::vector<FuzzInstruction> InstructionMutator::generate_ecadd_instruction(std::mt19937_64& rng)
 {
-    AddressRefMutationOptions option = BASIC_ADDRESS_REF_MUTATION_CONFIGURATION.select(rng);
-    switch (option) {
-    case AddressRefMutationOptions::address:
-        mutate_uint32_t(address.address, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
-        // Constrain address for Direct mode
-        if (address.mode == AddressingMode::Direct) {
-            address.address = address.address % (max_operand_value + 1);
-        }
-        break;
-    case AddressRefMutationOptions::pointer_address:
-        mutate_uint16_t(address.pointer_address_seed, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
-        break;
-    case AddressRefMutationOptions::base_offset:
-        mutate_uint32_t(address.base_offset_seed, rng, BASIC_UINT32_T_MUTATION_CONFIGURATION);
-        break;
-    case AddressRefMutationOptions::mode:
-        address.mode = generate_addressing_mode(rng);
-        // Constrain address if mode changed to Direct
-        if (address.mode == AddressingMode::Direct) {
-            address.address = address.address % (max_operand_value + 1);
-        }
-        break;
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        // Random mode: use existing memory values (may fail if not valid points on curve)
+        return { ECADD_Instruction{ .p1_x = generate_variable_ref(rng),
+                                    .p1_y = generate_variable_ref(rng),
+                                    .p1_infinite = generate_variable_ref(rng),
+                                    .p2_x = generate_variable_ref(rng),
+                                    .p2_y = generate_variable_ref(rng),
+                                    .p2_infinite = generate_variable_ref(rng),
+                                    .result = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
     }
+
+    // Backfill mode: generate valid points on the Grumpkin curve and SET them
+    // 6 SET instructions (2 points * 3 fields each) + 1 ECADD = 7 instructions
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(7);
+
+    // Generate a valid point via scalar multiplication of the generator (always on curve)
+    auto generate_point = [&rng]() {
+        bb::avm2::Fq scalar(generate_random_field(rng));
+        return bb::avm2::EmbeddedCurvePoint::one() * scalar;
+    };
+
+    // Generate SET instructions to backfill a point at the given addresses
+    auto backfill_point = [&instructions](const bb::avm2::EmbeddedCurvePoint& point,
+                                          AddressRef x_addr,
+                                          AddressRef y_addr,
+                                          AddressRef inf_addr) {
+        instructions.push_back(
+            SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = x_addr, .value = point.x() });
+        instructions.push_back(
+            SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = y_addr, .value = point.y() });
+        instructions.push_back(SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
+                                                  .result_address = inf_addr,
+                                                  .value = static_cast<uint8_t>(point.is_infinity() ? 1 : 0) });
+    };
+
+    auto p1 = generate_point();
+    auto p2 = generate_point();
+
+    // Generate addresses (SET_FF uses 16-bit, SET_8 uses 8-bit operands)
+    AddressRef p1_x_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef p1_y_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef p1_inf_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
+    AddressRef p2_x_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef p2_y_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef p2_inf_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
+
+    backfill_point(p1, p1_x_addr, p1_y_addr, p1_inf_addr);
+    backfill_point(p2, p2_x_addr, p2_y_addr, p2_inf_addr);
+
+    instructions.push_back(ECADD_Instruction{ .p1_x = p1_x_addr,
+                                              .p1_y = p1_y_addr,
+                                              .p1_infinite = p1_inf_addr,
+                                              .p2_x = p2_x_addr,
+                                              .p2_y = p2_y_addr,
+                                              .p2_infinite = p2_inf_addr,
+                                              .result = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+
+    return instructions;
 }
 
-void mutate_param_ref(ParamRef& param,
-                      std::mt19937_64& rng,
-                      std::optional<MemoryTag> default_tag,
-                      uint32_t max_operand_value)
+// Generate binary ALU instruction with optional backfill for matching tagged operands
+template <typename InstructionType>
+std::vector<FuzzInstruction> InstructionMutator::generate_alu_with_matching_tags(std::mt19937_64& rng,
+                                                                                 uint32_t max_operand)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        return { InstructionType{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng, max_operand) } };
+    }
+
+    auto tag = generate_memory_tag(rng, BASIC_MEMORY_TAG_GENERATION_CONFIGURATION);
+    AddressRef a_addr = generate_address_ref(rng, max_operand);
+    AddressRef b_addr = generate_address_ref(rng, max_operand);
+
+    std::vector<FuzzInstruction> instructions;
+    instructions.push_back(generate_set_for_tag(tag, a_addr, rng));
+    instructions.push_back(generate_set_for_tag(tag, b_addr, rng));
+    instructions.push_back(InstructionType{
+        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
+    return instructions;
+}
+
+// Generate binary ALU instruction with optional backfill for matching non-FF tagged operands
+// Used for bitwise operations (AND, OR, XOR) and integer DIV which don't support FF
+template <typename InstructionType>
+std::vector<FuzzInstruction> InstructionMutator::generate_alu_with_matching_tags_not_ff(std::mt19937_64& rng,
+                                                                                        uint32_t max_operand)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        return { InstructionType{ .a_address = generate_variable_ref(rng),
+                                  .b_address = generate_variable_ref(rng),
+                                  .result_address = generate_address_ref(rng, max_operand) } };
+    }
+
+    // Pick a random non-FF tag (U1, U8, U16, U32, U64, U128)
+    static constexpr std::array<bb::avm2::MemoryTag, 6> int_tags = {
+        bb::avm2::MemoryTag::U1,  bb::avm2::MemoryTag::U8,  bb::avm2::MemoryTag::U16,
+        bb::avm2::MemoryTag::U32, bb::avm2::MemoryTag::U64, bb::avm2::MemoryTag::U128
+    };
+    auto tag = int_tags[std::uniform_int_distribution<size_t>(0, int_tags.size() - 1)(rng)];
+
+    AddressRef a_addr = generate_address_ref(rng, max_operand);
+    AddressRef b_addr = generate_address_ref(rng, max_operand);
+
+    std::vector<FuzzInstruction> instructions;
+    instructions.push_back(generate_set_for_tag(tag, a_addr, rng));
+    instructions.push_back(generate_set_for_tag(tag, b_addr, rng));
+    instructions.push_back(InstructionType{
+        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_fdiv_instruction(std::mt19937_64& rng, uint32_t max_operand)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        // Random mode: use existing memory values
+        return { FDIV_8_Instruction{ .a_address = generate_variable_ref(rng),
+                                     .b_address = generate_variable_ref(rng),
+                                     .result_address = generate_address_ref(rng, max_operand) } };
+    }
+
+    // Backfill mode: generate two non-zero FF values
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(3);
+
+    // Generate non-zero field values (avoid division by zero)
+    auto generate_nonzero_field = [&rng]() {
+        bb::avm2::FF value;
+        do {
+            value = generate_random_field(rng);
+        } while (value.is_zero());
+        return value;
+    };
+
+    AddressRef a_addr = generate_address_ref(rng, max_operand);
+    AddressRef b_addr = generate_address_ref(rng, max_operand);
+
+    // SET the dividend (a)
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = a_addr, .value = generate_nonzero_field() });
+
+    // SET the divisor (b) - must be non-zero
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = b_addr, .value = generate_nonzero_field() });
+
+    // FDIV instruction
+    instructions.push_back(FDIV_8_Instruction{
+        .a_address = a_addr, .b_address = b_addr, .result_address = generate_address_ref(rng, max_operand) });
+
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_keccakf_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        // Random mode
+        return { KECCAKF1600_Instruction{ .src_address = generate_variable_ref(rng),
+                                          .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+    // Backfill mode
+    std::vector<FuzzInstruction> instructions;
+
+    // Keccak needs to backfill 25 U64 values, these need be contiguous in memory
+    AddressRef src_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 24);
+    for (size_t i = 0; i < 25; i++) {
+        AddressRef item_address = src_address;
+        item_address.address += static_cast<uint32_t>(i);
+        instructions.push_back(SET_64_Instruction{ .value_tag = bb::avm2::MemoryTag::U64,
+                                                   .result_address = item_address,
+                                                   .value = generate_random_uint64(rng) });
+    }
+    instructions.push_back(KECCAKF1600_Instruction{ .src_address = src_address,
+                                                    .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_sha256compression_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        // Random mode
+        return { SHA256COMPRESSION_Instruction{ .state_address = generate_variable_ref(rng),
+                                                .input_address = generate_variable_ref(rng),
+                                                .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+    // Backfill mode
+    // SHA256 compression needs 8 U32 values for state and 16 U32 values for input (contiguous)
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(8 + 16 + 1);
+
+    // Generate state address (8 contiguous U32 values)
+    AddressRef state_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 7);
+
+    for (size_t i = 0; i < 8; i++) {
+        AddressRef item_address = state_address;
+        item_address.address += static_cast<uint32_t>(i);
+        instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                                   .result_address = item_address,
+                                                   .value = generate_random_uint32(rng) });
+    }
+
+    // Generate input address (16 contiguous U32 values)
+    AddressRef input_address = generate_address_ref(rng, MAX_16BIT_OPERAND - 15);
+
+    for (size_t i = 0; i < 16; i++) {
+        AddressRef item_address = input_address;
+        item_address.address += static_cast<uint32_t>(i);
+        instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                                   .result_address = item_address,
+                                                   .value = generate_random_uint32(rng) });
+    }
+
+    instructions.push_back(
+        SHA256COMPRESSION_Instruction{ .state_address = state_address,
+                                       .input_address = input_address,
+                                       .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_toradixbe_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        // Random mode
+        return { TORADIXBE_Instruction{ .value_address = generate_variable_ref(rng),
+                                        .radix_address = generate_variable_ref(rng),
+                                        .num_limbs_address = generate_variable_ref(rng),
+                                        .output_bits_address = generate_variable_ref(rng),
+                                        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                        .is_output_bits = std::uniform_int_distribution<int>(0, 1)(rng) == 0 } };
+    }
+    // Backfill mode: set up proper typed values
+    // value: FF, radix: U32, num_limbs: U32, output_bits: U1
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(5);
+
+    AddressRef value_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef radix_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef num_limbs_addr = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    AddressRef output_bits_addr = generate_address_ref(rng, MAX_8BIT_OPERAND);
+
+    // SET the radix (U32) - pick radix between 2 and 256
+    uint32_t radix = std::uniform_int_distribution<uint32_t>(2, 256)(rng);
+    instructions.push_back(
+        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32, .result_address = radix_addr, .value = radix });
+
+    // SET the output_bits (U1)
+    bool is_output_bits = radix == 2;
+    instructions.push_back(SET_8_Instruction{ .value_tag = bb::avm2::MemoryTag::U1,
+                                              .result_address = output_bits_addr,
+                                              .value = static_cast<uint8_t>(is_output_bits ? 1 : 0) });
+
+    // Generate value with num_limbs digits
+    uint32_t num_limbs = std::uniform_int_distribution<uint32_t>(1, 256)(rng);
+    bb::avm2::FF value = 0;
+    bb::avm2::FF exponent = 1;
+    for (uint32_t i = 0; i < num_limbs; i++) {
+        uint32_t digit = std::uniform_int_distribution<uint32_t>(0, radix - 1)(rng);
+        value += bb::avm2::FF(digit) * exponent;
+        exponent *= radix;
+    }
+
+    // 20% chance to truncate - reduce the number of limbs we request
+    if (std::uniform_int_distribution<int>(0, 4)(rng) == 0) {
+        num_limbs--;
+    }
+
+    // SET the num_limbs (U32)
+    instructions.push_back(SET_32_Instruction{
+        .value_tag = bb::avm2::MemoryTag::U32, .result_address = num_limbs_addr, .value = num_limbs });
+
+    // SET the value (FF)
+    instructions.push_back(
+        SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF, .result_address = value_addr, .value = value });
+
+    // TORADIXBE instruction
+    instructions.push_back(TORADIXBE_Instruction{ .value_address = value_addr,
+                                                  .radix_address = radix_addr,
+                                                  .num_limbs_address = num_limbs_addr,
+                                                  .output_bits_address = output_bits_addr,
+                                                  .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                                  .is_output_bits = is_output_bits });
+    return instructions;
+}
+
+// A better way in the future is to pass in a vector of possible slots that have been written to,
+// this would allow us to supply external world state info.
+std::vector<FuzzInstruction> InstructionMutator::generate_sload_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        // Random mode: requires at least one prior SSTORE to have been processed
+        return { SLOAD_Instruction{ .slot_index = generate_random_uint16(rng),
+                                    .slot_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                    .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+
+    // Backfill mode: generate SSTORE first to ensure storage_addresses is non-empty
+    // This guarantees SLOAD will find a valid slot (get_slot uses modulo on non-empty vector)
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(3);
+
+    AddressRef sstore_src = generate_address_ref(rng, MAX_16BIT_OPERAND);
+
+    // SET a value to store
+    instructions.push_back(SET_FF_Instruction{
+        .value_tag = bb::avm2::MemoryTag::FF, .result_address = sstore_src, .value = generate_random_field(rng) });
+
+    // SSTORE - appends to storage_addresses in memory_manager
+    instructions.push_back(SSTORE_Instruction{ .src_address = sstore_src,
+                                               .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                               .slot = generate_random_field(rng) });
+
+    // SLOAD - now guaranteed to succeed (storage_addresses not empty, get_slot uses modulo)
+    instructions.push_back(SLOAD_Instruction{ .slot_index = generate_random_uint16(rng),
+                                              .slot_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                              .result_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_emitunencryptedlog_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+        return { EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = generate_variable_ref(rng),
+                                                 .log_values_address = generate_variable_ref(rng) } };
+    }
+
+    uint32_t log_size = std::uniform_int_distribution<uint32_t>(0, FLAT_PUBLIC_LOGS_PAYLOAD_LENGTH)(rng);
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(3);
+
+    auto log_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    auto log_values_address = generate_address_ref(rng, MAX_16BIT_OPERAND - log_size);
+
+    instructions.push_back(SET_32_Instruction{
+        .value_tag = bb::avm2::MemoryTag::U32, .result_address = log_size_address, .value = log_size });
+
+    // Write one random FF in the log
+    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
+                                               .result_address = log_values_address,
+                                               .value = generate_random_field(rng) });
+
+    instructions.push_back(EMITUNENCRYPTEDLOG_Instruction{ .log_size_address = log_size_address,
+                                                           .log_values_address = log_values_address });
+
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_call_instruction(std::mt19937_64& rng)
+{
+    // 80% chance to use backfill (4 out of 5) to increase success rate
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+
+    if (!use_backfill) {
+
+        return { CALL_Instruction{ .l2_gas_address = generate_variable_ref(rng),
+                                   .da_gas_address = generate_variable_ref(rng),
+                                   .contract_address_address = generate_variable_ref(rng),
+                                   .calldata_address = generate_variable_ref(rng),
+                                   .calldata_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+                                   .calldata_size = generate_random_uint16(rng),
+                                   .is_static_call = rng() % 2 == 0 } };
+    }
+
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(5);
+
+    auto contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
+                                               .result_address = contract_address_address,
+                                               .value = context.get_contract_address(generate_random_uint16(rng)) });
+
+    auto l2_gas_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = l2_gas_address,
+                                               .value = generate_random_uint32(rng) });
+
+    auto da_gas_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = da_gas_address,
+                                               .value = generate_random_uint32(rng) });
+
+    auto calldata_size = generate_random_uint16(rng);
+    auto calldata_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+
+    auto calldata_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    // Write one random FF in the calldata
+    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
+                                               .result_address = calldata_address,
+                                               .value = generate_random_field(rng) });
+
+    instructions.push_back(CALL_Instruction{ .l2_gas_address = l2_gas_address,
+                                             .da_gas_address = da_gas_address,
+                                             .contract_address_address = contract_address_address,
+                                             .calldata_address = calldata_address,
+                                             .calldata_size_address = calldata_size_address,
+                                             .calldata_size = calldata_size,
+                                             .is_static_call = rng() % 2 == 0 });
+
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_getcontractinstance_instruction(std::mt19937_64& rng)
+{
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        return { GETCONTRACTINSTANCE_Instruction{
+            .contract_address_address = generate_variable_ref(rng),
+            .member_enum = generate_random_uint8(rng),
+            .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+        } };
+    }
+
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(2);
+
+    auto contract_address_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_FF_Instruction{ .value_tag = bb::avm2::MemoryTag::FF,
+                                               .result_address = contract_address_address,
+                                               .value = context.get_contract_address(generate_random_uint16(rng)) });
+    uint8_t member_enum = std::uniform_int_distribution<uint8_t>(0, 2)(rng);
+
+    instructions.push_back(GETCONTRACTINSTANCE_Instruction{
+        .contract_address_address = contract_address_address,
+        .member_enum = member_enum,
+        .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
+    });
+
+    return instructions;
+}
+
+void InstructionMutator::mutate_param_ref(ParamRef& param,
+                                          std::mt19937_64& rng,
+                                          std::optional<MemoryTag> default_tag,
+                                          uint32_t max_operand_value)
 {
     std::visit(overloaded{ [&](VariableRef& var) { mutate_variable_ref(var, rng, default_tag); },
                            [&](AddressRef& addr) { mutate_address_ref(addr, rng, max_operand_value); } },
                param);
 }
 
-std::optional<MemoryTag> get_param_ref_tag(const ParamRef& param)
-{
-    return std::visit(overloaded{ [](const VariableRef& var) -> std::optional<MemoryTag> { return var.tag.value; },
-                                  [](const AddressRef&) -> std::optional<MemoryTag> { return std::nullopt; } },
-                      param);
-}
-
 template <typename BinaryInstructionType>
-void mutate_binary_instruction_8(BinaryInstructionType& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_binary_instruction_8(BinaryInstructionType& instruction, std::mt19937_64& rng)
 {
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -834,7 +907,7 @@ void mutate_binary_instruction_8(BinaryInstructionType& instruction, std::mt1993
 }
 
 template <typename BinaryInstructionType>
-void mutate_binary_instruction_16(BinaryInstructionType& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_binary_instruction_16(BinaryInstructionType& instruction, std::mt19937_64& rng)
 {
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -850,7 +923,7 @@ void mutate_binary_instruction_16(BinaryInstructionType& instruction, std::mt199
     }
 }
 
-void mutate_not_8_instruction(NOT_8_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_not_8_instruction(NOT_8_Instruction& instruction, std::mt19937_64& rng)
 {
     UnaryInstruction8MutationOptions option = BASIC_UNARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -863,7 +936,7 @@ void mutate_not_8_instruction(NOT_8_Instruction& instruction, std::mt19937_64& r
     }
 }
 
-void mutate_set_8_instruction(SET_8_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_8_instruction(SET_8_Instruction& instruction, std::mt19937_64& rng)
 {
     Set8MutationOptions option = BASIC_SET_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -879,7 +952,7 @@ void mutate_set_8_instruction(SET_8_Instruction& instruction, std::mt19937_64& r
     }
 }
 
-void mutate_set_16_instruction(SET_16_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_16_instruction(SET_16_Instruction& instruction, std::mt19937_64& rng)
 {
     Set16MutationOptions option = BASIC_SET_16_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -895,7 +968,7 @@ void mutate_set_16_instruction(SET_16_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_set_32_instruction(SET_32_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_32_instruction(SET_32_Instruction& instruction, std::mt19937_64& rng)
 {
     Set32MutationOptions option = BASIC_SET_32_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -911,7 +984,7 @@ void mutate_set_32_instruction(SET_32_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_set_64_instruction(SET_64_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_64_instruction(SET_64_Instruction& instruction, std::mt19937_64& rng)
 {
     Set64MutationOptions option = BASIC_SET_64_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -927,7 +1000,7 @@ void mutate_set_64_instruction(SET_64_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_set_128_instruction(SET_128_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_128_instruction(SET_128_Instruction& instruction, std::mt19937_64& rng)
 {
     Set128MutationOptions option = BASIC_SET_128_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -946,7 +1019,7 @@ void mutate_set_128_instruction(SET_128_Instruction& instruction, std::mt19937_6
     }
 }
 
-void mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64& rng)
 {
     SetFFMutationOptions option = BASIC_SET_FF_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -962,7 +1035,7 @@ void mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_mov_8_instruction(MOV_8_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_mov_8_instruction(MOV_8_Instruction& instruction, std::mt19937_64& rng)
 {
     int choice = std::uniform_int_distribution<int>(0, 2)(rng);
     switch (choice) {
@@ -978,7 +1051,7 @@ void mutate_mov_8_instruction(MOV_8_Instruction& instruction, std::mt19937_64& r
     }
 }
 
-void mutate_mov_16_instruction(MOV_16_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_mov_16_instruction(MOV_16_Instruction& instruction, std::mt19937_64& rng)
 {
     int choice = std::uniform_int_distribution<int>(0, 2)(rng);
     switch (choice) {
@@ -994,7 +1067,7 @@ void mutate_mov_16_instruction(MOV_16_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64& rng)
 {
     UnaryInstruction8MutationOptions option = BASIC_UNARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1007,7 +1080,7 @@ void mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_cast_8_instruction(CAST_8_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_cast_8_instruction(CAST_8_Instruction& instruction, std::mt19937_64& rng)
 {
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1023,7 +1096,7 @@ void mutate_cast_8_instruction(CAST_8_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_cast_16_instruction(CAST_16_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_cast_16_instruction(CAST_16_Instruction& instruction, std::mt19937_64& rng)
 {
     BinaryInstruction8MutationOptions option = BASIC_BINARY_INSTRUCTION_8_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1039,7 +1112,7 @@ void mutate_cast_16_instruction(CAST_16_Instruction& instruction, std::mt19937_6
     }
 }
 
-void mutate_sstore_instruction(SSTORE_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_sstore_instruction(SSTORE_Instruction& instruction, std::mt19937_64& rng)
 {
     SStoreMutationOptions option = BASIC_SSTORE_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1055,7 +1128,7 @@ void mutate_sstore_instruction(SSTORE_Instruction& instruction, std::mt19937_64&
     }
 }
 
-void mutate_sload_instruction(SLOAD_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_sload_instruction(SLOAD_Instruction& instruction, std::mt19937_64& rng)
 {
     SLoadMutationOptions option = BASIC_SLOAD_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1071,7 +1144,7 @@ void mutate_sload_instruction(SLOAD_Instruction& instruction, std::mt19937_64& r
     }
 }
 
-void mutate_getenvvar_instruction(GETENVVAR_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_getenvvar_instruction(GETENVVAR_Instruction& instruction, std::mt19937_64& rng)
 {
     GetEnvVarMutationOptions option = BASIC_GETENVVAR_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1084,14 +1157,15 @@ void mutate_getenvvar_instruction(GETENVVAR_Instruction& instruction, std::mt199
     }
 }
 
-void mutate_emit_nullifier_instruction(EMITNULLIFIER_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_emit_nullifier_instruction(EMITNULLIFIER_Instruction& instruction, std::mt19937_64& rng)
 {
     // emitnulifier only has one field
 
     mutate_param_ref(instruction.nullifier_address, rng, MemoryTag::FF, MAX_16BIT_OPERAND);
 }
 
-void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instruction,
+                                                             std::mt19937_64& rng)
 {
     NullifierExistsMutationOptions option = BASIC_NULLIFIER_EXISTS_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1107,7 +1181,8 @@ void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instructio
     }
 }
 
-void mutate_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction& instruction,
+                                                            std::mt19937_64& rng)
 {
     L1ToL2MsgExistsMutationOptions option = BASIC_L1TOL2MSGEXISTS_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1123,7 +1198,7 @@ void mutate_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction& instruction
     }
 }
 
-void mutate_emit_note_hash_instruction(EMITNOTEHASH_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_emit_note_hash_instruction(EMITNOTEHASH_Instruction& instruction, std::mt19937_64& rng)
 {
     EmitNoteHashMutationOptions option = BASIC_EMITNOTEHASH_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1135,7 +1210,8 @@ void mutate_emit_note_hash_instruction(EMITNOTEHASH_Instruction& instruction, st
         break;
     }
 }
-void mutate_note_hash_exists_instruction(NOTEHASHEXISTS_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_note_hash_exists_instruction(NOTEHASHEXISTS_Instruction& instruction,
+                                                             std::mt19937_64& rng)
 {
     NoteHashExistsMutationOptions option = BASIC_NOTEHASHEXISTS_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1154,7 +1230,7 @@ void mutate_note_hash_exists_instruction(NOTEHASHEXISTS_Instruction& instruction
     }
 }
 
-void mutate_calldatacopy_instruction(CALLDATACOPY_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_calldatacopy_instruction(CALLDATACOPY_Instruction& instruction, std::mt19937_64& rng)
 {
     CalldataCopyMutationOptions option = BASIC_CALLDATACOPY_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1176,7 +1252,7 @@ void mutate_calldatacopy_instruction(CALLDATACOPY_Instruction& instruction, std:
     }
 }
 
-void mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, std::mt19937_64& rng)
 {
     SendL2ToL1MsgMutationOptions option = BASIC_SENDL2TOL1MSG_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1195,7 +1271,8 @@ void mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, st
     }
 }
 
-void mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instruction,
+                                                               std::mt19937_64& rng)
 {
     EmitUnencryptedLogMutationOptions option = BASIC_EMITUNENCRYPTEDLOG_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1208,7 +1285,7 @@ void mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instr
     }
 }
 
-void mutate_call_instruction(CALL_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_call_instruction(CALL_Instruction& instruction, std::mt19937_64& rng)
 {
     CallMutationOptions option = BASIC_CALL_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1236,8 +1313,8 @@ void mutate_call_instruction(CALL_Instruction& instruction, std::mt19937_64& rng
     }
 }
 
-void mutate_returndatasize_with_returndatacopy_instruction(RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instruction,
-                                                           std::mt19937_64& rng)
+void InstructionMutator::mutate_returndatasize_with_returndatacopy_instruction(
+    RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instruction, std::mt19937_64& rng)
 {
     ReturndatasizeWithReturndatacopyMutationOptions option =
         BASIC_RETURNDATASIZE_WITH_RETURNDATACOPY_MUTATION_CONFIGURATION.select(rng);
@@ -1254,7 +1331,8 @@ void mutate_returndatasize_with_returndatacopy_instruction(RETURNDATASIZE_WITH_R
     }
 }
 
-void mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& instruction,
+                                                                std::mt19937_64& rng)
 {
     GetContractInstanceMutationOptions option = BASIC_GETCONTRACTINSTANCE_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1270,7 +1348,7 @@ void mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& ins
     }
 }
 
-void mutate_successcopy_instruction(SUCCESSCOPY_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_successcopy_instruction(SUCCESSCOPY_Instruction& instruction, std::mt19937_64& rng)
 {
     SuccessCopyMutationOptions option = BASIC_SUCCESSCOPY_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1280,7 +1358,7 @@ void mutate_successcopy_instruction(SUCCESSCOPY_Instruction& instruction, std::m
     }
 }
 
-void mutate_ecadd_instruction(ECADD_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_ecadd_instruction(ECADD_Instruction& instruction, std::mt19937_64& rng)
 {
     // ECADD has 7 operands, select one to mutate
     int choice = std::uniform_int_distribution<int>(0, 6)(rng);
@@ -1309,7 +1387,7 @@ void mutate_ecadd_instruction(ECADD_Instruction& instruction, std::mt19937_64& r
     }
 }
 
-void mutate_poseidon2perm_instruction(POSEIDON2PERM_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_poseidon2perm_instruction(POSEIDON2PERM_Instruction& instruction, std::mt19937_64& rng)
 {
     int choice = std::uniform_int_distribution<int>(0, 1)(rng);
     switch (choice) {
@@ -1322,7 +1400,7 @@ void mutate_poseidon2perm_instruction(POSEIDON2PERM_Instruction& instruction, st
     }
 }
 
-void mutate_keccakf1600_instruction(KECCAKF1600_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_keccakf1600_instruction(KECCAKF1600_Instruction& instruction, std::mt19937_64& rng)
 {
     int choice = std::uniform_int_distribution<int>(0, 1)(rng);
     switch (choice) {
@@ -1335,7 +1413,8 @@ void mutate_keccakf1600_instruction(KECCAKF1600_Instruction& instruction, std::m
     }
 }
 
-void mutate_sha256compression_instruction(SHA256COMPRESSION_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_sha256compression_instruction(SHA256COMPRESSION_Instruction& instruction,
+                                                              std::mt19937_64& rng)
 {
     int choice = std::uniform_int_distribution<int>(0, 2)(rng);
     switch (choice) {
@@ -1351,7 +1430,7 @@ void mutate_sha256compression_instruction(SHA256COMPRESSION_Instruction& instruc
     }
 }
 
-void mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt19937_64& rng)
 {
     ToRadixBEMutationOptions option = BASIC_TORADIXBE_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1376,7 +1455,7 @@ void mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt199
     }
 }
 
-void mutate_debuglog_instruction(DEBUGLOG_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_debuglog_instruction(DEBUGLOG_Instruction& instruction, std::mt19937_64& rng)
 {
     DebugLogMutationOptions option = BASIC_DEBUGLOG_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
@@ -1396,77 +1475,6 @@ void mutate_debuglog_instruction(DEBUGLOG_Instruction& instruction, std::mt19937
         mutate_uint16_t(instruction.message_size, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
         break;
     }
-}
-
-void mutate_instruction(FuzzInstruction& instruction,
-                        std::mt19937_64& rng,
-                        [[maybe_unused]] const FuzzerContext& context)
-{
-    std::visit(
-        overloaded{
-            [&rng](ADD_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](SUB_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](MUL_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](DIV_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](EQ_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](LT_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](LTE_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](AND_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](OR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](XOR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](SHL_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](SHR_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](SET_8_Instruction& instr) { mutate_set_8_instruction(instr, rng); },
-            [&rng](SET_16_Instruction& instr) { mutate_set_16_instruction(instr, rng); },
-            [&rng](SET_32_Instruction& instr) { mutate_set_32_instruction(instr, rng); },
-            [&rng](SET_64_Instruction& instr) { mutate_set_64_instruction(instr, rng); },
-            [&rng](SET_128_Instruction& instr) { mutate_set_128_instruction(instr, rng); },
-            [&rng](SET_FF_Instruction& instr) { mutate_set_ff_instruction(instr, rng); },
-            [&rng](MOV_8_Instruction& instr) { mutate_mov_8_instruction(instr, rng); },
-            [&rng](MOV_16_Instruction& instr) { mutate_mov_16_instruction(instr, rng); },
-            [&rng](FDIV_8_Instruction& instr) { mutate_binary_instruction_8(instr, rng); },
-            [&rng](NOT_8_Instruction& instr) { mutate_not_8_instruction(instr, rng); },
-            [&rng](ADD_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](SUB_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](MUL_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](DIV_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](FDIV_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](EQ_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](LT_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](LTE_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](AND_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](OR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](XOR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](NOT_16_Instruction& instr) { mutate_not_16_instruction(instr, rng); },
-            [&rng](SHL_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](SHR_16_Instruction& instr) { mutate_binary_instruction_16(instr, rng); },
-            [&rng](CAST_8_Instruction& instr) { mutate_cast_8_instruction(instr, rng); },
-            [&rng](CAST_16_Instruction& instr) { mutate_cast_16_instruction(instr, rng); },
-            [&rng](SSTORE_Instruction& instr) { mutate_sstore_instruction(instr, rng); },
-            [&rng](SLOAD_Instruction& instr) { mutate_sload_instruction(instr, rng); },
-            [&rng](GETENVVAR_Instruction& instr) { mutate_getenvvar_instruction(instr, rng); },
-            [&rng](EMITNULLIFIER_Instruction& instr) { mutate_emit_nullifier_instruction(instr, rng); },
-            [&rng](NULLIFIEREXISTS_Instruction& instr) { mutate_nullifier_exists_instruction(instr, rng); },
-            [&rng](L1TOL2MSGEXISTS_Instruction& instr) { mutate_l1tol2msgexists_instruction(instr, rng); },
-            [&rng](EMITNOTEHASH_Instruction& instr) { mutate_emit_note_hash_instruction(instr, rng); },
-            [&rng](NOTEHASHEXISTS_Instruction& instr) { mutate_note_hash_exists_instruction(instr, rng); },
-            [&rng](CALLDATACOPY_Instruction& instr) { mutate_calldatacopy_instruction(instr, rng); },
-            [&rng](SENDL2TOL1MSG_Instruction& instr) { mutate_sendl2tol1msg_instruction(instr, rng); },
-            [&rng](EMITUNENCRYPTEDLOG_Instruction& instr) { mutate_emitunencryptedlog_instruction(instr, rng); },
-            [&rng](CALL_Instruction& instr) { mutate_call_instruction(instr, rng); },
-            [&rng](RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instr) {
-                mutate_returndatasize_with_returndatacopy_instruction(instr, rng);
-            },
-            [&rng](GETCONTRACTINSTANCE_Instruction& instr) { mutate_getcontractinstance_instruction(instr, rng); },
-            [&rng](SUCCESSCOPY_Instruction& instr) { mutate_successcopy_instruction(instr, rng); },
-            [&rng](ECADD_Instruction& instr) { mutate_ecadd_instruction(instr, rng); },
-            [&rng](POSEIDON2PERM_Instruction& instr) { mutate_poseidon2perm_instruction(instr, rng); },
-            [&rng](KECCAKF1600_Instruction& instr) { mutate_keccakf1600_instruction(instr, rng); },
-            [&rng](SHA256COMPRESSION_Instruction& instr) { mutate_sha256compression_instruction(instr, rng); },
-            [&rng](TORADIXBE_Instruction& instr) { mutate_toradixbe_instruction(instr, rng); },
-            [&rng](DEBUGLOG_Instruction& instr) { mutate_debuglog_instruction(instr, rng); },
-            [](auto&) { throw std::runtime_error("Unknown instruction"); } },
-        instruction);
 }
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.hpp
@@ -5,12 +5,92 @@
 
 #include "barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.hpp"
 #include "barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp"
-#include "barretenberg/avm_fuzzer/mutations/configuration.hpp"
+#include "barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp"
 
 namespace bb::avm2::fuzzer {
 
-/// @brief Generate one instruction and optionally backfill
-std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng, const FuzzerContext& context);
-void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng, const FuzzerContext& context);
+class InstructionMutator {
+  public:
+    InstructionMutator(uint32_t base_offset, const FuzzerContext& context)
+        : base_offset(base_offset)
+        , context(context)
+    {}
+
+    InstructionMutator(const InstructionBlock& instruction_block, const FuzzerContext& context)
+        : base_offset(instruction_block.base_offset)
+        , context(context)
+    {}
+
+    /// @brief Generate one instruction and optionally backfill
+    std::vector<FuzzInstruction> generate_instruction(std::mt19937_64& rng);
+    void mutate_instruction(FuzzInstruction& instruction, std::mt19937_64& rng);
+
+    uint32_t base_offset;
+    const FuzzerContext& context;
+
+  private:
+    AddressingMode generate_addressing_mode(std::mt19937_64& rng);
+    VariableRef generate_variable_ref(std::mt19937_64& rng);
+    AddressRef generate_address_ref(std::mt19937_64& rng, uint32_t max_operand_value);
+
+    std::vector<FuzzInstruction> generate_ecadd_instruction(std::mt19937_64& rng);
+    template <typename InstructionType>
+    std::vector<FuzzInstruction> generate_alu_with_matching_tags(std::mt19937_64& rng, uint32_t max_operand);
+    template <typename InstructionType>
+    std::vector<FuzzInstruction> generate_alu_with_matching_tags_not_ff(std::mt19937_64& rng, uint32_t max_operand);
+    std::vector<FuzzInstruction> generate_fdiv_instruction(std::mt19937_64& rng, uint32_t max_operand);
+    std::vector<FuzzInstruction> generate_keccakf_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_sha256compression_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_toradixbe_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_sload_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_emitunencryptedlog_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_call_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_getcontractinstance_instruction(std::mt19937_64& rng);
+
+    void mutate_variable_ref(VariableRef& variable, std::mt19937_64& rng, std::optional<MemoryTag> default_tag);
+    void mutate_address_ref(AddressRef& address, std::mt19937_64& rng, uint32_t max_operand_value);
+    void mutate_param_ref(ParamRef& param,
+                          std::mt19937_64& rng,
+                          std::optional<MemoryTag> default_tag,
+                          uint32_t max_operand_value);
+    template <typename BinaryInstructionType>
+    void mutate_binary_instruction_8(BinaryInstructionType& instruction, std::mt19937_64& rng);
+    template <typename BinaryInstructionType>
+    void mutate_binary_instruction_16(BinaryInstructionType& instruction, std::mt19937_64& rng);
+    void mutate_not_8_instruction(NOT_8_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_8_instruction(SET_8_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_16_instruction(SET_16_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_32_instruction(SET_32_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_64_instruction(SET_64_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_128_instruction(SET_128_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_set_ff_instruction(SET_FF_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_mov_8_instruction(MOV_8_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_mov_16_instruction(MOV_16_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_not_16_instruction(NOT_16_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_cast_8_instruction(CAST_8_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_cast_16_instruction(CAST_16_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_sstore_instruction(SSTORE_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_sload_instruction(SLOAD_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_getenvvar_instruction(GETENVVAR_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_emit_nullifier_instruction(EMITNULLIFIER_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_nullifier_exists_instruction(NULLIFIEREXISTS_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_l1tol2msgexists_instruction(L1TOL2MSGEXISTS_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_emit_note_hash_instruction(EMITNOTEHASH_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_note_hash_exists_instruction(NOTEHASHEXISTS_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_calldatacopy_instruction(CALLDATACOPY_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_call_instruction(CALL_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_returndatasize_with_returndatacopy_instruction(
+        RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_successcopy_instruction(SUCCESSCOPY_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_ecadd_instruction(ECADD_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_poseidon2perm_instruction(POSEIDON2PERM_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_keccakf1600_instruction(KECCAKF1600_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_sha256compression_instruction(SHA256COMPRESSION_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_toradixbe_instruction(TORADIXBE_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_debuglog_instruction(DEBUGLOG_Instruction& instruction, std::mt19937_64& rng);
+};
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction_block.cpp
@@ -11,25 +11,29 @@ namespace bb::avm2::fuzzer {
 
 constexpr uint16_t MAX_INSTRUCTION_BLOCK_SIZE_ON_GENERATION = 10;
 
-std::vector<FuzzInstruction> generate_instruction_block(std::mt19937_64& rng, const FuzzerContext& context)
+InstructionBlock generate_instruction_block(std::mt19937_64& rng, const FuzzerContext& context)
 {
-    std::vector<FuzzInstruction> instruction_block;
+    InstructionBlock instruction_block;
+    instruction_block.base_offset = std::uniform_int_distribution<uint32_t>(0, AVM_HIGHEST_MEM_ADDRESS)(rng);
+    InstructionMutator instruction_mutator(instruction_block, context);
     for (uint16_t i = 0; i < std::uniform_int_distribution<uint16_t>(1, MAX_INSTRUCTION_BLOCK_SIZE_ON_GENERATION)(rng);
          i++) {
-        auto instructions = generate_instruction(rng, context);
-        instruction_block.insert(instruction_block.end(), instructions.begin(), instructions.end());
+        auto new_instructions = instruction_mutator.generate_instruction(rng);
+        instruction_block.instructions.insert(
+            instruction_block.instructions.end(), new_instructions.begin(), new_instructions.end());
     }
     return instruction_block;
 }
 
-void mutate_instruction_block(std::vector<FuzzInstruction>& instruction_block,
-                              std::mt19937_64& rng,
-                              const FuzzerContext& context)
+void mutate_instruction_block(InstructionBlock& instruction_block, std::mt19937_64& rng, const FuzzerContext& context)
 {
+    InstructionMutator instruction_mutator(instruction_block, context);
+
     // If vector is empty, force insertion (other mutations do nothing on empty vectors)
-    if (instruction_block.empty()) {
-        auto new_instructions = generate_instruction(rng, context);
-        instruction_block.insert(instruction_block.end(), new_instructions.begin(), new_instructions.end());
+    if (instruction_block.instructions.empty()) {
+        auto new_instructions = instruction_mutator.generate_instruction(rng);
+        instruction_block.instructions.insert(
+            instruction_block.instructions.end(), new_instructions.begin(), new_instructions.end());
         return;
     }
 
@@ -37,26 +41,28 @@ void mutate_instruction_block(std::vector<FuzzInstruction>& instruction_block,
     switch (option) {
     case VecMutationOptions::Insertion: {
         // Custom insertion logic to handle vector-returning generator
-        auto new_instructions = generate_instruction(rng, context);
+        auto new_instructions = instruction_mutator.generate_instruction(rng);
         if (!new_instructions.empty()) {
-            std::uniform_int_distribution<size_t> dist(0, instruction_block.size());
+            std::uniform_int_distribution<size_t> dist(0, instruction_block.instructions.size());
             size_t index = dist(rng);
-            instruction_block.insert(instruction_block.begin() + static_cast<std::ptrdiff_t>(index),
-                                     new_instructions.begin(),
-                                     new_instructions.end());
+            instruction_block.instructions.insert(instruction_block.instructions.begin() +
+                                                      static_cast<std::ptrdiff_t>(index),
+                                                  new_instructions.begin(),
+                                                  new_instructions.end());
         }
         break;
     }
     case VecMutationOptions::Deletion:
-        RandomDeletion::mutate(rng, instruction_block);
+        RandomDeletion::mutate(rng, instruction_block.instructions);
         break;
     case VecMutationOptions::Swap:
-        RandomSwap::mutate(rng, instruction_block);
+        RandomSwap::mutate(rng, instruction_block.instructions);
         break;
     case VecMutationOptions::ElementMutation:
-        RandomElementMutation::mutate(rng, instruction_block, [&context](FuzzInstruction& instr, std::mt19937_64& r) {
-            mutate_instruction(instr, r, context);
-        });
+        RandomElementMutation::mutate(
+            rng, instruction_block.instructions, [&instruction_mutator](FuzzInstruction& instr, std::mt19937_64& r) {
+                instruction_mutator.mutate_instruction(instr, r);
+            });
         break;
     }
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction_block.hpp
@@ -8,9 +8,28 @@
 
 namespace bb::avm2::fuzzer {
 
-std::vector<FuzzInstruction> generate_instruction_block(std::mt19937_64& rng, const FuzzerContext& context);
-void mutate_instruction_block(std::vector<FuzzInstruction>& instruction_block,
-                              std::mt19937_64& rng,
-                              const FuzzerContext& context);
+struct InstructionBlock {
+    std::vector<FuzzInstruction> instructions;
+    uint32_t base_offset = 0;
+
+    MSGPACK_FIELDS(instructions, base_offset);
+};
+
+inline std::ostream& operator<<(std::ostream& os, const InstructionBlock& instruction_block)
+{
+    os << "InstructionBlock {\n";
+    os << "  instructions: [\n";
+    for (const auto& instr : instruction_block.instructions) {
+        os << "    " << instr << ",\n";
+    }
+    os << "  ],\n";
+    os << "  base_offset: " << instruction_block.base_offset << ",\n";
+    os << "}";
+    return os;
+}
+
+InstructionBlock generate_instruction_block(std::mt19937_64& rng, const FuzzerContext& context);
+
+void mutate_instruction_block(InstructionBlock& instruction_block, std::mt19937_64& rng, const FuzzerContext& context);
 
 } // namespace bb::avm2::fuzzer


### PR DESCRIPTION
Resolves https://linear.app/aztec-labs/issue/AVM-198/fix-relative-addressing
Relative addressing was pretty broken in the fuzzer: we created references to addresses with different base pointers for the same instruction. This made it so the last base pointer "won", rendering all the other references to addresses invalid, triggering more tag mismatch errors. With this fix we execute roughly 50% more opcodes in the same fuzzer iterations.
The fix is to have a common base pointer for all instructions in an instruction block, and to generate code aware of that base pointer. When generating bytecode for that instruction block, we write the base pointer first and then we generate the bytecode for the recorded instructions.