### PR TITLE
fix: prover-nodes listen for checkpoint proposals

### DIFF
--- a/yarn-project/stdlib/src/p2p/topic_type.ts
+++ b/yarn-project/stdlib/src/p2p/topic_type.ts
@@ -31,7 +31,7 @@ export function getTopicTypeForClientType(clientType: P2PClientType) {
   if (clientType === P2PClientType.Full) {
     return [TopicType.tx, TopicType.block_proposal, TopicType.checkpoint_proposal, TopicType.checkpoint_attestation];
   } else if (clientType === P2PClientType.Prover) {
-    return [TopicType.tx, TopicType.block_proposal];
+    return [TopicType.tx, TopicType.block_proposal, TopicType.checkpoint_proposal];
   } else {
     const _: never = clientType;
     return [TopicType.tx];


### PR DESCRIPTION
Noticed while working on #19573 that prover-nodes on next-net don't listen for checkpoint proposals.