### PR TITLE
fix: avoid instanceof for L2BlockHash

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -577,7 +577,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block.
    */
   public async getBlock(block: BlockParameter): Promise<L2BlockNew | undefined> {
-    if (block instanceof L2BlockHash) {
+    if (L2BlockHash.isL2BlockHash(block)) {
       return this.getBlockByHash(Fr.fromBuffer(block.toBuffer()));
     }
     const blockNumber = block === 'latest' ? await this.getBlockNumber() : (block as BlockNumber);
@@ -1090,7 +1090,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   public async getBlockHeader(block: BlockParameter = 'latest'): Promise<BlockHeader | undefined> {
-    if (block instanceof L2BlockHash) {
+    if (L2BlockHash.isL2BlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.
@@ -1411,7 +1411,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       return this.worldStateSynchronizer.getCommitted();
     }
 
-    if (block instanceof L2BlockHash) {
+    if (L2BlockHash.isL2BlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.

--- a/yarn-project/stdlib/src/block/block_hash.test.ts
+++ b/yarn-project/stdlib/src/block/block_hash.test.ts
@@ -1,0 +1,76 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import { L2BlockHash } from './block_hash.js';
+
+describe('L2BlockHash', () => {
+  describe('isL2BlockHash', () => {
+    it('returns true for L2BlockHash instances', () => {
+      const hash = L2BlockHash.random();
+      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    });
+
+    it('returns true for L2BlockHash created from field', () => {
+      const hash = L2BlockHash.fromField(Fr.random());
+      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    });
+
+    it('returns true for L2BlockHash created from buffer', () => {
+      const hash = L2BlockHash.fromBuffer(Buffer.alloc(32, 1));
+      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    });
+
+    it('returns true for duck-typed Buffer32-like objects with 32-byte buffer', () => {
+      // Simulates a case where instanceof fails due to module duplication
+      const fakeHash = {
+        buffer: Buffer.alloc(32, 0xab),
+        toBuffer: () => Buffer.alloc(32, 0xab),
+      };
+      expect(L2BlockHash.isL2BlockHash(fakeHash)).toBe(true);
+    });
+
+    it('returns false for plain numbers', () => {
+      expect(L2BlockHash.isL2BlockHash(0)).toBe(false);
+      expect(L2BlockHash.isL2BlockHash(123)).toBe(false);
+      expect(L2BlockHash.isL2BlockHash(-1)).toBe(false);
+    });
+
+    it('returns false for strings', () => {
+      expect(L2BlockHash.isL2BlockHash('latest')).toBe(false);
+      expect(L2BlockHash.isL2BlockHash('0x1234')).toBe(false);
+    });
+
+    it('returns false for null and undefined', () => {
+      expect(L2BlockHash.isL2BlockHash(null)).toBe(false);
+      expect(L2BlockHash.isL2BlockHash(undefined)).toBe(false);
+    });
+
+    it('returns false for objects without buffer property', () => {
+      expect(L2BlockHash.isL2BlockHash({})).toBe(false);
+      expect(L2BlockHash.isL2BlockHash({ toBuffer: () => Buffer.alloc(32) })).toBe(false);
+    });
+
+    it('returns false for objects with non-Buffer buffer property', () => {
+      expect(L2BlockHash.isL2BlockHash({ buffer: 'not a buffer', toBuffer: () => Buffer.alloc(32) })).toBe(false);
+      expect(L2BlockHash.isL2BlockHash({ buffer: [1, 2, 3], toBuffer: () => Buffer.alloc(32) })).toBe(false);
+    });
+
+    it('returns false for objects with wrong buffer length', () => {
+      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(16), toBuffer: () => Buffer.alloc(16) })).toBe(false);
+      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(64), toBuffer: () => Buffer.alloc(64) })).toBe(false);
+    });
+
+    it('returns false for objects without toBuffer method', () => {
+      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(32) })).toBe(false);
+    });
+
+    it('returns false for plain Buffer32 instances when checking type strictly', () => {
+      // Note: Buffer32 will pass duck typing since it has the same structure
+      // This is acceptable since the goal is to identify hash-like objects
+      const buf32 = Buffer32.random();
+      // Buffer32 has the same structure, so duck typing will return true
+      // This is expected behavior - we want to handle Buffer32-like objects
+      expect(L2BlockHash.isL2BlockHash(buf32)).toBe(true);
+    });
+  });
+});

--- a/yarn-project/stdlib/src/block/block_hash.ts
+++ b/yarn-project/stdlib/src/block/block_hash.ts
@@ -13,6 +13,28 @@ export class L2BlockHash extends Buffer32 {
     super(hash);
   }
 
+  /**
+   * Type guard that checks if a value is an L2BlockHash instance.
+   * Uses duck typing to handle cases where instanceof fails due to module duplication.
+   * Checks for Buffer32-like structure with a 32-byte buffer.
+   */
+  static isL2BlockHash(value: unknown): value is L2BlockHash {
+    if (value instanceof L2BlockHash) {
+      return true;
+    }
+    // Duck typing fallback: check if it looks like a Buffer32 with a 32-byte buffer
+    // This helps when instanceof fails due to module duplication
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'buffer' in value &&
+      Buffer.isBuffer((value as Buffer32).buffer) &&
+      (value as Buffer32).buffer.length === 32 &&
+      'toBuffer' in value &&
+      typeof (value as Buffer32).toBuffer === 'function'
+    );
+  }
+
   static override random() {
     return new L2BlockHash(Fr.random().toBuffer());
   }


### PR DESCRIPTION
Do not use `instanceof` for testing for L2BlockHash in aztec-node, given the struct is defined in a different package and we could have issues with the check if the package is loaded more than once by accident.