### PR TITLE
chore: bump timeout for token bridge tutorial e2e

### DIFF
--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -236,5 +236,5 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     logger.info(`New L1 balance of ${ownerEthAddress} is ${newL1Balance}`);
     // docs:end:l1-withdraw
     expect(newL1Balance).toBe(withdrawAmount);
-  }, 150_000);
+  }, 300_000);
 });


### PR DESCRIPTION
This test is flaking a lot on CI. Successful runs show completion at over 140s, and failed runs are hitting the 150s timeout. This doubles the timeout.
