### PR TITLE
chore: add assume to staking asset handler claim

### DIFF
--- a/l1-contracts/test/staking_asset_handler/claim.t.sol
+++ b/l1-contracts/test/staking_asset_handler/claim.t.sol
@@ -53,6 +53,7 @@ contract ClaimTest is StakingAssetHandlerBase {
   }
 
   modifier whenCallerIsNotUnhinged(address _caller) {
+    vm.assume(_caller != address(stakingAssetHandler));
     vm.assume(!stakingAssetHandler.isUnhinged(_caller));
     _;
   }


### PR DESCRIPTION
There was a flake in the `claim.t.sol` for the staking asset handler as the `_caller` sometimes ended up being the staking asset handler itself, leading to a case where it was sending funds to itself, which did not work well with expecting a balance to change.