### PR TITLE
chore: remove unnecessary "inputs" structs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -622,21 +622,13 @@ void add_blackbox_func_call_to_acir_format(Acir::Opcode::BlackBoxFuncCall const&
                 af.original_opcode_indices.sha256_compression.push_back(opcode_index);
             } else if constexpr (std::is_same_v<T, Acir::BlackBoxFuncCall::Blake2s>) {
                 af.blake2s_constraints.push_back(Blake2sConstraint{
-                    .inputs = transform::map(arg.inputs,
-                                             [&](auto& e) {
-                                                 return Blake2sInput{
-                                                     .blackbox_input = parse_input(e),
-                                                     .num_bits = 8,
-                                                 };
-                                             }),
+                    .inputs = transform::map(arg.inputs, to_witness_or_constant),
                     .result = transform::map(*arg.outputs, to_witness),
                 });
                 af.original_opcode_indices.blake2s_constraints.push_back(opcode_index);
             } else if constexpr (std::is_same_v<T, Acir::BlackBoxFuncCall::Blake3>) {
                 af.blake3_constraints.push_back(Blake3Constraint{
-                    .inputs = transform::map(
-                        arg.inputs,
-                        [&](auto& e) { return Blake3Input{ .blackbox_input = parse_input(e), .num_bits = 8 }; }),
+                    .inputs = transform::map(arg.inputs, to_witness_or_constant),
                     .result = transform::map(*arg.outputs, to_witness),
                 });
                 af.original_opcode_indices.blake3_constraints.push_back(opcode_index);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.cpp
@@ -48,7 +48,7 @@ template <typename Builder> void create_aes128_constraints(Builder& builder, con
         return converted;
     };
 
-    const size_t padding_size = 16 - constraint.inputs.size() % 16;
+    const size_t padding_size = 16 - (constraint.inputs.size() % 16);
 
     // Perform the conversions from array of bytes to field elements
     std::vector<field_ct> converted_inputs;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/aes128_constraint.hpp
@@ -13,13 +13,6 @@
 
 namespace acir_format {
 
-struct AES128Input {
-    uint32_t witness;
-    uint32_t num_bits;
-
-    friend bool operator==(AES128Input const& lhs, AES128Input const& rhs) = default;
-};
-
 struct AES128Constraint {
     std::vector<WitnessOrConstant<bb::fr>> inputs;
     std::array<WitnessOrConstant<bb::fr>, 16> iv;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.cpp
@@ -21,8 +21,7 @@ template <typename Builder> void create_blake2s_constraints(Builder& builder, co
     // Build input byte array by appending constrained byte_arrays
     byte_array_ct arr = byte_array_ct::constant_padding(&builder, 0); // Start with empty array
 
-    for (const auto& witness_index_num_bits : constraint.inputs) {
-        auto witness_index = witness_index_num_bits.blackbox_input;
+    for (const auto& witness_index : constraint.inputs) {
         field_ct element = to_field_ct(witness_index, builder);
 
         // byte_array_ct(field, num_bytes) constructor adds range constraints for each byte. Note that num_bytes =

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.hpp
@@ -12,15 +12,8 @@
 
 namespace acir_format {
 
-struct Blake2sInput {
-    WitnessOrConstant<bb::fr> blackbox_input;
-    uint32_t num_bits;
-
-    friend bool operator==(Blake2sInput const& lhs, Blake2sInput const& rhs) = default;
-};
-
 struct Blake2sConstraint {
-    std::vector<Blake2sInput> inputs;
+    std::vector<WitnessOrConstant<bb::fr>> inputs;
     std::array<uint32_t, 32> result;
 
     friend bool operator==(Blake2sConstraint const& lhs, Blake2sConstraint const& rhs) = default;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake2s_constraint.test.cpp
@@ -45,10 +45,9 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
         case InvalidWitness::Target::Input: {
             // Tamper with the first input element
             if constexpr (IsInputConstant) {
-                constraint.inputs[0].blackbox_input =
-                    WitnessOrConstant<FF>::from_constant(constraint.inputs[0].blackbox_input.value + bb::fr(1));
+                constraint.inputs[0] = WitnessOrConstant<FF>::from_constant(constraint.inputs[0].value + bb::fr(1));
             } else {
-                witness_values[constraint.inputs[0].blackbox_input.index] += bb::fr(1);
+                witness_values[constraint.inputs[0].index] += bb::fr(1);
             }
             break;
         }
@@ -95,8 +94,7 @@ template <class BuilderType, bool IsInputConstant> class Blake2sTestingFunctions
         // Create the constraint
         blake2s_constraint.inputs.reserve(input_state.size());
         for (const auto& state : construct_state(input_state, IsInputConstant)) {
-            Blake2sInput input{ .blackbox_input = state, .num_bits = 8 };
-            blake2s_constraint.inputs.push_back(input);
+            blake2s_constraint.inputs.push_back(state);
         }
 
         // Add output state to witness

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.cpp
@@ -19,8 +19,7 @@ template <typename Builder> void create_blake3_constraints(Builder& builder, con
     // Build input byte array by appending constrained byte_arrays
     byte_array_ct arr = byte_array_ct::constant_padding(&builder, 0); // Start with empty array
 
-    for (const auto& witness_index_num_bits : constraint.inputs) {
-        auto witness_index = witness_index_num_bits.blackbox_input;
+    for (const auto& witness_index : constraint.inputs) {
         field_ct element = to_field_ct(witness_index, builder);
 
         // byte_array_ct(field, num_bytes) constructor adds range constraints for each byte. Note that num_bytes =

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.hpp
@@ -12,15 +12,8 @@
 
 namespace acir_format {
 
-struct Blake3Input {
-    WitnessOrConstant<bb::fr> blackbox_input;
-    uint32_t num_bits;
-
-    friend bool operator==(Blake3Input const& lhs, Blake3Input const& rhs) = default;
-};
-
 struct Blake3Constraint {
-    std::vector<Blake3Input> inputs;
+    std::vector<WitnessOrConstant<bb::fr>> inputs;
     std::array<uint32_t, 32> result;
 
     friend bool operator==(Blake3Constraint const& lhs, Blake3Constraint const& rhs) = default;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/blake3_constraint.test.cpp
@@ -45,10 +45,9 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
         case InvalidWitness::Target::Input: {
             // Tamper with the first input element
             if constexpr (IsInputConstant) {
-                constraint.inputs[0].blackbox_input =
-                    WitnessOrConstant<FF>::from_constant(constraint.inputs[0].blackbox_input.value + bb::fr(1));
+                constraint.inputs[0] = WitnessOrConstant<FF>::from_constant(constraint.inputs[0].value + bb::fr(1));
             } else {
-                witness_values[constraint.inputs[0].blackbox_input.index] += bb::fr(1);
+                witness_values[constraint.inputs[0].index] += bb::fr(1);
             }
             break;
         }
@@ -95,8 +94,7 @@ template <class BuilderType, bool IsInputConstant> class Blake3TestingFunctions 
         // Create the constraint
         blake3_constraint.inputs.reserve(input_state.size());
         for (const auto& state : construct_state(input_state, IsInputConstant)) {
-            Blake3Input input{ .blackbox_input = state, .num_bits = 8 };
-            blake3_constraint.inputs.push_back(input);
+            blake3_constraint.inputs.push_back(state);
         }
 
         // Add output state to witness

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/opcode_gate_count.test.cpp
@@ -398,10 +398,7 @@ TYPED_TEST(OpcodeGateCountTests, Blake2s)
 {
     Blake2sConstraint blake2s_constraint;
 
-    blake2s_constraint.inputs.push_back(Blake2sInput{
-        .blackbox_input = WitnessOrConstant<bb::fr>::from_index(0),
-        .num_bits = 8,
-    });
+    blake2s_constraint.inputs.push_back(WitnessOrConstant<bb::fr>::from_index(0));
 
     for (size_t i = 0; i < 32; ++i) {
         blake2s_constraint.result[i] = static_cast<uint32_t>(i + 1);
@@ -428,10 +425,7 @@ TYPED_TEST(OpcodeGateCountTests, Blake3)
 {
     Blake3Constraint blake3_constraint;
 
-    blake3_constraint.inputs.push_back(Blake3Input{
-        .blackbox_input = WitnessOrConstant<bb::fr>::from_index(0),
-        .num_bits = 8,
-    });
+    blake3_constraint.inputs.push_back(WitnessOrConstant<bb::fr>::from_index(0));
 
     for (size_t i = 0; i < 32; ++i) {
         blake3_constraint.result[i] = static_cast<uint32_t>(i + 1);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -316,7 +316,7 @@ template <typename ConstraintType> std::vector<Acir::Opcode> constraint_to_acir_
     } else if constexpr (std::is_same_v<ConstraintType, Blake2sConstraint>) {
         std::vector<Acir::FunctionInput> inputs;
         for (const auto& input : constraint.inputs) {
-            inputs.push_back(witness_or_constant_to_function_input(input.blackbox_input));
+            inputs.push_back(witness_or_constant_to_function_input(input));
         }
         auto outputs = std::make_shared<std::array<Acir::Witness, 32>>();
         for (size_t i = 0; i < 32; ++i) {
@@ -330,7 +330,7 @@ template <typename ConstraintType> std::vector<Acir::Opcode> constraint_to_acir_
     } else if constexpr (std::is_same_v<ConstraintType, Blake3Constraint>) {
         std::vector<Acir::FunctionInput> inputs;
         for (const auto& input : constraint.inputs) {
-            inputs.push_back(witness_or_constant_to_function_input(input.blackbox_input));
+            inputs.push_back(witness_or_constant_to_function_input(input));
         }
         auto outputs = std::make_shared<std::array<Acir::Witness, 32>>();
         for (size_t i = 0; i < 32; ++i) {


### PR DESCRIPTION
This removes some unnecessary wrappers around the inputs to some blackbox functions