### PR TITLE
chore: deflake test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -348,11 +348,6 @@ tests:
     owners:
       - *spyros
 
-  - regex: "prover-client/src/proving_broker/proving_broker.test.ts"
-    error_regex: "1:PARITY_BASE"
-    owners:
-      - *alex
-
   # http://ci.aztec-labs.com/e8228a36afda93b8
   # Test passed but there was an error on stopping
   - regex: "playground/scripts/run_test.sh"

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.test.ts
@@ -291,14 +291,6 @@ describe.each([
   });
 
   describe('Consumer API', () => {
-    beforeEach(async () => {
-      await broker.start();
-    });
-
-    afterEach(async () => {
-      await broker.stop();
-    });
-
     it('returns undefined if no jobs are available', async () => {
       const provingJob = await broker.getProvingJob({ allowList: [ProvingRequestType.PARITY_BASE] });
       expect(provingJob).toBeUndefined();
@@ -546,6 +538,7 @@ describe.each([
     });
 
     it('returns a new job if job is already in progress elsewhere', async () => {
+      await broker.start();
       // this test simulates the broker crashing and when it comes back online it has two agents working the same job
       const job1: ProvingJob = {
         id: makeRandomProvingJobId(),
@@ -614,6 +607,7 @@ describe.each([
     });
 
     it('avoids sending the same job to a new agent after a restart', async () => {
+      await broker.start();
       // this test simulates the broker crashing and when it comes back online it has two agents working the same job
       const job1: ProvingJob = {
         id: makeRandomProvingJobId(),
@@ -669,6 +663,7 @@ describe.each([
     });
 
     it('avoids sending a completed job to a new agent after a restart', async () => {
+      await broker.start();
       // this test simulates the broker crashing and when it comes back online it has two agents working the same job
       const job1: ProvingJob = {
         id: makeRandomProvingJobId(),


### PR DESCRIPTION
Fix flake in the prover broker test. The issue was caused by the CI machine being overloaded and taking longer than expected to run the test.

The test set a 100ms timeout for proving jobs and a job timing out is be a fail condition. In CI, under load, the test could take 250-300ms to run leading to failure. This PR only starts the job timeout cleaning loop in the tests that need it.