### PR TITLE
refactor(archiver): make addLogs idempotent

### DIFF
--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -2708,4 +2708,104 @@ describe('KVArchiverDataStore', () => {
       expect(retrievedStatus).toEqual(statusWithEmptyArrays);
     });
   });
+
+  describe('idempotency', () => {
+    it('handles adding blocks via addBlocks then same blocks via addCheckpoints', async () => {
+      // First add checkpoint 1 to establish a base
+      const checkpoint1 = makePublishedCheckpoint(
+        await Checkpoint.random(CheckpointNumber(1), { numBlocks: 1, startBlockNumber: 1 }),
+        5,
+      );
+      await store.addCheckpoints([checkpoint1]);
+
+      // Add provisional block 2 via addBlocks
+      const provisionalBlock = await L2BlockNew.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: 0,
+        lastArchive: checkpoint1.checkpoint.blocks[0].archive,
+      });
+      await store.addBlocks([provisionalBlock]);
+
+      // Now add checkpoint 2 containing the same block via addCheckpoints
+      const checkpoint2 = new Checkpoint(
+        provisionalBlock.archive,
+        CheckpointHeader.random(),
+        [provisionalBlock],
+        CheckpointNumber(2),
+      );
+      const publishedCheckpoint2 = makePublishedCheckpoint(checkpoint2, 10);
+
+      // This should NOT throw - addCheckpoints uses .set() which is idempotent
+      await expect(store.addCheckpoints([publishedCheckpoint2])).resolves.toBe(true);
+
+      // Verify block exists and is consistent
+      const storedBlock = await store.getBlock(BlockNumber(2));
+      expect(storedBlock?.archive.root.equals(provisionalBlock.archive.root)).toBe(true);
+    });
+
+    it('does not throw when adding the same contract class twice', async () => {
+      const contractClass = await makeContractClassPublic();
+      const commitment = await computePublicBytecodeCommitment(contractClass.packedBytecode);
+
+      // Add contract class first time
+      await store.addContractClasses([contractClass], [commitment], BlockNumber(1));
+
+      // Add same contract class again - should not throw (uses setIfNotExists)
+      await store.addContractClasses([contractClass], [commitment], BlockNumber(2));
+
+      // Verify contract class exists
+      const retrieved = await store.getContractClass(contractClass.id);
+      expect(retrieved).toBeDefined();
+    });
+
+    it('does not throw when adding the same contract instance twice', async () => {
+      const contractClass = await makeContractClassPublic();
+      await store.addContractClasses(
+        [contractClass],
+        [await computePublicBytecodeCommitment(contractClass.packedBytecode)],
+        BlockNumber(1),
+      );
+
+      const instance = {
+        ...(await SerializableContractInstance.random({
+          currentContractClassId: contractClass.id,
+          originalContractClassId: contractClass.id,
+        })),
+        address: await AztecAddress.random(),
+      };
+
+      // Add contract instance first time
+      await store.addContractInstances([instance], BlockNumber(1));
+
+      // Add same contract instance again - should not throw (uses set)
+      await store.addContractInstances([instance], BlockNumber(2));
+
+      // Verify instance exists
+      const retrieved = await store.getContractInstance(instance.address, 1000n);
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.address.equals(instance.address)).toBe(true);
+    });
+
+    it('does not duplicate logs when addLogs is called twice with same block', async () => {
+      const block = await L2BlockNew.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: 0,
+      });
+
+      // Add logs first time
+      await store.addLogs([block]);
+
+      // Get initial log count
+      const initialLogs = await store.getPublicLogs({ fromBlock: BlockNumber(1), toBlock: BlockNumber(2) });
+      const initialCount = initialLogs.logs.length;
+      expect(initialCount).toBeGreaterThan(0);
+
+      // Add logs second time (same block)
+      await store.addLogs([block]);
+
+      // Verify logs are NOT duplicated
+      const finalLogs = await store.getPublicLogs({ fromBlock: BlockNumber(1), toBlock: BlockNumber(2) });
+      expect(finalLogs.logs.length).toBe(initialCount);
+    });
+  });
 });

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -1,5 +1,6 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { filterAsync } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, numToUInt32BE } from '@aztec/foundation/serialize';
@@ -144,92 +145,127 @@ export class LogStore {
     return { privateTaggedLogs, publicTaggedLogs };
   }
 
+  async #addPrivateLogs(blocks: L2BlockNew[]): Promise<void> {
+    const newBlocks = await filterAsync(
+      blocks,
+      async block => !(await this.#privateLogKeysByBlock.hasAsync(block.number)),
+    );
+
+    const { privateTaggedLogs } = this.#extractTaggedLogs(newBlocks);
+    const keysOfPrivateLogsToUpdate = Array.from(privateTaggedLogs.keys());
+
+    const currentPrivateTaggedLogs = await Promise.all(
+      keysOfPrivateLogsToUpdate.map(async key => ({
+        tag: key,
+        logBuffers: await this.#privateLogsByTag.getAsync(key),
+      })),
+    );
+
+    for (const taggedLogBuffer of currentPrivateTaggedLogs) {
+      if (taggedLogBuffer.logBuffers && taggedLogBuffer.logBuffers.length > 0) {
+        privateTaggedLogs.set(
+          taggedLogBuffer.tag,
+          taggedLogBuffer.logBuffers!.concat(privateTaggedLogs.get(taggedLogBuffer.tag)!),
+        );
+      }
+    }
+
+    for (const block of newBlocks) {
+      const privateTagsInBlock: string[] = [];
+      for (const [tag, logs] of privateTaggedLogs.entries()) {
+        await this.#privateLogsByTag.set(tag, logs);
+        privateTagsInBlock.push(tag);
+      }
+      await this.#privateLogKeysByBlock.set(block.number, privateTagsInBlock);
+    }
+  }
+
+  async #addPublicLogs(blocks: L2BlockNew[]): Promise<void> {
+    const newBlocks = await filterAsync(
+      blocks,
+      async block => !(await this.#publicLogKeysByBlock.hasAsync(block.number)),
+    );
+
+    const { publicTaggedLogs } = this.#extractTaggedLogs(newBlocks);
+    const keysOfPublicLogsToUpdate = Array.from(publicTaggedLogs.keys());
+
+    const currentPublicTaggedLogs = await Promise.all(
+      keysOfPublicLogsToUpdate.map(async key => ({
+        tag: key,
+        logBuffers: await this.#publicLogsByContractAndTag.getAsync(key),
+      })),
+    );
+
+    for (const taggedLogBuffer of currentPublicTaggedLogs) {
+      if (taggedLogBuffer.logBuffers && taggedLogBuffer.logBuffers.length > 0) {
+        publicTaggedLogs.set(
+          taggedLogBuffer.tag,
+          taggedLogBuffer.logBuffers!.concat(publicTaggedLogs.get(taggedLogBuffer.tag)!),
+        );
+      }
+    }
+
+    for (const block of newBlocks) {
+      const blockHash = await block.hash();
+      const publicTagsInBlock: string[] = [];
+      for (const [tag, logs] of publicTaggedLogs.entries()) {
+        await this.#publicLogsByContractAndTag.set(tag, logs);
+        publicTagsInBlock.push(tag);
+      }
+      await this.#publicLogKeysByBlock.set(block.number, publicTagsInBlock);
+
+      const publicLogsInBlock = block.body.txEffects
+        .map((txEffect, txIndex) =>
+          [
+            numToUInt32BE(txIndex),
+            numToUInt32BE(txEffect.publicLogs.length),
+            txEffect.publicLogs.map(log => log.toBuffer()),
+          ].flat(),
+        )
+        .flat();
+
+      await this.#publicLogsByBlock.set(block.number, this.#packWithBlockHash(blockHash, publicLogsInBlock));
+    }
+  }
+
+  async #addContractClassLogs(blocks: L2BlockNew[]): Promise<void> {
+    const newBlocks = await filterAsync(
+      blocks,
+      async block => !(await this.#contractClassLogsByBlock.hasAsync(block.number)),
+    );
+
+    for (const block of newBlocks) {
+      const blockHash = await block.hash();
+
+      const contractClassLogsInBlock = block.body.txEffects
+        .map((txEffect, txIndex) =>
+          [
+            numToUInt32BE(txIndex),
+            numToUInt32BE(txEffect.contractClassLogs.length),
+            txEffect.contractClassLogs.map(log => log.toBuffer()),
+          ].flat(),
+        )
+        .flat();
+
+      await this.#contractClassLogsByBlock.set(
+        block.number,
+        this.#packWithBlockHash(blockHash, contractClassLogsInBlock),
+      );
+    }
+  }
+
   /**
    * Append new logs to the store's list.
    * @param blocks - The blocks for which to add the logs.
    * @returns True if the operation is successful.
    */
   addLogs(blocks: L2BlockNew[]): Promise<boolean> {
-    const { privateTaggedLogs, publicTaggedLogs } = this.#extractTaggedLogs(blocks);
-
-    const keysOfPrivateLogsToUpdate = Array.from(privateTaggedLogs.keys());
-    const keysOfPublicLogsToUpdate = Array.from(publicTaggedLogs.keys());
-
     return this.db.transactionAsync(async () => {
-      const currentPrivateTaggedLogs = await Promise.all(
-        keysOfPrivateLogsToUpdate.map(async key => ({
-          tag: key,
-          logBuffers: await this.#privateLogsByTag.getAsync(key),
-        })),
-      );
-      currentPrivateTaggedLogs.forEach(taggedLogBuffer => {
-        if (taggedLogBuffer.logBuffers && taggedLogBuffer.logBuffers.length > 0) {
-          privateTaggedLogs.set(
-            taggedLogBuffer.tag,
-            taggedLogBuffer.logBuffers!.concat(privateTaggedLogs.get(taggedLogBuffer.tag)!),
-          );
-        }
-      });
-
-      const currentPublicTaggedLogs = await Promise.all(
-        keysOfPublicLogsToUpdate.map(async key => ({
-          key,
-          logBuffers: await this.#publicLogsByContractAndTag.getAsync(key),
-        })),
-      );
-      currentPublicTaggedLogs.forEach(taggedLogBuffer => {
-        if (taggedLogBuffer.logBuffers && taggedLogBuffer.logBuffers.length > 0) {
-          publicTaggedLogs.set(
-            taggedLogBuffer.key,
-            taggedLogBuffer.logBuffers!.concat(publicTaggedLogs.get(taggedLogBuffer.key)!),
-          );
-        }
-      });
-
-      for (const block of blocks) {
-        const blockHash = await block.hash();
-
-        const privateTagsInBlock: string[] = [];
-        for (const [tag, logs] of privateTaggedLogs.entries()) {
-          await this.#privateLogsByTag.set(tag, logs);
-          privateTagsInBlock.push(tag);
-        }
-        await this.#privateLogKeysByBlock.set(block.number, privateTagsInBlock);
-
-        const publicKeysInBlock: string[] = [];
-        for (const [key, logs] of publicTaggedLogs.entries()) {
-          await this.#publicLogsByContractAndTag.set(key, logs);
-          publicKeysInBlock.push(key);
-        }
-        await this.#publicLogKeysByBlock.set(block.number, publicKeysInBlock);
-
-        const publicLogsInBlock = block.body.txEffects
-          .map((txEffect, txIndex) =>
-            [
-              numToUInt32BE(txIndex),
-              numToUInt32BE(txEffect.publicLogs.length),
-              txEffect.publicLogs.map(log => log.toBuffer()),
-            ].flat(),
-          )
-          .flat();
-
-        const contractClassLogsInBlock = block.body.txEffects
-          .map((txEffect, txIndex) =>
-            [
-              numToUInt32BE(txIndex),
-              numToUInt32BE(txEffect.contractClassLogs.length),
-              txEffect.contractClassLogs.map(log => log.toBuffer()),
-            ].flat(),
-          )
-          .flat();
-
-        await this.#publicLogsByBlock.set(block.number, this.#packWithBlockHash(blockHash, publicLogsInBlock));
-        await this.#contractClassLogsByBlock.set(
-          block.number,
-          this.#packWithBlockHash(blockHash, contractClassLogsInBlock),
-        );
-      }
-
+      await Promise.all([
+        this.#addPrivateLogs(blocks),
+        this.#addPublicLogs(blocks),
+        this.#addContractClassLogs(blocks),
+      ]);
       return true;
     });
   }


### PR DESCRIPTION
Split `addLogs` into separate private methods (`#addPrivateLogs`, `#addPublicLogs`, `#addContractClassLogs`), such that each method checks if the block was already processed before adding logs, preventing duplicates.

This adds a line of defense against accidentally processing block data twice in the arhiver, which had happened when processing proposed and checkpointed blocks, but is now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)