### PR TITLE
feat: Export Prometheus metrics to benchmarks

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -118,7 +118,17 @@ function network_tests {
 }
 
 function network_bench_cmds {
-  echo "$hash:TIMEOUT=7200 BENCH_OUTPUT=bench-out/n_tps.bench.json LOW_VALUE_TPS=0.2 HIGH_VALUE_TPS=0.1 TEST_DURATION=600 $root/yarn-project/end-to-end/scripts/run_test.sh simple n_tps.test.ts"
+  local high_value_tps=0.1
+  local low_value_tps_list=(0.1 0.2 0.5 1 2)
+
+  for low_value_tps in "${low_value_tps_list[@]}"; do
+    local low_label=${low_value_tps/./_}
+    local high_label=${high_value_tps/./_}
+    local scenario="low_${low_label}_high_${high_label}"
+    local test_duration=1800 #30 mins
+    local timeout=7200 #2 hours
+    echo "$hash:TIMEOUT=${timeout} BENCH_OUTPUT=bench-out/n_tps.${scenario}.bench.json BENCH_SCENARIO=${scenario} LOW_VALUE_TPS=${low_value_tps} HIGH_VALUE_TPS=${high_value_tps} TEST_DURATION=${test_duration} $root/yarn-project/end-to-end/scripts/run_test.sh simple n_tps.test.ts"
+  done
 }
 
 function network_bench {

--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -62,6 +62,36 @@ const CHAOS_MESH_NAME = 'network-shaping';
 const p2pLatencyQuery = (perc: string, topicName: TopicType) =>
   `histogram_quantile(${perc}, sum(rate(aztec_p2p_gossip_message_latency_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}", aztec_gossip_topic_name="${topicName}"}[1m])) by (le))`;
 
+const attestationLatencyQuery = (perc: string) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_sequencer_checkpoint_attestation_delay_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}"}[1m])) by (le))`;
+
+const attestationSuccessCountQuery = () =>
+  `sum(aztec_validator_attestation_success_count{k8s_namespace_name="${config.NAMESPACE}"})`;
+
+const attestationFailedBadProposalCountQuery = () =>
+  `sum(aztec_validator_attestation_failed_bad_proposal_count{k8s_namespace_name="${config.NAMESPACE}"})`;
+
+const attestationFailedNodeIssueCountQuery = () =>
+  `sum(aztec_validator_attestation_failed_node_issue_count{k8s_namespace_name="${config.NAMESPACE}"})`;
+
+const reqRespTxsFractionQuery = () =>
+  `sum(rate(aztec_tx_collector_txs_requested_fraction_sum{k8s_namespace_name="${config.NAMESPACE}"}[1m])) / ` +
+  `sum(rate(aztec_tx_collector_txs_requested_fraction_count{k8s_namespace_name="${config.NAMESPACE}"}[1m]))`;
+
+const reqRespTxsDelayQuery = (perc: string) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_tx_collector_txs_requested_delay_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}"}[1m])) by (le))`;
+
+const mempoolTxMinedDelayQuery = (perc: string) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_mempool_tx_mined_delay_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}"}[1m])) by (le))`;
+
+const mempoolAttestationMinedDelayQuery = (perc: string) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_mempool_attestations_mined_delay_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}"}[1m])) by (le))`;
+
+const peerCountQuery = () => `avg(aztec_peer_manager_peer_count{k8s_namespace_name="${config.NAMESPACE}"})`;
+
+const peerConnectionDurationQuery = (perc: string) =>
+  `histogram_quantile(${perc}, sum(rate(aztec_peer_manager_peer_connection_duration_milliseconds_bucket{k8s_namespace_name="${config.NAMESPACE}"}[1m])) by (le))`;
+
 describe('sustained N TPS test', () => {
   jest.setTimeout(60 * 60 * 1000 * 10); // 10 hours
 
@@ -90,8 +120,63 @@ describe('sustained N TPS test', () => {
 
           metrics.recordP2PGossipLatency(topic, p50, p95);
         } catch (err) {
-          logger.warn(`Failed to scrape prometheus data: ${err}`, { err });
+          logger.warn(`Failed to scrape P2P gossip latency: ${err}`, { err });
         }
+      }
+
+      try {
+        const [p50, p95] = await Promise.all([
+          prometheusClient.querySingleValue(attestationLatencyQuery('0.50')),
+          prometheusClient.querySingleValue(attestationLatencyQuery('0.95')),
+        ]);
+        metrics.recordAttestationLatency(p50, p95);
+      } catch (err) {
+        logger.warn(`Failed to scrape attestation latency: ${err}`, { err });
+      }
+
+      try {
+        const [success, failedBad, failedNode] = await Promise.all([
+          prometheusClient.querySingleValue(attestationSuccessCountQuery()),
+          prometheusClient.querySingleValue(attestationFailedBadProposalCountQuery()),
+          prometheusClient.querySingleValue(attestationFailedNodeIssueCountQuery()),
+        ]);
+        metrics.recordAttestationCounts(success, failedBad, failedNode);
+      } catch (err) {
+        logger.warn(`Failed to scrape attestation counts: ${err}`, { err });
+      }
+
+      try {
+        const [fraction, delayP50, delayP95] = await Promise.all([
+          prometheusClient.querySingleValue(reqRespTxsFractionQuery()),
+          prometheusClient.querySingleValue(reqRespTxsDelayQuery('0.50')),
+          prometheusClient.querySingleValue(reqRespTxsDelayQuery('0.95')),
+        ]);
+        metrics.recordReqRespStats(fraction, delayP50, delayP95);
+      } catch (err) {
+        logger.warn(`Failed to scrape req/resp stats: ${err}`, { err });
+      }
+
+      try {
+        const [avgCount, durationP50, durationP95] = await Promise.all([
+          prometheusClient.querySingleValue(peerCountQuery()),
+          prometheusClient.querySingleValue(peerConnectionDurationQuery('0.50')),
+          prometheusClient.querySingleValue(peerConnectionDurationQuery('0.95')),
+        ]);
+        metrics.recordPeerStats(avgCount, durationP50, durationP95);
+      } catch (err) {
+        logger.warn(`Failed to scrape peer stats: ${err}`, { err });
+      }
+
+      try {
+        const [txP50, txP95, attestationP50, attestationP95] = await Promise.all([
+          prometheusClient.querySingleValue(mempoolTxMinedDelayQuery('0.50')),
+          prometheusClient.querySingleValue(mempoolTxMinedDelayQuery('0.95')),
+          prometheusClient.querySingleValue(mempoolAttestationMinedDelayQuery('0.50')),
+          prometheusClient.querySingleValue(mempoolAttestationMinedDelayQuery('0.95')),
+        ]);
+        metrics.recordMempoolMinedDelay(txP50, txP95, attestationP50, attestationP95);
+      } catch (err) {
+        logger.warn(`Failed to scrape mempool mined delay stats: ${err}`, { err });
       }
 
       await mkdir(dirname(process.env.BENCH_OUTPUT), { recursive: true });

--- a/yarn-project/end-to-end/src/spartan/tx_metrics.ts
+++ b/yarn-project/end-to-end/src/spartan/tx_metrics.ts
@@ -24,6 +24,14 @@ export class TxInclusionMetrics {
 
   private p2pGossipLatencyByTopic: Partial<Record<TopicType, { p50: number; p95: number }>> = {};
 
+  private attestationLatency: { p50: number; p95: number } | undefined;
+  private attestationCounts: { success: number; failedBad: number; failedNode: number } | undefined;
+  private reqRespStats: { fraction: number; delayP50: number; delayP95: number } | undefined;
+  private peerStats: { avgCount: number; connectionDurationP50: number; connectionDurationP95: number } | undefined;
+  private mempoolMinedDelay:
+    | { txP50: number; txP95: number; attestationP50: number; attestationP95: number }
+    | undefined;
+
   constructor(private aztecNode: AztecNode) {}
 
   recordSentTx(tx: Tx, group: string): void {
@@ -111,6 +119,26 @@ export class TxInclusionMetrics {
     this.p2pGossipLatencyByTopic[topicName] = { p50, p95 };
   }
 
+  public recordAttestationLatency(p50: number, p95: number): void {
+    this.attestationLatency = { p50, p95 };
+  }
+
+  public recordAttestationCounts(success: number, failedBad: number, failedNode: number): void {
+    this.attestationCounts = { success, failedBad, failedNode };
+  }
+
+  public recordReqRespStats(fraction: number, delayP50: number, delayP95: number): void {
+    this.reqRespStats = { fraction, delayP50, delayP95 };
+  }
+
+  public recordPeerStats(avgCount: number, connectionDurationP50: number, connectionDurationP95: number): void {
+    this.peerStats = { avgCount, connectionDurationP50, connectionDurationP95 };
+  }
+
+  public recordMempoolMinedDelay(txP50: number, txP95: number, attestationP50: number, attestationP95: number): void {
+    this.mempoolMinedDelay = { txP50, txP95, attestationP50, attestationP95 };
+  }
+
   toGithubActionBenchmarkJSON(): Array<{ name: string; unit: string; value: number; range?: number; extra?: string }> {
     const data: Array<{ name: string; unit: string; value: number; range?: number; extra?: string }> = [];
     for (const group of this.groups) {
@@ -148,6 +176,56 @@ export class TxInclusionMetrics {
       });
     }
 
-    return data;
+    if (this.attestationLatency) {
+      data.push(
+        { name: 'attestation_latency/p50', unit: 'ms', value: this.attestationLatency.p50 },
+        { name: 'attestation_latency/p95', unit: 'ms', value: this.attestationLatency.p95 },
+      );
+    }
+
+    if (this.attestationCounts) {
+      const { success, failedBad, failedNode } = this.attestationCounts;
+      const total = success + failedBad + failedNode;
+      const ratio = total > 0 ? success / total : 0;
+      data.push(
+        { name: 'attestation/success_count', unit: 'count', value: success },
+        { name: 'attestation/failed_bad_proposal_count', unit: 'count', value: failedBad },
+        { name: 'attestation/failed_node_issue_count', unit: 'count', value: failedNode },
+        { name: 'attestation/success_ratio', unit: 'ratio', value: ratio },
+      );
+    }
+
+    if (this.reqRespStats) {
+      data.push(
+        { name: 'req_resp/txs_requested_fraction', unit: 'ratio', value: this.reqRespStats.fraction },
+        { name: 'req_resp/delay_p50', unit: 'ms', value: this.reqRespStats.delayP50 },
+        { name: 'req_resp/delay_p95', unit: 'ms', value: this.reqRespStats.delayP95 },
+      );
+    }
+
+    if (this.peerStats) {
+      data.push(
+        { name: 'peers/avg_count', unit: 'peers', value: this.peerStats.avgCount },
+        { name: 'peers/connection_duration_p50', unit: 'ms', value: this.peerStats.connectionDurationP50 },
+        { name: 'peers/connection_duration_p95', unit: 'ms', value: this.peerStats.connectionDurationP95 },
+      );
+    }
+
+    if (this.mempoolMinedDelay) {
+      data.push(
+        { name: 'mempool/tx_mined_delay_p50', unit: 'ms', value: this.mempoolMinedDelay.txP50 },
+        { name: 'mempool/tx_mined_delay_p95', unit: 'ms', value: this.mempoolMinedDelay.txP95 },
+        { name: 'mempool/attestation_mined_delay_p50', unit: 'ms', value: this.mempoolMinedDelay.attestationP50 },
+        { name: 'mempool/attestation_mined_delay_p95', unit: 'ms', value: this.mempoolMinedDelay.attestationP95 },
+      );
+    }
+
+    const scenario = process.env.BENCH_SCENARIO?.trim();
+    if (!scenario) {
+      return data;
+    }
+
+    const scenarioPrefix = `scenario/${scenario}/`;
+    return data.map(entry => ({ ...entry, name: `${scenarioPrefix}${entry.name}` }));
   }
 }


### PR DESCRIPTION
Ref: A-470.
1. Adds missing metrics to benchmarks
2. `n_tps` runs different scenarios  