### PR TITLE
docs: expand on fn macro docs

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -27,12 +27,56 @@ use auth_registry::AUTHORIZE_ONCE_REGISTRY;
 // and `#[external(public)]` to check if it's been applied. Therefore, the execution order of `#[only_self]` and
 // `#[external(...)]` is irrelevant.
 
-/// An initializer function is similar to a constructor:
-///  - it can only be called once
-///  - if there are multiple initializer functions, only one of them can be called
-///  - no non-initializer functions can be called until an initializer has ben called (except `noinitcheck` functions)
+/// An initializer function is where a contract initializes its state.
+///
+/// Initializer functions are similar to constructors:
+///  - can only be called once
+///  - [external] non-initializer functions cannot be called until one of the initializers has ben called
+///
+/// The only exception are [noinitcheck] functions, which can be called even if none of the initializers has been
+/// called.
+///
+/// ## Initialization Commitment
+///
+/// All contract instances have their address include a commitment to one of their initializer functions, along with
+/// parameters and calling address. Any of the following will therefore fail:
+///  - calling the wrong initializer function
+///  - calling the initializer function with incorrect parameters
+///  - calling the initializer function from the incorrect address
+///
+/// It is possible however to allow for any account to call the specified initializer by setting the intended caller to
+/// the zero address. These are called 'universal deployments'.
+///
+/// ## Multiple Initializers
+///
+/// A contract can have multiple initializer functions, but it is not possible to call multiple initializers on the same
+/// instance: all initializers become disabled once any of them executes. Each individual instance can call any of the
+/// initializers.
+///
+/// Initializers can be either private or public. If a contract needs to initialize both private and public
+/// state, then it should have an [external] private function marked as [initializer] which then enqueues a call to an
+/// [external] public function **not** marked as [initializer] and instead marked as [only_self] (so that it can only be
+/// called in this manner).
+///
+/// ## Lack of Initializers
+///
+/// If a contract has no initializer function, initialization is then not required and all functions can be called at
+/// any time. Contracts that do have initializers can also make some of their functions available prior to
+/// initialization by marking them with the `#[noinitcheck]` attribute - though any contract state initialization will
+/// of course not have taken place.
+///
+/// ## Cost
+///
+/// The initialization process emits a nullifier which marks the contract as initialized. All other [external] functions
+/// are automatically made to check that this nullifier exists, ensuring initialization.
+///
+/// For private non-initializer functions, the cost of this check is equivalent to that of a call to
+/// [crate::context::private_context::PrivateContext::push_nullifier_read_request]. For public ones, it is equivalent to
+/// a call to [crate::context::public_context::PublicContext::nullifier_exists].
+///
+/// The [noinitcheck] attribute can be used to skip the initialization nullifer checks.
 pub comptime fn initializer(f: FunctionDefinition) {
-    // Marker attribute - see the comment above
+    // Marker attribute - see the comment at the top of this file
 
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
@@ -45,9 +89,21 @@ pub comptime fn initializer(f: FunctionDefinition) {
     }
 }
 
-/// Functions with noinitcheck can be called before contract initialization.
+/// A no-init-check [external] function can be called even if none of the [initializer] functions have been called yet.
+///
+/// Contracts that have no [initializer] functions do not require this attribute: all of their functions behave as if
+/// they implicitly had it (i.e. they don't check for initialization nullifiers).
+///
+/// ## Use Case
+///
+/// This is an optimization as it skips the initialization check, possibly reducing proving time for private functions
+/// and L2 gas for public ones.
+///
+/// It is dangerous attribute however, as the contract will not be able to rely on its storage having been initialized.
+/// Valid use cases include those in which the contract indirectly infers initialization, e.g. by reading one of its
+/// state variables and testing for a non-default value.
 pub comptime fn noinitcheck(f: FunctionDefinition) {
-    // Marker attribute - see the comment above
+    // Marker attribute - see the comment at the top of this file
 
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
@@ -66,9 +122,13 @@ pub comptime fn noinitcheck(f: FunctionDefinition) {
     }
 }
 
-/// Functions marked with #[nophasecheck] will handle phase changes internally
+/// A no-phase-check function will allow transitioning from the non-revertible to the revertible phase during its
+/// execution.
+///
+/// This is an advanced feature that is typically only required for account contract entrypoints that handle transaction
+/// fee payment.
 pub comptime fn nophasecheck(f: FunctionDefinition) {
-    // Marker attribute - see the comment above
+    // Marker attribute - see the comment at the top of this file
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility or public function here as Noir does not support
         // getting arguments passed to attributes. For this reason, we will check for this when the utility and public macro
@@ -80,15 +140,51 @@ pub comptime fn nophasecheck(f: FunctionDefinition) {
     }
 }
 
-/// Functions marked with #[only_self] attribute can only be called by the contract itself.
+/// Restricts an [external] function so that it can only be called by the contract itself.
 ///
-/// # Usage
-/// This attribute is commonly used when an action starts in private but needs to be completed in public. The public
-/// function must be marked with #[only_self] to restrict access to only the contract itself. A typical example is a
-/// private token mint operation that needs to enqueue a call to a public function to update the publicly tracked total
-/// token supply.
+/// [external] functions can normally be called by any address - it is up to contracts to set up access control checks
+/// e.g. to admin functions. [only_self] similarly makes it so that the only authorized address is the account contract,
+/// i.e. the function _requires_ reentrancy.
+///
+/// These are different from [internal] functions in that those are _internally_ called, i.e. they don't result in
+/// contract calls.
+///
+/// ## Use Cases
+///
+/// This attribute can be applied to both private or public [external] functions, so there are multiple scenarios to
+/// consider.
+///
+/// ### Private
+///
+/// Private functions can only be externally called by other private functions. In this case, [only_self] can be used to
+/// recursively call circuits, achieving proving time performance improvements for low-load scenarios.
+///
+/// For example, consider a token transfer for some amount: the number of notes that need to be read and nullified is
+/// not known at compile time. Selecting a large maximum number of notes to read per transfer would result in a large
+/// circuit with excess capacity in transfers of few notes, while a small maximum would outright prevent many notes from
+/// being used at once.
+///
+/// A better approach is to create a private [only_self] external function in which notes are read and nullified,
+/// recursively calling itself if the sum of the values does not add up to some target amount. This makes the circuit
+/// adapt itself to the number of notes required, resulting in either few or many recursive invocations and therefore
+/// proving time roughly proportional to the number of notes. The recursive function must be [only_self] because we
+/// want to prevent any other contract from calling it - it is only an internal mechanism.
+///
+/// ### Public
+///
+/// Public functions can only be externally called by both private and public functions. Public to public [only_self]
+/// calls are rare and not very useful (it'd be equivalent to an `external` Solidity function with
+/// `require(msg.sender == address(this))`). Private to public calls do enable useful design patterns though.
+///
+/// A private function that needs to perform some public check (like some public state assertion) or follow-up public
+/// action (like some public state mutation) can do so by enqueuing a call to an [external] [only_self] public function.
+/// The [only_self] attribute will prevent external callers from invoking the function, making it be a purely internal
+/// mechanism.
+///
+/// A classic example is a private mint function in a token, which would require an enqueued public call in which the
+/// total supply is incremented.
 pub comptime fn only_self(f: FunctionDefinition) {
-    // Marker attribute - see the comment above
+    // Marker attribute - see the comment at the top of this file
 
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
@@ -101,9 +197,32 @@ pub comptime fn only_self(f: FunctionDefinition) {
     }
 }
 
-/// View functions can only be called in a static execution context.
+/// View functions cannot modify state in any way, including performing contract calls that would in turn modify state.
+///
+/// This makes them easy to reason about: they are simply 'pure' functions that return a value, and carry e.g. no
+/// reentrancy risk.
+///
+/// ## Use Cases
+///
+/// Only public and private functions can be [view].
+///
+/// Private [view] functions are typically not very useful as they cannot emit nullifiers, which is often required when
+/// reading private state (e.g. from a [crate::state_vars::private_mutable::PrivateMutable] or
+/// [crate::state_vars::private_set::PrivateSet] state variable). They do however have their use cases, such as
+/// performing a [crate::state_vars::delayed_public_mutable::DelayedPublicMutable] read.
+///
+/// Public view functions on the other hand are very common, since reading public storage does not require any state
+/// modifications. These are essentially equivalent to a Solidity `view` function.
+///
+/// ## Guarantees
+///
+/// [view] functions can *only* be called in a static execution context, which is typically achieved by calling the
+/// [crate::contract_self::ContractSelf::view] method on `self`.
+///
+/// No compile time checks are performed on whether a function can be made [view]. If a function marked as view attempts
+/// to modify state, that will result in *runtime* failures.
 pub comptime fn view(f: FunctionDefinition) {
-    // Marker attribute - see the comment above
+    // Marker attribute - see the comment at the top of this file
 
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility function here as Noir does not support
@@ -116,14 +235,30 @@ pub comptime fn view(f: FunctionDefinition) {
     }
 }
 
-/// Private and public functions can require an authorization check to be performed before execution. This
-/// is typically the case when the function allows performing an action on behalf of someone who is not
-/// the caller.
-/// This macro injects the necessary code to perform the check via the authwit mechanism and additionally
-/// emit the authorization request as an offchain effect, so a user/wallet can verify what are they
-/// being asked to sign.
-/// This check also emits a nullifier with the provided nonce argument, so authorizations are valid
-/// once and only once, preventing replay attacks.
+/// Restricts access to an [external] private or public function so that it can only be called by an authorized account.
+///
+/// Receives the name of a `from` `AztecAddress` variable which will be the default authorized account, and the name of a
+/// `nonce` `Field` variable which is used by `from` to grant one-time-only access to other accounts.
+///
+/// ## Usage
+///
+/// The `from` account can always call an [authorize_once] function by passing a value of 0 as the `nonce`. Any other
+/// caller requires explicit permission granted by the `from` account, which 1) will be tied to a specific `nonce` value
+/// that must be passed by the caller, and which can only be used once, and 2) will restrict all other function params
+/// to be exactly the ones that have been authorized by `from`.
+///
+/// ## Cost
+///
+/// Private functions perform a private authwit check by calling the standard account contract `verify_private_authwit`
+/// function on `from` with the hash resulting of all function params and the nonce. A nullifier is then emitted,
+/// preventing the same permission from being used again. Note that this requires that the caller has access to
+/// `from`'s contract class ID and salted initialization hash, as it would otherwise not be possible to call the
+/// `verify_private_authwit` function.
+///
+/// Public functions call the `consume` function on the `AuthRegistry` contract, which requires that either a) `from`
+/// first calls the `set_authorized` public function, or b) that a private authwit check by `from` is passed for the
+/// registry's `set_authorized_private` function, allowing in turn the caller to privately call `set_authorized_private`
+/// in the same transaction in which the [authorize_once] function is invoked.
 pub comptime fn authorize_once(
     f: FunctionDefinition,
     from_arg_name: CtString,
@@ -142,18 +277,22 @@ pub comptime fn authorize_once(
     AUTHORIZE_ONCE_REGISTRY.insert(f, (from_arg_name, nonce_arg_name));
 }
 
-/// Same as in Solidity external functions are functions that our callable from outside the contract.
+/// An external function is callable from outside the contract.
 ///
-/// There are 3 types of external functions: private, public, and utility.
-/// - private functions are executed client-side and preserve privacy.
-/// - public functions are executed sequencer-side and do not preserve privacy, similar to the EVM.
-/// - utility functions are standalone unconstrained functions that cannot be called from another function in a
-///   contract. They are typically used either to obtain some information from the contract (e.g. token balance of a
-///   user) or to modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
+/// There are three types of external functions:
+///  - private: executed client-side and preserve privacy
+///  - public: executed by the sequencer and do not preserve privacy (like on the EVM)
+///  - utility: helpers that are never executed on-chain, typically used for state queries
 ///
-/// In this function we perform basic checks on the function to ensure it is valid and then we add the function to the
-/// external functions registry for later processing by the `#[aztec]` macro.
+/// [external] functions are the Aztec equivalent of a Solidity `external` function, though their behavior differs
+/// slightly for public, private and utiliy functions.
+///
+/// [external] functions can also be made [initializer] (for contract intialization), [view] (for read-only behavior),
+/// [authorize_once] (for basic access control) and [only_self] (to prevent other contracts from calling them).
 pub comptime fn external(f: FunctionDefinition, f_type: CtString) {
+    // In this function we perform basic checks on the function to ensure it is valid and then we add the function to the
+    // external functions registry for later processing by the `#[aztec]` macro.
+
     if f_type.eq("private") {
         assert_valid_private(f);
         external_functions_registry::add_private(f);
@@ -171,16 +310,13 @@ pub comptime fn external(f: FunctionDefinition, f_type: CtString) {
     }
 }
 
-/// Same as in Solidity internal functions are functions that are callable from inside the contract. Unlike #[only_self]
-/// functions, internal functions are inlined (e.g. akin to EVM's JUMP and not EVM's CALL).
+/// An internal function is only callable from inside the contract.
 ///
-/// Internal function can be called using the following API:
-/// ```noir
-/// self.internal.my_internal_function(...)
-/// ```
+/// [internal] functions are the Aztec equivalent of a Solidity `internal` function, though their behavior differs
+/// slightly for public, private and utiliy functions.
 ///
-/// Private internal functions can only be called from other private external or internal functions.
-/// Public internal functions can only be called from other public external or internal functions.
+/// Note that these are different from [only_self] in that those are [external] and so are externally called (via
+/// contract calls).
 pub comptime fn internal(f: FunctionDefinition, f_type: CtString) {
     let function_name = f.name();
     if is_fn_external(f) {


### PR DESCRIPTION
Largely a replacement of https://github.com/AztecProtocol/aztec-packages/pull/16333.

I'm thinking we'd drop usage of "private" etc and instead use enums, letting us add docs for each option. The only downside is we'd need to import those values, but I don't think that's the end of the world. Eventually once we have `*` imports we'll be able to put these things in a prelude:

```noir
import aztec::prelude::*;

#[aztec]
contract Foo {
  #[external(PRIVATE)]
  fn my_fn(..) { }
}
```