### PR TITLE
feat(archiver): Reconcile provisional blocks with L1 checkpoints

### DIFF
--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -19,16 +19,17 @@ An Aztec **node** syncs L2 state and serves RPC requests. A node may also act as
 
 ### When to Run Bootstrap
 
-**ONLY** run `./bootstrap.sh` from the git root when:
+**ALWAYS** run `./bootstrap.sh` from the git root when:
 
 - Pulling new changes that have modifications outside `yarn-project`
 - Switching branches with changes from outside `yarn-project`
+- Rebasing on a branch that has changes outside `yarn-project`
 
 ```bash
-cd $(git rev-parse --show-toplevel) && ./bootstrap.sh
+(cd $(git rev-parse --show-toplevel) && BOOTSTRAP_TO=yarn-project ./bootstrap.sh)
 ```
 
-**DO NOT** run bootstrap in any other circumstance - it takes several minutes.
+Bootstrap takes several minutes to run. Be patient.
 
 ### Compile Before Testing
 

--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -10,7 +10,8 @@ The interfaces `L2BlockSource`, `L2LogsSource`, and `ContractDataSource` define 
 
 The archiver emits events for other subsystems to react to state changes:
 
-- **`L2PruneDetected`**: Emitted before unwinding checkpoints due to epoch prune. Contains the epoch number and affected blocks. Subscribers (e.g., world-state) use this to prepare for the unwind.
+- **`L2PruneUnproven`**: Emitted before unwinding checkpoints due to epoch prune. Contains the epoch number and affected blocks. Subscribers (e.g., world-state) use this to prepare for the unwind.
+- **`L2PruneUncheckpointed`**: Emitted when provisional blocks are pruned due to checkpoint mismatch or slot expiration. Contains the slot number and affected blocks.
 - **`L2BlockProven`**: Emitted when the proven checkpoint advances. Contains the block number, slot, and epoch.
 - **`InvalidAttestationsCheckpointDetected`**: Emitted when a checkpoint with invalid attestations is encountered during sync.
 
@@ -29,6 +30,7 @@ sync()
 └── syncFromL1()
     ├── handleL1ToL2Messages()  # Sync messages from Inbox contract
     ├── handleCheckpoints()     # Sync checkpoints from Rollup contract
+    ├── pruneUncheckpointedBlocks()  # Prune provisional blocks from expired slots
     ├── handleEpochPrune()      # Proactive unwind before proof window expires
     └── checkForNewCheckpointsBeforeL1SyncPoint()  # Handle L1 reorg edge case
 ```
@@ -89,6 +91,12 @@ archiver.addBlock(block);  // Queues block for processing
 
 Queued blocks are processed at the start of each sync iteration. This allows the sequencer to make blocks available locally before checkpoint publication. This is used to make the `proposed` chain (ie blocks that have been broadcasted via p2p but not checkpointed on L1) available to consumers.
 
+Blocks added via `addBlock()` are considered "provisional" until they appear in an L1 checkpoint. These provisional blocks may need to be reconciled when:
+- **Checkpoint mismatch**: A checkpoint lands on L1 with different blocks than stored locally (e.g., a different proposer won the slot)
+- **Slot expiration**: An L2 slot ends without any checkpoint being mined on L1
+
+When `handleCheckpoints()` processes incoming checkpoints, it compares archive roots of local blocks against the checkpoint's blocks. If they differ, local blocks are pruned and replaced with the checkpoint's blocks. After checkpoint sync, `pruneUncheckpointedBlocks()` removes any remaining provisional blocks from slots that have ended. Both cases emit `L2PruneUncheckpointed`.
+
 ### Edge Cases
 
 #### L1 Reorgs
@@ -115,7 +123,7 @@ This handles the case where an epoch's proof submission window has passed withou
 **Example**: The proven checkpoint is 10, and pending checkpoints 11-15 exist locally. The proof submission window for the epoch containing checkpoint 11 will expire. On sync:
 1. Archiver calls `canPruneAtTime()` with the next L1 block's timestamp — returns true
 2. Archiver unwinds checkpoints 11-15
-3. Emits `L2PruneDetected` event so subscribed subsystems can react
+3. Emits `L2PruneUnproven` event so subscribed subsystems can react
 4. Local state now shows checkpoint 10 as latest
 
 #### Checkpoints Behind Syncpoint

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -30,7 +30,7 @@ import { Archiver, type ArchiverEmitter } from './archiver.js';
 import type { ArchiverInstrumentation } from './modules/instrumentation.js';
 import { ArchiverL1Synchronizer } from './modules/l1_synchronizer.js';
 import { KVArchiverDataStore } from './store/kv_archiver_store.js';
-import { FakeL1State, type FakeL1StateConfig } from './test/fake_l1_state.js';
+import { FakeL1State } from './test/fake_l1_state.js';
 
 describe('Archiver Sync', () => {
   const rollupAddress = EthAddress.random();
@@ -57,7 +57,6 @@ describe('Archiver Sync', () => {
   let now: number;
 
   const GENESIS_ROOT = new Fr(GENESIS_ARCHIVE_ROOT);
-  const ETHEREUM_SLOT_DURATION = BigInt(DefaultL1ContractsConfig.ethereumSlotDuration);
 
   beforeEach(async () => {
     logger = createLogger('archiver:sync:test');
@@ -65,16 +64,20 @@ describe('Archiver Sync', () => {
     now = Math.floor(Date.now() / 1000);
     dateProvider = new TestDateProvider();
 
-    // Create fake L1 state
-    const fakeConfig: FakeL1StateConfig = {
-      genesisArchiveRoot: GENESIS_ROOT,
-      l1StartBlock: 0n,
+    // L1 constants
+    l1Constants = {
       l1GenesisTime: BigInt(now),
-      ethereumSlotDuration: Number(ETHEREUM_SLOT_DURATION),
-      rollupAddress,
-      inboxAddress,
+      l1StartBlock: 0n,
+      l1StartBlockHash: Buffer32.random(),
+      epochDuration: 4,
+      slotDuration: 24,
+      ethereumSlotDuration: DefaultL1ContractsConfig.ethereumSlotDuration,
+      proofSubmissionEpochs: 1,
+      genesisArchiveRoot: GENESIS_ROOT,
     };
-    fake = new FakeL1State(fakeConfig);
+
+    // Create fake L1 state
+    fake = new FakeL1State({ ...l1Constants, rollupAddress, inboxAddress });
 
     // Create mock clients from the fake
     publicClient = fake.createMockPublicClient();
@@ -90,18 +93,6 @@ describe('Archiver Sync', () => {
 
     // Create archiver store
     archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_sync_test'), 1000);
-
-    // L1 constants
-    l1Constants = {
-      l1GenesisTime: BigInt(now),
-      l1StartBlock: 0n,
-      l1StartBlockHash: Buffer32.random(),
-      epochDuration: 4,
-      slotDuration: 24,
-      ethereumSlotDuration: 12,
-      proofSubmissionEpochs: 1,
-      genesisArchiveRoot: GENESIS_ROOT,
-    };
 
     const contractAddresses = {
       registryAddress,
@@ -984,8 +975,19 @@ describe('Archiver Sync', () => {
     xit('does not attempt to download data for a checkpoint that has been pruned', () => {});
   });
 
-  describe('addBlock and L1 sync interaction', () => {
-    it('blocks added via addBlock become checkpointed when checkpoint syncs from L1', async () => {
+  describe('checkpointing local proposed blocks', () => {
+    let pruneSpy: jest.Mock;
+
+    beforeEach(() => {
+      pruneSpy = jest.fn();
+      archiver.events.on(L2BlockSourceEvents.L2PruneUncheckpointed, pruneSpy);
+    });
+
+    afterEach(() => {
+      archiver.events.off(L2BlockSourceEvents.L2PruneUncheckpointed, pruneSpy);
+    });
+
+    it('checkpoints local blocks when matching checkpoint syncs from L1', async () => {
       // First, sync checkpoint 1 from L1 to establish a baseline
       const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,
@@ -994,8 +996,7 @@ describe('Archiver Sync', () => {
       });
 
       fake.setL1BlockNumber(100n);
-      await archiver.start(false);
-      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
+      await archiver.syncImmediate();
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
@@ -1022,6 +1023,7 @@ describe('Archiver Sync', () => {
       const lastBlockInCheckpoint2 = cp2.blocks[cp2.blocks.length - 1].number;
       expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+      expect((await archiver.getL2BlockNew(cp2.blocks[0].number))!.equals(cp2.blocks[0])).toBe(true);
 
       // Verify L2Tips after adding blocks: proposed advances but checkpointed stays at checkpoint 1
       const tipsAfterAddBlock = await archiver.getL2Tips();
@@ -1041,7 +1043,10 @@ describe('Archiver Sync', () => {
       // Now advance L1 so checkpoint 2 becomes visible
       fake.setL1BlockNumber(5010n);
 
-      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)), 'sync');
+      await archiver.syncImmediate();
+
+      // Verify NO prune event was emitted (blocks matched)
+      expect(pruneSpy).not.toHaveBeenCalled();
 
       // Now the blocks should be checkpointed
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
@@ -1058,7 +1063,7 @@ describe('Archiver Sync', () => {
       expect(checkpointedBlock!.checkpointNumber).toEqual(2);
     }, 10_000);
 
-    it('blocks added via checkpoints can not be added via addBlocks', async () => {
+    it('rejects adding blocks that are already checkpointed', async () => {
       // First, sync checkpoint 1 from L1 to establish a baseline
       const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,
@@ -1067,8 +1072,7 @@ describe('Archiver Sync', () => {
       });
 
       fake.setL1BlockNumber(100n);
-      await archiver.start(false);
-      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
+      await archiver.syncImmediate();
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const blockAlreadySyncedFromCheckpoint = cp1.blocks[cp1.blocks.length - 1];
@@ -1077,74 +1081,301 @@ describe('Archiver Sync', () => {
       await expect(archiver.addBlock(blockAlreadySyncedFromCheckpoint)).rejects.toThrow();
     }, 10_000);
 
-    it('can add more blocks after checkpoint syncs and then sync another checkpoint', async () => {
-      // Sync the first checkpoint normally
-      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+    it('adds missing blocks when checkpoint has more blocks than local', async () => {
+      // Sync checkpoint 1 from L1
+      await fake.addCheckpoint(CheckpointNumber(1), {
         l1BlockNumber: 70n,
         messagesL1BlockNumber: 60n,
         numL1ToL2Messages: 3,
       });
 
       fake.setL1BlockNumber(100n);
-      await archiver.start(false);
-      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Create checkpoint 2 on L1 with 2 blocks (not yet visible)
+      const { checkpoint: cp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 5000n,
+        messagesL1BlockNumber: 4990n,
+        numL1ToL2Messages: 3,
+        numBlocks: 2,
+      });
+
+      // Add only the FIRST block locally via addBlock
+      await archiver.addBlock(cp2.blocks[0]);
+
+      // Verify only first block is visible
+      const firstBlockNumber = cp2.blocks[0].number;
+      expect(await archiver.getBlockNumber()).toEqual(firstBlockNumber);
+
+      // Make L1 checkpoint visible
+      fake.setL1BlockNumber(5010n);
+
+      // Sync - should add the second block from the checkpoint
+      await archiver.syncImmediate();
+
+      // Verify NO prune event was emitted
+      expect(pruneSpy).not.toHaveBeenCalled();
+
+      // Both blocks should now be visible
+      const lastBlockInCheckpoint2 = cp2.blocks[cp2.blocks.length - 1].number;
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
+
+      // Verify we can retrieve both blocks
+      const syncedCheckpoints = await archiver.getPublishedCheckpoints(CheckpointNumber(2), 1);
+      expect(syncedCheckpoints[0].checkpoint.blocks.length).toEqual(2);
+    }, 15_000);
+
+    it('checkpoints local blocks from multiple slots when multiple checkpoints sync at once', async () => {
+      // Sync checkpoint 1 from L1 to establish baseline
+      await fake.addCheckpoint(CheckpointNumber(1), { l1BlockNumber: 70n });
+      fake.setL1BlockNumber(100n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Create checkpoint 2 on L1 (NOT visible yet - L1 block is far in the future)
+      const { checkpoint: cp2 } = await fake.addCheckpoint(CheckpointNumber(2), { l1BlockNumber: 5000n });
+
+      // Create checkpoint 3 on L1 (also NOT visible yet)
+      const { checkpoint: cp3 } = await fake.addCheckpoint(CheckpointNumber(3), { l1BlockNumber: 5010n });
+
+      // Add blocks from BOTH checkpoints locally (matching the L1 checkpoints)
+      await archiverStore.addBlocks(cp2.blocks, { force: true });
+      await archiverStore.addBlocks(cp3.blocks, { force: true });
+
+      // Verify all blocks are visible locally
+      const lastBlockInCheckpoint3 = cp3.blocks[cp3.blocks.length - 1].number;
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint3);
+
+      // Still at checkpoint 1 (checkpoints 2 and 3 not synced yet)
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Advance L1 to make BOTH checkpoints visible at once
+      fake.setL1BlockNumber(5010n);
+
+      // Sync the archiver - this should process both checkpoints in one call
+      await archiver.syncImmediate();
+
+      // Assert: NO prune event was emitted (blocks matched)
+      expect(pruneSpy).not.toHaveBeenCalled();
+
+      // Assert: All blocks are still present
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint3);
+
+      // Assert: Both checkpoints are synced
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(3));
+    }, 15_000);
+
+    it('prunes and replaces local blocks when checkpoint has different blocks', async () => {
+      // Sync checkpoint 1 from L1 to establish baseline
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), { l1BlockNumber: 70n });
+      const cp1Archive = cp1.blocks[cp1.blocks.length - 1].archive;
+
+      fake.setL1BlockNumber(80n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Create blocks for checkpoint 2 locally (not yet on L1)
+      const provisionalBlocks = await fake.makeBlocks(CheckpointNumber(2), {
+        l1BlockNumber: 100n,
+        previousArchive: cp1Archive,
+      });
+
+      // Add blocks locally via addBlock
+      for (const block of provisionalBlocks) {
+        await archiver.addBlock(block);
+      }
+
+      // Verify blocks are visible but not checkpointed
+      const lastBlockInCheckpoint2 = provisionalBlocks[provisionalBlocks.length - 1].number;
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Now create a DIFFERENT checkpoint 2 on L1 (different blocks)
+      const { checkpoint: differentCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 100n,
+        previousArchive: cp1Archive,
+      });
+
+      // Verify the blocks are actually different (compare archive roots of last blocks)
+      const provisionalLastArchive = provisionalBlocks[provisionalBlocks.length - 1].archive.root;
+      expect(provisionalLastArchive.toString()).not.toEqual(differentCp2.archive.root.toString());
+
+      // Make L1 checkpoint visible
+      fake.setL1BlockNumber(101n);
+
+      // Sync and replace provisional blocks with L1 checkpoint
+      await archiver.syncImmediate();
+
+      // Verify prune event was emitted
+      expect(pruneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: L2BlockSourceEvents.L2PruneUncheckpointed,
+          slotNumber: expect.any(Number),
+          blocks: expect.arrayContaining(provisionalBlocks.map(b => expect.objectContaining({ number: b.number }))),
+        }),
+      );
+
+      // Verify blocks were replaced with L1 checkpoint's blocks
+      const syncedCheckpoints = await archiver.getPublishedCheckpoints(CheckpointNumber(2), 1);
+      expect(syncedCheckpoints[0].checkpoint.archive.root.toString()).toEqual(differentCp2.archive.root.toString());
+    }, 15_000);
+
+    it('prunes excess local blocks when checkpoint has fewer blocks', async () => {
+      // Sync checkpoint 1 from L1 to establish baseline
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), { l1BlockNumber: 70n });
+      const cp1Archive = cp1.blocks[cp1.blocks.length - 1].archive;
+
+      fake.setL1BlockNumber(80n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Create 2 provisional blocks locally (not on L1)
+      const provisionalBlocks = await fake.makeBlocks(CheckpointNumber(2), {
+        numBlocks: 2,
+        previousArchive: cp1Archive,
+        l1BlockNumber: 5000n,
+      });
+
+      // Add both blocks locally via addBlock
+      for (const block of provisionalBlocks) {
+        await archiver.addBlock(block);
+      }
+
+      // Verify both blocks are visible
+      expect(await archiver.getBlockNumber()).toEqual(provisionalBlocks[1].number);
+
+      // Now create a checkpoint 2 on L1 with only the first provisional block
+      const { checkpoint: differentCp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
+        l1BlockNumber: 5000n,
+        previousArchive: cp1Archive,
+        blocks: [provisionalBlocks[0]],
+      });
+
+      // Make L1 checkpoint visible
+      fake.setL1BlockNumber(5010n);
+
+      // Sync
+      await archiver.syncImmediate();
+
+      // Verify prune event was emitted for only the last local block
+      expect(pruneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: L2BlockSourceEvents.L2PruneUncheckpointed,
+          blocks: expect.arrayContaining(
+            provisionalBlocks.slice(1).map(b => expect.objectContaining({ number: b.number })),
+          ),
+        }),
+      );
+
+      // Verify only the L1 checkpoint's single block is now present
+      const syncedCheckpoints = await archiver.getPublishedCheckpoints(CheckpointNumber(2), 1);
+      expect(syncedCheckpoints[0].checkpoint.blocks.length).toEqual(1);
+      expect(syncedCheckpoints[0].checkpoint.archive.root.toString()).toEqual(differentCp2.archive.root.toString());
+    }, 15_000);
+
+    it('prunes local blocks when slot ends without checkpoint', async () => {
+      // Slot calculation: L2_slot = L1_block / 2 (since slotDuration=24, ethereumSlotDuration=12)
+      // So: L1 blocks 0-1 → slot 0, L1 blocks 2-3 → slot 1, L1 blocks 4-5 → slot 2
+
+      // Sync checkpoint 1 in slot 0 (at L1 block 1, which is still in slot 0)
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 1n,
+        messagesL1BlockNumber: 1n,
+        numL1ToL2Messages: 3,
+        slotNumber: SlotNumber(0),
+      });
+      const cp1Archive = cp1.blocks[cp1.blocks.length - 1].archive;
+      fake.setL1BlockNumber(1n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
+
+      // Create blocks for slot 1 (not yet on L1)
+      const provisionalBlocks = await fake.makeBlocks(CheckpointNumber(2), {
+        l1BlockNumber: 2n,
+        previousArchive: cp1Archive,
+      });
+
+      // Add blocks locally via addBlock for slot 1
+      for (const block of provisionalBlocks) {
+        await archiver.addBlock(block);
+      }
+
+      // Verify blocks are visible
+      const lastProvisionalBlockNumber = provisionalBlocks[provisionalBlocks.length - 1].number;
+      expect(await archiver.getBlockNumber()).toEqual(lastProvisionalBlockNumber);
+
+      // Advance L1 to block 2 (still in slot 1) - should NOT trigger prune yet
+      fake.setL1BlockNumber(2n);
+      await archiver.syncImmediate();
+
+      // Verify NO prune event was emitted (we're still in slot 1)
+      expect(pruneSpy).not.toHaveBeenCalled();
+
+      // Clear the spy to check for new calls after the next sync
+      pruneSpy.mockClear();
+
+      // Blocks should still be visible
+      expect(await archiver.getBlockNumber()).toEqual(lastProvisionalBlockNumber);
+
+      // Now advance L1 to block 3, ending slot 1 without checkpoint
+      // This simulates slot 1 ending without a checkpoint landing on L1
+      // The pruning logic checks all slots between previous sync (slot 0) and current (slot 2)
+      fake.setL1BlockNumber(3n);
+      await archiver.syncImmediate();
+
+      // Verify prune event was emitted
+      expect(pruneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: L2BlockSourceEvents.L2PruneUncheckpointed,
+          slotNumber: SlotNumber(1),
+          blocks: expect.arrayContaining(provisionalBlocks.map(b => expect.objectContaining({ number: b.number }))),
+        }),
+      );
+
+      // Block number should revert to last checkpointed block
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint1);
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+    }, 15_000);
+
+    it('does nothing when slot ends without local blocks', async () => {
+      // Slot calculation: L2_slot = L1_block / 2 (since slotDuration=24, ethereumSlotDuration=12)
+      // So: L1 blocks 0-1 → slot 0, L1 blocks 2-3 → slot 1, L1 blocks 4-5 → slot 2
+
+      // Sync checkpoint 1 in slot 0
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 1n,
+        messagesL1BlockNumber: 1n,
+        numL1ToL2Messages: 3,
+        slotNumber: SlotNumber(0),
+      });
+
+      fake.setL1BlockNumber(1n);
+      await archiver.syncImmediate();
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
 
-      // Verify L2Tips after syncing checkpoint 1: proposed and checkpointed at checkpoint 1
-      const tipsAfterCheckpoint1 = await archiver.getL2Tips();
-      expect(tipsAfterCheckpoint1.proposed.number).toEqual(lastBlockInCheckpoint1);
-      expect(tipsAfterCheckpoint1.checkpointed.block.number).toEqual(lastBlockInCheckpoint1);
-      expect(tipsAfterCheckpoint1.checkpointed.checkpoint.number).toEqual(CheckpointNumber(1));
+      // Do NOT add any provisional blocks for slot 1
 
-      // Create checkpoint 2 on L1 at a future block (not yet visible)
-      const { checkpoint: cp2 } = await fake.addCheckpoint(CheckpointNumber(2), {
-        l1BlockNumber: 5000n, // Far in the future
-        messagesL1BlockNumber: 4990n,
-        numL1ToL2Messages: 3,
-      });
+      // Advance L1 directly to slot 2 (L1 block 4), skipping slot 1
+      // Slot 1 ends without a checkpoint, but there are no provisional blocks
+      fake.setL1BlockNumber(4n);
+      await archiver.syncImmediate();
 
-      // Now add more blocks via addBlock (simulating local block production ahead of L1)
-      for (const block of cp2.blocks) {
-        await archiver.addBlock(block);
-      }
+      // Verify NO prune event was emitted (nothing to prune)
+      expect(pruneSpy).not.toHaveBeenCalled();
 
-      // Verify blocks are retrievable
-      const lastBlockInCheckpoint2 = cp2.blocks[cp2.blocks.length - 1].number;
-      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint2);
-
-      // But checkpoint number should still be 1
+      // Block number should remain at last checkpointed block
+      expect(await archiver.getBlockNumber()).toEqual(lastBlockInCheckpoint1);
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
-
-      // Verify L2Tips after adding blocks: proposed advances, checkpointed stays at checkpoint 1
-      const tipsAfterAddBlock = await archiver.getL2Tips();
-      expect(tipsAfterAddBlock.proposed.number).toEqual(lastBlockInCheckpoint2);
-      expect(tipsAfterAddBlock.checkpointed.block.number).toEqual(lastBlockInCheckpoint1);
-      expect(tipsAfterAddBlock.checkpointed.checkpoint.number).toEqual(CheckpointNumber(1));
-
-      // New blocks should not be checkpointed yet
-      const firstNewBlockNumber = BlockNumber(lastBlockInCheckpoint1 + 1);
-      const uncheckpointedBlock = await archiver.getCheckpointedBlock(firstNewBlockNumber);
-      expect(uncheckpointedBlock).toBeUndefined();
-
-      // Now advance L1 so checkpoint 2 becomes visible
-      fake.setL1BlockNumber(5010n);
-
-      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)), 'sync');
-
-      // Now all blocks should be checkpointed
-      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
-
-      // Verify L2Tips after syncing checkpoint 2: both proposed and checkpointed at checkpoint 2
-      const tipsAfterCheckpoint2 = await archiver.getL2Tips();
-      expect(tipsAfterCheckpoint2.proposed.number).toEqual(lastBlockInCheckpoint2);
-      expect(tipsAfterCheckpoint2.checkpointed.block.number).toEqual(lastBlockInCheckpoint2);
-      expect(tipsAfterCheckpoint2.checkpointed.checkpoint.number).toEqual(CheckpointNumber(2));
-
-      const checkpointedBlock = await archiver.getCheckpointedBlock(firstNewBlockNumber);
-      expect(checkpointedBlock).toBeDefined();
-      expect(checkpointedBlock!.checkpointNumber).toEqual(2);
-    }, 10_000);
+    }, 15_000);
   });
 });

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -64,7 +64,7 @@ export type ArchiverDeps = {
  * concern themselves with it.
  */
 export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Traceable {
-  /** Event emitter for archiver events (L2BlockProven, L2PruneDetected, etc). */
+  /** Event emitter for archiver events (L2BlockProven, L2PruneUnproven, L2PruneUncheckpointed, etc). */
   public readonly events: ArchiverEmitter;
 
   /** A loop in which we will be continually fetching new checkpoints. */
@@ -215,7 +215,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     // Process each block individually to properly resolve/reject each promise
     for (const { block, resolve, reject } of queuedItems) {
       try {
-        await this.updater.addBlocksWithContractData([block]);
+        await this.updater.addBlocks([block]);
         this.log.debug(`Added block ${block.number} to store`);
         resolve();
       } catch (err: any) {
@@ -356,14 +356,16 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   }
 
   public unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number): Promise<boolean> {
-    return this.updater.unwindCheckpointsWithContractData(from, checkpointsToUnwind);
+    return this.updater.unwindCheckpoints(from, checkpointsToUnwind);
   }
 
-  public addCheckpoints(
+  /** Used by TXE to add checkpoints directly without syncing from L1. */
+  public async addCheckpoints(
     checkpoints: PublishedCheckpoint[],
     pendingChainValidationStatus?: ValidateCheckpointResult,
   ): Promise<boolean> {
-    return this.updater.addCheckpointsWithContractData(checkpoints, pendingChainValidationStatus);
+    await this.updater.setNewCheckpointData(checkpoints, pendingChainValidationStatus);
+    return true;
   }
 
   public async getL2Tips(): Promise<L2Tips> {
@@ -504,7 +506,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     }
     const targetL1BlockHash = Buffer32.fromString(targetL1Block.hash);
     this.log.info(`Unwinding ${blocksToUnwind} checkpoints from L2 block ${currentL2Block}`);
-    await this.updater.unwindCheckpointsWithContractData(CheckpointNumber(currentL2Block), blocksToUnwind);
+    await this.updater.unwindCheckpoints(CheckpointNumber(currentL2Block), blocksToUnwind);
     this.log.info(`Unwinding L1 to L2 messages to checkpoint ${targetCheckpointNumber}`);
     await this.store.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber);
     this.log.info(`Setting L1 syncpoints to ${targetL1BlockNumber}`);

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -269,6 +269,10 @@ export abstract class ArchiverDataSourceBase
     return fullCheckpoints;
   }
 
+  public getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]> {
+    return this.store.getBlocksForSlot(slotNumber);
+  }
+
   public async getBlocksForEpoch(epochNumber: EpochNumber): Promise<L2Block[]> {
     if (!this.l1Constants) {
       throw new Error('L1 constants not set');

--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -1,0 +1,233 @@
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
+import { ContractInstancePublishedEvent } from '@aztec/protocol-contracts/instance-registry';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockNew } from '@aztec/stdlib/block';
+import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { ContractClassLog, PrivateLog } from '@aztec/stdlib/logs';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
+import '@aztec/stdlib/testing/jest';
+
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import { KVArchiverDataStore } from '../store/kv_archiver_store.js';
+import { makePublishedCheckpoint } from '../test/mock_structs.js';
+import { ArchiverDataStoreUpdater } from './data_store_updater.js';
+
+/** Loads the sample ContractClassPublished event payload from protocol-contracts fixtures. */
+function getSampleContractClassPublishedEventPayload(): Buffer {
+  const fixturePath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../protocol-contracts/fixtures/ContractClassPublishedEventData.hex',
+  );
+  return Buffer.from(readFileSync(fixturePath).toString(), 'hex');
+}
+
+/** Loads the sample ContractInstancePublished event payload from protocol-contracts fixtures. */
+function getSampleContractInstancePublishedEventPayload(): Buffer {
+  const fixturePath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../protocol-contracts/fixtures/ContractInstancePublishedEventData.hex',
+  );
+  return Buffer.from(readFileSync(fixturePath).toString(), 'hex');
+}
+
+describe('ArchiverDataStoreUpdater', () => {
+  let store: KVArchiverDataStore;
+  let updater: ArchiverDataStoreUpdater;
+  let contractClassLog: ContractClassLog;
+  let contractClassId: Fr;
+  let instanceAddress: AztecAddress;
+
+  beforeEach(async () => {
+    store = new KVArchiverDataStore(await openTmpStore('data_store_updater_test'));
+    updater = new ArchiverDataStoreUpdater(store);
+
+    // Create contract class log from sample fixture data
+    contractClassLog = ContractClassLog.fromBuffer(getSampleContractClassPublishedEventPayload());
+    const classEvent = ContractClassPublishedEvent.fromLog(contractClassLog);
+    contractClassId = classEvent.contractClassId;
+
+    // Create contract instance log from sample fixture data
+    const instanceLog = PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload());
+    const instanceEvent = ContractInstancePublishedEvent.fromLog(instanceLog);
+    instanceAddress = instanceEvent.address;
+  });
+
+  describe('contract data', () => {
+    it('stores contract class and instance data when blocks are added via addBlocks', async () => {
+      // Create block with contract class and instance logs
+      const block = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      block.body.txEffects[0].contractClassLogs = [contractClassLog];
+      block.body.txEffects[0].privateLogs = [PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload())];
+
+      await updater.addBlocks([block]);
+
+      // Verify contract class was stored
+      const retrievedClass = await store.getContractClass(contractClassId);
+      expect(retrievedClass).toBeDefined();
+      expect(retrievedClass?.id.equals(contractClassId)).toBe(true);
+
+      // Verify contract instance was stored (use a timestamp after block creation)
+      const timestamp = block.header.globalVariables.timestamp + 1n;
+      const retrievedInstance = await store.getContractInstance(instanceAddress, timestamp);
+      expect(retrievedInstance).toBeDefined();
+      expect(retrievedInstance?.address.equals(instanceAddress)).toBe(true);
+    });
+
+    it('removes contract class and instance data when blocks are pruned via setCheckpointData', async () => {
+      // First, add a local provisional block with contract data
+      const localBlock = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+      localBlock.body.txEffects[0].contractClassLogs = [contractClassLog];
+      localBlock.body.txEffects[0].privateLogs = [
+        PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload()),
+      ];
+
+      await updater.addBlocks([localBlock]);
+
+      // Verify contract data was stored
+      const timestamp = localBlock.header.globalVariables.timestamp + 1n;
+      expect(await store.getContractClass(contractClassId)).toBeDefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+
+      // Now create a checkpoint with a conflicting block (same slot but different archive root)
+      const conflictingBlock = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100), // Same slot as local block
+      });
+      // Make sure it has a different archive root (which it will by default from random)
+      expect(conflictingBlock.archive.root.equals(localBlock.archive.root)).toBe(false);
+
+      const checkpointWithConflict = new Checkpoint(
+        conflictingBlock.archive,
+        CheckpointHeader.random({ slotNumber: SlotNumber(100) }),
+        [conflictingBlock],
+        CheckpointNumber(1),
+      );
+      const publishedCheckpoint = makePublishedCheckpoint(checkpointWithConflict, 10);
+
+      // setCheckpointData should detect the conflict and prune the local block
+      await updater.setNewCheckpointData([publishedCheckpoint]);
+
+      // Verify the contract data from the local block was removed
+      expect(await store.getContractClass(contractClassId)).toBeUndefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeUndefined();
+    });
+
+    it('removes contract data when checkpoints are unwound', async () => {
+      // Create block with contract data and add it as a checkpoint
+      const block = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      block.body.txEffects[0].contractClassLogs = [contractClassLog];
+      block.body.txEffects[0].privateLogs = [PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload())];
+
+      const checkpoint = new Checkpoint(block.archive, CheckpointHeader.random(), [block], CheckpointNumber(1));
+      const publishedCheckpoint = makePublishedCheckpoint(checkpoint, 10);
+
+      await updater.setNewCheckpointData([publishedCheckpoint]);
+
+      // Verify contract data was stored
+      const timestamp = block.header.globalVariables.timestamp + 1n;
+      expect(await store.getContractClass(contractClassId)).toBeDefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
+
+      // Unwind the checkpoint
+      await updater.unwindCheckpoints(CheckpointNumber(1), 1);
+
+      // Verify the contract data was removed
+      expect(await store.getContractClass(contractClassId)).toBeUndefined();
+      expect(await store.getContractInstance(instanceAddress, timestamp)).toBeUndefined();
+    });
+  });
+
+  describe('logs handling', () => {
+    it('does not duplicate logs when checkpoint contains same block as provisional', async () => {
+      // Add provisional block with some logs
+      const block = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+
+      await updater.addBlocks([block]);
+
+      // Create checkpoint with the SAME block (same archive root)
+      const checkpoint = new Checkpoint(block.archive, CheckpointHeader.random(), [block], CheckpointNumber(1));
+      const publishedCheckpoint = makePublishedCheckpoint(checkpoint, 10);
+
+      await updater.setNewCheckpointData([publishedCheckpoint]);
+
+      // Verify logs are NOT duplicated
+      const publicLogs = await store.getPublicLogs({ fromBlock: block.number, toBlock: block.number + 1 });
+      expect(publicLogs.logs.length).toBe(block.body.txEffects.flatMap(tx => tx.publicLogs).length);
+      expect(publicLogs.logs.length).toBeGreaterThan(0);
+    });
+
+    it('replaces logs when checkpoint conflicts with provisional block', async () => {
+      // Add local provisional block
+      const localBlock = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+      await updater.addBlocks([localBlock]);
+      const publicLogsBefore = await store.getPublicLogs({});
+      expect(publicLogsBefore.logs.map(l => l.log)).toEqual(localBlock.body.txEffects.flatMap(tx => tx.publicLogs));
+
+      // Create checkpoint with DIFFERENT block (different archive root)
+      const checkpointBlock = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+      expect(checkpointBlock.archive.root.equals(localBlock.archive.root)).toBe(false);
+
+      const checkpoint = new Checkpoint(
+        checkpointBlock.archive,
+        CheckpointHeader.random({ slotNumber: SlotNumber(100) }),
+        [checkpointBlock],
+        CheckpointNumber(1),
+      );
+      await updater.setNewCheckpointData([makePublishedCheckpoint(checkpoint, 10)]);
+
+      // Verify checkpoint block is stored
+      const storedBlock = await store.getBlock(BlockNumber(1));
+      expect(storedBlock?.archive.root.equals(checkpointBlock.archive.root)).toBe(true);
+      const publicLogsAfter = await store.getPublicLogs({});
+      expect(publicLogsAfter.logs.map(l => l.log)).toEqual(checkpointBlock.body.txEffects.flatMap(tx => tx.publicLogs));
+    });
+
+    it('removes logs when unwinding blocks', async () => {
+      // Add local provisional block
+      const localBlock = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+      await updater.addBlocks([localBlock]);
+      const publicLogsBefore = await store.getPublicLogs({});
+      expect(publicLogsBefore.logs.map(l => l.log)).toEqual(localBlock.body.txEffects.flatMap(tx => tx.publicLogs));
+
+      // Unwind the block
+      await updater.removeBlocksAfter(BlockNumber.ZERO);
+
+      // Verify logs are removed
+      const publicLogsAfter = await store.getPublicLogs({});
+      expect(publicLogsAfter.logs.length).toBe(0);
+    });
+  });
+});

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -1,4 +1,4 @@
-import type { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, type CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import {
@@ -32,6 +32,14 @@ enum Operation {
   Delete,
 }
 
+/** Result of adding checkpoints with information about any pruned blocks. */
+type ReconcileCheckpointsResult = {
+  /** Blocks that were pruned due to conflict with L1 checkpoints. */
+  prunedBlocks: L2BlockNew[] | undefined;
+  /** Last block number that was already inserted locally, or undefined if none. */
+  lastAlreadyInsertedBlockNumber: BlockNumber | undefined;
+};
+
 /** Archiver helper module to handle updates to the data store. */
 export class ArchiverDataStoreUpdater {
   private readonly log = createLogger('archiver:store_updater');
@@ -47,10 +55,7 @@ export class ArchiverDataStoreUpdater {
    * @param pendingChainValidationStatus - Optional validation status to set.
    * @returns True if the operation is successful.
    */
-  public addBlocksWithContractData(
-    blocks: L2BlockNew[],
-    pendingChainValidationStatus?: ValidateCheckpointResult,
-  ): Promise<boolean> {
+  public addBlocks(blocks: L2BlockNew[], pendingChainValidationStatus?: ValidateCheckpointResult): Promise<boolean> {
     return this.store.transactionAsync(async () => {
       await this.store.addBlocks(blocks);
 
@@ -68,32 +73,136 @@ export class ArchiverDataStoreUpdater {
   }
 
   /**
+   * Reconciles local blocks with incoming checkpoints from L1.
    * Adds checkpoints to the store with contract class/instance extraction from logs.
+   * Prunes any local blocks that conflict with checkpoint data (by comparing archive roots).
    * Extracts ContractClassPublished, ContractInstancePublished, ContractInstanceUpdated events,
    * and individually broadcasted functions from the checkpoint block logs.
    *
    * @param checkpoints - The published checkpoints to add.
    * @param pendingChainValidationStatus - Optional validation status to set.
-   * @returns True if the operation is successful.
+   * @returns Result with information about any pruned blocks.
    */
-  public addCheckpointsWithContractData(
+  public setNewCheckpointData(
     checkpoints: PublishedCheckpoint[],
     pendingChainValidationStatus?: ValidateCheckpointResult,
-  ): Promise<boolean> {
+  ): Promise<ReconcileCheckpointsResult> {
     return this.store.transactionAsync(async () => {
-      await this.store.addCheckpoints(checkpoints);
-      const allBlocks = checkpoints.flatMap((ch: PublishedCheckpoint) => ch.checkpoint.blocks);
+      // Before adding checkpoints, check for conflicts with local blocks if any
+      const { prunedBlocks, lastAlreadyInsertedBlockNumber } = await this.pruneMismatchingLocalBlocks(checkpoints);
 
-      const opResults = await Promise.all([
+      await this.store.addCheckpoints(checkpoints);
+
+      // Filter out blocks that were already inserted via addBlocks() to avoid duplicating logs/contract data
+      const newBlocks = checkpoints
+        .flatMap((ch: PublishedCheckpoint) => ch.checkpoint.blocks)
+        .filter(b => lastAlreadyInsertedBlockNumber === undefined || b.number > lastAlreadyInsertedBlockNumber);
+
+      await Promise.all([
         // Update the pending chain validation status if provided
         pendingChainValidationStatus && this.store.setPendingChainValidationStatus(pendingChainValidationStatus),
         // Add any logs emitted during the retrieved blocks
-        this.store.addLogs(allBlocks),
+        this.store.addLogs(newBlocks),
         // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
-        ...allBlocks.map(block => this.addBlockDataToDB(block)),
+        ...newBlocks.map(block => this.addBlockDataToDB(block)),
       ]);
 
-      return opResults.every(Boolean);
+      return { prunedBlocks, lastAlreadyInsertedBlockNumber };
+    });
+  }
+
+  /**
+   * Checks for local proposed blocks that do not match the ones to be checkpointed and prunes them.
+   * This method handles multiple checkpoints but returns after pruning the first conflict found.
+   * This is correct because pruning from the first conflict point removes all subsequent blocks,
+   * and when checkpoints are added afterward, they include all the correct blocks.
+   */
+  private async pruneMismatchingLocalBlocks(checkpoints: PublishedCheckpoint[]): Promise<ReconcileCheckpointsResult> {
+    const [lastCheckpointedBlockNumber, lastBlockNumber] = await Promise.all([
+      this.store.getCheckpointedL2BlockNumber(),
+      this.store.getLatestBlockNumber(),
+    ]);
+
+    // Exit early if there are no local uncheckpointed blocks
+    if (lastBlockNumber === lastCheckpointedBlockNumber) {
+      return { prunedBlocks: undefined, lastAlreadyInsertedBlockNumber: undefined };
+    }
+
+    // Get all uncheckpointed local blocks
+    const uncheckpointedLocalBlocks = await this.store.getBlocks(
+      BlockNumber.add(lastCheckpointedBlockNumber, 1),
+      lastBlockNumber - lastCheckpointedBlockNumber,
+    );
+
+    let lastAlreadyInsertedBlockNumber: BlockNumber | undefined;
+
+    for (const publishedCheckpoint of checkpoints) {
+      const checkpointBlocks = publishedCheckpoint.checkpoint.blocks;
+      const slot = publishedCheckpoint.checkpoint.slot;
+      const localBlocksInSlot = uncheckpointedLocalBlocks.filter(b => b.slot === slot);
+
+      if (checkpointBlocks.length === 0) {
+        this.log.warn(`Checkpoint ${publishedCheckpoint.checkpoint.number} for slot ${slot} has no blocks`);
+        continue;
+      }
+
+      // Find the first checkpoint block that conflicts with an existing local block and prune local afterwards
+      for (const checkpointBlock of checkpointBlocks) {
+        const blockNumber = checkpointBlock.number;
+        const existingBlock = localBlocksInSlot.find(b => b.number === blockNumber);
+        const blockInfos = {
+          existingBlock: existingBlock?.toBlockInfo(),
+          checkpointBlock: checkpointBlock.toBlockInfo(),
+        };
+
+        if (!existingBlock) {
+          this.log.verbose(`No local block found for checkpointed block number ${blockNumber}`, blockInfos);
+        } else if (existingBlock.archive.root.equals(checkpointBlock.archive.root)) {
+          this.log.verbose(`Block number ${blockNumber} already inserted and matches checkpoint`, blockInfos);
+          lastAlreadyInsertedBlockNumber = blockNumber;
+        } else {
+          this.log.warn(`Conflict detected at block ${blockNumber} between checkpointed and local block`, blockInfos);
+          const prunedBlocks = await this.removeBlocksAfter(BlockNumber(blockNumber - 1));
+          return { prunedBlocks, lastAlreadyInsertedBlockNumber };
+        }
+      }
+
+      // If local has more blocks than the checkpoint (e.g., local has [2,3,4] but checkpoint has [2,3]),
+      // we need to prune the extra local blocks so they match what was checkpointed
+      const lastCheckpointBlockNumber = checkpointBlocks.at(-1)!.number;
+      const lastLocalBlockNumber = localBlocksInSlot.at(-1)?.number;
+
+      if (lastLocalBlockNumber !== undefined && lastLocalBlockNumber > lastCheckpointBlockNumber) {
+        this.log.warn(
+          `Local chain for slot ${slot} ends at block ${lastLocalBlockNumber} but checkpoint ends at ${lastCheckpointBlockNumber}. Pruning blocks after block ${lastCheckpointBlockNumber}.`,
+        );
+        const prunedBlocks = await this.removeBlocksAfter(lastCheckpointBlockNumber);
+        return { prunedBlocks, lastAlreadyInsertedBlockNumber };
+      }
+    }
+
+    return { prunedBlocks: undefined, lastAlreadyInsertedBlockNumber };
+  }
+
+  /**
+   * Removes all blocks strictly after the specified block number and cleans up associated contract data.
+   * This handles removal of provisionally added blocks along with their contract classes/instances.
+   *
+   * @param blockNumber - Remove all blocks with number greater than this.
+   * @returns The removed blocks.
+   */
+  public removeBlocksAfter(blockNumber: BlockNumber): Promise<L2BlockNew[]> {
+    return this.store.transactionAsync(async () => {
+      // First get the blocks to be removed so we can clean up contract data
+      const removedBlocks = await this.store.removeBlocksAfter(blockNumber);
+
+      // Clean up contract data and logs for the removed blocks
+      await Promise.all([
+        this.store.deleteLogs(removedBlocks),
+        ...removedBlocks.map(block => this.removeBlockDataFromDB(block)),
+      ]);
+
+      return removedBlocks;
     });
   }
 
@@ -106,10 +215,7 @@ export class ArchiverDataStoreUpdater {
    * @param checkpointsToUnwind - The number of checkpoints to unwind.
    * @returns True if the operation is successful.
    */
-  public async unwindCheckpointsWithContractData(
-    from: CheckpointNumber,
-    checkpointsToUnwind: number,
-  ): Promise<boolean> {
+  public async unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number): Promise<boolean> {
     if (checkpointsToUnwind <= 0) {
       throw new Error(`Cannot unwind ${checkpointsToUnwind} blocks`);
     }
@@ -132,22 +238,8 @@ export class ArchiverDataStoreUpdater {
     const opResults = await Promise.all([
       // Prune rolls back to the last proven block, which is by definition valid
       this.store.setPendingChainValidationStatus({ valid: true }),
-      // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
-      ...blocks.map(async block => {
-        const contractClassLogs = block.body.txEffects.flatMap(txEffect => txEffect.contractClassLogs);
-        // ContractInstancePublished event logs are broadcast in privateLogs.
-        const privateLogs = block.body.txEffects.flatMap(txEffect => txEffect.privateLogs);
-        const publicLogs = block.body.txEffects.flatMap(txEffect => txEffect.publicLogs);
-
-        return (
-          await Promise.all([
-            this.updatePublishedContractClasses(contractClassLogs, block.number, Operation.Delete),
-            this.updateDeployedContractInstances(privateLogs, block.number, Operation.Delete),
-            this.updateUpdatedContractInstances(publicLogs, block.header.globalVariables.timestamp, Operation.Delete),
-          ])
-        ).every(Boolean);
-      }),
-
+      // Remove contract data for all blocks being unwound
+      ...blocks.map(block => this.removeBlockDataFromDB(block)),
       this.store.deleteLogs(blocks),
       this.store.unwindCheckpoints(from, checkpointsToUnwind),
     ]);
@@ -155,21 +247,30 @@ export class ArchiverDataStoreUpdater {
     return opResults.every(Boolean);
   }
 
-  /**
-   * Extracts and stores contract data from a single block.
-   */
-  private async addBlockDataToDB(block: L2BlockNew): Promise<boolean> {
+  /** Extracts and stores contract data from a single block. */
+  private addBlockDataToDB(block: L2BlockNew): Promise<boolean> {
+    return this.editContractBlockData(block, Operation.Store);
+  }
+
+  /** Removes contract data associated with a block. */
+  private removeBlockDataFromDB(block: L2BlockNew): Promise<boolean> {
+    return this.editContractBlockData(block, Operation.Delete);
+  }
+
+  /** Adds or remove contract data associated with a block. */
+  private async editContractBlockData(block: L2BlockNew, operation: Operation): Promise<boolean> {
     const contractClassLogs = block.body.txEffects.flatMap(txEffect => txEffect.contractClassLogs);
-    // ContractInstancePublished event logs are broadcast in privateLogs.
     const privateLogs = block.body.txEffects.flatMap(txEffect => txEffect.privateLogs);
     const publicLogs = block.body.txEffects.flatMap(txEffect => txEffect.publicLogs);
 
     return (
       await Promise.all([
-        this.updatePublishedContractClasses(contractClassLogs, block.number, Operation.Store),
-        this.updateDeployedContractInstances(privateLogs, block.number, Operation.Store),
-        this.updateUpdatedContractInstances(publicLogs, block.header.globalVariables.timestamp, Operation.Store),
-        this.storeBroadcastedIndividualFunctions(contractClassLogs, block.number),
+        this.updatePublishedContractClasses(contractClassLogs, block.number, operation),
+        this.updateDeployedContractInstances(privateLogs, block.number, operation),
+        this.updateUpdatedContractInstances(publicLogs, block.header.globalVariables.timestamp, operation),
+        operation === Operation.Store
+          ? this.storeBroadcastedIndividualFunctions(contractClassLogs, block.number)
+          : Promise.resolve(true),
       ])
     ).every(Boolean);
   }

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -16,7 +16,7 @@ import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
 import { isDefined } from '@aztec/foundation/types';
 import { type ArchiverEmitter, L2BlockSourceEvents, type ValidateCheckpointResult } from '@aztec/stdlib/block';
 import { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
-import { type L1RollupConstants, getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
+import { type L1RollupConstants, getEpochAtSlot, getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
@@ -182,6 +182,10 @@ export class ArchiverL1Synchronizer implements Traceable {
       // First we retrieve new checkpoints and L2 blocks and store them in the DB. This will also update the
       // pending chain validation status, proven checkpoint number, and synched L1 block number.
       const rollupStatus = await this.handleCheckpoints(blocksSynchedTo, currentL1BlockNumber, initialSyncComplete);
+
+      // Then we try pruning uncheckpointed blocks if a new slot was mined without checkpoints
+      await this.pruneUncheckpointedBlocks(currentL1Timestamp);
+
       // Then we prune the current epoch if it'd reorg on next submission.
       // Note that we don't do this before retrieving checkpoints because we may need to retrieve
       // checkpoints from more than 2 epochs ago, so we want to make sure we have the latest view of
@@ -224,6 +228,46 @@ export class ArchiverL1Synchronizer implements Traceable {
       l1TimestampAtStart: currentL1Timestamp,
       l1BlockNumberAtEnd,
     });
+  }
+
+  /** Prune all proposed local blocks that should have been checkpointed by now. */
+  private async pruneUncheckpointedBlocks(currentL1Timestamp: bigint) {
+    const [lastCheckpointedBlockNumber, lastProposedBlockNumber] = await Promise.all([
+      this.store.getCheckpointedL2BlockNumber(),
+      this.store.getLatestBlockNumber(),
+    ]);
+
+    // If there are no uncheckpointed blocks, we got nothing to do
+    if (lastProposedBlockNumber === lastCheckpointedBlockNumber) {
+      this.log.trace(`No uncheckpointed blocks to prune.`);
+      return;
+    }
+
+    // What's the slot of the first uncheckpointed block?
+    const firstUncheckpointedBlockNumber = BlockNumber(lastCheckpointedBlockNumber + 1);
+    const [firstUncheckpointedBlockHeader] = await this.store.getBlockHeaders(firstUncheckpointedBlockNumber, 1);
+    const firstUncheckpointedBlockSlot = firstUncheckpointedBlockHeader?.getSlot();
+
+    // What's the slot at the next L1 block? All blocks for slots strictly before this one should've been checkpointed by now.
+    const nextL1BlockTimestamp = currentL1Timestamp + BigInt(this.l1Constants.ethereumSlotDuration);
+    const slotAtNextL1Block = getSlotAtTimestamp(nextL1BlockTimestamp, this.l1Constants);
+
+    // Prune provisional blocks from slots that have ended without being checkpointed
+    if (firstUncheckpointedBlockSlot !== undefined && firstUncheckpointedBlockSlot < slotAtNextL1Block) {
+      this.log.warn(
+        `Pruning blocks after block ${lastCheckpointedBlockNumber} due to slot ${firstUncheckpointedBlockSlot} not being checkpointed`,
+        { firstUncheckpointedBlockHeader: firstUncheckpointedBlockHeader.toInspect(), slotAtNextL1Block },
+      );
+      const prunedBlocks = await this.updater.removeBlocksAfter(lastCheckpointedBlockNumber);
+
+      if (prunedBlocks.length > 0) {
+        this.events.emit(L2BlockSourceEvents.L2PruneUncheckpointed, {
+          type: L2BlockSourceEvents.L2PruneUncheckpointed,
+          slotNumber: firstUncheckpointedBlockSlot,
+          blocks: prunedBlocks,
+        });
+      }
+    }
   }
 
   /** Queries the rollup contract on whether a prune can be executed on the immediate next L1 block. */
@@ -278,8 +322,8 @@ export class ArchiverL1Synchronizer implements Traceable {
       const newBlocks = blockPromises.filter(isDefined).flat();
 
       // Emit an event for listening services to react to the chain prune
-      this.events.emit(L2BlockSourceEvents.L2PruneDetected, {
-        type: L2BlockSourceEvents.L2PruneDetected,
+      this.events.emit(L2BlockSourceEvents.L2PruneUnproven, {
+        type: L2BlockSourceEvents.L2PruneUnproven,
         epochNumber: pruneFromEpochNumber,
         blocks: newBlocks,
       });
@@ -287,7 +331,7 @@ export class ArchiverL1Synchronizer implements Traceable {
       this.log.debug(
         `L2 prune from ${provenCheckpointNumber + 1} to ${localPendingCheckpointNumber} will occur on next checkpoint submission.`,
       );
-      await this.updater.unwindCheckpointsWithContractData(localPendingCheckpointNumber, checkpointsToUnwind);
+      await this.updater.unwindCheckpoints(localPendingCheckpointNumber, checkpointsToUnwind);
       this.log.warn(
         `Unwound ${count(checkpointsToUnwind, 'checkpoint')} from checkpoint ${localPendingCheckpointNumber} ` +
           `to ${provenCheckpointNumber} due to predicted reorg at L1 block ${currentL1BlockNumber}. ` +
@@ -632,7 +676,7 @@ export class ArchiverL1Synchronizer implements Traceable {
         }
 
         const checkpointsToUnwind = localPendingCheckpointNumber - tipAfterUnwind;
-        await this.updater.unwindCheckpointsWithContractData(localPendingCheckpointNumber, checkpointsToUnwind);
+        await this.updater.unwindCheckpoints(localPendingCheckpointNumber, checkpointsToUnwind);
 
         this.log.warn(
           `Unwound ${count(checkpointsToUnwind, 'checkpoint')} from checkpoint ${localPendingCheckpointNumber} ` +
@@ -761,15 +805,35 @@ export class ArchiverL1Synchronizer implements Traceable {
       try {
         const updatedValidationResult =
           rollupStatus.validationResult === initialValidationResult ? undefined : rollupStatus.validationResult;
-        const [processDuration] = await elapsed(() =>
-          execInSpan(this.tracer, 'Archiver.addCheckpoints', () =>
-            this.updater.addCheckpointsWithContractData(validCheckpoints, updatedValidationResult),
+        const [processDuration, result] = await elapsed(() =>
+          execInSpan(this.tracer, 'Archiver.setCheckpointData', () =>
+            this.updater.setNewCheckpointData(validCheckpoints, updatedValidationResult),
           ),
         );
         this.instrumentation.processNewBlocks(
           processDuration / validCheckpoints.length,
           validCheckpoints.flatMap(c => c.checkpoint.blocks),
         );
+
+        // If blocks were pruned due to conflict with L1 checkpoints, emit event
+        if (result.prunedBlocks && result.prunedBlocks.length > 0) {
+          const prunedCheckpointNumber = result.prunedBlocks[0].checkpointNumber;
+          const prunedSlotNumber = result.prunedBlocks[0].header.globalVariables.slotNumber;
+
+          this.log.warn(
+            `Pruned ${result.prunedBlocks.length} mismatching blocks for checkpoint ${prunedCheckpointNumber}`,
+            { prunedBlocks: result.prunedBlocks.map(b => b.toBlockInfo()), prunedSlotNumber, prunedCheckpointNumber },
+          );
+
+          // Emit event for listening services to react to the prune.
+          // Note: slotNumber comes from the first pruned block. If pruned blocks theoretically spanned multiple slots,
+          // only one slot number would be reported (though in practice all blocks in a checkpoint span a single slot).
+          this.events.emit(L2BlockSourceEvents.L2PruneUncheckpointed, {
+            type: L2BlockSourceEvents.L2PruneUncheckpointed,
+            slotNumber: prunedSlotNumber,
+            blocks: result.prunedBlocks,
+          });
+        }
       } catch (err) {
         if (err instanceof InitialCheckpointNumberNotSequentialError) {
           const { previousCheckpointNumber, newCheckpointNumber } = err;

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -1,5 +1,5 @@
 import { INITIAL_CHECKPOINT_NUMBER, INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
-import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
@@ -350,6 +350,23 @@ export class BlockStore {
     await this.#blockArchiveIndex.set(block.archive.root.toString(), block.number);
   }
 
+  /** Deletes a block and all associated data (tx effects, indices). */
+  private async deleteBlock(block: L2BlockNew): Promise<void> {
+    // Delete the block from the main blocks map
+    await this.#blocks.delete(block.number);
+
+    // Delete all tx effects for this block
+    await Promise.all(block.body.txEffects.map(tx => this.#txEffects.delete(tx.txHash.toString())));
+
+    // Delete block txs mapping
+    const blockHash = (await block.hash()).toString();
+    await this.#blockTxs.delete(blockHash);
+
+    // Clean up indices
+    await this.#blockHashIndex.delete(blockHash);
+    await this.#blockArchiveIndex.delete(block.archive.root.toString());
+  }
+
   /**
    * Unwinds checkpoints from the database
    * @param from -  The tip of the chain, passed for verification purposes,
@@ -387,16 +404,11 @@ export class BlockStore {
             this.#log.warn(`Cannot remove block ${blockNumber} from the store since we don't have it`);
             continue;
           }
-          await this.#blocks.delete(block.number);
-          await Promise.all(block.body.txEffects.map(tx => this.#txEffects.delete(tx.txHash.toString())));
-          const blockHash = (await block.hash()).toString();
-          await this.#blockTxs.delete(blockHash);
 
-          // Clean up indices
-          await this.#blockHashIndex.delete(blockHash);
-          await this.#blockArchiveIndex.delete(block.archive.root.toString());
-
-          this.#log.debug(`Unwound block ${blockNumber} ${blockHash} for checkpoint ${checkpointNumber}`);
+          await this.deleteBlock(block);
+          this.#log.debug(
+            `Unwound block ${blockNumber} ${(await block.hash()).toString()} for checkpoint ${checkpointNumber}`,
+          );
         }
       }
 
@@ -452,6 +464,61 @@ export class BlockStore {
 
     const converted = await Promise.all(blocksForCheckpoint.map(x => this.getBlockFromBlockStorage(x[0], x[1])));
     return converted.filter(isDefined);
+  }
+
+  /**
+   * Gets all blocks that have the given slot number.
+   * Iterates backwards through blocks for efficiency since we usually query for the last slot.
+   * @param slotNumber - The slot number to search for.
+   * @returns All blocks with the given slot number, in ascending block number order.
+   */
+  async getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]> {
+    const blocks: L2BlockNew[] = [];
+
+    // Iterate backwards through all blocks and filter by slot number
+    // This is more efficient since we usually query for the most recent slot
+    for await (const [blockNumber, blockStorage] of this.#blocks.entriesAsync({ reverse: true })) {
+      const block = await this.getBlockFromBlockStorage(blockNumber, blockStorage);
+      const blockSlot = block?.header.globalVariables.slotNumber;
+      if (block && blockSlot === slotNumber) {
+        blocks.push(block);
+      } else if (blockSlot && blockSlot < slotNumber) {
+        break; // Blocks are stored in slot ascending order, so we can stop searching
+      }
+    }
+
+    // Reverse to return blocks in ascending order (block number order)
+    return blocks.reverse();
+  }
+
+  /**
+   * Removes all blocks with block number > blockNumber.
+   * @param blockNumber - The block number to remove after.
+   * @returns The removed blocks (for event emission).
+   */
+  async unwindBlocksAfter(blockNumber: BlockNumber): Promise<L2BlockNew[]> {
+    return await this.db.transactionAsync(async () => {
+      const removedBlocks: L2BlockNew[] = [];
+
+      // Get the latest block number to determine the range
+      const latestBlockNumber = await this.getLatestBlockNumber();
+
+      // Iterate from blockNumber + 1 to latestBlockNumber
+      for (let bn = blockNumber + 1; bn <= latestBlockNumber; bn++) {
+        const block = await this.getBlock(BlockNumber(bn));
+
+        if (block === undefined) {
+          this.#log.warn(`Cannot remove block ${bn} from the store since we don't have it`);
+          continue;
+        }
+
+        removedBlocks.push(block);
+        await this.deleteBlock(block);
+        this.#log.debug(`Removed block ${bn} ${(await block.hash()).toString()}`);
+      }
+
+      return removedBlocks;
+    });
   }
 
   async getProvenBlockNumber(): Promise<BlockNumber> {
@@ -538,6 +605,7 @@ export class BlockStore {
     }
     return this.getCheckpointedBlock(BlockNumber(blockNumber));
   }
+
   async getCheckpointedBlockByArchive(archive: Fr): Promise<CheckpointedL2Block | undefined> {
     const blockNumber = await this.#blockArchiveIndex.getAsync(archive.toString());
     if (blockNumber === undefined) {
@@ -672,6 +740,7 @@ export class BlockStore {
     const header = BlockHeader.fromBuffer(blockStorage.header);
     const archive = AppendOnlyTreeSnapshot.fromBuffer(blockStorage.archive);
     const blockHash = blockStorage.blockHash;
+    header.setHash(Fr.fromBuffer(blockHash));
     const blockHashString = bufferToHex(blockHash);
     const blockTxsBuffer = await this.#blockTxs.getAsync(blockHashString);
     if (blockTxsBuffer === undefined) {

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -1,5 +1,5 @@
 import { INITIAL_CHECKPOINT_NUMBER, INITIAL_L2_BLOCK_NUM, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
-import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer16, Buffer32 } from '@aztec/foundation/buffer';
 import { times } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto/random';
@@ -2806,6 +2806,252 @@ describe('KVArchiverDataStore', () => {
       // Verify logs are NOT duplicated
       const finalLogs = await store.getPublicLogs({ fromBlock: BlockNumber(1), toBlock: BlockNumber(2) });
       expect(finalLogs.logs.length).toBe(initialCount);
+    });
+  });
+
+  describe('getBlocksForSlot', () => {
+    it('returns blocks matching the given slot number', async () => {
+      // Create blocks with specific slot numbers
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+        slotNumber: SlotNumber(100), // Same slot number as block1
+      });
+      const block3 = await L2BlockNew.random(BlockNumber(3), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 2,
+        lastArchive: block2.archive,
+        slotNumber: SlotNumber(101), // Different slot number
+      });
+
+      await store.addBlocks([block1, block2, block3]);
+
+      const blocksForSlot100 = await store.getBlocksForSlot(SlotNumber(100));
+      expect(blocksForSlot100.length).toBe(2);
+      expect(blocksForSlot100[0].equals(block1)).toBe(true);
+      expect(blocksForSlot100[1].equals(block2)).toBe(true);
+
+      const blocksForSlot101 = await store.getBlocksForSlot(SlotNumber(101));
+      expect(blocksForSlot101.length).toBe(1);
+      expect(blocksForSlot101[0].equals(block3)).toBe(true);
+    });
+
+    it('returns empty array when no blocks exist for that slot', async () => {
+      // Create a block with a specific slot number
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(100),
+      });
+
+      await store.addBlocks([block1]);
+
+      const blocksForSlot999 = await store.getBlocksForSlot(SlotNumber(999));
+      expect(blocksForSlot999).toEqual([]);
+    });
+
+    it('returns empty array when store is empty', async () => {
+      const blocksForSlot = await store.getBlocksForSlot(SlotNumber(1));
+      expect(blocksForSlot).toEqual([]);
+    });
+
+    it('returns blocks in ascending block number order', async () => {
+      // Create multiple blocks with the same slot number
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        slotNumber: SlotNumber(50),
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+        slotNumber: SlotNumber(50),
+      });
+      const block3 = await L2BlockNew.random(BlockNumber(3), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 2,
+        lastArchive: block2.archive,
+        slotNumber: SlotNumber(50),
+      });
+
+      await store.addBlocks([block1, block2, block3]);
+
+      const blocksForSlot = await store.getBlocksForSlot(SlotNumber(50));
+      expect(blocksForSlot.length).toBe(3);
+      expect(blocksForSlot[0].number).toBe(1);
+      expect(blocksForSlot[1].number).toBe(2);
+      expect(blocksForSlot[2].number).toBe(3);
+    });
+  });
+
+  describe('removeBlocksAfterBlock', () => {
+    it('removes blocks with number > given blockNumber', async () => {
+      // Create blocks for initial checkpoint
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+      });
+      const block3 = await L2BlockNew.random(BlockNumber(3), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 2,
+        lastArchive: block2.archive,
+      });
+      const block4 = await L2BlockNew.random(BlockNumber(4), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 3,
+        lastArchive: block3.archive,
+      });
+
+      await store.addBlocks([block1, block2, block3, block4]);
+      expect(await store.getLatestBlockNumber()).toBe(4);
+
+      // Remove blocks after block 2
+      await store.removeBlocksAfter(BlockNumber(2));
+
+      expect(await store.getLatestBlockNumber()).toBe(2);
+      expect(await store.getBlock(BlockNumber(1))).toBeDefined();
+      expect(await store.getBlock(BlockNumber(2))).toBeDefined();
+      expect(await store.getBlock(BlockNumber(3))).toBeUndefined();
+      expect(await store.getBlock(BlockNumber(4))).toBeUndefined();
+    });
+
+    it('returns the removed blocks', async () => {
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+      });
+      const block3 = await L2BlockNew.random(BlockNumber(3), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 2,
+        lastArchive: block2.archive,
+      });
+
+      await store.addBlocks([block1, block2, block3]);
+
+      // Remove blocks after block 1
+      const removedBlocks = await store.removeBlocksAfter(BlockNumber(1));
+
+      expect(removedBlocks.length).toBe(2);
+      expect(removedBlocks[0].equals(block2)).toBe(true);
+      expect(removedBlocks[1].equals(block3)).toBe(true);
+    });
+
+    it('returns empty array when no blocks need to be removed', async () => {
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+      });
+
+      await store.addBlocks([block1, block2]);
+
+      // Remove blocks after block 2 (none to remove)
+      const removedBlocks = await store.removeBlocksAfter(BlockNumber(2));
+
+      expect(removedBlocks).toEqual([]);
+      expect(await store.getLatestBlockNumber()).toBe(2);
+    });
+
+    it('returns empty array when store is empty', async () => {
+      const removedBlocks = await store.removeBlocksAfter(BlockNumber(0));
+
+      expect(removedBlocks).toEqual([]);
+    });
+
+    it('cleans up related data (tx effects, hash index, archive index)', async () => {
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+        txsPerBlock: 2,
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+        txsPerBlock: 2,
+      });
+
+      await store.addBlocks([block1, block2]);
+
+      // Verify block2 is retrievable by hash and archive before removal
+      const block2Hash = await block2.header.hash();
+      const block2Archive = block2.archive.root;
+
+      expect(await store.getBlockByHash(block2Hash)).toBeDefined();
+      expect(await store.getBlockByArchive(block2Archive)).toBeDefined();
+
+      // Verify tx effects for block2 are retrievable before removal
+      for (const txEffect of block2.body.txEffects) {
+        const retrieved = await store.getTxEffect(txEffect.txHash);
+        expect(retrieved).toBeDefined();
+      }
+
+      // Remove blocks after block 1
+      await store.removeBlocksAfter(BlockNumber(1));
+
+      // Verify block2 is no longer retrievable by hash or archive
+      expect(await store.getBlockByHash(block2Hash)).toBeUndefined();
+      expect(await store.getBlockByArchive(block2Archive)).toBeUndefined();
+
+      // Verify tx effects for block2 are no longer retrievable
+      for (const txEffect of block2.body.txEffects) {
+        const retrieved = await store.getTxEffect(txEffect.txHash);
+        expect(retrieved).toBeUndefined();
+      }
+
+      // Verify block1's data is still intact
+      const block1Hash = await block1.header.hash();
+      const block1Archive = block1.archive.root;
+
+      expect(await store.getBlockByHash(block1Hash)).toBeDefined();
+      expect(await store.getBlockByArchive(block1Archive)).toBeDefined();
+
+      for (const txEffect of block1.body.txEffects) {
+        const retrieved = await store.getTxEffect(txEffect.txHash);
+        expect(retrieved).toBeDefined();
+      }
+    });
+
+    it('removes all blocks when blockNumber is 0', async () => {
+      const block1 = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+      const block2 = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 1,
+        lastArchive: block1.archive,
+      });
+
+      await store.addBlocks([block1, block2]);
+
+      const removedBlocks = await store.removeBlocksAfter(BlockNumber(0));
+
+      expect(removedBlocks.length).toBe(2);
+      expect(await store.getLatestBlockNumber()).toBe(0);
+      expect(await store.getBlock(BlockNumber(1))).toBeUndefined();
+      expect(await store.getBlock(BlockNumber(2))).toBeUndefined();
     });
   });
 });

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -1,5 +1,5 @@
 import type { L1BlockId } from '@aztec/ethereum/l1-types';
-import type { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
+import type { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
@@ -600,5 +600,23 @@ export class KVArchiverDataStore implements ContractDataSource {
    */
   getCheckpointData(checkpointNumber: CheckpointNumber): Promise<CheckpointData | undefined> {
     return this.#blockStore.getCheckpointData(checkpointNumber);
+  }
+
+  /**
+   * Gets all blocks that have the given slot number.
+   * @param slotNumber - The slot number to search for.
+   * @returns All blocks with the given slot number.
+   */
+  getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]> {
+    return this.#blockStore.getBlocksForSlot(slotNumber);
+  }
+
+  /**
+   * Removes all blocks with block number > blockNumber.
+   * @param blockNumber - The block number to remove after.
+   * @returns The removed blocks (for event emission).
+   */
+  removeBlocksAfter(blockNumber: BlockNumber): Promise<L2BlockNew[]> {
+    return this.#blockStore.unwindBlocksAfter(blockNumber);
   }
 }

--- a/yarn-project/archiver/src/test/fake_l1_state.ts
+++ b/yarn-project/archiver/src/test/fake_l1_state.ts
@@ -10,8 +10,9 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
-import { CommitteeAttestation, CommitteeAttestationsAndSigners } from '@aztec/stdlib/block';
+import { CommitteeAttestation, CommitteeAttestationsAndSigners, L2BlockNew } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
+import { getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { InboxLeaf } from '@aztec/stdlib/messaging';
 import {
   makeAndSignCommitteeAttestationsAndSigners,
@@ -39,6 +40,8 @@ export type FakeL1StateConfig = {
   rollupAddress: EthAddress;
   /** Inbox address for mock contracts. */
   inboxAddress: EthAddress;
+  /** Aztec slot duration in seconds */
+  slotDuration: number;
 };
 
 /** Options for adding a checkpoint. */
@@ -47,6 +50,8 @@ type AddCheckpointOptions = {
   l1BlockNumber: bigint;
   /** Number of L2 blocks in the checkpoint. Default: 1 */
   numBlocks?: number;
+  /** Or the actual blocks for the checkpoint */
+  blocks?: L2BlockNew[];
   /** Number of transactions per block. Default: 4 */
   txsPerBlock?: number;
   /** Max number of effects per tx (for generating large blobs). Default: undefined */
@@ -158,37 +163,31 @@ export class FakeL1State {
   }
 
   /**
+   * Creates blocks for a checkpoint without adding them to L1 state.
+   * Useful for creating blocks to pass to addBlock() for testing provisional block handling.
+   * Returns the blocks directly.
+   */
+  public async makeBlocks(checkpointNumber: CheckpointNumber, options: Partial<AddCheckpointOptions>) {
+    return (await this.makeCheckpointAndMessages(checkpointNumber, options)).checkpoint.blocks;
+  }
+
+  /**
    * Creates and adds a checkpoint with its L1-to-L2 messages.
    * Returns both the checkpoint and the message leaves.
    * Auto-chains from lastArchive, auto-updates pending status if L1 block >= checkpoint's L1 block.
    */
-  async addCheckpoint(checkpointNumber: CheckpointNumber, options: AddCheckpointOptions): Promise<AddCheckpointResult> {
+  public async addCheckpoint(
+    checkpointNumber: CheckpointNumber,
+    options: AddCheckpointOptions,
+  ): Promise<AddCheckpointResult> {
     this.log.warn(`Adding checkpoint ${checkpointNumber}`);
 
-    const {
-      l1BlockNumber,
-      numBlocks = 1,
-      txsPerBlock = 4,
-      maxEffects,
-      signers = [],
-      slotNumber,
-      previousArchive = this.lastArchive,
-      timestamp,
-      numL1ToL2Messages = 3,
-      messagesL1BlockNumber = l1BlockNumber - 3n,
-    } = options;
+    const { l1BlockNumber, signers = [], messagesL1BlockNumber = l1BlockNumber - 3n } = options;
 
     // Create the checkpoint using the stdlib helper
-    // Only pass slotNumber and timestamp if they're defined to avoid overwriting defaults
-    const { checkpoint, messages, lastArchive } = await mockCheckpointAndMessages(checkpointNumber, {
-      startBlockNumber: this.getNextBlockNumber(checkpointNumber),
-      numBlocks,
-      numTxsPerBlock: txsPerBlock,
-      numL1ToL2Messages,
-      previousArchive,
-      ...(slotNumber !== undefined ? { slotNumber } : {}),
-      ...(timestamp !== undefined ? { timestamp } : {}),
-      ...(maxEffects !== undefined ? { maxEffects } : {}),
+    const { checkpoint, messages, lastArchive } = await this.makeCheckpointAndMessages(checkpointNumber, {
+      ...options,
+      numL1ToL2Messages: options.numL1ToL2Messages ?? 3,
     });
 
     // Store the messages internally so they match the checkpoint's inHash
@@ -217,6 +216,45 @@ export class FakeL1State {
     this.updatePendingCheckpointNumber();
 
     return { checkpoint, messages };
+  }
+
+  /** Creates a checkpoint and messages without adding them to L1 state. */
+  private makeCheckpointAndMessages(checkpointNumber: CheckpointNumber, options: Partial<AddCheckpointOptions>) {
+    const {
+      numBlocks = 1,
+      txsPerBlock = 4,
+      maxEffects,
+      slotNumber,
+      previousArchive = this.lastArchive,
+      timestamp,
+      l1BlockNumber,
+      numL1ToL2Messages = 0,
+      blocks,
+    } = options;
+
+    return mockCheckpointAndMessages(checkpointNumber, {
+      startBlockNumber: this.getNextBlockNumber(checkpointNumber),
+      numBlocks,
+      blocks,
+      numTxsPerBlock: txsPerBlock,
+      numL1ToL2Messages,
+      previousArchive,
+      slotNumber: slotNumber ?? (l1BlockNumber !== undefined ? this.getL2SlotAtL1Block(l1BlockNumber) : undefined),
+      timestamp: timestamp ?? (l1BlockNumber !== undefined ? this.getTimestampAtL1Block(l1BlockNumber) : undefined),
+      ...(maxEffects !== undefined ? { maxEffects } : {}),
+    });
+  }
+
+  /** Returns the L2 slot at the given L1 block (assuming all L1 blocks are mined) */
+  public getL2SlotAtL1Block(l1BlockNumber: bigint): SlotNumber {
+    const timestamp = this.getTimestampAtL1Block(l1BlockNumber);
+    return getSlotAtTimestamp(timestamp, this.config);
+  }
+
+  /** Returns the timestamp at the given L1 block (assuming all L1 blocks are mined) */
+  public getTimestampAtL1Block(l1BlockNumber: bigint): bigint {
+    const { l1GenesisTime, l1StartBlock, ethereumSlotDuration } = this.config;
+    return l1GenesisTime + (l1BlockNumber - l1StartBlock) * BigInt(ethereumSlotDuration);
   }
 
   /**

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -255,6 +255,11 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve(blocks);
   }
 
+  getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]> {
+    const blocks = this.l2Blocks.filter(b => b.header.globalVariables.slotNumber === slotNumber);
+    return Promise.resolve(blocks.map(b => b.toL2Block()));
+  }
+
   async getBlockHeadersForEpoch(epochNumber: EpochNumber): Promise<BlockHeader[]> {
     const blocks = await this.getBlocksForEpoch(epochNumber);
     return blocks.map(b => b.getBlockHeader());

--- a/yarn-project/foundation/src/branded-types/block_number.ts
+++ b/yarn-project/foundation/src/branded-types/block_number.ts
@@ -87,6 +87,11 @@ BlockNumber.isValid = function (value: unknown): value is BlockNumber {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0;
 };
 
+/** Increments a BlockNumber by a given value. */
+BlockNumber.add = function (bn: BlockNumber, increment: number): BlockNumber {
+  return BlockNumber(bn + increment);
+};
+
 /**
  * The zero block value (genesis block).
  */

--- a/yarn-project/foundation/src/types/index.ts
+++ b/yarn-project/foundation/src/types/index.ts
@@ -33,7 +33,7 @@ export type Prettify<T> = {
  * Type-safe Event Emitter type
  * @example
  * export type ArchiverEmitter = TypedEventEmitter<{
- *  [L2BlockSourceEvents.L2PruneDetected]: (args: L2BlockSourceEvent) => void;
+ *  [L2BlockSourceEvents.L2PruneUnproven]: (args: L2BlockSourceEvent) => void;
  *  [L2BlockSourceEvents.L2BlockProven]: (args: L2BlockSourceEvent) => void;
  * }>;
  * class Archiver extends (EventEmitter as new () => ArchiverEmitter) {

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -65,7 +65,6 @@ describe('BlockSynchronizer', () => {
     await synchronizer.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: { number: BlockNumber(3), hash: '0x3' },
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 
@@ -89,7 +88,6 @@ describe('BlockSynchronizer', () => {
     await synchronizer.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: { number: BlockNumber(3), hash: '0x3' },
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.test.ts
@@ -93,10 +93,10 @@ describe('EpochPruneWatcher', () => {
       epoch: epochNumber,
     });
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {
+    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneUnproven, {
       epochNumber: EpochNumber(1),
       blocks: [block],
-      type: L2BlockSourceEvents.L2PruneDetected,
+      type: L2BlockSourceEvents.L2PruneUnproven,
     });
 
     // Just need to yield to the event loop to clear our synchronous promises
@@ -146,10 +146,10 @@ describe('EpochPruneWatcher', () => {
       epoch: EpochNumber(1),
     });
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {
+    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneUnproven, {
       epochNumber: EpochNumber(1),
       blocks: [block],
-      type: L2BlockSourceEvents.L2PruneDetected,
+      type: L2BlockSourceEvents.L2PruneUnproven,
     });
 
     // Just need to yield to the event loop to clear our synchronous promises
@@ -209,10 +209,10 @@ describe('EpochPruneWatcher', () => {
       epoch: EpochNumber(1),
     });
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneDetected, {
+    l2BlockSource.events.emit(L2BlockSourceEvents.L2PruneUnproven, {
       epochNumber: EpochNumber(1),
       blocks: [blockFromL1],
-      type: L2BlockSourceEvents.L2PruneDetected,
+      type: L2BlockSourceEvents.L2PruneUnproven,
     });
 
     // Just need to yield to the event loop to clear our synchronous promises

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -6,9 +6,9 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import {
   EthAddress,
   L2BlockNew,
-  type L2BlockPruneEvent,
   type L2BlockSourceEventEmitter,
   L2BlockSourceEvents,
+  type L2PruneUnprovenEvent,
 } from '@aztec/stdlib/block';
 import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import type {
@@ -64,12 +64,12 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
   }
 
   public start() {
-    this.l2BlockSource.events.on(L2BlockSourceEvents.L2PruneDetected, this.boundHandlePruneL2Blocks);
+    this.l2BlockSource.events.on(L2BlockSourceEvents.L2PruneUnproven, this.boundHandlePruneL2Blocks);
     return Promise.resolve();
   }
 
   public stop() {
-    this.l2BlockSource.events.removeListener(L2BlockSourceEvents.L2PruneDetected, this.boundHandlePruneL2Blocks);
+    this.l2BlockSource.events.removeListener(L2BlockSourceEvents.L2PruneUnproven, this.boundHandlePruneL2Blocks);
     return Promise.resolve();
   }
 
@@ -78,7 +78,7 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
     this.log.verbose('EpochPruneWatcher config updated', this.penalties);
   }
 
-  private handlePruneL2Blocks(event: L2BlockPruneEvent): void {
+  private handlePruneL2Blocks(event: L2PruneUnprovenEvent): void {
     const { blocks, epochNumber } = event;
     void this.processPruneL2Blocks(blocks, epochNumber).catch(err =>
       this.log.error('Error processing pruned L2 blocks', err, { epochNumber }),

--- a/yarn-project/stdlib/src/block/l2_block_new.ts
+++ b/yarn-project/stdlib/src/block/l2_block_new.ts
@@ -1,5 +1,5 @@
 import { type BlockBlobData, encodeBlockBlobData } from '@aztec/blob-lib/encoding';
-import { BlockNumber, CheckpointNumber, CheckpointNumberSchema } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, CheckpointNumberSchema, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
@@ -35,6 +35,10 @@ export class L2BlockNew {
 
   get number(): BlockNumber {
     return this.header.globalVariables.blockNumber;
+  }
+
+  get slot(): SlotNumber {
+    return this.header.globalVariables.slotNumber;
   }
 
   get timestamp(): bigint {

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -195,6 +195,13 @@ export interface L2BlockSource {
   getBlocksForEpoch(epochNumber: EpochNumber): Promise<L2Block[]>;
 
   /**
+   * Returns all blocks for a given slot.
+   * @dev Use this method only with recent slots, since it walks the block list backwards.
+   * @param slotNumber - The slot number to return blocks for.
+   */
+  getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]>;
+
+  /**
    * Gets a published block by its block hash.
    * @param blockHash - The block hash to retrieve.
    * @returns The requested block (or undefined if not found).
@@ -238,7 +245,8 @@ export interface L2BlockSink {
  * see L2BlockSourceEvents for the events emitted.
  */
 export type ArchiverEmitter = TypedEventEmitter<{
-  [L2BlockSourceEvents.L2PruneDetected]: (args: L2BlockPruneEvent) => void;
+  [L2BlockSourceEvents.L2PruneUnproven]: (args: L2PruneUnprovenEvent) => void;
+  [L2BlockSourceEvents.L2PruneUncheckpointed]: (args: L2PruneUncheckpointedEvent) => void;
   [L2BlockSourceEvents.L2BlockProven]: (args: L2BlockProvenEvent) => void;
   [L2BlockSourceEvents.InvalidAttestationsCheckpointDetected]: (args: InvalidCheckpointDetectedEvent) => void;
   [L2BlockSourceEvents.L2BlocksCheckpointed]: (args: L2CheckpointEvent) => void;
@@ -255,13 +263,6 @@ export interface L2BlockSourceEventEmitter extends L2BlockSource {
  * - finalized: Proven block on a finalized L1 block (not implemented, set to proven for now).
  */
 export type L2BlockTag = 'proposed' | 'checkpointed' | 'proven' | 'finalized';
-
-/**
- * Reason for L2 block prune.
- * - uncheckpointed: L2 blocks were pruned due to a failure to checkpoint.
- * - unproven: L2 blocks were pruned due to a failure to prove.
- */
-export type L2BlockPruneReason = 'uncheckpointed' | 'unproven';
 
 /** Tips of the L2 chain. */
 export type L2Tips = {
@@ -316,7 +317,8 @@ export const L2TipsSchema = z.object({
 });
 
 export enum L2BlockSourceEvents {
-  L2PruneDetected = 'l2PruneDetected',
+  L2PruneUnproven = 'l2PruneUnproven',
+  L2PruneUncheckpointed = 'l2PruneUncheckpointed',
   L2BlockProven = 'l2BlockProven',
   L2BlocksCheckpointed = 'l2BlocksCheckpointed',
   InvalidAttestationsCheckpointDetected = 'invalidCheckpointDetected',
@@ -329,9 +331,15 @@ export type L2BlockProvenEvent = {
   epochNumber: EpochNumber;
 };
 
-export type L2BlockPruneEvent = {
-  type: 'l2PruneDetected';
+export type L2PruneUnprovenEvent = {
+  type: 'l2PruneUnproven';
   epochNumber: EpochNumber;
+  blocks: L2BlockNew[];
+};
+
+export type L2PruneUncheckpointedEvent = {
+  type: 'l2PruneUncheckpointed';
+  slotNumber: SlotNumber;
   blocks: L2BlockNew[];
 };
 

--- a/yarn-project/stdlib/src/block/l2_block_stream/interfaces.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/interfaces.ts
@@ -1,6 +1,6 @@
 import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
 import type { L2BlockNew } from '../l2_block_new.js';
-import type { CheckpointId, L2BlockId, L2BlockPruneReason, L2Tips } from '../l2_block_source.js';
+import type { CheckpointId, L2BlockId, L2Tips } from '../l2_block_source.js';
 
 /** Interface to the local view of the chain. Implemented by world-state and l2-tips-store. */
 export interface L2BlockStreamLocalDataProvider {
@@ -29,7 +29,6 @@ export type L2BlockStreamEvent =
    * events that will push the anchor block forward.
    */ {
       type: 'chain-pruned';
-      reason: L2BlockPruneReason;
       block: L2BlockId;
       checkpoint: CheckpointId;
     }

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -215,7 +215,7 @@ describe('L2BlockStream', () => {
 
       await blockStream.work();
       expect(handler.events).toEqual([
-        { type: 'chain-pruned', block: makeBlockId(36), reason: 'unproven', checkpoint: makeCheckpointId(0) },
+        { type: 'chain-pruned', block: makeBlockId(36), checkpoint: makeCheckpointId(0) },
         { type: 'blocks-added', blocks: times(9, i => makeBlock(i + 37)) },
       ] satisfies L2BlockStreamEvent[]);
     });
@@ -290,11 +290,10 @@ describe('L2BlockStream', () => {
 
       await blockStream.work();
 
-      // Prune to block 3 (checkpointed tip), reason should be 'uncheckpointed'
+      // Prune to block 3 (checkpointed tip)
       expect(handler.events[0]).toEqual({
         type: 'chain-pruned',
         block: makeBlockId(3),
-        reason: 'uncheckpointed',
         checkpoint: makeCheckpointId(3),
       });
     });
@@ -335,7 +334,7 @@ describe('L2BlockStream', () => {
       setRemoteTips(25, 25, 25, 10);
       await blockStream.work();
       expect(handler.events).toEqual([
-        { type: 'chain-pruned', block: makeBlockId(25), reason: 'unproven', checkpoint: makeCheckpointId(25) },
+        { type: 'chain-pruned', block: makeBlockId(25), checkpoint: makeCheckpointId(25) },
       ]);
     });
   });
@@ -771,12 +770,11 @@ describe('L2BlockStream', () => {
 
         await blockStream.work();
 
-        // Should emit chain-pruned back to block 6, reason 'uncheckpointed'
+        // Should emit chain-pruned back to block 6
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(6),
-            reason: 'uncheckpointed',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(2) }),
           },
         ]);
@@ -841,12 +839,10 @@ describe('L2BlockStream', () => {
         await blockStream.work();
 
         // Should emit chain-pruned back to block 6
-        // Reason is 'unproven' because we're pruning beyond the local checkpointed tip (12)
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(6),
-            reason: 'unproven',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(2) }),
           },
         ]);
@@ -913,7 +909,6 @@ describe('L2BlockStream', () => {
           {
             type: 'chain-pruned',
             block: makeBlockId(3),
-            reason: 'uncheckpointed',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(1) }),
           },
         ]);
@@ -964,12 +959,11 @@ describe('L2BlockStream', () => {
 
         await blockStream.work();
 
-        // Should emit chain-pruned back to block 0, reason 'uncheckpointed' (pruned to checkpointed tip which is 0)
+        // Should emit chain-pruned back to block 0
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(0),
-            reason: 'uncheckpointed',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(0) }),
           },
         ]);
@@ -1026,12 +1020,10 @@ describe('L2BlockStream', () => {
         await blockStream.work();
 
         // Should emit chain-pruned back to block 0
-        // Reason is 'unproven' because we're pruning beyond the local checkpointed tip (3)
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(0),
-            reason: 'unproven',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(0) }),
           },
         ]);
@@ -1135,12 +1127,10 @@ describe('L2BlockStream', () => {
         await blockStream.work();
 
         // Should emit chain-pruned event (prune events are always emitted), no checkpoint events
-        // Note: reason is 'unproven' (not 'uncheckpointed') because ignoreCheckpoints is true
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(6),
-            reason: 'unproven',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(2) }),
           },
         ]);
@@ -1177,12 +1167,11 @@ describe('L2BlockStream', () => {
 
         await blockStream.work();
 
-        // Should emit chain-pruned event with 'unproven' reason (pruning beyond checkpointed tip)
+        // Should emit chain-pruned event
         expect(handler.events).toEqual([
           {
             type: 'chain-pruned',
             block: makeBlockId(3),
-            reason: 'unproven',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(1) }),
           },
         ]);
@@ -1269,7 +1258,6 @@ describe('L2BlockStream', () => {
           {
             type: 'chain-pruned',
             block: makeBlockId(6),
-            reason: 'unproven',
             checkpoint: expect.objectContaining({ number: CheckpointNumber(2) }),
           },
         ]);

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.ts
@@ -4,7 +4,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
 import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
-import { type L2BlockId, type L2BlockPruneReason, type L2BlockSource, makeL2BlockId } from '../l2_block_source.js';
+import { type L2BlockId, type L2BlockSource, makeL2BlockId } from '../l2_block_source.js';
 import type { L2BlockStreamEvent, L2BlockStreamEventHandler, L2BlockStreamLocalDataProvider } from './interfaces.js';
 
 /** Creates a stream of events for new blocks, chain tips updates, and reorgs, out of polling an archiver or a node. */
@@ -85,18 +85,9 @@ export class L2BlockStream {
         this.log.verbose(
           `Reorg detected. Pruning blocks from ${latestBlockNumber + 1} to ${localTips.proposed.number}.`,
         );
-        // This check is not 100% accurate
-        // If the local tips are sufficiently behind the source tips, such that we are missing at least one checkpoint
-        // that has now been re-orged due to a proof failure then this will indicate a failure to checkpoint rather than a failure to prove
-        // TODO: (mbps/PhilWindle): Improve re-org detection accuracy when we come to do re-orgs
-        let reason: L2BlockPruneReason = 'unproven';
-        if (latestBlockNumber === localTips.checkpointed.block.number && !this.opts.ignoreCheckpoints) {
-          reason = 'uncheckpointed';
-        }
         await this.emitEvent({
           type: 'chain-pruned',
           block: makeL2BlockId(latestBlockNumber, hash),
-          reason,
           checkpoint: sourceTips.checkpointed.checkpoint,
         });
       }

--- a/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
+++ b/yarn-project/stdlib/src/block/test/l2_tips_store_test_suite.ts
@@ -243,7 +243,6 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     await tipsStore.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: makeBlockId(5),
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 
@@ -268,7 +267,6 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     await tipsStore.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: makeTip(0),
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 
@@ -334,7 +332,6 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     await tipsStore.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: makeBlockId(5),
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 
@@ -399,7 +396,6 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     await tipsStore.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: makeBlockId(3),
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 
@@ -478,7 +474,6 @@ export function testL2TipsStore(makeTipsStore: () => Promise<L2TipsStore>) {
     await tipsStore.handleBlockStreamEvent({
       type: 'chain-pruned',
       block: makeBlockId(3),
-      reason: 'unproven',
       checkpoint: { number: CheckpointNumber.ZERO, hash: GENESIS_CHECKPOINT_HEADER_HASH.toString() },
     });
 

--- a/yarn-project/stdlib/src/checkpoint/checkpoint.ts
+++ b/yarn-project/stdlib/src/checkpoint/checkpoint.ts
@@ -1,5 +1,5 @@
 import { encodeCheckpointBlobDataFromBlocks } from '@aztec/blob-lib/encoding';
-import { BlockNumber, CheckpointNumber, CheckpointNumberSchema } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber, CheckpointNumberSchema, SlotNumber } from '@aztec/foundation/branded-types';
 import { sum } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
@@ -14,6 +14,8 @@ import { CheckpointHeader } from '../rollup/checkpoint_header.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import type { CheckpointInfo } from './checkpoint_info.js';
 
+type FieldsOfCheckpoint = Omit<FieldsOf<Checkpoint>, 'slot'>;
+
 export class Checkpoint {
   constructor(
     /** Snapshot of archive tree after the checkpoint is added. */
@@ -26,6 +28,10 @@ export class Checkpoint {
     public number: CheckpointNumber,
   ) {}
 
+  get slot(): SlotNumber {
+    return this.header.slotNumber;
+  }
+
   static get schema() {
     return z
       .object({
@@ -37,11 +43,11 @@ export class Checkpoint {
       .transform(({ archive, header, blocks, number }) => new Checkpoint(archive, header, blocks, number));
   }
 
-  static from(fields: FieldsOf<Checkpoint>) {
+  static from(fields: FieldsOfCheckpoint) {
     return new Checkpoint(...Checkpoint.getFields(fields));
   }
 
-  static getFields(fields: FieldsOf<Checkpoint>) {
+  static getFields(fields: FieldsOfCheckpoint) {
     return [fields.archive, fields.header, fields.blocks, fields.number] as const;
   }
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -194,6 +194,11 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual([expect.any(L2Block)]);
   });
 
+  it('getBlocksForSlot', async () => {
+    const result = await context.client.getBlocksForSlot(SlotNumber(1));
+    expect(result).toEqual([expect.any(L2BlockNew)]);
+  });
+
   it('getBlockHeadersForEpoch', async () => {
     const result = await context.client.getBlockHeadersForEpoch(EpochNumber(1));
     expect(result).toEqual([expect.any(BlockHeader)]);
@@ -476,6 +481,10 @@ class MockArchiver implements ArchiverApi {
   async getBlocksForEpoch(epochNumber: EpochNumber): Promise<L2Block[]> {
     expect(epochNumber).toEqual(EpochNumber(1));
     return [await L2Block.random(BlockNumber(Number(epochNumber)))];
+  }
+  async getBlocksForSlot(slotNumber: SlotNumber): Promise<L2BlockNew[]> {
+    expect(slotNumber).toEqual(SlotNumber(1));
+    return [await L2BlockNew.random(BlockNumber(Number(slotNumber)))];
   }
   async getBlockHeadersForEpoch(epochNumber: EpochNumber): Promise<BlockHeader[]> {
     expect(epochNumber).toEqual(EpochNumber(1));

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -120,6 +120,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL2EpochNumber: z.function().args().returns(EpochNumberSchema.optional()),
   getCheckpointsForEpoch: z.function().args(EpochNumberSchema).returns(z.array(Checkpoint.schema)),
   getBlocksForEpoch: z.function().args(EpochNumberSchema).returns(z.array(L2Block.schema)),
+  getBlocksForSlot: z.function().args(schemas.SlotNumber).returns(z.array(L2BlockNew.schema)),
   getBlockHeadersForEpoch: z.function().args(EpochNumberSchema).returns(z.array(BlockHeader.schema)),
   isEpochComplete: z.function().args(EpochNumberSchema).returns(z.boolean()),
   getL2Tips: z.function().args().returns(L2TipsSchema),

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -400,6 +400,7 @@ export async function mockCheckpointAndMessages(
   {
     startBlockNumber = BlockNumber(1),
     numBlocks = 1,
+    blocks,
     numTxsPerBlock = 1,
     numL1ToL2Messages = 1,
     makeBlockOptions = () => ({}),
@@ -412,6 +413,7 @@ export async function mockCheckpointAndMessages(
     numL1ToL2Messages?: number;
     makeBlockOptions?: (blockNumber: BlockNumber) => Partial<Parameters<typeof L2BlockNew.random>[1]>;
     previousArchive?: AppendOnlyTreeSnapshot;
+    blocks?: L2BlockNew[];
   } & Partial<Parameters<typeof Checkpoint.random>[1]> &
     Partial<Parameters<typeof L2BlockNew.random>[1]> = {},
 ) {
@@ -420,18 +422,20 @@ export async function mockCheckpointAndMessages(
   // Track the previous block's archive to ensure consecutive blocks have consistent archive roots.
   // The current block's header.lastArchive must equal the previous block's archive.
   let lastArchive: AppendOnlyTreeSnapshot | undefined = previousArchive;
-  for (let i = 0; i < numBlocks; i++) {
+  for (let i = 0; i < (blocks?.length ?? numBlocks); i++) {
     const blockNumber = BlockNumber(startBlockNumber + i);
     const { block, messages } = {
-      block: await L2BlockNew.random(blockNumber, {
-        checkpointNumber,
-        indexWithinCheckpoint: i,
-        txsPerBlock: numTxsPerBlock,
-        slotNumber,
-        ...options,
-        ...makeBlockOptions(blockNumber),
-        ...(lastArchive ? { lastArchive } : {}),
-      }),
+      block:
+        blocks?.[i] ??
+        (await L2BlockNew.random(blockNumber, {
+          checkpointNumber,
+          indexWithinCheckpoint: i,
+          txsPerBlock: numTxsPerBlock,
+          slotNumber,
+          ...options,
+          ...makeBlockOptions(blockNumber),
+          ...(lastArchive ? { lastArchive } : {}),
+        })),
       messages: mockL1ToL2Messages(numL1ToL2Messages),
     };
     // Update lastArchive for the next block

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -168,6 +168,11 @@ export class BlockHeader {
     return this._cachedHash;
   }
 
+  /** Manually set the hash for this block header if already computed */
+  setHash(hashed: Fr) {
+    this._cachedHash = Promise.resolve(hashed);
+  }
+
   static random(overrides: Partial<FieldsOf<BlockHeader>> & Partial<FieldsOf<GlobalVariables>> = {}): BlockHeader {
     return BlockHeader.from({
       lastArchive: AppendOnlyTreeSnapshot.random(),

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -22,8 +22,9 @@ export class TXEArchiver extends ArchiverDataSourceBase {
   }
 
   // TXE-specific method for adding checkpoints
-  public addCheckpoints(checkpoints: PublishedCheckpoint[], result?: ValidateCheckpointResult): Promise<boolean> {
-    return this.updater.addCheckpointsWithContractData(checkpoints, result);
+  public async addCheckpoints(checkpoints: PublishedCheckpoint[], result?: ValidateCheckpointResult): Promise<boolean> {
+    await this.updater.setNewCheckpointData(checkpoints, result);
+    return true;
   }
 
   // Abstract method implementations

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -1,7 +1,7 @@
 import type { BlobClientInterface } from '@aztec/blob-client/client';
 import { type Blob, getBlobsPerL1Block } from '@aztec/blob-lib';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import type { EthAddress } from '@aztec/foundation/eth-address';
@@ -533,16 +533,8 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return { isValid: false, reason: 'last_block_not_found' };
     }
 
-    // Get the last full block to determine checkpoint number
-    const lastBlock = await this.blockSource.getL2BlockNew(lastBlockHeader.getBlockNumber());
-    if (!lastBlock) {
-      this.log.warn(`Last block ${lastBlockHeader.getBlockNumber()} not found`, proposalInfo);
-      return { isValid: false, reason: 'last_block_not_found' };
-    }
-    const checkpointNumber = lastBlock.checkpointNumber;
-
     // Get all full blocks for the slot and checkpoint
-    const blocks = await this.getBlocksForSlot(slot, lastBlockHeader, checkpointNumber);
+    const blocks = await this.blockSource.getBlocksForSlot(slot);
     if (blocks.length === 0) {
       this.log.warn(`No blocks found for slot ${slot}`, proposalInfo);
       return { isValid: false, reason: 'no_blocks_for_slot' };
@@ -556,6 +548,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     // Get checkpoint constants from first block
     const firstBlock = blocks[0];
     const constants = this.extractCheckpointConstants(firstBlock);
+    const checkpointNumber = firstBlock.checkpointNumber;
 
     // Get L1-to-L2 messages for this checkpoint
     const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(checkpointNumber);
@@ -627,46 +620,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   /**
-   * Get all full blocks for a given slot and checkpoint by walking backwards from the last block.
-   * Returns blocks in ascending order (earliest to latest).
-   * TODO(palla/mbps): Add getL2BlocksForSlot() to L2BlockSource interface for efficiency.
-   */
-  private async getBlocksForSlot(
-    slot: SlotNumber,
-    lastBlockHeader: BlockHeader,
-    checkpointNumber: CheckpointNumber,
-  ): Promise<L2BlockNew[]> {
-    const blocks: L2BlockNew[] = [];
-    let currentHeader = lastBlockHeader;
-    const { genesisArchiveRoot } = await this.blockSource.getGenesisValues();
-
-    while (currentHeader.getSlot() === slot) {
-      const block = await this.blockSource.getL2BlockNew(currentHeader.getBlockNumber());
-      if (!block) {
-        this.log.warn(`Block ${currentHeader.getBlockNumber()} not found while getting blocks for slot ${slot}`);
-        break;
-      }
-      if (block.checkpointNumber !== checkpointNumber) {
-        break;
-      }
-      blocks.unshift(block);
-
-      const prevArchive = currentHeader.lastArchive.root;
-      if (prevArchive.equals(genesisArchiveRoot)) {
-        break;
-      }
-
-      const prevHeader = await this.blockSource.getBlockHeaderByArchive(prevArchive);
-      if (!prevHeader || prevHeader.getSlot() !== slot) {
-        break;
-      }
-      currentHeader = prevHeader;
-    }
-
-    return blocks;
-  }
-
-  /**
    * Extract checkpoint global variables from a block.
    */
   private extractCheckpointConstants(block: L2BlockNew): CheckpointGlobalVariables {
@@ -692,14 +645,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         return;
       }
 
-      // Get the last full block to determine checkpoint number
-      const lastBlock = await this.blockSource.getL2BlockNew(lastBlockHeader.getBlockNumber());
-      if (!lastBlock) {
-        this.log.warn(`Failed to get last block for blob upload`, proposalInfo);
-        return;
-      }
-
-      const blocks = await this.getBlocksForSlot(proposal.slotNumber, lastBlockHeader, lastBlock.checkpointNumber);
+      const blocks = await this.blockSource.getBlocksForSlot(proposal.slotNumber);
       if (blocks.length === 0) {
         this.log.warn(`No blocks found for blob upload`, proposalInfo);
         return;


### PR DESCRIPTION
## Summary

Fixes A-223

Implements reconciliation of locally-stored provisional blocks with L1 checkpoints in the archiver. When the archiver receives blocks locally via `addBlock()` (e.g., from the sequencer/validator), these blocks are now properly reconciled when checkpoints arrive from L1, handling mismatches and slot expirations.

**Key changes:**
- **Checkpoint reconciliation**: When a checkpoint lands on L1 with different blocks than what was stored locally, the archiver detects the conflict by comparing archive roots and replaces local blocks with the L1 checkpoint's blocks
- **Slot-based pruning**: When an L2 slot ends without any checkpoint being mined on L1, provisional blocks for that slot are pruned automatically
- **Event system refinement**: Split the existing `L2PruneDetected` event into two distinct events: `L2PruneUnproven` (epoch proving failures) and `L2PruneUncheckpointed` (checkpoint mismatches or slot expiration)
- **New `getBlocksForSlot` API**: Added to `L2BlockSource` interface for efficiently querying all blocks in a given slot

## Implementation Details

### Checkpoint Reconciliation (`data_store_updater.ts`)

The `setNewCheckpointData()` method now reconciles local blocks with incoming checkpoints:
1. Fetches existing local blocks for the checkpoint's slot
2. Compares archive roots to detect conflicts
3. Prunes mismatching blocks and emits `L2PruneUncheckpointed` event
4. Inserts the L1 checkpoint's blocks

Handles three scenarios:
- **Matching blocks**: No action needed (common case)
- **Different blocks**: Prune local, insert L1 blocks
- **Extra local blocks**: Prune blocks beyond what L1 checkpointed

### Slot-Based Pruning (`l1_synchronizer.ts`)

After each L1 sync in `syncFromL1()`:
1. Checks if there are uncheckpointed blocks
2. Determines the slot of the first uncheckpointed block
3. If that slot has ended (based on L1 timestamp), prunes all provisional blocks for it
4. Emits `L2PruneUncheckpointed` event

### Store Layer Changes

- **`BlockStore.getBlocksForSlot()`**: Efficiently iterates backwards through blocks to find all blocks for a given slot
- **`BlockStore.unwindBlocksAfter()`**: New method to remove all blocks after a given block number (for pruning provisional blocks)
- **`removeBlocksAfter()`**: Wrapper with contract data cleanup

### Validator Client Simplification

Replaced the manual `getBlocksForSlot()` implementation in `validator.ts` with calls to the new `L2BlockSource.getBlocksForSlot()` API, removing ~40 lines of duplicated logic.

## Test Plan

- Unit tests for `getBlocksForSlot()` in `kv_archiver_store.test.ts`
- Unit tests for `removeBlocksAfter()` in `kv_archiver_store.test.ts`
- Unit tests for contract data cleanup during pruning in `data_store_updater.test.ts`
- Integration tests for all reconciliation scenarios in `archiver-sync.test.ts`:
  - Checkpoints local blocks when matching checkpoint syncs from L1
  - Rejects adding blocks that are already checkpointed
  - Adds missing blocks when checkpoint has more blocks than local
  - Checkpoints local blocks from multiple slots when multiple checkpoints sync at once
  - Prunes and replaces local blocks when checkpoint has different blocks
  - Prunes excess local blocks when checkpoint has fewer blocks
  - Prunes local blocks when slot ends without checkpoint
  - Does nothing when slot ends without local blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)