### PR TITLE
fix: Increase slot duration for p2p tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -61,6 +61,7 @@ describe('e2e_p2p_network', () => {
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
+        aztecSlotDuration: 24,
         listenAddress: '127.0.0.1',
       },
     });

--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -32,6 +32,7 @@ describe('e2e_p2p_rediscovery', () => {
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
+        aztecSlotDuration: 24,
         listenAddress: '127.0.0.1',
       },
     });

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -37,6 +37,7 @@ describe('e2e_p2p_reqresp_tx', () => {
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
+        aztecSlotDuration: 24,
         listenAddress: '127.0.0.1',
         aztecEpochDuration: 64, // stable committee
       },

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
@@ -41,6 +41,7 @@ describe('e2e_p2p_reqresp_tx_no_handshake', () => {
       metricsPort: shouldCollectMetrics(),
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
+        aztecSlotDuration: 24,
         p2pDisableStatusHandshake: true, // DIFFERENCE FROM reqresp.test.ts
         listenAddress: '127.0.0.1',
         aztecEpochDuration: 64, // stable committee


### PR DESCRIPTION
A number of the p2p tests (typically those that submit transactions and wait for inclusion) experience flakes/errors because they can't build blocks and obtain attestations in time. This PR increases their aztec slot duration configured value.
