### PR TITLE
refactor(avm): Refactor calldata copy and return data copy fuzzing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/instruction.hpp
@@ -508,15 +508,11 @@ struct NOTEHASHEXISTS_Instruction {
     MSGPACK_FIELDS(notehash_address, leaf_index_address, result_address);
 };
 
-/// @brief CALLDATACOPY: M[dstOffset:dstOffset+M[copySizeOffset]] =
-/// calldata[M[cdStartOffset]:M[cdStartOffset]+M[copySizeOffset]]
 struct CALLDATACOPY_Instruction {
+    ParamRef copy_size_address;
+    ParamRef cd_offset_address;
     AddressRef dst_address;
-    uint8_t copy_size;
-    AddressRef copy_size_address; // where copy size will be stored
-    uint16_t cd_start;
-    AddressRef cd_start_address; // where cd start will be stored
-    MSGPACK_FIELDS(dst_address, copy_size, copy_size_address, cd_start, cd_start_address);
+    MSGPACK_FIELDS(copy_size_address, cd_offset_address, dst_address);
 };
 
 struct SENDL2TOL1MSG_Instruction {
@@ -552,17 +548,17 @@ struct CALL_Instruction {
                    is_static_call);
 };
 
-/// @brief: RETURNDATASIZE + RETURNDATACOPY:
-// M[copySizeOffset] = nestedReturndata.size()
-// M[dstOffset:dstOffset+M[copySizeOffset]] =
-/// nestedReturndata[M[rdStartOffset]:M[rdStartOffset]+M[copySizeOffset]]
-/// All addresses are DIRECT
-struct RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction {
-    uint16_t copy_size_offset;
-    uint16_t dst_address;
-    uint32_t rd_start;
-    uint16_t rd_start_offset;
-    MSGPACK_FIELDS(copy_size_offset, dst_address, rd_start, rd_start_offset);
+struct RETURNDATASIZE_Instruction {
+    AddressRef dst_address;
+    MSGPACK_FIELDS(dst_address);
+};
+
+struct RETURNDATACOPY_Instruction {
+    ParamRef copy_size_address;
+    ParamRef rd_offset_address;
+    AddressRef dst_address;
+
+    MSGPACK_FIELDS(copy_size_address, rd_offset_address, dst_address);
 };
 
 struct GETCONTRACTINSTANCE_Instruction {
@@ -685,7 +681,8 @@ using FuzzInstruction = std::variant<ADD_8_Instruction,
                                      SENDL2TOL1MSG_Instruction,
                                      EMITUNENCRYPTEDLOG_Instruction,
                                      CALL_Instruction,
-                                     RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction,
+                                     RETURNDATASIZE_Instruction,
+                                     RETURNDATACOPY_Instruction,
                                      GETCONTRACTINSTANCE_Instruction,
                                      SUCCESSCOPY_Instruction,
                                      ECADD_Instruction,
@@ -867,8 +864,8 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzInstruction& instruc
                    << arg.leaf_index_address << " " << arg.result_address;
             },
             [&](CALLDATACOPY_Instruction arg) {
-                os << "CALLDATACOPY_Instruction " << arg.dst_address << " " << static_cast<int>(arg.copy_size) << " "
-                   << arg.copy_size_address << " " << arg.cd_start_address << " " << arg.cd_start_address;
+                os << "CALLDATACOPY_Instruction " << arg.copy_size_address << " " << arg.cd_offset_address << " "
+                   << arg.dst_address;
             },
             [&](SENDL2TOL1MSG_Instruction arg) {
                 os << "SENDL2TOL1MSG_Instruction " << arg.recipient << " " << arg.recipient_address << " "
@@ -882,9 +879,10 @@ inline std::ostream& operator<<(std::ostream& os, const FuzzInstruction& instruc
                    << arg.contract_address_address << " " << arg.calldata_size_address << " " << arg.calldata_address
                    << " " << arg.is_static_call;
             },
-            [&](RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction arg) {
-                os << "RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction " << arg.copy_size_offset << " "
-                   << arg.dst_address << " " << arg.rd_start_offset;
+            [&](RETURNDATASIZE_Instruction arg) { os << "RETURNDATASIZE_Instruction " << arg.dst_address; },
+            [&](RETURNDATACOPY_Instruction arg) {
+                os << "RETURNDATACOPY_Instruction " << arg.copy_size_address << " " << arg.rd_offset_address << " "
+                   << arg.dst_address;
             },
             [&](ECADD_Instruction arg) {
                 os << "ECADD_Instruction " << arg.p1_x << " " << arg.p1_y << " " << arg.p1_infinite << " " << arg.p2_x

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.cpp
@@ -1103,39 +1103,23 @@ void ProgramBlock::process_calldatacopy_instruction(CALLDATACOPY_Instruction ins
 #ifdef DISABLE_CALLDATACOPY_INSTRUCTION
     return;
 #endif
-    auto copy_size_set_instruction = SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                                         .result_address = instruction.copy_size_address,
-                                                         .value = instruction.copy_size };
-    this->process_set_32_instruction(copy_size_set_instruction);
-    auto cd_start_set_instruction = SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                                                        .result_address = instruction.cd_start_address,
-                                                        .value = instruction.cd_start };
-    this->process_set_32_instruction(cd_start_set_instruction);
-    // CALLDATACOPY expects UINT16 operands for all three addresses
     auto copy_size_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.copy_size_address);
-    auto cd_start_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.cd_start_address);
+    auto cd_offset_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.cd_offset_address);
     auto dst_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
-    if (!copy_size_address_operand.has_value() || !cd_start_address_operand.has_value() ||
+    if (!copy_size_address_operand.has_value() || !cd_offset_address_operand.has_value() ||
         !dst_address_operand.has_value()) {
         return;
     }
 
     preprocess_memory_addresses(copy_size_address_operand.value().first);
-    preprocess_memory_addresses(cd_start_address_operand.value().first);
+    preprocess_memory_addresses(cd_offset_address_operand.value().first);
     preprocess_memory_addresses(dst_address_operand.value().first);
     auto calldatacopy_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::CALLDATACOPY)
                                         .operand(copy_size_address_operand.value().second)
-                                        .operand(cd_start_address_operand.value().second)
+                                        .operand(cd_offset_address_operand.value().second)
                                         .operand(dst_address_operand.value().second)
                                         .build();
     instructions.push_back(calldatacopy_instruction);
-
-    // setting calldata_addr to u32 to avoid overflows
-    uint32_t calldata_base_offset = dst_address_operand.value().first.absolute_address;
-    auto loop_upper_bound = static_cast<uint32_t>(std::min((calldata_base_offset) + instruction.copy_size, 65535U));
-    for (uint32_t calldata_addr = calldata_base_offset; calldata_addr < loop_upper_bound; calldata_addr++) {
-        memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, calldata_addr);
-    }
 }
 
 void ProgramBlock::process_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction instruction)
@@ -1224,29 +1208,44 @@ void ProgramBlock::process_call_instruction(CALL_Instruction instruction)
     instructions.push_back(call_instruction);
 }
 
-void ProgramBlock::process_returndatasize_with_returndatacopy_instruction(
-    RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction instruction)
+void ProgramBlock::process_returndatasize_instruction(RETURNDATASIZE_Instruction instruction)
 {
-#ifdef DISABLE_RETURNDATASIZE_WITH_RETURNDATACOPY_INSTRUCTION
+#ifdef DISABLE_RETURNDATASIZE_INSTRUCTION
     return;
 #endif
+    auto dst_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
+    if (!dst_address_operand.has_value()) {
+        return;
+    }
+    preprocess_memory_addresses(dst_address_operand.value().first);
     auto returndatasize_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::RETURNDATASIZE)
-                                          .operand(instruction.copy_size_offset)
+                                          .operand(dst_address_operand.value().second)
                                           .build();
     instructions.push_back(returndatasize_instruction);
-    auto rd_start_set_instruction =
-        SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
-                            .result_address =
-                                AddressRef{ .address = instruction.rd_start_offset, .mode = AddressingMode::Direct },
-                            .value = instruction.rd_start };
-    this->process_set_32_instruction(rd_start_set_instruction);
+    memory_manager.set_memory_address(bb::avm2::MemoryTag::U32, dst_address_operand.value().first.absolute_address);
+}
+
+void ProgramBlock::process_returndatacopy_instruction(RETURNDATACOPY_Instruction instruction)
+{
+#ifdef DISABLE_RETURNDATACOPY_INSTRUCTION
+    return;
+#endif
+    auto copy_size_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.copy_size_address);
+    auto rd_offset_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.rd_offset_address);
+    auto dst_address_operand = memory_manager.get_resolved_address_and_operand_16(instruction.dst_address);
+    if (!copy_size_address_operand.has_value() || !rd_offset_address_operand.has_value() ||
+        !dst_address_operand.has_value()) {
+        return;
+    }
+    preprocess_memory_addresses(copy_size_address_operand.value().first);
+    preprocess_memory_addresses(rd_offset_address_operand.value().first);
+    preprocess_memory_addresses(dst_address_operand.value().first);
+
     auto returndatacopy_instruction = bb::avm2::testing::InstructionBuilder(bb::avm2::WireOpCode::RETURNDATACOPY)
-                                          .operand(instruction.copy_size_offset)
-                                          .operand(instruction.rd_start_offset)
-                                          .operand(instruction.dst_address)
+                                          .operand(copy_size_address_operand.value().second)
+                                          .operand(rd_offset_address_operand.value().second)
+                                          .operand(dst_address_operand.value().second)
                                           .build();
-    // TODO(defkit): function can return more than one value :D
-    memory_manager.set_memory_address(bb::avm2::MemoryTag::FF, instruction.dst_address);
     instructions.push_back(returndatacopy_instruction);
 }
 
@@ -1726,8 +1725,11 @@ void ProgramBlock::process_instruction(FuzzInstruction instruction)
                 return this->process_emitunencryptedlog_instruction(instruction);
             },
             [this](CALL_Instruction instruction) { return this->process_call_instruction(instruction); },
-            [this](RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction instruction) {
-                return this->process_returndatasize_with_returndatacopy_instruction(instruction);
+            [this](RETURNDATASIZE_Instruction instruction) {
+                return this->process_returndatasize_instruction(instruction);
+            },
+            [this](RETURNDATACOPY_Instruction instruction) {
+                return this->process_returndatacopy_instruction(instruction);
             },
             [this](GETCONTRACTINSTANCE_Instruction instruction) {
                 return this->process_getcontractinstance_instruction(instruction);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/program_block.hpp
@@ -106,8 +106,8 @@ class ProgramBlock {
     void process_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction instruction);
     void process_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction instruction);
     void process_call_instruction(CALL_Instruction instruction);
-    void process_returndatasize_with_returndatacopy_instruction(
-        RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction instruction);
+    void process_returndatasize_instruction(RETURNDATASIZE_Instruction instruction);
+    void process_returndatacopy_instruction(RETURNDATACOPY_Instruction instruction);
     void process_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction instruction);
     void process_successcopy_instruction(SUCCESSCOPY_Instruction instruction);
     void process_ecadd_instruction(ECADD_Instruction instruction);

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/configuration.hpp
@@ -265,7 +265,8 @@ enum class InstructionGenerationOptions {
     SENDL2TOL1MSG,
     EMITUNENCRYPTEDLOG,
     CALL,
-    RETURNDATASIZE_WITH_RETURNDATACOPY,
+    RETURNDATASIZE,
+    RETURNDATACOPY,
     GETCONTRACTINSTANCE,
     SUCCESSCOPY,
     ECADD,
@@ -276,7 +277,7 @@ enum class InstructionGenerationOptions {
     DEBUGLOG,
 };
 
-using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 59>;
+using InstructionGenerationConfig = WeightedSelectionConfig<InstructionGenerationOptions, 60>;
 
 constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION = InstructionGenerationConfig({
     { InstructionGenerationOptions::ADD_8, 1 },
@@ -329,7 +330,8 @@ constexpr InstructionGenerationConfig BASIC_INSTRUCTION_GENERATION_CONFIGURATION
     { InstructionGenerationOptions::SENDL2TOL1MSG, 1 },
     { InstructionGenerationOptions::EMITUNENCRYPTEDLOG, 1 },
     { InstructionGenerationOptions::CALL, 1 },
-    { InstructionGenerationOptions::RETURNDATASIZE_WITH_RETURNDATACOPY, 1 },
+    { InstructionGenerationOptions::RETURNDATASIZE, 1 },
+    { InstructionGenerationOptions::RETURNDATACOPY, 1 },
     { InstructionGenerationOptions::GETCONTRACTINSTANCE, 1 },
     { InstructionGenerationOptions::SUCCESSCOPY, 1 },
     { InstructionGenerationOptions::ECADD, 1 },
@@ -401,15 +403,17 @@ constexpr NoteHashExistsMutationConfig BASIC_NOTEHASHEXISTS_MUTATION_CONFIGURATI
     { NoteHashExistsMutationOptions::result_address, 1 },
 });
 
-enum class CalldataCopyMutationOptions { dst_address, copy_size, copy_size_address, cd_start, cd_start_address };
-using CalldataCopyMutationConfig = WeightedSelectionConfig<CalldataCopyMutationOptions, 5>;
+enum class CalldataCopyMutationOptions {
+    copy_size_address,
+    cd_offset_address,
+    dst_address,
+};
+using CalldataCopyMutationConfig = WeightedSelectionConfig<CalldataCopyMutationOptions, 3>;
 
 constexpr CalldataCopyMutationConfig BASIC_CALLDATACOPY_MUTATION_CONFIGURATION = CalldataCopyMutationConfig({
-    { CalldataCopyMutationOptions::dst_address, 1 },
-    { CalldataCopyMutationOptions::copy_size, 1 },
     { CalldataCopyMutationOptions::copy_size_address, 1 },
-    { CalldataCopyMutationOptions::cd_start, 1 },
-    { CalldataCopyMutationOptions::cd_start_address, 1 },
+    { CalldataCopyMutationOptions::cd_offset_address, 1 },
+    { CalldataCopyMutationOptions::dst_address, 1 },
 });
 
 enum class SendL2ToL1MsgMutationOptions { recipient, recipient_address, content, content_address };
@@ -452,16 +456,14 @@ constexpr CallMutationConfig BASIC_CALL_MUTATION_CONFIGURATION = CallMutationCon
     { CallMutationOptions::is_static_call, 1 },
 });
 
-enum class ReturndatasizeWithReturndatacopyMutationOptions { copy_size_offset, dst_address, rd_start_offset };
-using ReturndatasizeWithReturndatacopyMutationConfig =
-    WeightedSelectionConfig<ReturndatasizeWithReturndatacopyMutationOptions, 3>;
+enum class ReturndataCopyMutationOptions { copy_size_address, rd_offset_address, dst_address };
+using ReturndataCopyMutationConfig = WeightedSelectionConfig<ReturndataCopyMutationOptions, 3>;
 
-constexpr ReturndatasizeWithReturndatacopyMutationConfig
-    BASIC_RETURNDATASIZE_WITH_RETURNDATACOPY_MUTATION_CONFIGURATION = ReturndatasizeWithReturndatacopyMutationConfig({
-        { ReturndatasizeWithReturndatacopyMutationOptions::copy_size_offset, 1 },
-        { ReturndatasizeWithReturndatacopyMutationOptions::dst_address, 1 },
-        { ReturndatasizeWithReturndatacopyMutationOptions::rd_start_offset, 1 },
-    });
+constexpr ReturndataCopyMutationConfig BASIC_RETURNDATACOPY_MUTATION_CONFIGURATION = ReturndataCopyMutationConfig({
+    { ReturndataCopyMutationOptions::copy_size_address, 1 },
+    { ReturndataCopyMutationOptions::rd_offset_address, 1 },
+    { ReturndataCopyMutationOptions::dst_address, 1 },
+});
 
 enum class GetContractInstanceMutationOptions { contract_address_address, dst_address, member_enum };
 using GetContractInstanceMutationConfig = WeightedSelectionConfig<GetContractInstanceMutationOptions, 3>;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.cpp
@@ -240,11 +240,7 @@ std::vector<FuzzInstruction> InstructionMutator::generate_instruction(std::mt199
     case InstructionGenerationOptions::NOTEHASHEXISTS:
         return generate_notehashexists_instruction(rng);
     case InstructionGenerationOptions::CALLDATACOPY:
-        return { CALLDATACOPY_Instruction{ .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                           .copy_size = generate_random_uint8(rng),
-                                           .copy_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
-                                           .cd_start = generate_random_uint16(rng),
-                                           .cd_start_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+        return generate_calldatacopy_instruction(rng);
     case InstructionGenerationOptions::SENDL2TOL1MSG:
         return { SENDL2TOL1MSG_Instruction{ .recipient = generate_random_field(rng),
                                             .recipient_address = generate_address_ref(rng, MAX_16BIT_OPERAND),
@@ -254,10 +250,10 @@ std::vector<FuzzInstruction> InstructionMutator::generate_instruction(std::mt199
         return generate_emitunencryptedlog_instruction(rng);
     case InstructionGenerationOptions::CALL:
         return generate_call_instruction(rng);
-    case InstructionGenerationOptions::RETURNDATASIZE_WITH_RETURNDATACOPY:
-        return { RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction{ .copy_size_offset = generate_random_uint16(rng),
-                                                                 .dst_address = generate_random_uint16(rng),
-                                                                 .rd_start_offset = generate_random_uint16(rng) } };
+    case InstructionGenerationOptions::RETURNDATASIZE:
+        return generate_returndatasize_instruction(rng);
+    case InstructionGenerationOptions::RETURNDATACOPY:
+        return generate_returndatacopy_instruction(rng);
     case InstructionGenerationOptions::GETCONTRACTINSTANCE:
         return generate_getcontractinstance_instruction(rng);
     case InstructionGenerationOptions::SUCCESSCOPY:
@@ -336,9 +332,8 @@ void InstructionMutator::mutate_instruction(FuzzInstruction& instruction, std::m
             [&rng, this](SENDL2TOL1MSG_Instruction& instr) { mutate_sendl2tol1msg_instruction(instr, rng); },
             [&rng, this](EMITUNENCRYPTEDLOG_Instruction& instr) { mutate_emitunencryptedlog_instruction(instr, rng); },
             [&rng, this](CALL_Instruction& instr) { mutate_call_instruction(instr, rng); },
-            [&rng, this](RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instr) {
-                mutate_returndatasize_with_returndatacopy_instruction(instr, rng);
-            },
+            [&rng, this](RETURNDATASIZE_Instruction& instr) { mutate_returndatasize_instruction(instr, rng); },
+            [&rng, this](RETURNDATACOPY_Instruction& instr) { mutate_returndatacopy_instruction(instr, rng); },
             [&rng, this](GETCONTRACTINSTANCE_Instruction& instr) {
                 mutate_getcontractinstance_instruction(instr, rng);
             },
@@ -907,6 +902,69 @@ std::vector<FuzzInstruction> InstructionMutator::generate_notehashexists_instruc
     return instructions;
 }
 
+std::vector<FuzzInstruction> InstructionMutator::generate_returndatasize_instruction(std::mt19937_64& rng)
+{
+    return { RETURNDATASIZE_Instruction{ .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_returndatacopy_instruction(std::mt19937_64& rng)
+{
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        return { RETURNDATACOPY_Instruction{ .copy_size_address = generate_variable_ref(rng),
+                                             .rd_offset_address = generate_variable_ref(rng),
+                                             .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(3);
+    auto copy_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = copy_size_address,
+                                               // We generate small sizes so we fail less often due to gas
+                                               // Mutations might change this to a larger value.
+                                               .value = generate_random_uint8(rng) });
+
+    auto rd_offset_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = rd_offset_address,
+                                               .value = generate_random_uint8(rng) });
+
+    instructions.push_back(RETURNDATACOPY_Instruction{ .copy_size_address = copy_size_address,
+                                                       .rd_offset_address = rd_offset_address,
+                                                       .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+
+    return instructions;
+}
+
+std::vector<FuzzInstruction> InstructionMutator::generate_calldatacopy_instruction(std::mt19937_64& rng)
+{
+    bool use_backfill = std::uniform_int_distribution<int>(0, 4)(rng) != 0;
+    if (!use_backfill) {
+        return { CALLDATACOPY_Instruction{ .copy_size_address = generate_variable_ref(rng),
+                                           .cd_offset_address = generate_variable_ref(rng),
+                                           .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) } };
+    }
+    std::vector<FuzzInstruction> instructions;
+    instructions.reserve(3);
+    auto copy_size_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = copy_size_address,
+                                               // We generate small sizes so we fail less often due to gas
+                                               // Mutations might change this to a larger value.
+                                               .value = generate_random_uint8(rng) });
+
+    auto cd_offset_address = generate_address_ref(rng, MAX_16BIT_OPERAND);
+    instructions.push_back(SET_32_Instruction{ .value_tag = bb::avm2::MemoryTag::U32,
+                                               .result_address = cd_offset_address,
+                                               .value = generate_random_uint8(rng) });
+
+    instructions.push_back(CALLDATACOPY_Instruction{ .copy_size_address = copy_size_address,
+                                                     .cd_offset_address = cd_offset_address,
+                                                     .dst_address = generate_address_ref(rng, MAX_16BIT_OPERAND) });
+
+    return instructions;
+}
+
 void InstructionMutator::mutate_param_ref(ParamRef& param,
                                           std::mt19937_64& rng,
                                           std::optional<MemoryTag> default_tag,
@@ -1259,20 +1317,14 @@ void InstructionMutator::mutate_calldatacopy_instruction(CALLDATACOPY_Instructio
 {
     CalldataCopyMutationOptions option = BASIC_CALLDATACOPY_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
+    case CalldataCopyMutationOptions::copy_size_address:
+        mutate_param_ref(instruction.copy_size_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
+        break;
+    case CalldataCopyMutationOptions::cd_offset_address:
+        mutate_param_ref(instruction.cd_offset_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
+        break;
     case CalldataCopyMutationOptions::dst_address:
         mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);
-        break;
-    case CalldataCopyMutationOptions::copy_size:
-        mutate_uint8_t(instruction.copy_size, rng, BASIC_UINT8_T_MUTATION_CONFIGURATION);
-        break;
-    case CalldataCopyMutationOptions::copy_size_address:
-        mutate_address_ref(instruction.copy_size_address, rng, MAX_16BIT_OPERAND);
-        break;
-    case CalldataCopyMutationOptions::cd_start:
-        mutate_uint16_t(instruction.cd_start, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
-        break;
-    case CalldataCopyMutationOptions::cd_start_address:
-        mutate_address_ref(instruction.cd_start_address, rng, MAX_16BIT_OPERAND);
         break;
     }
 }
@@ -1338,20 +1390,25 @@ void InstructionMutator::mutate_call_instruction(CALL_Instruction& instruction, 
     }
 }
 
-void InstructionMutator::mutate_returndatasize_with_returndatacopy_instruction(
-    RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instruction, std::mt19937_64& rng)
+void InstructionMutator::mutate_returndatasize_instruction(RETURNDATASIZE_Instruction& instruction,
+                                                           std::mt19937_64& rng)
 {
-    ReturndatasizeWithReturndatacopyMutationOptions option =
-        BASIC_RETURNDATASIZE_WITH_RETURNDATACOPY_MUTATION_CONFIGURATION.select(rng);
+    mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);
+}
+
+void InstructionMutator::mutate_returndatacopy_instruction(RETURNDATACOPY_Instruction& instruction,
+                                                           std::mt19937_64& rng)
+{
+    ReturndataCopyMutationOptions option = BASIC_RETURNDATACOPY_MUTATION_CONFIGURATION.select(rng);
     switch (option) {
-    case ReturndatasizeWithReturndatacopyMutationOptions::copy_size_offset:
-        mutate_uint16_t(instruction.copy_size_offset, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+    case ReturndataCopyMutationOptions::copy_size_address:
+        mutate_param_ref(instruction.copy_size_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
         break;
-    case ReturndatasizeWithReturndatacopyMutationOptions::dst_address:
-        mutate_uint16_t(instruction.dst_address, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+    case ReturndataCopyMutationOptions::rd_offset_address:
+        mutate_param_ref(instruction.rd_offset_address, rng, MemoryTag::U32, MAX_16BIT_OPERAND);
         break;
-    case ReturndatasizeWithReturndatacopyMutationOptions::rd_start_offset:
-        mutate_uint16_t(instruction.rd_start_offset, rng, BASIC_UINT16_T_MUTATION_CONFIGURATION);
+    case ReturndataCopyMutationOptions::dst_address:
+        mutate_address_ref(instruction.dst_address, rng, MAX_16BIT_OPERAND);
         break;
     }
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/instructions/instruction.hpp
@@ -47,6 +47,9 @@ class InstructionMutator {
     std::vector<FuzzInstruction> generate_call_instruction(std::mt19937_64& rng);
     std::vector<FuzzInstruction> generate_getcontractinstance_instruction(std::mt19937_64& rng);
     std::vector<FuzzInstruction> generate_notehashexists_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_returndatasize_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_returndatacopy_instruction(std::mt19937_64& rng);
+    std::vector<FuzzInstruction> generate_calldatacopy_instruction(std::mt19937_64& rng);
 
     void mutate_variable_ref(VariableRef& variable, std::mt19937_64& rng, std::optional<MemoryTag> default_tag);
     void mutate_address_ref(AddressRef& address, std::mt19937_64& rng, uint32_t max_operand_value);
@@ -82,8 +85,8 @@ class InstructionMutator {
     void mutate_sendl2tol1msg_instruction(SENDL2TOL1MSG_Instruction& instruction, std::mt19937_64& rng);
     void mutate_emitunencryptedlog_instruction(EMITUNENCRYPTEDLOG_Instruction& instruction, std::mt19937_64& rng);
     void mutate_call_instruction(CALL_Instruction& instruction, std::mt19937_64& rng);
-    void mutate_returndatasize_with_returndatacopy_instruction(
-        RETURNDATASIZE_WITH_RETURNDATACOPY_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_returndatasize_instruction(RETURNDATASIZE_Instruction& instruction, std::mt19937_64& rng);
+    void mutate_returndatacopy_instruction(RETURNDATACOPY_Instruction& instruction, std::mt19937_64& rng);
     void mutate_getcontractinstance_instruction(GETCONTRACTINSTANCE_Instruction& instruction, std::mt19937_64& rng);
     void mutate_successcopy_instruction(SUCCESSCOPY_Instruction& instruction, std::mt19937_64& rng);
     void mutate_ecadd_instruction(ECADD_Instruction& instruction, std::mt19937_64& rng);


### PR DESCRIPTION
Resolves https://linear.app/aztec-labs/issue/AVM-195/refactor-returndatasize-and-returndatacopy-fuzzing