### PR TITLE
feat: add JSON output format for VK, proof, and public inputs

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -21,11 +21,6 @@ tests_hash=$(hash_str \
     ../ts/.rebuild_patterns \
     ../noir/))
 
-function hex_to_fields_json {
-  # 1. split encoded hex into 64-character lines 3. encode as JSON array of hex strings
-  fold -w64 | jq -R -s -c 'split("\n") | map(select(length > 0)) | map("0x" + .)'
-}
-
 # Generate inputs for a given recursively verifying program.
 function run_proof_generation {
   local program=$1
@@ -47,17 +42,15 @@ function run_proof_generation {
   if [[ $program == *"zk"* ]]; then
     disable_zk=""
   fi
-  local prove_cmd="$bb prove --scheme ultra_honk $disable_zk $ipa_accumulation_flag --write_vk -o $outdir -b ./target/program.json -w ./target/witness.gz"
+  local prove_cmd="$bb prove --scheme ultra_honk $disable_zk $ipa_accumulation_flag --write_vk --output_format json -o $outdir -b ./target/program.json -w ./target/witness.gz"
   echo_stderr "$prove_cmd"
   dump_fail "$prove_cmd"
 
-
-  # Split the hex-encoded vk bytes into fields boundaries (but still hex-encoded), first making 64-character lines and then encoding as JSON.
-  # This used to be done by barretenberg itself, but with serialization now always being in field elements we can do it outside of bb.
-  local vk_fields=$(cat "$outdir/vk" | xxd -p -c 0 | hex_to_fields_json)
-  local vk_hash_field="\"0x$(cat "$outdir/vk_hash" | xxd -p -c 0)\""
-  local public_inputs_fields=$(cat "$outdir/public_inputs" | xxd -p -c 0 | hex_to_fields_json)
-  local proof_fields=$(cat "$outdir/proof" | xxd -p -c 0 | hex_to_fields_json)
+  # Extract fields from JSON output (already hex-encoded with 0x prefix)
+  local vk_fields=$(jq -c '.fields' "$outdir/vk.json")
+  local vk_hash_field=$(jq -c '.vk_hash' "$outdir/vk.json")
+  local public_inputs_fields=$(jq -c '.fields' "$outdir/public_inputs.json")
+  local proof_fields=$(jq -c '.fields' "$outdir/proof.json")
 
   generate_toml "$program" "$vk_fields" "$vk_hash_field" "$proof_fields" "$public_inputs_fields"
 }
@@ -96,7 +89,7 @@ function regenerate_recursive_inputs {
   parallel 'run_proof_generation {}' ::: "double_verify_honk_proof" "verify_honk_proof" "verify_honk_zk_proof" "double_verify_honk_zk_proof" "verify_rollup_honk_proof"
 }
 
-export -f hex_to_fields_json regenerate_recursive_inputs run_proof_generation generate_toml
+export -f regenerate_recursive_inputs run_proof_generation generate_toml
 
 function compile {
   echo_header "Compiling acir_tests"

--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -28,6 +28,8 @@ class API {
 
         bool optimized_solidity_verifier{ false }; // should we use the optimized sol verifier? (temp)
 
+        std::string output_format{ "binary" }; // output format for proofs/vks: "binary" or "json"
+
         friend std::ostream& operator<<(std::ostream& os, const Flags& flags)
         {
             os << "flags: [\n"
@@ -45,6 +47,7 @@ class API {
                << "  slow_low_memory " << flags.slow_low_memory << "\n"
                << "  storage_budget " << flags.storage_budget << "\n"
                << "  vk_policy " << flags.vk_policy << "\n"
+               << "  output_format " << flags.output_format << "\n"
                << "]" << std::endl;
             return os;
         }

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -1,5 +1,6 @@
 #include "api_chonk.hpp"
 #include "barretenberg/api/file_io.hpp"
+#include "barretenberg/api/json_output.hpp"
 #include "barretenberg/api/log.hpp"
 #include "barretenberg/bbapi/bbapi.hpp"
 #include "barretenberg/chonk/chonk.hpp"
@@ -10,73 +11,15 @@
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/try_catch_shim.hpp"
-#include "barretenberg/common/version.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/dsl/acir_format/hypernova_recursion_constraint.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/serialize/msgpack_check_eq.hpp"
-#include "barretenberg/serialize/msgpack_impl.hpp"
 #include <algorithm>
-#include <sstream>
 #include <stdexcept>
 
 namespace bb {
 namespace { // anonymous namespace
-
-/**
- * @brief Convert a vector of field elements to a vector of hex strings
- */
-inline std::vector<std::string> fr_vector_to_hex_strings(const std::vector<fr>& fields)
-{
-    std::vector<std::string> result;
-    result.reserve(fields.size());
-    for (const auto& field : fields) {
-        std::stringstream ss;
-        ss << field; // fr's operator<< outputs "0x" prefix
-        result.push_back(ss.str());
-    }
-    return result;
-}
-
-/**
- * @brief Serializable structure for JSON output (msgpack-compatible)
- */
-struct JsonOutput {
-    std::vector<std::string> fields;
-    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
-    std::string file_kind; // "vk" or "proof"
-    std::string bb_version;
-    std::string scheme;
-    std::string verifier_target; // Optional
-
-    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
-};
-
-/**
- * @brief Build JSON output string using msgpack serialization
- */
-std::string build_json_output(const std::vector<fr>& fields,
-                              const std::string& file_kind,
-                              const API::Flags& flags,
-                              const std::string& vk_hash = "")
-{
-    JsonOutput output{
-        .fields = fr_vector_to_hex_strings(fields),
-        .vk_hash = vk_hash,
-        .file_kind = file_kind,
-        .bb_version = BB_VERSION,
-        .scheme = flags.scheme,
-        .verifier_target = flags.verifier_target,
-    };
-
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, output);
-    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
-
-    std::stringstream ss;
-    ss << oh.get();
-    return ss.str();
-}
 
 /**
  * @brief Compute and write to file a MegaHonk VK for a circuit to be accumulated by Chonk.

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -119,17 +119,17 @@ void write_standalone_vk(std::vector<uint8_t> bytecode,
  * @param output_dir Directory to write the VK (or "-" for stdout)
  * @param flags API flags including output_format
  */
-void write_chonk_vk(std::vector<uint8_t> bytecode,
-                    const std::filesystem::path& output_dir,
-                    [[maybe_unused]] const API::Flags& flags)
+void write_chonk_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& output_dir, const API::Flags& flags)
 {
     info("Chonk: computing IVC vk for hiding kernel circuit");
     auto response = bbapi::ChonkComputeIvcVk{ .circuit{ .bytecode = std::move(bytecode) } }.execute();
     const bool output_to_stdout = output_dir == "-";
+    if (flags.output_format == "json") {
+        throw_or_abort("JSON output format is not supported for IVC verification keys");
+    }
     if (output_to_stdout) {
         write_bytes_to_stdout(response.bytes);
     } else {
-        // Note: ChonkComputeIvcVk::Response only has bytes, not fields, so JSON output is not supported
         write_file(output_dir / "vk", response.bytes);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -68,7 +68,8 @@ void write_chonk_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& 
     auto response = bbapi::ChonkComputeIvcVk{ .circuit{ .bytecode = std::move(bytecode) } }.execute();
     const bool output_to_stdout = output_dir == "-";
     if (flags.output_format == "json") {
-        throw_or_abort("JSON output format is not supported for IVC verification keys");
+        // IVC VK doesn't have field elements, only bytes - output as binary with a warning
+        info("Warning: JSON output format is not supported for IVC verification keys, writing binary format");
     }
     if (output_to_stdout) {
         write_bytes_to_stdout(response.bytes);

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -10,16 +10,73 @@
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/try_catch_shim.hpp"
+#include "barretenberg/common/version.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/dsl/acir_format/hypernova_recursion_constraint.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/serialize/msgpack_check_eq.hpp"
+#include "barretenberg/serialize/msgpack_impl.hpp"
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>
 
 namespace bb {
 namespace { // anonymous namespace
+
+/**
+ * @brief Convert a vector of field elements to a vector of hex strings
+ */
+inline std::vector<std::string> fr_vector_to_hex_strings(const std::vector<fr>& fields)
+{
+    std::vector<std::string> result;
+    result.reserve(fields.size());
+    for (const auto& field : fields) {
+        std::stringstream ss;
+        ss << field; // fr's operator<< outputs "0x" prefix
+        result.push_back(ss.str());
+    }
+    return result;
+}
+
+/**
+ * @brief Serializable structure for JSON output (msgpack-compatible)
+ */
+struct JsonOutput {
+    std::vector<std::string> fields;
+    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
+    std::string file_kind; // "vk" or "proof"
+    std::string bb_version;
+    std::string scheme;
+    std::string verifier_target; // Optional
+
+    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
+};
+
+/**
+ * @brief Build JSON output string using msgpack serialization
+ */
+std::string build_json_output(const std::vector<fr>& fields,
+                              const std::string& file_kind,
+                              const API::Flags& flags,
+                              const std::string& vk_hash = "")
+{
+    JsonOutput output{
+        .fields = fr_vector_to_hex_strings(fields),
+        .vk_hash = vk_hash,
+        .file_kind = file_kind,
+        .bb_version = BB_VERSION,
+        .scheme = flags.scheme,
+        .verifier_target = flags.verifier_target,
+    };
+
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, output);
+    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+    std::stringstream ss;
+    ss << oh.get();
+    return ss.str();
+}
 
 /**
  * @brief Compute and write to file a MegaHonk VK for a circuit to be accumulated by Chonk.
@@ -29,8 +86,11 @@ namespace { // anonymous namespace
  *
  * @param bytecode ACIR bytecode of the circuit
  * @param output_path Directory to write the VK (or "-" for stdout)
+ * @param flags API flags including output_format
  */
-void write_standalone_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& output_path)
+void write_standalone_vk(std::vector<uint8_t> bytecode,
+                         const std::filesystem::path& output_path,
+                         const API::Flags& flags)
 {
     auto response = bbapi::ChonkComputeStandaloneVk{
         .circuit = { .name = "standalone_circuit", .bytecode = std::move(bytecode) }
@@ -39,6 +99,10 @@ void write_standalone_vk(std::vector<uint8_t> bytecode, const std::filesystem::p
     bool is_stdout = output_path == "-";
     if (is_stdout) {
         write_bytes_to_stdout(response.bytes);
+    } else if (flags.output_format == "json") {
+        std::string json_content = build_json_output(response.fields, "vk", flags);
+        write_file(output_path / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
+        info("VK (JSON) saved to ", output_path / "vk.json");
     } else {
         write_file(output_path / "vk", response.bytes);
     }
@@ -53,8 +117,11 @@ void write_standalone_vk(std::vector<uint8_t> bytecode, const std::filesystem::p
  *
  * @param bytecode ACIR bytecode of the final circuit in the IVC chain
  * @param output_dir Directory to write the VK (or "-" for stdout)
+ * @param flags API flags including output_format
  */
-void write_chonk_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& output_dir)
+void write_chonk_vk(std::vector<uint8_t> bytecode,
+                    const std::filesystem::path& output_dir,
+                    [[maybe_unused]] const API::Flags& flags)
 {
     info("Chonk: computing IVC vk for hiding kernel circuit");
     auto response = bbapi::ChonkComputeIvcVk{ .circuit{ .bytecode = std::move(bytecode) } }.execute();
@@ -62,6 +129,7 @@ void write_chonk_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& 
     if (output_to_stdout) {
         write_bytes_to_stdout(response.bytes);
     } else {
+        // Note: ChonkComputeIvcVk::Response only has bytes, not fields, so JSON output is not supported
         write_file(output_dir / "vk", response.bytes);
     }
 }
@@ -90,18 +158,21 @@ void ChonkAPI::prove(const Flags& flags,
 
     auto proof = bbapi::ChonkProve{}.execute(request).proof;
 
-    // We'd like to use the `write` function that UltraHonkAPI uses, but there are missing functions for creating
-    // std::string representations of vks that don't feel worth implementing
     const bool output_to_stdout = output_dir == "-";
 
     const auto write_proof = [&]() {
-        const auto buf = to_buffer(proof.to_field_elements());
+        const auto proof_fields = proof.to_field_elements();
         if (output_to_stdout) {
             vinfo("writing Chonk proof to stdout");
-            write_bytes_to_stdout(buf);
+            write_bytes_to_stdout(to_buffer(proof_fields));
+        } else if (flags.output_format == "json") {
+            vinfo("writing Chonk proof (JSON) in directory ", output_dir);
+            std::string json_content = build_json_output(proof_fields, "proof", flags);
+            write_file(output_dir / "proof.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
+            info("Proof (JSON) saved to ", output_dir / "proof.json");
         } else {
             vinfo("writing Chonk proof in directory ", output_dir);
-            write_file(output_dir / "proof", buf);
+            write_file(output_dir / "proof", to_buffer(proof_fields));
         }
     };
 
@@ -110,7 +181,7 @@ void ChonkAPI::prove(const Flags& flags,
     if (flags.write_vk) {
         vinfo("writing Chonk vk in directory ", output_dir);
         // write CHONK vk using the bytecode of the Hiding kernel (the last step of the execution)
-        write_chonk_vk(raw_steps[raw_steps.size() - 1].bytecode, output_dir);
+        write_chonk_vk(raw_steps[raw_steps.size() - 1].bytecode, output_dir, flags);
     }
 }
 
@@ -201,12 +272,12 @@ void ChonkAPI::write_vk(const Flags& flags,
     BB_BENCH_NAME("ChonkAPI::write_vk");
     auto bytecode = get_bytecode(bytecode_path);
     if (flags.verifier_type == "ivc") {
-        write_chonk_vk(bytecode, output_path);
+        write_chonk_vk(bytecode, output_path, flags);
     } else if (flags.verifier_type == "standalone") {
-        write_standalone_vk(bytecode, output_path);
+        write_standalone_vk(bytecode, output_path, flags);
     } else if (flags.verifier_type == "standalone_hiding") {
         // write the VK for the hiding kernel which DOES NOT utilize a structured trace
-        write_standalone_vk(bytecode, output_path);
+        write_standalone_vk(bytecode, output_path, flags);
     } else {
         const std::string msg = std::string("Can't write vk for verifier type ") + flags.verifier_type;
         throw_or_abort(msg);

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -6,12 +6,14 @@
 #include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
+#include "barretenberg/common/version.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_contract.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_optimized_contract.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_zk_contract.hpp"
 #include "barretenberg/honk/proof_system/types/proof.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
+#include "barretenberg/serialize/msgpack_impl.hpp"
 #include "barretenberg/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/srs/global_crs.hpp"
 #include <iomanip>
@@ -22,23 +24,113 @@ namespace bb {
 
 namespace {
 
-void write_vk_outputs(const bbapi::CircuitComputeVk::Response& vk_response, const std::filesystem::path& output_dir)
+/**
+ * @brief Convert a vector of uint256_t to a vector of hex strings
+ */
+inline std::vector<std::string> uint256_vector_to_hex_strings(const std::vector<uint256_t>& fields)
 {
-    write_file(output_dir / "vk", vk_response.bytes);
-    info("VK saved to ", output_dir / "vk");
-    write_file(output_dir / "vk_hash", vk_response.hash);
-    info("VK Hash saved to ", output_dir / "vk_hash");
+    std::vector<std::string> result;
+    result.reserve(fields.size());
+    for (const auto& field : fields) {
+        std::stringstream ss;
+        ss << field; // uint256_t's operator<< outputs "0x" prefix
+        result.push_back(ss.str());
+    }
+    return result;
 }
 
-void write_proof_outputs(const bbapi::CircuitProve::Response& prove_response, const std::filesystem::path& output_dir)
+/**
+ * @brief Convert bytes to a hex string with 0x prefix
+ */
+inline std::string bytes_to_hex_string(const std::vector<uint8_t>& bytes)
 {
-    auto public_inputs_buf = to_buffer(prove_response.public_inputs);
-    auto proof_buf = to_buffer(prove_response.proof);
+    std::stringstream ss;
+    ss << "0x" << std::hex << std::setfill('0');
+    for (const auto& byte : bytes) {
+        ss << std::setw(2) << static_cast<int>(byte);
+    }
+    return ss.str();
+}
 
-    write_file(output_dir / "public_inputs", public_inputs_buf);
-    write_file(output_dir / "proof", proof_buf);
-    info("Public inputs saved to ", output_dir / "public_inputs");
-    info("Proof saved to ", output_dir / "proof");
+/**
+ * @brief Serializable structure for JSON output (msgpack-compatible)
+ */
+struct JsonOutput {
+    std::vector<std::string> fields;
+    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
+    std::string file_kind; // "vk", "proof", or "public_inputs"
+    std::string bb_version;
+    std::string scheme;
+    std::string verifier_target; // Optional
+
+    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
+};
+
+/**
+ * @brief Build JSON output string using msgpack serialization
+ */
+std::string build_json_output(const std::vector<uint256_t>& fields,
+                              const std::string& file_kind,
+                              const API::Flags& flags,
+                              const std::string& hash = "")
+{
+    JsonOutput output{
+        .fields = uint256_vector_to_hex_strings(fields),
+        .vk_hash = hash,
+        .file_kind = file_kind,
+        .bb_version = BB_VERSION,
+        .scheme = flags.scheme,
+        .verifier_target = flags.verifier_target,
+    };
+
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, output);
+    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+    std::stringstream ss;
+    ss << oh.get();
+    return ss.str();
+}
+
+void write_vk_outputs(const bbapi::CircuitComputeVk::Response& vk_response,
+                      const std::filesystem::path& output_dir,
+                      const API::Flags& flags)
+{
+    if (flags.output_format == "json") {
+        std::string json_content =
+            build_json_output(vk_response.fields, "vk", flags, bytes_to_hex_string(vk_response.hash));
+        write_file(output_dir / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
+        info("VK (JSON) saved to ", output_dir / "vk.json");
+    } else {
+        write_file(output_dir / "vk", vk_response.bytes);
+        info("VK saved to ", output_dir / "vk");
+        write_file(output_dir / "vk_hash", vk_response.hash);
+        info("VK Hash saved to ", output_dir / "vk_hash");
+    }
+}
+
+void write_proof_outputs(const bbapi::CircuitProve::Response& prove_response,
+                         const std::filesystem::path& output_dir,
+                         const API::Flags& flags)
+{
+    if (flags.output_format == "json") {
+        std::string vk_hash = bytes_to_hex_string(prove_response.vk.hash);
+        std::string proof_json = build_json_output(prove_response.proof, "proof", flags, vk_hash);
+        write_file(output_dir / "proof.json", std::vector<uint8_t>(proof_json.begin(), proof_json.end()));
+        info("Proof (JSON) saved to ", output_dir / "proof.json");
+
+        std::string pi_json = build_json_output(prove_response.public_inputs, "public_inputs", flags);
+        write_file(output_dir / "public_inputs.json", std::vector<uint8_t>(pi_json.begin(), pi_json.end()));
+        info("Public inputs (JSON) saved to ", output_dir / "public_inputs.json");
+    } else {
+        auto public_inputs_buf = to_buffer(prove_response.public_inputs);
+        auto proof_buf = to_buffer(prove_response.proof);
+
+        write_file(output_dir / "public_inputs", public_inputs_buf);
+        write_file(output_dir / "proof", proof_buf);
+        info("Public inputs saved to ", output_dir / "public_inputs");
+        info("Proof saved to ", output_dir / "proof");
+    }
 }
 
 } // anonymous namespace
@@ -86,9 +178,9 @@ void UltraHonkAPI::prove(const Flags& flags,
                                          .witness = std::move(witness),
                                          .settings = std::move(settings) }
                         .execute();
-    write_proof_outputs(response, output_dir);
+    write_proof_outputs(response, output_dir, flags);
     if (flags.write_vk) {
-        write_vk_outputs(response.vk, output_dir);
+        write_vk_outputs(response.vk, output_dir, flags);
     }
 }
 
@@ -148,7 +240,7 @@ void UltraHonkAPI::write_vk(const Flags& flags,
                                              .settings = settings }
                         .execute();
 
-    write_vk_outputs(response, output_dir);
+    write_vk_outputs(response, output_dir, flags);
 }
 
 void UltraHonkAPI::gates([[maybe_unused]] const Flags& flags,

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -1,96 +1,25 @@
 #include "api_ultra_honk.hpp"
 
 #include "barretenberg/api/file_io.hpp"
+#include "barretenberg/api/json_output.hpp"
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
 #include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/common/map.hpp"
 #include "barretenberg/common/throw_or_abort.hpp"
-#include "barretenberg/common/version.hpp"
 #include "barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_contract.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_optimized_contract.hpp"
 #include "barretenberg/dsl/acir_proofs/honk_zk_contract.hpp"
 #include "barretenberg/honk/proof_system/types/proof.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
-#include "barretenberg/serialize/msgpack_impl.hpp"
 #include "barretenberg/special_public_inputs/special_public_inputs.hpp"
 #include "barretenberg/srs/global_crs.hpp"
-#include <iomanip>
 #include <optional>
-#include <sstream>
 
 namespace bb {
 
 namespace {
-
-/**
- * @brief Convert a vector of uint256_t to a vector of hex strings
- */
-inline std::vector<std::string> uint256_vector_to_hex_strings(const std::vector<uint256_t>& fields)
-{
-    std::vector<std::string> result;
-    result.reserve(fields.size());
-    for (const auto& field : fields) {
-        std::stringstream ss;
-        ss << field; // uint256_t's operator<< outputs "0x" prefix
-        result.push_back(ss.str());
-    }
-    return result;
-}
-
-/**
- * @brief Convert bytes to a hex string with 0x prefix
- */
-inline std::string bytes_to_hex_string(const std::vector<uint8_t>& bytes)
-{
-    std::stringstream ss;
-    ss << "0x" << std::hex << std::setfill('0');
-    for (const auto& byte : bytes) {
-        ss << std::setw(2) << static_cast<int>(byte);
-    }
-    return ss.str();
-}
-
-/**
- * @brief Serializable structure for JSON output (msgpack-compatible)
- */
-struct JsonOutput {
-    std::vector<std::string> fields;
-    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
-    std::string file_kind; // "vk", "proof", or "public_inputs"
-    std::string bb_version;
-    std::string scheme;
-    std::string verifier_target; // Optional
-
-    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
-};
-
-/**
- * @brief Build JSON output string using msgpack serialization
- */
-std::string build_json_output(const std::vector<uint256_t>& fields,
-                              const std::string& file_kind,
-                              const API::Flags& flags,
-                              const std::string& hash = "")
-{
-    JsonOutput output{
-        .fields = uint256_vector_to_hex_strings(fields),
-        .vk_hash = hash,
-        .file_kind = file_kind,
-        .bb_version = BB_VERSION,
-        .scheme = flags.scheme,
-        .verifier_target = flags.verifier_target,
-    };
-
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, output);
-    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
-
-    std::stringstream ss;
-    ss << oh.get();
-    return ss.str();
-}
 
 void write_vk_outputs(const bbapi::CircuitComputeVk::Response& vk_response,
                       const std::filesystem::path& output_dir,

--- a/barretenberg/cpp/src/barretenberg/api/json_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/json_output.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "barretenberg/api/api.hpp"
+#include "barretenberg/common/version.hpp"
+#include "barretenberg/serialize/msgpack.hpp"
+#include "barretenberg/serialize/msgpack_impl.hpp"
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace bb {
+
+/**
+ * @brief Convert bytes to a hex string with 0x prefix
+ */
+inline std::string bytes_to_hex_string(const std::vector<uint8_t>& bytes)
+{
+    std::stringstream ss;
+    ss << "0x" << std::hex << std::setfill('0');
+    for (const auto& byte : bytes) {
+        ss << std::setw(2) << static_cast<int>(byte);
+    }
+    return ss.str();
+}
+
+/**
+ * @brief Serializable structure for JSON output (msgpack-compatible)
+ */
+struct JsonOutput {
+    std::vector<std::string> fields;
+    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
+    std::string file_kind; // "vk", "proof", or "public_inputs"
+    std::string bb_version;
+    std::string scheme;
+    std::string verifier_target; // Optional
+
+    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
+};
+
+/**
+ * @brief Build JSON output string using msgpack serialization
+ *
+ * @tparam T Field element type (must have operator<< that outputs 0x-prefixed hex)
+ * @param fields Vector of field elements to serialize
+ * @param file_kind Type identifier: "vk", "proof", or "public_inputs"
+ * @param flags API flags containing scheme and verifier_target
+ * @param vk_hash Optional hash string for VK or proof files
+ * @return JSON string
+ */
+template <typename T>
+std::string build_json_output(const std::vector<T>& fields,
+                              const std::string& file_kind,
+                              const API::Flags& flags,
+                              const std::string& vk_hash = "")
+{
+    std::vector<std::string> hex_fields;
+    hex_fields.reserve(fields.size());
+    for (const auto& field : fields) {
+        std::stringstream ss;
+        ss << field; // T's operator<< outputs "0x" prefix
+        hex_fields.push_back(ss.str());
+    }
+
+    JsonOutput output{
+        .fields = std::move(hex_fields),
+        .vk_hash = vk_hash,
+        .file_kind = file_kind,
+        .bb_version = BB_VERSION,
+        .scheme = flags.scheme,
+        .verifier_target = flags.verifier_target,
+    };
+
+    msgpack::sbuffer buffer;
+    msgpack::pack(buffer, output);
+    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+    std::stringstream ss;
+    ss << oh.get();
+    return ss.str();
+}
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -360,6 +360,15 @@ int parse_and_run_cli_command(int argc, char* argv[])
             "--optimized", flags.optimized_solidity_verifier, "Use the optimized Solidity verifier.");
     };
 
+    const auto add_output_format_option = [&](CLI::App* subcommand) {
+        return subcommand
+            ->add_option("--output_format",
+                         flags.output_format,
+                         "Output format for proofs and verification keys: 'binary' (default) or 'json'.\n"
+                         "JSON format includes metadata like bb_version, scheme, and verifier_target.")
+            ->check(CLI::IsMember({ "binary", "json" }).name("is_member"));
+    };
+
     bool print_bench = false;
     const auto add_print_bench_flag = [&](CLI::App* subcommand) {
         return subcommand
@@ -458,6 +467,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_bench_out_option(prove);
     add_bench_out_hierarchical_option(prove);
     add_storage_budget_option(prove);
+    add_output_format_option(prove);
 
     prove->add_flag("--verify", "Verify the proof natively, resulting in a boolean output. Useful for testing.");
 
@@ -484,6 +494,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_ipa_accumulation_flag(write_vk);
     add_verifier_type_option(write_vk)->default_val("standalone");
     remove_zk_option(write_vk);
+    add_output_format_option(write_vk);
 
     /***************************************************************************************************************
      * Subcommand: verify


### PR DESCRIPTION
## Summary

Adds `--output_format` option to `prove` and `write_vk` commands in the BB CLI. When set to `json`, outputs human-readable JSON files with metadata.

Closes https://github.com/AztecProtocol/barretenberg/issues/1605

### JSON Output Format

```json
{
  "fields": ["0x...", "0x...", ...],
  "vk_hash": "0x...",           // Only for VK and proof (proof includes hash of VK it targets)
  "file_kind": "vk" | "proof" | "public_inputs",
  "bb_version": "x.x.x",
  "scheme": "ultra_honk",
  "verifier_target": "evm"      // optional, only when specified
}
```

### Changes

- Added `--output_format json` flag to CLI
- VK JSON includes `vk_hash` field
- Proof JSON includes `vk_hash` so users can cross-verify against the VK they're using
- Updated `acir_tests/bootstrap.sh` to use JSON output instead of manual byte parsing with xxd/fold

### Usage

```bash
# Generate VK in JSON format
bb write_vk -b program.json -o ./output --output_format json

# Generate proof/public_inputs/vk in JSON format
bb prove -b program.json -w witness.gz -o ./output --output_format json --write_vk

# With verifier target
bb write_vk -b program.json -o ./output --output_format json --verifier_target evm
```

### Sample Output

**vk.json:**
```json
{
  "fields": ["0x0000000000000000000000000000000000000000000000000000000000000006",...],
  "vk_hash": "0x12788292c26a9e0b15461735c345786d66cdc599f39699836f99dd5db99733ac",
  "file_kind": "vk",
  "bb_version": "0.x.x",
  "scheme": "ultra_honk",
  "verifier_target": "evm"
}
```

**proof.json:**
```json
{
  "fields": ["0x0000000000000000000000000000000000000000000000042ab5d6d1986846cf",...],
  "vk_hash": "0x12788292c26a9e0b15461735c345786d66cdc599f39699836f99dd5db99733ac",
  "file_kind": "proof",
  "bb_version": "0.x.x",
  "scheme": "ultra_honk"
}
```

**public_inputs.json:**
```json
{
  "fields": ["0x0000000000000000000000000000000000000000000000000000000000000003"],
  "vk_hash": "",
  "file_kind": "public_inputs",
  "bb_version": "0.x.x",
  "scheme": "ultra_honk"
}
```

## Test plan

- [x] Build passes
- [x] Tested `bb write_vk --output_format json` produces valid JSON
- [x] Tested `bb prove --output_format json --write_vk` produces proof.json, public_inputs.json, and vk.json
- [x] Tested with `--verifier_target evm` includes the verifier_target in output
- [x] Tested acir_tests/bootstrap.sh works with JSON output