### PR TITLE
refactor: parallelizing kernel hints building

### DIFF
--- a/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
@@ -157,16 +157,6 @@ export class PrivateKernelResetPrivateInputsBuilder {
       allowRemainder,
     );
 
-    const previousVkMembershipWitness = await oracle.getVkMembershipWitness(
-      this.previousKernelOutput.verificationKey.keyAsFields,
-    );
-    const vkData = new VkData(
-      this.previousKernelOutput.verificationKey,
-      Number(previousVkMembershipWitness.leafIndex),
-      previousVkMembershipWitness.siblingPath,
-    );
-    const previousKernelData = new PrivateKernelData(this.previousKernelOutput.publicInputs, vkData);
-
     this.reduceReadRequestActions(
       this.noteHashResetActions,
       dimensions.NOTE_HASH_PENDING_READ,
@@ -178,6 +168,41 @@ export class PrivateKernelResetPrivateInputsBuilder {
       dimensions.NULLIFIER_SETTLED_READ,
     );
 
+    // Execute all the expensive node querying operations in parallel.
+    const [previousVkMembershipWitness, noteHashReadRequestHints, nullifierReadRequestHints, keyValidationHints] =
+      await Promise.all([
+        oracle.getVkMembershipWitness(this.previousKernelOutput.verificationKey.keyAsFields),
+        buildNoteHashReadRequestHintsFromResetActions<
+          typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+          typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
+        >(
+          oracle,
+          this.previousKernel.validationRequests.noteHashReadRequests,
+          this.previousKernel.end.noteHashes,
+          this.noteHashResetActions,
+        ),
+        buildNullifierReadRequestHintsFromResetActions<
+          typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+          typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX
+        >(
+          { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },
+          this.previousKernel.validationRequests.nullifierReadRequests,
+          this.nullifierResetActions,
+        ),
+        getMasterSecretKeysAndAppKeyGenerators(
+          this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
+          dimensions.KEY_VALIDATION,
+          oracle,
+        ),
+      ]);
+
+    const vkData = new VkData(
+      this.previousKernelOutput.verificationKey,
+      Number(previousVkMembershipWitness.leafIndex),
+      previousVkMembershipWitness.siblingPath,
+    );
+    const previousKernelData = new PrivateKernelData(this.previousKernelOutput.publicInputs, vkData);
+
     // TODO: Enable padding when we have a better idea what are the final amounts we should pad to.
     const paddedSideEffects = PaddedSideEffects.empty();
 
@@ -185,22 +210,9 @@ export class PrivateKernelResetPrivateInputsBuilder {
       previousKernelData,
       paddedSideEffects,
       new PrivateKernelResetHints(
-        await buildNoteHashReadRequestHintsFromResetActions(
-          oracle,
-          this.previousKernel.validationRequests.noteHashReadRequests,
-          this.previousKernel.end.noteHashes,
-          this.noteHashResetActions,
-        ),
-        await buildNullifierReadRequestHintsFromResetActions(
-          { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },
-          this.previousKernel.validationRequests.nullifierReadRequests,
-          this.nullifierResetActions,
-        ),
-        await getMasterSecretKeysAndAppKeyGenerators(
-          this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
-          dimensions.KEY_VALIDATION,
-          oracle,
-        ),
+        noteHashReadRequestHints,
+        nullifierReadRequestHints,
+        keyValidationHints,
         this.transientDataSquashingHints,
       ),
       dimensions,

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
@@ -76,15 +76,26 @@ export async function buildNoteHashReadRequestHintsFromResetActions<PENDING exte
     builder.addPendingReadRequest(hint.readRequestIndex, hint.pendingValueIndex);
   });
 
+  // Collect all settled read requests
+  const settledRequests: { index: number; readRequest: ScopedReadRequest }[] = [];
   for (let i = 0; i < resetActions.actions.length; i++) {
     if (resetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
-      const readRequest = noteHashReadRequests.array[i];
-      const membershipWitness = await oracle.getNoteHashMembershipWitness(readRequest.value);
-      if (!membershipWitness) {
-        throw new Error('Read request is reading an unknown note hash.');
-      }
-      builder.addSettledReadRequest(i, membershipWitness, readRequest.value);
+      settledRequests.push({ index: i, readRequest: noteHashReadRequests.array[i] });
     }
+  }
+
+  // Fetch all membership witnesses in parallel
+  const membershipWitnesses = await Promise.all(
+    settledRequests.map(({ readRequest }) => oracle.getNoteHashMembershipWitness(readRequest.value)),
+  );
+
+  // Add settled read requests to builder
+  for (let i = 0; i < settledRequests.length; i++) {
+    const membershipWitness = membershipWitnesses[i];
+    if (!membershipWitness) {
+      throw new Error('Read request is reading an unknown note hash.');
+    }
+    builder.addSettledReadRequest(settledRequests[i].index, membershipWitness, settledRequests[i].readRequest.value);
   }
 
   const noteHashMap: Map<bigint, { noteHash: ScopedNoteHash; index: number }[]> = new Map();

--- a/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
@@ -82,19 +82,31 @@ export async function buildNullifierReadRequestHintsFromResetActions<PENDING ext
     builder.addPendingReadRequest(hint.readRequestIndex, hint.pendingValueIndex);
   });
 
+  // Collect all settled read requests
+  const settledRequests: { index: number; readRequest: ScopedReadRequest }[] = [];
   for (let i = 0; i < resetActions.actions.length; i++) {
     if (resetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
-      const readRequest = nullifierReadRequests.array[i];
-      const siloedValue = siloed
-        ? readRequest.value
-        : await siloNullifier(readRequest.contractAddress, readRequest.value);
-      const membershipWitnessWithPreimage = await oracle.getNullifierMembershipWitness(siloedValue);
-      builder.addSettledReadRequest(
-        i,
-        membershipWitnessWithPreimage.membershipWitness,
-        membershipWitnessWithPreimage.leafPreimage,
-      );
+      settledRequests.push({ index: i, readRequest: nullifierReadRequests.array[i] });
     }
+  }
+
+  // Compute siloed values in parallel (if not already siloed)
+  const siloedValues = siloed
+    ? settledRequests.map(({ readRequest }) => readRequest.value)
+    : await Promise.all(
+        settledRequests.map(({ readRequest }) => siloNullifier(readRequest.contractAddress, readRequest.value)),
+      );
+
+  // Fetch all membership witnesses in parallel
+  const membershipWitnesses = await Promise.all(siloedValues.map(value => oracle.getNullifierMembershipWitness(value)));
+
+  // Add settled read requests to builder
+  for (let i = 0; i < settledRequests.length; i++) {
+    builder.addSettledReadRequest(
+      settledRequests[i].index,
+      membershipWitnesses[i].membershipWitness,
+      membershipWitnesses[i].leafPreimage,
+    );
   }
 
   return builder.toHints();


### PR DESCRIPTION
Kernel hints building has been done sequentially. This is slow due to the need to query a node multiple times. In this PR I parallelize the requests.

Fixes https://linear.app/aztec-labs/issue/F-140/review-kernel-read-requests-data-queries

Before the optimizatioin:

```
    ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
    ║  ROUND TRIP DEBUGGING INFORMATION                                                                                    ║
    ╠══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╣
    ║  Account Type: ECDSAR1                                                                                               ║
    ╠──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╣
    ║  Configuration: ecdsar1+sponsored_fpc                                                                                ║
    ║  Total Round Trips: 165                                                                                              ║
    ║  Payment Method: sponsored_fpc                                                                                       ║
    ║                                                                                                                      ║
    ║  Per Round Trip:                                                                                                     ║
    ║    ...
    ║    RT 151: [getPublicDataWitness]                                                                                    ║
    ║    RT 152: [getPublicStorageAt]                                                                                      ║
    ║    RT 153: [getPublicStorageAt]                                                                                      ║
    ║    RT 154: [getPublicStorageAt]                                                                                      ║
    ║    RT 155: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 156: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 157: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 158: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 159: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 160: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 161: [getNoteHashMembershipWitness]                                                                            ║
    ║    RT 162: [getNullifierMembershipWitness]                                                                           ║
    ║    RT 163: [getNullifierMembershipWitness]                                                                           ║
    ║    RT 164: [getNullifierMembershipWitness]                                                                           ║
    ║    RT 165: [getNullifierMembershipWitness]                                                                           ║
```

After the optimization:

```
    ╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
    ║  ROUND TRIP DEBUGGING INFORMATION                                                                                    ║
    ╠══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╣
    ║  Account Type: ECDSAR1                                                                                               ║
    ╠──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╣
    ║  Configuration: ecdsar1+sponsored_fpc                                                                                ║
    ║  Total Round Trips: 158                                                                                              ║
    ║  Payment Method: sponsored_fpc                                                                                       ║
    ║                                                                                                                      ║
    ║  Per Round Trip:                                                                                                     ║
    ║    ...
    ║    RT 151: [getPublicDataWitness]                                                                                    ║
    ║    RT 152: [getPublicStorageAt]                                                                                      ║
    ║    RT 153: [getPublicStorageAt]                                                                                      ║
    ║    RT 154: [getPublicStorageAt]                                                                                      ║
    ║    RT 155: [getNoteHashMembershipWitness, getNoteHashMembershipWitness, getNoteHashMembershipWitness,                ║
    ║        getNoteHashMembershipWitness, getNoteHashMembershipWitness, getNoteHashMembershipWitness,                     ║
    ║        getNoteHashMembershipWitness, getNullifierMembershipWitness, getNullifierMembershipWitness,                   ║
    ║        getNullifierMembershipWitness, getNullifierMembershipWitness]                                                 ║
```