### PR TITLE
fix(ethereum): don't rely on exec'ing in /tmp

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -270,10 +270,6 @@ tests:
     owners:
       - *david
 
-  - regex: "src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts"
-    owners:
-      - *grego
-
   - regex: "amm_flow.sh"
     owners:
       - *grego

--- a/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from '@aztec/foundation/url';
 import { bn254 } from '@noble/curves/bn254';
 import type { Abi, Narrow } from 'abitype';
 import { spawn } from 'child_process';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 import readline from 'readline';
@@ -141,11 +141,14 @@ function cleanupDeployDir() {
  */
 export function prepareL1ContractsForDeployment(): string {
   if (preparedDeployDir && existsSync(preparedDeployDir)) {
+    logger.verbose(`Using cached deployment directory: ${preparedDeployDir}`);
     return preparedDeployDir;
   }
 
   const basePath = getL1ContractsPath();
+  logger.verbose(`Preparing L1 contracts from: ${basePath}`);
   const tempDir = mkdtempSync(join(tmpdir(), '.foundry-deploy-'));
+  logger.verbose(`Created temp directory for deployment: ${tempDir}`);
   preparedDeployDir = tempDir;
   process.on('exit', cleanupDeployDir);
 
@@ -157,13 +160,21 @@ export function prepareL1ContractsForDeployment(): string {
   cpSync(join(basePath, 'src'), join(tempDir, 'src'), copyOpts);
   cpSync(join(basePath, 'script'), join(tempDir, 'script'), copyOpts);
   cpSync(join(basePath, 'generated'), join(tempDir, 'generated'), copyOpts);
-  cpSync(join(basePath, 'foundry.toml'), join(tempDir, 'foundry.toml'));
+  // Kludge: copy test/ to appease forge cache which references test/shouting.t.sol
+  cpSync(join(basePath, 'test'), join(tempDir, 'test'), copyOpts);
   cpSync(join(basePath, 'foundry.lock'), join(tempDir, 'foundry.lock'));
-  for (const file of readdirSync(basePath)) {
-    if (file.startsWith('solc-')) {
-      cpSync(join(basePath, file), join(tempDir, file));
-    }
+
+  // Update foundry.toml to use absolute path to solc binary (avoids copying to noexec tmpfs)
+  const foundryTomlPath = join(basePath, 'foundry.toml');
+  let foundryToml = readFileSync(foundryTomlPath, 'utf-8');
+  const solcPathMatch = foundryToml.match(/solc\s*=\s*"\.\/solc-([^"]+)"/);
+  if (solcPathMatch) {
+    const solcVersion = solcPathMatch[1];
+    const absoluteSolcPath = join(basePath, `solc-${solcVersion}`);
+    foundryToml = foundryToml.replace(/solc\s*=\s*"\.\/solc-[^"]+"/, `solc = "${absoluteSolcPath}"`);
+    logger.verbose(`Updated solc path in foundry.toml to: ${absoluteSolcPath}`);
   }
+  writeFileSync(join(tempDir, 'foundry.toml'), foundryToml);
 
   mkdirSync(join(tempDir, 'broadcast'));
   return tempDir;

--- a/yarn-project/l1-artifacts/scripts/copy-foundry-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/copy-foundry-artifacts.sh
@@ -19,6 +19,9 @@ mkdir -p "l1-contracts/script" "l1-contracts/lib" "l1-contracts/broadcast"
 # Copy build artifacts, cache, sources, and config (preserving timestamps for cache validity)
 cp -rp "$src"/{out,cache,src,generated} "l1-contracts/"
 cp -rp "$src/script/deploy" "l1-contracts/script/"  # only deploy/, other scripts depend on test files
+# Kludge: copy one test file to appease forge cache which references test/shouting.t.sol
+mkdir -p "l1-contracts/test"
+cp -p "$src/test/shouting.t.sol" "l1-contracts/test/"
 cp -p "$src"/{foundry.toml,foundry.lock,solc-*} "l1-contracts/"
 abs_dest=$(pwd)/l1-contracts
 # Keep only the foundry relevant files from lib


### PR DESCRIPTION
Fixes and unflakes src/composed/web3signer/e2e_multi_validator_node_key_store.test.ts

- Fix "Permission denied" error when deploying L1 contracts in our docker compose scripts due to `/tmp` being mounted as noexec tmpfs
- Instead of copying solc binary to temp directory, we update `foundry.toml` to use absolute path to the original location

Included:
- Copy `test/shouting.t.sol` to appease forge cache warnings about missing source files