### PR TITLE
fix(sequencer): query L1 for pending tip archive when building on invalid chain

### DIFF
--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -47,6 +47,15 @@ export class LightweightCheckpointBuilder {
     public readonly l1ToL2Messages: Fr[],
     private readonly previousCheckpointOutHashes: Fr[],
     public readonly db: MerkleTreeWriteOperations,
+    /**
+     * Override for the initial lastArchive root. When provided, the builder will use this root
+     * instead of reading from the database. This is used when building on top of an invalid
+     * checkpoint that the archiver has skipped, where we need to reference the invalid
+     * checkpoint's archive root even though we don't have its state. The nextAvailableLeafIndex
+     * will be taken from the current database state, which may be inconsistent but is acceptable
+     * since these blocks are expected to fail proof verification anyway.
+     */
+    private readonly lastArchiveRootOverride?: Fr,
   ) {
     this.spongeBlob = SpongeBlob.init();
     this.logger.debug('Starting new checkpoint', { constants, l1ToL2Messages });
@@ -58,6 +67,7 @@ export class LightweightCheckpointBuilder {
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     db: MerkleTreeWriteOperations,
+    lastArchiveRootOverride?: Fr,
   ): Promise<LightweightCheckpointBuilder> {
     // Insert l1-to-l2 messages into the tree.
     await db.appendLeaves(
@@ -71,6 +81,7 @@ export class LightweightCheckpointBuilder {
       l1ToL2Messages,
       previousCheckpointOutHashes,
       db,
+      lastArchiveRootOverride,
     );
   }
 
@@ -151,7 +162,14 @@ export class LightweightCheckpointBuilder {
     }
 
     if (isFirstBlock) {
-      this.lastArchives.push(await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db));
+      // Get the archive snapshot from current world state
+      const currentArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.db);
+      // Use the override root if provided (e.g., when building on top of an invalid checkpoint
+      // that the archiver has skipped), but keep the current state's nextAvailableLeafIndex.
+      const initialArchive = this.lastArchiveRootOverride
+        ? new AppendOnlyTreeSnapshot(this.lastArchiveRootOverride, currentArchive.nextAvailableLeafIndex)
+        : currentArchive;
+      this.lastArchives.push(initialArchive);
     }
 
     const lastArchive = this.lastArchives.at(-1)!;

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -410,6 +410,15 @@ export class SequencerPublisher {
   }
 
   /**
+   * Gets the current pending tip archive from L1.
+   * This is useful when building on top of an invalid chain, where the archiver's state
+   * may not reflect L1's actual pending tip (e.g., when multiple invalid checkpoints exist).
+   */
+  public getL1PendingTipArchive(): Promise<Fr> {
+    return this.rollupContract.archive();
+  }
+
+  /**
    * @notice  Will call `canProposeAtNextEthBlock` to make sure that it is possible to propose
    * @param tipArchive - The archive to check
    * @returns The slot and block number if it is possible to propose, undefined otherwise

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -433,6 +433,7 @@ describe('CheckpointProposalJob', () => {
       publisher,
       attestorAddress,
       undefined, // invalidateBlock
+      undefined, // lastArchiveOverride
       validatorClient,
       globalVariableBuilder,
       p2p,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -67,6 +67,8 @@ export class CheckpointProposalJob implements Traceable {
     private readonly publisher: SequencerPublisher,
     private readonly attestorAddress: EthAddress,
     private readonly invalidateCheckpoint: InvalidateCheckpointRequest | undefined,
+    /** Archive root override to use when building on top of an invalid checkpoint that wasn't synced. */
+    private readonly lastArchiveRootOverride: Fr | undefined,
     private readonly validatorClient: ValidatorClient,
     private readonly globalsBuilder: GlobalVariableBuilder,
     private readonly p2pClient: P2P,
@@ -157,7 +159,9 @@ export class CheckpointProposalJob implements Traceable {
       this.metrics.incOpenSlot(this.slot, this.proposer?.toString() ?? 'unknown');
 
       // Enqueues checkpoint invalidation (constant for the whole slot)
-      if (this.invalidateCheckpoint && !this.config.skipInvalidateBlockAsProposer) {
+      const invalidationEnqueued =
+        this.invalidateCheckpoint !== undefined && !this.config.skipInvalidateBlockAsProposer;
+      if (invalidationEnqueued) {
         this.publisher.enqueueInvalidateCheckpoint(this.invalidateCheckpoint);
       }
 
@@ -188,6 +192,7 @@ export class CheckpointProposalJob implements Traceable {
         l1ToL2Messages,
         previousCheckpointOutHashes,
         fork,
+        this.lastArchiveRootOverride,
       );
 
       // Options for the validator client when creating block and checkpoint proposals
@@ -271,7 +276,10 @@ export class CheckpointProposalJob implements Traceable {
       const txTimeoutAt = new Date((slotStartBuildTimestamp + aztecSlotDuration) * 1000);
       await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
         txTimeoutAt,
-        forcePendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
+        // Only include forcePendingCheckpointNumber if the invalidation was enqueued
+        forcePendingCheckpointNumber: invalidationEnqueued
+          ? this.invalidateCheckpoint?.forcePendingCheckpointNumber
+          : undefined,
       });
 
       return checkpoint;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -264,8 +264,21 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return undefined;
     }
 
-    // Next checkpoint follows from the last synced one
-    const checkpointNumber = CheckpointNumber(syncedTo.checkpointNumber + 1);
+    // Next checkpoint number follows from the last synced one, unless the pending chain is invalid
+    // and we're configured to skip invalidation (skipInvalidateBlockAsProposer). In that case,
+    // we need to build on top of the invalid checkpoint instead of trying to replace it.
+    let checkpointNumber: CheckpointNumber;
+    if (
+      !syncedTo.pendingChainValidationStatus.valid &&
+      this.config.skipInvalidateBlockAsProposer &&
+      syncedTo.pendingChainValidationStatus.checkpoint
+    ) {
+      // Build on top of the invalid checkpoint
+      checkpointNumber = CheckpointNumber(syncedTo.pendingChainValidationStatus.checkpoint.checkpointNumber + 1);
+    } else {
+      // Normal case: build from the last synced checkpoint
+      checkpointNumber = CheckpointNumber(syncedTo.checkpointNumber + 1);
+    }
 
     const logCtx = {
       now,
@@ -313,15 +326,60 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     // Prepare invalidation request if the pending chain is invalid (returns undefined if no need)
-    const invalidateCheckpoint = await publisher.simulateInvalidateCheckpoint(syncedTo.pendingChainValidationStatus);
+    // Skip this if skipInvalidateBlockAsProposer is true, since we won't actually invalidate
+    const invalidateCheckpoint = this.config.skipInvalidateBlockAsProposer
+      ? undefined
+      : await publisher.simulateInvalidateCheckpoint(syncedTo.pendingChainValidationStatus);
+
+    // When building on top of an invalid checkpoint (skipInvalidateBlockAsProposer is true),
+    // we need to use L1's actual pending tip archive, not the archiver's synced archive.
+    // The archiver's pendingChainValidationStatus points to the FIRST invalid checkpoint,
+    // but when multiple invalid checkpoints exist, L1's tip is at the LATEST one.
+    // lastArchiveRootOverride is passed to the checkpoint builder to override the initial archive root
+    // when building blocks, since our world state doesn't have the invalid checkpoint's state.
+    const shouldBuildOnInvalidChain =
+      !syncedTo.pendingChainValidationStatus.valid && this.config.skipInvalidateBlockAsProposer;
+    let lastArchiveRootOverride: Fr | undefined;
+
+    if (shouldBuildOnInvalidChain && !syncedTo.pendingChainValidationStatus.valid) {
+      // Query L1 directly for the actual pending tip archive, since the archiver may not have synced
+      // all invalid checkpoints (it only tracks the first one).
+      lastArchiveRootOverride = await publisher.getL1PendingTipArchive();
+      this.log.info(`Building on invalid chain with L1 tip archive`, {
+        ...logCtx,
+        l1TipArchive: lastArchiveRootOverride.toString(),
+        archiverFirstInvalidCheckpoint: syncedTo.pendingChainValidationStatus.checkpoint.archive.toString(),
+      });
+    }
+    const proposalArchive = lastArchiveRootOverride ?? syncedTo.archive;
 
     // Check with the rollup contract if we can indeed propose at the next L2 slot. This check should not fail
     // if all the previous checks are good, but we do it just in case.
-    const canProposeCheck = await publisher.canProposeAtNextEthBlock(
-      syncedTo.archive,
+    let canProposeCheck = await publisher.canProposeAtNextEthBlock(
+      proposalArchive,
       proposer ?? EthAddress.ZERO,
       invalidateCheckpoint,
     );
+
+    // If the check failed and we were using lastArchiveRootOverride, it might be because the invalid
+    // checkpoint was already invalidated on L1 (but the archiver's status is stale). Retry with the
+    // synced archive instead.
+    if (canProposeCheck === undefined && lastArchiveRootOverride) {
+      this.log.info(
+        `Retrying canProposeAtNextEthBlock with synced archive (invalid checkpoint may have been removed)`,
+        { ...logCtx, originalArchive: lastArchiveRootOverride.toString(), syncedArchive: syncedTo.archive.toString() },
+      );
+      canProposeCheck = await publisher.canProposeAtNextEthBlock(
+        syncedTo.archive,
+        proposer ?? EthAddress.ZERO,
+        invalidateCheckpoint,
+      );
+      if (canProposeCheck !== undefined) {
+        // The invalid checkpoint was indeed removed, so we should build on the synced checkpoint instead
+        checkpointNumber = CheckpointNumber(syncedTo.checkpointNumber + 1);
+        lastArchiveRootOverride = undefined;
+      }
+    }
 
     if (canProposeCheck === undefined) {
       this.log.warn(
@@ -344,13 +402,23 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     if (canProposeCheck.checkpointNumber !== checkpointNumber) {
-      this.log.warn(
-        `Cannot propose due to block mismatch with rollup contract (this can be caused by a pending archiver sync). Expected checkpoint ${checkpointNumber} but got ${canProposeCheck.checkpointNumber}.`,
-        { ...logCtx, rollup: canProposeCheck, expectedSlot: slot },
-      );
-      this.emit('proposer-rollup-check-failed', { reason: 'Block mismatch', slot });
-      this.metrics.recordBlockProposalPrecheckFailed('block_number_mismatch');
-      return undefined;
+      // When building on an invalid chain, the archiver's checkpoint number may be stale.
+      // Use L1's checkpoint number instead.
+      if (shouldBuildOnInvalidChain) {
+        this.log.info(
+          `Using L1 checkpoint number ${canProposeCheck.checkpointNumber} instead of archiver's ${checkpointNumber} when building on invalid chain`,
+          { ...logCtx, rollup: canProposeCheck },
+        );
+        checkpointNumber = canProposeCheck.checkpointNumber;
+      } else {
+        this.log.warn(
+          `Cannot propose due to block mismatch with rollup contract (this can be caused by a pending archiver sync). Expected checkpoint ${checkpointNumber} but got ${canProposeCheck.checkpointNumber}.`,
+          { ...logCtx, rollup: canProposeCheck, expectedSlot: slot },
+        );
+        this.emit('proposer-rollup-check-failed', { reason: 'Block mismatch', slot });
+        this.metrics.recordBlockProposalPrecheckFailed('block_number_mismatch');
+        return undefined;
+      }
     }
 
     this.lastSlotForCheckpointProposalJob = slot;
@@ -366,6 +434,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       publisher,
       attestorAddress,
       invalidateCheckpoint,
+      lastArchiveRootOverride,
     );
   }
 
@@ -378,6 +447,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     publisher: SequencerPublisher,
     attestorAddress: EthAddress,
     invalidateCheckpoint: InvalidateCheckpointRequest | undefined,
+    lastArchiveRootOverride: Fr | undefined,
   ): CheckpointProposalJob {
     return new CheckpointProposalJob(
       epoch,
@@ -388,6 +458,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       publisher,
       attestorAddress,
       invalidateCheckpoint,
+      lastArchiveRootOverride,
       this.validatorClient,
       this.globalsBuilder,
       this.p2pClient,

--- a/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
+++ b/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
@@ -189,6 +189,7 @@ export class MockCheckpointsBuilder implements FunctionsOf<FullNodeCheckpointsBu
     constants: CheckpointGlobalVariables;
     l1ToL2Messages: Fr[];
     previousCheckpointOutHashes: Fr[];
+    lastArchiveRootOverride?: Fr;
   }> = [];
   public openCheckpointCalls: Array<{
     checkpointNumber: CheckpointNumber;
@@ -244,8 +245,15 @@ export class MockCheckpointsBuilder implements FunctionsOf<FullNodeCheckpointsBu
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     _fork: unknown,
+    lastArchiveRootOverride?: Fr,
   ): Promise<CheckpointBuilder> {
-    this.startCheckpointCalls.push({ checkpointNumber, constants, l1ToL2Messages, previousCheckpointOutHashes });
+    this.startCheckpointCalls.push({
+      checkpointNumber,
+      constants,
+      l1ToL2Messages,
+      previousCheckpointOutHashes,
+      lastArchiveRootOverride,
+    });
 
     if (!this.checkpointBuilder) {
       // Auto-create a builder if none was set

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -191,6 +191,10 @@ export class FullNodeCheckpointsBuilder {
 
   /**
    * Starts a new checkpoint and returns a CheckpointBuilder to build blocks within it.
+   * @param lastArchiveRootOverride - Optional archive root to use as the initial lastArchive
+   *   instead of reading from the fork's database. This is used when building on top of an
+   *   invalid checkpoint that the archiver has skipped, where we need to reference the invalid
+   *   checkpoint's archive root even though we don't have its state.
    */
   async startCheckpoint(
     checkpointNumber: CheckpointNumber,
@@ -198,6 +202,7 @@ export class FullNodeCheckpointsBuilder {
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     fork: MerkleTreeWriteOperations,
+    lastArchiveRootOverride?: Fr,
   ): Promise<CheckpointBuilder> {
     const stateReference = await fork.getStateReference();
     const archiveTree = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
@@ -207,6 +212,7 @@ export class FullNodeCheckpointsBuilder {
       msgCount: l1ToL2Messages.length,
       initialStateReference: stateReference.toInspect(),
       initialArchiveRoot: bufferToHex(archiveTree.root),
+      lastArchiveRootOverride: lastArchiveRootOverride?.toString(),
       constants,
     });
 
@@ -216,6 +222,7 @@ export class FullNodeCheckpointsBuilder {
       l1ToL2Messages,
       previousCheckpointOutHashes,
       fork,
+      lastArchiveRootOverride,
     );
 
     return new CheckpointBuilder(


### PR DESCRIPTION
## Summary

When building checkpoints on top of an invalid chain (`skipInvalidateBlockAsProposer=true`), the sequencer now queries L1 directly for the actual pending tip archive instead of using the archiver's stale state. This fixes the "proposer invalidates multiple blocks" e2e test which was timing out.

- Add `getL1PendingTipArchive()` to query L1's actual pending tip archive
- Pass `lastArchiveRootOverride` through the checkpoint building pipeline
- Accept L1's checkpoint number when building on invalid chains (archiver's is stale)

The fix addresses two issues:
1. **Archive mismatch**: The archiver only stores the first invalid checkpoint's archive in `pendingChainValidationStatus`, but when multiple invalid checkpoints exist, L1's actual tip is at the latest one
2. **Checkpoint number mismatch**: The archiver's checkpoint number is stale compared to L1's when checkpoints are invalidated and re-published

## Test plan

- [x] Ran `e2e_epochs/epochs_invalidate_block.parallel.test.ts` - "proposer invalidates multiple blocks" test now passes (~185s vs 600s timeout before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)