### PR TITLE
feat: node knows of escape hatch

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -67,6 +67,9 @@ function build_src {
     # Output storage information for the rollup contract.
     forge inspect --json src/core/Rollup.sol:Rollup storage > ./out/Rollup.sol/storage.json
 
+    # Output storage information for the escape hatch contract.
+    forge inspect --json src/core/EscapeHatch.sol:EscapeHatch storage > ./out/EscapeHatch.sol/storage.json
+
     cache_upload $artifact out cache
   fi
 }

--- a/yarn-project/archiver/src/modules/validation.test.ts
+++ b/yarn-project/archiver/src/modules/validation.test.ts
@@ -32,6 +32,7 @@ describe('validateCheckpointAttestations', () => {
       committee,
       seed: 0n,
       epoch: EpochNumber(0),
+      isEscapeHatchOpen: false,
     });
   };
 
@@ -61,6 +62,15 @@ describe('validateCheckpointAttestations', () => {
 
       expect(result.valid).toBe(true);
       expect(epochCache.getCommitteeForEpoch).toHaveBeenCalledWith(EpochNumber(0));
+    });
+
+    it('validates a checkpoint if escape hatch is open', async () => {
+      // This should already be covered by the case of empty committee
+      epochCache.isEscapeHatchOpen.mockResolvedValue(true);
+      const checkpoint = await makeCheckpoint(signers, committee);
+      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      expect(result.valid).toBe(true);
+      expect(epochCache.isEscapeHatchOpen).not.toHaveBeenCalled();
     });
   });
 
@@ -176,6 +186,14 @@ describe('validateCheckpointAttestations', () => {
       expect(result.committee).toEqual(committee);
       // The first mismatched attestation should be at index 1
       expect(result.invalidIndex).toBe(1);
+    });
+
+    it('validates a checkpoint if escape hatch is open', async () => {
+      epochCache.isEscapeHatchOpen.mockResolvedValue(true);
+      const checkpoint = await makeCheckpoint(signers, committee);
+      const result = await validateCheckpointAttestations(checkpoint, epochCache, constants, logger);
+      expect(result.valid).toBe(true);
+      expect(epochCache.isEscapeHatchOpen).toHaveBeenCalledWith(EpochNumber(0));
     });
   });
 });

--- a/yarn-project/archiver/src/modules/validation.ts
+++ b/yarn-project/archiver/src/modules/validation.ts
@@ -61,6 +61,11 @@ export async function validateCheckpointAttestations(
     return { valid: true };
   }
 
+  if (await epochCache.isEscapeHatchOpen(epoch)) {
+    logger?.warn(`Escape hatch open for epoch ${epoch} at slot ${slot}, skipping checkpoint validation`);
+    return { valid: true };
+  }
+
   const requiredAttestationCount = Math.floor((committee.length * 2) / 3) + 1;
 
   const failedValidationResult = <TReason extends ValidateCheckpointNegativeResult['reason']>(reason: TReason) => ({

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -576,6 +576,7 @@ describe('sentinel', () => {
         committee: [validator1, validator2, validator3],
         seed: 0n,
         epoch: epochNumber,
+        isEscapeHatchOpen: false,
       });
 
       const statsResult: ValidatorsStats = {

--- a/yarn-project/end-to-end/src/e2e_sequencer/escape_hatch_vote_only.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/escape_hatch_vote_only.test.ts
@@ -1,0 +1,249 @@
+import { CheatCodes, EthCheatCodes } from '@aztec/aztec/testing';
+import { GovernanceProposerContract, RollupContract } from '@aztec/ethereum/contracts';
+import type { DeployAztecL1ContractsReturnType } from '@aztec/ethereum/deploy-aztec-l1-contracts';
+import { deployL1Contract } from '@aztec/ethereum/deploy-l1-contract';
+import { EpochNumber } from '@aztec/foundation/branded-types';
+import { times } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { Logger } from '@aztec/foundation/log';
+import { retryUntil } from '@aztec/foundation/retry';
+import { EscapeHatchAbi } from '@aztec/l1-artifacts/EscapeHatchAbi';
+import { EscapeHatchBytecode } from '@aztec/l1-artifacts/EscapeHatchBytecode';
+import { EscapeHatchStorage } from '@aztec/l1-artifacts/EscapeHatchStorage';
+import { NewGovernanceProposerPayloadAbi } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadAbi';
+import { NewGovernanceProposerPayloadBytecode } from '@aztec/l1-artifacts/NewGovernanceProposerPayloadBytecode';
+import type { SequencerClient, SequencerEvents } from '@aztec/sequencer-client';
+import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { getPrivateKeyFromIndex, setup } from '../fixtures/utils.js';
+
+const OPEN_THE_HATCH = true;
+
+const ETHEREUM_SLOT_DURATION = 12;
+const AZTEC_SLOT_DURATION = 36;
+const AZTEC_EPOCH_DURATION = 4;
+const ROUND_SIZE = AZTEC_EPOCH_DURATION * 64;
+const QUORUM_SIZE = ROUND_SIZE - 1; // Don't matter if almost impossible, not what we test
+const COMMITTEE_SIZE = 4;
+
+const ESCAPE_HATCH_FREQUENCY = 17n;
+const ESCAPE_HATCH_ACTIVE_DURATION = 16n;
+
+jest.setTimeout(1000 * 60 * 5);
+
+describe('e2e_escape_hatch_vote_only', () => {
+  let logger: Logger;
+  let teardown: () => Promise<void>;
+  let aztecNodeAdmin: AztecNodeAdmin | undefined;
+  let deployL1ContractsValues: DeployAztecL1ContractsReturnType;
+  let cheatCodes: CheatCodes;
+  let ethCheatCodes: EthCheatCodes;
+  let rollup: RollupContract;
+  let governanceProposer: GovernanceProposerContract;
+  let newGovernanceProposerPayloadAddress: EthAddress;
+  let sequencerClient: SequencerClient | undefined;
+
+  const escapeHatchProposerAddress = EthAddress.fromString('0x0000000000000000000000000000000000000001');
+
+  beforeEach(async () => {
+    const validatorOffset = 10;
+    const validators = times(COMMITTEE_SIZE, i => {
+      const privateKey = `0x${getPrivateKeyFromIndex(i + validatorOffset)!.toString('hex')}` as const;
+      const account = privateKeyToAccount(privateKey);
+      const address = EthAddress.fromString(account.address);
+      expect(address).not.toBe(escapeHatchProposerAddress);
+      return { attester: address, withdrawer: address, privateKey };
+    });
+
+    const context = await setup(1, {
+      anvilAccounts: 10,
+      aztecTargetCommitteeSize: COMMITTEE_SIZE,
+      initialValidators: validators.map(v => ({ ...v, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) })),
+      validatorPrivateKeys: new SecretValue(validators.map(v => v.privateKey)),
+      governanceProposerRoundSize: ROUND_SIZE,
+      governanceProposerQuorum: QUORUM_SIZE,
+      ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+      aztecSlotDuration: AZTEC_SLOT_DURATION,
+      aztecEpochDuration: AZTEC_EPOCH_DURATION,
+      // Keep pruning far away for this test.
+      aztecProofSubmissionEpochs: 15, // needed so ACTIVE_DURATION=2 is a valid EscapeHatch config
+      minTxsPerBlock: 0,
+      enforceTimeTable: true,
+      automineL1Setup: true,
+    });
+
+    ({
+      teardown,
+      logger,
+      aztecNodeAdmin,
+      deployL1ContractsValues,
+      cheatCodes,
+      ethCheatCodes,
+      sequencer: sequencerClient,
+    } = context);
+
+    const { l1Client, l1ContractAddresses } = deployL1ContractsValues;
+    rollup = RollupContract.getFromL1ContractsValues(deployL1ContractsValues);
+    governanceProposer = new GovernanceProposerContract(
+      l1Client,
+      l1ContractAddresses.governanceProposerAddress.toString(),
+    );
+
+    // Deploy a new governance proposer payload so we can observe signals for it.
+    const payloadDeployment = await deployL1Contract(
+      l1Client,
+      NewGovernanceProposerPayloadAbi,
+      NewGovernanceProposerPayloadBytecode,
+      [l1ContractAddresses.registryAddress.toString(), l1ContractAddresses.gseAddress!.toString()],
+      { salt: '0x2a' },
+    );
+    newGovernanceProposerPayloadAddress = payloadDeployment.address;
+    logger.warn(`Deployed governance proposer payload at ${newGovernanceProposerPayloadAddress}`);
+
+    // Deploy escape hatch with a deterministic open/closed epoch window.
+    const lagInHatches = 1n;
+    const proposingExitDelay = 0n;
+    const bondSize = 1n;
+    const withdrawalTax = 0n;
+    const failedHatchPunishment = 0n;
+
+    const escapeHatchDeployment = await deployL1Contract(
+      l1Client,
+      EscapeHatchAbi,
+      EscapeHatchBytecode,
+      [
+        rollup.address.toString(),
+        l1ContractAddresses.stakingAssetAddress.toString(),
+        bondSize,
+        withdrawalTax,
+        failedHatchPunishment,
+        ESCAPE_HATCH_FREQUENCY,
+        ESCAPE_HATCH_ACTIVE_DURATION,
+        lagInHatches,
+        proposingExitDelay,
+      ],
+      { salt: '0x6a' },
+    );
+    const escapeHatchAddress = escapeHatchDeployment.address;
+    logger.warn(`Deployed escape hatch at ${escapeHatchAddress}`);
+
+    // Wire escape hatch into the rollup (owner-only).
+    await cheatCodes.rollup.asOwner(async (owner, rollupAsOwner) => {
+      const hash = await rollupAsOwner.write.updateEscapeHatch([escapeHatchAddress.toString()], { account: owner });
+      await l1Client.waitForTransactionReceipt({ hash });
+    });
+  });
+
+  afterEach(() => teardown());
+
+  it('casts governance signals and advances checkpoints while escape hatch is closed', async () => {
+    // Enable voting from the sequencer.
+    await aztecNodeAdmin!.setConfig({
+      governanceProposerPayload: newGovernanceProposerPayloadAddress,
+      minTxsPerBlock: 0,
+    });
+
+    // Set up event listeners to track sequencer behavior
+    const failEvents: Array<{ type: keyof SequencerEvents; args: any }> = [];
+    const blockProposedEvents: Array<{ blockNumber: any; slot: any }> = [];
+    const checkpointPublishedEvents: Array<{ checkpoint: any; slot: any }> = [];
+
+    const sequencer = sequencerClient!.getSequencer();
+
+    // Track failure events that indicate problems
+    const failEventTypes: (keyof SequencerEvents)[] = [
+      'block-build-failed',
+      'checkpoint-publish-failed',
+      'proposer-rollup-check-failed',
+      'checkpoint-error',
+    ];
+
+    failEventTypes.forEach(eventType => {
+      sequencer.on(eventType, (args: Parameters<SequencerEvents[typeof eventType]>[0]) => {
+        // Filter out SequencerTooSlowError as it's expected in slow CI environments when escape hatch is open.
+        // The sequencer may be too slow to vote after sync checks, which is acceptable since we're not building blocks.
+        if (eventType === 'checkpoint-error') {
+          const checkpointErrorArgs = args as Parameters<SequencerEvents['checkpoint-error']>[0];
+          if (checkpointErrorArgs.error.name === 'SequencerTooSlowError') {
+            logger.debug(`Ignoring SequencerTooSlowError (expected in slow CI environments)`, checkpointErrorArgs);
+            return;
+          }
+        }
+        failEvents.push({ type: eventType, args });
+        logger.error(`Sequencer emitted failure event: ${String(eventType)}`, args);
+      });
+    });
+
+    // Track block building attempts (should not happen when escape hatch is open)
+    sequencer.on('block-proposed', (args: Parameters<SequencerEvents['block-proposed']>[0]) => {
+      blockProposedEvents.push({ blockNumber: args.blockNumber, slot: args.slot });
+      logger.warn(`Sequencer proposed block when escape hatch should be open`, args);
+    });
+
+    // Track checkpoint publishing (should not happen when escape hatch is open)
+    sequencer.on('checkpoint-published', (args: Parameters<SequencerEvents['checkpoint-published']>[0]) => {
+      checkpointPublishedEvents.push({ checkpoint: args.checkpoint, slot: args.slot });
+      logger.warn(`Sequencer published checkpoint when escape hatch should be open`, args);
+    });
+
+    // We need to set it for hatch 1, and then make a time jump. We do this such that we don't pollute the epoch cache
+    if (OPEN_THE_HATCH) {
+      await ethCheatCodes.store(
+        await rollup.getEscapeHatchAddress(),
+        ethCheatCodes.keccak256(BigInt(EscapeHatchStorage.find(s => s.label === '$designatedProposer')!.slot), 1n),
+        escapeHatchProposerAddress.toField().toBigInt(),
+      );
+      expect(await rollup.isEscapeHatchOpen(EpochNumber(Number(ESCAPE_HATCH_FREQUENCY)))).toBeTruthy();
+
+      logger.info(`Advancing to epoch ${ESCAPE_HATCH_FREQUENCY}`);
+
+      await cheatCodes.rollup.advanceToEpoch(EpochNumber(Number(ESCAPE_HATCH_FREQUENCY)), {
+        offset: -ETHEREUM_SLOT_DURATION,
+      });
+    }
+
+    const getStats = async () => ({
+      slot: await rollup.getSlotNumber(),
+      epoch: await rollup.getEpochNumberForSlotNumber(await rollup.getSlotNumber()),
+      pending: await rollup.getCheckpointNumber(),
+      proven: await rollup.getProvenCheckpointNumber(),
+      votes: Number(
+        await governanceProposer.getPayloadSignals(rollup.address, 0n, newGovernanceProposerPayloadAddress.toString()),
+      ),
+    });
+
+    const initialStats = await getStats();
+
+    // We will wait until epochs advance
+    await retryUntil(
+      async () =>
+        (await rollup.getEpochNumberForSlotNumber(await rollup.getSlotNumber())) >= initialStats.epoch + EpochNumber(2),
+      'epoch to advance',
+      AZTEC_SLOT_DURATION * AZTEC_EPOCH_DURATION * 3,
+      1,
+    );
+
+    const finalStats = await getStats();
+
+    // Due to the the stats not being pulled at the same time, a vote could land after the slot is fetched, but before the votes are.
+    // Therefore, we use the slots passed as the lower bound.
+    const slotsPassed = finalStats.slot - initialStats.slot;
+    expect(slotsPassed).toBeGreaterThan(0);
+    expect(finalStats.votes - initialStats.votes).toBeGreaterThanOrEqual(slotsPassed);
+    if (OPEN_THE_HATCH) {
+      expect(finalStats.pending - initialStats.pending).toBe(0);
+
+      // When escape hatch is open, sequencer should only vote, not build blocks nor checkpoints, but there should also be no failures.
+      expect(blockProposedEvents).toEqual([]);
+      expect(failEvents).toEqual([]);
+      expect(checkpointPublishedEvents).toEqual([]);
+    } else {
+      expect(finalStats.pending - initialStats.pending).toBeGreaterThanOrEqual(slotsPassed);
+    }
+  });
+});

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -48,6 +48,7 @@ describe('EpochCache', () => {
     rollupContract.getCommitteeAt.mockResolvedValue(testCommittee);
     rollupContract.getSampleSeedAt.mockResolvedValue(Buffer32.fromBigInt(0n));
     rollupContract.getAttesters.mockResolvedValue(testCommittee);
+    rollupContract.isEscapeHatchOpen.mockResolvedValue(false);
 
     l1GenesisTime = BigInt(Math.floor(Date.now() / 1000));
 
@@ -81,6 +82,7 @@ describe('EpochCache', () => {
       epoch: EpochNumber(0),
       committee: testCommittee,
       seed: 0n,
+      isEscapeHatchOpen: false,
     });
   });
 

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -28,6 +28,8 @@ export type EpochCommitteeInfo = {
   committee: EthAddress[] | undefined;
   seed: bigint;
   epoch: EpochNumber;
+  /** True if the epoch is within an open escape hatch window. */
+  isEscapeHatchOpen: boolean;
 };
 
 export type SlotTag = 'now' | 'next' | SlotNumber;
@@ -173,6 +175,38 @@ export class EpochCache implements EpochCacheInterface {
   }
 
   /**
+   * Returns whether the escape hatch is open for the given epoch.
+   *
+   * Uses the already-cached EpochCommitteeInfo when available. If not cached, it will fetch
+   * the epoch committee info (which includes the escape hatch flag) and return it.
+   */
+  public async isEscapeHatchOpen(epoch: EpochNumber): Promise<boolean> {
+    const cached = this.cache.get(epoch);
+    if (cached) {
+      return cached.isEscapeHatchOpen;
+    }
+    const info = await this.getCommitteeForEpoch(epoch);
+    return info.isEscapeHatchOpen;
+  }
+
+  /**
+   * Returns whether the escape hatch is open for the epoch containing the given slot.
+   *
+   * This is a lightweight helper intended for callers that already have a slot number and only
+   * need the escape hatch flag (without pulling full committee info).
+   */
+  public async isEscapeHatchOpenAtSlot(slot: SlotTag = 'now'): Promise<boolean> {
+    const epoch =
+      slot === 'now'
+        ? this.getEpochAndSlotNow().epoch
+        : slot === 'next'
+          ? this.getEpochAndSlotInNextL1Slot().epoch
+          : getEpochAtSlot(slot, this.l1constants);
+
+    return await this.isEscapeHatchOpen(epoch);
+  }
+
+  /**
    * Get the current validator set
    * @param nextSlot - If true, get the validator set for the next slot.
    * @returns The current validator set.
@@ -211,10 +245,11 @@ export class EpochCache implements EpochCacheInterface {
 
   private async computeCommittee(when: { epoch: EpochNumber; ts: bigint }): Promise<EpochCommitteeInfo> {
     const { ts, epoch } = when;
-    const [committee, seedBuffer, l1Timestamp] = await Promise.all([
+    const [committee, seedBuffer, l1Timestamp, isEscapeHatchOpen] = await Promise.all([
       this.rollup.getCommitteeAt(ts),
       this.rollup.getSampleSeedAt(ts),
       this.rollup.client.getBlock({ includeTransactions: false }).then(b => b.timestamp),
+      this.rollup.isEscapeHatchOpen(epoch),
     ]);
     const { lagInEpochsForValidatorSet, epochDuration, slotDuration } = this.l1constants;
     const sub = BigInt(lagInEpochsForValidatorSet) * BigInt(epochDuration) * BigInt(slotDuration);
@@ -223,7 +258,7 @@ export class EpochCache implements EpochCacheInterface {
         `Cannot query committee for future epoch ${epoch} with timestamp ${ts} (current L1 time is ${l1Timestamp}). Check your Ethereum node is synced.`,
       );
     }
-    return { committee, seed: seedBuffer.toBigInt(), epoch };
+    return { committee, seed: seedBuffer.toBigInt(), epoch, isEscapeHatchOpen };
   }
 
   /**

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -5,6 +5,7 @@ import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ViemSignature } from '@aztec/foundation/eth-signature';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
+import { EscapeHatchAbi } from '@aztec/l1-artifacts/EscapeHatchAbi';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { RollupStorage } from '@aztec/l1-artifacts/RollupStorage';
 
@@ -205,6 +206,10 @@ export class RollupContract {
   private readonly rollup: GetContractReturnType<typeof RollupAbi, ViemClient>;
 
   private static cachedStfStorageSlot: Hex | undefined;
+  private cachedEscapeHatch?: {
+    address: EthAddress;
+    contract: GetContractReturnType<typeof EscapeHatchAbi, ViemClient>;
+  };
 
   static get checkBlobStorageSlot(): bigint {
     const asString = RollupStorage.find(storage => storage.label === 'checkBlob')?.slot;
@@ -405,6 +410,58 @@ export class RollupContract {
 
   async getSlasherAddress(): Promise<EthAddress> {
     return EthAddress.fromString(await this.rollup.read.getSlasher());
+  }
+
+  /**
+   * Returns the configured escape hatch contract address, or zero if disabled.
+   */
+  async getEscapeHatchAddress(): Promise<EthAddress> {
+    return EthAddress.fromString(await this.rollup.read.getEscapeHatch());
+  }
+
+  private async getEscapeHatchContract(): Promise<
+    GetContractReturnType<typeof EscapeHatchAbi, ViemClient> | undefined
+  > {
+    const escapeHatchAddress = await this.getEscapeHatchAddress();
+    if (escapeHatchAddress.isZero()) {
+      return undefined;
+    }
+
+    // Cache the viem contract wrapper since it will be used frequently.
+    if (!this.cachedEscapeHatch || !this.cachedEscapeHatch.address.equals(escapeHatchAddress)) {
+      this.cachedEscapeHatch = {
+        address: escapeHatchAddress,
+        contract: getContract({
+          address: escapeHatchAddress.toString(),
+          abi: EscapeHatchAbi,
+          client: this.client,
+        }),
+      };
+    }
+
+    return this.cachedEscapeHatch.contract;
+  }
+
+  /**
+   * Returns whether the escape hatch is open for the given epoch.
+   * If escape hatch is not configured, returns false.
+   *
+   * This function is intentionally defensive: any failure to query the escape hatch
+   * (RPC issues, transient errors, etc.) is treated as "closed" to avoid callers
+   * needing to sprinkle try/catch everywhere.
+   */
+  async isEscapeHatchOpen(epoch: EpochNumber): Promise<boolean> {
+    try {
+      const escapeHatch = await this.getEscapeHatchContract();
+      if (!escapeHatch) {
+        return false;
+      }
+
+      const [isOpen] = await escapeHatch.read.isHatchOpen([BigInt(epoch)]);
+      return isOpen;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -12,6 +12,7 @@ cd $(git rev-parse --show-toplevel)/yarn-project/l1-artifacts
 
 contracts=(
   "CoinIssuer"
+  "EscapeHatch"
   "TallySlashingProposer"
   "EmpireBase"
   "EmpireSlashingProposer"
@@ -135,6 +136,19 @@ done
 
 # Update index.ts exports
 echo "export * from './RollupStorage.js';" >>"src/index.ts"
+
+# Generate EscapeHatchStorage.ts
+(
+  echo "/**"
+  echo " * Escape hatch storage."
+  echo " */"
+  echo -n "export const EscapeHatchStorage = "
+  jq -j '.storage' "../../l1-contracts/out/EscapeHatch.sol/storage.json"
+  echo " as const;"
+) >"src/EscapeHatchStorage.ts"
+
+# Update index.ts exports
+echo "export * from './EscapeHatchStorage.js';" >>"src/index.ts"
 
 # Write abis hash. Consider excluding some contracts from this hash if
 # we don't want to consider them as breaking for the interfaces.

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -88,7 +88,7 @@ function mockAttestationPool(): AttestationPool {
 
 function mockEpochCache(): EpochCacheInterface {
   return {
-    getCommittee: () => Promise.resolve({ committee: [], seed: 1n, epoch: EpochNumber.ZERO }),
+    getCommittee: () => Promise.resolve({ committee: [], seed: 1n, epoch: EpochNumber.ZERO, isEscapeHatchOpen: false }),
     getProposerIndexEncoding: () => '0x' as `0x${string}`,
     getEpochAndSlotNow: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n }),
     computeProposerIndex: () => 0n,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -133,7 +133,12 @@ describe('SequencerPublisher', () => {
 
     const epochCache = mock<EpochCache>();
     epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 3n, now: 3n });
-    epochCache.getCommittee.mockResolvedValue({ committee: [], seed: 1n, epoch: EpochNumber(1) });
+    epochCache.getCommittee.mockResolvedValue({
+      committee: [],
+      seed: 1n,
+      epoch: EpochNumber(1),
+      isEscapeHatchOpen: false,
+    });
 
     publisher = new SequencerPublisher(config, {
       blobClient,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -143,6 +143,7 @@ describe('CheckpointProposalJob', () => {
       committee,
       seed: 0n,
       epoch: EpochNumber(1),
+      isEscapeHatchOpen: false,
     });
 
     publisher = mockDeep<SequencerPublisher>();
@@ -710,6 +711,7 @@ describe('CheckpointProposalJob', () => {
         committee: [],
         seed: 0n,
         epoch: EpochNumber(1),
+        isEscapeHatchOpen: false,
       });
 
       const { txs, block } = await setupTxsAndBlock(p2p, globalVariables, 1, chainId);

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -155,6 +155,7 @@ describe('sequencer', () => {
     l1Constants = { l1GenesisTime, slotDuration, ethereumSlotDuration };
 
     epochCache = mockDeep<EpochCache>();
+    epochCache.isEscapeHatchOpen.mockResolvedValue(false);
     epochCache.getEpochAndSlotInNextL1Slot.mockImplementation(() => ({
       epoch: EpochNumber(1),
       slot: SlotNumber(1),
@@ -165,6 +166,7 @@ describe('sequencer', () => {
       committee,
       seed: 1n,
       epoch: EpochNumber(1),
+      isEscapeHatchOpen: false,
     });
 
     publisher = mockDeep<SequencerPublisher>();
@@ -187,6 +189,7 @@ describe('sequencer', () => {
     } satisfies AttestorPublisherPair);
 
     rollupContract = mockDeep<RollupContract>();
+    rollupContract.isEscapeHatchOpen.mockResolvedValue(false);
 
     globalVariableBuilder = mock<GlobalVariableBuilder>();
     globalVariableBuilder.buildGlobalVariables.mockResolvedValue(globalVariables);
@@ -416,7 +419,12 @@ describe('sequencer', () => {
     it('should proceed with block proposal when there is no proposer yet', async () => {
       // Mock that there is no official proposer yet
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValueOnce(undefined);
-      epochCache.getCommittee.mockResolvedValueOnce({ committee: [] as EthAddress[] } as EpochCommitteeInfo);
+      epochCache.getCommittee.mockResolvedValueOnce({
+        committee: [] as EthAddress[],
+        seed: 1n,
+        epoch: EpochNumber(1),
+        isEscapeHatchOpen: false,
+      } as EpochCommitteeInfo);
 
       // Mock that we have some pending transactions
       const txs = [await makeTx(1), await makeTx(2)];
@@ -483,6 +491,74 @@ describe('sequencer', () => {
           { txTimeoutAt: expect.any(Date) },
         );
       }
+    });
+  });
+
+  describe('voting when escape hatch is open', () => {
+    const mockSlashActions = [{ type: 'vote-offenses' as const, round: 1n, votes: [], committees: [] }];
+
+    it('should vote but not propose checkpoint when escape hatch is open', async () => {
+      // Escape hatch is open for the epoch/slot
+      epochCache.getCommittee.mockResolvedValue({
+        committee,
+        seed: 1n,
+        epoch: EpochNumber(1),
+        isEscapeHatchOpen: true,
+      });
+      epochCache.isEscapeHatchOpen.mockResolvedValue(true);
+
+      // Set us as the proposer
+      validatorClient.getValidatorAddresses.mockReturnValue([signer.address]);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+
+      // Mock slashing actions and governance payload
+      slasherClient.getProposerActions.mockResolvedValue(mockSlashActions);
+      const governancePayload = EthAddress.random();
+      sequencer.updateConfig({ governanceProposerPayload: governancePayload });
+
+      // Ensure enqueues succeed
+      publisher.enqueueSlashingActions.mockResolvedValue(true);
+      publisher.enqueueGovernanceCastSignal.mockResolvedValue(true);
+
+      await sequencer.work();
+
+      // Vote-only path should run
+      expect(slasherClient.getProposerActions).toHaveBeenCalledWith(SlotNumber(1));
+      expect(publisher.enqueueSlashingActions).toHaveBeenCalled();
+      expect(publisher.enqueueGovernanceCastSignal).toHaveBeenCalled();
+      expect(publisher.sendRequests).toHaveBeenCalled();
+
+      // But checkpoint proposal must not start
+      expect(publisher.enqueueProposeCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('should not attempt to vote twice in the same slot when escape hatch is open', async () => {
+      epochCache.getCommittee.mockResolvedValue({
+        committee,
+        seed: 1n,
+        epoch: EpochNumber(1),
+        isEscapeHatchOpen: true,
+      });
+      epochCache.isEscapeHatchOpen.mockResolvedValue(true);
+
+      validatorClient.getValidatorAddresses.mockReturnValue([signer.address]);
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(signer.address);
+      slasherClient.getProposerActions.mockResolvedValue(mockSlashActions);
+
+      publisher.enqueueSlashingActions.mockResolvedValue(true);
+
+      await sequencer.work();
+      expect(publisher.enqueueSlashingActions).toHaveBeenCalledTimes(1);
+      expect(publisher.sendRequests).toHaveBeenCalledTimes(1);
+
+      publisher.enqueueSlashingActions.mockClear();
+      publisher.sendRequests.mockClear();
+      slasherClient.getProposerActions.mockClear();
+
+      await sequencer.work();
+      expect(slasherClient.getProposerActions).not.toHaveBeenCalled();
+      expect(publisher.enqueueSlashingActions).not.toHaveBeenCalled();
+      expect(publisher.sendRequests).not.toHaveBeenCalled();
     });
   });
 
@@ -644,6 +720,7 @@ describe('sequencer', () => {
         committee: [validator2],
         seed: 123n,
         epoch: EpochNumber(1),
+        isEscapeHatchOpen: false,
       });
 
       // Setup validator client
@@ -689,6 +766,7 @@ describe('sequencer', () => {
         committee: [EthAddress.random()],
         seed: 123n,
         epoch: EpochNumber(1),
+        isEscapeHatchOpen: false,
       });
 
       // Set time past the non-committee member threshold

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -57,8 +57,8 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   private state = SequencerState.STOPPED;
   private metrics: SequencerMetrics;
 
-  /** The last slot for which we attempted to vote when sync failed, to prevent duplicate attempts. */
-  private lastSlotForVoteWhenSyncFailed: SlotNumber | undefined;
+  /** The last slot for which we attempted to perform our voting duties with degraded block production */
+  private lastSlotForFallbackVote: SlotNumber | undefined;
 
   /** The last slot for which we triggered a checkpoint proposal job, to prevent duplicate attempts. */
   private lastSlotForCheckpointProposalJob: SlotNumber | undefined;
@@ -261,6 +261,25 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     const syncedTo = await this.checkSync({ ts, slot });
     if (!syncedTo) {
       await this.tryVoteWhenSyncFails({ slot, ts });
+      return undefined;
+    }
+
+    // If escape hatch is open for this epoch, do not start checkpoint proposal work and do not attempt invalidations.
+    // Still perform governance/slashing voting (as proposer) once per slot.
+    const isEscapeHatchOpen = await this.epochCache.isEscapeHatchOpen(epoch);
+
+    if (isEscapeHatchOpen) {
+      this.setState(SequencerState.PROPOSER_CHECK, slot);
+      const [canPropose, proposer] = await this.checkCanPropose(slot);
+      if (canPropose) {
+        await this.tryVoteWhenEscapeHatchOpen({ slot, proposer });
+      } else {
+        this.log.trace(`Escape hatch open but we are not proposer, skipping vote-only actions`, {
+          slot,
+          epoch,
+          proposer,
+        });
+      }
       return undefined;
     }
 
@@ -574,7 +593,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     const { slot } = args;
 
     // Prevent duplicate attempts in the same slot
-    if (this.lastSlotForVoteWhenSyncFailed === slot) {
+    if (this.lastSlotForFallbackVote === slot) {
       this.log.trace(`Already attempted to vote in slot ${slot} (skipping)`);
       return;
     }
@@ -606,7 +625,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     // Mark this slot as attempted
-    this.lastSlotForVoteWhenSyncFailed = slot;
+    this.lastSlotForFallbackVote = slot;
 
     // Get a publisher for voting
     const { attestorAddress, publisher } = await this.publisherFactory.create(proposer);
@@ -641,7 +660,55 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   }
 
   /**
-   * Considers invalidating a checkpoint if the pending chain is invalid. Depends on how long the invalid checkpoint
+   * Tries to vote on slashing actions and governance proposals when escape hatch is open.
+   * This allows the sequencer to participate in voting without performing checkpoint proposal work.
+   */
+  @trackSpan('Sequencer.tryVoteWhenEscapeHatchOpen', ({ slot }) => ({ [Attributes.SLOT_NUMBER]: slot }))
+  protected async tryVoteWhenEscapeHatchOpen(args: {
+    slot: SlotNumber;
+    proposer: EthAddress | undefined;
+  }): Promise<void> {
+    const { slot, proposer } = args;
+
+    // Prevent duplicate attempts in the same slot
+    if (this.lastSlotForFallbackVote === slot) {
+      this.log.trace(`Already attempted to vote in slot ${slot} (escape hatch open, skipping)`);
+      return;
+    }
+
+    // Mark this slot as attempted
+    this.lastSlotForFallbackVote = slot;
+
+    const { attestorAddress, publisher } = await this.publisherFactory.create(proposer);
+
+    this.log.debug(`Escape hatch open for slot ${slot}, attempting vote-only actions`, { slot, attestorAddress });
+
+    const voter = new CheckpointVoter(
+      slot,
+      publisher,
+      attestorAddress,
+      this.validatorClient,
+      this.slasherClient,
+      this.l1Constants,
+      this.config,
+      this.metrics,
+      this.log,
+    );
+
+    const votesPromises = voter.enqueueVotes();
+    const votes = await Promise.all(votesPromises);
+
+    if (votes.every(p => !p)) {
+      this.log.debug(`No votes to enqueue for slot ${slot} (escape hatch open)`);
+      return;
+    }
+
+    this.log.info(`Voting in slot ${slot} (escape hatch open)`, { slot });
+    await publisher.sendRequests();
+  }
+
+  /**
+   * Considers invalidating a block if the pending chain is invalid. Depends on how long the invalid block
    * has been there without being invalidated and whether the sequencer is in the committee or not. We always
    * have the proposer try to invalidate, but if they fail, the sequencers in the committee are expected to try,
    * and if they fail, any sequencer will try as well.

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -127,7 +127,9 @@ describe('TallySlasherClient', () => {
 
     // Create mock EpochCache
     mockEpochCache = mockDeep<EpochCache>();
-    mockEpochCache.getCommitteeForEpoch.mockImplementation(epoch => Promise.resolve({ committee, seed: 0n, epoch }));
+    mockEpochCache.getCommitteeForEpoch.mockImplementation(epoch =>
+      Promise.resolve({ committee, seed: 0n, epoch, isEscapeHatchOpen: false }),
+    );
     mockEpochCache.getL1Constants.mockReturnValue({
       l1StartBlock: 0n,
       l1GenesisTime: 0n,
@@ -258,6 +260,7 @@ describe('TallySlasherClient', () => {
           committee: undefined,
           seed: 0n,
           epoch: EpochNumber(0),
+          isEscapeHatchOpen: false,
         });
 
         const action = await tallySlasherClient.getVoteOffensesAction(SlotNumber.fromBigInt(currentSlot));

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
@@ -142,6 +142,7 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
       committee: validationResult.committee,
       seed: validationResult.seed,
       epoch: validationResult.epoch,
+      isEscapeHatchOpen: false,
     };
     const proposer = this.epochCache.getProposerFromEpochCommittee(epochCommitteeInfo, slot);
 

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
@@ -91,6 +91,7 @@ describe('EpochPruneWatcher', () => {
       committee: committee.map(EthAddress.fromString),
       seed: 0n,
       epoch: epochNumber,
+      isEscapeHatchOpen: false,
     });
 
     l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {
@@ -144,6 +145,7 @@ describe('EpochPruneWatcher', () => {
       committee: committee.map(EthAddress.fromString),
       seed: 0n,
       epoch: EpochNumber(1),
+      isEscapeHatchOpen: false,
     });
 
     l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {
@@ -207,6 +209,7 @@ describe('EpochPruneWatcher', () => {
       committee: committee.map(EthAddress.fromString),
       seed: 0n,
       epoch: EpochNumber(1),
+      isEscapeHatchOpen: false,
     });
 
     l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {

--- a/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
+++ b/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
@@ -12,6 +12,7 @@ export class MockEpochCache implements EpochCacheInterface {
       committee: undefined,
       seed: 0n,
       epoch: EpochNumber.ZERO,
+      isEscapeHatchOpen: false,
     });
   }
 

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -91,6 +91,7 @@ describe('ValidatorClient', () => {
     >[1] as any);
     blockSource = mock<L2BlockSource & L2BlockSink>();
     blockSource.getBlocksForEpoch.mockResolvedValue([]);
+    epochCache.isEscapeHatchOpenAtSlot.mockResolvedValue(false);
     l1ToL2MessageSource = mock<L1ToL2MessageSource>();
     txProvider = mock<TxProvider>();
     l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
@@ -317,6 +318,7 @@ describe('ValidatorClient', () => {
         nextSlot: SlotNumber(proposal.slotNumber + 1),
       });
       epochCache.filterInCommittee.mockResolvedValue([EthAddress.fromString(validatorAccounts[0].address)]);
+      epochCache.isEscapeHatchOpenAtSlot.mockResolvedValue(false);
 
       // Return parent block header when requested
       blockSource.getBlockHeaderByArchive.mockResolvedValue({
@@ -361,6 +363,56 @@ describe('ValidatorClient', () => {
       epochCache.filterInCommittee.mockResolvedValue([EthAddress.fromString(validatorAccounts[0].address)]);
       const isValid = await validatorClient.validateBlockProposal(proposal, sender);
       expect(isValid).toBe(true);
+    });
+
+    it('should return early when escape hatch is open', async () => {
+      epochCache.isEscapeHatchOpenAtSlot.mockResolvedValueOnce(true);
+
+      const handleSpy = jest.spyOn(validatorClient.getBlockProposalHandler(), 'handleBlockProposal');
+
+      const isValid = await validatorClient.validateBlockProposal(proposal, sender);
+      expect(isValid).toBe(false);
+      // We still validate for observability, but we reject the proposal while escape hatch is open.
+      expect(handleSpy).toHaveBeenCalled();
+    });
+
+    it('should not attest to a checkpoint proposal if we did not validate a block for that slot', async () => {
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+
+      const checkpointProposal = await makeCheckpointProposal({
+        archiveRoot: proposal.archive,
+        lastBlock: {
+          blockHeader: makeL2BlockHeader(1, 123, proposal.slotNumber),
+          indexWithinCheckpoint: 0,
+          txHashes: proposal.txHashes,
+        },
+      });
+
+      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+      expect(attestations).toBeUndefined();
+      expect(addCheckpointAttestationsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should attest to a checkpoint proposal after validating a block for that slot', async () => {
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+
+      const didValidate = await validatorClient.validateBlockProposal(proposal, sender);
+      expect(didValidate).toBe(true);
+
+      const checkpointProposal = await makeCheckpointProposal({
+        archiveRoot: proposal.archive,
+        lastBlock: {
+          blockHeader: makeL2BlockHeader(1, 123, proposal.slotNumber),
+          indexWithinCheckpoint: 0,
+          txHashes: proposal.txHashes,
+        },
+      });
+
+      const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
+
+      expect(attestations).toBeDefined();
+      expect(attestations).toHaveLength(1);
+      expect(addCheckpointAttestationsSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should wait for previous block to sync', async () => {

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -303,6 +303,11 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
    */
   async validateBlockProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<boolean> {
     const slotNumber = proposal.slotNumber;
+
+    // Note: During escape hatch, we still want to "validate" proposals for observability,
+    // but we intentionally reject them and disable slashing invalid block and attestation flow.
+    const escapeHatchOpen = await this.epochCache.isEscapeHatchOpenAtSlot(slotNumber);
+
     const proposer = proposal.getSender();
 
     // Reject proposals with invalid signatures
@@ -336,7 +341,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     const validationResult = await this.blockProposalHandler.handleBlockProposal(
       proposal,
       proposalSender,
-      !!shouldReexecute,
+      !!shouldReexecute && !escapeHatchOpen,
     );
 
     if (!validationResult.isValid) {
@@ -361,6 +366,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
       // Slash invalid block proposals (can happen even when not in committee)
       if (
+        !escapeHatchOpen &&
         validationResult.reason &&
         SLASHABLE_BLOCK_PROPOSAL_VALIDATION_RESULT.includes(validationResult.reason) &&
         slashBroadcastedInvalidBlockPenalty > 0n
@@ -375,7 +381,13 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       ...proposalInfo,
       inCommittee: partOfCommittee,
       fishermanMode: this.config.fishermanMode || false,
+      escapeHatchOpen,
     });
+
+    if (escapeHatchOpen) {
+      this.log.warn(`Escape hatch open for slot ${slotNumber}, rejecting block proposal`, proposalInfo);
+      return false;
+    }
 
     // TODO(palla/mbps): Remove this once checkpoint validation is stable.
     // Track that we successfully validated a block for this slot, so we can attest to checkpoint proposals for it.
@@ -396,6 +408,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   ): Promise<CheckpointAttestation[] | undefined> {
     const slotNumber = proposal.slotNumber;
     const proposer = proposal.getSender();
+
+    // If escape hatch is open for this slot's epoch, do not attest.
+    if (await this.epochCache.isEscapeHatchOpenAtSlot(slotNumber)) {
+      this.log.warn(`Escape hatch open for slot ${slotNumber}, skipping checkpoint attestation handling`);
+      return undefined;
+    }
 
     // Reject proposals with invalid signatures
     if (!proposer) {


### PR DESCRIPTION
This pr fixes TMNT-466

Since the escape hatch being open or closed is stable for an epoch, I have added an extra value `isEscapeHatchOpen` in the `EpochCache` that we are then using throughout the "normal" work of the sequencer.

If the value is true, we skip most of the block production work, but keep participating in governance and slashing. 

The validator node is also updated slightly to not attest to checkpoints if the hatch is open. 

I have tried following similar implementation as `tryVoteWhenSyncFails` for the function.

A new E2E test is created that showcases that escape hatch being opens means no new checkpoints but still new signals being cast.
