### PR TITLE
docs: add deployWithOpts documentation for contracts with multiple initializers

### DIFF
--- a/docs/docs-developers/docs/aztec-js/how_to_deploy_contract.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_deploy_contract.md
@@ -125,6 +125,23 @@ await contract.methods
   .wait();
 ```
 
+### Deploy with a specific initializer
+
+Some contracts have multiple initializer functions (e.g., both a private `constructor` and a `public_constructor`). By default, the generated `deploy()` method uses the default initializer (typically named `constructor`). To deploy using a different initializer, use `deployWithOpts`:
+
+#include_code deploy_with_opts yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts typescript
+
+The `deployWithOpts` method accepts an options object as its first argument:
+- `wallet`: The wallet to use for deployment (required)
+- `method`: The name of the initializer function to call (optional, defaults to `constructor`)
+- `publicKeys`: Custom public keys for the contract instance (optional)
+
+The remaining arguments are the parameters for the chosen initializer function.
+
+:::tip
+This is useful for contracts that support multiple initialization patterns, such as token standards that allow both private and public minting during deployment.
+:::
+
 ## Calculate deployment address
 
 ### Get address before deployment

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -80,9 +80,11 @@ describe('e2e_deploy_contract deploy method', () => {
   it('publicly deploys and initializes via a public function', async () => {
     const owner = defaultAccountAddress;
     logger.debug(`Deploying contract via a public constructor`);
+    // docs:start:deploy_with_opts
     const contract = await StatefulTestContract.deployWithOpts({ wallet, method: 'public_constructor' }, owner, 42)
       .send({ from: defaultAccountAddress })
       .deployed();
+    // docs:end:deploy_with_opts
     expect(await contract.methods.get_public_value(owner).simulate({ from: defaultAccountAddress })).toEqual(42n);
     logger.debug(`Calling a private function to ensure the contract was properly initialized`);
     await contract.methods.create_note(owner, 30).send({ from: defaultAccountAddress }).wait();


### PR DESCRIPTION
## Summary
- Adds documentation for `deployWithOpts` method to the "How to deploy contract" guide
- Documents how to deploy contracts with multiple initializers (e.g., both private `constructor` and `public_constructor`)
- Adds docs markers to the e2e test for code inclusion

Fixes TRIAGE-72
