### PR TITLE
chore: quiet tsc.sh output

### DIFF
--- a/yarn-project/scripts/tsc.sh
+++ b/yarn-project/scripts/tsc.sh
@@ -25,21 +25,50 @@ done
 
 # Build tsgo command
 tsgo_cmd="$tsgo -b"
+[ "${CLAUDECODE:-0}" = "1" ] || tsgo_cmd+=" --pretty"
 $no_emit && tsgo_cmd+=" --noEmit" || tsgo_cmd+=" --emitDeclarationOnly"
 $watch && tsgo_cmd+=" --watch"
 for arg in "${extra_args[@]+"${extra_args[@]}"}"; do tsgo_cmd+=" $arg"; done
 
-if $skip_swc; then
-  exec $tsgo_cmd
-fi
-
 swc_cmd="cd {} && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
 $watch && swc_cmd+=" --watch"
 
-if [[ -d "src" ]]; then
-  # Package mode - run tsgo and swc in parallel
-  parallel --halt now,fail=1 ::: "$tsgo_cmd" "cd . && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
-else
-  # Root mode - run tsgo and all swc calls in parallel
-  { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"; done; } | parallel --halt now,fail=1 --line-buffered --tag
+# In watch mode, run with full output
+if $watch; then
+  if $skip_swc; then
+    exec $tsgo_cmd
+  elif [[ -d "src" ]]; then
+    parallel --halt now,fail=1 ::: "$tsgo_cmd" "cd . && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
+  else
+    { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"; done; } | parallel --halt now,fail=1 --line-buffered
+  fi
+  exit 0
 fi
+
+# Non-watch mode: capture output per job, only show output from failed jobs
+results_dir=$(mktemp -d)
+trap "rm -rf $results_dir" EXIT
+
+run_parallel() {
+  local exit_code
+  parallel --halt now,fail=1 --results "$results_dir" --joblog "$results_dir/log" "$@" 2>/dev/null && exit_code=0 || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    # Show output only from failed jobs (Exitval column 7 != 0)
+    # parallel encodes / as +z in directory names
+    awk -F'\t' 'NR>1 && $7!=0 {gsub("/", "+z", $NF); print $NF}' "$results_dir/log" | while read -r encoded_cmd; do
+      dir="$results_dir/1/$encoded_cmd"
+      [[ -s "$dir/stdout" ]] && cat "$dir/stdout"
+      [[ -s "$dir/stderr" ]] && cat "$dir/stderr"
+    done
+    return $exit_code
+  fi
+}
+
+if $skip_swc; then
+  run_parallel ::: "$tsgo_cmd"
+elif [[ -d "src" ]]; then
+  run_parallel ::: "$tsgo_cmd" "cd . && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
+else
+  { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"; done; } | run_parallel
+fi
+echo "Typescript build succeeded"

--- a/yarn-project/scripts/tsc.test.sh
+++ b/yarn-project/scripts/tsc.test.sh
@@ -276,10 +276,81 @@ export const DEFAULT_VALUE = 42;
 EOF
 
   # Test from pkg-a (--noEmit doesn't work with project references from root)
-  if (cd "$test_root/pkg-a" && ../scripts/tsc.sh --noEmit) 2>&1; then
+  if (cd "$test_root/pkg-a" && CLAUDECODE=1 ../scripts/tsc.sh --noEmit) 2>&1; then
     fail "Should have detected type error"
   else
     pass "Type error detected correctly"
+  fi
+
+  # Restore valid code
+  cat > "$test_root/pkg-a/src/index.ts" << 'EOF'
+export interface Config {
+  name: string;
+  value: number;
+}
+
+export function createConfig(name: string, value: number): Config {
+  return { name, value };
+}
+
+export const DEFAULT_VALUE = 42;
+EOF
+}
+
+test_quiet_success_output() {
+  log "\nTest 7: Quiet success output"
+  clean_build_artifacts
+
+  local output
+  output=$(cd "$test_root" && ./scripts/tsc.sh 2>&1)
+
+  if [[ "$output" == "Typescript build succeeded" ]]; then
+    pass "Success output is single line 'Typescript build succeeded'"
+  else
+    fail "Success output should be 'Typescript build succeeded', got: $output"
+  fi
+}
+
+test_quiet_error_output() {
+  log "\nTest 8: Quiet error output (only failed command output shown)"
+  clean_build_artifacts
+
+  # Introduce a type error
+  cat > "$test_root/pkg-a/src/index.ts" << 'EOF'
+export interface Config {
+  name: string;
+  value: number;
+}
+
+export function createConfig(name: string, value: number): Config {
+  return { name, value: "not a number" };  // Type error!
+}
+
+export const DEFAULT_VALUE = 42;
+EOF
+
+  local output
+  output=$(cd "$test_root" && CLAUDECODE=1 ./scripts/tsc.sh 2>&1) || true
+
+  # Check that output contains error line
+  if echo "$output" | grep -q ": error TS"; then
+    pass "Error output contains TypeScript error"
+  else
+    fail "Error output should contain TypeScript error"
+  fi
+
+  # Check that output does NOT contain swc success messages
+  if echo "$output" | grep -q "Successfully compiled"; then
+    fail "Error output should not contain swc success messages"
+  else
+    pass "Error output does not contain swc noise"
+  fi
+
+  # Check that output does NOT contain "Typescript build succeeded"
+  if echo "$output" | grep -q "Typescript build succeeded"; then
+    fail "Error output should not contain 'Typescript build succeeded'"
+  else
+    pass "Error output does not contain success message"
   fi
 
   # Restore valid code
@@ -308,6 +379,8 @@ main() {
   test_root_full_build
   test_no_emit
   test_type_error_detection
+  test_quiet_success_output
+  test_quiet_error_output
 
   log "\n=== Results ==="
   echo -e "\033[32mPassed: $passed\033[0m"


### PR DESCRIPTION
## Summary

- Makes `tsc.sh` output less noisy for easier identification of build errors
- On success: prints only "Typescript build succeeded"
- On failure: prints only the output from the failed command(s), not all the swc success messages
- Watch mode (`-w`) retains the original verbose behavior for interactive use

## Implementation

Uses GNU parallel's `--results` and `--joblog` options to capture per-job output. On failure, parses the joblog to identify failed jobs and prints only their stdout/stderr.

## CLAUDECODE / --pretty

The script now adds `--pretty` to tsgo by default, which enables colored error output for better human readability. When the `CLAUDECODE` environment variable is set to `1`, `--pretty` is disabled since Claude Code processes the raw output programmatically.

## Test plan

- Added tests 7 and 8 to `tsc.test.sh` to verify quiet output behavior
- Run `./scripts/tsc.test.sh` - all 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)