### PR TITLE
fix: comments and assertions

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/src/abis/blob_accumulator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/abis/blob_accumulator.nr
@@ -64,7 +64,7 @@ impl BlobAccumulator {
     * Init the first accumulation state of the epoch.
     *
     * First state of the accumulator:
-    * - v_acc := sha256(C_0)
+    * - blob_commitments_hash_acc := sha256(C_0)
     * - z_acc := z_0
     * - y_acc := gamma^0 * y_0 = y_0
     * - c_acc := gamma^0 * c_0 = c_0
@@ -94,7 +94,7 @@ impl BlobAccumulator {
     * NB: blob_commitments_hash is written as v below
     *
     * Each accumulation:
-    * - v_acc := sha256(v_acc, C_i)
+    * - blob_commitments_hash_acc := sha256(blob_commitments_hash_acc, C_i)
     * - z_acc := poseidon2(z_acc, z_i)
     * - y_acc := y_acc + (gamma^i * y_i)
     * - c_acc := c_acc + (gamma^i * c_i)
@@ -102,7 +102,7 @@ impl BlobAccumulator {
     * - gamma^(i + 1) = gamma^i * gamma // denoted gamma_pow_acc
     *
     * Final accumulated values (from last blob of last checkpoint of epoch):
-    * - v := v_acc (hash of all commitments (C_i s) to be checked on L1)
+    * - blob_commitments_hash := blob_commitments_hash_acc (hash of all commitments (C_i s) to be checked on L1)
     * - z := z_acc (final challenge, at which all blobs are evaluated)
     * - y := y_acc (final opening to be checked on L1)
     * - c := c_acc (final commitment to be checked on L1)

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/abis/final_blob_batching_challenges.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/abis/final_blob_batching_challenges.nr
@@ -9,7 +9,7 @@ use types::{
 * Final values z and gamma are injected into each block root circuit. We ensure they are correct by:
 * - Checking equality in each block merge circuit and propagating up
 * - Checking final z_acc == z in root circuit
-* - Checking final gamma_acc == gamma in root circuit
+* - Checking final h(gamma_acc, z) == gamma in root circuit
 *
 *  - z = H(...H(H(z_0, z_1) z_2)..z_n)
 *    - where z_i = H(H(fields of blob_i), C_i),

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
@@ -21,7 +21,7 @@ use types::constants::FIELDS_PER_BLOB;
  * - (1 / d)
  *
  * @param z
- * @param ys - the many y_i's of the blob.
+ * @param ys - ("ys" being the plural of "y") - the many y_i's of the blob.
  *
  * @return y = p(z)
  */

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup.nr
@@ -14,6 +14,7 @@ use dep::types::{
     proof::proof_data::RollupHonkProofData,
 };
 
+// Note: see `rollup_structure_tests.nr` for valid combinations of left and right vks.
 global ALLOWED_RIGHT_ROLLUP_VK_INDICES: [u32; 3] =
     [BLOCK_ROOT_ROLLUP_VK_INDEX, BLOCK_ROOT_SINGLE_TX_ROLLUP_VK_INDEX, BLOCK_MERGE_ROLLUP_VK_INDEX];
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/tests/consecutive_block_rollups_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/tests/consecutive_block_rollups_tests.nr
@@ -203,6 +203,7 @@ fn non_consecutive_archive_next_available_leaf_indices() {
 
     // Tweak the next_available_leaf_index of the right rollup.
     builder.right_rollup.previous_archive.next_available_leaf_index += 1;
+    builder.right_rollup.new_archive.next_available_leaf_index += 1; // ensures the `num_blocks()` fn still returns the correct value.
 
     builder.execute_and_fail();
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/merge_block_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/merge_block_rollups.nr
@@ -2,6 +2,7 @@ use crate::{abis::BlockRollupPublicInputs, tx_merge::accumulate_out_hash};
 use types::hash::poseidon2_hash;
 
 pub fn accumulate_block_headers_hash(left_hash: Field, right_hash: Field) -> Field {
+    // TODO: this needs a domain separator, to be safe.
     poseidon2_hash([left_hash, right_hash])
 }
 
@@ -9,6 +10,9 @@ pub fn merge_block_rollups(
     left: BlockRollupPublicInputs,
     right: BlockRollupPublicInputs,
 ) -> BlockRollupPublicInputs {
+    // We need a way to, given a checkpoint header and a set of block headers, verify that the block headers
+    // are indeed part of that checkpoint. The `block_headers_hash` is a commitment to all block hashes: the
+    // root of a small unbalanced merkle tree of all block hashes.
     let block_headers_hash =
         accumulate_block_headers_hash(left.block_headers_hash, right.block_headers_hash);
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/validate_consecutive_block_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/utils/validate_consecutive_block_rollups.nr
@@ -42,7 +42,9 @@ fn assert_prev_block_rollups_follow_on_from_each_other(
         "Mismatched timestamps: expected right.timestamp to match left.timestamp",
     );
 
-    // Non-empty `in_hash` originates from the first block root and is propagated through all merge
+    // TODO: Consider extracting into its own function:
+
+    // A non-empty `in_hash` originates from the first block root only, and is propagated through all merge
     // steps via the left rollup only (see merge_block_rollups.nr).
     // We prevent the right rollup from propagating a nonzero `in_hash`, so it's impossible for any
     // block but the first to propagate a nonzero `in_hash` up to the checkpoint root.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_empty_tx_first_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_empty_tx_first_rollup.nr
@@ -47,14 +47,10 @@ pub struct BlockRootEmptyTxFirstRollupPrivateInputs {
 pub fn execute(inputs: BlockRootEmptyTxFirstRollupPrivateInputs) -> BlockRollupPublicInputs {
     validate_parity_root(inputs.parity_root, inputs.constants.vk_tree_root);
 
-    // Since it's the first block in a checkpoint, the start sponge blob is empty.
-    let start_sponge_blob = SpongeBlob::init();
-
     BlockRollupPublicInputsComposer::new_from_no_rollups(
         inputs.previous_archive,
         inputs.previous_state,
         inputs.constants,
-        start_sponge_blob,
         inputs.timestamp,
     )
         .with_new_l1_to_l2_messages(

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_rollup_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_rollup_public_inputs_composer.nr
@@ -41,9 +41,10 @@ impl BlockRollupPublicInputsComposer {
         previous_archive: AppendOnlyTreeSnapshot,
         previous_state: StateReference,
         constants: CheckpointConstantData,
-        start_sponge_blob: SpongeBlob,
         timestamp: u64,
     ) -> Self {
+        let empty_sponge_blob = SpongeBlob::init();
+
         Self {
             constants,
             previous_archive,
@@ -51,8 +52,9 @@ impl BlockRollupPublicInputsComposer {
             // The state remains the same since there are no tx effects in this block.
             start_tree_snapshots: previous_state.partial,
             end_tree_snapshots: previous_state.partial,
-            start_sponge_blob,
-            end_sponge_blob: start_sponge_blob,
+            // Since it's the first block in a checkpoint, the start sponge blob is empty.
+            start_sponge_blob: empty_sponge_blob,
+            end_sponge_blob: empty_sponge_blob,
             timestamp,
             // The followings are 0 since there are no tx effects in this block.
             out_hash: 0,
@@ -78,6 +80,9 @@ impl BlockRollupPublicInputsComposer {
             fee_recipient: global_variables.fee_recipient,
             gas_fees: global_variables.gas_fees,
         };
+
+        // This should never bite, because both private/public tx base rollups set num_txs to 1. Nevertheless, it's here.
+        assert(rollup.num_txs != 0, "Must use new_from_no_rollups instead.");
 
         Self {
             constants,
@@ -179,8 +184,11 @@ impl BlockRollupPublicInputsComposer {
         // Block number equals the index at which the new block header hash is inserted into the archive tree.
         let block_number = self.previous_archive.next_available_leaf_index as u32;
 
+        // TODO: this feels like "validation" that should therefore be done by the "Validator", rather than this "Composer".
+        // TODO: consider doing this as part of the "empty" variant's validation. It doesn't seem to belong here?
+
         // Note: For non-empty blocks, a check is performed in `block_root_rollup_inputs_validator.nr` to ensure that
-        // the leaf index matches the block number (u32) in the tx constants, which implies that the leaf index does not
+        // the leaf index (field) matches the block number (u32) in the tx constants, which implies that the leaf index does not
         // exceed u32. However, for empty blocks, without the check below, the block number would be truncated to a
         // smaller value (dropping the high bits) if the leaf index exceeded u32. This would allow the block to follow
         // a block with a much smaller block number, while `last_archive` would still contain the large index.
@@ -189,6 +197,10 @@ impl BlockRollupPublicInputsComposer {
         // Note: An empty block with a mismatched `last_archive` leaf index could be rolled up if it is in the first
         // checkpoint of an epoch, since only the `last_archive.root` is output from the root rollup and checked on L1.
         self.previous_archive.next_available_leaf_index.assert_max_bit_size::<32>();
+        std::static_assert(
+            ARCHIVE_HEIGHT <= 32,
+            "You need to update the max bit size on the line above",
+        );
 
         let global_variables = GlobalVariables {
             chain_id: self.constants.chain_id,
@@ -203,6 +215,7 @@ impl BlockRollupPublicInputsComposer {
 
         // Absorb data for this block into the end sponge blob.
         let mut block_end_sponge_blob = self.end_sponge_blob;
+
         // `in_hash` is not 0 if and only if it's the first block in the checkpoint.
         // Note: the `in_hash` of the first block in the checkpoint is asserted to be nonzero
         // by the Checkpoint Root circuit.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/utils/merge_checkpoint_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_merge/utils/merge_checkpoint_rollups.nr
@@ -11,10 +11,17 @@ pub fn merge_checkpoint_rollups(
     // Make sure that the total number of checkpoints does not exceed the maximum allowed in an epoch, preventing the
     // merged arrays (`checkpoint_header_hashes`, `out_hashes`, `fees`) from being truncated.
     let num_checkpoints = num_left_checkpoints + num_right_checkpoints;
+
     assert(
         num_checkpoints <= AZTEC_MAX_EPOCH_DURATION,
         "total number of checkpoints exceeds max allowed in an epoch",
     );
+
+    // Note: we have a guarantee that the number of left/right checkpoints equals the number of left/right fees:
+    // Each checkpoint root adds its header hash and fee to index 0 of the arrays, which means each checkpoint
+    // has the same amount (1) of header hash and fee entries. So we are able to use the number of header hashes
+    // (which is the only property that doesn't have empty values), for the number of fees.
+    // Hence, we don't need to assert left.num_fees == num_left_checkpoints and right.num_fees == num_right_checkpoints.
 
     // We use `copy_items_into_array` here because we know exactly how many items should be taken from each side when
     // merging checkpoints.

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/tree_snapshot_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/tree_snapshot_builder.nr
@@ -30,6 +30,7 @@ pub struct TreeSnapshotDiffHints {
     pub fee_payer_balance_membership_witness: MembershipWitness<PUBLIC_DATA_TREE_HEIGHT>,
 }
 
+/// Builds the _end_ tree snapshots,
 pub fn build_tree_snapshots(
     start_tree_snapshots: PartialStateReference,
     note_hashes: [Field; MAX_NOTE_HASHES_PER_TX],

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/merge_tx_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/merge_tx_rollups.nr
@@ -1,12 +1,20 @@
 use crate::abis::TxRollupPublicInputs;
 use dep::types::hash::accumulate_sha256;
 
+// The `out_hash` is the root of a (potentially wonky, greedy) subtree of L2->L1 messages that the
+// various functions of txs of this block have emitted.
 pub fn accumulate_out_hash(left_out_hash: Field, right_out_hash: Field) -> Field {
+    // An out_hash will only be 0 if no L2->L1 msgs were emitted by the functions of the txs of the
+    // left/right subtree.
     if left_out_hash == 0 {
         right_out_hash
     } else if right_out_hash == 0 {
         left_out_hash
     } else {
+        // TODO: should probably have a domain separator, to be safe
+        // We use sha256 for EVM compatibility: some time after this circuit is executed, an L1 contract will consume
+        // a message from this `out_hash` subtree (the subtree of L2->L1 messages) by doing a merkle
+        // membership check in the Outbox.sol contract: sha256 is cheaper than poseidon2 on L1.
         accumulate_sha256(left_out_hash, right_out_hash)
     }
 }
@@ -15,9 +23,24 @@ pub fn merge_tx_rollups(
     left: TxRollupPublicInputs,
     right: TxRollupPublicInputs,
 ) -> TxRollupPublicInputs {
+    // Ensure num_txs >= 2:
+    assert(left.num_txs != 0);
+    assert(right.num_txs != 0);
     let num_txs = left.num_txs + right.num_txs;
 
     let out_hash = accumulate_out_hash(left.out_hash, right.out_hash);
+
+    // Convincing the reader the below Field additions won't overflow:
+    //
+    // mana is the sum of all txs' l2_gas, each of which is a u32. So it's not possible to overflow because it
+    // will be limited by the number of txs we can accumulate (num_txs, which is a u16).
+    // 16 + 32 < 254.
+    //
+    // And fees is the sum of all txs' fee, each of which is computed as:
+    // (da_gas as Field) * (fee_per_da_gas as Field) + (l2_gas as Field) * (fee_per_l2_gas as Field)
+    // gas is u32 and fee_per_gas is u128, so each fee is at most 32 + 128 + 1 = 161 bits.
+    // With num_txs being u16, the maximum fee per block is 16 + 161 = 177 bits, which won't overflow.
+    // (Also bear in mind that in practice `num_txs` will be much smaller).
 
     let accumulated_fees = left.accumulated_fees + right.accumulated_fees;
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/validate_consecutive_tx_rollups.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_merge/utils/validate_consecutive_tx_rollups.nr
@@ -14,6 +14,8 @@ pub fn validate_consecutive_tx_rollups(left: TxRollupPublicInputs, right: TxRoll
 /// When called from the `block_merge` or `checkpoint_root`, it represents the total number of `block_root` rollups.
 /// When called from the `checkpoint_merge` or `root`, it represents the total number of `checkpoint_root` rollups.
 pub fn assert_rollups_filled_greedily(num_left_rollups: u16, num_right_rollups: u16) {
+    assert(num_right_rollups != 0, "num_right_rollups must not be 0");
+
     // The left rollup must be a balanced tree (i.e., `num_left_rollups` is a power of 2).
     assert(
         is_power_of_2(num_left_rollups),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -27,6 +27,8 @@ pub use poseidon2_chunks::poseidon2_absorb_in_chunks_existing_sponge;
 use poseidon2_chunks::poseidon2_absorb_in_chunks;
 use std::embedded_curve_ops::EmbeddedCurveScalar;
 
+// TODO: refactor these into their own files: sha256, poseidon2, some protocol-specific hash computations, some merkle computations.
+
 pub fn sha256_to_field<let N: u32>(bytes_to_hash: [u8; N]) -> Field {
     let sha256_hashed = sha256::digest(bytes_to_hash);
     let hash_in_a_field = field_from_bytes_32_trunc(sha256_hashed);
@@ -205,6 +207,7 @@ pub fn silo_l2_to_l1_message(
     }
 }
 
+// TODO: consider a variant that enables domain separation with a u32 (we seem to have standardised u32s for domain separators)
 /// Computes sha256 hash of 2 input fields.
 ///
 /// @returns A truncated field (i.e., the first byte is always 0).
@@ -217,6 +220,7 @@ pub fn accumulate_sha256(v0: Field, v1: Field) -> Field {
     sha256_to_field(hash_input_flattened)
 }
 
+// TODO: remove this. The protocol doesn't need it.
 #[inline_always]
 pub fn pedersen_hash<let N: u32>(inputs: [Field; N], hash_index: u32) -> Field {
     std::hash::pedersen_hash_with_separator(inputs, hash_index)

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
@@ -30,7 +30,10 @@ where
     Leaf: IndexedTreeLeafPreimage<Value>,
 {
     // Sanity check: ensure this function is called with correct generics.
-    assert_eq(SubtreeWidth, 1 << SubtreeHeight, "subtree items must be 2^subtree height");
+    std::static_assert(
+        SubtreeWidth == 1 << SubtreeHeight,
+        "subtree items must be 2^subtree height",
+    );
 
     // Check that `sorted_values` is a permutation of `values_to_insert`.
     // Values must be sorted by key in descending order. Failing to do so will still pass the permutation check,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/merkle_tree.nr
@@ -1,4 +1,4 @@
-use crate::{hash::{accumulate_sha256, merkle_hash}, traits::Empty};
+use crate::{hash::{accumulate_sha256, merkle_hash}, traits::Empty, utils::math::is_power_of_2_u32};
 
 #[derive(Eq)]
 pub struct MerkleTree<let N: u32> {
@@ -63,11 +63,14 @@ pub fn sibling_index(index: u32) -> u32 {
     }
 }
 
-// Note: `N` must be a power of 2.
 fn compute_merkle_tree_nodes<let N: u32>(
     leaves: [Field; N],
     hasher: fn(Field, Field) -> Field,
 ) -> [Field; N - 1] {
+    // Note: `N` must be a power of 2.
+    std::static_assert(is_power_of_2_u32(N), "N must be a power of 2");
+    std::static_assert(N != 1, "2 must divide N");
+
     let mut nodes = [0; N - 1];
 
     let total_nodes = N - 1;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/math.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/math.nr
@@ -7,15 +7,32 @@ pub fn is_power_of_2(n: u16) -> bool {
     }
 }
 
+// TODO: make the above generic for all uint types.
+pub fn is_power_of_2_u32(n: u32) -> bool {
+    if n == 0 {
+        false
+    } else {
+        // See https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+        n & (n - 1) == 0
+    }
+}
+
 #[test]
 fn test_is_power_of_2() {
-    assert(is_power_of_2(0) == false);
-    assert(is_power_of_2(1) == true);
-    assert(is_power_of_2(2) == true);
-    assert(is_power_of_2(3) == false);
-    assert(is_power_of_2(4) == true);
-    assert(is_power_of_2(5) == false);
-    assert(is_power_of_2(6) == false);
-    assert(is_power_of_2(7) == false);
-    assert(is_power_of_2(8) == true);
+    for i in 0..65 {
+        let n = i as u16;
+        let expected =
+            (n == 1) | (n == 2) | (n == 4) | (n == 8) | (n == 16) | (n == 32) | (n == 64);
+        assert(is_power_of_2(n) == expected);
+    }
+}
+
+#[test]
+fn test_is_power_of_2_u32() {
+    for i in 0..65 {
+        let n = i as u32;
+        let expected =
+            (n == 1) | (n == 2) | (n == 4) | (n == 8) | (n == 16) | (n == 32) | (n == 64);
+        assert(is_power_of_2_u32(n) == expected);
+    }
 }


### PR DESCRIPTION
Extracting everything that wasn't a question from that other PR #19337.
I.e. extracting things that should actually be merged into `next`.
