### PR TITLE
fix(archiver): update l1 synchronizer config on archiver config update

### DIFF
--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -144,6 +144,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   /** Updates archiver config */
   public updateConfig(newConfig: Partial<ArchiverConfig>) {
     this.config = merge(this.config, mapArchiverConfig(newConfig));
+    this.synchronizer.setConfig(this.config);
   }
 
   /**

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -64,7 +64,7 @@ export class ArchiverL1Synchronizer implements Traceable {
       'registryAddress' | 'governanceProposerAddress' | 'slashFactoryAddress'
     > & { slashingProposerAddress: EthAddress },
     private readonly store: KVArchiverDataStore,
-    private readonly config: {
+    private config: {
       batchSize: number;
       skipValidateCheckpointAttestations?: boolean;
       maxAllowedEthClientDriftSeconds: number;
@@ -80,6 +80,15 @@ export class ArchiverL1Synchronizer implements Traceable {
   ) {
     this.updater = new ArchiverDataStoreUpdater(this.store);
     this.tracer = tracer;
+  }
+
+  /** Sets new config */
+  public setConfig(newConfig: {
+    batchSize: number;
+    skipValidateCheckpointAttestations?: boolean;
+    maxAllowedEthClientDriftSeconds: number;
+  }) {
+    this.config = newConfig;
   }
 
   /** Returns the last L1 block number that was synced. */


### PR DESCRIPTION
When we extracted the archiver l1 synchronizer to a separate module, we forgot to wire the archiver's updateConfig to also update the synchronizer's config.

That broke tests that dependend on updating config dynamically, such as `proposer invalidates multiple blocks` by setting
`skipValidateCheckpointAttestations`.