### PR TITLE
fix(avm): some fuzzer bugs and contract addresses in external call

### DIFF
--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.cpp
@@ -86,6 +86,11 @@ void FuzzerContext::set_existing_note_hashes(std::span<const std::pair<FF, uint6
     existing_note_hashes_.assign(note_hashes.begin(), note_hashes.end());
 }
 
+void FuzzerContext::set_existing_contract_addresses(std::span<const AztecAddress> contract_addresses)
+{
+    contract_addresses_.assign(contract_addresses.begin(), contract_addresses.end());
+}
+
 void FuzzerContext::reset()
 {
     contract_addresses_.clear();

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzz_lib/fuzzer_context.hpp
@@ -57,6 +57,8 @@ class FuzzerContext {
 
     void set_existing_note_hashes(std::span<const std::pair<FF, uint64_t>> note_hashes);
 
+    void set_existing_contract_addresses(std::span<const FF> contract_addresses);
+
   private:
     std::vector<FF> contract_addresses_;
     std::unique_ptr<FuzzerContractDB> contract_db_;

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.cpp
@@ -322,12 +322,6 @@ size_t mutate_tx_data(FuzzerContext& context,
 
     populate_context_from_tx_data(context, tx_data);
 
-    // Mutate the fuzzer data multiple times for better bytecode variety
-    auto num_mutations = std::uniform_int_distribution<uint8_t>(1, 5)(rng);
-    for (uint8_t i = 0; i < num_mutations; i++) {
-        mutate_fuzzer_data_vec(context, tx_data.input_programs, rng, 64);
-    }
-
     // Build up bytecodes, contract classes and instances from the fuzzer data
     tx_data.contract_classes.clear();
     tx_data.contract_instances.clear();
@@ -357,8 +351,8 @@ size_t mutate_tx_data(FuzzerContext& context,
 
     // Ensure all enqueued calls have valid contract addresses (not placeholders)
     // We may add more advanced mutation to change contract addresses later, right now we just ensure they are valid
-    auto idx_dist = std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1);
     if (!contract_addresses.empty()) {
+        auto idx_dist = std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1);
         for (auto& call : tx_data.tx.setup_enqueued_calls) {
             call.request.contract_address = contract_addresses[idx_dist(rng)];
         }
@@ -371,23 +365,22 @@ size_t mutate_tx_data(FuzzerContext& context,
     FuzzerTxDataMutationType mutation_choice = FUZZER_TX_DATA_MUTATION_CONFIGURATION.select(rng);
 
     switch (mutation_choice) {
+    case FuzzerTxDataMutationType::TxFuzzerDataMutation:
+        mutate_fuzzer_data_vec(context, tx_data.input_programs, rng, 64);
+        break;
     case FuzzerTxDataMutationType::TxMutation:
         mutate_tx(tx_data.tx, contract_addresses, rng);
         break;
-    case FuzzerTxDataMutationType::BytecodeMutation: {
-        // Mutate bytecode and append public data writes for world state setup
+    case FuzzerTxDataMutationType::BytecodeMutation:
         mutate_bytecode(tx_data.contract_classes,
                         tx_data.contract_instances,
                         tx_data.contract_addresses,
                         tx_data.public_data_writes,
                         rng);
         break;
-    }
+
     case FuzzerTxDataMutationType::ContractClassMutation:
         mutate_contract_classes(tx_data.contract_classes, tx_data.contract_instances, tx_data.contract_addresses, rng);
-        // The fuzzer (like the AVM) assumes that all triplets of contract classes, instances and addresses are in sync
-        // So when we mutate contract classes, we also need to update the corresponding artifacts
-
         break;
     case FuzzerTxDataMutationType::ContractInstanceMutation:
         mutate_contract_instances(tx_data.contract_instances, tx_data.contract_addresses, rng);
@@ -413,8 +406,8 @@ size_t mutate_tx_data(FuzzerContext& context,
         }
     }
 
-    // todo: do we need to ensure this or are should we able to process 0 enqueued calls?
-    // Ensure at least 1 app_logic enqueued call exists (mutations may have deleted all)
+    // Ensure at least 1 app_logic enqueued call exists (mutations may have deleted all), the public base kernel circuit
+    // guarantees that there is at least 1 enqueued call in an public tx (so this is a valid assumption)
     if (tx_data.tx.app_logic_enqueued_calls.empty() && !contract_addresses.empty()) {
         auto idx = std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1)(rng);
         std::vector<FF> calldata = {};
@@ -473,4 +466,6 @@ void populate_context_from_tx_data(FuzzerContext& context, const FuzzerTxData& t
     }
 
     context.set_existing_note_hashes(note_hash_leaf_index_pairs);
+
+    context.set_existing_contract_addresses(tx_data.contract_addresses);
 }

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/fuzzer_lib.hpp
@@ -61,6 +61,7 @@ using FuzzerContext = bb::avm2::fuzzer::FuzzerContext;
 
 // Mutation configuration
 enum class FuzzerTxDataMutationType : uint8_t {
+    TxFuzzerDataMutation,
     TxMutation,
     BytecodeMutation,
     ContractClassMutation,
@@ -69,9 +70,10 @@ enum class FuzzerTxDataMutationType : uint8_t {
     ProtocolContractsMutation
 };
 
-using FuzzerTxDataMutationConfig = WeightedSelectionConfig<FuzzerTxDataMutationType, 6>;
+using FuzzerTxDataMutationConfig = WeightedSelectionConfig<FuzzerTxDataMutationType, 7>;
 
 constexpr FuzzerTxDataMutationConfig FUZZER_TX_DATA_MUTATION_CONFIGURATION = FuzzerTxDataMutationConfig({
+    { FuzzerTxDataMutationType::TxFuzzerDataMutation, 20 },
     { FuzzerTxDataMutationType::TxMutation, 10 },
     { FuzzerTxDataMutationType::BytecodeMutation, 1 },
     { FuzzerTxDataMutationType::ContractClassMutation, 1 },

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.cpp
@@ -127,18 +127,18 @@ void mutate_fuzzer_data_vec(const FuzzerContext& context,
                             std::mt19937_64& rng,
                             size_t max_size)
 {
-    auto choice = std::uniform_int_distribution<uint8_t>(0, 1)(rng);
+    auto choice = ENQUEUED_CALL_MUTATION_CONFIGURATION.select(rng);
+
     switch (choice) {
-    case 0: {
+    case EnqueuedCallMutation::Add:
         fuzz_info("Adding a new enqueued call");
         // Add a new enqueued call
         if (enqueued_calls.size() < max_size) {
-            FuzzerData new_enqueued_call = generate_fuzzer_data(rng, context);
-            enqueued_calls.push_back(new_enqueued_call);
+            enqueued_calls.push_back(generate_fuzzer_data(rng, context));
         }
         break;
-    }
-    case 1: {
+
+    case EnqueuedCallMutation::Mutate: {
         // Mutate an existing enqueued call
         fuzz_info("Mutating an existing enqueued call");
         if (!enqueued_calls.empty()) {
@@ -149,15 +149,14 @@ void mutate_fuzzer_data_vec(const FuzzerContext& context,
         }
         break;
     }
-        // case 2: {
-        //     // Remove an existing enqueued call
-        //     vinfo("Removing an existing enqueued call");
-        //     if (!enqueued_calls.empty()) {
-        //         size_t idx = std::uniform_int_distribution<size_t>(0, enqueued_calls.size() - 1)(rng);
-        //         enqueued_calls.erase(enqueued_calls.begin() + static_cast<std::ptrdiff_t>(idx));
-        //     }
-        //     break;
-        // }
+    case EnqueuedCallMutation::Remove:
+        // Remove an existing enqueued call
+        fuzz_info("Removing an existing enqueued call");
+        if (!enqueued_calls.empty()) {
+            size_t idx = std::uniform_int_distribution<size_t>(0, enqueued_calls.size() - 1)(rng);
+            enqueued_calls.erase(enqueued_calls.begin() + static_cast<std::ptrdiff_t>(idx));
+        }
+        break;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_data.hpp
@@ -35,6 +35,15 @@ constexpr TxMutationConfig TX_MUTATION_CONFIGURATION = TxMutationConfig({
     { TxMutationOptions::FeePayer, 1 },
 });
 
+enum class EnqueuedCallMutation { Add, Mutate, Remove };
+
+using EnqueuedCallMutationConfig = WeightedSelectionConfig<EnqueuedCallMutation, 3>;
+constexpr EnqueuedCallMutationConfig ENQUEUED_CALL_MUTATION_CONFIGURATION = EnqueuedCallMutationConfig({
+    { EnqueuedCallMutation::Add, 30 },
+    { EnqueuedCallMutation::Mutate, 50 },
+    { EnqueuedCallMutation::Remove, 20 },
+});
+
 namespace bb::avm2::fuzzer {
 
 void mutate_tx(Tx& tx, std::vector<AztecAddress>& contract_addresses, std::mt19937_64& rng);
@@ -42,6 +51,6 @@ void mutate_tx(Tx& tx, std::vector<AztecAddress>& contract_addresses, std::mt199
 void mutate_fuzzer_data_vec(const FuzzerContext& context,
                             std::vector<FuzzerData>& enqueued_calls,
                             std::mt19937_64& rng,
-                            size_t max_size = 10);
+                            size_t max_size = 64);
 
 } // namespace bb::avm2::fuzzer

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_types/public_call_request.cpp
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/mutations/tx_types/public_call_request.cpp
@@ -16,7 +16,7 @@ namespace {
 void mutate_contract_address(AztecAddress& address, std::vector<AztecAddress>& contract_addresses, std::mt19937_64& rng)
 {
     if (contract_addresses.empty()) {
-        address = generate_random_field(rng);
+        return;
     }
     // Most of the time we want to pick from the existing contract addresses, since a random address will fail early
     auto contract_address_choice = std::uniform_int_distribution<size_t>(0, contract_addresses.size() - 1)(rng);


### PR DESCRIPTION
Adding contract addresses to the context so that external call can utilise them.


also some bugs that impacted enqueued call mutations