### PR TITLE
feat: add claudebox Docker image for dangerously skipping permissions

### DIFF
--- a/build-images/README.md
+++ b/build-images/README.md
@@ -55,3 +55,17 @@ Internal aztec engineers use the mainframe.
 If the version number changed a mainframe administrator to update the `/usr/local/bin/launch_sysbox` script.
 
 Users will then need to perform a `sudo halt` to reboot with the new image.
+
+## Claudebox
+
+Extends devbox with Claude Code pre-installed. Defaults to a strict network firewall so Claude can be run with skip permissions.
+
+Run via `yarn-project/scripts/claude-in-docker.sh`. The script mounts your repo and Claude credentials.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_DOCKER_IMAGE` | `aztecprotocol/claudebox:latest` | Docker image to use |
+| `CLAUDE_DOCKER_MODE` | `privileged` | Docker access: `none`, `socket`, `dind`, `privileged` |
+| `CLAUDE_SSH_MODE` | `none` | SSH access: `none`, `agent`, `keys` |
+| `CLAUDE_FIREWALL_MODE` | `on` | Network firewall: `on`, `off` |
+| `CLAUDE_USE_HOST_NETWORK` | `0` | Use host network (disables firewall, dangerous) |

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -5,18 +5,18 @@
 FROM ubuntu:noble AS base-build
 RUN export DEBIAN_FRONTEND="noninteractive" \
     && apt update && apt install --no-install-recommends -y \
-      build-essential \
-      ca-certificates \
-      bash \
-      clang \
-      cmake \
-      make \
-      ninja-build \
-      git \
-      curl \
-      gnupg \
-      python3 \
-      wget \
+    build-essential \
+    ca-certificates \
+    bash \
+    clang \
+    cmake \
+    make \
+    ninja-build \
+    git \
+    curl \
+    gnupg \
+    python3 \
+    wget \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -44,8 +44,8 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
     && $FOUNDRY_BIN_DIR/foundryup -i $FOUNDRY_VERSION \
     && mkdir -p /opt/foundry/bin \
     && for t in forge cast anvil chisel; do \
-        mv $FOUNDRY_BIN_DIR/$t /opt/foundry/bin/$t; \
-        strip /opt/foundry/bin/$t; \
+    mv $FOUNDRY_BIN_DIR/$t /opt/foundry/bin/$t; \
+    strip /opt/foundry/bin/$t; \
     done \
     && rm -rf $FOUNDRY_BIN_DIR
 
@@ -68,47 +68,47 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
 
 RUN apt update && \
     apt install -y \
-        # Utils
-        curl \
-        git \
-        wget \
-        time \
-        jq \
-        gawk \
-        unzip \
-        netcat-openbsd \
-        parallel \
-        xz-utils \
-        lsof \
-        xxd \
-        zstd \
-        # C++
-        lsb-release \
-        gnupg \
-        software-properties-common \
-        build-essential \
-        clang \
-        clang-16 \
-        clang-format-16 \
-        cmake \
-        ninja-build \
-        libc++-dev \
-        libomp-dev \
-        doxygen \
-        # C++ stack trace support
-        libdw-dev \
-        libelf-dev \
-        # Rust
-        pkg-config \
-        libssl-dev \
-        # Node
-        # WARNING: Need to downgrade to this version in the basebox below as well.
-        nodejs=24.12.0-1nodesource1 \
-        # Python (clang bindings for wasm bindgen.)
-        python3 \
-        python3-clang \
-        # Unminimize ubuntu installation.
-        unminimize \
+    # Utils
+    curl \
+    git \
+    wget \
+    time \
+    jq \
+    gawk \
+    unzip \
+    netcat-openbsd \
+    parallel \
+    xz-utils \
+    lsof \
+    xxd \
+    zstd \
+    # C++
+    lsb-release \
+    gnupg \
+    software-properties-common \
+    build-essential \
+    clang \
+    clang-16 \
+    clang-format-16 \
+    cmake \
+    ninja-build \
+    libc++-dev \
+    libomp-dev \
+    doxygen \
+    # C++ stack trace support
+    libdw-dev \
+    libelf-dev \
+    # Rust
+    pkg-config \
+    libssl-dev \
+    # Node
+    # WARNING: Need to downgrade to this version in the basebox below as well.
+    nodejs=24.12.0-1nodesource1 \
+    # Python (clang bindings for wasm bindgen.)
+    python3 \
+    python3-clang \
+    # Unminimize ubuntu installation.
+    unminimize \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -170,7 +170,7 @@ RUN arch=$(uname -m) && \
 
 # Install yq
 RUN curl -sL https://github.com/mikefarah/yq/releases/download/v4.42.1/yq_linux_$(dpkg --print-architecture) \
-        -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+    -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 # Install playwright for browser testing. Ensure accessible for other users.
 RUN npx -y playwright@1.49 install --with-deps && mv /root/.cache/ms-playwright /opt/ms-playwright
@@ -186,41 +186,41 @@ RUN yes | unminimize
 # Install stuff devs need.
 RUN apt update && \
     apt install -y --allow-downgrades \
-        cgroup-tools \
-        clangd-16 \
-        clangd-18 \
-        fzf \
-        gnupg \
-        htop \
-        iproute2 \
-        iputils-ping \
-        lcov \
-        less \
-        libfuse2 \
-        lldb \
-        lsb-release \
-        man \
-        neovim \
-        psmisc \
-        python3-blessed \
-        redis-tools \
-        rsync \
-        software-properties-common \
-        ssh \
-        strace \
-        sudo \
-        telnet \
-        tmux \
-        vim \
-        zsh \
-        inotify-tools \
-        # Annoyingly unminimize upgrades nodejs.
-        nodejs=24.12.0-1nodesource1 \
-        # smt_verification dependencies
-        python3-venv \
-        python3-pip \
-        m4 \
-        bison \
+    cgroup-tools \
+    clangd-16 \
+    clangd-18 \
+    fzf \
+    gnupg \
+    htop \
+    iproute2 \
+    iputils-ping \
+    lcov \
+    less \
+    libfuse2 \
+    lldb \
+    lsb-release \
+    man \
+    neovim \
+    psmisc \
+    python3-blessed \
+    redis-tools \
+    rsync \
+    software-properties-common \
+    ssh \
+    strace \
+    sudo \
+    telnet \
+    tmux \
+    vim \
+    zsh \
+    inotify-tools \
+    # Annoyingly unminimize upgrades nodejs.
+    nodejs=24.12.0-1nodesource1 \
+    # smt_verification dependencies
+    python3-venv \
+    python3-pip \
+    m4 \
+    bison \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install gh (github cli).
@@ -273,11 +273,11 @@ RUN apt install -y gosu
 
 # Detect if the host machine is Mac, if so set an env var, and disable prompts vcs info for performance.
 RUN echo ' \
-  if mount | grep -q /host_mark/Users; then \
-      export HOST_OSTYPE=darwin; \
-      export PROMPT_LEAN_VCS=0; \
-  fi \
-  ' >> /etc/zsh/zshrc
+    if mount | grep -q /host_mark/Users; then \
+    export HOST_OSTYPE=darwin; \
+    export PROMPT_LEAN_VCS=0; \
+    fi \
+    ' >> /etc/zsh/zshrc
 
 # Create the user we'll run as (remove ubuntu first).
 RUN userdel -r ubuntu && useradd --shell /bin/zsh -G sudo -m aztec-dev
@@ -315,43 +315,43 @@ FROM basebox AS sysbox
 #
 RUN apt-get update &&                            \
     apt-get install -y --no-install-recommends   \
-            systemd                              \
-            systemd-sysv                         \
-            libsystemd0                          \
-            ca-certificates                      \
-            dbus                                 \
-            iptables                             \
-            iproute2                             \
-            kmod                                 \
-            locales                              \
-            sudo                                 \
-            udev &&                              \
-                                                \
+    systemd                              \
+    systemd-sysv                         \
+    libsystemd0                          \
+    ca-certificates                      \
+    dbus                                 \
+    iptables                             \
+    iproute2                             \
+    kmod                                 \
+    locales                              \
+    sudo                                 \
+    udev &&                              \
+    \
     # Prevents journald from reading kernel messages from /dev/kmsg
     echo "ReadKMsg=no" >> /etc/systemd/journald.conf &&               \
-                                                                      \
+    \
     # Housekeeping
     apt-get clean -y &&                                               \
     rm -rf                                                            \
-      /var/cache/debconf/*                                           \
-      /var/lib/apt/lists/*                                           \
-      /var/log/*                                                     \
-      /tmp/*                                                         \
-      /var/tmp/*                                                     \
-      /usr/share/local/* &&                                          \
-                                                                      \
+    /var/cache/debconf/*                                           \
+    /var/lib/apt/lists/*                                           \
+    /var/log/*                                                     \
+    /tmp/*                                                         \
+    /var/tmp/*                                                     \
+    /usr/share/local/* &&                                          \
+    \
     # Create default 'ubuntu/ubuntu' user
     echo "ubuntu:ubuntu" | chpasswd && adduser ubuntu sudo
 
 # Disable systemd services/units that are unnecessary within a container.
 RUN systemctl mask systemd-udevd.service \
-                  systemd-udevd-kernel.socket \
-                  systemd-udevd-control.socket \
-                  systemd-modules-load.service \
-                  sys-kernel-config.mount \
-                  sys-kernel-debug.mount \
-                  sys-kernel-tracing.mount \
-                  e2scrub_reap.service
+    systemd-udevd-kernel.socket \
+    systemd-udevd-control.socket \
+    systemd-modules-load.service \
+    sys-kernel-config.mount \
+    sys-kernel-debug.mount \
+    sys-kernel-tracing.mount \
+    e2scrub_reap.service
 
 # Make use of stopsignal (instead of sigterm) to stop systemd containers.
 STOPSIGNAL SIGRTMIN+3
@@ -394,3 +394,37 @@ RUN mkdir -p /etc/systemd/user.conf.d /etc/systemd/user/user.slice.d /etc/system
     printf "[Slice]\nTasksMax=infinity\n" > /etc/systemd/system/user-.slice.d/override.conf
 
 EXPOSE 22
+
+
+########################################################################################################################
+# Claude Code development container.
+# Extends devbox with Claude Code CLI, firewall configuration, and security hardening.
+# Use this for AI-assisted development with network isolation.
+FROM devbox AS claudebox
+
+# Install additional packages needed for firewall
+RUN apt update && apt install -y \
+    aggregate \
+    dnsutils \
+    ipset \
+    iptables \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Copy firewall initialization script
+COPY ./init-firewall.sh /usr/local/bin/init-firewall.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh
+
+# Allow aztec-dev to run firewall script without password
+RUN echo 'aztec-dev ALL=(ALL) NOPASSWD: /usr/local/bin/init-firewall.sh' >> /etc/sudoers
+
+# Environment variables for Claude Code
+ENV DEVCONTAINER=true
+ENV EDITOR=vim
+ENV VISUAL=vim
+
+# Pre-create .claude.json to skip onboarding prompts
+RUN echo '{"hasCompletedOnboarding":true}' > /home/aztec-dev/.claude.json \
+    && chown aztec-dev:aztec-dev /home/aztec-dev/.claude.json

--- a/build-images/src/init-firewall.sh
+++ b/build-images/src/init-firewall.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Firewall initialization script for Claude Code container
+# Based on https://github.com/anthropics/claude-code/.devcontainer/init-firewall.sh
+# Implements a deny-by-default firewall allowing only approved domains
+set -euo pipefail
+IFS=$'\n\t'
+
+# Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# Restore Docker DNS rules if they existed
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
+
+# Allow DNS and localhost before any restrictions
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and add their IP ranges
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    exit 1
+fi
+
+echo "Processing GitHub IPs and adding to allowed-domains..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    # echo "Adding GitHub range $cidr"
+    ipset add allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# Resolve and add other allowed domains
+for domain in \
+    "registry.npmjs.org" \
+    "api.anthropic.com" \
+    "sentry.io" \
+    "statsig.anthropic.com" \
+    "statsig.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com" \
+    "aztec.network" \
+    "ci.aztec-labs.com"; do
+    echo "Resolving $domain and adding to allowed-domains..."
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "ERROR: Failed to resolve $domain"
+        exit 1
+    fi
+
+    while read -r ip; do
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IP from DNS for $domain: $ip"
+            exit 1
+        fi
+        # echo "Adding $ip for $domain"
+        ipset add allowed-domains "$ip"
+    done < <(echo "$ips")
+done
+
+# Get host IP from default route and allow host network communication
+HOST_IP=$(ip route | grep default | head -1 | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+
+# Set up remaining iptables rules
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# Set default policies to DROP
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# Allow established connections
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Reject other outbound traffic with immediate feedback
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+else
+    echo "Firewall verification passed (unable to reach https://example.com as expected)"
+fi
+
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+else
+    echo "Firewall verification passed (able to reach https://api.github.com as expected)"
+fi

--- a/yarn-project/scripts/claude-in-docker.sh
+++ b/yarn-project/scripts/claude-in-docker.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Run Claude Code inside an aztecprotocol/claudebox container
+set -eu
+
+# Image to use - claudebox extends devbox with Claude Code pre-installed
+IMAGE="${CLAUDE_DOCKER_IMAGE:-aztecprotocol/claudebox:latest}"
+
+# Docker mode:
+# - "none": No Docker support (minimal, most secure)
+# - "socket": Mount host Docker socket (less isolation, simpler)
+# - "dind": Docker-in-Docker with specific capabilities (more isolated)
+# - "privileged": Full privileged mode (least secure, but guaranteed to work)
+DOCKER_MODE="${CLAUDE_DOCKER_MODE:-privileged}"
+
+# SSH mode (opt-in):
+# - "none": No SSH access (default)
+# - "agent": Mount SSH agent socket (recommended - keys stay on host)
+# - "keys": Mount SSH keys directly (less secure)
+SSH_MODE="${CLAUDE_SSH_MODE:-none}"
+
+# Firewall mode:
+# - "off": No firewall (default, full network access)
+# - "on": Enable firewall to restrict network access to approved domains only
+FIREWALL_MODE="${CLAUDE_FIREWALL_MODE:-on}"
+
+# Get the git root to mount the whole repo
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [[ -z "$GIT_ROOT" ]]; then
+  MOUNT_DIR="$PWD"
+  WORKDIR="/workspace"
+else
+  MOUNT_DIR="$GIT_ROOT"
+  # Calculate relative path from git root to current dir
+  REL_PATH="${PWD#$GIT_ROOT}"
+  WORKDIR="/workspaces/aztec-packages${REL_PATH}"
+fi
+
+# Claude Code config directory (credentials, settings)
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+CLAUDE_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/claude-code"
+
+# On linux, align uid/gid so files have correct ownership
+ID_ARGS=""
+if [[ "$OSTYPE" == "linux"* ]]; then
+  ID_ARGS="-e LOCAL_USER_ID=$(id -u) -e LOCAL_GROUP_ID=$(id -g)"
+fi
+
+# Build mount arguments for Claude credentials
+CLAUDE_MOUNTS=""
+if [[ -d "$CLAUDE_HOME" ]]; then
+  CLAUDE_MOUNTS="$CLAUDE_MOUNTS -v$CLAUDE_HOME:/home/aztec-dev/.claude:rw"
+fi
+if [[ -d "$CLAUDE_CONFIG" ]]; then
+  CLAUDE_MOUNTS="$CLAUDE_MOUNTS -v$CLAUDE_CONFIG:/home/aztec-dev/.config/claude-code:rw"
+fi
+
+# SSH access based on mode
+SSH_ARGS=""
+case "$SSH_MODE" in
+  none)
+    # No SSH access (default)
+    ;;
+  agent)
+    # Mount SSH agent socket - keys stay on host, works with hardware keys
+    if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+      echo "SSH mode: agent (forwarding SSH agent socket)"
+      SSH_ARGS="-v$SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+    else
+      echo "Warning: SSH_AUTH_SOCK not set, cannot forward SSH agent"
+    fi
+    # Still mount known_hosts for host verification
+    if [[ -f "$HOME/.ssh/known_hosts" ]]; then
+      SSH_ARGS="$SSH_ARGS -v$HOME/.ssh/known_hosts:/home/aztec-dev/.ssh/known_hosts:ro"
+    fi
+    ;;
+  keys)
+    # Mount SSH keys directly (less secure, use agent mode when possible)
+    echo "SSH mode: keys (mounting SSH keys directly - consider using 'agent' mode instead)"
+    if [[ -f "$HOME/.ssh/id_rsa" ]]; then
+      SSH_ARGS="-v$HOME/.ssh/id_rsa:/home/aztec-dev/.ssh/id_rsa:ro"
+    elif [[ -f "$HOME/.ssh/id_ed25519" ]]; then
+      SSH_ARGS="-v$HOME/.ssh/id_ed25519:/home/aztec-dev/.ssh/id_ed25519:ro"
+    fi
+    if [[ -f "$HOME/.ssh/known_hosts" ]]; then
+      SSH_ARGS="$SSH_ARGS -v$HOME/.ssh/known_hosts:/home/aztec-dev/.ssh/known_hosts:ro"
+    fi
+    ;;
+  *)
+    echo "Unknown CLAUDE_SSH_MODE: $SSH_MODE"
+    echo "Valid options: none, agent, keys"
+    exit 1
+    ;;
+esac
+
+# Git config (read-only)
+GIT_MOUNTS=""
+if [[ -f "$HOME/.gitconfig" ]]; then
+  GIT_MOUNTS="-v$HOME/.gitconfig:/home/aztec-dev/.gitconfig:ro"
+fi
+
+# Network mode:
+# - Default is bridge networking (isolated from host)
+# - Host networking shares the host's network namespace (DANGEROUS with firewall!)
+NETWORK_ARGS=""
+if [[ "${CLAUDE_USE_HOST_NETWORK:-0}" == "1" ]]; then
+  NETWORK_ARGS="--network=host"
+  # Firewall MUST be disabled with host networking - it would modify host iptables!
+  if [[ "$FIREWALL_MODE" == "on" ]]; then
+    echo "ERROR: Cannot use firewall with host networking - it would modify your host's iptables!"
+    echo "Either set CLAUDE_USE_HOST_NETWORK=0 (default) or CLAUDE_FIREWALL_MODE=off"
+    exit 1
+  fi
+fi
+
+# Mount VS Code server directory if it exists (for extension data sharing)
+VSCODE_MOUNTS=""
+if [[ -d "$HOME/.vscode-server" ]]; then
+  VSCODE_MOUNTS="-v$HOME/.vscode-server:/home/aztec-dev/.vscode-server"
+fi
+
+# Docker support based on mode
+DOCKER_ARGS=""
+case "$DOCKER_MODE" in
+  none)
+    # No Docker support - most secure, sufficient for most Claude Code tasks
+    echo "Docker mode: none (no container spawning support)"
+    ;;
+  socket)
+    # Mount host Docker socket - containers run on host, less isolation
+    echo "Docker mode: socket (using host Docker daemon)"
+    DOCKER_ARGS="-v/var/run/docker.sock:/var/run/docker.sock"
+    ;;
+  dind)
+    # Docker-in-Docker with specific capabilities
+    echo "Docker mode: dind (Docker-in-Docker with specific capabilities)"
+    DOCKER_ARGS="--cap-add=SYS_ADMIN --cap-add=NET_ADMIN --cap-add=MKNOD"
+    DOCKER_ARGS="$DOCKER_ARGS --security-opt seccomp=unconfined"
+    DOCKER_ARGS="$DOCKER_ARGS --security-opt apparmor=unconfined"
+    DOCKER_ARGS="$DOCKER_ARGS -vdevbox-var-lib-docker:/var/lib/docker"
+    ;;
+  privileged)
+    # Full privileged mode - guaranteed to work but least secure
+    echo "Docker mode: privileged (full access)"
+    DOCKER_ARGS="--privileged -vdevbox-var-lib-docker:/var/lib/docker"
+    ;;
+  *)
+    echo "Unknown CLAUDE_DOCKER_MODE: $DOCKER_MODE"
+    echo "Valid options: none, socket, dind, privileged"
+    exit 1
+    ;;
+esac
+
+# Firewall setup command
+FIREWALL_CMD=""
+if [[ "$FIREWALL_MODE" == "on" ]]; then
+  echo "Firewall: enabled (network restricted to approved domains)"
+  FIREWALL_CMD="sudo /usr/local/bin/init-firewall.sh && "
+else
+  echo "Firewall: disabled (full network access)"
+fi
+
+echo "Starting container with image $IMAGE..."
+echo "Mounting: $MOUNT_DIR -> /workspaces/aztec-packages"
+echo "Working directory: $WORKDIR"
+[[ -n "$CLAUDE_MOUNTS" ]] && echo "Claude credentials mounted" || true
+
+docker run \
+  -it --rm \
+  --hostname claude-devbox \
+  -e SSH_CONNECTION=' ' \
+  -e DOCKER_CONFIG=/home/aztec-dev/.docker-devbox \
+  -e TERM="${TERM:-xterm-256color}" \
+  -e HOME=/home/aztec-dev \
+  ${ID_ARGS} \
+  -w"$WORKDIR" \
+  -v"$MOUNT_DIR":/workspaces/aztec-packages \
+  $CLAUDE_MOUNTS \
+  $SSH_ARGS \
+  $GIT_MOUNTS \
+  $VSCODE_MOUNTS \
+  $NETWORK_ARGS \
+  $DOCKER_ARGS \
+  "$IMAGE" \
+  /bin/bash -c "${FIREWALL_CMD}claude --dangerously-skip-permissions"


### PR DESCRIPTION
Adds a new `claudebox` Docker stage extending devbox with Claude Code pre-installed.

- New `claudebox` stage in Dockerfile with Claude Code CLI and firewall tools
- `init-firewall.sh` script implementing deny-by-default network policy (restricts to GitHub, npm, Anthropic APIs, VS Code services, aztec.network, ci.aztec-labs.com) as implemented in the official Claude devcontainer
- `claude-in-docker.sh` helper script to run Claude Code in container with dangerously skip permissions

Based on the official Claude Code devcontainer:
- https://github.com/anthropics/claude-code/blob/main/.devcontainer/Dockerfile
- https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)