### PR TITLE
feat: searching for nullifiers and tags concurrently

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -350,10 +350,16 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.jobId,
     );
 
-    await logService.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
-
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore);
-    await noteService.syncNoteNullifiers(this.contractAddress);
+
+    // It is acceptable to run the following operations in parallel for several reasons:
+    // 1. syncTaggedLogs does not write to the note store — it only stores the pending tagged logs in a capsule array,
+    //    which is then processed in Noir after this handler returns.
+    // 2. Even if syncTaggedLogs did write to the note store, it would not cause inconsistent state.
+    await Promise.all([
+      logService.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes),
+      noteService.syncNoteNullifiers(this.contractAddress),
+    ]);
   }
 
   /**


### PR DESCRIPTION
Closes https://linear.app/aztec-labs/issue/F-159/search-for-nullifiers-and-tags-concurrently

Roundtrips before optimization:

```
    ║  Configuration: ecdsar1+private_fpc                                                                                  ║
    ║  Total Round Trips: 195                                                                                              ║
    ║  Payment Method: private_fpc                                                                                         ║
    ║                                                                                                                      ║
    ║  Per Round Trip:                                                                                                     ║
    ║    RT   1: [getNodeInfo]                                                                                             ║
    ║    ...
    ║    RT  36: [getL2Tips, getBlockHeader, getL2Tips, getBlockHeader]                                                    ║
    ║    RT  37: [getPrivateLogsByTags, getPrivateLogsByTags]                                                              ║
    ║    RT  38: [findLeavesIndexes]                                                                                       ║
    ║    ...
```

(RT 36 and 37 correspond solely to `syncTaggedLogs`, RT 38 to `syncNoteNullifiers`)

after optimization:

```
    ║  Configuration: ecdsar1+private_fpc                                                                                  ║
    ║  Total Round Trips: 189                                                                                              ║
    ║  Payment Method: private_fpc                                                                                         ║
    ║                                                                                                                      ║
    ║  Per Round Trip:                                                                                                     ║
    ║    RT   1: [getNodeInfo]                                                                                             ║
    ║    ...
    ║    RT  36: [findLeavesIndexes, getL2Tips, getBlockHeader, getL2Tips, getBlockHeader]                                 ║
    ║    RT  37: [getPrivateLogsByTags, getPrivateLogsByTags]                                                              ║
```

We can see that RT 38 got merged with RT 36 and for the full run we saved 6 round trips 🎉🎉🎉🚀🚀🚀