### PR TITLE
chore: add port forward testing in smoke test

### DIFF
--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -13,6 +13,7 @@ import {
   getGitProjectRoot,
   installChaosMeshChart,
   setupEnvironment,
+  startPortForward,
   startPortForwardForEthereum,
   startPortForwardForRPC,
 } from './utils.js';
@@ -106,5 +107,134 @@ describe('smoke test', () => {
       helmChartDir: `${spartanDir}/aztec-chaos-scenarios`,
       logger,
     });
+  });
+
+  it('can establish all port forwards used by spartan tests', async () => {
+    // This test validates all the port forwarding mechanisms used across the spartan test suite.
+    // It helps build confidence that the K8s infrastructure is accessible before running more complex tests.
+
+    const testForwardProcesses: ChildProcess[] = [];
+    const RETRY_TIMEOUT_SECONDS = 60 * 60; // 1 hour
+    const RETRY_INTERVAL_SECONDS = 12;
+
+    try {
+      logger.info('Testing all port forwards...');
+
+      const [rpcResult, ethResult, promResult, adminResult] = await Promise.all([
+        // Test RPC port forward
+        retryUntil(
+          async () => {
+            try {
+              const { process: rpcProcess, port: rpcPort } = await startPortForwardForRPC(config.NAMESPACE);
+              const rpcUrl = `http://127.0.0.1:${rpcPort}`;
+              const testNode = createAztecNodeClient(rpcUrl);
+              const nodeInfo = await testNode.getNodeInfo();
+              if (nodeInfo?.enr?.startsWith('enr:-')) {
+                return { process: rpcProcess, port: rpcPort };
+              }
+              rpcProcess.kill();
+              return undefined;
+            } catch {
+              return undefined;
+            }
+          },
+          'RPC port forward',
+          RETRY_TIMEOUT_SECONDS,
+          RETRY_INTERVAL_SECONDS,
+        ),
+
+        // Test Ethereum port forward
+        retryUntil(
+          async () => {
+            try {
+              const { process: ethProcess, port: ethPort } = await startPortForwardForEthereum(config.NAMESPACE);
+              const ethUrl = `http://127.0.0.1:${ethPort}`;
+              const testEthClient = createPublicClient({ transport: http(ethUrl) });
+              const blockNumber = await testEthClient.getBlockNumber();
+              if (blockNumber >= 0n) {
+                return { process: ethProcess, port: ethPort, blockNumber };
+              }
+              ethProcess.kill();
+              return undefined;
+            } catch {
+              return undefined;
+            }
+          },
+          'Ethereum port forward',
+          RETRY_TIMEOUT_SECONDS,
+          RETRY_INTERVAL_SECONDS,
+        ),
+
+        // Test Prometheus port forward
+        retryUntil(
+          async () => {
+            // Try metrics namespace first
+            try {
+              const result = await startPortForward({
+                resource: `svc/metrics-prometheus-server`,
+                namespace: 'metrics',
+                containerPort: 80,
+              });
+              return { ...result, namespace: 'metrics' };
+            } catch {
+              // Fall back to test namespace
+              try {
+                const result = await startPortForward({
+                  resource: `svc/prometheus-server`,
+                  namespace: config.NAMESPACE,
+                  containerPort: 80,
+                });
+                return { ...result, namespace: config.NAMESPACE };
+              } catch {
+                return undefined;
+              }
+            }
+          },
+          'Prometheus port forward',
+          RETRY_TIMEOUT_SECONDS,
+          RETRY_INTERVAL_SECONDS,
+        ),
+
+        // Test validator admin port forward
+        retryUntil(
+          async () => {
+            try {
+              const result = await startPortForward({
+                resource: `pod/${config.NAMESPACE}-validator-aztec-node-0`,
+                namespace: config.NAMESPACE,
+                containerPort: 8880,
+              });
+              return result;
+            } catch {
+              return undefined;
+            }
+          },
+          'Validator admin port forward',
+          RETRY_TIMEOUT_SECONDS,
+          RETRY_INTERVAL_SECONDS,
+        ),
+      ]);
+
+      testForwardProcesses.push(rpcResult.process, ethResult.process, promResult.process, adminResult.process);
+
+      expect(rpcResult.port).toBeGreaterThan(0);
+      logger.info(`RPC port forward OK on port ${rpcResult.port}`);
+
+      expect(ethResult.port).toBeGreaterThan(0);
+      logger.info(`Ethereum port forward OK on port ${ethResult.port}, block number: ${ethResult.blockNumber}`);
+
+      expect(promResult.port).toBeGreaterThan(0);
+      logger.info(`Prometheus port forward OK on port ${promResult.port} (${promResult.namespace} namespace)`);
+
+      expect(adminResult.port).toBeGreaterThan(0);
+      logger.info(`Validator admin port forward OK on port ${adminResult.port}`);
+
+      logger.info('All port forward checks completed successfully');
+    } finally {
+      // Clean up all test port forwards
+      for (const proc of testForwardProcesses) {
+        proc.kill();
+      }
+    }
   });
 });


### PR DESCRIPTION
- adds port forward testing that covers all network tests for robustness
