### PR TITLE
docs: update message delivery option names to new syntax

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_define_storage.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_define_storage.md
@@ -98,7 +98,7 @@ fn initialize_value(value: Field) {
     let note = FieldNote { value };
 
     self.storage.private_value.at(owner).initialize(note).deliver(
-        MessageDelivery.CONSTRAINED_ONCHAIN,
+        MessageDelivery.ONCHAIN_CONSTRAINED,
     );
 }
 ```
@@ -107,9 +107,9 @@ fn initialize_value(value: Field) {
 
 Private state operations return a `NoteMessage` that must be delivered. Choose based on your needs:
 
-- **`CONSTRAINED_ONCHAIN`** - Cryptographic guarantees that recipients can decrypt. Use when contracts need to verify message contents.
-- **`UNCONSTRAINED_ONCHAIN`** - Faster proving, stored onchain. Use when recipients can verify validity through other means.
-- **`UNCONSTRAINED_OFFCHAIN`** - Lowest cost, requires custom delivery infrastructure. Use for high-volume applications.
+- **`ONCHAIN_CONSTRAINED`** - Cryptographic guarantees that recipients can decrypt. Use when contracts need to verify message contents.
+- **`ONCHAIN_UNCONSTRAINED`** - Faster proving, stored onchain. Use when recipients can verify validity through other means.
+- **`OFFCHAIN`** - Lowest cost, requires custom delivery infrastructure. Use for high-volume applications.
 
 :::
 
@@ -122,7 +122,7 @@ Updates the value by nullifying the current note and inserting a new one. Takes 
 fn update_value(new_value: Field) {
     let owner = self.msg_sender().unwrap();
     self.storage.private_value.at(owner).replace(|_old_note| FieldNote { value: new_value }).deliver(
-        MessageDelivery.CONSTRAINED_ONCHAIN,
+        MessageDelivery.ONCHAIN_CONSTRAINED,
     );
 }
 
@@ -131,7 +131,7 @@ fn increment_value() {
     let owner = self.msg_sender().unwrap();
     self.storage.private_value.at(owner).replace(|old_note| {
         FieldNote { value: old_note.value + 1 }
-    }).deliver(MessageDelivery.CONSTRAINED_ONCHAIN);
+    }).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 }
 ```
 
@@ -146,7 +146,7 @@ fn set_value(new_value: Field) {
     self.storage.private_value.at(owner).initialize_or_replace(|maybe_note| {
         // maybe_note is None if uninitialized, Some(note) if exists
         FieldNote { value: new_value }
-    }).deliver(MessageDelivery.CONSTRAINED_ONCHAIN);
+    }).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 }
 ```
 
@@ -160,7 +160,7 @@ fn read_value() {
     let owner = self.msg_sender().unwrap();
     let note_message = self.storage.private_value.at(owner).get_note();
     // Access the note content via note_message.get_new_note()
-    note_message.deliver(MessageDelivery.CONSTRAINED_ONCHAIN);
+    note_message.deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 }
 ```
 
@@ -211,7 +211,7 @@ fn set_config(value: Field) {
     let note = ConfigNote { value };
 
     self.storage.private_config.at(owner).initialize(note).deliver(
-        MessageDelivery.CONSTRAINED_ONCHAIN,
+        MessageDelivery.ONCHAIN_CONSTRAINED,
     );
 }
 ```
@@ -243,7 +243,7 @@ Adds a new note to the set:
 ```rust
 let note = UintNote { value: amount };
 self.storage.balances.at(owner).insert(note).deliver(
-    MessageDelivery.CONSTRAINED_ONCHAIN,
+    MessageDelivery.ONCHAIN_CONSTRAINED,
 );
 ```
 
@@ -327,7 +327,7 @@ When initializing, you still pass an owner address - but this specifies who can 
 
 ```rust
 // owner_address determines who can see the note, not where it's stored
-self.storage.admin.initialize(note, owner_address).deliver(MessageDelivery.CONSTRAINED_ONCHAIN);
+self.storage.admin.initialize(note, owner_address).deliver(MessageDelivery.ONCHAIN_CONSTRAINED);
 ```
 
 ## Public storage types

--- a/docs/docs-developers/docs/aztec-nr/framework-description/how_to_emit_event.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/how_to_emit_event.md
@@ -40,7 +40,7 @@ fn transfer(to: AztecAddress, amount: u128) {
 
     self.emit(Transfer { from, to, amount }).deliver_to(
         to,
-        MessageDelivery.UNCONSTRAINED_ONCHAIN,
+        MessageDelivery.ONCHAIN_UNCONSTRAINED,
     );
 }
 ```
@@ -55,15 +55,15 @@ You can deliver the same event to multiple recipients with different delivery mo
 
 ```rust
 let message = self.emit(Transfer { from, to, amount });
-message.deliver_to(from, MessageDelivery.UNCONSTRAINED_OFFCHAIN);
-message.deliver_to(to, MessageDelivery.CONSTRAINED_ONCHAIN);
+message.deliver_to(from, MessageDelivery.OFFCHAIN);
+message.deliver_to(to, MessageDelivery.ONCHAIN_CONSTRAINED);
 ```
 
 The `MessageDelivery` options are:
 
-- **`CONSTRAINED_ONCHAIN`** - Constrained encryption with onchain delivery. Slowest proving but provides cryptographic guarantees that recipients can decrypt messages.
-- **`UNCONSTRAINED_ONCHAIN`** - Unconstrained encryption with onchain delivery. Faster proving, but trusts the sender to encrypt correctly.
-- **`UNCONSTRAINED_OFFCHAIN`** - Unconstrained encryption with offchain delivery. Lowest cost, but requires custom infrastructure to deliver messages to recipients.
+- **`ONCHAIN_CONSTRAINED`** - Constrained encryption with onchain delivery. Slowest proving but provides cryptographic guarantees that recipients can decrypt messages.
+- **`ONCHAIN_UNCONSTRAINED`** - Unconstrained encryption with onchain delivery. Faster proving, but trusts the sender to encrypt correctly.
+- **`OFFCHAIN`** - Unconstrained encryption with offchain delivery. Lowest cost, but requires custom infrastructure to deliver messages to recipients.
 
 :::note
 Emitting private events is optional. Onchain delivery publishes encrypted data to Ethereum blobs, inheriting Ethereum's data availability guarantees. You can choose to share information offchain instead.
@@ -110,7 +110,7 @@ const publicLogs = (await node.getPublicLogs(logFilter)).logs;
 
 Event data published onchain is stored in Ethereum blobs, which incurs costs. Consider:
 
-- Use `UNCONSTRAINED_OFFCHAIN` delivery for lower costs when you have custom delivery infrastructure
+- Use `OFFCHAIN` delivery for lower costs when you have custom delivery infrastructure
 - Only emit events when necessary for your application's functionality
 
 ## Next steps

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -226,7 +226,7 @@ The `self.context.msg_sender_unsafe` method has been dropped as its use can be r
 The following terms have been renamed:
 
 - `MessageDelivery::UNCONSTRAINED_OFFCHAIN` -> `MessageDelivery::OFFCHAIN`
-- `MessageDelivery::UNCONSTRAINED_ONCHAIN` -> `MessageDelivery::OFFCHAIN_UNCONSTRAINED`
+- `MessageDelivery::UNCONSTRAINED_ONCHAIN` -> `MessageDelivery::ONCHAIN_UNCONSTRAINED`
 - `MessageDelivery::CONSTRAINED_ONCHAIN` -> `MessageDelivery::ONCHAIN_CONSTRAINED`
 
 We believe these names will better convey the meaning of the concepts.

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -102,7 +102,7 @@ Let’s create a constructor method to run on deployment that assigns an initial
 
 #include_code constructor /docs/examples/contracts/counter_contract/src/main.nr rust
 
-This function accesses the counters from storage. It adds the `headstart` value to the `owner`'s counter using `at().add()`, then calls `.deliver(MessageDelivery.CONSTRAINED_ONCHAIN)` to ensure the note is delivered onchain.
+This function accesses the counters from storage. It adds the `headstart` value to the `owner`'s counter using `at().add()`, then calls `.deliver(MessageDelivery.ONCHAIN_CONSTRAINED)` to ensure the note is delivered onchain.
 
 We have annotated this and other functions with `#[external("private")]` which are ABI macros so the compiler understands it will handle private inputs.
 


### PR DESCRIPTION
## Summary
- Updates documentation references from old message delivery naming to new syntax
- Fixes typo in migration_notes.md where `OFFCHAIN_UNCONSTRAINED` was incorrectly used instead of `ONCHAIN_UNCONSTRAINED`

**Changes:**
- `CONSTRAINED_ONCHAIN` → `ONCHAIN_CONSTRAINED`
- `UNCONSTRAINED_ONCHAIN` → `ONCHAIN_UNCONSTRAINED`
- `UNCONSTRAINED_OFFCHAIN` → `OFFCHAIN`

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm code examples match actual API

🤖 Generated with [Claude Code](https://claude.ai/code)