### PR TITLE
chore(claude): add parent dir to yarn-project permissions

### DIFF
--- a/yarn-project/.claude/settings.json
+++ b/yarn-project/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "additionalDirectories": ["../"],
     "allow": [
       "Bash(yarn:*)",
       "Bash(forge:*)",


### PR DESCRIPTION
Should allow running commands from the project root, such as git commands, bootstrap, or ci.