### PR TITLE
fix: (A-433) prevent blob overflow during block building

### DIFF
--- a/yarn-project/blob-lib/src/encoding/block_blob_data.ts
+++ b/yarn-project/blob-lib/src/encoding/block_blob_data.ts
@@ -17,6 +17,18 @@ import { type TxBlobData, decodeTxBlobData, encodeTxBlobData } from './tx_blob_d
 
 // Must match the implementation in `noir-protocol-circuits/crates/types/src/blob_data/block_blob_data.nr`.
 
+export const NUM_BLOCK_END_BLOB_FIELDS = 6;
+export const NUM_FIRST_BLOCK_END_BLOB_FIELDS = 7;
+export const NUM_CHECKPOINT_END_MARKER_FIELDS = 1;
+
+/**
+ * Returns the number of blob fields used for block end data.
+ * @param isFirstBlockInCheckpoint - Whether this is the first block in a checkpoint.
+ */
+export function getNumBlockEndBlobFields(isFirstBlockInCheckpoint: boolean): number {
+  return isFirstBlockInCheckpoint ? NUM_FIRST_BLOCK_END_BLOB_FIELDS : NUM_BLOCK_END_BLOB_FIELDS;
+}
+
 export interface BlockEndBlobData {
   blockEndMarker: BlockEndMarker;
   blockEndStateField: BlockEndStateField;
@@ -46,7 +58,7 @@ export function encodeBlockEndBlobData(blockEndBlobData: BlockEndBlobData): Fr[]
 export function decodeBlockEndBlobData(fields: Fr[] | FieldReader, isFirstBlock: boolean): BlockEndBlobData {
   const reader = FieldReader.asReader(fields);
 
-  const numBlockEndData = isFirstBlock ? 7 : 6;
+  const numBlockEndData = getNumBlockEndBlobFields(isFirstBlock);
   if (numBlockEndData > reader.remainingFields()) {
     throw new BlobDeserializationError(
       `Incorrect encoding of blob fields: not enough fields for block end data. Expected ${numBlockEndData} fields, only ${reader.remainingFields()} remaining.`,

--- a/yarn-project/blob-lib/src/encoding/checkpoint_blob_data.ts
+++ b/yarn-project/blob-lib/src/encoding/checkpoint_blob_data.ts
@@ -2,7 +2,14 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, FieldReader } from '@aztec/foundation/serialize';
 
 import { BlobDeserializationError } from '../errors.js';
-import { type BlockBlobData, decodeBlockBlobData, encodeBlockBlobData } from './block_blob_data.js';
+import {
+  type BlockBlobData,
+  NUM_BLOCK_END_BLOB_FIELDS,
+  NUM_CHECKPOINT_END_MARKER_FIELDS,
+  NUM_FIRST_BLOCK_END_BLOB_FIELDS,
+  decodeBlockBlobData,
+  encodeBlockBlobData,
+} from './block_blob_data.js';
 import {
   type CheckpointEndMarker,
   decodeCheckpointEndMarker,
@@ -25,7 +32,7 @@ export function encodeCheckpointBlobData(checkpointBlobData: CheckpointBlobData)
 
 export function encodeCheckpointBlobDataFromBlocks(blocks: BlockBlobData[]): Fr[] {
   const blocksBlobFields = blocks.map(block => encodeBlockBlobData(block)).flat();
-  const numBlobFields = blocksBlobFields.length + 1; // +1 for the checkpoint end marker.
+  const numBlobFields = blocksBlobFields.length + NUM_CHECKPOINT_END_MARKER_FIELDS;
   return blocksBlobFields.concat(encodeCheckpointEndMarker({ numBlobFields }));
 }
 
@@ -87,9 +94,9 @@ export function getTotalNumBlobFieldsFromTxs(txsPerBlock: TxStartMarker[][]): nu
   }
 
   return (
-    (numBlocks ? 1 : 0) + // l1ToL2Messages root in the first block
-    numBlocks * 6 + // 6 fields for each block end blob data.
+    (numBlocks ? NUM_FIRST_BLOCK_END_BLOB_FIELDS - NUM_BLOCK_END_BLOB_FIELDS : 0) + // l1ToL2Messages root in the first block
+    numBlocks * NUM_BLOCK_END_BLOB_FIELDS + // 6 fields for each block end blob data.
     txsPerBlock.reduce((total, txs) => total + txs.reduce((total, tx) => total + tx.numBlobFields, 0), 0) +
-    1 // checkpoint end marker
+    NUM_CHECKPOINT_END_MARKER_FIELDS // checkpoint end marker
   );
 }

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -130,7 +130,7 @@ describe('epoch-proving-job', () => {
     publicProcessor.process.mockImplementation(async txs => {
       const txsArray = await toArray(txs);
       const processedTxs = await Promise.all(txsArray.map(tx => mock<ProcessedTx>({ hash: tx.getTxHash() })));
-      return [processedTxs, [], txsArray, []];
+      return [processedTxs, [], txsArray, [], 0];
     });
   });
 
@@ -175,7 +175,7 @@ describe('epoch-proving-job', () => {
     publicProcessor.process.mockImplementation(async txs => {
       const txsArray = await toArray(txs);
       const errors = txsArray.map(tx => ({ error: new Error('Failed to process tx'), tx }));
-      return [[], errors, [], []];
+      return [[], errors, [], [], 0];
     });
 
     const job = createJob();
@@ -186,7 +186,7 @@ describe('epoch-proving-job', () => {
   });
 
   it('fails if does not process all txs for a block', async () => {
-    publicProcessor.process.mockImplementation(_txs => Promise.resolve([[], [], [], []]));
+    publicProcessor.process.mockImplementation(_txs => Promise.resolve([[], [], [], [], 0]));
 
     const job = createJob();
     await job.run();

--- a/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
@@ -137,9 +137,10 @@ describe('BlockBuilder', () => {
     publicProcessor.process.mockImplementation(
       async (
         pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>,
-      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[]]> => {
+      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[], number]> => {
         const processedTxs: ProcessedTx[] = [];
         const allTxs: Tx[] = [];
+        let totalBlobFields = 0;
 
         for await (const tx of pendingTxsIterator) {
           allTxs.push(tx);
@@ -150,9 +151,10 @@ describe('BlockBuilder', () => {
             globalVariables,
           );
           processedTxs.push(processedTx);
+          totalBlobFields += processedTx.txEffect.getNumBlobFields();
         }
         // Assuming all txs are processed successfully and none failed for this mock
-        return [processedTxs, [], allTxs, []];
+        return [processedTxs, [], allTxs, [], totalBlobFields];
       },
     );
     blockBuilder = new TestBlockBuilder(l1Constants, worldState, contractDataSource, dateProvider);
@@ -211,10 +213,11 @@ describe('BlockBuilder', () => {
     publicProcessor.process.mockImplementation(
       async (
         pendingTxsIterator: AsyncIterable<Tx> | Iterable<Tx>,
-      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[]]> => {
+      ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[], number]> => {
         const processedTxs: ProcessedTx[] = [];
         const usedTxs: Tx[] = [];
         const failedTxs: FailedTx[] = [];
+        let totalBlobFields = 0;
 
         for await (const tx of pendingTxsIterator) {
           if (validTxHashes.includes(tx.getTxHash())) {
@@ -227,12 +230,13 @@ describe('BlockBuilder', () => {
             );
 
             processedTxs.push(processedTx);
+            totalBlobFields += processedTx.txEffect.getNumBlobFields();
           } else {
             failedTxs.push({ tx, error: new Error() });
           }
         }
         // Assuming all txs are processed successfully and none failed for this mock
-        return [processedTxs, failedTxs, usedTxs, []];
+        return [processedTxs, failedTxs, usedTxs, [], totalBlobFields];
       },
     );
 

--- a/yarn-project/sequencer-client/src/sequencer/block_builder.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.ts
@@ -66,7 +66,7 @@ async function buildBlock(
   const blockFactory = new LightweightBlockFactory(previousCheckpointOutHashes, worldStateFork, telemetryClient);
   await blockFactory.startNewBlock(newGlobalVariables, l1ToL2Messages);
 
-  const [publicProcessorDuration, [processedTxs, failedTxs, usedTxs]] = await elapsed(() =>
+  const [publicProcessorDuration, [processedTxs, failedTxs, usedTxs, _, usedTxBlobFields]] = await elapsed(() =>
     processor.process(pendingTxs, opts, validator),
   );
 
@@ -86,6 +86,7 @@ async function buildBlock(
     failedTxs: failedTxs,
     blockBuildingTimer,
     usedTxs,
+    usedTxBlobFields,
   };
   log.trace('Built block', res.block.header);
   return res;

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -1,3 +1,9 @@
+import {
+  NUM_BLOCK_END_BLOB_FIELDS,
+  NUM_CHECKPOINT_END_MARKER_FIELDS,
+  NUM_FIRST_BLOCK_END_BLOB_FIELDS,
+} from '@aztec/blob-lib/encoding';
+import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
@@ -612,6 +618,53 @@ describe('CheckpointProposalJob', () => {
 
       // waitUntilTimeInSlot should NOT be called since the only block is the last block
       expect(waitSpy).not.toHaveBeenCalled();
+    });
+
+    it('tracks remaining blob field capacity across multiple blocks', async () => {
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 10, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 18, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      const txs = await Promise.all([makeTx(1, chainId), makeTx(2, chainId), makeTx(3, chainId)]);
+
+      p2p.getPendingTxCount.mockResolvedValue(10);
+      p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
+
+      // Create 2 blocks - block 1 has 2 txs, block 2 has 1 tx
+      const block1 = await makeBlock(txs.slice(0, 2), globalVariables);
+      const globalVariables2 = new GlobalVariables(
+        chainId,
+        version,
+        BlockNumber(newBlockNumber + 1),
+        SlotNumber(newSlotNumber),
+        0n,
+        coinbase,
+        feeRecipient,
+        gasFees,
+      );
+      const block2 = await makeBlock([txs[2]], globalVariables2);
+
+      checkpointBuilder.seedBlocks([block1, block2], [txs.slice(0, 2), [txs[2]]]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(block2));
+
+      await job.execute();
+
+      // Verify blob field limits were correctly calculated
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(2);
+
+      const initialCapacity = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB - NUM_CHECKPOINT_END_MARKER_FIELDS;
+
+      // Block 1 (first in checkpoint): gets initial capacity - first block overhead (7)
+      const block1MaxBlobFields = initialCapacity - NUM_FIRST_BLOCK_END_BLOB_FIELDS;
+      expect(checkpointBuilder.buildBlockCalls[0].opts.maxBlobFields).toBe(block1MaxBlobFields);
+
+      // Block 2: gets remaining capacity - subsequent block overhead (6)
+      const block1BlobFieldsUsed = block1.body.txEffects.reduce((sum, tx) => sum + tx.getNumBlobFields(), 0);
+      const remainingAfterBlock1 = block1MaxBlobFields - block1BlobFieldsUsed;
+      const block2MaxBlobFields = remainingAfterBlock1 - NUM_BLOCK_END_BLOB_FIELDS;
+      expect(checkpointBuilder.buildBlockCalls[1].opts.maxBlobFields).toBe(block2MaxBlobFields);
     });
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1,3 +1,4 @@
+import { NUM_CHECKPOINT_END_MARKER_FIELDS, getNumBlockEndBlobFields } from '@aztec/blob-lib/encoding';
 import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -298,6 +299,9 @@ export class CheckpointProposalJob implements Traceable {
     const txHashesAlreadyIncluded = new Set<string>();
     const initialBlockNumber = BlockNumber(this.syncedToBlockNumber + 1);
 
+    // Remaining blob fields available for blocks (checkpoint end marker already subtracted)
+    let remainingBlobFields = BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB - NUM_CHECKPOINT_END_MARKER_FIELDS;
+
     // Last block in the checkpoint will usually be flagged as pending broadcast, so we send it along with the checkpoint proposal
     let blockPendingBroadcast: { block: L2BlockNew; txs: Tx[] } | undefined = undefined;
 
@@ -330,6 +334,7 @@ export class CheckpointProposalJob implements Traceable {
         blockNumber,
         indexWithinCheckpoint,
         txHashesAlreadyIncluded,
+        remainingBlobFields,
       });
 
       if (!buildResult && timingInfo.isLastBlock) {
@@ -354,8 +359,11 @@ export class CheckpointProposalJob implements Traceable {
         break;
       }
 
-      const { block, usedTxs } = buildResult;
+      const { block, usedTxs, remainingBlobFields: newRemainingBlobFields } = buildResult;
       blocksInCheckpoint.push(block);
+
+      // Update remaining blob fields for the next block
+      remainingBlobFields = newRemainingBlobFields;
 
       // Sync the proposed block to the archiver to make it available
       // Note that the checkpoint builder uses its own fork so it should not need to wait for this syncing
@@ -419,10 +427,18 @@ export class CheckpointProposalJob implements Traceable {
       indexWithinCheckpoint: number;
       buildDeadline: Date | undefined;
       txHashesAlreadyIncluded: Set<string>;
+      remainingBlobFields: number;
     },
-  ): Promise<{ block: L2BlockNew; usedTxs: Tx[] } | { error: Error } | undefined> {
-    const { blockTimestamp, forceCreate, blockNumber, indexWithinCheckpoint, buildDeadline, txHashesAlreadyIncluded } =
-      opts;
+  ): Promise<{ block: L2BlockNew; usedTxs: Tx[]; remainingBlobFields: number } | { error: Error } | undefined> {
+    const {
+      blockTimestamp,
+      forceCreate,
+      blockNumber,
+      indexWithinCheckpoint,
+      buildDeadline,
+      txHashesAlreadyIncluded,
+      remainingBlobFields,
+    } = opts;
 
     this.log.verbose(
       `Preparing block ${blockNumber} index ${indexWithinCheckpoint} at checkpoint ${this.checkpointNumber} for slot ${this.slot}`,
@@ -455,18 +471,31 @@ export class CheckpointProposalJob implements Traceable {
         { slot: this.slot, blockNumber, indexWithinCheckpoint },
       );
       this.setStateFn(SequencerState.CREATING_BLOCK, this.slot);
+
+      // Calculate blob fields limit for txs (remaining capacity - this block's end overhead)
+      const blockEndOverhead = getNumBlockEndBlobFields(indexWithinCheckpoint === 0);
+      const maxBlobFieldsForTxs = remainingBlobFields - blockEndOverhead;
+
       const blockBuilderOptions: PublicProcessorLimits = {
         maxTransactions: this.config.maxTxsPerBlock,
         maxBlockSize: this.config.maxBlockSizeInBytes,
         maxBlockGas: new Gas(this.config.maxDABlockGas, this.config.maxL2BlockGas),
-        maxBlobFields: BLOBS_PER_CHECKPOINT * FIELDS_PER_BLOB,
+        maxBlobFields: maxBlobFieldsForTxs,
         deadline: buildDeadline,
       };
 
       // Actually build the block by executing txs
       const workTimer = new Timer();
-      const { publicGas, block, publicProcessorDuration, numTxs, blockBuildingTimer, usedTxs, failedTxs } =
-        await checkpointBuilder.buildBlock(pendingTxs, blockNumber, blockTimestamp, blockBuilderOptions);
+      const {
+        publicGas,
+        block,
+        publicProcessorDuration,
+        numTxs,
+        blockBuildingTimer,
+        usedTxs,
+        failedTxs,
+        usedTxBlobFields,
+      } = await checkpointBuilder.buildBlock(pendingTxs, blockNumber, blockTimestamp, blockBuilderOptions);
       const blockBuildDuration = workTimer.ms();
 
       // If any txs failed during execution, drop them from the mempool so we don't pick them up again
@@ -510,7 +539,7 @@ export class CheckpointProposalJob implements Traceable {
       this.eventEmitter.emit('block-proposed', { blockNumber: block.number, slot: this.slot });
       this.metrics.recordBuiltBlock(blockBuildDuration, publicGas.l2Gas);
 
-      return { block, usedTxs };
+      return { block, usedTxs, remainingBlobFields: maxBlobFieldsForTxs - usedTxBlobFields };
     } catch (err: any) {
       this.eventEmitter.emit('block-build-failed', { reason: err.message, slot: this.slot });
       this.log.error(`Error building block`, err, { blockNumber, slot: this.slot });

--- a/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
+++ b/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
@@ -104,6 +104,7 @@ export class MockCheckpointBuilder implements FunctionsOf<CheckpointBuilder> {
       blockBuildingTimer: new Timer(),
       usedTxs,
       failedTxs: [],
+      usedTxBlobFields: block?.body?.txEffects?.reduce((sum, tx) => sum + tx.getNumBlobFields(), 0) ?? 0,
     });
   }
 

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -199,13 +199,16 @@ describe('public_processor', () => {
       const maxBlobFields = actualBlobFields * 2;
 
       // Process all 3 transactions with the blob field limit
-      const [processed, failed] = await processor.process(txs, { maxBlobFields });
+      const [processed, failed, _usedTxs, _returns, usedTxBlobFields] = await processor.process(txs, { maxBlobFields });
 
       // Should only process 2 transactions due to blob field limit
       expect(processed.length).toBe(2);
       expect(processed[0].hash).toEqual(txs[0].getTxHash());
       expect(processed[1].hash).toEqual(txs[1].getTxHash());
       expect(failed).toEqual([]);
+
+      const expectedBlobFields = actualBlobFields * 2;
+      expect(usedTxBlobFields).toBe(expectedBlobFields);
     });
 
     it('does not send a transaction to the prover if pre validation fails', async function () {

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -146,7 +146,7 @@ export class PublicProcessor implements Traceable {
     txs: Iterable<Tx> | AsyncIterable<Tx>,
     limits: PublicProcessorLimits = {},
     validator: PublicProcessorValidator = {},
-  ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[]]> {
+  ): Promise<[ProcessedTx[], FailedTx[], Tx[], NestedProcessReturnValues[], number]> {
     const { maxTransactions, maxBlockSize, deadline, maxBlockGas, maxBlobFields } = limits;
     const { preprocessValidator, nullifierCache } = validator;
     const result: ProcessedTx[] = [];
@@ -254,6 +254,7 @@ export class PublicProcessor implements Traceable {
         }
 
         // If the actual blob fields of this tx would exceed the limit, skip it
+        // Note: maxBlobFields already accounts for block end blob fields and previous blocks in checkpoint.
         if (maxBlobFields !== undefined && totalBlobFields + txBlobFields > maxBlobFields) {
           this.log.debug(
             `Skipping processed tx ${txHash} with ${txBlobFields} blob fields due to max blob fields limit.`,
@@ -349,7 +350,7 @@ export class PublicProcessor implements Traceable {
       totalSizeInBytes,
     });
 
-    return [result, failed, usedTxs, returns];
+    return [result, failed, usedTxs, returns, totalBlobFields];
   }
 
   private async checkWorldStateUnchanged(

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -56,6 +56,7 @@ export interface BuildBlockResult {
   failedTxs: FailedTx[];
   blockBuildingTimer: Timer;
   usedTxs: Tx[];
+  usedTxBlobFields: number;
 }
 
 export type FullNodeBlockBuilderConfig = Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration'> &

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -38,6 +38,7 @@ export interface BuildBlockInCheckpointResult {
   failedTxs: FailedTx[];
   blockBuildingTimer: Timer;
   usedTxs: Tx[];
+  usedTxBlobFields: number;
 }
 
 /**
@@ -90,7 +91,7 @@ export class CheckpointBuilder {
     });
     const { processor, validator } = await this.makeBlockBuilderDeps(globalVariables, this.fork);
 
-    const [publicProcessorDuration, [processedTxs, failedTxs, usedTxs]] = await elapsed(() =>
+    const [publicProcessorDuration, [processedTxs, failedTxs, usedTxs, _, usedTxBlobFields]] = await elapsed(() =>
       processor.process(pendingTxs, opts, validator),
     );
 
@@ -110,6 +111,7 @@ export class CheckpointBuilder {
       failedTxs,
       blockBuildingTimer,
       usedTxs,
+      usedTxBlobFields,
     };
     log.debug('Built block within checkpoint', res.block.header);
     return res;

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -347,6 +347,7 @@ describe('ValidatorClient', () => {
         failedTxs: [],
         publicGas: Gas.empty(),
         usedTxs: [],
+        usedTxBlobFields: 0,
         block: {
           header: l2BlockHeader,
           body: { txEffects: times(proposal.txHashes.length, () => TxEffect.empty()) },


### PR DESCRIPTION
Track remaining blob fields across blocks in a checkpoint, accounting for block end overhead and checkpoint end marker

Fixes:
- Previously each block was given the full checkpoint capacity, ignoring blob fields used by prior blocks in the same checkpoint
- Block end data blob overhead not subtracted correctly