### PR TITLE
refactor: don't use pow

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/utils/point.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/point.nr
@@ -52,7 +52,6 @@ mod test {
         BN254_FR_MODULUS_DIV_2, get_sign_of_point, point_from_x_coord, point_from_x_coord_and_sign,
     };
     use dep::protocol_types::point::Point;
-    use dep::protocol_types::utils::field::pow;
 
     #[test]
     unconstrained fn test_point_from_x_coord_and_sign() {
@@ -84,7 +83,7 @@ mod test {
         let point = result.unwrap();
         assert_eq(point.x, Field::from(8));
         // Check curve equation y^2 = x^3 - 17
-        assert_eq(pow(point.y, 2), pow(point.x, 3) - 17);
+        assert_eq(point.y * point.y, point.x * point.x * point.x - 17);
     }
 
     #[test]


### PR DESCRIPTION
Avoid using pow, where possible. I just happened upon this minor thing whilst reviewing kernel circuits. It's just a test fn, but every little helps.
(A comment to discourage usage of pow is being added in a separate pr here (to be reviewed by Leila): https://github.com/AztecProtocol/aztec-packages/pull/19707). I won't go as far as removing the `pub` keyword from `pow` yet.
