### PR TITLE
feat: add inclusion status to tx-receipt

### DIFF
--- a/playground/src/components/common/TransactionModal.tsx
+++ b/playground/src/components/common/TransactionModal.tsx
@@ -17,13 +17,7 @@ import { trackButtonClick } from '../../utils/matomo';
 import { useWindowSize } from '@uidotdev/usehooks';
 import { colors, commonStyles } from '../../global.styles';
 
-const TX_ERRORS = [
-  'error',
-  TxStatus.APP_LOGIC_REVERTED,
-  TxStatus.TEARDOWN_REVERTED,
-  TxStatus.BOTH_REVERTED,
-  TxStatus.DROPPED,
-];
+const TX_ERRORS = ['error', TxStatus.DROPPED];
 
 const minimizeButton = css({
   position: 'absolute',
@@ -147,7 +141,7 @@ export function TransactionModal(props: { transaction: UserTx; isOpen: boolean; 
     return null;
   }
 
-  const isError = TX_ERRORS.includes(transaction?.status);
+  const isError = TX_ERRORS.includes(transaction?.status) || transaction?.receipt?.hasExecutionReverted();
   const isProving = transaction?.status === 'proving';
   const isSending = transaction?.status === 'sending';
   const isSuccess = transaction?.status === 'success';

--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -6,7 +6,6 @@ import {
   Contract,
   DeployMethod,
 } from '@aztec/aztec.js/contracts';
-import { TxStatus } from '@aztec/aztec.js/tx';
 import { type FunctionAbi, getAllFunctionAbis, FunctionType } from '@aztec/stdlib/abi';
 import { AztecContext } from '../../aztecContext';
 import Button from '@mui/material/Button';
@@ -233,7 +232,7 @@ export function ContractComponent() {
     if (contract && publiclyDeploy) {
       const txReceipt = await sendTx(`Deploy ${currentContractArtifact.name}`, interaction, contract.address, opts);
       // Temporarily ignore undeployed contracts
-      if (txReceipt?.status === TxStatus.SUCCESS) {
+      if (txReceipt?.hasExecutionSucceeded()) {
         setCurrentContractAddress(contract.address);
       }
     } else if (contract) {

--- a/playground/src/components/home/components/Landing.tsx
+++ b/playground/src/components/home/components/Landing.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import welcomeIconURL from '../../../assets/welcome_icon.svg';
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
-import { TxStatus } from '@aztec/aztec.js/tx';
 import type { DeployAccountOptions } from '@aztec/aztec.js/wallet';
 import { useNotifications } from '@toolpad/core/useNotifications';
 import { Box, Button, CircularProgress, Tooltip } from '@mui/material';
@@ -415,7 +414,7 @@ export function Landing() {
 
       const txReceipt = await sendTx(`Deploy account contract`, deployMethod, address, opts);
 
-      if (txReceipt?.status === TxStatus.SUCCESS) {
+      if (txReceipt?.hasExecutionSucceeded()) {
         setFrom(address);
       }
     } catch (e) {

--- a/playground/src/components/navbar/TxPanel.tsx
+++ b/playground/src/components/navbar/TxPanel.tsx
@@ -16,13 +16,7 @@ import { useLocalStorage } from '@uidotdev/usehooks';
 import { CopyToClipboardButton } from '../common/CopyToClipboardButton';
 import { colors, commonStyles } from '../../global.styles';
 
-const TX_ERRORS = [
-  'error',
-  TxStatus.APP_LOGIC_REVERTED,
-  TxStatus.TEARDOWN_REVERTED,
-  TxStatus.BOTH_REVERTED,
-  TxStatus.DROPPED,
-];
+const TX_ERRORS = ['error', TxStatus.DROPPED];
 
 const container = css({
   width: '320px',
@@ -253,7 +247,7 @@ export function TxPanel() {
     lastLog = lastLog.slice(0, 100) + '...';
   }
 
-  const hasError = pendingTx?.error || TX_ERRORS.includes(pendingTx?.status);
+  const hasError = pendingTx?.error || TX_ERRORS.includes(pendingTx?.status) || pendingTx?.receipt?.hasExecutionReverted();
   const errorMessage = pendingTx?.error;
 
   let subtitle;

--- a/playground/src/hooks/useTransaction.tsx
+++ b/playground/src/hooks/useTransaction.tsx
@@ -46,7 +46,7 @@ export function useTransaction() {
       // TODO: Don't send the tx if the user has cancelled the transaction
       receipt = await tx.wait({ dontThrowOnRevert: true, timeout: TX_TIMEOUT, interval: 5 });
 
-      if (showNotifications && receipt.status === TxStatus.SUCCESS) {
+      if (showNotifications && receipt.hasExecutionSucceeded()) {
         notifications.show('Congratulations! Your transaction was included in a block.', {
           severity: 'success',
         });
@@ -63,14 +63,14 @@ export function useTransaction() {
         ...currentTx,
         ...{
           txHash,
-          status: receipt.status,
+          status: receipt.hasExecutionSucceeded() ? 'success' : receipt.status,
           receipt,
           error: receipt.error,
         },
       });
     } catch (e) {
       if (e instanceof TimeoutError) {
-        const txReceipt = new TxReceipt(txHash, TxStatus.PENDING, e.message);
+        const txReceipt = new TxReceipt(txHash, TxStatus.PENDING, undefined, e.message);
         await playgroundDB.storeTx({
           contractAddress,
           txHash,

--- a/playground/src/utils/txs.ts
+++ b/playground/src/utils/txs.ts
@@ -6,7 +6,7 @@ export type UserTx = {
   txHash?: TxHash;
   receipt?: TxReceipt;
   date?: number;
-  status: 'error' | 'simulating' | 'proving' | 'sending' | TxStatus;
+  status: 'error' | 'simulating' | 'proving' | 'sending' | 'success' | TxStatus;
   name: string;
   error?: string;
   contractAddress: AztecAddress;

--- a/yarn-project/archiver/src/archiver-store.test.ts
+++ b/yarn-project/archiver/src/archiver-store.test.ts
@@ -61,7 +61,7 @@ describe('Archiver Store', () => {
     const tracer = getTelemetryClient().getTracer('');
     instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
 
-    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000);
+    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000, { epochDuration: 4 });
 
     l1Constants = {
       l1GenesisTime: BigInt(now),

--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -92,7 +92,7 @@ describe('Archiver Sync', () => {
     instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
 
     // Create archiver store
-    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_sync_test'), 1000);
+    archiverStore = new KVArchiverDataStore(await openTmpStore('archiver_sync_test'), 1000, { epochDuration: 32 });
 
     const contractAddresses = {
       registryAddress,

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -369,16 +369,12 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   }
 
   public async getL2Tips(): Promise<L2Tips> {
-    const [latestBlockNumber, provenBlockNumber, checkpointedBlockNumber] = await Promise.all([
+    const [latestBlockNumber, provenBlockNumber, checkpointedBlockNumber, finalizedBlockNumber] = await Promise.all([
       this.getBlockNumber(),
       this.getProvenBlockNumber(),
-      this.getCheckpointedBlockNumber(),
+      this.getCheckpointedL2BlockNumber(),
+      this.getFinalizedL2BlockNumber(),
     ] as const);
-
-    // TODO(#13569): Compute proper finalized block number based on L1 finalized block.
-    // We just force it 2 epochs worth of proven data for now.
-    // NOTE: update end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts as that uses finalized blocks in computations
-    const finalizedBlockNumber = BlockNumber(Math.max(provenBlockNumber - this.l1Constants.epochDuration * 2, 0));
 
     const beforeInitialblockNumber = BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
 

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -15,6 +15,7 @@ import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/prov
 import { FunctionType, decodeFunctionSignature } from '@aztec/stdlib/abi';
 import type { ArchiverEmitter } from '@aztec/stdlib/block';
 import { type ContractClassPublic, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import { EventEmitter } from 'events';
@@ -31,13 +32,14 @@ export const ARCHIVER_STORE_NAME = 'archiver';
 /** Creates an archiver store. */
 export async function createArchiverStore(
   userConfig: Pick<ArchiverConfig, 'archiverStoreMapSizeKb' | 'maxLogs'> & DataStoreConfig,
+  l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
 ) {
   const config = {
     ...userConfig,
     dataStoreMapSizeKb: userConfig.archiverStoreMapSizeKb ?? userConfig.dataStoreMapSizeKb,
   };
   const store = await createStore(ARCHIVER_STORE_NAME, ARCHIVER_DB_VERSION, config, createLogger('archiver:lmdb'));
-  return new KVArchiverDataStore(store, config.maxLogs);
+  return new KVArchiverDataStore(store, config.maxLogs, l1Constants);
 }
 
 /**
@@ -52,7 +54,7 @@ export async function createArchiver(
   deps: ArchiverDeps,
   opts: { blockUntilSync: boolean } = { blockUntilSync: true },
 ): Promise<Archiver> {
-  const archiverStore = await createArchiverStore(config);
+  const archiverStore = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
   await registerProtocolContracts(archiverStore);
 
   // Create Ethereum clients

--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -87,8 +87,12 @@ export abstract class ArchiverDataSourceBase
     return this.store.getCheckpointedBlock(number);
   }
 
-  public getCheckpointedBlockNumber(): Promise<BlockNumber> {
+  public getCheckpointedL2BlockNumber(): Promise<BlockNumber> {
     return this.store.getCheckpointedL2BlockNumber();
+  }
+
+  public getFinalizedL2BlockNumber(): Promise<BlockNumber> {
+    return this.store.getFinalizedL2BlockNumber();
   }
 
   public async getCheckpointHeader(number: CheckpointNumber | 'latest'): Promise<CheckpointHeader | undefined> {

--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -44,7 +44,7 @@ describe('ArchiverDataStoreUpdater', () => {
   let instanceAddress: AztecAddress;
 
   beforeEach(async () => {
-    store = new KVArchiverDataStore(await openTmpStore('data_store_updater_test'));
+    store = new KVArchiverDataStore(await openTmpStore('data_store_updater_test'), 1000, { epochDuration: 32 });
     updater = new ArchiverDataStoreUpdater(store);
 
     // Create contract class log from sample fixture data

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -19,6 +19,7 @@ import {
   serializeValidateCheckpointResult,
 } from '@aztec/stdlib/block';
 import { L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
 import {
@@ -27,6 +28,7 @@ import {
   TxEffect,
   TxHash,
   TxReceipt,
+  TxStatus,
   deserializeIndexedTxEffect,
   serializeIndexedTxEffect,
 } from '@aztec/stdlib/tx';
@@ -111,7 +113,10 @@ export class BlockStore {
 
   #log = createLogger('archiver:block_store');
 
-  constructor(private db: AztecAsyncKVStore) {
+  constructor(
+    private db: AztecAsyncKVStore,
+    private l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
+  ) {
     this.#blocks = db.openMap('archiver_blocks');
     this.#blockTxs = db.openMap('archiver_block_txs');
     this.#txEffects = db.openMap('archiver_tx_effects');
@@ -122,6 +127,18 @@ export class BlockStore {
     this.#lastProvenCheckpoint = db.openSingleton('archiver_last_proven_l2_checkpoint');
     this.#pendingChainValidationStatus = db.openSingleton('archiver_pending_chain_validation_status');
     this.#checkpoints = db.openMap('archiver_checkpoints');
+  }
+
+  /**
+   * Computes the finalized block number based on the proven block number.
+   * A block is considered finalized when it's 2 epochs behind the proven block.
+   * TODO(#13569): Compute proper finalized block number based on L1 finalized block.
+   * TODO(palla/mbps): Even the provisional computation is wrong, since it should subtract checkpoints, not blocks
+   * @returns The finalized block number.
+   */
+  async getFinalizedL2BlockNumber(): Promise<BlockNumber> {
+    const provenBlockNumber = await this.getProvenBlockNumber();
+    return BlockNumber(Math.max(provenBlockNumber - this.l1Constants.epochDuration * 2, 0));
   }
 
   /**
@@ -802,13 +819,34 @@ export class BlockStore {
       return undefined;
     }
 
+    const blockNumber = BlockNumber(txEffect.l2BlockNumber);
+
+    // Use existing archiver methods to determine finalization level
+    const [provenBlockNumber, checkpointedBlockNumber, finalizedBlockNumber] = await Promise.all([
+      this.getProvenBlockNumber(),
+      this.getCheckpointedL2BlockNumber(),
+      this.getFinalizedL2BlockNumber(),
+    ]);
+
+    let status: TxStatus;
+    if (blockNumber <= finalizedBlockNumber) {
+      status = TxStatus.FINALIZED;
+    } else if (blockNumber <= provenBlockNumber) {
+      status = TxStatus.PROVEN;
+    } else if (blockNumber <= checkpointedBlockNumber) {
+      status = TxStatus.CHECKPOINTED;
+    } else {
+      status = TxStatus.PROPOSED;
+    }
+
     return new TxReceipt(
       txHash,
-      TxReceipt.statusFromRevertCode(txEffect.data.revertCode),
-      '',
+      status,
+      TxReceipt.executionResultFromRevertCode(txEffect.data.revertCode),
+      undefined,
       txEffect.data.transactionFee.toBigInt(),
       txEffect.l2BlockHash,
-      BlockNumber(txEffect.l2BlockNumber),
+      blockNumber,
     );
   }
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -88,7 +88,7 @@ describe('KVArchiverDataStore', () => {
   };
 
   beforeEach(async () => {
-    store = new KVArchiverDataStore(await openTmpStore('archiver_test'));
+    store = new KVArchiverDataStore(await openTmpStore('archiver_test'), 1000, { epochDuration: 32 });
     // Create checkpoints sequentially to ensure archive roots are chained properly.
     // Each block's header.lastArchive must equal the previous block's archive.
     publishedCheckpoints = [];

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -16,6 +16,7 @@ import type {
   ExecutablePrivateFunctionWithMembershipProof,
   UtilityFunctionWithMembershipProof,
 } from '@aztec/stdlib/contract';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import type { LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { BlockHeader, TxHash, TxReceipt } from '@aztec/stdlib/tx';
@@ -64,8 +65,9 @@ export class KVArchiverDataStore implements ContractDataSource {
   constructor(
     private db: AztecAsyncKVStore,
     logsMaxPageSize: number = 1000,
+    l1Constants: Pick<L1RollupConstants, 'epochDuration'>,
   ) {
-    this.#blockStore = new BlockStore(db);
+    this.#blockStore = new BlockStore(db, l1Constants);
     this.#logStore = new LogStore(db, this.#blockStore, logsMaxPageSize);
     this.#messageStore = new MessageStore(db);
     this.#contractClassStore = new ContractClassStore(db);
@@ -99,6 +101,11 @@ export class KVArchiverDataStore implements ContractDataSource {
   /** Closes the underlying data store. */
   public close() {
     return this.db.close();
+  }
+
+  /** Computes the finalized block number based on the proven block number. */
+  getFinalizedL2BlockNumber(): Promise<BlockNumber> {
+    return this.#blockStore.getFinalizedL2BlockNumber();
   }
 
   /** Looks up a public function name given a selector. */

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -18,7 +18,7 @@ import {
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { EmptyL1RollupConstants, type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
-import { type BlockHeader, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
+import { type BlockHeader, TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 import type { UInt64 } from '@aztec/stdlib/types';
 
 /**
@@ -94,6 +94,14 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
 
   public getProvenBlockNumber() {
     return Promise.resolve(BlockNumber(this.provenBlockNumber));
+  }
+
+  public getCheckpointedL2BlockNumber() {
+    return Promise.resolve(BlockNumber(this.checkpointedBlockNumber));
+  }
+
+  public getFinalizedL2BlockNumber() {
+    return Promise.resolve(BlockNumber(this.finalizedBlockNumber));
   }
 
   public getCheckpointedBlock(number: BlockNumber): Promise<CheckpointedL2Block | undefined> {
@@ -348,10 +356,12 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     for (const block of this.l2Blocks) {
       for (const txEffect of block.body.txEffects) {
         if (txEffect.txHash.equals(txHash)) {
+          // In mock, assume all txs are checkpointed with successful execution
           return new TxReceipt(
             txHash,
-            TxStatus.SUCCESS,
-            '',
+            TxStatus.CHECKPOINTED,
+            TxExecutionResult.SUCCESS,
+            undefined,
             txEffect.transactionFee.toBigInt(),
             L2BlockHash.fromField(await block.hash()),
             block.number,

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -756,13 +756,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   public async getTxReceipt(txHash: TxHash): Promise<TxReceipt> {
-    let txReceipt = new TxReceipt(txHash, TxStatus.DROPPED, 'Tx dropped by P2P node.');
+    let txReceipt = new TxReceipt(txHash, TxStatus.DROPPED, undefined, 'Tx dropped by P2P node.');
 
     // We first check if the tx is in pending (instead of first checking if it is mined) because if we first check
     // for mined and then for pending there could be a race condition where the tx is mined between the two checks
     // and we would incorrectly return a TxReceipt with status DROPPED
     if ((await this.p2pClient.getTxStatus(txHash)) === 'pending') {
-      txReceipt = new TxReceipt(txHash, TxStatus.PENDING, '');
+      txReceipt = new TxReceipt(txHash, TxStatus.PENDING, undefined, undefined);
     }
 
     const settledTxReceipt = await this.blockSource.getSettledTxReceipt(txHash);

--- a/yarn-project/aztec.js/src/api/tx.ts
+++ b/yarn-project/aztec.js/src/api/tx.ts
@@ -1,9 +1,11 @@
 export {
   Tx,
   TxExecutionRequest,
+  TxExecutionResult,
   TxHash,
   TxReceipt,
   TxStatus,
+  SortedTxStatuses,
   Capsule,
   HashedValues,
   GlobalVariables,

--- a/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
@@ -1,7 +1,6 @@
 import { createLogger } from '@aztec/foundation/log';
-import type { FieldsOf } from '@aztec/foundation/types';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import type { TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import { type TxHash, TxReceipt } from '@aztec/stdlib/tx';
 
 import type { Wallet } from '../wallet/wallet.js';
 import type { ContractBase } from './contract_base.js';
@@ -14,12 +13,43 @@ export type DeployedWaitOpts = WaitOpts & {
 };
 
 /** Extends a transaction receipt with a contract instance that represents the newly deployed contract. */
-export type DeployTxReceipt<TContract extends ContractBase = ContractBase> = FieldsOf<TxReceipt> & {
-  /** Instance of the newly deployed contract. */
-  contract: TContract;
-  /** The deployed contract instance with address and metadata. */
-  instance: ContractInstanceWithAddress;
-};
+export class DeployTxReceipt<TContract extends ContractBase = ContractBase> extends TxReceipt {
+  constructor(
+    /** Instance of the newly deployed contract. */
+    public contract: TContract,
+    /** The deployed contract instance with address and metadata. */
+    public instance: ContractInstanceWithAddress,
+    /** Arguments for the tx receipt */
+    ...args: ConstructorParameters<typeof TxReceipt>
+  ) {
+    super(...args);
+  }
+
+  /**
+   * Creates a new instance out of a TxReceipt
+   * @param contract - The contract class
+   * @param instance - The deployed contract instance with address and metadata
+   * @param receipt - The transaction receipt
+   * @returns A new DeployTxReceipt instance
+   */
+  static fromTxReceipt<TContract extends ContractBase = ContractBase>(
+    contract: TContract,
+    instance: ContractInstanceWithAddress,
+    receipt: TxReceipt,
+  ): DeployTxReceipt<TContract> {
+    return new DeployTxReceipt(
+      contract,
+      instance,
+      receipt.txHash,
+      receipt.status,
+      receipt.executionResult,
+      receipt.error,
+      receipt.transactionFee,
+      receipt.blockHash,
+      receipt.blockNumber,
+    );
+  }
+}
 
 /**
  * A contract deployment transaction sent to the network, extending SentTx with methods to publish a contract instance.
@@ -70,6 +100,6 @@ export class DeploySentTx<TContract extends ContractBase = ContractBase> extends
     }
     const instance = await this.instanceGetter();
     const contract = this.postDeployCtor(instance, contractWallet) as TContract;
-    return { ...receipt, contract, instance };
+    return DeployTxReceipt.fromTxReceipt(contract, instance, receipt);
   }
 }

--- a/yarn-project/aztec.js/src/contract/sent_tx.test.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.test.ts
@@ -1,6 +1,7 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
-import { TxHash, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
+import { TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -22,28 +23,179 @@ describe('SentTx', () => {
   describe('wait with Wallet', () => {
     let txReceipt: TxReceipt;
     beforeEach(() => {
-      txReceipt = { status: TxStatus.SUCCESS, blockNumber: 20 } as TxReceipt;
+      txReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
       wallet.getTxReceipt.mockResolvedValue(txReceipt);
       sentTx = new SentTx(wallet, txHashGetter);
     });
 
     it('throws if tx is dropped', async () => {
-      wallet.getTxReceipt.mockResolvedValue({ ...txReceipt, status: TxStatus.DROPPED } as TxReceipt);
+      const droppedReceipt = new TxReceipt(TxHash.random(), TxStatus.DROPPED, undefined, 'Tx dropped');
+      wallet.getTxReceipt.mockResolvedValue(droppedReceipt);
       await expect(sentTx.wait({ timeout: 1, interval: 0.4, ignoreDroppedReceiptsFor: 0 })).rejects.toThrow(/dropped/);
+    });
+
+    it('throws if tx reverts and dontThrowOnRevert is false', async () => {
+      const revertedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.APP_LOGIC_REVERTED,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(revertedReceipt);
+      await expect(sentTx.wait({ timeout: 1, interval: 0.4 })).rejects.toThrow(/reverted/);
+    });
+
+    it('does not throw if tx reverts and dontThrowOnRevert is true', async () => {
+      const revertedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.APP_LOGIC_REVERTED,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(revertedReceipt);
+      const receipt = await sentTx.wait({ timeout: 1, interval: 0.4, dontThrowOnRevert: true });
+      expect(receipt.hasExecutionReverted()).toBe(true);
     });
   });
 
   describe('wait with Aztec Node', () => {
     let txReceipt: TxReceipt;
     beforeEach(() => {
-      txReceipt = { status: TxStatus.SUCCESS, blockNumber: 20 } as TxReceipt;
+      txReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
       node.getTxReceipt.mockResolvedValue(txReceipt);
       sentTx = new SentTx(node, txHashGetter);
     });
 
     it('throws if tx is dropped', async () => {
-      node.getTxReceipt.mockResolvedValue({ ...txReceipt, status: TxStatus.DROPPED } as TxReceipt);
+      const droppedReceipt = new TxReceipt(TxHash.random(), TxStatus.DROPPED, undefined, 'Tx dropped');
+      node.getTxReceipt.mockResolvedValue(droppedReceipt);
       await expect(sentTx.wait({ timeout: 1, interval: 0.4, ignoreDroppedReceiptsFor: 0 })).rejects.toThrow(/dropped/);
+    });
+  });
+
+  describe('waitForStatus option', () => {
+    beforeEach(() => {
+      sentTx = new SentTx(wallet, txHashGetter);
+    });
+
+    it('returns immediately when receipt status matches requested status', async () => {
+      const checkpointedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(checkpointedReceipt);
+
+      const receipt = await sentTx.wait({ timeout: 1, interval: 0.1, waitForStatus: TxStatus.CHECKPOINTED });
+      expect(receipt.status).toBe(TxStatus.CHECKPOINTED);
+    });
+
+    it('returns when receipt status exceeds requested status', async () => {
+      const provenReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.PROVEN,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(provenReceipt);
+
+      // Request CHECKPOINTED, but receive PROVEN - should return immediately
+      const receipt = await sentTx.wait({ timeout: 1, interval: 0.1, waitForStatus: TxStatus.CHECKPOINTED });
+      expect(receipt.status).toBe(TxStatus.PROVEN);
+    });
+
+    it('waits until receipt reaches requested status', async () => {
+      const proposedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.PROPOSED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      const checkpointedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+
+      // First call returns PROPOSED, second returns CHECKPOINTED
+      wallet.getTxReceipt
+        .mockResolvedValueOnce(proposedReceipt)
+        .mockResolvedValueOnce(proposedReceipt)
+        .mockResolvedValueOnce(checkpointedReceipt);
+
+      const receipt = await sentTx.wait({ timeout: 2, interval: 0.1, waitForStatus: TxStatus.CHECKPOINTED });
+      expect(receipt.status).toBe(TxStatus.CHECKPOINTED);
+      expect(wallet.getTxReceipt).toHaveBeenCalledTimes(3);
+    });
+
+    it('times out if receipt never reaches requested status', async () => {
+      const proposedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.PROPOSED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(proposedReceipt);
+
+      // Request PROVEN but only get PROPOSED
+      await expect(sentTx.wait({ timeout: 0.5, interval: 0.1, waitForStatus: TxStatus.PROVEN })).rejects.toThrow(
+        /Timeout/,
+      );
+    });
+
+    it('defaults to CHECKPOINTED if waitForStatus is not specified', async () => {
+      const checkpointedReceipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.CHECKPOINTED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(20),
+      );
+      wallet.getTxReceipt.mockResolvedValue(checkpointedReceipt);
+
+      const receipt = await sentTx.wait({ timeout: 1, interval: 0.1 });
+      expect(receipt.status).toBe(TxStatus.CHECKPOINTED);
     });
   });
 

--- a/yarn-project/aztec.js/src/contract/sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.ts
@@ -1,9 +1,14 @@
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
-import { TxHash, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
+import { SortedTxStatuses, TxHash, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import type { Wallet } from '../wallet/wallet.js';
+
+/** Returns true if the receipt status is at least the desired status level. */
+function hasReachedStatus(receipt: TxReceipt, desiredStatus: TxStatus): boolean {
+  return SortedTxStatuses.indexOf(receipt.status) >= SortedTxStatuses.indexOf(desiredStatus);
+}
 
 /** Options related to waiting for a tx. */
 export type WaitOpts = {
@@ -15,6 +20,8 @@ export type WaitOpts = {
   interval?: number;
   /** Whether to accept a revert as a status code for the tx when waiting for it. If false, will throw if the tx reverts. */
   dontThrowOnRevert?: boolean;
+  /** The minimum inclusion status to wait for. If set, waits until the receipt reaches this status or higher. Defaults to CHECKPOINTED. */
+  waitForStatus?: TxStatus;
 };
 
 export const DefaultWaitOpts: WaitOpts = {
@@ -89,9 +96,14 @@ export class SentTx {
    */
   public async wait(opts?: WaitOpts): Promise<TxReceipt> {
     const receipt = await this.waitForReceipt(opts);
-    if (receipt.status !== TxStatus.SUCCESS && !opts?.dontThrowOnRevert) {
+    if (!receipt.isMined()) {
       throw new Error(
         `Transaction ${(await this.getTxHash()).toString()} was ${receipt.status}. Reason: ${receipt.error ?? 'unknown'}`,
+      );
+    }
+    if (!receipt.hasExecutionSucceeded() && !opts?.dontThrowOnRevert) {
+      throw new Error(
+        `Transaction ${(await this.getTxHash()).toString()} reverted: ${receipt.executionResult}. Reason: ${receipt.error ?? 'unknown'}`,
       );
     }
     return receipt;
@@ -101,22 +113,27 @@ export class SentTx {
     const txHash = await this.getTxHash();
     const startTime = Date.now();
     const ignoreDroppedReceiptsFor = opts?.ignoreDroppedReceiptsFor ?? DefaultWaitOpts.ignoreDroppedReceiptsFor;
+    const waitForStatus = opts?.waitForStatus ?? TxStatus.CHECKPOINTED;
 
     return await retryUntil(
       async () => {
         const txReceipt = await this.walletOrNode.getTxReceipt(txHash);
         // If receipt is not yet available, try again
-        if (txReceipt.status === TxStatus.PENDING) {
+        if (txReceipt.isPending()) {
           return undefined;
         }
         // If the tx was "dropped", either return it or ignore based on timing.
         // We can ignore it at first because the transaction may have been sent to node 1, and now we're asking node 2 for the receipt.
         // If we don't allow a short grace period, we could incorrectly return a TxReceipt with status DROPPED.
-        if (txReceipt.status === TxStatus.DROPPED) {
+        if (txReceipt.isDropped()) {
           const elapsedSeconds = (Date.now() - startTime) / 1000;
           if (!ignoreDroppedReceiptsFor || elapsedSeconds > ignoreDroppedReceiptsFor) {
             return txReceipt;
           }
+          return undefined;
+        }
+        // Check if the receipt has reached the desired status level
+        if (!hasReachedStatus(txReceipt, waitForStatus)) {
           return undefined;
         }
         return txReceipt;

--- a/yarn-project/cli-wallet/src/cmds/check_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/check_tx.ts
@@ -32,7 +32,10 @@ async function inspectTx(wallet: CLIWallet, aztecNode: AztecNode, txHash: TxHash
   const [receipt, effectsInBlock] = await Promise.all([aztecNode.getTxReceipt(txHash), aztecNode.getTxEffect(txHash)]);
   // Base tx data
   log(`Tx ${txHash.toString()}`);
-  log(` Status: ${receipt.status} ${effectsInBlock ? `(${effectsInBlock.data.revertCode.getDescription()})` : ''}`);
+  log(` Status: ${receipt.status}`);
+  if (receipt.executionResult) {
+    log(` Execution result: ${receipt.executionResult}`);
+  }
   if (receipt.error) {
     log(` Error: ${receipt.error}`);
   }

--- a/yarn-project/cli-wallet/test/flows/tx_management.sh
+++ b/yarn-project/cli-wallet/test/flows/tx_management.sh
@@ -16,6 +16,6 @@ TX_HASH=$(echo "${TX_LIST}" | grep "transactions:last" | awk '{print $3}')
 
 section Last transaction hash is ${TX_HASH}
 
-TX_STATUS=$(aztec-wallet get-tx ${TX_HASH} | grep "Status: " | awk '{print $2}')
+TX_RESULT=$(aztec-wallet get-tx ${TX_HASH} | grep "Execution result: " | awk '{print $3}')
 
-assert_eq ${TX_STATUS} "success"
+assert_eq ${TX_RESULT} "success"

--- a/yarn-project/cli/src/utils/inspect.ts
+++ b/yarn-project/cli/src/utils/inspect.ts
@@ -44,7 +44,10 @@ export async function inspectTx(
   const [receipt, effectsInBlock] = await Promise.all([aztecNode.getTxReceipt(txHash), aztecNode.getTxEffect(txHash)]);
   // Base tx data
   log(`Tx ${txHash.toString()}`);
-  log(` Status: ${receipt.status} ${effectsInBlock ? `(${effectsInBlock.data.revertCode.getDescription()})` : ''}`);
+  log(` Status: ${receipt.status}`);
+  if (receipt.executionResult) {
+    log(` Execution result: ${receipt.executionResult}`);
+  }
   if (receipt.error) {
     log(` Error: ${receipt.error}`);
   }

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -4,7 +4,6 @@ import type { WaitOpts } from '@aztec/aztec.js/contracts';
 import { FeeJuicePaymentMethodWithClaim } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
-import { TxStatus } from '@aztec/aztec.js/tx';
 import type { Logger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { retryUntil } from '@aztec/foundation/retry';
@@ -171,7 +170,7 @@ describe('End-to-end tests for devnet', () => {
     //   waitOpts.interval,
     // );
 
-    expect(txReceipt.status).toBe(TxStatus.SUCCESS);
+    expect(txReceipt.isMined() && txReceipt.hasExecutionSucceeded()).toBe(true);
     const feeJuice = FeeJuiceContract.at((await node.getNodeInfo()).protocolContractAddresses.feeJuice, wallet);
     const balance = await feeJuice.methods.balance_of_public(l2AccountAddress).simulate({ from: l2AccountAddress });
     expect(balance).toEqual(amount - txReceipt.transactionFee!);

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -1,7 +1,7 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { BatchCall, type ContractInstanceWithAddress } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { AvmInitializerTestContract } from '@aztec/noir-test-contracts.js/AvmInitializerTest';
 import { AvmTestContract } from '@aztec/noir-test-contracts.js/AvmTest';
@@ -155,7 +155,7 @@ describe('e2e_avm_simulator', () => {
           )
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
     });
 
@@ -166,17 +166,17 @@ describe('e2e_avm_simulator', () => {
           .emit_nullifier_and_check(123456)
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
 
       // Nullifier will have been siloed by the kernel, but we check against the unsiloed one.
       it('Emit and check in separate tx', async () => {
         const nullifier = new Fr(123456);
         let tx = await avmContract.methods.new_nullifier(nullifier).send({ from: defaultAccountAddress }).wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
 
         tx = await avmContract.methods.assert_nullifier_exists(nullifier).send({ from: defaultAccountAddress }).wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
 
       it('Emit and check in separate enqueued calls but same tx', async () => {
@@ -206,7 +206,7 @@ describe('e2e_avm_simulator', () => {
           .nested_call_to_nothing_recovers()
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
       it('Should NOT be able to emit the same unsiloed nullifier from the same contract', async () => {
         const nullifier = new Fr(1);
@@ -224,7 +224,7 @@ describe('e2e_avm_simulator', () => {
           .create_different_nullifier_in_nested_call(avmContract.address, nullifier)
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
 
       it('Should be able to emit the same unsiloed nullifier from two different contracts', async () => {
@@ -233,7 +233,7 @@ describe('e2e_avm_simulator', () => {
           .create_same_nullifier_in_nested_call(secondAvmContract.address, nullifier)
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
 
       it('Should be able to emit different unsiloed nullifiers from two different contracts', async () => {
@@ -242,7 +242,7 @@ describe('e2e_avm_simulator', () => {
           .create_different_nullifier_in_nested_call(secondAvmContract.address, nullifier)
           .send({ from: defaultAccountAddress })
           .wait();
-        expect(tx.status).toEqual(TxStatus.SUCCESS);
+        expect(tx.executionResult).toEqual(TxExecutionResult.SUCCESS);
       });
     });
   });

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -424,7 +424,7 @@ describe('e2e_block_building', () => {
       const rct = await tx.send().wait();
 
       // compare logs
-      expect(rct.status).toEqual('success');
+      expect(rct.hasExecutionSucceeded()).toBe(true);
       const privateLogs = tx.data.getNonEmptyPrivateLogs();
       expect(privateLogs.length).toBe(3);
 
@@ -636,7 +636,10 @@ describe('e2e_block_building', () => {
       // And wait until it is brought back tx1
       logger.info(`Waiting for node to re-include tx1`);
       await retryUntil(
-        async () => (await aztecNode.getTxReceipt(tx1.txHash)).status === TxStatus.SUCCESS,
+        async () => {
+          const receipt = await aztecNode.getTxReceipt(tx1.txHash);
+          return receipt.isMined() && receipt.hasExecutionSucceeded();
+        },
         'wait for re-inclusion',
         15,
         1,

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -5,7 +5,7 @@ import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import { isL1ToL2MessageReady } from '@aztec/aztec.js/messaging';
 import type { AztecNode } from '@aztec/aztec.js/node';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { timesAsync } from '@aztec/foundation/collection';
@@ -215,8 +215,8 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
           // On public, we actually send the tx and check that it reverts due to the missing message.
           // This advances the block too as a side-effect. Note that we do not rely on a simulation since the cross chain messages
           // do not get added at the beginning of the block during node_simulatePublicCalls (maybe they should?).
-          const { status } = await consume().send({ from: user1Address }).wait({ dontThrowOnRevert: true });
-          expect(status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+          const receipt = await consume().send({ from: user1Address }).wait({ dontThrowOnRevert: true });
+          expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
           await t.context.watcher!.markAsProven();
         }
       });

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -15,10 +15,9 @@ import {
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
-import { type TxReceipt, TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult, type TxReceipt } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { writeTestData } from '@aztec/foundation/testing/files';
-import type { FieldsOf } from '@aztec/foundation/types';
 import { StatefulTestContract } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
@@ -38,7 +37,7 @@ describe('e2e_deploy_contract contract class registration', () => {
 
   let artifact: ContractArtifact;
   let contractClass: ContractClassWithId & ContractClassIdPreimage;
-  let publicationTxReceipt: FieldsOf<TxReceipt>;
+  let publicationTxReceipt: TxReceipt;
 
   beforeAll(async () => {
     ({ logger, wallet, aztecNode, defaultAccountAddress } = await t.setup());
@@ -218,7 +217,7 @@ describe('e2e_deploy_contract contract class registration', () => {
             .increment_public_value(whom, 10)
             .send({ from: defaultAccountAddress })
             .wait({ dontThrowOnRevert: true });
-          expect(receipt.status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+          expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
 
           // Meanwhile we check we didn't increment the value
           expect(await contract.methods.get_public_value(whom).simulate({ from: defaultAccountAddress })).toEqual(0n);
@@ -265,7 +264,7 @@ describe('e2e_deploy_contract contract class registration', () => {
             .public_constructor(whom, 43)
             .send({ from: defaultAccountAddress })
             .wait({ dontThrowOnRevert: true });
-          expect(receipt.status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+          expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
           expect(await contract.methods.get_public_value(whom).simulate({ from: defaultAccountAddress })).toEqual(0n);
         });
 
@@ -320,7 +319,7 @@ describe('e2e_deploy_contract contract class registration', () => {
         .increment_public_value_no_init_check(whom, 10)
         .send({ from: defaultAccountAddress })
         .wait({ dontThrowOnRevert: true });
-      expect(tx.status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+      expect(tx.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -3,7 +3,7 @@ import { type DeployOptions, getContractInstanceFromInstantiationParams } from '
 import { ContractDeployer } from '@aztec/aztec.js/deployment';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { StatefulTestContract } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
@@ -123,7 +123,7 @@ describe('e2e_deploy_contract legacy', () => {
     expect(goodTxReceipt.blockNumber).toEqual(expect.any(Number));
     expect(badTxReceipt.blockNumber).toEqual(expect.any(Number));
 
-    expect(badTxReceipt.status).toEqual(TxStatus.APP_LOGIC_REVERTED);
+    expect(badTxReceipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
 
     const badInstance = await badDeploy.getInstance();
     // But the bad tx did not deploy the class

--- a/yarn-project/end-to-end/src/e2e_double_spend.test.ts
+++ b/yarn-project/end-to-end/src/e2e_double_spend.test.ts
@@ -1,7 +1,7 @@
 import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 
@@ -46,7 +46,7 @@ describe('e2e_double_spend', () => {
       // tx will be included in a block but with app logic reverted
       await expect(
         contract.methods.emit_nullifier_public(nullifier).send({ from: defaultAccountAddress }).wait(),
-      ).rejects.toThrow(TxStatus.APP_LOGIC_REVERTED);
+      ).rejects.toThrow(TxExecutionResult.APP_LOGIC_REVERTED);
     });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -166,7 +166,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
 
     // Verify the transaction was eventually included
     const receipt = await sentTx.wait({ timeout: 30 });
-    expect(receipt.status).toBe('success');
+    expect(receipt.isMined()).toBeTrue();
     logger.warn(`Transaction included in block ${receipt.blockNumber}`);
 
     // Check that we have tagged an offense for that

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -2,7 +2,7 @@ import { generateClaimSecret } from '@aztec/aztec.js/ethereum';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
 import { waitForL1ToL2MessageReady } from '@aztec/aztec.js/messaging';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { retryUntil } from '@aztec/foundation/retry';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
@@ -96,7 +96,7 @@ describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
       )
       .send({ from: context.accounts[0] })
       .wait({ dontThrowOnRevert: true });
-    expect(failedReceipt.status).toBe(TxStatus.APP_LOGIC_REVERTED);
+    expect(failedReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
 
     logger.info(`Test succeeded`);
   });

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -4,7 +4,7 @@ import { EthAddress } from '@aztec/aztec.js/addresses';
 import { SetPublicAuthwitContractInteraction } from '@aztec/aztec.js/authorization';
 import { PrivateFeePaymentMethod, PublicFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
-import { TxStatus } from '@aztec/aztec.js/tx';
+import { TxExecutionResult } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
 import type { TokenContract as BananaCoin } from '@aztec/noir-contracts.js/Token';
@@ -94,7 +94,7 @@ describe('e2e_fees failures', () => {
       })
       .wait({ dontThrowOnRevert: true });
 
-    expect(txReceipt.status).toBe(TxStatus.APP_LOGIC_REVERTED);
+    expect(txReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
 
     const { sequencerBlockRewards } = await t.getBlockRewards();
 
@@ -200,7 +200,7 @@ describe('e2e_fees failures', () => {
       })
       .wait({ dontThrowOnRevert: true });
 
-    expect(txReceipt.status).toBe(TxStatus.APP_LOGIC_REVERTED);
+    expect(txReceipt.executionResult).toBe(TxExecutionResult.APP_LOGIC_REVERTED);
     const feeAmount = txReceipt.transactionFee!;
 
     // and thus we paid the fee
@@ -303,7 +303,7 @@ describe('e2e_fees failures', () => {
       .wait({
         dontThrowOnRevert: true,
       });
-    expect(receipt.status).toEqual(TxStatus.TEARDOWN_REVERTED);
+    expect(receipt.executionResult).toEqual(TxExecutionResult.TEARDOWN_REVERTED);
     expect(receipt.transactionFee).toBeGreaterThan(0n);
 
     await expectMapping(

--- a/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_eoa.test.ts
@@ -1,7 +1,6 @@
 import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
 import { Fr } from '@aztec/aztec.js/fields';
 import type { Logger } from '@aztec/aztec.js/log';
-import { TxStatus } from '@aztec/aztec.js/tx';
 import { EthCheatCodes } from '@aztec/aztec/testing';
 import type { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
 import type { PublisherManager } from '@aztec/ethereum/publisher-manager';
@@ -164,7 +163,7 @@ describe('e2e_multi_eoa', () => {
       logger.warn(`L2 deploy tx sent with hash ${(await tx.getTxHash()).toString()}`);
 
       const receipt = await tx.wait();
-      expect(receipt.status).toBe(TxStatus.SUCCESS);
+      expect(receipt.isMined() && receipt.hasExecutionSucceeded()).toBe(true);
 
       logger.warn(`Got ${blockedTxs.length} blocked txs for ${blockedSender}`);
       expect(blockedTxs.length).toBeGreaterThan(0);

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -1,14 +1,13 @@
 import type { AztecAddress } from '@aztec/aztec.js/addresses';
 import { EthAddress } from '@aztec/aztec.js/addresses';
 import { waitForProven } from '@aztec/aztec.js/contracts';
-import { Tx, TxReceipt, TxStatus } from '@aztec/aztec.js/tx';
+import { Tx, TxExecutionResult, TxReceipt } from '@aztec/aztec.js/tx';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { parseBooleanEnv } from '@aztec/foundation/config';
 import { getTestData, isGenerateTestDataEnabled } from '@aztec/foundation/testing';
 import { updateProtocolCircuitSampleInputs } from '@aztec/foundation/testing/files';
-import type { FieldsOf } from '@aztec/foundation/types';
 import { FeeJuicePortalAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { Gas } from '@aztec/stdlib/gas';
 import { PrivateKernelTailCircuitPublicInputs } from '@aztec/stdlib/kernel';
@@ -371,8 +370,8 @@ describe('full_prover', () => {
       }
 
       // Assert that the valid tx is successfully sent and mined
-      const validTxReceipt = (results[NUM_INVALID_TXS] as PromiseFulfilledResult<FieldsOf<TxReceipt>>).value;
-      expect(validTxReceipt.status).toBe(TxStatus.SUCCESS);
+      const validTxReceipt = (results[NUM_INVALID_TXS] as PromiseFulfilledResult<TxReceipt>).value;
+      expect(validTxReceipt.executionResult).toBe(TxExecutionResult.SUCCESS);
 
       logger.info(`Valid tx was mined and invalid txs were dropped by P2P node`);
     },

--- a/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
@@ -64,7 +64,7 @@ describe('e2e_sequencer_config', () => {
       // Run a tx to get the total mana used
       const receipt: TxReceipt = (await bot.run()) as TxReceipt;
       expect(receipt).toBeDefined();
-      expect(receipt.status).toBe('success');
+      expect(receipt.hasExecutionSucceeded()).toBe(true);
       const block = await aztecNode.getBlock(receipt.blockNumber!);
       expect(block).toBeDefined();
       const totalManaUsed = block?.header.totalManaUsed!.toBigInt();
@@ -84,7 +84,7 @@ describe('e2e_sequencer_config', () => {
       // Run a tx and expect it to succeed
       const receipt2: TxReceipt = (await bot.run()) as TxReceipt;
       expect(receipt2).toBeDefined();
-      expect(receipt2.status).toBe('success');
+      expect(receipt2.hasExecutionSucceeded()).toBe(true);
 
       // Set the maxL2BlockGas to the total mana used - 1
       sequencer!.updateConfig({

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -18,7 +18,6 @@ import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses'
 import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { retryUntil } from '@aztec/foundation/retry';
-import type { FieldsOf } from '@aztec/foundation/types';
 import { TestERC20Abi, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
@@ -276,7 +275,7 @@ export class CrossChainTestHarness {
     withdrawAmount: bigint,
     authwitNonce: Fr = Fr.ZERO,
     authWitness: AuthWitness,
-  ): Promise<FieldsOf<TxReceipt>> {
+  ): Promise<TxReceipt> {
     const withdrawReceipt = await this.l2Bridge.methods
       .exit_to_l1_private(this.l2Token.address, this.ethAccount, withdrawAmount, EthAddress.ZERO, authwitNonce)
       .send({ authWitnesses: [authWitness], from: this.ownerAddress })
@@ -285,7 +284,7 @@ export class CrossChainTestHarness {
     return withdrawReceipt;
   }
 
-  async withdrawPublicFromAztecToL1(withdrawAmount: bigint, authwitNonce: Fr = Fr.ZERO): Promise<FieldsOf<TxReceipt>> {
+  async withdrawPublicFromAztecToL1(withdrawAmount: bigint, authwitNonce: Fr = Fr.ZERO): Promise<TxReceipt> {
     const withdrawReceipt = await this.l2Bridge.methods
       .exit_to_l1_public(this.ethAccount, withdrawAmount, EthAddress.ZERO, authwitNonce)
       .send({ from: this.ownerAddress })

--- a/yarn-project/end-to-end/src/shared/submit-transactions.ts
+++ b/yarn-project/end-to-end/src/shared/submit-transactions.ts
@@ -23,12 +23,7 @@ export const submitTxsTo = async (
 
       logger.info(`Tx sent with hash ${txHash}`);
       const receipt = await tx.getReceipt();
-      expect(receipt).toEqual(
-        expect.objectContaining({
-          status: TxStatus.PENDING,
-          error: '',
-        }),
-      );
+      expect(receipt.status).toBe(TxStatus.PENDING);
       logger.info(`Receipt received for ${txHash}`);
       txs.push(tx);
     }),

--- a/yarn-project/end-to-end/src/spartan/tx_metrics.ts
+++ b/yarn-project/end-to-end/src/spartan/tx_metrics.ts
@@ -1,7 +1,7 @@
 import type { AztecNode } from '@aztec/aztec.js/node';
 import type { L2BlockNew } from '@aztec/stdlib/block';
 import type { TopicType } from '@aztec/stdlib/p2p';
-import { Tx, type TxReceipt, TxStatus } from '@aztec/stdlib/tx';
+import { Tx, type TxReceipt } from '@aztec/stdlib/tx';
 
 import { createHistogram } from 'perf_hooks';
 
@@ -53,8 +53,8 @@ export class TxInclusionMetrics {
   }
 
   async recordMinedTx(txReceipt: TxReceipt): Promise<void> {
-    const { status, txHash, blockNumber } = txReceipt;
-    if (status !== TxStatus.SUCCESS || !blockNumber) {
+    const { txHash, blockNumber } = txReceipt;
+    if (!txReceipt.isMined() || !txReceipt.hasExecutionSucceeded() || !blockNumber) {
       return;
     }
 

--- a/yarn-project/node-lib/src/actions/snapshot-sync.ts
+++ b/yarn-project/node-lib/src/actions/snapshot-sync.ts
@@ -1,6 +1,7 @@
 import { ARCHIVER_DB_VERSION, ARCHIVER_STORE_NAME, type ArchiverConfig, createArchiverStore } from '@aztec/archiver';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { type EthereumClientConfig, getPublicClient } from '@aztec/ethereum/client';
+import type { L1ContractsConfig } from '@aztec/ethereum/config';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { tryRmDir } from '@aztec/foundation/fs';
 import type { Logger } from '@aztec/foundation/log';
@@ -28,6 +29,7 @@ const MIN_L1_BLOCKS_TO_TRIGGER_REPLACE = 86400 / 2 / 12;
 
 type SnapshotSyncConfig = Pick<SharedNodeConfig, 'syncMode'> &
   Pick<ChainConfig, 'l1ChainId' | 'rollupVersion'> &
+  Pick<L1ContractsConfig, 'aztecEpochDuration'> &
   Pick<ArchiverConfig, 'archiverStoreMapSizeKb' | 'maxLogs'> &
   Required<DataStoreConfig> &
   EthereumClientConfig & {
@@ -58,7 +60,7 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
 
   // Create an archiver store to check the current state (do this only once)
   log.verbose(`Creating temporary archiver data store`);
-  const archiverStore = await createArchiverStore(config);
+  const archiverStore = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
   let archiverL1BlockNumber: bigint | undefined;
   let archiverL2BlockNumber: number | undefined;
   try {

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -1,4 +1,5 @@
 import { createArchiverStore } from '@aztec/archiver';
+import type { L1ContractsConfig } from '@aztec/ethereum/config';
 import type { Logger } from '@aztec/foundation/log';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { type ProverClientConfig, createProverClient } from '@aztec/prover-client';
@@ -21,7 +22,7 @@ import { ProverNodeJobMetrics } from '../metrics.js';
 export async function rerunEpochProvingJob(
   localPath: string,
   log: Logger,
-  config: DataStoreConfig & ProverBrokerConfig & ProverClientConfig,
+  config: DataStoreConfig & ProverBrokerConfig & ProverClientConfig & Pick<L1ContractsConfig, 'aztecEpochDuration'>,
 ) {
   const jobData = deserializeEpochProvingJobData(readFileSync(localPath));
   log.info(`Loaded proving job data for epoch ${jobData.epochNumber}`);
@@ -29,7 +30,7 @@ export async function rerunEpochProvingJob(
   const telemetry = getTelemetryClient();
   const metrics = new ProverNodeJobMetrics(telemetry.getMeter('prover-job'), telemetry.getTracer('prover-job'));
   const worldState = await createWorldState(config);
-  const archiver = await createArchiverStore(config);
+  const archiver = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
   const publicProcessorFactory = new PublicProcessorFactory(archiver);
 
   const publisher = { submitEpochProof: () => Promise.resolve(true) };

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -1,9 +1,10 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
-import { makeL2Tips, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
-import { TxHash, TxStatus } from '@aztec/stdlib/tx';
+import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
+import { TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -54,7 +55,6 @@ describe('syncSenderTaggingIndexes', () => {
   // These tests need to be run together in sequence.
   describe('sequential tests', () => {
     const finalizedIndexStep1 = 3;
-    const finalizedBlockNumberStep1 = 15;
 
     const pendingTxHashStep2 = TxHash.random();
     const pendingIndexStep2 = 5;
@@ -66,23 +66,27 @@ describe('syncSenderTaggingIndexes', () => {
     it('step 1: highest finalized index is updated', async () => {
       // Create a log with tag index 3
       const index3Tag = await computeSiloedTagForIndex(finalizedIndexStep1);
+      const finalizedTxHash = TxHash.random();
 
       aztecNode.getPrivateLogsByTags.mockImplementation((tags: SiloedTag[]) => {
         // Return empty arrays for all tags except the one at index 3
         return Promise.resolve(
-          tags.map((tag: SiloedTag) => (tag.equals(index3Tag) ? [makeLog(TxHash.random(), index3Tag.value)] : [])),
+          tags.map((tag: SiloedTag) => (tag.equals(index3Tag) ? [makeLog(finalizedTxHash, index3Tag.value)] : [])),
         );
       });
 
-      // Mock getTxReceipt to return a successful, finalized tx (finalized because it is included in a block before
-      // the finalized block)
-      aztecNode.getTxReceipt.mockResolvedValue({
-        status: TxStatus.SUCCESS,
-        blockNumber: finalizedBlockNumberStep1 - 1,
-      } as any);
-
-      // Mock getL2Tips to return a finalized block number >= the tx block number
-      aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumberStep1));
+      // Mock getTxReceipt to return a finalized and successful tx
+      aztecNode.getTxReceipt.mockResolvedValue(
+        new TxReceipt(
+          finalizedTxHash,
+          TxStatus.FINALIZED,
+          TxExecutionResult.SUCCESS,
+          undefined,
+          undefined,
+          undefined,
+          BlockNumber(14),
+        ),
+      );
 
       await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
 
@@ -103,13 +107,18 @@ describe('syncSenderTaggingIndexes', () => {
         );
       });
 
-      // Mock getTxReceipt to return a successful but still pending tx
-      aztecNode.getTxReceipt.mockResolvedValue({
-        status: TxStatus.SUCCESS,
-        blockNumber: finalizedBlockNumberStep1 + 1,
-      } as any);
-
-      aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumberStep1));
+      // Mock getTxReceipt to return a proposed (mined but not finalized) tx
+      aztecNode.getTxReceipt.mockResolvedValue(
+        new TxReceipt(
+          pendingTxHashStep2,
+          TxStatus.PROPOSED,
+          TxExecutionResult.SUCCESS,
+          undefined,
+          undefined,
+          undefined,
+          BlockNumber(16),
+        ),
+      );
 
       await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
 
@@ -120,8 +129,6 @@ describe('syncSenderTaggingIndexes', () => {
     });
 
     it('step 3: syncs logs across 2 windows', async () => {
-      // Move finalized block into the future
-      const newFinalizedBlockNumber = finalizedBlockNumberStep1 + 5;
       const newHighestFinalizedIndex = finalizedIndexStep1 + 4;
       const newHighestUsedIndex = newHighestFinalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN;
 
@@ -154,29 +161,47 @@ describe('syncSenderTaggingIndexes', () => {
       aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
         if (hash.equals(pendingTxHashStep2)) {
           // The previously pending tx (index pendingIndexStep2) is now finalized
-          return {
-            status: TxStatus.SUCCESS,
-            blockNumber: newFinalizedBlockNumber - 3,
-          } as any;
+          return Promise.resolve(
+            new TxReceipt(
+              hash,
+              TxStatus.FINALIZED,
+              TxExecutionResult.SUCCESS,
+              undefined,
+              undefined,
+              undefined,
+              BlockNumber(17),
+            ),
+          );
         } else if (hash.equals(newHighestFinalizedTxHash)) {
           // This tx (index newHighestFinalizedIndex) is finalized
-          return {
-            status: TxStatus.SUCCESS,
-            blockNumber: newFinalizedBlockNumber - 2,
-          } as any;
+          return Promise.resolve(
+            new TxReceipt(
+              hash,
+              TxStatus.FINALIZED,
+              TxExecutionResult.SUCCESS,
+              undefined,
+              undefined,
+              undefined,
+              BlockNumber(18),
+            ),
+          );
         } else if (hash.equals(newHighestUsedTxHash)) {
-          // This tx (index newHighestUsedIndex) is pending
-          return {
-            status: TxStatus.SUCCESS,
-            blockNumber: newFinalizedBlockNumber + 2,
-          } as any;
+          // This tx (index newHighestUsedIndex) is pending (mined but not finalized)
+          return Promise.resolve(
+            new TxReceipt(
+              hash,
+              TxStatus.PROPOSED,
+              TxExecutionResult.SUCCESS,
+              undefined,
+              undefined,
+              undefined,
+              BlockNumber(22),
+            ),
+          );
         } else {
           throw new Error(`Unexpected tx hash: ${hash.toString()}`);
         }
       });
-
-      // Mock getL2Tips with the new finalized block number
-      aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(newFinalizedBlockNumber));
 
       await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
 
@@ -195,7 +220,6 @@ describe('syncSenderTaggingIndexes', () => {
     const finalizedTxHash = TxHash.random();
     const pendingTxHash = TxHash.random();
 
-    const finalizedBlockNumber = 15;
     const pendingAndFinalizedIndex = 3;
 
     const index3Tag = await computeSiloedTagForIndex(pendingAndFinalizedIndex);
@@ -213,21 +237,33 @@ describe('syncSenderTaggingIndexes', () => {
 
     aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
       if (hash.equals(finalizedTxHash)) {
-        return {
-          status: TxStatus.SUCCESS,
-          blockNumber: finalizedBlockNumber - 1, // Finalized tx
-        } as any;
+        return Promise.resolve(
+          new TxReceipt(
+            hash,
+            TxStatus.FINALIZED,
+            TxExecutionResult.SUCCESS,
+            undefined,
+            undefined,
+            undefined,
+            BlockNumber(14),
+          ),
+        );
       } else if (hash.equals(pendingTxHash)) {
-        return {
-          status: TxStatus.SUCCESS,
-          blockNumber: finalizedBlockNumber + 1, // Pending tx
-        } as any;
+        return Promise.resolve(
+          new TxReceipt(
+            hash,
+            TxStatus.PROPOSED,
+            TxExecutionResult.SUCCESS,
+            undefined,
+            undefined,
+            undefined,
+            BlockNumber(16),
+          ),
+        );
       } else {
         throw new Error(`Unexpected tx hash: ${hash.toString()}`);
       }
     });
-
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
 
     // Sync tagged logs
     await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.test.ts
@@ -1,7 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { makeL2Tips } from '@aztec/stdlib/testing';
-import { TxHash, TxStatus } from '@aztec/stdlib/tx';
+import { TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -15,8 +14,6 @@ describe('getStatusChangeOfPending', () => {
   });
 
   it('handles mixed scenarios with multiple transaction hashes', async () => {
-    const finalizedBlockNumber = 10;
-
     const finalizedTxHash = TxHash.random();
     const droppedTxHash = TxHash.random();
     const pendingTxHash = TxHash.random();
@@ -26,37 +23,43 @@ describe('getStatusChangeOfPending', () => {
 
     aztecNode.getTxReceipt.mockImplementation((hash: TxHash) => {
       if (hash.equals(finalizedTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.SUCCESS,
-          blockNumber: BlockNumber(finalizedBlockNumber - 1),
-        } as any);
+        // Finalized and successful
+        return Promise.resolve(
+          new TxReceipt(
+            hash,
+            TxStatus.FINALIZED,
+            TxExecutionResult.SUCCESS,
+            undefined,
+            undefined,
+            undefined,
+            BlockNumber(9),
+          ),
+        );
       } else if (hash.equals(droppedTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.DROPPED,
-        } as any);
+        return Promise.resolve(new TxReceipt(hash, TxStatus.DROPPED, undefined, 'Tx dropped'));
       } else if (hash.equals(pendingTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.SUCCESS,
-          blockNumber: BlockNumber(finalizedBlockNumber + 1),
-        } as any);
+        // Mined but not finalized yet
+        return Promise.resolve(
+          new TxReceipt(
+            hash,
+            TxStatus.PROPOSED,
+            TxExecutionResult.SUCCESS,
+            undefined,
+            undefined,
+            undefined,
+            BlockNumber(11),
+          ),
+        );
       } else if (hash.equals(appLogicRevertedTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.APP_LOGIC_REVERTED,
-        } as any);
+        return Promise.resolve(new TxReceipt(hash, TxStatus.PROPOSED, TxExecutionResult.APP_LOGIC_REVERTED, undefined));
       } else if (hash.equals(teardownRevertedTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.TEARDOWN_REVERTED,
-        } as any);
+        return Promise.resolve(new TxReceipt(hash, TxStatus.PROPOSED, TxExecutionResult.TEARDOWN_REVERTED, undefined));
       } else if (hash.equals(bothRevertedTxHash)) {
-        return Promise.resolve({
-          status: TxStatus.BOTH_REVERTED,
-        } as any);
+        return Promise.resolve(new TxReceipt(hash, TxStatus.PROPOSED, TxExecutionResult.BOTH_REVERTED, undefined));
       } else {
         throw new Error(`Unexpected tx hash: ${hash.toString()}`);
       }
     });
-
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
 
     const result = await getStatusChangeOfPending(
       [
@@ -79,20 +82,46 @@ describe('getStatusChangeOfPending', () => {
     ]);
   });
 
-  it('returns txHash in txHashesToFinalize when blockNumber equals finalized block number', async () => {
-    const finalizedBlockNumber = 10;
+  it('returns txHash in txHashesToFinalize when status is finalized and successful', async () => {
     const txHash = TxHash.random();
 
-    aztecNode.getTxReceipt.mockResolvedValue({
-      status: TxStatus.SUCCESS,
-      blockNumber: BlockNumber(finalizedBlockNumber),
-    } as any);
-
-    aztecNode.getL2Tips.mockResolvedValue(makeL2Tips(finalizedBlockNumber));
+    aztecNode.getTxReceipt.mockResolvedValue(
+      new TxReceipt(
+        txHash,
+        TxStatus.FINALIZED,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(10),
+      ),
+    );
 
     const result = await getStatusChangeOfPending([txHash], aztecNode);
 
     expect(result.txHashesToFinalize).toEqual([txHash]);
+    expect(result.txHashesToDrop).toEqual([]);
+  });
+
+  it('does not finalize tx that is only proven', async () => {
+    const txHash = TxHash.random();
+
+    aztecNode.getTxReceipt.mockResolvedValue(
+      new TxReceipt(
+        txHash,
+        TxStatus.PROVEN,
+        TxExecutionResult.SUCCESS,
+        undefined,
+        undefined,
+        undefined,
+        BlockNumber(10),
+      ),
+    );
+
+    const result = await getStatusChangeOfPending([txHash], aztecNode);
+
+    // Not finalized yet, so stays pending
+    expect(result.txHashesToFinalize).toEqual([]);
     expect(result.txHashesToDrop).toEqual([]);
   });
 });

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/get_status_change_of_pending.ts
@@ -9,11 +9,8 @@ export async function getStatusChangeOfPending(
   pending: TxHash[],
   aztecNode: AztecNode,
 ): Promise<{ txHashesToFinalize: TxHash[]; txHashesToDrop: TxHash[] }> {
-  // Get receipts for all pending tx hashes and the finalized block number.
-  const [receipts, tips] = await Promise.all([
-    Promise.all(pending.map(pendingTxHash => aztecNode.getTxReceipt(pendingTxHash))),
-    aztecNode.getL2Tips(),
-  ]);
+  // Get receipts for all pending tx hashes.
+  const receipts = await Promise.all(pending.map(pendingTxHash => aztecNode.getTxReceipt(pendingTxHash)));
 
   const txHashesToFinalize: TxHash[] = [];
   const txHashesToDrop: TxHash[] = [];
@@ -22,25 +19,16 @@ export async function getStatusChangeOfPending(
     const receipt = receipts[i];
     const txHash = pending[i];
 
-    if (
-      receipt.status === TxStatus.SUCCESS &&
-      receipt.blockNumber &&
-      receipt.blockNumber <= tips.finalized.block.number
-    ) {
+    if (receipt.status === TxStatus.FINALIZED && receipt.hasExecutionSucceeded()) {
       // Tx has been included in a block and the corresponding block is finalized --> we mark the indexes as
       // finalized.
       txHashesToFinalize.push(txHash);
-    } else if (
-      receipt.status === TxStatus.DROPPED ||
-      receipt.status === TxStatus.APP_LOGIC_REVERTED ||
-      receipt.status === TxStatus.TEARDOWN_REVERTED ||
-      receipt.status === TxStatus.BOTH_REVERTED
-    ) {
+    } else if (receipt.isDropped() || receipt.hasExecutionReverted()) {
       // Tx was dropped or reverted --> we drop the corresponding pending indexes.
       // TODO(#17615): Don't drop pending indexes corresponding to non-revertible phases.
       txHashesToDrop.push(txHash);
     } else {
-      // Tx is still pending or the corresponding block is not yet finalized --> we don't do anything.
+      // Tx is still pending, not yet finalized, or was mined successfully but not yet finalized --> we don't do anything.
     }
   }
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -53,6 +53,20 @@ export interface L2BlockSource {
   getProvenBlockNumber(): Promise<BlockNumber>;
 
   /**
+   * Gets the number of the latest L2 block checkpointed seen by the block source implementation.
+   * @returns The number of the latest L2 block checkpointed seen by the block source implementation.
+   */
+  getCheckpointedL2BlockNumber(): Promise<BlockNumber>;
+
+  /**
+   * Computes the finalized block number based on the proven block number.
+   * A block is considered finalized when it's 2 epochs behind the proven block.
+   * TODO(#13569): Compute proper finalized block number based on L1 finalized block.
+   * @returns The finalized block number.
+   */
+  getFinalizedL2BlockNumber(): Promise<BlockNumber>;
+
+  /**
    * Gets an l2 block header.
    * @param number - The block number to return or 'latest' for the most recent one.
    * @returns The requested L2 block header.

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -85,6 +85,16 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual(BlockNumber(1));
   });
 
+  it('getCheckpointedL2BlockNumber', async () => {
+    const result = await context.client.getCheckpointedL2BlockNumber();
+    expect(result).toEqual(BlockNumber(1));
+  });
+
+  it('getFinalizedL2BlockNumber', async () => {
+    const result = await context.client.getFinalizedL2BlockNumber();
+    expect(result).toEqual(BlockNumber(0));
+  });
+
   it('getBlock', async () => {
     const result = await context.client.getBlock(BlockNumber(1));
     expect(result).toBeInstanceOf(L2BlockNew);
@@ -384,6 +394,12 @@ class MockArchiver implements ArchiverApi {
   }
   getProvenBlockNumber(): Promise<BlockNumber> {
     return Promise.resolve(BlockNumber(1));
+  }
+  getCheckpointedL2BlockNumber(): Promise<BlockNumber> {
+    return Promise.resolve(BlockNumber(1));
+  }
+  getFinalizedL2BlockNumber(): Promise<BlockNumber> {
+    return Promise.resolve(BlockNumber(0));
   }
   getBlock(number: BlockNumber): Promise<L2BlockNew | undefined> {
     return L2BlockNew.random(number);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -82,6 +82,8 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getRegistryAddress: z.function().args().returns(schemas.EthAddress),
   getBlockNumber: z.function().args().returns(BlockNumberSchema),
   getProvenBlockNumber: z.function().args().returns(BlockNumberSchema),
+  getCheckpointedL2BlockNumber: z.function().args().returns(BlockNumberSchema),
+  getFinalizedL2BlockNumber: z.function().args().returns(BlockNumberSchema),
   getBlock: z.function().args(BlockNumberSchema).returns(L2BlockNew.schema.optional()),
   getBlockHeader: z
     .function()

--- a/yarn-project/stdlib/src/tx/tx_receipt.test.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.test.ts
@@ -3,18 +3,88 @@ import { jsonStringify } from '@aztec/foundation/json-rpc';
 
 import { L2BlockHash } from '../block/block_hash.js';
 import { TxHash } from './tx_hash.js';
-import { TxReceipt, TxStatus } from './tx_receipt.js';
+import { TxExecutionResult, TxReceipt, TxStatus } from './tx_receipt.js';
 
 describe('TxReceipt', () => {
   it('serializes and deserializes from json', () => {
-    const receipt = new TxReceipt(TxHash.random(), TxStatus.SUCCESS, 'error', 1n, L2BlockHash.random(), BlockNumber(1));
+    const receipt = new TxReceipt(
+      TxHash.random(),
+      TxStatus.PROVEN,
+      TxExecutionResult.SUCCESS,
+      'error',
+      1n,
+      L2BlockHash.random(),
+      BlockNumber(1),
+    );
 
     expect(TxReceipt.schema.parse(JSON.parse(jsonStringify(receipt)))).toEqual(receipt);
   });
 
   it('serializes and deserializes from json with undefined fields', () => {
-    const receipt = new TxReceipt(TxHash.random(), TxStatus.DROPPED, 'error', undefined, undefined, undefined);
+    const receipt = new TxReceipt(
+      TxHash.random(),
+      TxStatus.DROPPED,
+      undefined,
+      'error',
+      undefined,
+      undefined,
+      undefined,
+    );
 
     expect(TxReceipt.schema.parse(JSON.parse(jsonStringify(receipt)))).toEqual(receipt);
+  });
+
+  describe('helper methods', () => {
+    it('isSuccess returns true for successful execution', () => {
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.PROPOSED, TxExecutionResult.SUCCESS, undefined);
+      expect(receipt.hasExecutionSucceeded()).toBe(true);
+    });
+
+    it('isSuccess returns false for reverted execution', () => {
+      const receipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.PROPOSED,
+        TxExecutionResult.APP_LOGIC_REVERTED,
+        undefined,
+      );
+      expect(receipt.hasExecutionSucceeded()).toBe(false);
+    });
+
+    it('isReverted returns true for reverted execution', () => {
+      const receipt = new TxReceipt(
+        TxHash.random(),
+        TxStatus.PROPOSED,
+        TxExecutionResult.APP_LOGIC_REVERTED,
+        undefined,
+      );
+      expect(receipt.hasExecutionReverted()).toBe(true);
+    });
+
+    it('isReverted returns false for successful execution', () => {
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.PROPOSED, TxExecutionResult.SUCCESS, undefined);
+      expect(receipt.hasExecutionReverted()).toBe(false);
+    });
+
+    it('isMined returns true for proposed, checkpointed, proven, and finalized', () => {
+      expect(new TxReceipt(TxHash.random(), TxStatus.PROPOSED, undefined, undefined).isMined()).toBe(true);
+      expect(new TxReceipt(TxHash.random(), TxStatus.CHECKPOINTED, undefined, undefined).isMined()).toBe(true);
+      expect(new TxReceipt(TxHash.random(), TxStatus.PROVEN, undefined, undefined).isMined()).toBe(true);
+      expect(new TxReceipt(TxHash.random(), TxStatus.FINALIZED, undefined, undefined).isMined()).toBe(true);
+    });
+
+    it('isMined returns false for pending and dropped', () => {
+      expect(new TxReceipt(TxHash.random(), TxStatus.PENDING, undefined, undefined).isMined()).toBe(false);
+      expect(new TxReceipt(TxHash.random(), TxStatus.DROPPED, undefined, undefined).isMined()).toBe(false);
+    });
+
+    it('isPending returns true for pending status', () => {
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.PENDING, undefined, undefined);
+      expect(receipt.isPending()).toBe(true);
+    });
+
+    it('isDropped returns true for dropped status', () => {
+      const receipt = new TxReceipt(TxHash.random(), TxStatus.DROPPED, undefined, undefined);
+      expect(receipt.isDropped()).toBe(true);
+    });
   });
 });

--- a/yarn-project/stdlib/src/tx/tx_receipt.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.ts
@@ -1,5 +1,4 @@
 import { BlockNumber, BlockNumberSchema } from '@aztec/foundation/branded-types';
-import type { FieldsOf } from '@aztec/foundation/types';
 
 import { z } from 'zod';
 
@@ -8,12 +7,28 @@ import { L2BlockHash } from '../block/block_hash.js';
 import { type ZodFor, schemas } from '../schemas/schemas.js';
 import { TxHash } from './tx_hash.js';
 
-/**
- * Possible status of a transaction.
- */
+/** Block inclusion/finalization status. */
 export enum TxStatus {
   DROPPED = 'dropped',
   PENDING = 'pending',
+  PROPOSED = 'proposed',
+  CHECKPOINTED = 'checkpointed',
+  PROVEN = 'proven',
+  FINALIZED = 'finalized', // TODO(#13569): Implement finalized status properly
+}
+
+/** Tx status sorted by finalization progress. */
+export const SortedTxStatuses: TxStatus[] = [
+  TxStatus.DROPPED,
+  TxStatus.PENDING,
+  TxStatus.PROPOSED,
+  TxStatus.CHECKPOINTED,
+  TxStatus.PROVEN,
+  TxStatus.FINALIZED,
+];
+
+/** Execution result - only set when tx is in a block. */
+export enum TxExecutionResult {
   SUCCESS = 'success',
   APP_LOGIC_REVERTED = 'app_logic_reverted',
   TEARDOWN_REVERTED = 'teardown_reverted',
@@ -30,10 +45,12 @@ export class TxReceipt {
   constructor(
     /** A unique identifier for a transaction. */
     public txHash: TxHash,
-    /** The transaction's status. */
+    /** The transaction's block finalization status. */
     public status: TxStatus,
+    /** The execution result of the transaction, only set when tx is in a block. */
+    public executionResult: TxExecutionResult | undefined,
     /** Description of transaction error, if any. */
-    public error: string,
+    public error: string | undefined,
     /** The transaction fee paid for the transaction. */
     public transactionFee?: bigint,
     /** The hash of the block containing the transaction. */
@@ -42,8 +59,38 @@ export class TxReceipt {
     public blockNumber?: BlockNumber,
   ) {}
 
+  /** Returns true if the transaction was executed successfully. */
+  hasExecutionSucceeded(): boolean {
+    return this.executionResult === TxExecutionResult.SUCCESS;
+  }
+
+  /** Returns true if the transaction execution reverted. */
+  hasExecutionReverted(): boolean {
+    return this.executionResult !== undefined && this.executionResult !== TxExecutionResult.SUCCESS;
+  }
+
+  /** Returns true if the transaction has been included in a block (proposed, checkpointed, proven, or finalized). */
+  isMined(): boolean {
+    return (
+      this.status === TxStatus.PROPOSED ||
+      this.status === TxStatus.CHECKPOINTED ||
+      this.status === TxStatus.PROVEN ||
+      this.status === TxStatus.FINALIZED
+    );
+  }
+
+  /** Returns true if the transaction is pending. */
+  isPending(): boolean {
+    return this.status === TxStatus.PENDING;
+  }
+
+  /** Returns true if the transaction was dropped. */
+  isDropped(): boolean {
+    return this.status === TxStatus.DROPPED;
+  }
+
   static empty() {
-    return new TxReceipt(TxHash.zero(), TxStatus.DROPPED, '');
+    return new TxReceipt(TxHash.zero(), TxStatus.DROPPED, undefined, undefined);
   }
 
   static get schema(): ZodFor<TxReceipt> {
@@ -51,18 +98,28 @@ export class TxReceipt {
       .object({
         txHash: TxHash.schema,
         status: z.nativeEnum(TxStatus),
-        error: z.string(),
+        executionResult: z.nativeEnum(TxExecutionResult).optional(),
+        error: z.string().optional(),
         blockHash: L2BlockHash.schema.optional(),
         blockNumber: BlockNumberSchema.optional(),
         transactionFee: schemas.BigInt.optional(),
       })
-      .transform(TxReceipt.from);
+      .transform(fields => TxReceipt.from(fields));
   }
 
-  static from(fields: FieldsOf<TxReceipt>) {
+  static from(fields: {
+    txHash: TxHash;
+    status: TxStatus;
+    executionResult?: TxExecutionResult;
+    error?: string;
+    transactionFee?: bigint;
+    blockHash?: L2BlockHash;
+    blockNumber?: BlockNumber;
+  }) {
     return new TxReceipt(
       fields.txHash,
       fields.status,
+      fields.executionResult,
       fields.error,
       fields.transactionFee,
       fields.blockHash,
@@ -70,15 +127,15 @@ export class TxReceipt {
     );
   }
 
-  public static statusFromRevertCode(revertCode: RevertCode) {
+  public static executionResultFromRevertCode(revertCode: RevertCode): TxExecutionResult {
     if (revertCode.equals(RevertCode.OK)) {
-      return TxStatus.SUCCESS;
+      return TxExecutionResult.SUCCESS;
     } else if (revertCode.equals(RevertCode.APP_LOGIC_REVERTED)) {
-      return TxStatus.APP_LOGIC_REVERTED;
+      return TxExecutionResult.APP_LOGIC_REVERTED;
     } else if (revertCode.equals(RevertCode.TEARDOWN_REVERTED)) {
-      return TxStatus.TEARDOWN_REVERTED;
+      return TxExecutionResult.TEARDOWN_REVERTED;
     } else if (revertCode.equals(RevertCode.BOTH_REVERTED)) {
-      return TxStatus.BOTH_REVERTED;
+      return TxExecutionResult.BOTH_REVERTED;
     } else {
       throw new Error(`Unknown revert code: ${revertCode.getCode()}`);
     }

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -17,7 +17,7 @@ export class TXEArchiver extends ArchiverDataSourceBase {
   private readonly updater = new ArchiverDataStoreUpdater(this.store);
 
   constructor(db: AztecAsyncKVStore) {
-    const store = new KVArchiverDataStore(db, 9999);
+    const store = new KVArchiverDataStore(db, 9999, { epochDuration: 32 });
     super(store);
   }
 


### PR DESCRIPTION
This PR splits `TxReceipt.status` into two separate fields to      
better distinguish between block finalization level and transaction
execution outcome.                                                

**New `TxStatus` values (block finalization level):**              
- `DROPPED` - Tx dropped by P2P node                               
- `PENDING` - Tx pending in mempool                                
- `PROPOSED` - Tx included in a proposed block                     
- `CHECKPOINTED` - Block checkpointed on L1                        
- `PROVEN` - Checkpoint proven on L1                               
- `FINALIZED` - Proven on a finalized L1 block                     

**New `TxExecutionResult` enum (execution outcome):**              
- `SUCCESS` - Transaction executed successfully                    
- `APP_LOGIC_REVERTED` - App logic reverted                        
- `TEARDOWN_REVERTED` - Teardown phase reverted                    
- `BOTH_REVERTED` - Both app logic and teardown reverted           

This PR also adds an option to `waitForTxReceipt` so that the user can choose the finalization status of the receipt. This is set to default to `CHECKPOINTED`, so we can preserve old behaviour where we do not proceed with an action until the tx was checkpointed to L1.

**Key changes:**                                                   

- Updated `TxReceipt` class with new fields and helper methods     
(`isSuccess()`, `isReverted()`, `isMined()`, `isPending()`,        
`isDropped()`)                                                     
- Added finalized block tracking to archiver with                  
`getFinalizedL2BlockNumber()` and `getCheckpointedL2BlockNumber()` 
methods                                                            
- Updated `getSettledTxReceipt` in BlockStore to determine proper  
finalization level based on archiver state                         
- Set default `waitForStatus` to `CHECKPOINTED`

Fixes A-333

🤖 Generated with [Claude Code](https://claude.com/claude-code)  