### PR TITLE
chore: remove some flaky sleeps from unit tests

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -356,8 +356,3 @@ tests:
     error_regex: "tried to kill container, but did not receive an exit event"
     owners:
       - *adam
-
-  - regex: "slash_offenses_collector.test.ts"
-    error_regex: "expect(pendingOffenses"
-    owners:
-      - *palla

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -12,7 +12,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2BlockSourceEvents } from '@aztec/stdlib/block';
@@ -597,7 +597,7 @@ describe('Archiver Sync', () => {
       await archiver.syncImmediate();
 
       // Now initial sync should be complete (103 + 1 >= 103)
-      await retryUntil(() => Promise.resolve(archiver.isInitialSyncComplete()), 'initial sync complete', 10, 0.1);
+      await retryFastUntil(() => archiver.isInitialSyncComplete(), 'initial sync complete');
       expect(archiver.isInitialSyncComplete()).toBe(true);
     });
 
@@ -969,12 +969,7 @@ describe('Archiver Sync', () => {
 
       fake.setL1BlockNumber(100n);
       await archiver.start(false);
-      await retryUntil(
-        () => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)),
-        'sync',
-        10,
-        0.1,
-      );
+      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
@@ -1020,12 +1015,7 @@ describe('Archiver Sync', () => {
       // Now advance L1 so checkpoint 2 becomes visible
       fake.setL1BlockNumber(5010n);
 
-      await retryUntil(
-        () => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)),
-        'sync',
-        10,
-        0.1,
-      );
+      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)), 'sync');
 
       // Now the blocks should be checkpointed
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));
@@ -1052,12 +1042,7 @@ describe('Archiver Sync', () => {
 
       fake.setL1BlockNumber(100n);
       await archiver.start(false);
-      await retryUntil(
-        () => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)),
-        'sync',
-        10,
-        0.1,
-      );
+      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const blockAlreadySyncedFromCheckpoint = cp1.blocks[cp1.blocks.length - 1];
@@ -1076,12 +1061,7 @@ describe('Archiver Sync', () => {
 
       fake.setL1BlockNumber(100n);
       await archiver.start(false);
-      await retryUntil(
-        () => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)),
-        'sync',
-        10,
-        0.1,
-      );
+      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(1)), 'sync');
 
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const lastBlockInCheckpoint1 = cp1.blocks[cp1.blocks.length - 1].number;
@@ -1125,12 +1105,7 @@ describe('Archiver Sync', () => {
       // Now advance L1 so checkpoint 2 becomes visible
       fake.setL1BlockNumber(5010n);
 
-      await retryUntil(
-        () => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)),
-        'sync',
-        10,
-        0.1,
-      );
+      await retryFastUntil(() => archiver.getSynchedCheckpointNumber().then(n => n === CheckpointNumber(2)), 'sync');
 
       // Now all blocks should be checkpointed
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(2));

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -4,7 +4,7 @@ import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
+import { retryFastUntil, retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 
@@ -1076,7 +1076,7 @@ describe('L1TxUtils', () => {
       await cheatCodes.evmMine();
       logger.warn('Block has been mined');
 
-      await retryUntil(() => gasUtils.state === TxUtilsState.MINED, 'Waiting for mined status', 10, 0.1);
+      await retryFastUntil(() => gasUtils.state === TxUtilsState.MINED, 'Waiting for mined status');
       logger.warn('Tx is now mined according to monitor');
 
       // Although the monitoring threw that the tx timed out. Internally it should have recognized that the tx was mined
@@ -1287,7 +1287,7 @@ describe('L1TxUtils', () => {
 
       // But now yes
       await cheatCodes.mineEmptyBlock();
-      await retryUntil(() => gasUtils.state === TxUtilsState.SPEED_UP, 'wait for speed-up', 10, 0.1);
+      await retryFastUntil(() => gasUtils.state === TxUtilsState.SPEED_UP, 'wait for speed-up');
       expect(state.txHashes.length).toBeGreaterThan(1);
 
       // Wait for completion

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -103,3 +103,21 @@ export async function retryUntil<T>(
     }
   }
 }
+
+/**
+ * Convenience wrapper around retryUntil with fast polling for tests.
+ * Uses 10s timeout and 100ms polling interval by default.
+ *
+ * @param fn - The function to retry until it returns a truthy value.
+ * @param name - Description of what we're waiting for (for error messages).
+ * @param timeout - Optional timeout in seconds. Defaults to 10s.
+ * @param interval - Optional interval in seconds. Defaults to 0.1s (100ms).
+ */
+export function retryFastUntil<T>(
+  fn: () => (T | undefined) | Promise<T | undefined>,
+  name = '',
+  timeout = 10,
+  interval = 0.1,
+) {
+  return retryUntil(fn, name, timeout, interval);
+}

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -2,7 +2,7 @@ import { MockL2BlockSource } from '@aztec/archiver/test';
 import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { retryUntil } from '@aztec/foundation/retry';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2Block } from '@aztec/stdlib/block';
@@ -75,12 +75,12 @@ describe('P2P Client', () => {
 
   const advanceToProvenBlock = async (blockNumber: BlockNumber) => {
     blockSource.setProvenBlockNumber(blockNumber);
-    await retryUntil(async () => (await client.getSyncedProvenBlockNum()) >= blockNumber, 'synced', 10, 0.1);
+    await retryFastUntil(async () => (await client.getSyncedProvenBlockNum()) >= blockNumber, 'synced');
   };
 
   const advanceToFinalizedBlock = async (blockNumber: BlockNumber) => {
     blockSource.setFinalizedBlockNumber(blockNumber);
-    await retryUntil(async () => (await client.getSyncedFinalizedBlockNum()) >= blockNumber, 'synced', 10, 0.1);
+    await retryFastUntil(async () => (await client.getSyncedFinalizedBlockNum()) >= blockNumber, 'synced');
   };
 
   afterEach(async () => {

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -7,7 +7,7 @@ import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import type {
   WorldStateSyncStatus,
   WorldStateSynchronizer,
@@ -168,7 +168,7 @@ describe('PeerManager', () => {
 
       await (peerManager as any).discover();
 
-      await sleep(100);
+      await retryFastUntil(() => recordPeerCountSpy.mock.calls.length > 0, 'peer count metric to be recorded');
 
       expect(recordPeerCountSpy).toHaveBeenCalledWith(1);
     });
@@ -182,21 +182,17 @@ describe('PeerManager', () => {
       expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(1);
 
       // dial peer happens asynchronously, so we need to wait
-      await sleep(100);
+      await retryFastUntil(() => mockLibP2PNode.dial.mock.calls.length >= 1, 'first dial to complete');
 
       // Second attempt
       await (peerManager as any).discover();
+      await retryFastUntil(() => mockLibP2PNode.dial.mock.calls.length >= 2, 'second dial to complete');
       expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(2);
-
-      // dial peer happens asynchronously, so we need to wait
-      await sleep(100);
 
       // Third attempt
       await (peerManager as any).discover();
+      await retryFastUntil(() => mockLibP2PNode.dial.mock.calls.length >= 3, 'third dial to complete');
       expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(3);
-
-      // dial peer happens asynchronously, so we need to wait
-      await sleep(100);
 
       // After the third attempt, the peer should be removed from
       // the cache, and placed in timeout
@@ -207,10 +203,10 @@ describe('PeerManager', () => {
     const triggerTimeout = async (enr: ENR) => {
       // First attempt - adds it to the cache
       await discoveredPeerCallback(enr);
-      await sleep(100);
+      await retryFastUntil(() => mockLibP2PNode.dial.mock.calls.length >= 1, 'first dial to complete');
       // Second attempt - on heartbeat
       await (peerManager as any).discover();
-      await sleep(100);
+      await retryFastUntil(() => mockLibP2PNode.dial.mock.calls.length >= 2, 'second dial to complete');
       // Third attempt - on heartbeat
       await (peerManager as any).discover();
     };
@@ -295,7 +291,8 @@ describe('PeerManager', () => {
 
       // Try peer2 once
       await discoveredPeerCallback(enr2);
-      await sleep(100);
+      // Wait for async dial operations to settle - dial happens asynchronously after callback
+      await retryFastUntil(() => peerManager.getPeers(true).length === 2, 'peers to be added to cache');
 
       const peers = peerManager.getPeers(true);
       expect(peers).toHaveLength(2);
@@ -333,7 +330,7 @@ describe('PeerManager', () => {
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(() => mockLibP2PNode.hangUp.mock.calls.length === 2, 'unhealthy peers to be disconnected');
 
       // Verify that hangUp and a goodbye was sent for both unhealthy peers
       expect(mockLibP2PNode.hangUp).toHaveBeenCalledWith(peerIdFromString(bannedPeerId.toString()));
@@ -389,7 +386,7 @@ describe('PeerManager', () => {
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(() => mockLibP2PNode.hangUp.mock.calls.length === 2, 'low scoring peers to be disconnected');
 
       // Verify that hangUp and a goodbye was sent for low scoring peers to satisfy max peer limit
       expect(mockLibP2PNode.hangUp).toHaveBeenCalledWith(peerIdFromString(lowScoringPeerId1.toString()));
@@ -446,7 +443,11 @@ describe('PeerManager', () => {
       // Trigger heartbeat which should call pruneUnhealthyPeers
       await peerManager.heartbeat();
 
-      await sleep(100);
+      // Give time for async operations to complete
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'heartbeat to complete',
+      );
 
       // Verify that hangUp was not called for the trusted peer
       expect(mockLibP2PNode.hangUp).not.toHaveBeenCalled();
@@ -472,7 +473,10 @@ describe('PeerManager', () => {
       // Trigger heartbeat which should call pruneUnhealthyPeers
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'first heartbeat to complete',
+      );
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
@@ -502,7 +506,10 @@ describe('PeerManager', () => {
       // Trigger heartbeat which should call pruneUnhealthyPeers
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'first heartbeat to complete',
+      );
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
@@ -618,6 +625,9 @@ describe('PeerManager', () => {
       // Set the maxPeerCount to 3 in the mock peer manager
       peerManager = createMockPeerManager('test', mockLibP2PNode, 3);
 
+      // Mock sendRequestToPeer to return success for goodbye messages
+      mockReqResp.sendRequestToPeer.mockResolvedValue({ status: ReqRespStatus.SUCCESS, data: Buffer.alloc(0) });
+
       // Create 2 trusted peers and 3 regular peers (total 5 peers, exceeding maxPeerCount of 3)
       const trustedPeerId1 = await createSecp256k1PeerId();
       const trustedPeerId2 = await createSecp256k1PeerId();
@@ -660,13 +670,14 @@ describe('PeerManager', () => {
       // This ensures prioritizePeers gets the correct connections
       jest.spyOn(peerManager as any, 'pruneUnhealthyPeers').mockImplementation(connections => connections);
 
-      // Trigger heartbeat which should call prioritizePeers
+      // First heartbeat: prioritizePeers marks peers for disconnect (sends goodbye and schedules)
       await peerManager.heartbeat();
+      // Wait for the async goodbye messages to complete and peers to be marked for disconnect
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length === 2, 'goodbye messages to be sent');
 
-      // Wait for async operations to complete
-      await sleep(100);
-      // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
+      // Second heartbeat: processScheduledDisconnects actually disconnects the marked peers
       await peerManager.heartbeat();
+      await retryFastUntil(() => mockLibP2PNode.hangUp.mock.calls.length === 2, 'peers to be disconnected');
 
       // Verify that hangUp was called for the lowest scoring regular peers
       // Since we have 2 trusted peers and maxPeerCount is 3, we can only keep 1 regular peer
@@ -711,7 +722,10 @@ describe('PeerManager', () => {
 
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'first heartbeat to complete',
+      );
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
@@ -794,7 +808,10 @@ describe('PeerManager', () => {
       peerManager.penalizePeer(trustedAndPrivatePeerId, PeerErrorSeverity.LowToleranceError);
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'heartbeat to complete',
+      );
 
       expect(mockLibP2PNode.hangUp).not.toHaveBeenCalled();
 
@@ -821,7 +838,10 @@ describe('PeerManager', () => {
 
       await peerManager.heartbeat();
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockPeerDiscoveryService.runRandomNodesQuery.mock.calls.length > 0,
+        'first heartbeat to complete',
+      );
       // We need second heartbeat to actually disconnect  - the first one just marks peers to disconnect
       await peerManager.heartbeat();
 
@@ -1009,7 +1029,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'status request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1065,7 +1085,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'status request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1125,7 +1145,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'status request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1184,7 +1204,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1234,7 +1254,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1298,7 +1318,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
       expect(mockReqResp.sendRequestToPeer).toHaveBeenLastCalledWith(
@@ -1372,7 +1392,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       // Peer should not be authenticated as it is not registered as a validator
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
@@ -1439,7 +1459,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       // Should be authenticated
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
@@ -1518,7 +1538,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'auth request to be sent');
 
       // Should be authenticated
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
@@ -1546,7 +1566,10 @@ describe('PeerManager', () => {
       // Reconnecting should trigger a new auth process
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockReqResp.sendRequestToPeer.mock.calls.length >= 2,
+        'second auth request to be sent',
+      );
 
       // Should be authenticated
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(2);
@@ -1615,7 +1638,7 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 1, 'first auth request to be sent');
 
       // Should be authenticated
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(1);
@@ -1634,7 +1657,10 @@ describe('PeerManager', () => {
       };
       (newPeerManager as any).handleConnectedPeerEvent(ev2);
 
-      await sleep(100);
+      await retryFastUntil(
+        () => mockReqResp.sendRequestToPeer.mock.calls.length >= 2,
+        'second auth request to be sent',
+      );
 
       // Should not be authenticated as the validator key is already in use
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(2);
@@ -1654,7 +1680,7 @@ describe('PeerManager', () => {
       // Now the second peer should be able to connect and auth
       (newPeerManager as any).handleConnectedPeerEvent(ev2);
 
-      await sleep(100);
+      await retryFastUntil(() => mockReqResp.sendRequestToPeer.mock.calls.length >= 3, 'third auth request to be sent');
 
       // Should not be authenticated as the validator key is already in use
       expect(mockReqResp.sendRequestToPeer).toHaveBeenCalledTimes(3);
@@ -1899,8 +1925,11 @@ describe('PeerManager', () => {
       for (let i = 0; i < 3; i++) {
         const ev = { detail: peerId };
         (peerManager as any).handleConnectedPeerEvent(ev);
-        // Sleep a bit to allow processing of auth handshake
-        await sleep(1000);
+        // Wait for auth handshake to complete
+        await retryFastUntil(
+          () => mockReqResp.sendRequestToPeer.mock.calls.length >= i + 1,
+          'auth handshake to complete',
+        );
       }
 
       // Should now be blocked

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -3,7 +3,7 @@ import { EpochNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
-import { sleep } from '@aztec/foundation/sleep';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import { ProtocolCircuitVks } from '@aztec/noir-protocol-circuits-types/server/vks';
 import {
   type PublicInputsAndRecursiveProof,
@@ -100,16 +100,20 @@ describe('prover/orchestrator', () => {
         // the prover broker deduplicates jobs, so the base parity proof
         // for the three sets empty messages is called only once. so total
         // calls is one for the empty messages and one for the custom message.
-        await sleep(2000);
-        expect(mockProver.getBaseParityProof).toHaveBeenCalledTimes(2);
+        await retryFastUntil(
+          () => mockProver.getBaseParityProof.mock.calls.length === 2,
+          'base parity proofs to be called',
+        );
         expect(mockProver.getRootParityProof).not.toHaveBeenCalled();
 
         // only after the base parity proof is resolved, the root parity should be called
         pendingBaseParityResult.resolve(expectedBaseParityResult);
 
         // give the orchestrator a chance to calls its callbacks
-        await sleep(5000);
-        expect(mockProver.getRootParityProof).toHaveBeenCalledTimes(1);
+        await retryFastUntil(
+          () => mockProver.getRootParityProof.mock.calls.length === 1,
+          'root parity proof to be called',
+        );
 
         orchestrator.cancel();
       });
@@ -145,9 +149,6 @@ describe('prover/orchestrator', () => {
         const { blockNumber, timestamp } = header.globalVariables;
         await orchestrator.startNewBlock(blockNumber, timestamp, txs.length);
 
-        // wait for the block root proof to try to be enqueued
-        await sleep(1000);
-
         // now finish the block
         await orchestrator.setBlockCompleted(blockNumber);
 
@@ -176,9 +177,6 @@ describe('prover/orchestrator', () => {
 
         const { blockNumber, timestamp } = header.globalVariables;
         await orchestrator.startNewBlock(blockNumber, timestamp, txs.length);
-
-        // wait for the block root proof to try to be enqueued
-        await sleep(1000);
 
         // now finish the block
         await orchestrator.setBlockCompleted(blockNumber);
@@ -226,8 +224,7 @@ describe('prover/orchestrator', () => {
           ),
         );
 
-        await sleep(100);
-        expect(getChonkVerifierSpy).toHaveBeenCalledTimes(2);
+        await retryFastUntil(() => getChonkVerifierSpy.mock.calls.length === 2, 'chonk verifier proofs to be called');
         getChonkVerifierSpy.mockReset();
 
         const { blockNumber, timestamp } = header.globalVariables;

--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.test.ts
@@ -1,7 +1,7 @@
 import { RECURSIVE_PROOF_LENGTH } from '@aztec/constants';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
-import { sleep } from '@aztec/foundation/sleep';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import { type ProvingJobStatus, makePublicInputsAndRecursiveProof } from '@aztec/stdlib/interfaces/server';
 import { makeRecursiveProof } from '@aztec/stdlib/proofs';
 import { makeParityBasePrivateInputs, makeParityPublicInputs } from '@aztec/stdlib/testing';
@@ -110,7 +110,7 @@ describe('BrokerCircuitProverFacade', () => {
 
     const resultPromise = promiseWithResolvers<any>();
     jest.spyOn(broker, 'enqueueProvingJob');
-    jest.spyOn(prover, 'getBaseParityProof').mockReturnValue(resultPromise.promise);
+    const getBaseParityProofSpy = jest.spyOn(prover, 'getBaseParityProof').mockReturnValue(resultPromise.promise);
     jest.spyOn(errorProofStore, 'saveProofInput');
 
     // send N identical proof requests
@@ -120,7 +120,7 @@ describe('BrokerCircuitProverFacade', () => {
       promises.push(facade.getBaseParityProof(inputs, controller.signal, EpochNumber(42)).catch(err => ({ err })));
     }
 
-    await sleep(agentPollInterval);
+    await retryFastUntil(() => getBaseParityProofSpy.mock.calls.length > 0, 'prover to be called');
 
     resultPromise.reject(new Error('TEST ERROR'));
 
@@ -155,13 +155,12 @@ describe('BrokerCircuitProverFacade', () => {
 
     const resultPromise = promiseWithResolvers<any>();
     jest.spyOn(broker, 'enqueueProvingJob');
-    jest.spyOn(prover, 'getBaseParityProof').mockReturnValue(resultPromise.promise);
+    const getBaseParityProofSpy = jest.spyOn(prover, 'getBaseParityProof').mockReturnValue(resultPromise.promise);
     jest.spyOn(errorProofStore, 'saveProofInput');
 
     const promise = facade.getBaseParityProof(inputs, controller.signal, EpochNumber(42)).catch(err => ({ err }));
 
-    await sleep(agentPollInterval);
-    expect(prover.getBaseParityProof).toHaveBeenCalled();
+    await retryFastUntil(() => getBaseParityProofSpy.mock.calls.length > 0, 'prover to be called');
 
     controller.abort();
 
@@ -191,11 +190,11 @@ describe('BrokerCircuitProverFacade', () => {
 
     // make sure the job hangs on waiting for the broker
     const enqueueJobPromise = promiseWithResolvers<ProvingJobStatus>();
-    jest.spyOn(broker, 'enqueueProvingJob').mockReturnValue(enqueueJobPromise.promise);
+    const enqueueProvingJobSpy = jest.spyOn(broker, 'enqueueProvingJob').mockReturnValue(enqueueJobPromise.promise);
     const promise = facade.getBaseParityProof(inputs, controller.signal, EpochNumber(42));
 
     // now stop the facade after giving it time, which will trigger a rejection
-    await sleep(agentPollInterval);
+    await retryFastUntil(() => enqueueProvingJobSpy.mock.calls.length > 0, 'broker to be called');
     await facade.stop();
 
     // and expect we don't blow up the entire node process

--- a/yarn-project/slasher/src/slash_offenses_collector.test.ts
+++ b/yarn-project/slasher/src/slash_offenses_collector.test.ts
@@ -1,6 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
 import { type Offense, OffenseType } from '@aztec/stdlib/slashing';
@@ -8,12 +7,10 @@ import { type Offense, OffenseType } from '@aztec/stdlib/slashing';
 import { DefaultSlasherConfig } from './config.js';
 import { SlashOffensesCollector, type SlashOffensesCollectorSettings } from './slash_offenses_collector.js';
 import { SlasherOffensesStore } from './stores/offenses_store.js';
-import { DummyWatcher } from './test/dummy_watcher.js';
 import type { WantToSlashArgs } from './watcher.js';
 
 describe('SlashOffensesCollector', () => {
   let offensesCollector: SlashOffensesCollector;
-  let dummyWatcher: DummyWatcher;
   let kvStore: ReturnType<typeof openTmpStore>;
   let offensesStore: SlasherOffensesStore;
   let logger: Logger;
@@ -36,20 +33,16 @@ describe('SlashOffensesCollector', () => {
       epochDuration: 32,
       slashOffenseExpirationRounds: 4,
     });
-    dummyWatcher = new DummyWatcher();
     logger = createLogger('test');
 
-    offensesCollector = new SlashOffensesCollector(config, settings, [dummyWatcher], offensesStore, logger);
+    offensesCollector = new SlashOffensesCollector(config, settings, [], offensesStore, logger);
   });
 
   afterEach(async () => {
-    await offensesCollector.stop();
     await kvStore.close();
   });
 
-  it('should handle want-to-slash events from watchers', async () => {
-    await offensesCollector.start();
-
+  it('should handle want-to-slash events', async () => {
     const wantToSlashArgs: WantToSlashArgs[] = [
       {
         validator: EthAddress.random(),
@@ -59,13 +52,8 @@ describe('SlashOffensesCollector', () => {
       },
     ];
 
-    // Mock the watcher emitting a want-to-slash event
-    dummyWatcher.triggerSlash(wantToSlashArgs);
+    await offensesCollector.handleWantToSlash(wantToSlashArgs);
 
-    // Give it a moment to process
-    await sleep(100);
-
-    // Check that the offense was stored
     const pendingOffenses = await offensesStore.getPendingOffenses();
     expect(pendingOffenses).toHaveLength(1);
     expect(pendingOffenses[0]).toMatchObject({
@@ -77,8 +65,6 @@ describe('SlashOffensesCollector', () => {
   });
 
   it('should skip duplicate offenses', async () => {
-    await offensesCollector.start();
-
     const validator = EthAddress.random();
     const wantToSlashArgs: WantToSlashArgs[] = [
       {
@@ -89,15 +75,11 @@ describe('SlashOffensesCollector', () => {
       },
     ];
 
-    // Emit the same offense twice
-    dummyWatcher.triggerSlash(wantToSlashArgs);
-    await sleep(100);
+    // Handle the same offense twice
+    await offensesCollector.handleWantToSlash(wantToSlashArgs);
+    await offensesCollector.handleWantToSlash(wantToSlashArgs);
 
-    // Emit the exact same offense again
-    dummyWatcher.triggerSlash(wantToSlashArgs);
-    await sleep(100);
-
-    // Check that only one offense was stored
+    // Check that only one offense was stored (duplicate was skipped)
     const pendingOffenses = await offensesStore.getPendingOffenses();
     expect(pendingOffenses).toHaveLength(1);
     expect(pendingOffenses[0]).toMatchObject({
@@ -109,8 +91,6 @@ describe('SlashOffensesCollector', () => {
   });
 
   it('should skip offenses that happen during grace period', async () => {
-    await offensesCollector.start();
-
     const validator1 = EthAddress.random();
     const validator2 = EthAddress.random();
 
@@ -134,12 +114,9 @@ describe('SlashOffensesCollector', () => {
       },
     ];
 
-    // Emit both offenses
-    dummyWatcher.triggerSlash(gracePeriodOffense);
-    await sleep(100);
-
-    dummyWatcher.triggerSlash(validOffense);
-    await sleep(100);
+    // Handle both offenses
+    await offensesCollector.handleWantToSlash(gracePeriodOffense);
+    await offensesCollector.handleWantToSlash(validOffense);
 
     // Check that only the valid offense (after grace period) was stored
     const pendingOffenses = await offensesStore.getPendingOffenses();
@@ -152,9 +129,7 @@ describe('SlashOffensesCollector', () => {
     });
   });
 
-  it('should handle event with multiple items making multiple insertions', async () => {
-    await offensesCollector.start();
-
+  it('should handle multiple offenses in a single call', async () => {
     const validator1 = EthAddress.random();
     const validator2 = EthAddress.random();
     const validator3 = EthAddress.random();
@@ -181,9 +156,7 @@ describe('SlashOffensesCollector', () => {
       },
     ];
 
-    // Emit all offenses in a single event
-    dummyWatcher.triggerSlash(multipleOffensesArgs);
-    await sleep(100);
+    await offensesCollector.handleWantToSlash(multipleOffensesArgs);
 
     // Check that all three offenses were stored
     const pendingOffenses = await offensesStore.getPendingOffenses();

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -4,7 +4,7 @@ import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
+import { retryFastUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
@@ -642,15 +642,10 @@ describe('TallySlasherClient', () => {
 
   describe('integration', () => {
     const waitForOffenses = (count: number) =>
-      retryUntil(
-        async () => {
-          const pendingOffenses = await offensesStore.getPendingOffenses();
-          return pendingOffenses.length >= count ? true : undefined;
-        },
-        'offense to be processed',
-        5,
-        0.1,
-      );
+      retryFastUntil(async () => {
+        const pendingOffenses = await offensesStore.getPendingOffenses();
+        return pendingOffenses.length >= count ? true : undefined;
+      }, 'offense to be processed');
 
     it('should handle from offense detection to execution', async () => {
       // Round 3: Offense occurs

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.test.ts
@@ -2,19 +2,16 @@ import type { EpochCache } from '@aztec/epoch-cache';
 import { CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { sleep } from '@aztec/foundation/sleep';
-import {
-  type InvalidCheckpointDetectedEvent,
-  type L2BlockSourceEventEmitter,
-  L2BlockSourceEvents,
-  type ValidateCheckpointNegativeResult,
+import type {
+  InvalidCheckpointDetectedEvent,
+  L2BlockSourceEventEmitter,
+  ValidateCheckpointNegativeResult,
 } from '@aztec/stdlib/block';
 import type { CheckpointInfo } from '@aztec/stdlib/checkpoint';
 import { OffenseType } from '@aztec/stdlib/slashing';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
-import EventEmitter from 'node:events';
 
 import { DefaultSlasherConfig, type SlasherConfig } from '../config.js';
 import { WANT_TO_SLASH_EVENT, type WantToSlashArgs } from '../watcher.js';
@@ -22,7 +19,6 @@ import { AttestationsBlockWatcher } from './attestations_block_watcher.js';
 
 describe('AttestationsBlockWatcher', () => {
   let watcher: AttestationsBlockWatcher;
-  let l2BlockSource: L2BlockSourceEventEmitter;
   let epochCache: MockProxy<EpochCache>;
   let config: SlasherConfig;
   let handler: jest.MockedFunction<(args: WantToSlashArgs[]) => void>;
@@ -30,15 +26,13 @@ describe('AttestationsBlockWatcher', () => {
   let proposer: EthAddress;
   let committee: EthAddress[];
 
-  beforeEach(async () => {
-    l2BlockSource = new MockL2BlockSource() as unknown as L2BlockSourceEventEmitter;
+  beforeEach(() => {
     epochCache = mock<EpochCache>();
     config = DefaultSlasherConfig;
     handler = jest.fn();
 
-    watcher = new AttestationsBlockWatcher(l2BlockSource, epochCache, config);
+    watcher = new AttestationsBlockWatcher(mock<L2BlockSourceEventEmitter>(), epochCache, config);
     watcher.on(WANT_TO_SLASH_EVENT, handler);
-    await watcher.start();
 
     // Set up common test data
     checkpointInfo = {
@@ -55,11 +49,7 @@ describe('AttestationsBlockWatcher', () => {
     epochCache.getProposerFromEpochCommittee.mockReturnValue(proposer);
   });
 
-  afterEach(async () => {
-    await watcher.stop();
-  });
-
-  it('should emit WANT_TO_SLASH_EVENT for proposer when invalid checkpoint detected due to insufficient attestations', async () => {
+  it('should emit WANT_TO_SLASH_EVENT for proposer when invalid checkpoint detected due to insufficient attestations', () => {
     const validationResult: ValidateCheckpointNegativeResult = {
       valid: false,
       reason: 'insufficient-attestations',
@@ -76,9 +66,7 @@ describe('AttestationsBlockWatcher', () => {
       validationResult,
     };
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, event);
-
-    await sleep(100);
+    watcher.handleInvalidCheckpoint(event);
 
     expect(handler).toHaveBeenCalledWith([
       {
@@ -91,7 +79,7 @@ describe('AttestationsBlockWatcher', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('should emit WANT_TO_SLASH_EVENT for proposer when invalid checkpoint detected due to invalid attestations', async () => {
+  it('should emit WANT_TO_SLASH_EVENT for proposer when invalid checkpoint detected due to invalid attestations', () => {
     const validationResult: ValidateCheckpointNegativeResult = {
       valid: false,
       reason: 'invalid-attestation',
@@ -109,9 +97,7 @@ describe('AttestationsBlockWatcher', () => {
       validationResult,
     };
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, event);
-
-    await sleep(100);
+    watcher.handleInvalidCheckpoint(event);
 
     expect(handler).toHaveBeenCalledWith([
       {
@@ -124,8 +110,8 @@ describe('AttestationsBlockWatcher', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('should emit WANT_TO_SLASH_EVENT for attestors when checkpoint built on invalid parent', async () => {
-    // First, emit an invalid checkpoint using the pre-configured data
+  it('should emit WANT_TO_SLASH_EVENT for attestors when checkpoint built on invalid parent', () => {
+    // First, handle an invalid checkpoint using the pre-configured data
     const invalidCheckpointValidationResult: ValidateCheckpointNegativeResult = {
       valid: false,
       reason: 'insufficient-attestations',
@@ -142,11 +128,9 @@ describe('AttestationsBlockWatcher', () => {
       validationResult: invalidCheckpointValidationResult,
     };
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, invalidCheckpointEvent);
+    watcher.handleInvalidCheckpoint(invalidCheckpointEvent);
 
-    await sleep(100);
-
-    // Now emit a checkpoint that builds on the invalid checkpoint
+    // Now handle a checkpoint that builds on the invalid checkpoint
     const childCheckpointInfo: CheckpointInfo = {
       archive: Fr.random(),
       lastArchive: checkpointInfo.archive, // Parent archive
@@ -178,9 +162,7 @@ describe('AttestationsBlockWatcher', () => {
     };
 
     handler.mockClear();
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, childEvent);
-
-    await sleep(100);
+    watcher.handleInvalidCheckpoint(childEvent);
 
     expect(handler).toHaveBeenCalledWith([
       {
@@ -208,7 +190,7 @@ describe('AttestationsBlockWatcher', () => {
     expect(handler).toHaveBeenCalledTimes(2);
   });
 
-  it('should not process the same invalid checkpoint twice', async () => {
+  it('should not process the same invalid checkpoint twice', () => {
     const validationResult: ValidateCheckpointNegativeResult = {
       valid: false,
       reason: 'insufficient-attestations',
@@ -225,17 +207,15 @@ describe('AttestationsBlockWatcher', () => {
       validationResult,
     };
 
-    // Emit the same event twice
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, event);
-    await sleep(100);
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, event);
-    await sleep(100);
+    // Handle the same event twice
+    watcher.handleInvalidCheckpoint(event);
+    watcher.handleInvalidCheckpoint(event);
 
-    // Should only emit once
+    // Should only emit once (duplicate was skipped)
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle case when no proposer is found', async () => {
+  it('should handle case when no proposer is found', () => {
     epochCache.getProposerFromEpochCommittee.mockReturnValue(undefined);
 
     const validationResult: ValidateCheckpointNegativeResult = {
@@ -254,17 +234,9 @@ describe('AttestationsBlockWatcher', () => {
       validationResult,
     };
 
-    l2BlockSource.events.emit(L2BlockSourceEvents.InvalidAttestationsCheckpointDetected, event);
-
-    await sleep(100);
+    watcher.handleInvalidCheckpoint(event);
 
     // Should not emit any events
     expect(handler).not.toHaveBeenCalled();
   });
 });
-
-class MockL2BlockSource {
-  public readonly events = new EventEmitter();
-
-  constructor() {}
-}

--- a/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
+++ b/yarn-project/slasher/src/watchers/attestations_block_watcher.ts
@@ -82,7 +82,8 @@ export class AttestationsBlockWatcher extends (EventEmitter as new () => Watcher
     return Promise.resolve();
   }
 
-  private handleInvalidCheckpoint(event: InvalidCheckpointDetectedEvent): void {
+  /** Event handler for invalid checkpoints as reported by the archiver. Public for testing purposes. */
+  public handleInvalidCheckpoint(event: InvalidCheckpointDetectedEvent): void {
     const { validationResult } = event;
     const checkpoint = validationResult.checkpoint;
 


### PR DESCRIPTION
Refactors some (not all) unit tests to remove sleeps in favor of either `retryUntil` or calling event handlers directly (to avoid having to sleep while the handler was executed). Also introduces a `retryFastUntil` wrapper that calls `retryUntil` with faster interval and a short timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)