### PR TITLE
chore: mark `function_name` and `current_witness_index` fields as optional in ACIR deserializer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
@@ -1120,7 +1120,6 @@ bool test_acir_circuit(const uint8_t* data, size_t size)
         // Create ACIR Circuit
         // Note: num_witnesses may have been updated by logic constraint generation
         Acir::Circuit circuit;
-        circuit.function_name = "main";
         circuit.private_parameters = {};
         circuit.public_parameters.value = {};
         circuit.return_values.value = {};

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_dsl.fuzzer.cpp
@@ -1121,7 +1121,6 @@ bool test_acir_circuit(const uint8_t* data, size_t size)
         // Note: num_witnesses may have been updated by logic constraint generation
         Acir::Circuit circuit;
         circuit.function_name = "main";
-        circuit.current_witness_index = num_witnesses - 1;
         circuit.private_parameters = {};
         circuit.public_parameters.value = {};
         circuit.return_values.value = {};

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.test.cpp
@@ -31,7 +31,6 @@ TYPED_TEST(AcirFormatTests, ExpressionWithOnlyConstantTermFails)
     // In both cases, we should not construct a circuit as either the circuit is not satisfiable, or there is zero gate.
     Acir::Expression expr{ .q_c = bb::fr::one().to_buffer() };
     Acir::Circuit circuit{
-        .current_witness_index = 0,
         .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
         .public_parameters = {},
         .return_values = {},
@@ -49,7 +48,6 @@ TYPED_TEST(AcirFormatTests, ExpressionWithCancellingCoefficientsFails)
                                                     { bb::fr(-1).to_buffer(), Acir::Witness{ 0 } } },
                            .q_c = bb::fr::zero().to_buffer() };
     Acir::Circuit circuit{
-        .current_witness_index = 0,
         .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
         .public_parameters = {},
         .return_values = {},
@@ -70,7 +68,6 @@ TYPED_TEST(AcirFormatTests, PublicInputs)
                            .q_c = bb::fr(-2).to_buffer() };
 
     Acir::Circuit circuit{
-        .current_witness_index = static_cast<uint32_t>(witnesses.size() - 1),
         .opcodes = { Acir::Opcode{ Acir::Opcode::AssertZero{ .value = expr } } },
         .public_parameters =
             Acir::PublicInputs{ .value = { Acir::Witness{ .value = 0 }, Acir::Witness{ .value = 1 } } },

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/arithmetic_constraints.test.cpp
@@ -378,8 +378,7 @@ TYPED_TEST(BigQuadOpcodeGateCountTest, OpcodeGateCount)
     WitnessVector witness_values;
     BigQuadConstraintTest::generate_constraints(big_quad_constraint, witness_values);
 
-    AcirFormat constraint_system =
-        constraint_to_acir_format(big_quad_constraint, static_cast<uint32_t>(witness_values.size() - 1));
+    AcirFormat constraint_system = constraint_to_acir_format(big_quad_constraint);
     AcirProgram program{ constraint_system, witness_values };
     const ProgramMetadata metadata{ .collect_gates_per_opcode = true };
     auto builder = create_circuit<TypeParam>(program, metadata);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -308,8 +308,7 @@ class HonkRecursionConstraintTestingFunctions {
                     RecursionConstraint recursion_constraint = constraints[idx];
                     WitnessVector witnesses = witness_vectors[idx];
 
-                    AcirFormat acir_format = constraint_to_acir_format(
-                        recursion_constraint, /*max_witness_index=*/static_cast<uint32_t>(witnesses.size()) - 1);
+                    AcirFormat acir_format = constraint_to_acir_format(recursion_constraint);
 
                     AcirProgram acir_program{ .constraints = acir_format, .witness = witnesses };
 
@@ -396,8 +395,7 @@ TYPED_TEST(HonkRecursionConstraintTestWithPredicate, GateCountSingleHonkRecursio
         auto [updated_constraint, updated_witness_values] =
             TestFixture::update_witness_based_on_predicate(constraint, witness_values, predicate);
 
-        AcirFormat constraint_system = constraint_to_acir_format(
-            updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+        AcirFormat constraint_system = constraint_to_acir_format(updated_constraint);
 
         AcirProgram program{ constraint_system, updated_witness_values };
         ProgramMetadata metadata = TestFixture::Base::generate_metadata();
@@ -487,8 +485,7 @@ TYPED_TEST(HonkRecursionConstraintTestWithoutPredicate, GateCountRootRollup)
     WitnessVector witness_values;
     TestFixture::Base::generate_constraints(constraint, witness_values);
 
-    AcirFormat constraint_system =
-        constraint_to_acir_format(constraint, /*max_witness_index=*/static_cast<uint32_t>(witness_values.size()) - 1);
+    AcirFormat constraint_system = constraint_to_acir_format(constraint);
 
     AcirProgram program{ constraint_system, witness_values };
     ProgramMetadata metadata = TestFixture::Base::generate_metadata();

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -3493,8 +3493,8 @@ struct PublicInputs {
 };
 
 struct Circuit {
-    std::string function_name;
-    uint32_t current_witness_index;
+    std::optional<std::string> function_name;
+    std::optional<uint32_t> current_witness_index;
     std::vector<Acir::Opcode> opcodes;
     std::vector<Acir::Witness> private_parameters;
     Acir::PublicInputs public_parameters;
@@ -3508,8 +3508,8 @@ struct Circuit {
         std::string name = "Circuit";
         if (o.type == msgpack::type::MAP) {
             auto kvmap = Helpers::make_kvmap(o, name);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, true);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, true);
             Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
             Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
             Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -478,7 +478,6 @@ template <typename ConstraintType> std::vector<Acir::Opcode> constraint_to_acir_
 inline Acir::Circuit build_acir_circuit(const std::vector<Acir::Opcode>& opcodes)
 {
     return Acir::Circuit{
-        .function_name = "test_circuit",
         .opcodes = opcodes,
         .private_parameters = {},
         .public_parameters = Acir::PublicInputs{ .value = {} },

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class.hpp
@@ -475,11 +475,10 @@ template <typename ConstraintType> std::vector<Acir::Opcode> constraint_to_acir_
  *
  * @note max_witness_index is not used by circuit_serde_to_acir_format, but we pass it for completeness
  */
-inline Acir::Circuit build_acir_circuit(const std::vector<Acir::Opcode>& opcodes, uint32_t max_witness_index)
+inline Acir::Circuit build_acir_circuit(const std::vector<Acir::Opcode>& opcodes)
 {
     return Acir::Circuit{
         .function_name = "test_circuit",
-        .current_witness_index = max_witness_index,
         .opcodes = opcodes,
         .private_parameters = {},
         .public_parameters = Acir::PublicInputs{ .value = {} },
@@ -499,11 +498,9 @@ inline Acir::Circuit build_acir_circuit(const std::vector<Acir::Opcode>& opcodes
  * When ConstraintType is a std::vector, iterates over all constraints and collects their opcodes.
  *
  * @param constraint The constraint (or vector of constraints) to convert
- * @param varnum The number of witnesses
  * @return AcirFormat The resulting AcirFormat
  */
-template <typename ConstraintType>
-AcirFormat constraint_to_acir_format(const ConstraintType& constraint, uint32_t varnum)
+template <typename ConstraintType> AcirFormat constraint_to_acir_format(const ConstraintType& constraint)
 {
     std::vector<Acir::Opcode> opcodes;
 
@@ -518,7 +515,7 @@ AcirFormat constraint_to_acir_format(const ConstraintType& constraint, uint32_t 
         opcodes = constraint_to_acir_opcode(constraint);
     }
 
-    Acir::Circuit circuit = build_acir_circuit(opcodes, varnum);
+    Acir::Circuit circuit = build_acir_circuit(opcodes);
     return circuit_serde_to_acir_format(circuit);
 }
 
@@ -613,8 +610,7 @@ template <TestBase Base_> class TestClass {
             Base::invalidate_witness(constraint, witness_values, invalid_witness_target);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
-        AcirFormat constraint_system = constraint_to_acir_format(
-            updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+        AcirFormat constraint_system = constraint_to_acir_format(updated_constraint);
         AcirProgram program{ constraint_system, updated_witness_values };
         auto builder = create_circuit<Builder>(program, Base::generate_metadata());
 
@@ -642,8 +638,7 @@ template <TestBase Base_> class TestClass {
         Base::generate_constraints(constraint, witness_values);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
-        AcirFormat constraint_system = constraint_to_acir_format(
-            constraint, /*max_witness_index=*/static_cast<uint32_t>(witness_values.size()) - 1);
+        AcirFormat constraint_system = constraint_to_acir_format(constraint);
 
         // Construct the vks
         std::shared_ptr<VerificationKey> vk_from_witness;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/test_class_predicate.hpp
@@ -167,8 +167,7 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
             update_witness_based_on_predicate(constraint, witness_values, predicate);
 
         // Use the full ACIR flow: constraint -> Acir::Opcode -> Acir::Circuit -> circuit_serde_to_acir_format
-        AcirFormat constraint_system = constraint_to_acir_format(
-            updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+        AcirFormat constraint_system = constraint_to_acir_format(updated_constraint);
         AcirProgram program{ constraint_system, updated_witness_values };
         auto builder = create_circuit<Builder>(program, Base::generate_metadata());
 
@@ -209,8 +208,7 @@ template <TestBaseWithPredicate Base_> class TestClassWithPredicate {
                 update_witness_based_on_predicate(constraint, witness_values, predicate);
 
             // Use the full ACIR flow
-            AcirFormat constraint_system = constraint_to_acir_format(
-                updated_constraint, /*max_witness_index=*/static_cast<uint32_t>(updated_witness_values.size()) - 1);
+            AcirFormat constraint_system = constraint_to_acir_format(updated_constraint);
             // Construct the vks
             std::shared_ptr<VerificationKey> vk_from_witness;
             {

--- a/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/dsl/avm2_recursion_constraint.test.cpp
@@ -139,7 +139,7 @@ TEST_F(AvmRecursionConstraintTest, DISABLED_GateCountAndVKCheck)
     WitnessVector witness;
     Base::generate_constraints(constraint, witness);
 
-    AcirFormat acir_format = constraint_to_acir_format(constraint, static_cast<uint32_t>(witness.size() - 1));
+    AcirFormat acir_format = constraint_to_acir_format(constraint);
 
     AcirProgram program = { acir_format, {} };
     ProgramMetadata metadata = Base::generate_metadata();


### PR DESCRIPTION
These fields are being removed from the ACIR format so I'm marking them as optional temporarily so barretenberg will tolerate them being missing.