### PR TITLE
fix: Make test more deterministic

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
@@ -2,6 +2,7 @@ import type { AztecNodeService } from '@aztec/aztec-node';
 import { EthAddress } from '@aztec/aztec.js/addresses';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { retryUntil } from '@aztec/foundation/retry';
 import { OffenseType } from '@aztec/slasher';
 
 import { jest } from '@jest/globals';
@@ -14,7 +15,9 @@ import { createNodes } from '../fixtures/setup_p2p_test.js';
 import { P2PNetworkTest } from './p2p_network.js';
 import { awaitCommitteeExists, awaitOffenseDetected } from './shared.js';
 
-jest.setTimeout(1000000);
+const TEST_TIMEOUT = 1_000_000;
+
+jest.setTimeout(TEST_TIMEOUT);
 
 // Don't set this to a higher value than 9 because each node will use a different L1 publisher account and anvil seeds
 const NUM_VALIDATORS = 4;
@@ -148,13 +151,43 @@ describe('e2e_p2p_broadcasted_invalid_block_proposal_slash', () => {
 
     await awaitCommitteeExists({ rollup, logger: t.logger });
 
+    const startSlot = await rollup.getSlotNumber();
+    const proposerEarliestSlot = startSlot + 1;
+
+    // Wait until the bad proposer has had a slot
+    await retryUntil(
+      async () => {
+        const currentSlot = await rollup.getSlotNumber();
+        return currentSlot >= proposerEarliestSlot;
+      },
+      'Wait for next slot...',
+      TEST_TIMEOUT / 1000,
+      ETHEREUM_SLOT_DURATION,
+    );
+
+    await retryUntil(
+      async () => {
+        const currentProposer = await rollup.getCurrentProposer();
+        if (!currentProposer.equals(invalidProposerAddress)) {
+          t.logger.info(
+            `Current proposer: ${currentProposer}, waiting for malicious proposer ${invalidProposerAddress} to get a slot...`,
+          );
+          return false;
+        }
+        return true;
+      },
+      'Wait for malicious proposer slot...',
+      TEST_TIMEOUT / 1000,
+      ETHEREUM_SLOT_DURATION,
+    );
+
     const offenses = await awaitOffenseDetected({
       epochDuration: t.ctx.aztecNodeConfig.aztecEpochDuration,
       logger: t.logger,
       nodeAdmin: nodes[1], // Use honest node to check for offenses
       slashingRoundSize,
       waitUntilOffenseCount: 1,
-      timeoutSeconds: AZTEC_SLOT_DURATION * 16, // Eventually it should be turn for the invalid proposer to propose
+      timeoutSeconds: AZTEC_SLOT_DURATION * 16,
     });
 
     // Check offense is correct


### PR DESCRIPTION
Ths test `broadcasted_invalid_block_proposal_slash` simply waited 16 slots and assumed a dishonest proposer would get a slot in that time. This PR forces the test to run until such time that this proposer does get a slot.
