### PR TITLE
fix: preserve newlines in bb CLI help text formatting

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -233,14 +233,16 @@ int parse_and_run_cli_command(int argc, char* argv[])
             ->add_option("--verifier_target, -t",
                          flags.verifier_target,
                          "Target verification environment. Determines hash function and ZK settings.\n"
-                         "  evm:                    Ethereum/Solidity verification (keccak, ZK)\n"
-                         "  evm-no-zk:              Ethereum/Solidity without zero-knowledge\n"
-                         "  noir-recursive:         Recursive verification in Noir circuits (poseidon2, ZK)\n"
-                         "  noir-recursive-no-zk:   Recursive verification without ZK\n"
-                         "  noir-rollup:            Rollup circuits with IPA accumulation (poseidon2, ZK)\n"
-                         "  noir-rollup-no-zk:      Rollup circuits without ZK\n"
-                         "  starknet:               Starknet verification via Garaga (ZK)\n"
-                         "  starknet-no-zk:         Starknet without zero-knowledge")
+                         "\n"
+                         "Options:\n"
+                         "  evm                  Ethereum/Solidity (keccak, ZK)\n"
+                         "  evm-no-zk            Ethereum/Solidity without ZK\n"
+                         "  noir-recursive       Noir circuits (poseidon2, ZK)\n"
+                         "  noir-recursive-no-zk Noir circuits without ZK\n"
+                         "  noir-rollup          Rollup with IPA (poseidon2, ZK)\n"
+                         "  noir-rollup-no-zk    Rollup without ZK\n"
+                         "  starknet             Starknet via Garaga (ZK)\n"
+                         "  starknet-no-zk       Starknet without ZK")
             ->envname("BB_VERIFIER_TARGET")
             ->check(CLI::IsMember({ "evm",
                                     "evm-no-zk",

--- a/barretenberg/cpp/src/barretenberg/bb/cli11_formatter.hpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli11_formatter.hpp
@@ -87,16 +87,34 @@ class Formatter : public CLI::Formatter {
             }
             first_line = false;
 
-            // Now wrap each line individually
-            std::istringstream words(line);
+            // If the line fits within width, output it verbatim to preserve formatting
+            if (line.length() <= width) {
+                out << line;
+                continue;
+            }
+
+            // Line is too long - need to wrap it
+            // Preserve leading whitespace for continuation lines
+            size_t indent = 0;
+            while (indent < line.size() && (line[indent] == ' ' || line[indent] == '\t')) {
+                indent++;
+            }
+            std::string leading_space = line.substr(0, indent);
+            std::string content = line.substr(indent);
+
+            // Output leading whitespace
+            out << leading_space;
+
+            // Now wrap the content, using the same indent for continuation lines
+            std::istringstream words(content);
             std::string word;
-            size_t line_length = 0;
+            size_t line_length = indent;
             while (words >> word) {
                 if (line_length + word.length() + 1 > width) {
-                    out << "\n";
-                    line_length = 0;
+                    out << "\n" << leading_space;
+                    line_length = indent;
                 }
-                if (line_length > 0) {
+                if (line_length > indent) {
                     out << " ";
                     line_length++;
                 }

--- a/barretenberg/cpp/src/barretenberg/bb/cli11_formatter.hpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli11_formatter.hpp
@@ -77,20 +77,32 @@ class Formatter : public CLI::Formatter {
   private:
     static void wrap_text(std::ostream& out, const std::string& text, size_t width)
     {
-        std::istringstream words(text);
-        std::string word;
-        size_t line_length = 0;
-        while (words >> word) {
-            if (line_length + word.length() + 1 > width) {
+        // Split by newlines first to preserve explicit line breaks
+        std::istringstream lines(text);
+        std::string line;
+        bool first_line = true;
+        while (std::getline(lines, line)) {
+            if (!first_line) {
                 out << "\n";
-                line_length = 0;
             }
-            if (line_length > 0) {
-                out << " ";
-                line_length++;
+            first_line = false;
+
+            // Now wrap each line individually
+            std::istringstream words(line);
+            std::string word;
+            size_t line_length = 0;
+            while (words >> word) {
+                if (line_length + word.length() + 1 > width) {
+                    out << "\n";
+                    line_length = 0;
+                }
+                if (line_length > 0) {
+                    out << " ";
+                    line_length++;
+                }
+                out << word;
+                line_length += word.length();
             }
-            out << word;
-            line_length += word.length();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/barretenberg/issues/1606

## Summary
- Fixes help text formatting in bb CLI to preserve explicit newlines
- Formats `--verifier_target` options as an aligned table for better readability

**Before:**
```
-t,--verifier_target [BB_VERIFIER_TARGET]
                     Target verification environment. Determines hash function
                     and ZK settings. evm: Ethereum/Solidity verification
                     (keccak, ZK) evm-no-zk: Ethereum/Solidity without
                     zero-knowledge noir-recursive: Recursive verification in
                     Noir circuits (poseidon2, ZK) ...
```

**After:**
```
-t,--verifier_target [BB_VERIFIER_TARGET]
                     Target verification environment. Determines hash function
                     and ZK settings.

                     Options:
                       evm                  Ethereum/Solidity (keccak, ZK)
                       evm-no-zk            Ethereum/Solidity without ZK
                       noir-recursive       Noir circuits (poseidon2, ZK)
                       noir-recursive-no-zk Noir circuits without ZK
                       noir-rollup          Rollup with IPA (poseidon2, ZK)
                       noir-rollup-no-zk    Rollup without ZK
                       starknet             Starknet via Garaga (ZK)
                       starknet-no-zk       Starknet without ZK
```

## Test plan
- [x] Built bb and verified `bb prove --help` shows formatted options