### PR TITLE
chore: add topology spread constraints

### DIFF
--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -31,6 +31,11 @@ spec:
     {{- toYaml .Values.tolerations | nindent 4 }}
   {{- end }}
 
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml .Values.topologySpreadConstraints | nindent 4 }}
+  {{- end }}
+
   initContainers:
   {{- if .Values.initContainers }}
     {{- tpl (toYaml .Values.initContainers | nindent 4) $ }}

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -68,6 +68,7 @@ statefulSet:
 nodeSelector: null
 affinity: null
 tolerations: []
+topologySpreadConstraints: []
 
 # -- Aztec node configuration
 node:

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -142,6 +142,18 @@ locals {
         service = {
           p2p = { publicIP = var.P2P_PUBLIC_IP }
         }
+        # spread validator pods to different nodes to avoid having two validators with the same attester keys on the same physical node
+        topologySpreadConstraints = [{
+          maxSkew           = 1
+          topologyKey       = "kubernetes.io/hostname"
+          whenUnsatisfiable = "ScheduleAnyway" # soft constraint
+          labelSelector = {
+            matchLabels = {
+              "app.kubernetes.io/component" = "sequencer-node"
+            }
+          }
+          matchLabelKeys = ["apps.kubernetes.io/pod-index"]
+        }]
       }
     })]
     boot_node_host_path  = "validator.node.env.BOOT_NODE_HOST"


### PR DESCRIPTION
Use `topoligySpreadConstraints` to schedule HA validator pods on different nodes. Builds on top of #19755 