### PR TITLE
refactor: use job coordinator in TXE

### DIFF
--- a/yarn-project/pxe/src/entrypoints/server/index.ts
+++ b/yarn-project/pxe/src/entrypoints/server/index.ts
@@ -6,3 +6,4 @@ export * from './utils.js';
 export { NoteService } from '../../notes/note_service.js';
 export { ORACLE_VERSION } from '../../oracle_version.js';
 export { type PXECreationOptions } from '../pxe_creation_options.js';
+export { JobCoordinator } from '../../job_coordinator/job_coordinator.js';

--- a/yarn-project/txe/src/constants.ts
+++ b/yarn-project/txe/src/constants.ts
@@ -1,4 +1,3 @@
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 export const DEFAULT_ADDRESS = AztecAddress.fromNumber(42);
-export const TXE_JOB_ID = 'test-job-id';

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -80,7 +80,7 @@ import {
 import type { UInt64 } from '@aztec/stdlib/types';
 import { ForkCheckpoint } from '@aztec/world-state';
 
-import { DEFAULT_ADDRESS, TXE_JOB_ID } from '../constants.js';
+import { DEFAULT_ADDRESS } from '../constants.js';
 import type { TXEStateMachine } from '../state_machine/index.js';
 import type { TXEAccountStore } from '../util/txe_account_store.js';
 import type { TXEContractStore } from '../util/txe_contract_store.js';
@@ -106,6 +106,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     private senderAddressBookStore: SenderAddressBookStore,
     private capsuleStore: CapsuleStore,
     private privateEventStore: PrivateEventStore,
+    private jobId: string,
     private nextBlockTimestamp: bigint,
     private version: Fr,
     private chainId: Fr,
@@ -345,7 +346,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
-      TXE_JOB_ID,
+      this.jobId,
       0,
       1,
       undefined, // log
@@ -683,7 +684,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
         this.senderAddressBookStore,
         this.capsuleStore,
         this.privateEventStore,
-        TXE_JOB_ID,
+        this.jobId,
       );
       const acirExecutionResult = await new WASMSimulator()
         .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())

--- a/yarn-project/txe/src/txe_session.test.ts
+++ b/yarn-project/txe/src/txe_session.test.ts
@@ -21,6 +21,8 @@ describe('TXESession.processFunction', () => {
       {} as any, // senderAddressBook
       {} as any, // capsuleStore
       {} as any, // privateEventStore
+      {} as any, // jobCoordinator
+      {} as any, // initialJobId
       new Fr(1), // chainId
       new Fr(1), // version
       0n, // nextBlockTimestamp

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -7,6 +7,7 @@ import type { ProtocolContract } from '@aztec/protocol-contracts';
 import {
   AddressStore,
   CapsuleStore,
+  JobCoordinator,
   NoteService,
   NoteStore,
   PrivateEventStore,
@@ -43,7 +44,7 @@ import { CallContext, GlobalVariables, TxContext } from '@aztec/stdlib/tx';
 
 import { z } from 'zod';
 
-import { DEFAULT_ADDRESS, TXE_JOB_ID } from './constants.js';
+import { DEFAULT_ADDRESS } from './constants.js';
 import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfaces.js';
 import { TXEOraclePublicContext } from './oracle/txe_oracle_public_context.js';
 import { TXEOracleTopLevelContext } from './oracle/txe_oracle_top_level_context.js';
@@ -139,6 +140,8 @@ export class TXESession implements TXESessionStateHandler {
     private senderAddressBookStore: SenderAddressBookStore,
     private capsuleStore: CapsuleStore,
     private privateEventStore: PrivateEventStore,
+    private jobCoordinator: JobCoordinator,
+    private currentJobId: string,
     private chainId: Fr,
     private version: Fr,
     private nextBlockTimestamp: bigint,
@@ -158,6 +161,10 @@ export class TXESession implements TXESessionStateHandler {
     const keyStore = new KeyStore(store);
     const accountStore = new TXEAccountStore(store);
 
+    // Create job coordinator and register staged stores
+    const jobCoordinator = new JobCoordinator(store);
+    jobCoordinator.registerStores([capsuleStore, senderTaggingStore, recipientTaggingStore]);
+
     // Register protocol contracts.
     for (const { contractClass, instance, artifact } of protocolContracts) {
       await contractStore.addContractArtifact(contractClass.id, artifact);
@@ -169,6 +176,8 @@ export class TXESession implements TXESessionStateHandler {
     const nextBlockTimestamp = BigInt(Math.floor(new Date().getTime() / 1000));
     const version = new Fr(await stateMachine.node.getVersion());
     const chainId = new Fr(await stateMachine.node.getChainId());
+
+    const initialJobId = jobCoordinator.beginJob();
 
     const topLevelOracleHandler = new TXEOracleTopLevelContext(
       stateMachine,
@@ -182,6 +191,7 @@ export class TXESession implements TXESessionStateHandler {
       senderAddressBookStore,
       capsuleStore,
       privateEventStore,
+      initialJobId,
       nextBlockTimestamp,
       version,
       chainId,
@@ -203,6 +213,8 @@ export class TXESession implements TXESessionStateHandler {
       senderAddressBookStore,
       capsuleStore,
       privateEventStore,
+      jobCoordinator,
+      initialJobId,
       version,
       chainId,
       nextBlockTimestamp,
@@ -262,6 +274,10 @@ export class TXESession implements TXESessionStateHandler {
       }
     }
 
+    // Commit all staged stores from the job that was just completed, then begin a new job
+    await this.jobCoordinator.commitJob(this.currentJobId);
+    this.currentJobId = this.jobCoordinator.beginJob();
+
     this.oracleHandler = new TXEOracleTopLevelContext(
       this.stateMachine,
       this.contractStore,
@@ -274,6 +290,7 @@ export class TXESession implements TXESessionStateHandler {
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
+      this.currentJobId,
       this.nextBlockTimestamp,
       this.version,
       this.chainId,
@@ -337,7 +354,7 @@ export class TXESession implements TXESessionStateHandler {
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
-      TXE_JOB_ID,
+      this.currentJobId,
     );
 
     // We store the note and tagging index caches fed into the PrivateExecutionOracle (along with some other auxiliary
@@ -406,7 +423,7 @@ export class TXESession implements TXESessionStateHandler {
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
-      TXE_JOB_ID,
+      this.currentJobId,
     );
 
     this.state = { name: 'UTILITY' };
@@ -501,7 +518,7 @@ export class TXESession implements TXESessionStateHandler {
           this.senderAddressBookStore,
           this.capsuleStore,
           this.privateEventStore,
-          TXE_JOB_ID,
+          this.currentJobId,
         );
         await new WASMSimulator()
           .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())


### PR DESCRIPTION
Use the JobCoordinator from TXE, mimicking PXE job semantics. This is needed so we can call `get_private_events` from Noir tests. 

Given all store operations except `get_private_event` are supposed to work in a job context, we need TXE to be smart enough to commit jobs each time it enters or re-enters its top level state. 