### PR TITLE
fix: validate pubkeys on curve in instance registry

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
@@ -11,6 +11,7 @@ pub contract ContractInstanceRegistry {
                 CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE, DEFAULT_UPDATE_DELAY, MINIMUM_UPDATE_DELAY,
             },
             contract_class_id::ContractClassId,
+            point::validate_on_curve,
             public_keys::PublicKeys,
             traits::{Serialize, ToField},
         },
@@ -116,6 +117,14 @@ pub contract ContractInstanceRegistry {
 
         let partial_address =
             PartialAddress::compute(contract_class_id, salt, initialization_hash, deployer);
+
+        // Note: Out of all the public keys, only the Ivpk_m is checked to be on the curve
+        // (implicitly as part of the `add` operation of deriving the address). This at least
+        // protects the AVM against DoS attacks.
+        // For thoroughness, we also ensure the other points are on the curve:
+        validate_on_curve(public_keys.npk_m.inner);
+        validate_on_curve(public_keys.ovpk_m.inner);
+        validate_on_curve(public_keys.tpk_m.inner);
 
         let address = AztecAddress::compute(public_keys, partial_address);
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
@@ -35,6 +35,19 @@ impl Deserialize for Point {
     }
 }
 
+pub fn validate_on_curve(p: Point) {
+    // y^2 == x^3 - 17
+    let x = p.x;
+    let y = p.y;
+    if p.is_infinite {
+        // Assert the canonical representation of infinity
+        assert_eq(x, 0, "Point at infinity should have canonical representation (0 0)");
+        assert_eq(y, 0, "Point at infinity should have canonical representation (0 0)");
+    } else {
+        assert_eq(y * y, x * x * x - 17, "Point not on curve");
+    }
+}
+
 // TODO(#11356): use compact representation here.
 impl Packable for Point {
     let N: u32 = POINT_LENGTH;
@@ -45,5 +58,45 @@ impl Packable for Point {
 
     fn unpack(packed: [Field; Self::N]) -> Self {
         Self::deserialize(packed)
+    }
+}
+
+mod tests {
+    use super::validate_on_curve;
+    use dep::std::embedded_curve_ops::EmbeddedCurvePoint as Point;
+
+    #[test]
+    unconstrained fn test_validate_on_curve_generator() {
+        // The generator point should be on the curve
+        let generator = Point::generator();
+        validate_on_curve(generator);
+    }
+
+    #[test]
+    unconstrained fn test_validate_on_curve_infinity() {
+        // Canonical infinite point (x=0, y=0) should pass
+        let infinity = Point { x: 0, y: 0, is_infinite: true };
+        validate_on_curve(infinity);
+    }
+
+    #[test(should_fail_with = "Point not on curve")]
+    unconstrained fn test_validate_on_curve_invalid_point() {
+        // A point not on the curve should fail
+        let invalid = Point { x: 1, y: 1, is_infinite: false };
+        validate_on_curve(invalid);
+    }
+
+    #[test(should_fail_with = "Point at infinity should have canonical representation (0 0)")]
+    unconstrained fn test_validate_on_curve_infinity_non_canonical_x() {
+        // Infinite point with non-zero x should fail
+        let invalid_infinity = Point { x: 1, y: 0, is_infinite: true };
+        validate_on_curve(invalid_infinity);
+    }
+
+    #[test(should_fail_with = "Point at infinity should have canonical representation (0 0)")]
+    unconstrained fn test_validate_on_curve_infinity_non_canonical_y() {
+        // Infinite point with non-zero y should fail
+        let invalid_infinity = Point { x: 0, y: 1, is_infinite: true };
+        validate_on_curve(invalid_infinity);
     }
 }


### PR DESCRIPTION
Possibly not essential, but these checks prevent unexpected problems for just a handful of constraints.
