### PR TITLE
chore: fix tsc.sh unintentional ref

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -114,7 +114,7 @@ function compile_all {
   cd pxe && yarn check_oracle_version
   cd ..
 
-  cmds=('format --check' './scripts/tsc.sh --emitDeclarationOnly')
+  cmds=('format --check' 'yarn tsgo -b --emitDeclarationOnly')
   if [ "${CI:-0}" -eq 1 ]; then
     cmds+=('lint --check')
   fi


### PR DESCRIPTION
This wasn't meant to be changed to tsc.sh
