### PR TITLE
chore: remove p2p unit tests from flake group

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -199,6 +199,10 @@ tests:
     error_regex: "Failed to commit transaction: InitialBlockNumberNotSequentialError: Cannot insert new block"
     owners:
       - *palla
+  - regex: "p2p/src/services/discv5/discv5_service.test.ts"
+    owners:
+      - *phil
+      - *palla
 
   # Nightly GKE tests
   - regex: "spartan/bootstrap.sh"
@@ -294,9 +298,10 @@ tests:
     owners:
       - *palla
 
-  - regex: "p2p/.*\\.test\\.ts"
+  - regex: "p2p/src/client/test/.*\\.test\\.ts"
     flake_group_id: e2e-p2p-epoch-flakes
     owners:
+      - *palla
       - *phil
 
   - regex: "ethereum/src/l1_tx_utils/.*\\.test\\.ts"


### PR DESCRIPTION
Flake group should only include e2e p2p tests and p2p integration tests. Also adds the discv5 service individually as flakey, which has been historically problematic.

