### PR TITLE
chore: backporting kernel hint optimizatin to `devnet`

### DIFF
--- a/yarn-project/pxe/src/private_kernel/hints/build_private_kernel_reset_private_inputs.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/build_private_kernel_reset_private_inputs.ts
@@ -138,7 +138,7 @@ export class PrivateKernelResetPrivateInputsBuilder {
     }
   }
 
-  async build(oracle: PrivateKernelOracle, noteHashLeafIndexMap: Map<bigint, bigint>) {
+  async build(oracle: PrivateKernelOracle) {
     if (privateKernelResetDimensionNames.every(name => !this.requestedDimensions[name])) {
       throw new Error('Reset is not required.');
     }
@@ -157,16 +157,6 @@ export class PrivateKernelResetPrivateInputsBuilder {
       allowRemainder,
     );
 
-    const previousVkMembershipWitness = await oracle.getVkMembershipWitness(
-      this.previousKernelOutput.verificationKey.keyAsFields,
-    );
-    const vkData = new VkData(
-      this.previousKernelOutput.verificationKey,
-      Number(previousVkMembershipWitness.leafIndex),
-      previousVkMembershipWitness.siblingPath,
-    );
-    const previousKernelData = new PrivateKernelData(this.previousKernelOutput.publicInputs, vkData);
-
     this.reduceReadRequestActions(
       this.noteHashResetActions,
       dimensions.NOTE_HASH_PENDING_READ,
@@ -178,6 +168,41 @@ export class PrivateKernelResetPrivateInputsBuilder {
       dimensions.NULLIFIER_SETTLED_READ,
     );
 
+    // Execute all the expensive node querying operations in parallel.
+    const [previousVkMembershipWitness, noteHashReadRequestHints, nullifierReadRequestHints, keyValidationHints] =
+      await Promise.all([
+        oracle.getVkMembershipWitness(this.previousKernelOutput.verificationKey.keyAsFields),
+        buildNoteHashReadRequestHintsFromResetActions<
+          typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+          typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
+        >(
+          oracle,
+          this.previousKernel.validationRequests.noteHashReadRequests,
+          this.previousKernel.end.noteHashes,
+          this.noteHashResetActions,
+        ),
+        buildNullifierReadRequestHintsFromResetActions<
+          typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+          typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX
+        >(
+          { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },
+          this.previousKernel.validationRequests.nullifierReadRequests,
+          this.nullifierResetActions,
+        ),
+        getMasterSecretKeysAndAppKeyGenerators(
+          this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
+          dimensions.KEY_VALIDATION,
+          oracle,
+        ),
+      ]);
+
+    const vkData = new VkData(
+      this.previousKernelOutput.verificationKey,
+      Number(previousVkMembershipWitness.leafIndex),
+      previousVkMembershipWitness.siblingPath,
+    );
+    const previousKernelData = new PrivateKernelData(this.previousKernelOutput.publicInputs, vkData);
+
     // TODO: Enable padding when we have a better idea what are the final amounts we should pad to.
     const paddedSideEffects = PaddedSideEffects.empty();
 
@@ -185,23 +210,9 @@ export class PrivateKernelResetPrivateInputsBuilder {
       previousKernelData,
       paddedSideEffects,
       new PrivateKernelResetHints(
-        await buildNoteHashReadRequestHintsFromResetActions(
-          oracle,
-          this.previousKernel.validationRequests.noteHashReadRequests,
-          this.previousKernel.end.noteHashes,
-          this.noteHashResetActions,
-          noteHashLeafIndexMap,
-        ),
-        await buildNullifierReadRequestHintsFromResetActions(
-          { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },
-          this.previousKernel.validationRequests.nullifierReadRequests,
-          this.nullifierResetActions,
-        ),
-        await getMasterSecretKeysAndAppKeyGenerators(
-          this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
-          dimensions.KEY_VALIDATION,
-          oracle,
-        ),
+        noteHashReadRequestHints,
+        nullifierReadRequestHints,
+        keyValidationHints,
         this.transientDataSquashingHints,
       ),
       dimensions,

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
@@ -28,7 +28,6 @@ import {
   type PrivateCallExecutionResult,
   type PrivateExecutionResult,
   TxRequest,
-  collectNoteHashLeafIndexMap,
   collectNoteHashNullifierCounterMap,
   getFinalMinRevertibleSideEffectCounter,
 } from '@aztec/stdlib/tx';
@@ -101,7 +100,6 @@ export class PrivateKernelExecutionProver {
 
     const executionSteps: PrivateExecutionStep[] = [];
 
-    const noteHashLeafIndexMap = collectNoteHashLeafIndexMap(executionResult);
     const noteHashNullifierCounterMap = collectNoteHashNullifierCounterMap(executionResult);
     const minRevertibleSideEffectCounter = getFinalMinRevertibleSideEffectCounter(executionResult);
     const splitCounter = isPrivateOnlyTx ? 0 : minRevertibleSideEffectCounter;
@@ -116,7 +114,7 @@ export class PrivateKernelExecutionProver {
         );
         while (resetBuilder.needsReset()) {
           const witgenTimer = new Timer();
-          const privateInputs = await resetBuilder.build(this.oracle, noteHashLeafIndexMap);
+          const privateInputs = await resetBuilder.build(this.oracle);
           output = generateWitnesses
             ? await this.proofCreator.generateResetOutput(privateInputs)
             : await this.proofCreator.simulateReset(privateInputs);
@@ -224,7 +222,7 @@ export class PrivateKernelExecutionProver {
     );
     while (resetBuilder.needsReset()) {
       const witgenTimer = new Timer();
-      const privateInputs = await resetBuilder.build(this.oracle, noteHashLeafIndexMap);
+      const privateInputs = await resetBuilder.build(this.oracle);
       output = generateWitnesses
         ? await this.proofCreator.generateResetOutput(privateInputs)
         : await this.proofCreator.simulateReset(privateInputs);

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
@@ -43,7 +43,8 @@ export interface PrivateKernelOracle {
 
   /**
    * Returns a membership witness with the sibling path and leaf index in our private function indexed merkle tree.
-   */ getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+   */
+  getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
 
   /**
    * Returns a membership witness with the sibling path and leaf index in our nullifier indexed merkle tree.

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle_impl.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle_impl.ts
@@ -2,7 +2,6 @@ import { NOTE_HASH_TREE_HEIGHT, PUBLIC_DATA_TREE_HEIGHT, VK_TREE_HEIGHT } from '
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
 import { createLogger } from '@aztec/foundation/log';
-import type { Tuple } from '@aztec/foundation/serialize';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import { getVKIndex, getVKSiblingPath } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -70,13 +69,8 @@ export class PrivateKernelOracleImpl implements PrivateKernelOracle {
     return Promise.resolve(new MembershipWitness(VK_TREE_HEIGHT, BigInt(leafIndex), getVKSiblingPath(leafIndex)));
   }
 
-  async getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>> {
-    const path = await this.node.getNoteHashSiblingPath(this.blockNumber, leafIndex);
-    return new MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>(
-      path.pathSize,
-      leafIndex,
-      path.toFields() as Tuple<Fr, typeof NOTE_HASH_TREE_HEIGHT>,
-    );
+  getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
+    return this.node.getNoteHashMembershipWitness(this.blockNumber, noteHash);
   }
 
   getNullifierMembershipWitness(nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
@@ -31,7 +31,7 @@ describe('buildNoteHashReadRequestHints', () => {
 
   const settledNoteHashes = [111, 222, 333];
   const oracle = {
-    getNoteHashMembershipWitness: async (noteHash: Fr) =>
+    getNoteHashMembershipWitness: (noteHash: Fr) =>
       settledNoteHashes.map(v => BigInt(v)).includes(noteHash.toBigInt()) ? ({} as any) : (undefined as any),
   };
 

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.test.ts
@@ -30,17 +30,15 @@ describe('buildNoteHashReadRequestHints', () => {
   );
 
   const settledNoteHashes = [111, 222, 333];
-  const settledLeafIndexes = [1010n, 2020n, 3030n];
   const oracle = {
-    getNoteHashMembershipWitness: (leafIndex: bigint) =>
-      settledLeafIndexes.includes(leafIndex) ? ({} as any) : undefined,
+    getNoteHashMembershipWitness: async (noteHash: Fr) =>
+      settledNoteHashes.map(v => BigInt(v)).includes(noteHash.toBigInt()) ? ({} as any) : (undefined as any),
   };
 
   /**
    * Create initial state.
    */
   let noteHashReadRequests: Tuple<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>;
-  let noteHashLeafIndexMap: Map<bigint, bigint> = new Map();
   let expectedHints: NoteHashReadRequestHints<
     typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
     typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
@@ -66,7 +64,6 @@ describe('buildNoteHashReadRequestHints', () => {
     const readRequestIndex = numReadRequests;
     const hintIndex = numSettledReads;
     const value = settledNoteHashes[noteHashIndex];
-    noteHashLeafIndexMap.set(BigInt(value), settledLeafIndexes[noteHashIndex]);
     noteHashReadRequests[readRequestIndex] = makeReadRequest(settledNoteHashes[noteHashIndex]);
     expectedHints.readRequestActions[readRequestIndex] = ReadRequestAction.readAsSettled(hintIndex);
     expectedHints.settledReadHints[hintIndex] = new SettledReadHint(readRequestIndex, {} as any, new Fr(value));
@@ -85,13 +82,11 @@ describe('buildNoteHashReadRequestHints', () => {
       oracle,
       new ClaimedLengthArray(noteHashReadRequests, numReadRequests),
       new ClaimedLengthArray(noteHashes, MAX_NOTE_HASHES_PER_TX),
-      noteHashLeafIndexMap,
       futureNoteHashes,
     );
 
   beforeEach(() => {
     noteHashReadRequests = makeTuple(MAX_NOTE_HASH_READ_REQUESTS_PER_TX, ScopedReadRequest.empty);
-    noteHashLeafIndexMap = new Map();
     expectedHints = NoteHashReadRequestHintsBuilder.empty(
       MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
       MAX_NOTE_HASH_READ_REQUESTS_PER_TX,

--- a/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_note_hash_read_request_hints.ts
@@ -3,6 +3,7 @@ import {
   MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
   type NOTE_HASH_TREE_HEIGHT,
 } from '@aztec/constants';
+import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 
 import type { ClaimedLengthArray } from '../claimed_length_array.js';
@@ -61,12 +62,11 @@ export function getNoteHashReadRequestResetActions(
 
 export async function buildNoteHashReadRequestHintsFromResetActions<PENDING extends number, SETTLED extends number>(
   oracle: {
-    getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+    getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
   },
   noteHashReadRequests: ClaimedLengthArray<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
   noteHashes: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
   resetActions: ReadRequestResetActions<typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
-  noteHashLeafIndexMap: Map<bigint, bigint>,
   maxPending: PENDING = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as SETTLED,
 ) {
@@ -76,16 +76,26 @@ export async function buildNoteHashReadRequestHintsFromResetActions<PENDING exte
     builder.addPendingReadRequest(hint.readRequestIndex, hint.pendingValueIndex);
   });
 
+  // Collect all settled read requests
+  const settledRequests: { index: number; readRequest: ScopedReadRequest }[] = [];
   for (let i = 0; i < resetActions.actions.length; i++) {
     if (resetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
-      const readRequest = noteHashReadRequests.array[i];
-      const leafIndex = noteHashLeafIndexMap.get(readRequest.value.toBigInt());
-      if (leafIndex === undefined) {
-        throw new Error('Read request is reading an unknown note hash.');
-      }
-      const membershipWitness = await oracle.getNoteHashMembershipWitness(leafIndex);
-      builder.addSettledReadRequest(i, membershipWitness, readRequest.value);
+      settledRequests.push({ index: i, readRequest: noteHashReadRequests.array[i] });
     }
+  }
+
+  // Fetch all membership witnesses in parallel
+  const membershipWitnesses = await Promise.all(
+    settledRequests.map(({ readRequest }) => oracle.getNoteHashMembershipWitness(readRequest.value)),
+  );
+
+  // Add settled read requests to builder
+  for (let i = 0; i < settledRequests.length; i++) {
+    const membershipWitness = membershipWitnesses[i];
+    if (!membershipWitness) {
+      throw new Error('Read request is reading an unknown note hash.');
+    }
+    builder.addSettledReadRequest(settledRequests[i].index, membershipWitness, settledRequests[i].readRequest.value);
   }
 
   const noteHashMap: Map<bigint, { noteHash: ScopedNoteHash; index: number }[]> = new Map();
@@ -101,11 +111,10 @@ export async function buildNoteHashReadRequestHintsFromResetActions<PENDING exte
 
 export async function buildNoteHashReadRequestHints<PENDING extends number, SETTLED extends number>(
   oracle: {
-    getNoteHashMembershipWitness(leafIndex: bigint): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
+    getNoteHashMembershipWitness(noteHash: Fr): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT>>;
   },
   noteHashReadRequests: ClaimedLengthArray<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
   noteHashes: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
-  noteHashLeafIndexMap: Map<bigint, bigint>,
   futureNoteHashes: ScopedNoteHash[],
   maxPending: PENDING = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NOTE_HASH_READ_REQUESTS_PER_TX as SETTLED,
@@ -116,7 +125,6 @@ export async function buildNoteHashReadRequestHints<PENDING extends number, SETT
     noteHashReadRequests,
     noteHashes,
     resetActions,
-    noteHashLeafIndexMap,
     maxPending,
     maxSettled,
   );

--- a/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
@@ -82,19 +82,31 @@ export async function buildNullifierReadRequestHintsFromResetActions<PENDING ext
     builder.addPendingReadRequest(hint.readRequestIndex, hint.pendingValueIndex);
   });
 
+  // Collect all settled read requests
+  const settledRequests: { index: number; readRequest: ScopedReadRequest }[] = [];
   for (let i = 0; i < resetActions.actions.length; i++) {
     if (resetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
-      const readRequest = nullifierReadRequests.array[i];
-      const siloedValue = siloed
-        ? readRequest.value
-        : await siloNullifier(readRequest.contractAddress, readRequest.value);
-      const membershipWitnessWithPreimage = await oracle.getNullifierMembershipWitness(siloedValue);
-      builder.addSettledReadRequest(
-        i,
-        membershipWitnessWithPreimage.membershipWitness,
-        membershipWitnessWithPreimage.leafPreimage,
-      );
+      settledRequests.push({ index: i, readRequest: nullifierReadRequests.array[i] });
     }
+  }
+
+  // Compute siloed values in parallel (if not already siloed)
+  const siloedValues = siloed
+    ? settledRequests.map(({ readRequest }) => readRequest.value)
+    : await Promise.all(
+        settledRequests.map(({ readRequest }) => siloNullifier(readRequest.contractAddress, readRequest.value)),
+      );
+
+  // Fetch all membership witnesses in parallel
+  const membershipWitnesses = await Promise.all(siloedValues.map(value => oracle.getNullifierMembershipWitness(value)));
+
+  // Add settled read requests to builder
+  for (let i = 0; i < settledRequests.length; i++) {
+    builder.addSettledReadRequest(
+      settledRequests[i].index,
+      membershipWitnesses[i].membershipWitness,
+      membershipWitnesses[i].leafPreimage,
+    );
   }
 
   return builder.toHints();


### PR DESCRIPTION
As requested by @Thunkar backporting [this PR](https://github.com/AztecProtocol/aztec-packages/pull/19689) to devnet. I had to do some more changes to get this to work (namely related to us no longer querying note hash membership witness by leaf index but by note hash on `next` but this was still done on `devnet`).