### PR TITLE
fix(l1-contracts): check escape hatch before committee setup in propose

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -198,10 +198,19 @@ library ProposeLib {
     // Compute header hash for computing the payload digest
     v.headerHash = ProposedHeaderLib.hash(v.header);
 
+    // Compute current epoch and check escape hatch BEFORE setupEpoch.
+    v.currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
+    v.escapeHatch = ValidatorSelectionLib.getEscapeHatch();
+    if (address(v.escapeHatch) != address(0)) {
+      (v.isEscapeHatch, v.escapeHatchProposer) = v.escapeHatch.isHatchOpen(v.currentEpoch);
+    }
+
     // Setup epoch by sampling the committee for the current epoch and setting the seed for the one after the next.
     // This is a no-op if the epoch is already set up, so it only gets executed by the first checkpoint of the epoch.
-    v.currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    ValidatorSelectionLib.setupEpoch(v.currentEpoch);
+    // Skip during escape hatch to allow proposals even with insufficient validators for committee formation.
+    if (!v.isEscapeHatch) {
+      ValidatorSelectionLib.setupEpoch(v.currentEpoch);
+    }
 
     // Calculate mana min fee components for header validation
     ManaMinFeeComponents memory components;
@@ -226,12 +235,6 @@ library ProposeLib {
     );
 
     RollupStore storage rollupStore = STFLib.getStorage();
-    {
-      v.escapeHatch = ValidatorSelectionLib.getEscapeHatch();
-      if (address(v.escapeHatch) != address(0)) {
-        (v.isEscapeHatch, v.escapeHatchProposer) = v.escapeHatch.isHatchOpen(v.currentEpoch);
-      }
-    }
 
     if (v.isEscapeHatch) {
       // During escape hatch, only the designated proposer can propose

--- a/l1-contracts/test/escape-hatch/integration/propose.t.sol
+++ b/l1-contracts/test/escape-hatch/integration/propose.t.sol
@@ -17,6 +17,13 @@ import {CommitteeAttestations, Signature} from "@aztec/core/libraries/rollup/Att
  *      and uses escape hatch proposer selection when escape hatch is active.
  */
 contract proposeTest is EscapeHatchIntegrationBase {
+  // Storage variables to avoid stack-too-deep in fuzz tests
+  uint256 internal upperLimit;
+  address internal designatedProposer;
+  bytes32 internal archiveRoot;
+  ProposeArgs internal proposeArgs;
+  bytes internal blobsData;
+
   function test_GivenEscapeHatchIsNotConfigured() external setup(4, 4) progressEpochsToInclusion {
     // it should use normal validator selection verification
     full = load("mixed_checkpoint_1");
@@ -47,7 +54,7 @@ contract proposeTest is EscapeHatchIntegrationBase {
     // We're at an epoch that is NOT an escape hatch epoch
     Epoch currentEpoch = rollup.getCurrentEpoch();
 
-    uint256 upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
+    upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
     // Any time during the epoch should be acceptable
     vm.warp(bound(_ts, block.timestamp, upperLimit));
 
@@ -72,47 +79,46 @@ contract proposeTest is EscapeHatchIntegrationBase {
     _;
   }
 
-  function test_WhenCallerIsNotTheDesignatedProposer(uint256 _ts)
+  function test_WhenCallerIsNotTheDesignatedProposer(uint256 _ts, uint256 _validatorCount, address _wrongProposer)
     external
-    setup(4, 4)
+    setup(bound(_validatorCount, 0, 4), 4)
     progressEpochsToInclusion
     givenEscapeHatchIsConfigured
     whenEscapeHatchIsOpenForCurrentEpoch
   {
+    vm.assume(_wrongProposer != CANDIDATE1 && _wrongProposer != address(0));
     // it should revert with Rollup__InvalidEscapeHatchProposer
     full = load("empty_checkpoint_1");
 
-    uint256 upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
+    upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
     // Any time during the epoch should be acceptable
     vm.warp(bound(_ts, block.timestamp, upperLimit));
 
-    // Try to propose as the committee proposer (not the escape hatch proposer)
-    address committeeProposer = rollup.getCurrentProposer();
-    address escapeHatchProposer = escapeHatch.getDesignatedProposer(targetHatch);
+    designatedProposer = escapeHatch.getDesignatedProposer(targetHatch);
 
-    assertEq(escapeHatchProposer, CANDIDATE1, "CANDIDATE1 should be escape hatch proposer");
-    assertTrue(committeeProposer != escapeHatchProposer, "Committee proposer should differ from escape hatch proposer");
+    assertEq(designatedProposer, CANDIDATE1, "CANDIDATE1 should be escape hatch proposer");
+    assertTrue(_wrongProposer != designatedProposer, "Wrong proposer should differ from escape hatch proposer");
 
-    (ProposeArgs memory args, bytes memory blobs) = _buildProposeArgs(committeeProposer);
+    (proposeArgs, blobsData) = _buildProposeArgs(_wrongProposer);
     skipBlobCheck(address(rollup));
 
     vm.expectRevert(
-      abi.encodeWithSelector(Errors.Rollup__InvalidEscapeHatchProposer.selector, escapeHatchProposer, committeeProposer)
+      abi.encodeWithSelector(Errors.Rollup__InvalidEscapeHatchProposer.selector, designatedProposer, _wrongProposer)
     );
 
-    vm.prank(committeeProposer);
+    vm.prank(_wrongProposer);
     rollup.propose(
-      args,
+      proposeArgs,
       CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
       new address[](0),
       Signature({v: 0, r: 0, s: 0}),
-      blobs
+      blobsData
     );
   }
 
-  function test_WhenCallerIsTheDesignatedProposer(uint256 _ts)
+  function test_WhenCallerIsTheDesignatedProposer(uint256 _ts, uint256 _validatorCount)
     external
-    setup(4, 4)
+    setup(bound(_validatorCount, 0, 4), 4)
     progressEpochsToInclusion
     givenEscapeHatchIsConfigured
     whenEscapeHatchIsOpenForCurrentEpoch
@@ -122,20 +128,19 @@ contract proposeTest is EscapeHatchIntegrationBase {
     // it should record the checkpoint normally
     full = load("empty_checkpoint_1");
 
-    address escapeHatchProposer = escapeHatch.getDesignatedProposer(targetHatch);
-    assertEq(escapeHatchProposer, CANDIDATE1, "CANDIDATE1 should be escape hatch proposer");
+    assertEq(escapeHatch.getDesignatedProposer(targetHatch), CANDIDATE1, "CANDIDATE1 should be escape hatch proposer");
 
     // Verify candidate info before proposal
     CandidateInfo memory infoBefore = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(infoBefore.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0 before");
     assertEq(infoBefore.lastSubmittedArchive, bytes32(0), "lastSubmittedArchive should be 0 before");
 
-    uint256 upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
+    upperLimit = Timestamp.unwrap(rollup.getTimestampForEpoch(rollup.getCurrentEpoch() + Epoch.wrap(2))) - 1;
     // Any time during the epoch should be acceptable
     vm.warp(bound(_ts, block.timestamp, upperLimit));
 
     // Propose as the escape hatch proposer
-    bytes32 archiveRoot = _proposeWithHatch(CANDIDATE1);
+    archiveRoot = _proposeWithHatch(CANDIDATE1);
 
     // Verify checkpoint was recorded
     assertEq(rollup.getPendingCheckpointNumber(), 1, "Checkpoint should be proposed");
@@ -145,18 +150,18 @@ contract proposeTest is EscapeHatchIntegrationBase {
     assertEq(infoAfter.lastCheckpointNumber, 1, "lastCheckpointNumber should be updated");
     assertEq(infoAfter.lastSubmittedArchive, archiveRoot, "lastSubmittedArchive should be updated");
 
-    //
+    // Verify proposing outside escape hatch window reverts
     vm.warp(upperLimit + 1);
-    (ProposeArgs memory args, bytes memory blobs) = _buildProposeArgs(CANDIDATE1);
+    (proposeArgs, blobsData) = _buildProposeArgs(CANDIDATE1);
 
     vm.expectRevert();
     vm.prank(CANDIDATE1);
     rollup.propose(
-      args,
+      proposeArgs,
       CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
       new address[](0),
       Signature({v: 0, r: 0, s: 0}),
-      blobs
+      blobsData
     );
   }
 }


### PR DESCRIPTION
There was an issue where a failure to sample a committee could cause the escape hatch to not pass. This meant that escape hatch worked for escaping if there were censoring committees, but not to produce blocks if there were no committee. 

Tested by fuzzing the amount of validators that are in depositing such that it sometimes have insufficient validators to draw a committee. Had to deal with stack-too-deep afterwards.