### PR TITLE
fix(world-state): handle native instance closed during fork disposal

### DIFF
--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -292,7 +292,16 @@ export class MerkleTreesForkFacade extends MerkleTreesFacade implements MerkleTr
 
   public async close(): Promise<void> {
     assert.notEqual(this.revision.forkId, 0, 'Fork ID must be set');
-    await this.instance.call(WorldStateMessageType.DELETE_FORK, { forkId: this.revision.forkId });
+    try {
+      await this.instance.call(WorldStateMessageType.DELETE_FORK, { forkId: this.revision.forkId });
+    } catch (err: any) {
+      // Ignore errors due to native instance being closed during shutdown.
+      // This can happen when validators are still processing block proposals while the node is stopping.
+      if (err?.message === 'Native instance is closed') {
+        return;
+      }
+      throw err;
+    }
   }
 
   async [Symbol.dispose](): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixes a race condition where validators processing block proposals during node shutdown would hit an assertion failure when closing world state forks. See [here](http://ci.aztec-labs.com/fdcc212d8be62da3) for an example.

## Problem
During test teardown or node shutdown:
1. Validators may still be processing gossiped block proposals asynchronously
2. `BlockProposalHandler.reexecuteTransactions()` uses `using fork = await this.worldState.fork(...)`
3. Test/node teardown closes the native world state instance
4. When the fork's `Symbol.dispose` triggers `close()`, it tries to call the (now closed) native instance
5. The assertion `assert.equal(this.open, true, 'Native instance is closed')` fails

## Fix
Catch the "Native instance is closed" error in `MerkleTreesForkFacade.close()` and gracefully return. This is consistent with how `[Symbol.dispose]` already handles this case when `closeDelayMs` is set.

🤖 Generated with [Claude Code](https://claude.ai/code)