### PR TITLE
chore: use docker buildx

### DIFF
--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -68,16 +68,14 @@ function release {
     done
 
     # We release with our tag, e.g. 1.0.0
-    docker manifest create aztecprotocol/aztec:$tag \
-      --amend aztecprotocol/aztec:$tag-amd64 \
-      --amend aztecprotocol/aztec:$tag-arm64
-    docker manifest push aztecprotocol/aztec:$tag
+    docker buildx imagetools create -t aztecprotocol/aztec:$tag \
+      aztecprotocol/aztec:$tag-amd64 \
+      aztecprotocol/aztec:$tag-arm64
 
     # We also release with our dist_tag, e.g. 'latest', 'staging' or 'nightly'.
-    docker manifest create aztecprotocol/aztec:$(dist_tag) \
-      --amend aztecprotocol/aztec:$tag-amd64 \
-      --amend aztecprotocol/aztec:$tag-arm64
-    docker manifest push aztecprotocol/aztec:$(dist_tag)
+    docker buildx imagetools create -t aztecprotocol/aztec:$(dist_tag) \
+      aztecprotocol/aztec:$tag-amd64 \
+      aztecprotocol/aztec:$tag-arm64
   fi
 }
 


### PR DESCRIPTION
Looks like the recent AMI change has changed the way docker pushes images. They are manifests now and the `docker manifest create` can't flatten a manifest in a manifest:

```
# yesterday's image
$ docker manifest inspect aztecprotocol/aztec:4.0.0-nightly.20260119-amd64 | jq .mediaType
"application/vnd.docker.distribution.manifest.v2+json"

# today's image
$ docker manifest inspect aztecprotocol/aztec:4.0.0-nightly.20260120-amd64 | jq .mediaType
"application/vnd.oci.image.index.v1+json"
```

CI logs from the nightly build:
```
04:16:46 Waiting for amd64 image to be pushed...
04:16:56 Waiting for amd64 image to be pushed...
04:17:08 docker.io/aztecprotocol/aztec:4.0.0-nightly.20260120-amd64 is a manifest list
04:17:08 + cleanup
04:17:08 + set +e
04:17:08 + '[' -n '' ']'
04:17:08 + '[' -n '' ']'
04:17:08 + '[' -n '' ']'
04:17:08 + local code=1
```