### PR TITLE
fix: Node will serve genesis blocks over its RPC API

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -45,8 +45,9 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   type BlockParameter,
   type DataInBlock,
-  type L2Block,
+  L2Block,
   L2BlockHash,
+  L2BlockHeader,
   L2BlockNew,
   type L2BlockSource,
   type PublishedL2Block,
@@ -128,6 +129,7 @@ import { NodeMetrics } from './node_metrics.js';
  */
 export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   private metrics: NodeMetrics;
+  private initialHeaderHashPromise: Promise<Fr> | undefined = undefined;
 
   // Prevent two snapshot operations to happen simultaneously
   private isUploadingSnapshot = false;
@@ -586,6 +588,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    */
   public async getBlock(number: BlockParameter): Promise<L2Block | undefined> {
     const blockNumber = number === 'latest' ? await this.getBlockNumber() : (number as BlockNumber);
+    if (blockNumber === BlockNumber.ZERO) {
+      return this.buildInitialBlock();
+    }
     return await this.blockSource.getBlock(blockNumber);
   }
 
@@ -595,8 +600,28 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block.
    */
   public async getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+    const initialBlockHash = await this.#getInitialHeaderHash();
+    if (blockHash.equals(initialBlockHash)) {
+      return this.buildInitialBlock();
+    }
     const publishedBlock = await this.blockSource.getPublishedBlockByHash(blockHash);
     return publishedBlock?.block;
+  }
+
+  private buildInitialBlock(): L2Block {
+    const initialHeader = this.worldStateSynchronizer.getCommitted().getInitialHeader();
+    // TODO: (pw/mbps) Clean this up when we move completely to the new types.
+    // return L2BlockNew.empty(initialHeader);
+    const oldBlockHeader = L2BlockHeader.empty();
+    oldBlockHeader.state.l1ToL2MessageTree.root = initialHeader.state.l1ToL2MessageTree.root;
+    oldBlockHeader.state.partial.noteHashTree.root = initialHeader.state.partial.noteHashTree.root;
+    oldBlockHeader.state.partial.nullifierTree.root = initialHeader.state.partial.nullifierTree.root;
+    oldBlockHeader.state.partial.nullifierTree.nextAvailableLeafIndex =
+      initialHeader.state.partial.nullifierTree.nextAvailableLeafIndex;
+    oldBlockHeader.state.partial.publicDataTree.root = initialHeader.state.partial.publicDataTree.root;
+    oldBlockHeader.state.partial.publicDataTree.nextAvailableLeafIndex =
+      initialHeader.state.partial.publicDataTree.nextAvailableLeafIndex;
+    return L2Block.empty(oldBlockHeader);
   }
 
   /**
@@ -1156,6 +1181,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block header.
    */
   public async getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
+    const initialBlockHash = await this.#getInitialHeaderHash();
+    if (blockHash.equals(initialBlockHash)) {
+      return this.worldStateSynchronizer.getCommitted().getInitialHeader();
+    }
     return await this.blockSource.getBlockHeaderByHash(blockHash);
   }
 
@@ -1430,6 +1459,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     } else {
       return this.slasherClient.gatherOffensesForRound(round === 'current' ? undefined : BigInt(round));
     }
+  }
+
+  #getInitialHeaderHash(): Promise<Fr> {
+    if (!this.initialHeaderHashPromise) {
+      this.initialHeaderHashPromise = this.worldStateSynchronizer.getCommitted().getInitialHeader().hash();
+    }
+    return this.initialHeaderHashPromise;
   }
 
   /**

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -5,6 +5,7 @@ import { ContractDeployer } from '@aztec/aztec.js/deployment';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
 
 import { jest } from '@jest/globals';
@@ -50,6 +51,22 @@ describe('e2e_simple', () => {
     });
 
     afterAll(() => teardown());
+
+    it('returns initial block data', async () => {
+      const initialHeader = await aztecNode.getBlockHeader(BlockNumber.ZERO);
+      expect(initialHeader).toBeDefined();
+      const initialHeaderHash = await initialHeader!.hash();
+      const initialBlockByHash = await aztecNode.getBlockByHash(initialHeaderHash);
+      expect(initialBlockByHash).toBeDefined();
+      const initialBlockHash = await initialBlockByHash!.hash();
+      expect(initialBlockHash.equals(initialHeaderHash)).toBeTrue();
+      expect(initialBlockByHash?.body.txEffects.length).toBe(0);
+      const initialBlockByNumber = await aztecNode.getBlock(BlockNumber.ZERO);
+      expect(initialBlockByNumber).toBeDefined();
+      const initialBlockByNumberHash = await initialBlockByNumber!.hash();
+      expect(initialBlockByNumberHash.equals(initialHeaderHash)).toBeTrue();
+      expect(initialBlockByNumber?.body.txEffects.length).toBe(0);
+    });
 
     it('deploys a contract', async () => {
       const deployer = new ContractDeployer(artifact, wallet);

--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -108,10 +108,11 @@ export class L2Block {
 
   /**
    * Creates an L2 block containing empty data.
+   * @param header - An optional header to assign to the block
    * @returns The L2 block.
    */
-  static empty(): L2Block {
-    return new L2Block(AppendOnlyTreeSnapshot.empty(), L2BlockHeader.empty(), Body.empty());
+  static empty(header?: L2BlockHeader): L2Block {
+    return new L2Block(AppendOnlyTreeSnapshot.empty(), header ?? L2BlockHeader.empty(), Body.empty());
   }
 
   get number(): BlockNumber {

--- a/yarn-project/stdlib/src/block/l2_block_new.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.test.ts
@@ -3,27 +3,28 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
-import { L2Block } from './l2_block.js';
-import { L2BlockHeader } from './l2_block_header.js';
+import { BlockHeader } from '../tx/block_header.js';
+import { L2BlockNew } from './l2_block_new.js';
 
-describe('L2Block', () => {
+describe('L2BlockNew', () => {
   it('can serialize an L2 block with logs to a buffer and back', async () => {
-    const block = await L2Block.random(BlockNumber(42));
+    const block = await L2BlockNew.random(BlockNumber(42));
 
     const buffer = block.toBuffer();
-    const recovered = L2Block.fromBuffer(buffer);
+    const recovered = L2BlockNew.fromBuffer(buffer);
 
     expect(recovered).toEqual(block);
   });
 
   it('convert to and from json', async () => {
-    const block = await L2Block.random(BlockNumber(42));
-    const parsed = L2Block.schema.parse(JSON.parse(jsonStringify(block)));
+    const block = await L2BlockNew.random(BlockNumber(42));
+    const parsed = L2BlockNew.schema.parse(JSON.parse(jsonStringify(block)));
     expect(parsed).toEqual(block);
   });
+
   it('can create an initial block', async () => {
     // Values taken from world_state.test.cpp WorldStateTest.GetInitialTreeInfoForAllTrees
-    const emptyBlockHeader = L2BlockHeader.empty();
+    const emptyBlockHeader = BlockHeader.empty();
     emptyBlockHeader.state.l1ToL2MessageTree.root = Fr.fromString(
       '0x0d582c10ff8115413aa5b70564fdd2f3cefe1f33a1e43a47bc495081e91e73e5',
     );
@@ -38,7 +39,7 @@ describe('L2Block', () => {
       '0x23c08a6b1297210c5e24c76b9a936250a1ce2721576c26ea797c7ec35f9e46a9',
     );
     emptyBlockHeader.state.partial.publicDataTree.nextAvailableLeafIndex = 128;
-    const emptyBlock = L2Block.empty(emptyBlockHeader);
+    const emptyBlock = L2BlockNew.empty(emptyBlockHeader);
     const emptyBlockHash = await emptyBlock.hash();
     expect(emptyBlockHash.equals(GENESIS_BLOCK_HEADER_HASH)).toBeTruthy();
   });

--- a/yarn-project/stdlib/src/block/l2_block_new.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.ts
@@ -131,8 +131,14 @@ export class L2BlockNew {
     };
   }
 
-  static empty() {
-    return new L2BlockNew(AppendOnlyTreeSnapshot.empty(), BlockHeader.empty(), Body.empty(), CheckpointNumber(0), 0);
+  static empty(header?: BlockHeader) {
+    return new L2BlockNew(
+      AppendOnlyTreeSnapshot.empty(),
+      header ?? BlockHeader.empty(),
+      Body.empty(),
+      CheckpointNumber(0),
+      0,
+    );
   }
 
   /**


### PR DESCRIPTION
This PR changes the node so that it will serve the genesis block (an empty block with the initial header).
