### PR TITLE
refactor: validate contract address

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -130,6 +130,8 @@
     "filestat",
     "Flashbots",
     "flatmap",
+    "footgun",
+    "footguns",
     "foundryup",
     "frontend",
     "frontends",

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
@@ -80,17 +80,51 @@ pub fn validate_contract_address(
 
     // Step 2: Check if it's a protocol contract (has a "magic" canonical address).
 
-    let is_protocol_contract = ProtocolContracts::is_protocol_contract_address(contract_address);
+    let is_protocol_contract =
+        ProtocolContracts::is_magic_protocol_contract_address(contract_address);
+
+    // We explicitly disallow private calls to the private functions of _derived_ protocol contract addresses,
+    // and instead demand that the _magic_ address be used.
+    //
+    // Important note:
+    // Derived addresses have _different state_ from their magic counterparts, since all state
+    // is siloed (in the reset kernel) by the address of the contract which emits that state, and a derived
+    // address is a different value from its corresponding magic address.
+    // So, even if derived protocol contracts were callable (which they are not, due to this assertion),
+    // the act of calling a _derived_ protocol contract and changing its state ought to have been ignored by
+    // all, and should have been universally recognized as meaningless. But it certainly could have been
+    // a potential footgun if users / wallets / apps were to accidentally make calls to derived addresses instead
+    // of magic addresses. It's this fear of footguns which has led to this explicit rejection of derived
+    // contract addresses.
+    //
+    // It's also important to think about whether the _public_ functions of derived addresses are callable,
+    // to avoid accidental inconsistencies between private and public execution.
+    // We have designed derived addresses in such a way that their _public_ functions are _not_ callable:
+    // All addresses contain a `deployer` field in their preimage, which can either be an actual address or 0.
+    // For each _derived_ protocol contract address, we intentionally set its `deployer` to be its
+    // corresponding magic address.
+    // So the _derived_ protocol contract for magic address 2 will have `deployer = 2`, etc.
+    // Only the `deployer` of a contract can make a call to the ContractInstanceRegistry to publish that
+    // contract's public functions for public execution.
+    // This means no one will be able to _publish_ the _derived_ version of any protocol contract, because no one
+    // can impersonate a magic protocol contract address. The inability to _publish_ any derived contract
+    // via the ContractInstanceRegistry means the _public_ functions of _derived_ protocol contracts will be
+    // impossible to execute, because the AVM can only execute a public function if its contract instance has
+    // been registered.
+    // (This slightly convoluted approach to preventing public execution of derived protocol contract functions
+    // was preferred over adding explicit checks within the AVM).
+    protocol_contracts.assert_not_derived_protocol_contract_address(contract_address);
 
     let expected_protocol_contract_derived_address = if is_protocol_contract {
         protocol_contracts.get_derived_address(contract_address)
     } else {
         AztecAddress::zero()
     };
-    let protocol_contract_check_ok = computed_address == expected_protocol_contract_derived_address;
+    let protocol_contract_address_derivation_check_ok =
+        computed_address == expected_protocol_contract_derived_address;
 
     assert(
-        !is_protocol_contract | protocol_contract_check_ok,
+        !is_protocol_contract | protocol_contract_address_derivation_check_ok,
         "computed contract address does not match protocol contract derived address",
     );
 
@@ -104,6 +138,22 @@ pub fn validate_contract_address(
         hints.updated_class_id_leaf,
     );
 
+    // If the ContractInstanceRegistry's mapping from `contract_address` to an updated class_id is
+    // nonempty, then we consider the contract to have been updated and we demand that the function
+    // being processed by this kernel belongs to that _updated_ class_id. (That is, we demand that
+    // the called function_selector -- and the vk_hash that we have used to verify the app circuit's
+    // proof -- belong to the updated class_id).
+    //
+    // Caveat (for protocol contracts): We expect that it's impossible for protocol contracts to be
+    // upgradeable, because there are no functions within any of the protocol contracts which are
+    // capable of making a call to the ContractInstanceRegistry::update function. Nevertheless, in
+    // the (expected-to-be-impossible) event that someone manages to update a protocol contract entry
+    // in the registry (through some bug exploit), we would prefer for that updated class_id to be
+    // ignored.
+    // Thankfully, if the contract_address is a protocol contract, the code above ensures that
+    // the `computed_contract_class_id` represents that of the _derived_ protocol contract's class_id
+    // and not that of any `updated_contract_class_id`. So if someone attempts to somehow execute
+    // an updated protocol contract, the `updated_class_check_ok` assertion below will fail.
     let is_updated_contract = !updated_contract_class_id.is_empty();
 
     let updated_class_check_ok = computed_contract_class_id == updated_contract_class_id;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/protocol_contracts.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/protocol_contracts.nr
@@ -10,24 +10,59 @@ pub struct ProtocolContracts {
     derived_addresses: [AztecAddress; MAX_PROTOCOL_CONTRACTS],
 }
 
+global MAX_PROTOCOL_CONTRACTS_BIT_SIZE: u32 = 4; // ceil(log2(MAX_PROTOCOL_CONTRACTS)) - tested below.
+
 impl ProtocolContracts {
     pub fn new(derived_addresses: [AztecAddress; MAX_PROTOCOL_CONTRACTS]) -> Self {
         Self { derived_addresses }
     }
 
     /// Checks if the given address is a protocol contract address.
-    pub fn is_protocol_contract_address(contract_address: AztecAddress) -> bool {
-        // Address 0 is not a protocol contract.
-        // For protocol contract address i, its actual address is stored in derived_addresses[i - 1].
-        // Underflow will happen if trying to check address zero, but that is fine, since it'll fail the lt check.
-        (contract_address.to_field() - 1).lt(MAX_PROTOCOL_CONTRACTS as Field)
+    pub fn is_magic_protocol_contract_address(contract_address: AztecAddress) -> bool {
+        // Address 0 is not a valid magic protocol contract address, so we loop from 1:
+        let mut acc = 1;
+        for i in 1..MAX_PROTOCOL_CONTRACTS + 1 {
+            // If any `i` matches, then `acc` will collapse to `0`.
+            acc *= (contract_address.to_field() - i as Field);
+        }
+        // If you think of acc as representing a polynomial (x - 1)*(x - 2)*(x - 3)*...*(x - 10)*(x - 11),
+        // then this polynomial only has roots 1,2,3,...,10,11.
+        acc == 0
     }
 
-    /// Obtains the derived address for the given protocol contract address.
-    /// Important! This assumes that the caller has already validated that the address is indeed a protocol contract
-    /// address by calling `is_protocol_contract_address` first.
-    pub fn get_derived_address(self, protocol_contract_address: AztecAddress) -> AztecAddress {
-        self.derived_addresses[(protocol_contract_address.to_field() - 1) as u32]
+    pub fn assert_not_derived_protocol_contract_address(self, contract_address: AztecAddress) {
+        for i in 0..self.derived_addresses.len() {
+            let derived_address = self.derived_addresses[i];
+            // At the time of writing, the unused elements at the rhs of the derived_addresses array are 0's.
+            // We don't disallow the 0 address in this function, simply because this function
+            // only seeks to disallow 'proper' derived protocol contract addresses (and because
+            // several tests use the 0 address).
+            if derived_address.inner != 0 {
+                assert(
+                    contract_address != derived_address,
+                    "Attempting to execute a 'derived' protocol contract address. This is not allowed.",
+                );
+            }
+        }
+    }
+
+    /// Obtains the derived address for the given magic protocol contract address.
+    ///
+    /// Important! This assumes that the caller has already validated that the address is indeed a magic protocol contract
+    /// address by calling `is_magic_protocol_contract_address` first, because this function fails if the input
+    /// address is not a valid magic protocol contract address.
+    pub fn get_derived_address(
+        self,
+        magic_protocol_contract_address: AztecAddress,
+    ) -> AztecAddress {
+        // Address 0 is not a valid magic protocol contract address: the below range check will fail in that case (see tests).
+        // For protocol contract address i, its actual address is stored in derived_addresses[i - 1].
+        let magic_protocol_contract_address_as_field = magic_protocol_contract_address.to_field();
+        let index_of_derived_address_as_field = magic_protocol_contract_address_as_field - 1; // underflow for input address 0 will be caught on the next line.
+        // We established a new variable, which we assert to be smaller than a u32, so as to make
+        // the `as u32` conversion cheaper.
+        index_of_derived_address_as_field.assert_max_bit_size::<MAX_PROTOCOL_CONTRACTS_BIT_SIZE>();
+        self.derived_addresses[index_of_derived_address_as_field as u32]
     }
 
     pub fn hash(self) -> Field {
@@ -41,5 +76,189 @@ impl ProtocolContracts {
 impl Empty for ProtocolContracts {
     fn empty() -> Self {
         Self { derived_addresses: [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS] }
+    }
+}
+
+mod test {
+    use crate::{
+        abis::protocol_contracts::ProtocolContracts, address::aztec_address::AztecAddress,
+        constants::MAX_PROTOCOL_CONTRACTS, traits::FromField,
+    };
+    use super::MAX_PROTOCOL_CONTRACTS_BIT_SIZE;
+
+    #[test]
+    fn test_max_protocol_contracts_bit_size() {
+        assert(1 << MAX_PROTOCOL_CONTRACTS_BIT_SIZE >= MAX_PROTOCOL_CONTRACTS);
+        assert(1 << (MAX_PROTOCOL_CONTRACTS_BIT_SIZE - 1) < MAX_PROTOCOL_CONTRACTS);
+    }
+
+    #[test]
+    fn test_max_protocol_contracts_bit_size_lte_32() {
+        assert(
+            MAX_PROTOCOL_CONTRACTS_BIT_SIZE <= 32,
+            "You need to update the logic of get_derived_address, because the range check is no longer sufficient",
+        );
+    }
+
+    #[test]
+    fn test_is_magic_protocol_contract_address_valid() {
+        // Protocol contract addresses are 1 through MAX_PROTOCOL_CONTRACTS
+        for i in 1..MAX_PROTOCOL_CONTRACTS + 1 {
+            let addr = AztecAddress::from_field(i as Field);
+            assert(
+                ProtocolContracts::is_magic_protocol_contract_address(addr),
+                "Address should be a protocol contract",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_magic_protocol_contract_address_zero_is_not_valid() {
+        // Address 0 is not a protocol contract
+        let addr = AztecAddress::from_field(0);
+        assert(
+            !ProtocolContracts::is_magic_protocol_contract_address(addr),
+            "Address 0 should not be a protocol contract",
+        );
+    }
+
+    #[test]
+    fn test_is_magic_protocol_contract_address_above_max_is_not_valid() {
+        // Addresses above MAX_PROTOCOL_CONTRACTS are not protocol contracts
+        let addr = AztecAddress::from_field((MAX_PROTOCOL_CONTRACTS + 1) as Field);
+        assert(
+            !ProtocolContracts::is_magic_protocol_contract_address(addr),
+            "Address above MAX should not be a protocol contract",
+        );
+
+        let large_addr = AztecAddress::from_field(1000);
+        assert(
+            !ProtocolContracts::is_magic_protocol_contract_address(large_addr),
+            "Large address should not be a protocol contract",
+        );
+    }
+
+    #[test]
+    fn test_get_derived_address() {
+        // Create an instance of ProtocolContracts with test derived addresses:
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        for i in 0..MAX_PROTOCOL_CONTRACTS {
+            addresses[i] = AztecAddress::from_field((i + 100) as Field);
+        }
+
+        let contracts = ProtocolContracts::new(addresses);
+
+        // Protocol contract address 1 maps to derived_addresses[0]
+        // Protocol contract address 2 maps to derived_addresses[1]
+        // etc.
+        for i in 1..MAX_PROTOCOL_CONTRACTS + 1 {
+            let protocol_addr = AztecAddress::from_field(i as Field);
+            let derived = contracts.get_derived_address(protocol_addr);
+            assert_eq(derived, AztecAddress::from_field((i - 1 + 100) as Field));
+        }
+    }
+
+    #[test(should_fail_with = "call to assert_max_bit_size")]
+    fn test_get_derived_address_zero_fails() {
+        // Create an instance of ProtocolContracts with test derived addresses:
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        for i in 0..MAX_PROTOCOL_CONTRACTS {
+            addresses[i] = AztecAddress::from_field((i + 100) as Field);
+        }
+        let contracts = ProtocolContracts::new(addresses);
+
+        // This will attempt to access the `derived_addresses` at index `-1`, which is out of bounds.
+        let protocol_addr = AztecAddress::from_field(0);
+        let _ = contracts.get_derived_address(protocol_addr);
+    }
+
+    #[test(should_fail_with = "Index out of bounds")]
+    fn test_get_derived_address_above_max_fails() {
+        // Create an instance of ProtocolContracts with test derived addresses:
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        for i in 0..MAX_PROTOCOL_CONTRACTS {
+            addresses[i] = AztecAddress::from_field((i + 100) as Field);
+        }
+        let contracts = ProtocolContracts::new(addresses);
+
+        // This will attempt to access the `derived_addresses` at index `MAX_PROTOCOL_CONTRACTS`, which is out of bounds.
+        let protocol_addr = AztecAddress::from_field((MAX_PROTOCOL_CONTRACTS + 1) as Field);
+        let _ = contracts.get_derived_address(protocol_addr);
+    }
+
+    #[test]
+    fn test_assert_not_derived_protocol_contract_address_passes_for_non_derived() {
+        // Create ProtocolContracts with some derived addresses
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        addresses[0] = AztecAddress::from_field(100);
+        addresses[1] = AztecAddress::from_field(200);
+        addresses[2] = AztecAddress::from_field(300);
+        let contracts = ProtocolContracts::new(addresses);
+
+        // A non-derived address should pass
+        let non_derived_address = AztecAddress::from_field(999);
+        contracts.assert_not_derived_protocol_contract_address(non_derived_address);
+    }
+
+    #[test]
+    fn test_assert_not_derived_protocol_contract_address_allows_zero_address() {
+        // Create ProtocolContracts with some derived addresses
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        addresses[0] = AztecAddress::from_field(100);
+        addresses[1] = AztecAddress::from_field(200);
+        let contracts = ProtocolContracts::new(addresses);
+
+        // Zero address is explicitly allowed (see function comment)
+        let zero_address = AztecAddress::zero();
+        contracts.assert_not_derived_protocol_contract_address(zero_address);
+    }
+
+    #[test(should_fail_with = "Attempting to execute a 'derived' protocol contract address")]
+    fn test_assert_not_derived_protocol_contract_address_fails_for_derived() {
+        // Create ProtocolContracts with some derived addresses
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        addresses[0] = AztecAddress::from_field(100);
+        addresses[1] = AztecAddress::from_field(200);
+        addresses[2] = AztecAddress::from_field(300);
+        let contracts = ProtocolContracts::new(addresses);
+
+        // Using a derived address should fail
+        let derived_address = AztecAddress::from_field(200);
+        contracts.assert_not_derived_protocol_contract_address(derived_address);
+    }
+
+    #[test(should_fail_with = "Attempting to execute a 'derived' protocol contract address")]
+    fn test_assert_not_derived_protocol_contract_address_fails_for_first_derived() {
+        // Create ProtocolContracts with some derived addresses
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        addresses[0] = AztecAddress::from_field(100);
+        addresses[1] = AztecAddress::from_field(200);
+        let contracts = ProtocolContracts::new(addresses);
+
+        // Using the first derived address (index 0) should fail
+        let first_derived = AztecAddress::from_field(100);
+        contracts.assert_not_derived_protocol_contract_address(first_derived);
+    }
+
+    #[test(should_fail_with = "Attempting to execute a 'derived' protocol contract address")]
+    fn test_assert_not_derived_protocol_contract_address_fails_for_last_derived() {
+        // Create ProtocolContracts with derived addresses spread across the array
+        let mut addresses = [AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS];
+        addresses[0] = AztecAddress::from_field(100);
+        addresses[MAX_PROTOCOL_CONTRACTS - 1] = AztecAddress::from_field(999);
+        let contracts = ProtocolContracts::new(addresses);
+
+        // Using the last derived address should fail
+        let last_derived = AztecAddress::from_field(999);
+        contracts.assert_not_derived_protocol_contract_address(last_derived);
+    }
+
+    #[test]
+    fn test_assert_not_derived_protocol_contract_address_passes_when_all_zeros() {
+        // When all derived addresses are zero, any non-zero address should pass
+        let contracts = ProtocolContracts::new([AztecAddress::zero(); MAX_PROTOCOL_CONTRACTS]);
+
+        let any_address = AztecAddress::from_field(12345);
+        contracts.assert_not_derived_protocol_contract_address(any_address);
     }
 }


### PR DESCRIPTION
Some minor changes:
- A couple of big comments to explain things that took me a while to remember.
- I ended up adding an assertion that explicitly forbids _derived_ protocol contract addresses from being callable in private-land. See the big block comment that explains why.
- A couple of minor renames to help my brain.
-  Changed the `is_magic_protocol_contract_address` implementation to a more efficient version. It only saves ~100 gates, but I couldn't resist.
- Tried to optimise `get_derived_address` early last week, although now that I'm seeing it with fresh eyes, I might have over-done it.
- Added tests for the protocol_contracts.nr file.