### PR TITLE
chore: deflake e2e "committee member invalidates a block"

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -16,6 +16,7 @@ import { timeoutPromise } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
 import { OffenseType } from '@aztec/slasher';
+import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 
 import { jest } from '@jest/globals';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -530,10 +531,13 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     });
 
     // Disable skipCollectingAttestations after the first block is mined
-    let invalidBlockTimestamp: bigint | undefined;
-    test.monitor.once('checkpoint', ({ checkpointNumber, timestamp }) => {
-      logger.warn(`Disabling skipCollectingAttestations after L2 block ${checkpointNumber} has been mined`);
-      invalidBlockTimestamp = timestamp;
+    let invalidCheckpointSlotNumber: SlotNumber | undefined;
+    test.monitor.once('checkpoint', ({ checkpointNumber, l2SlotNumber }) => {
+      logger.warn(
+        `Disabling skipCollectingAttestations after L2 block ${checkpointNumber} has been mined at L2 slot ${l2SlotNumber}`,
+        { checkpointNumber, l2SlotNumber },
+      );
+      invalidCheckpointSlotNumber = l2SlotNumber;
       sequencers.forEach(sequencer => {
         sequencer.updateConfig({ skipCollectingAttestations: false });
       });
@@ -571,10 +575,12 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     logger.warn(`CheckpointInvalidated event emitted`, { event });
     expect(event.args.checkpointNumber).toBeGreaterThan(initialBlockNumber);
 
-    // And check that the invalidation happened at least after the specified timeout
+    // And check that the invalidation happened at least after the specified timeout.
+    // We use the checkpoint header timestamp (L2 timestamp) since that's what the sequencer uses
+    // to calculate how long to wait before invalidating, not the L1 block timestamp when it landed.
+    const invalidSlotTimestamp = getTimestampForSlot(invalidCheckpointSlotNumber!, test.constants);
     const { timestamp: invalidationTimestamp } = await l1Client.getBlock({ blockNumber: event.blockNumber });
-    expect(invalidationTimestamp).toBeGreaterThanOrEqual(invalidBlockTimestamp! + BigInt(invalidationDelay));
-
+    expect(invalidationTimestamp).toBeGreaterThanOrEqual(invalidSlotTimestamp + BigInt(invalidationDelay));
     logger.warn(`Test succeeded '${expect.getState().currentTestName}'`);
   });
 });


### PR DESCRIPTION
We were testing the wrong timestamp in the e2e test (time when the checkpoint landed vs time of the slot). This should fix it.