### PR TITLE
chore: Disable GateCountAndVKCheck test for outer circuit in TwoLayerAvmRecursiveVerifier

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
@@ -126,7 +126,8 @@ TEST_F(AvmRecursionConstraintTest, Tampering)
     std::vector<std::string> _ = test_tampering();
 }
 
-TEST_F(AvmRecursionConstraintTest, GateCountAndVKCheck)
+// TODO(fcarreiro): Re-enable when the VK is fixed.
+TEST_F(AvmRecursionConstraintTest, DISABLED_GateCountAndVKCheck)
 {
     if (avm2::testing::skip_slow_tests()) {
         GTEST_SKIP() << "Skipping slow test";
@@ -150,12 +151,11 @@ TEST_F(AvmRecursionConstraintTest, GateCountAndVKCheck)
     auto prover_instance = std::make_shared<ProverInstance>(builder);
     auto vk = std::make_shared<typename UltraRollupFlavor::VerificationKey>(prover_instance->get_precomputed());
 
-    // TODO(fcarreiro): Re-enable when the VK is fixed.
-    // static constexpr FF EXPECTED_OUTER_VK_HASH =
-    //     FF("0x195059523571dbadeae1b213250567e17b4994568b736b73a1aae2b0c65fd2cd");
-    // EXPECT_EQ(vk->hash(), EXPECTED_OUTER_VK_HASH)
-    //     << "The VK hash of the outer circuit in the Goblinized AVM recursive verifier has changed. If this is "
-    //        "expected, update the expected value in the test.";
+    static constexpr FF EXPECTED_OUTER_VK_HASH =
+        FF("0x195059523571dbadeae1b213250567e17b4994568b736b73a1aae2b0c65fd2cd");
+    EXPECT_EQ(vk->hash(), EXPECTED_OUTER_VK_HASH)
+        << "The VK hash of the outer circuit in the Goblinized AVM recursive verifier has changed. If this is "
+           "expected, update the expected value in the test.";
 }
 
 class AvmRecursionInnerCircuitTests : public ::testing::Test {


### PR DESCRIPTION
Disabling the test because it changes often due to changes in the AVM. To be re-enabled once the VK and gate count are fixed