### PR TITLE
fix: use absolute path in run_test.sh for CI

### DIFF
--- a/barretenberg/rust/scripts/run_test.sh
+++ b/barretenberg/rust/scripts/run_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source $(git rev-parse --show-toplevel)/ci3/source
 
-cd "$(dirname "$0")/.."
+cd $(git rev-parse --show-toplevel)/barretenberg/rust
 
 # Ensure Cargo is in PATH
 if [ -f "$HOME/.cargo/env" ]; then


### PR DESCRIPTION
## Summary
Fix the barretenberg-rs test script path resolution for CI.

## Problem
The `run_test.sh` script was failing in CI with:
```
barretenberg/rust/scripts/run_test.sh: line 4: cd: barretenberg/rust/scripts/..: No such file or directory
```

This happened because `dirname "$0"` returns a relative path when the script is invoked with a relative path in CI, and the `cd` command fails to find the directory.

## Solution
Use `git rev-parse --show-toplevel` to get an absolute path instead of relying on `dirname "$0"`.