### PR TITLE
feat: re-introducing pagination in getPrivateLogsByTags and getPublicLogsByTagsFromContract

### DIFF
--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -173,12 +173,16 @@ export abstract class ArchiverDataSourceBase
     return blocks;
   }
 
-  public getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
-    return this.store.getPrivateLogsByTags(tags);
+  public getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]> {
+    return this.store.getPrivateLogsByTags(tags, page);
   }
 
-  public getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]> {
-    return this.store.getPublicLogsByTagsFromContract(contractAddress, tags);
+  public getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page?: number,
+  ): Promise<TxScopedL2Log[][]> {
+    return this.store.getPublicLogsByTagsFromContract(contractAddress, tags, page);
   }
 
   public getPublicLogs(filter: LogFilter): Promise<GetPublicLogsResponse> {

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -29,6 +29,7 @@ import {
   SerializableContractInstance,
   computePublicBytecodeCommitment,
 } from '@aztec/stdlib/contract';
+import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import { ContractClassLog, LogId } from '@aztec/stdlib/logs';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import {
@@ -2251,6 +2252,48 @@ describe('KVArchiverDataStore', () => {
         ],
       ]);
     });
+
+    describe('pagination', () => {
+      const paginationTag = makePrivateLogTag(1, 2, 1);
+
+      beforeEach(async () => {
+        // Add more blocks with the same tag to exceed MAX_LOGS_PER_TAG
+        for (let i = numBlocksForLogs; i < numBlocksForLogs + MAX_LOGS_PER_TAG + 5; i++) {
+          const previousArchive = logsCheckpoints[logsCheckpoints.length - 1].checkpoint.blocks[0].archive;
+          const newCheckpoint = await makeCheckpointWithLogs(i + 1, {
+            previousArchive,
+            numTxsPerBlock,
+            privateLogs: { numLogsPerTx: numPrivateLogsPerTx },
+          });
+          const newLog = newCheckpoint.checkpoint.blocks[0].body.txEffects[1].privateLogs[1];
+          newLog.fields[0] = paginationTag.value;
+          newCheckpoint.checkpoint.blocks[0].body.txEffects[1].privateLogs[1] = newLog;
+          await store.addCheckpoints([newCheckpoint]);
+          await store.addLogs([newCheckpoint.checkpoint.blocks[0]]);
+          logsCheckpoints.push(newCheckpoint);
+        }
+      });
+
+      it('returns first page of logs when page=0', async () => {
+        const logsByTags = await store.getPrivateLogsByTags([paginationTag], 0);
+
+        expect(logsByTags[0]).toHaveLength(MAX_LOGS_PER_TAG);
+        expect(logsByTags[0][0].blockNumber).toBe(1); // First log from block 1
+      });
+
+      it('returns second page of logs when page=1', async () => {
+        const logsByTags = await store.getPrivateLogsByTags([paginationTag], 1);
+
+        // Should have the remaining logs (total was MAX_LOGS_PER_TAG + 6, so page 1 has 6)
+        expect(logsByTags[0]).toHaveLength(6);
+      });
+
+      it('returns empty array when page is beyond available logs', async () => {
+        const logsByTags = await store.getPrivateLogsByTags([paginationTag], 100);
+
+        expect(logsByTags).toEqual([[]]);
+      });
+    });
   });
 
   describe('getPublicLogsByTagsFromContract', () => {
@@ -2350,6 +2393,48 @@ describe('KVArchiverDataStore', () => {
           }),
         ],
       ]);
+    });
+
+    describe('pagination', () => {
+      const paginationTag = makePublicLogTag(1, 2, 1);
+
+      beforeEach(async () => {
+        // Add more blocks with the same tag to exceed MAX_LOGS_PER_TAG
+        for (let i = numBlocksForLogs; i < numBlocksForLogs + MAX_LOGS_PER_TAG + 5; i++) {
+          const previousArchive = logsCheckpoints[logsCheckpoints.length - 1].checkpoint.blocks[0].archive;
+          const newCheckpoint = await makeCheckpointWithLogs(i + 1, {
+            previousArchive,
+            numTxsPerBlock,
+            publicLogs: { numLogsPerTx: numPublicLogsPerTx, contractAddress },
+          });
+          const newLog = newCheckpoint.checkpoint.blocks[0].body.txEffects[1].publicLogs[1];
+          newLog.fields[0] = paginationTag.value;
+          newCheckpoint.checkpoint.blocks[0].body.txEffects[1].publicLogs[1] = newLog;
+          await store.addCheckpoints([newCheckpoint]);
+          await store.addLogs([newCheckpoint.checkpoint.blocks[0]]);
+          logsCheckpoints.push(newCheckpoint);
+        }
+      });
+
+      it('returns first page of logs when page=0', async () => {
+        const logsByTags = await store.getPublicLogsByTagsFromContract(contractAddress, [paginationTag], 0);
+
+        expect(logsByTags[0]).toHaveLength(MAX_LOGS_PER_TAG);
+        expect(logsByTags[0][0].blockNumber).toBe(1); // First log from block 1
+      });
+
+      it('returns second page of logs when page=1', async () => {
+        const logsByTags = await store.getPublicLogsByTagsFromContract(contractAddress, [paginationTag], 1);
+
+        // Should have the remaining logs (total was MAX_LOGS_PER_TAG + 6, so page 1 has 6)
+        expect(logsByTags[0]).toHaveLength(6);
+      });
+
+      it('returns empty array when page is beyond available logs', async () => {
+        const logsByTags = await store.getPublicLogsByTagsFromContract(contractAddress, [paginationTag], 100);
+
+        expect(logsByTags).toEqual([[]]);
+      });
     });
   });
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -434,24 +434,33 @@ export class KVArchiverDataStore implements ContractDataSource {
   }
 
   /**
-   * Gets all private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
+   * Gets private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
    * array implies no logs match that tag.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination. Returns at most 10 logs per tag per page.
    */
-  getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
+  getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]> {
     try {
-      return this.#logStore.getPrivateLogsByTags(tags);
+      return this.#logStore.getPrivateLogsByTags(tags, page);
     } catch (err) {
       return Promise.reject(err);
     }
   }
 
   /**
-   * Gets all public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
+   * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
    * logs is returned. An empty array implies no logs match that tag.
+   * @param contractAddress - The contract address to search logs for.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination. Returns at most 10 logs per tag per page.
    */
-  getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]> {
+  getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page?: number,
+  ): Promise<TxScopedL2Log[][]> {
     try {
-      return this.#logStore.getPublicLogsByTagsFromContract(contractAddress, tags);
+      return this.#logStore.getPublicLogsByTagsFromContract(contractAddress, tags, page);
     } catch (err) {
       return Promise.reject(err);
     }

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -7,6 +7,7 @@ import { BufferReader, numToUInt32BE } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2BlockHash, L2BlockNew } from '@aztec/stdlib/block';
+import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import {
   ContractClassLog,
@@ -314,27 +315,49 @@ export class LogStore {
   }
 
   /**
-   * Gets all private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
+   * Gets private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
    * array implies no logs match that tag.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most MAX_LOGS_PER_TAG logs per tag per page. If
+   * MAX_LOGS_PER_TAG logs are returned for a tag, the caller should fetch the next page to check for more logs.
    */
-  async getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
+  async getPrivateLogsByTags(tags: SiloedTag[], page: number = 0): Promise<TxScopedL2Log[][]> {
     const logs = await Promise.all(tags.map(tag => this.#privateLogsByTag.getAsync(tag.toString())));
+    const start = page * MAX_LOGS_PER_TAG;
+    const end = start + MAX_LOGS_PER_TAG;
 
-    return logs.map(logBuffers => logBuffers?.map(logBuffer => TxScopedL2Log.fromBuffer(logBuffer)) ?? []);
+    return logs.map(
+      logBuffers => logBuffers?.slice(start, end).map(logBuffer => TxScopedL2Log.fromBuffer(logBuffer)) ?? [],
+    );
   }
 
   /**
-   * Gets all public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
+   * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
    * logs is returned. An empty array implies no logs match that tag.
+   * @param contractAddress - The contract address to search logs for.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most MAX_LOGS_PER_TAG logs per tag per page. If
+   * MAX_LOGS_PER_TAG logs are returned for a tag, the caller should fetch the next page to check for more logs.
    */
-  async getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]> {
+  async getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page: number = 0,
+  ): Promise<TxScopedL2Log[][]> {
     const logs = await Promise.all(
       tags.map(tag => {
         const key = `${contractAddress.toString()}_${tag.value.toString()}`;
         return this.#publicLogsByContractAndTag.getAsync(key);
       }),
     );
-    return logs.map(logBuffers => logBuffers?.map(logBuffer => TxScopedL2Log.fromBuffer(logBuffer)) ?? []);
+    const start = page * MAX_LOGS_PER_TAG;
+    const end = start + MAX_LOGS_PER_TAG;
+
+    return logs.map(
+      logBuffers => logBuffers?.slice(start, end).map(logBuffer => TxScopedL2Log.fromBuffer(logBuffer)) ?? [],
+    );
   }
 
   /**

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -700,12 +700,16 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return this.contractDataSource.getContract(address);
   }
 
-  public getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
-    return this.logsSource.getPrivateLogsByTags(tags);
+  public getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]> {
+    return this.logsSource.getPrivateLogsByTags(tags, page);
   }
 
-  public getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]> {
-    return this.logsSource.getPublicLogsByTagsFromContract(contractAddress, tags);
+  public getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page?: number,
+  ): Promise<TxScopedL2Log[][]> {
+    return this.logsSource.getPublicLogsByTagsFromContract(contractAddress, tags, page);
   }
 
   /**

--- a/yarn-project/stdlib/src/interfaces/api_limit.ts
+++ b/yarn-project/stdlib/src/interfaces/api_limit.ts
@@ -2,3 +2,4 @@ export const MAX_RPC_LEN = 100;
 export const MAX_RPC_TXS_LEN = 50;
 export const MAX_RPC_BLOCKS_LEN = 50;
 export const MAX_RPC_CHECKPOINTS_LEN = 50;
+export const MAX_LOGS_PER_TAG = 10;

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -127,11 +127,11 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL2Tips: z.function().args().returns(L2TipsSchema),
   getPrivateLogsByTags: z
     .function()
-    .args(z.array(SiloedTag.schema))
+    .args(z.array(SiloedTag.schema), optional(z.number().gte(0)))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
   getPublicLogsByTagsFromContract: z
     .function()
-    .args(schemas.AztecAddress, z.array(Tag.schema))
+    .args(schemas.AztecAddress, z.array(Tag.schema), optional(z.number().gte(0)))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
   getPublicLogs: z.function().args(LogFilterSchema).returns(GetPublicLogsResponseSchema),
   getContractClassLogs: z.function().args(LogFilterSchema).returns(GetContractClassLogsResponseSchema),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -343,16 +343,29 @@ export interface AztecNode
   getContractClassLogs(filter: LogFilter): Promise<GetContractClassLogsResponse>;
 
   /**
-   * Gets all private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
+   * Gets private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
    * array implies no logs match that tag.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
+   * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]>;
+  getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]>;
 
   /**
-   * Gets all public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
+   * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
    * logs is returned. An empty array implies no logs match that tag.
+   * @param contractAddress - The contract address to search logs for.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
+   * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]>;
+  getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page?: number,
+  ): Promise<TxScopedL2Log[][]>;
 
   /**
    * Method to submit a transaction to the p2p pool.
@@ -618,12 +631,12 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getPrivateLogsByTags: z
     .function()
-    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN))
+    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 
   getPublicLogsByTagsFromContract: z
     .function()
-    .args(schemas.AztecAddress, z.array(Tag.schema).max(MAX_RPC_LEN))
+    .args(schemas.AztecAddress, z.array(Tag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 
   sendTx: z.function().args(Tx.schema).returns(z.void()),

--- a/yarn-project/stdlib/src/interfaces/l2_logs_source.ts
+++ b/yarn-project/stdlib/src/interfaces/l2_logs_source.ts
@@ -12,16 +12,29 @@ import type { GetContractClassLogsResponse, GetPublicLogsResponse } from './get_
  */
 export interface L2LogsSource {
   /**
-   * Gets all private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
+   * Gets private logs that match any of the `tags`. For each tag, an array of matching logs is returned. An empty
    * array implies no logs match that tag.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
+   * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPrivateLogsByTags(tags: SiloedTag[]): Promise<TxScopedL2Log[][]>;
+  getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]>;
 
   /**
-   * Gets all public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
+   * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
    * logs is returned. An empty array implies no logs match that tag.
+   * @param contractAddress - The contract address to search logs for.
+   * @param tags - The tags to search for.
+   * @param page - The page number (0-indexed) for pagination.
+   * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
+   * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPublicLogsByTagsFromContract(contractAddress: AztecAddress, tags: Tag[]): Promise<TxScopedL2Log[][]>;
+  getPublicLogsByTagsFromContract(
+    contractAddress: AztecAddress,
+    tags: Tag[],
+    page?: number,
+  ): Promise<TxScopedL2Log[][]>;
 
   /**
    * Gets public logs based on the provided filter.


### PR DESCRIPTION
It has been decided that it makes sense to not have this assumption of there being some bounded num logs per tag (ie capped tag reuse) so I am re-introducing pagination this PR.

The log sync functionality will be updated in a PR up the stack to handle this.

No migration notes are necessary here since this is not a breaking change (the `page` arg is optional).

Closes https://linear.app/aztec-labs/issue/F-233/consider-handling-pagination-in-getlogsbytags-endpoints