### PR TITLE
fix(avm): Fix fuzzer coverage collection

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -630,11 +630,6 @@
       "configurePreset": "fuzzing-avm"
     },
     {
-      "name": "fuzzing-avm-tooling",
-      "inherits": "clang20",
-      "configurePreset": "fuzzing-avm-tooling"
-    },
-    {
       "name": "gperftools",
       "inherits": "clang20",
       "configurePreset": "gperftools"

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -297,6 +297,21 @@
       }
     },
     {
+      "name": "fuzzing-avm-tooling",
+      "displayName": "Build fuzzer tooling without instrumentation",
+      "description": "Build fuzzer tests and utilities like corpus analyzer without fuzzer instrumentation",
+      "inherits": "clang20",
+      "binaryDir": "build-fuzzing-avm-tooling",
+      "cacheVariables": {
+        "FUZZING": "OFF",
+        "DISABLE_ASM": "OFF",
+        "AVM_TRANSPILER_LIB": "",
+        "FUZZING_AVM": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithAssert",
+        "MULTITHREADING": "ON"
+      }
+    },
+    {
       "name": "smt-verification",
       "displayName": "Build with smt verification",
       "description": "Build default preset but with smt library included",
@@ -615,6 +630,11 @@
       "configurePreset": "fuzzing-avm"
     },
     {
+      "name": "fuzzing-avm-tooling",
+      "inherits": "clang20",
+      "configurePreset": "fuzzing-avm-tooling"
+    },
+    {
       "name": "gperftools",
       "inherits": "clang20",
       "configurePreset": "gperftools"
@@ -649,21 +669,29 @@
       "configurePreset": "wasm",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
-      "targets": ["barretenberg.wasm.gz"]
+      "targets": [
+        "barretenberg.wasm.gz"
+      ]
     },
     {
       "name": "wasm-threads-dbg",
       "configurePreset": "wasm-threads-dbg",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
-      "targets": ["barretenberg.wasm", "bb"]
+      "targets": [
+        "barretenberg.wasm",
+        "bb"
+      ]
     },
     {
       "name": "wasm-threads",
       "configurePreset": "wasm-threads",
       "inheritConfigureEnvironment": true,
       "jobs": 0,
-      "targets": ["barretenberg.wasm.gz", "ecc_tests"]
+      "targets": [
+        "barretenberg.wasm.gz",
+        "ecc_tests"
+      ]
     },
     {
       "name": "xray",

--- a/barretenberg/cpp/cmake/fuzzing-avm-allowlist.txt
+++ b/barretenberg/cpp/cmake/fuzzing-avm-allowlist.txt
@@ -1,2 +1,0 @@
-# Instrument vm2
-src:*/vm2/*

--- a/barretenberg/cpp/cmake/fuzzing-avm-ignorelist.txt
+++ b/barretenberg/cpp/cmake/fuzzing-avm-ignorelist.txt
@@ -7,3 +7,29 @@ src:*barretenberg/vm2/constraining/*
 
 # Exclude generated code (auto-generated circuit definitions)
 src:*barretenberg/vm2/generated/*
+
+
+# Exclude bb components we don't care about for coverage
+
+src:*barretenberg/commitment_schemes/*
+src:*barretenberg/common/*
+src:*barretenberg/crypto/*
+src:*barretenberg/ecc/*
+src:*barretenberg/eccvm/*
+src:*barretenberg/env/*
+src:*barretenberg/flavor/*
+src:*barretenberg/honk/*
+src:*barretenberg/numeric/*
+src:*barretenberg/polynomials/*
+src:*barretenberg/relations/*
+src:*barretenberg/serialize/*
+src:*barretenberg/srs/*
+src:*barretenberg/stdlib/*
+src:*barretenberg/stdlib_circuit_builders/*
+src:*barretenberg/sumcheck/*
+src:*barretenberg/transcript/*
+src:*barretenberg/world_state/*
+src:*barretenberg/lmdblib/*
+src:*barretenberg/api/*
+src:*barretenberg/op_queue/*
+src:*barretenberg/public_input_component/*

--- a/barretenberg/cpp/cmake/module.cmake
+++ b/barretenberg/cpp/cmake/module.cmake
@@ -95,7 +95,6 @@ function(barretenberg_module_with_sources MODULE_NAME)
                 target_compile_options(
                     ${MODULE_NAME}_objects
                     PRIVATE
-                    -fsanitize-coverage-allowlist=${CMAKE_SOURCE_DIR}/cmake/fuzzing-avm-allowlist.txt
                     -fsanitize-coverage-ignorelist=${CMAKE_SOURCE_DIR}/cmake/fuzzing-avm-ignorelist.txt
                 )
             endif()

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -126,8 +126,11 @@ if(NOT FUZZING AND NOT WASM)
 endif()
 
 if(FUZZING_AVM)
-    add_subdirectory(barretenberg/world_state)
-    add_subdirectory(barretenberg/vm2)
+    if(FUZZING)
+        # Only add these if they weren't added above (when NOT FUZZING AND NOT WASM)
+        add_subdirectory(barretenberg/world_state)
+        add_subdirectory(barretenberg/vm2)
+    endif()
     add_subdirectory(barretenberg/avm_fuzzer)
 endif()
 

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/CMakeLists.txt
@@ -36,6 +36,9 @@ if(FUZZING_AVM)
     add_subdirectory(harness)
 
     # Corpus analyzer tool (not a fuzzer, a standalone binary)
-    add_executable(avm_tx_corpus_analyzer avm_tx_corpus_analyzer.cpp)
-    target_link_libraries(avm_tx_corpus_analyzer avm_fuzzer)
+    # Only build when FUZZING=OFF to avoid linking against instrumented libraries
+    if(NOT FUZZING)
+        add_executable(avm_tx_corpus_analyzer avm_tx_corpus_analyzer.cpp)
+        target_link_libraries(avm_tx_corpus_analyzer avm_fuzzer)
+    endif()
 endif()

--- a/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
+++ b/barretenberg/cpp/src/barretenberg/avm_fuzzer/run_fuzzer.sh
@@ -51,8 +51,8 @@ if [ "$COMMAND" = "analyze" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     BARRETENBERG_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
     CPP_DIR="$BARRETENBERG_ROOT/cpp"
-    BUILD_DIR="$CPP_DIR/build-fuzzing-avm"
-    BUILD_PRESET="fuzzing-avm"
+    BUILD_DIR="$CPP_DIR/build-fuzzing-avm-tooling"
+    BUILD_PRESET="fuzzing-avm-tooling"
 
     cd "$CPP_DIR"
 


### PR DESCRIPTION
Resolves https://linear.app/aztec-labs/issue/AVM-204/investigate-why-we-dont-see-new-func-anymore
Switches to ignorelist the instrumentation skip. 2x slower but > 10x improvement in coverage building