### PR TITLE
fix: handling log pagination in PXE

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -13,7 +13,11 @@ import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_sto
 import { CapsuleStore } from '../storage/capsule_store/capsule_store.js';
 import type { RecipientTaggingStore } from '../storage/tagging_store/recipient_tagging_store.js';
 import type { SenderAddressBookStore } from '../storage/tagging_store/sender_address_book_store.js';
-import { loadPrivateLogsForSenderRecipientPair } from '../tagging/index.js';
+import {
+  getAllPrivateLogsByTags,
+  getAllPublicLogsByTagsFromContract,
+  loadPrivateLogsForSenderRecipientPair,
+} from '../tagging/index.js';
 
 export class LogService {
   private log = createLogger('log_service');
@@ -49,10 +53,10 @@ export class LogService {
   }
 
   async #getPublicLogByTag(tag: Tag, contractAddress: AztecAddress): Promise<LogRetrievalResponse | null> {
-    const logs = await this.aztecNode.getPublicLogsByTagsFromContract(contractAddress, [tag]);
-    const logsForTag = logs[0];
+    const allLogsPerTag = await getAllPublicLogsByTagsFromContract(this.aztecNode, contractAddress, [tag]);
+    const logsForTag = allLogsPerTag[0];
 
-    if (logsForTag.length == 0) {
+    if (logsForTag.length === 0) {
       return null;
     } else if (logsForTag.length > 1) {
       // TODO(#11627): handle this case
@@ -72,10 +76,10 @@ export class LogService {
   }
 
   async #getPrivateLogByTag(siloedTag: SiloedTag): Promise<LogRetrievalResponse | null> {
-    const logs = await this.aztecNode.getPrivateLogsByTags([siloedTag]);
-    const logsForTag = logs[0];
+    const allLogsPerTag = await getAllPrivateLogsByTags(this.aztecNode, [siloedTag]);
+    const logsForTag = allLogsPerTag[0];
 
-    if (logsForTag.length == 0) {
+    if (logsForTag.length === 0) {
       return null;
     } else if (logsForTag.length > 1) {
       // TODO(#11627): handle this case

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -1,0 +1,72 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
+import type { AztecNode } from '@aztec/stdlib/interfaces/server';
+import { SiloedTag, Tag } from '@aztec/stdlib/logs';
+import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { getAllPrivateLogsByTags } from './get_all_logs_by_tags.js';
+
+// We don't bother testing getAllPublicLogsByTagsFromContract because both of the functions are a simple wrapper around
+// getAllPages function so just testing the private logs function is enough.
+
+describe('getAllPrivateLogsByTags', () => {
+  let aztecNode: MockProxy<AztecNode>;
+  let tags: SiloedTag[];
+
+  beforeAll(async () => {
+    tags = await Promise.all(
+      [1, 2, 3].map(async () => SiloedTag.compute(new Tag(Fr.random()), await AztecAddress.random())),
+    );
+  });
+
+  beforeEach(() => {
+    aztecNode = mock<AztecNode>();
+  });
+
+  it('returns empty arrays when no logs found', async () => {
+    aztecNode.getPrivateLogsByTags.mockResolvedValue(tags.map(() => []));
+
+    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+
+    expect(result).toEqual([[], [], []]);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(tags, 0);
+  });
+
+  it('returns logs when all fit in a single page', async () => {
+    const logsPerTag = tags.map((tag, i) => Array(i + 1).fill(randomTxScopedPrivateL2Log({ tag: tag.value })));
+    aztecNode.getPrivateLogsByTags.mockResolvedValue(logsPerTag);
+
+    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+
+    expect(result.map(logs => logs.length)).toEqual([1, 2, 3]);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(1);
+  });
+
+  it('paginates when any tag has MAX_LOGS_PER_TAG logs', async () => {
+    const firstPage = [
+      Array(MAX_LOGS_PER_TAG).fill(randomTxScopedPrivateL2Log({ tag: tags[0].value })),
+      [randomTxScopedPrivateL2Log({ tag: tags[1].value })],
+      [],
+    ];
+    const secondPage = [Array(5).fill(randomTxScopedPrivateL2Log({ tag: tags[0].value })), [], []];
+
+    aztecNode.getPrivateLogsByTags.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
+
+    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+
+    expect(result.map(logs => logs.length)).toEqual([MAX_LOGS_PER_TAG + 5, 1, 0]);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(1, tags, 0);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, tags, 1);
+  });
+
+  it('handles empty tags array', async () => {
+    aztecNode.getPrivateLogsByTags.mockResolvedValue([]);
+
+    const result = await getAllPrivateLogsByTags(aztecNode, []);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -1,0 +1,56 @@
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
+import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import type { SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
+
+/**
+ * Generic pagination helper that fetches all pages of results.
+ * @param numTags - The number of tags being queried (determines result array size).
+ * @param fetchPage - Function that fetches a single page of results given a page number.
+ * @returns An array of arrays, one per tag, containing all results across all pages.
+ */
+async function getAllPages<T>(numTags: number, fetchPage: (page: number) => Promise<T[][]>): Promise<T[][]> {
+  const allResultsPerTag: T[][] = Array.from({ length: numTags }, () => []);
+  let page = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const resultsPage = await fetchPage(page);
+    hasMore = false;
+
+    for (let i = 0; i < resultsPage.length; i++) {
+      allResultsPerTag[i].push(...resultsPage[i]);
+      if (resultsPage[i].length === MAX_LOGS_PER_TAG) {
+        hasMore = true;
+      }
+    }
+    page++;
+  }
+
+  return allResultsPerTag;
+}
+
+/**
+ * Fetches all private logs for the given tags, automatically paginating through all pages.
+ * @param aztecNode - The Aztec node to query.
+ * @param tags - The siloed tags to search for.
+ * @returns An array of log arrays, one per tag, containing all logs across all pages.
+ */
+export function getAllPrivateLogsByTags(aztecNode: AztecNode, tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
+  return getAllPages(tags.length, page => aztecNode.getPrivateLogsByTags(tags, page));
+}
+
+/**
+ * Fetches all public logs for the given tags from a contract, automatically paginating through all pages.
+ * @param aztecNode - The Aztec node to query.
+ * @param contractAddress - The contract address to search logs for.
+ * @param tags - The tags to search for.
+ * @returns An array of log arrays, one per tag, containing all logs across all pages.
+ */
+export function getAllPublicLogsByTagsFromContract(
+  aztecNode: AztecNode,
+  contractAddress: AztecAddress,
+  tags: Tag[],
+): Promise<TxScopedL2Log[][]> {
+  return getAllPages(tags.length, page => aztecNode.getPublicLogsByTagsFromContract(contractAddress, tags, page));
+}

--- a/yarn-project/pxe/src/tagging/index.ts
+++ b/yarn-project/pxe/src/tagging/index.ts
@@ -12,6 +12,7 @@
 export { loadPrivateLogsForSenderRecipientPair } from './recipient_sync/load_private_logs_for_sender_recipient_pair.js';
 export { syncSenderTaggingIndexes } from './sender_sync/sync_sender_tagging_indexes.js';
 export { UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from './constants.js';
+export { getAllPrivateLogsByTags, getAllPublicLogsByTagsFromContract } from './get_all_logs_by_tags.js';
 
 // Re-export tagging-related types from stdlib
 export { DirectionalAppTaggingSecret, Tag, SiloedTag } from '@aztec/stdlib/logs';

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
@@ -4,6 +4,8 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, PreTag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
 
+import { getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
+
 /**
  * Gets private logs with their corresponding block timestamps and tagging indexes for the given index range, `app` and
  * `secret`. At most load logs from blocks up to and including `anchorBlockNumber`. `start` is inclusive and `end` is
@@ -25,7 +27,9 @@ export async function loadLogsForRange(
     Promise.all(tags.map(tag => SiloedTag.compute(tag, app))),
   );
 
-  const logs = await aztecNode.getPrivateLogsByTags(siloedTags);
+  // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
+  // pagination here.
+  const logs = await getAllPrivateLogsByTags(aztecNode, siloedTags);
 
   // Pair logs with their corresponding tagging indexes
   const logsWithIndexes: Array<{ log: TxScopedL2Log; taggingIndex: number }> = [];

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -5,6 +5,7 @@ import { SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import type { SenderTaggingStore } from '../../../storage/tagging_store/sender_tagging_store.js';
+import { getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
 
 /**
  * Loads tagging indexes from the Aztec node and stores them in the tagging data provider.
@@ -50,7 +51,9 @@ export async function loadAndStoreNewTaggingIndexes(
 // Returns txs that used the given tags. A tag might have been used in multiple txs and for this reason we return
 // an array for each tag.
 async function getTxsContainingTags(tags: SiloedTag[], aztecNode: AztecNode): Promise<TxHash[][]> {
-  const allLogs = await aztecNode.getPrivateLogsByTags(tags);
+  // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
+  // pagination here.
+  const allLogs = await getAllPrivateLogsByTags(aztecNode, tags);
   return allLogs.map(logs => logs.map(log => log.txHash));
 }
 


### PR DESCRIPTION
In a PR below I added pagination functionality to the `get*LogsByTags*` endpoints. In this PR I update PXE to handle this.