### PR TITLE
feat: adding MAXIMUM_GOSSIP_CLOCK_DISPARITY for p2p validation

### DIFF
--- a/docs/docs-network/reference/changelog/v4.md
+++ b/docs/docs-network/reference/changelog/v4.md
@@ -57,6 +57,14 @@ aztec add-l1-validator --withdrawer-address <address>
 
 ## New features
 
+### P2P clock tolerance for slot validation
+
+Added a 500ms tolerance window for P2P messages from the previous slot, following Ethereum's `MAXIMUM_GOSSIP_CLOCK_DISPARITY` approach. This prevents peers from being penalized for valid messages that arrive slightly after the slot boundary due to network latency.
+
+The tolerance is hardcoded at 500ms (matching Ethereum's current value) and can be made configurable via environment variables in the future if needed.
+
+**Impact**: Improved network stability with no action required from node operators.
+
 ## Changed defaults
 
 ## Troubleshooting

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -77,7 +77,7 @@ describe('sentinel', () => {
       proofSubmissionEpochs: 1,
     };
 
-    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch, slot, ts, now: ts });
+    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch, slot, ts, nowMs: ts * 1000n });
     epochCache.getL1Constants.mockReturnValue(l1Constants);
 
     sentinel = new TestSentinel(epochCache, archiver, p2p, store, config, blockStream);
@@ -566,7 +566,7 @@ describe('sentinel', () => {
         epoch: epochNumber,
         slot,
         ts,
-        now: ts,
+        nowMs: ts * 1000n,
       });
       archiver.getL2Block.calledWith(blockNumber).mockResolvedValue(mockBlock);
       archiver.getL1Constants.mockResolvedValue(l1Constants);

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -36,7 +36,7 @@ export type SlotTag = 'now' | 'next' | SlotNumber;
 
 export interface EpochCacheInterface {
   getCommittee(slot: SlotTag | undefined): Promise<EpochCommitteeInfo>;
-  getEpochAndSlotNow(): EpochAndSlot;
+  getEpochAndSlotNow(): EpochAndSlot & { nowMs: bigint };
   getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint };
   getProposerIndexEncoding(epoch: EpochNumber, slot: SlotNumber, seed: bigint): `0x${string}`;
   computeProposerIndex(slot: SlotNumber, epoch: EpochNumber, seed: bigint, size: bigint): bigint;
@@ -134,9 +134,10 @@ export class EpochCache implements EpochCacheInterface {
     return this.l1constants;
   }
 
-  public getEpochAndSlotNow(): EpochAndSlot & { now: bigint } {
-    const now = this.nowInSeconds();
-    return { ...this.getEpochAndSlotAtTimestamp(now), now };
+  public getEpochAndSlotNow(): EpochAndSlot & { nowMs: bigint } {
+    const nowMs = BigInt(this.dateProvider.now());
+    const nowSeconds = nowMs / 1000n;
+    return { ...this.getEpochAndSlotAtTimestamp(nowSeconds), nowMs };
   }
 
   public nowInSeconds(): bigint {

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.test.ts
@@ -23,8 +23,8 @@ describe('CheckpointAttestationValidator', () => {
     attester = Secp256k1Signer.random();
   });
 
-  it('returns high tolerance error if slot number is not current or next slot', async () => {
-    // Create an attestation for slot 97
+  it('returns high tolerance error if slot number is not current or next slot (outside clock tolerance)', async () => {
+    // Create an attestation for slot 97 (previous slot)
     const header = CheckpointHeader.random({ slotNumber: SlotNumber(97) });
     const mockAttestation = makeCheckpointAttestation({
       header,
@@ -37,10 +37,45 @@ describe('CheckpointAttestationValidator', () => {
       currentSlot: SlotNumber(98),
       nextSlot: SlotNumber(99),
     });
+    // Mock getEpochAndSlotNow to return time OUTSIDE clock tolerance (1000ms elapsed)
+    (epochCache.getEpochAndSlotNow as jest.Mock).mockReturnValue({
+      epoch: 1,
+      slot: SlotNumber(98),
+      ts: 1000n, // slot started at 1000 seconds
+      nowMs: 1001000n, // 1000ms elapsed, outside 500ms tolerance
+    });
     (epochCache.isInCommittee as jest.Mock).mockResolvedValue(true);
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
+  });
+
+  it('returns ignore if previous slot attestation is within clock tolerance', async () => {
+    // Create an attestation for slot 97 (previous slot)
+    const header = CheckpointHeader.random({ slotNumber: SlotNumber(97) });
+    const mockAttestation = makeCheckpointAttestation({
+      header,
+      attesterSigner: attester,
+      proposerSigner: proposer,
+    });
+
+    // Mock epoch cache - attestation is for previous slot (97) when current is 98
+    (epochCache.getCurrentAndNextSlot as jest.Mock).mockReturnValue({
+      currentSlot: SlotNumber(98),
+      nextSlot: SlotNumber(99),
+    });
+    // Mock getEpochAndSlotNow to return time WITHIN clock tolerance (100ms elapsed)
+    (epochCache.getEpochAndSlotNow as jest.Mock).mockReturnValue({
+      epoch: 1,
+      slot: SlotNumber(98),
+      ts: 1000n, // slot started at 1000 seconds
+      nowMs: 1000100n, // 100ms elapsed, within 500ms tolerance
+    });
+    (epochCache.isInCommittee as jest.Mock).mockResolvedValue(true);
+    (epochCache.getProposerAttesterAddressInSlot as jest.Mock).mockResolvedValue(proposer.address);
+
+    const result = await validator.validate(mockAttestation);
+    expect(result).toEqual({ result: 'ignore' });
   });
 
   it('returns high tolerance error if attester is not in committee', async () => {
@@ -60,7 +95,7 @@ describe('CheckpointAttestationValidator', () => {
     (epochCache.isInCommittee as jest.Mock).mockResolvedValue(false);
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
   });
 
   it('returns undefined if checkpoint attestation is valid (current slot)', async () => {
@@ -81,7 +116,7 @@ describe('CheckpointAttestationValidator', () => {
     (epochCache.getProposerAttesterAddressInSlot as jest.Mock).mockResolvedValue(proposer.address);
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ result: 'accept' });
   });
 
   it('returns undefined if checkpoint attestation is valid (next slot)', async () => {
@@ -102,7 +137,7 @@ describe('CheckpointAttestationValidator', () => {
     (epochCache.getProposerAttesterAddressInSlot as jest.Mock).mockResolvedValue(proposer.address);
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ result: 'accept' });
   });
 
   it('returns high tolerance error if proposer signature is invalid', async () => {
@@ -122,7 +157,7 @@ describe('CheckpointAttestationValidator', () => {
     (epochCache.isInCommittee as jest.Mock).mockResolvedValue(true);
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
   });
 
   it('returns low tolerance error if no committee exists', async () => {
@@ -143,6 +178,6 @@ describe('CheckpointAttestationValidator', () => {
     (epochCache.getProposerAttesterAddressInSlot as jest.Mock).mockRejectedValue(new NoCommitteeError());
 
     const result = await validator.validate(mockAttestation);
-    expect(result).toBe(PeerErrorSeverity.LowToleranceError);
+    expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
   });
 });

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -1,7 +1,14 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { type CheckpointAttestation, type P2PValidator, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import {
+  type CheckpointAttestation,
+  type P2PValidator,
+  PeerErrorSeverity,
+  type ValidationResult,
+} from '@aztec/stdlib/p2p';
+
+import { isWithinClockTolerance } from '../clock_tolerance.js';
 
 export class CheckpointAttestationValidator implements P2PValidator<CheckpointAttestation> {
   protected epochCache: EpochCacheInterface;
@@ -12,30 +19,35 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
     this.logger = createLogger('p2p:checkpoint-attestation-validator');
   }
 
-  async validate(message: CheckpointAttestation): Promise<PeerErrorSeverity | undefined> {
+  async validate(message: CheckpointAttestation): Promise<ValidationResult> {
     const slotNumber = message.payload.header.slotNumber;
 
     try {
       const { currentSlot, nextSlot } = this.epochCache.getCurrentAndNextSlot();
 
       if (slotNumber !== currentSlot && slotNumber !== nextSlot) {
-        this.logger.warn(
-          `Checkpoint attestation slot ${slotNumber} is not current (${currentSlot}) or next (${nextSlot}) slot`,
-        );
-        return PeerErrorSeverity.HighToleranceError;
+        // Check if message is for previous slot and within clock tolerance
+        if (!isWithinClockTolerance(slotNumber, currentSlot, this.epochCache)) {
+          this.logger.warn(
+            `Checkpoint attestation slot ${slotNumber} is not current (${currentSlot}) or next (${nextSlot}) slot`,
+          );
+          return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        }
+        this.logger.debug(`Ignoring checkpoint attestation for previous slot ${slotNumber} within clock tolerance`);
+        return { result: 'ignore' };
       }
 
       // Verify the signature is valid
       const attester = message.getSender();
       if (attester === undefined) {
         this.logger.warn(`Invalid signature in checkpoint attestation for slot ${slotNumber}`);
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
 
       // Verify the attester is in the committee for this slot
       if (!(await this.epochCache.isInCommittee(slotNumber, attester))) {
         this.logger.warn(`Attester ${attester.toString()} is not in committee for slot ${slotNumber}`);
-        return PeerErrorSeverity.HighToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
       }
 
       // Verify the proposer signature matches the expected proposer for the attestation's slot
@@ -45,26 +57,26 @@ export class CheckpointAttestationValidator implements P2PValidator<CheckpointAt
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
       if (!expectedProposer) {
         this.logger.warn(`No proposer defined for slot ${slotNumber}`);
-        return PeerErrorSeverity.HighToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
       }
       if (!proposer) {
         this.logger.warn(`Invalid proposer signature in checkpoint attestation for slot ${slotNumber}`);
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
       if (!proposer.equals(expectedProposer)) {
         this.logger.warn(
           `Proposer signature mismatch in checkpoint attestation. ` +
             `Expected ${expectedProposer?.toString() ?? 'none'} but got ${proposer.toString()} for slot ${slotNumber}`,
         );
-        return PeerErrorSeverity.HighToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
       }
 
-      return undefined;
+      return { result: 'accept' };
     } catch (e) {
       // People shouldn't be sending us attestations if the committee doesn't exist
       if (e instanceof NoCommitteeError) {
         this.logger.warn(`No committee exists for checkpoint attestation for slot ${slotNumber}`);
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
       throw e;
     }

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.test.ts
@@ -33,7 +33,7 @@ describe('FishermanAttestationValidator', () => {
   });
 
   describe('base validation', () => {
-    it('returns high tolerance error if slot number is not current or next slot', async () => {
+    it('returns high tolerance error if slot number is not current or next slot (outside clock tolerance)', async () => {
       // Create an attestation for slot 97
       const header = CheckpointHeader.random({ slotNumber: SlotNumber(97) });
       const mockAttestation = makeCheckpointAttestation({
@@ -47,10 +47,17 @@ describe('FishermanAttestationValidator', () => {
         currentSlot: SlotNumber(98),
         nextSlot: SlotNumber(99),
       });
+      // Mock getEpochAndSlotNow to return time OUTSIDE clock tolerance (1000ms elapsed)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: SlotNumber(98),
+        ts: 1000n, // slot started at 1000 seconds
+        nowMs: 1001000n, // 1000ms elapsed, outside 500ms tolerance
+      });
       epochCache.isInCommittee.mockResolvedValue(true);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
 
       // Should not check attestation pool if base validation fails
       expect(attestationPool.getCheckpointProposal).not.toHaveBeenCalled();
@@ -73,7 +80,7 @@ describe('FishermanAttestationValidator', () => {
       epochCache.isInCommittee.mockResolvedValue(false);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
 
       // Should not check attestation pool if base validation fails
       expect(attestationPool.getCheckpointProposal).not.toHaveBeenCalled();
@@ -95,7 +102,7 @@ describe('FishermanAttestationValidator', () => {
       epochCache.isInCommittee.mockResolvedValue(true);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
 
       // Should not check attestation pool if base validation fails
       expect(attestationPool.getCheckpointProposal).not.toHaveBeenCalled();
@@ -135,7 +142,7 @@ describe('FishermanAttestationValidator', () => {
       attestationPool.getCheckpointProposal.mockResolvedValue(mockProposal);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ result: 'accept' });
 
       // Should have checked the proposal
       expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
@@ -162,7 +169,7 @@ describe('FishermanAttestationValidator', () => {
       attestationPool.getCheckpointProposal.mockResolvedValue(mockProposal);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.LowToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
 
       // Should have checked the proposal
       expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
@@ -180,7 +187,7 @@ describe('FishermanAttestationValidator', () => {
       attestationPool.getCheckpointProposal.mockResolvedValue(undefined);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ result: 'accept' });
 
       // Should have tried to check the proposal
       expect(attestationPool.getCheckpointProposal).toHaveBeenCalledWith(mockAttestation.archive.toString());
@@ -206,7 +213,7 @@ describe('FishermanAttestationValidator', () => {
       attestationPool.getCheckpointProposal.mockResolvedValue(mockProposal);
 
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.LowToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
     });
 
     it('detects payload mismatch with different header hash', async () => {
@@ -231,7 +238,7 @@ describe('FishermanAttestationValidator', () => {
 
       // Headers are different, so payloads should be different
       const result = await validator.validate(mockAttestation);
-      expect(result).toBe(PeerErrorSeverity.LowToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
     });
   });
 

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/fisherman_attestation_validator.ts
@@ -1,5 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { type CheckpointAttestation, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { type CheckpointAttestation, PeerErrorSeverity, type ValidationResult } from '@aztec/stdlib/p2p';
 import { Attributes, Metrics, type TelemetryClient } from '@aztec/telemetry-client';
 
 import type { AttestationPool } from '../../mem_pools/attestation_pool/attestation_pool.js';
@@ -28,10 +28,10 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
     this.invalidAttestationCounter = meter.createUpDownCounter(Metrics.VALIDATOR_INVALID_ATTESTATION_RECEIVED_COUNT);
   }
 
-  override async validate(message: CheckpointAttestation): Promise<PeerErrorSeverity | undefined> {
+  override async validate(message: CheckpointAttestation): Promise<ValidationResult> {
     // First run the standard validation
     const baseValidationResult = await super.validate(message);
-    if (baseValidationResult !== undefined) {
+    if (baseValidationResult.result !== 'accept') {
       // Track base validation failures (invalid signature, wrong committee, etc.)
       this.invalidAttestationCounter.add(1, {
         [Attributes.ERROR_TYPE]: 'base_validation_failed',
@@ -45,7 +45,7 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
     const proposer = message.getProposer();
 
     if (!attester || !proposer) {
-      return undefined;
+      return { result: 'accept' };
     }
 
     const proposalId = message.archive.toString();
@@ -74,7 +74,7 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
         });
 
         // Return error to reject the message, but LibP2PService won't penalize in fisherman mode
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
     } else {
       // We might receive attestations before proposals in some cases
@@ -83,6 +83,6 @@ export class FishermanAttestationValidator extends CheckpointAttestationValidato
       );
     }
 
-    return undefined;
+    return { result: 'accept' };
   }
 }

--- a/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
+++ b/yarn-project/p2p/src/msg_validators/clock_tolerance.test.ts
@@ -1,0 +1,186 @@
+import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { SlotNumber } from '@aztec/foundation/branded-types';
+
+import { mock } from 'jest-mock-extended';
+
+import { MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS, isWithinClockTolerance } from './clock_tolerance.js';
+
+describe('clock_tolerance', () => {
+  describe('MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS', () => {
+    it('is set to 500ms', () => {
+      expect(MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS).toBe(500);
+    });
+  });
+
+  describe('isWithinClockTolerance', () => {
+    let epochCache: ReturnType<typeof mock<EpochCacheInterface>>;
+
+    beforeEach(() => {
+      epochCache = mock<EpochCacheInterface>();
+    });
+
+    it('returns true for previous slot message within tolerance window (100ms elapsed)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99); // previous slot
+
+      // Slot started at 1000 seconds (1000000ms), now is 1000100ms (100ms elapsed)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n, // seconds
+        nowMs: 1000100n, // 100ms after slot start
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(true);
+    });
+
+    it('returns true at exactly 499ms elapsed (just under tolerance)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99);
+
+      // 499ms elapsed - should be within tolerance (499 < 500)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000499n,
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(true);
+    });
+
+    it('returns false at exactly 500ms elapsed (at boundary)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99);
+
+      // 500ms elapsed - should be outside tolerance (500 is NOT < 500)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000500n,
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false at 501ms elapsed (just over tolerance)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99);
+
+      // 501ms elapsed - clearly outside tolerance
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000501n,
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false for previous slot message well outside tolerance (1000ms elapsed)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99);
+
+      // 1000ms elapsed - outside 500ms tolerance
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1001000n,
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false for message two slots behind (currentSlot - 2)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(98); // two slots behind
+
+      // Even within time tolerance, should reject slots older than previous
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000000n, // 0ms elapsed
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false for current slot message (handled by main validation)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(100); // current slot
+
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000000n,
+      });
+
+      // Current slot messages are handled by the main validation, not clock tolerance
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false for next slot message (handled by main validation)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(101); // next slot
+
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000000n,
+      });
+
+      // Next slot messages are handled by the main validation, not clock tolerance
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false when current slot is 0 (genesis edge case)', () => {
+      const currentSlot = SlotNumber(0);
+      const messageSlot = SlotNumber(0);
+
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 0 as any,
+        slot: currentSlot,
+        ts: 0n,
+        nowMs: 0n,
+      });
+
+      // Cannot have a previous slot when at genesis
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns false for future slot message', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(105); // future slot
+
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000000n,
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(false);
+    });
+
+    it('returns true at 0ms elapsed (exactly at slot boundary)', () => {
+      const currentSlot = SlotNumber(100);
+      const messageSlot = SlotNumber(99);
+
+      // 0ms elapsed - definitely within tolerance
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n,
+        nowMs: 1000000n, // exactly at slot start
+      });
+
+      expect(isWithinClockTolerance(messageSlot, currentSlot, epochCache)).toBe(true);
+    });
+  });
+});

--- a/yarn-project/p2p/src/msg_validators/clock_tolerance.ts
+++ b/yarn-project/p2p/src/msg_validators/clock_tolerance.ts
@@ -1,0 +1,51 @@
+import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { SlotNumber } from '@aztec/foundation/branded-types';
+
+/**
+ * Maximum clock disparity tolerance for P2P message validation (in milliseconds).
+ * Messages for the previous slot are accepted if we're within this many milliseconds
+ * of the current slot start. This prevents penalizing peers for messages that
+ * were valid when sent but arrived slightly late due to network latency.
+ *
+ * This follows Ethereum's MAXIMUM_GOSSIP_CLOCK_DISPARITY approach.
+ */
+export const MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS = 500;
+
+/**
+ * Checks if a message for the previous slot should be accepted due to clock tolerance.
+ *
+ * @param messageSlot - The slot number from the received message
+ * @param currentSlot - The current slot number
+ * @param epochCache - EpochCache to get timing information
+ * @returns true if the message is for the previous slot AND we're within the clock tolerance window
+ */
+export function isWithinClockTolerance(
+  messageSlot: SlotNumber,
+  currentSlot: SlotNumber,
+  epochCache: EpochCacheInterface,
+): boolean {
+  // Guard against slot 0 edge case (genesis)
+  if (currentSlot === SlotNumber.ZERO) {
+    return false;
+  }
+
+  // Only apply tolerance to messages for the previous slot
+  const previousSlot = SlotNumber(currentSlot - 1);
+  if (messageSlot !== previousSlot) {
+    return false;
+  }
+
+  // Check how far we are into the current slot (in milliseconds)
+  const { ts: slotStartTs, nowMs, slot } = epochCache.getEpochAndSlotNow();
+
+  // Sanity check: ensure the epoch cache's current slot matches the expected current slot
+  if (slot !== currentSlot) {
+    return false;
+  }
+
+  // ts is in seconds, convert to ms; nowMs is already in milliseconds
+  const slotStartMs = slotStartTs * 1000n;
+  const elapsedMs = Number(nowMs - slotStartMs);
+
+  return elapsedMs < MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS;
+}

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -1,7 +1,9 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { BlockProposal, CheckpointProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { BlockProposal, CheckpointProposal, PeerErrorSeverity, type ValidationResult } from '@aztec/stdlib/p2p';
+
+import { isWithinClockTolerance } from '../clock_tolerance.js';
 
 export abstract class ProposalValidator<TProposal extends BlockProposal | CheckpointProposal> {
   protected epochCache: EpochCacheInterface;
@@ -14,21 +16,26 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
     this.logger = createLogger(loggerName);
   }
 
-  public async validate(proposal: TProposal): Promise<PeerErrorSeverity | undefined> {
+  public async validate(proposal: TProposal): Promise<ValidationResult> {
     try {
       // Slot check
       const { currentSlot, nextSlot } = this.epochCache.getCurrentAndNextSlot();
       const slotNumber = proposal.slotNumber;
       if (slotNumber !== currentSlot && slotNumber !== nextSlot) {
-        this.logger.debug(`Penalizing peer for invalid slot number ${slotNumber}`, { currentSlot, nextSlot });
-        return PeerErrorSeverity.HighToleranceError;
+        // Check if message is for previous slot and within clock tolerance
+        if (!isWithinClockTolerance(slotNumber, currentSlot, this.epochCache)) {
+          this.logger.debug(`Penalizing peer for invalid slot number ${slotNumber}`, { currentSlot, nextSlot });
+          return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
+        }
+        this.logger.debug(`Ignoring proposal for previous slot ${slotNumber} within clock tolerance`);
+        return { result: 'ignore' };
       }
 
       // Signature validity
       const proposer = proposal.getSender();
       if (!proposer) {
         this.logger.debug(`Penalizing peer for proposal with invalid signature`);
-        return PeerErrorSeverity.MidToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
       // Transactions permitted check
@@ -37,7 +44,7 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
         this.logger.debug(
           `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when transactions are not permitted`,
         );
-        return PeerErrorSeverity.MidToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
       // Embedded txs must be listed in txHashes
@@ -52,7 +59,7 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
           txHashesLength: proposal.txHashes.length,
           missingTxHashes,
         });
-        return PeerErrorSeverity.MidToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
       // Proposer check
@@ -62,7 +69,7 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
           expectedProposer,
           proposer: proposer.toString(),
         });
-        return PeerErrorSeverity.MidToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
       // Validate tx hashes for all txs embedded in the proposal
@@ -71,13 +78,13 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
           proposer,
           slotNumber,
         });
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
 
-      return undefined;
+      return { result: 'accept' };
     } catch (e) {
       if (e instanceof NoCommitteeError) {
-        return PeerErrorSeverity.LowToleranceError;
+        return { result: 'reject', severity: PeerErrorSeverity.LowToleranceError };
       }
       throw e;
     }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator_test_suite.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator_test_suite.ts
@@ -1,7 +1,12 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import type { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { type BlockProposal, type CheckpointProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import {
+  type BlockProposal,
+  type CheckpointProposal,
+  PeerErrorSeverity,
+  type ValidationResult,
+} from '@aztec/stdlib/p2p';
 import type { TxHash } from '@aztec/stdlib/tx';
 
 import type { MockProxy } from 'jest-mock-extended';
@@ -10,7 +15,7 @@ export interface ProposalValidatorTestParams<TProposal extends BlockProposal | C
   validatorFactory: (
     epochCache: EpochCacheInterface,
     opts: { txsPermitted: boolean },
-  ) => { validate: (proposal: TProposal) => Promise<PeerErrorSeverity | undefined> };
+  ) => { validate: (proposal: TProposal) => Promise<ValidationResult> };
   makeProposal: (options?: any) => Promise<TProposal>;
   makeHeader: (epochNumber: number | bigint, slotNumber: number | bigint, blockNumber: number | bigint) => any;
   getSigner: () => Secp256k1Signer;
@@ -29,17 +34,21 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
   describe('shared proposal validation logic', () => {
     let epochCache: MockProxy<EpochCacheInterface>;
-    let validator: { validate: (proposal: TProposal) => Promise<PeerErrorSeverity | undefined> };
+    let validator: { validate: (proposal: TProposal) => Promise<ValidationResult> };
+    const previousSlot = getSlot(99);
     const currentSlot = getSlot(100);
     const nextSlot = getSlot(101);
 
-    function mockGetProposer(currentProposer: EthAddress, nextProposer: EthAddress) {
+    function mockGetProposer(currentProposer: EthAddress, nextProposer: EthAddress, previousProposer?: EthAddress) {
       epochCache.getProposerAttesterAddressInSlot.mockImplementation(slot => {
         if (slot === currentSlot) {
           return Promise.resolve(currentProposer);
         }
         if (slot === nextSlot) {
           return Promise.resolve(nextProposer);
+        }
+        if (slot === previousSlot && previousProposer) {
+          return Promise.resolve(previousProposer);
         }
         throw new Error('Unexpected argument');
       });
@@ -54,16 +63,46 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
       });
     });
 
-    it('returns high tolerance error if slot number is not current or next slot', async () => {
+    it('returns high tolerance error if slot number is not current or next slot (outside clock tolerance)', async () => {
       const header = makeHeader(1, 99, 99);
       const mockProposal = await makeProposal({ blockHeader: header, lastBlockHeader: header });
 
+      // Mock getEpochAndSlotNow to return time OUTSIDE clock tolerance (1000ms elapsed)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n, // slot started at 1000 seconds
+        nowMs: 1001000n, // 1000ms elapsed, outside 500ms tolerance
+      });
+
       epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(getAddress());
       const result = await validator.validate(mockProposal);
-      expect(result).toBe(PeerErrorSeverity.HighToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.HighToleranceError });
 
       // Should not try to resolve proposers if base validation fails
       expect(epochCache.getProposerAttesterAddressInSlot).not.toHaveBeenCalled();
+    });
+
+    it('returns ignore if previous slot proposal is within clock tolerance', async () => {
+      const previousProposer = getSigner();
+      const header = makeHeader(1, 99, 99);
+      const mockProposal = await makeProposal({
+        blockHeader: header,
+        lastBlockHeader: header,
+        signer: previousProposer,
+      });
+
+      // Mock getEpochAndSlotNow to return time WITHIN clock tolerance (100ms elapsed)
+      epochCache.getEpochAndSlotNow.mockReturnValue({
+        epoch: 1 as any,
+        slot: currentSlot,
+        ts: 1000n, // slot started at 1000 seconds
+        nowMs: 1000100n, // 100ms elapsed, within 500ms tolerance
+      });
+
+      mockGetProposer(getAddress(), getAddress(), getAddress(previousProposer));
+      const result = await validator.validate(mockProposal);
+      expect(result).toEqual({ result: 'ignore' });
     });
 
     it('returns mid tolerance error if proposer is not current proposer for current slot', async () => {
@@ -79,7 +118,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
-      expect(result).toBe(PeerErrorSeverity.MidToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
     });
 
     it('returns mid tolerance error if proposer is not next proposer for next slot', async () => {
@@ -95,7 +134,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
-      expect(result).toBe(PeerErrorSeverity.MidToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
     });
 
     it('returns mid tolerance error if proposer is current proposer but proposal is for next slot', async () => {
@@ -110,7 +149,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
-      expect(result).toBe(PeerErrorSeverity.MidToleranceError);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
     });
 
     it('returns undefined if proposal is valid for current slot and proposer', async () => {
@@ -125,7 +164,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ result: 'accept' });
     });
 
     it('returns undefined if proposal is valid for next slot and proposer', async () => {
@@ -136,7 +175,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
-      expect(result).toBeUndefined();
+      expect(result).toEqual({ result: 'accept' });
     });
 
     describe('transaction permission validation', () => {
@@ -153,7 +192,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
         mockGetProposer(getAddress(currentProposer), getAddress());
         const result = await validatorWithTxsDisabled.validate(mockProposal);
-        expect(result).toBe(PeerErrorSeverity.MidToleranceError);
+        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
       });
 
       it('returns undefined if txs not permitted but proposal has no txHashes', async () => {
@@ -169,7 +208,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
         mockGetProposer(getAddress(currentProposer), getAddress());
         const result = await validatorWithTxsDisabled.validate(mockProposal);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({ result: 'accept' });
       });
 
       it('returns undefined if txs permitted and proposal contains txHashes', async () => {
@@ -184,7 +223,7 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
 
         mockGetProposer(getAddress(currentProposer), getAddress());
         const result = await validator.validate(mockProposal);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({ result: 'accept' });
       });
     });
   });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -20,6 +20,7 @@ import {
   type Gossipable,
   P2PClientType,
   P2PMessage,
+  type ValidationResult as P2PValidationResult,
   PeerErrorSeverity,
   TopicType,
   createTopicString,
@@ -924,7 +925,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const validationFunc: () => Promise<ReceivedMessageValidationResult<CheckpointAttestation>> = async () => {
       const attestation = CheckpointAttestation.fromBuffer(payloadData);
       const pool = this.mempools.attestationPool;
-      const isValid = await this.validateCheckpointAttestation(source, attestation);
+      const validationResult = await this.validateCheckpointAttestation(source, attestation);
+      const isValid = validationResult.result === 'accept';
       const exists = isValid && (await pool.hasCheckpointAttestation(attestation));
 
       let canAdd = true;
@@ -943,9 +945,9 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
         [Attributes.P2P_ID]: source.toString(),
       });
 
-      if (!isValid) {
+      if (validationResult.result === 'reject') {
         return { result: TopicValidatorResult.Reject };
-      } else if (exists) {
+      } else if (validationResult.result === 'ignore' || exists) {
         return { result: TopicValidatorResult.Ignore, obj: attestation };
       } else if (!canAdd) {
         this.logger.warn(`Dropping checkpoint attestation due to per-(slot, proposalId) attestation cap`, {
@@ -986,7 +988,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   private async processBlockFromPeer(payloadData: Buffer, msgId: string, source: PeerId): Promise<void> {
     const validationFunc: () => Promise<ReceivedMessageValidationResult<BlockProposal>> = async () => {
       const block = BlockProposal.fromBuffer(payloadData);
-      const isValid = await this.validateBlockProposal(source, block);
+      const validationResult = await this.validateBlockProposal(source, block);
+      const isValid = validationResult.result === 'accept';
       const pool = this.mempools.attestationPool;
 
       const exists = isValid && (await pool.hasBlockProposal(block));
@@ -1000,9 +1003,9 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
         [Attributes.P2P_ID]: source.toString(),
       });
 
-      if (!isValid) {
+      if (validationResult.result === 'reject') {
         return { result: TopicValidatorResult.Reject };
-      } else if (exists) {
+      } else if (validationResult.result === 'ignore' || exists) {
         return { result: TopicValidatorResult.Ignore, obj: block };
       } else if (!canAdd) {
         this.peerManager.penalizePeer(source, PeerErrorSeverity.MidToleranceError);
@@ -1082,7 +1085,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     // TODO(palla/mbps): This pattern is repeated across multiple message handlers, consider abstracting it.
     const validationFunc: () => Promise<ReceivedMessageValidationResult<CheckpointProposal>> = async () => {
       const checkpoint = CheckpointProposal.fromBuffer(payloadData);
-      const isValid = await this.validateCheckpointProposal(source, checkpoint);
+      const validationResult = await this.validateCheckpointProposal(source, checkpoint);
+      const isValid = validationResult.result === 'accept';
       const pool = this.mempools.attestationPool;
 
       const exists = isValid && (await pool.hasCheckpointProposal(checkpoint));
@@ -1096,9 +1100,9 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
         [Attributes.P2P_ID]: source.toString(),
       });
 
-      if (!isValid) {
+      if (validationResult.result === 'reject') {
         return { result: TopicValidatorResult.Reject };
-      } else if (exists) {
+      } else if (validationResult.result === 'ignore' || exists) {
         return { result: TopicValidatorResult.Ignore, obj: checkpoint };
       } else if (!canAdd) {
         this.peerManager.penalizePeer(source, PeerErrorSeverity.MidToleranceError);
@@ -1576,15 +1580,18 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     [Attributes.BLOCK_ARCHIVE]: attestation.archive.toString(),
     [Attributes.P2P_ID]: await attestation.p2pMessageLoggingIdentifier().then(i => i.toString()),
   }))
-  public async validateCheckpointAttestation(peerId: PeerId, attestation: CheckpointAttestation): Promise<boolean> {
-    const severity = await this.checkpointAttestationValidator.validate(attestation);
-    if (severity) {
+  public async validateCheckpointAttestation(
+    peerId: PeerId,
+    attestation: CheckpointAttestation,
+  ): Promise<P2PValidationResult> {
+    const result = await this.checkpointAttestationValidator.validate(attestation);
+
+    if (result.result === 'reject') {
       this.logger.debug(`Penalizing peer ${peerId} for checkpoint attestation validation failure`);
-      this.peerManager.penalizePeer(peerId, severity);
-      return false;
+      this.peerManager.penalizePeer(peerId, result.severity);
     }
 
-    return true;
+    return result;
   }
 
   /**
@@ -1596,15 +1603,15 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   @trackSpan('Libp2pService.validateBlockProposal', (_peerId, block) => ({
     [Attributes.SLOT_NUMBER]: block.slotNumber.toString(),
   }))
-  public async validateBlockProposal(peerId: PeerId, block: BlockProposal): Promise<boolean> {
-    const severity = await this.blockProposalValidator.validate(block);
-    if (severity) {
+  public async validateBlockProposal(peerId: PeerId, block: BlockProposal): Promise<P2PValidationResult> {
+    const result = await this.blockProposalValidator.validate(block);
+
+    if (result.result === 'reject') {
       this.logger.debug(`Penalizing peer ${peerId} for block proposal validation failure`);
-      this.peerManager.penalizePeer(peerId, severity);
-      return false;
+      this.peerManager.penalizePeer(peerId, result.severity);
     }
 
-    return true;
+    return result;
   }
 
   /**
@@ -1616,15 +1623,18 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   @trackSpan('Libp2pService.validateCheckpointProposal', (_peerId, checkpoint) => ({
     [Attributes.SLOT_NUMBER]: checkpoint.slotNumber.toString(),
   }))
-  public async validateCheckpointProposal(peerId: PeerId, checkpoint: CheckpointProposal): Promise<boolean> {
-    const severity = await this.checkpointProposalValidator.validate(checkpoint);
-    if (severity) {
+  public async validateCheckpointProposal(
+    peerId: PeerId,
+    checkpoint: CheckpointProposal,
+  ): Promise<P2PValidationResult> {
+    const result = await this.checkpointProposalValidator.validate(checkpoint);
+
+    if (result.result === 'reject') {
       this.logger.debug(`Penalizing peer ${peerId} for checkpoint proposal validation failure`);
-      this.peerManager.penalizePeer(peerId, severity);
-      return false;
+      this.peerManager.penalizePeer(peerId, result.severity);
     }
 
-    return true;
+    return result;
   }
 
   public getPeerScore(peerId: PeerId): number {

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -89,7 +89,7 @@ function mockEpochCache(): EpochCacheInterface {
   return {
     getCommittee: () => Promise.resolve({ committee: [], seed: 1n, epoch: EpochNumber.ZERO, isEscapeHatchOpen: false }),
     getProposerIndexEncoding: () => '0x' as `0x${string}`,
-    getEpochAndSlotNow: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n }),
+    getEpochAndSlotNow: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n, nowMs: 0n }),
     computeProposerIndex: () => 0n,
     getCurrentAndNextSlot: () => ({
       currentSlot: SlotNumber.ZERO,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -133,7 +133,7 @@ describe('SequencerPublisher', () => {
     slashFactoryContract = mock<SlashFactoryContract>();
 
     const epochCache = mock<EpochCache>();
-    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 3n, now: 3n });
+    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 3n, nowMs: 3000n });
     epochCache.getCommittee.mockResolvedValue({
       committee: [],
       seed: 1n,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
@@ -286,8 +286,8 @@ describe('CheckpointVoter HA Integration', () => {
     epochCache.getEpochAndSlotNow.mockReturnValue({
       epoch: EpochNumber(1),
       slot: slot,
-      ts: BigInt(Date.now()),
-      now: BigInt(Date.now()),
+      ts: BigInt(Math.floor(Date.now() / 1000)),
+      nowMs: BigInt(Date.now()),
     });
 
     const slashFactoryContract = mock<SlashFactoryContract>();

--- a/yarn-project/stdlib/src/p2p/message_validator.ts
+++ b/yarn-project/stdlib/src/p2p/message_validator.ts
@@ -1,10 +1,22 @@
 import type { PeerErrorSeverity } from './peer_error.js';
 
 /**
+ * Result of validating a P2P message.
+ * - 'accept': Message is valid and should be accepted and processed
+ * - 'ignore': Message should be ignored (not propagated or processed, but sender not penalized)
+ * - 'reject': Message is invalid (rejected and sender penalized)
+ */
+export type ValidationResult =
+  | { result: 'accept' }
+  | { result: 'ignore' }
+  | { result: 'reject'; severity: PeerErrorSeverity };
+
+/**
  * P2PValidator
  *
- * A validator for P2P messages, which returns a severity of error to be applied to the peer
+ * A validator for P2P messages, which returns a ValidationResult indicating
+ * whether to accept, ignore, or reject the message
  */
 export interface P2PValidator<T> {
-  validate(message: T): Promise<PeerErrorSeverity | undefined>;
+  validate(message: T): Promise<ValidationResult>;
 }

--- a/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
+++ b/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
@@ -16,11 +16,12 @@ export class MockEpochCache implements EpochCacheInterface {
     });
   }
 
-  getEpochAndSlotNow(): EpochAndSlot {
+  getEpochAndSlotNow(): EpochAndSlot & { nowMs: bigint } {
     return {
       epoch: EpochNumber.ZERO,
       slot: SlotNumber(0),
       ts: 0n,
+      nowMs: 0n,
     };
   }
 

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -147,8 +147,8 @@ export class BlockProposalHandler {
 
     // Check that the proposal is from the current proposer, or the next proposer
     // This should have been handled by the p2p layer, but we double check here out of caution
-    const invalidProposal = await this.blockProposalValidator.validate(proposal);
-    if (invalidProposal) {
+    const validationResult = await this.blockProposalValidator.validate(proposal);
+    if (validationResult.result !== 'accept') {
       this.log.warn(`Proposal is not valid, skipping processing`, proposalInfo);
       return { isValid: false, reason: 'invalid_proposal' };
     }


### PR DESCRIPTION
## Summary

Adds clock tolerance for P2P message slot validation, following Ethereum's `MAXIMUM_GOSSIP_CLOCK_DISPARITY` approach.

**Problem:** P2P message validators currently reject messages (and penalize peers) if the message slot is not the current or next slot. This causes issues when valid messages are sent at the end of a slot and arrive slightly after the slot boundary due to network latency.

**Solution:** Add a 500ms tolerance window for messages from the previous slot. If we're within 500ms of the current slot start, we accept messages for the previous slot instead of penalizing the peer.

### Why only check the previous slot?

The validators already accept messages for both the **current slot** and the **next slot**. This means:
- **Future messages (next slot):** Already allowed - no change needed
- **Late messages (previous slot):** Now allowed within the 500ms tolerance window
- **Older messages (2+ slots behind):** Still rejected - these are too stale

Since we already permit early messages for the next slot, the only gap was handling slightly late messages for the previous slot. This change closes that gap.

### Key implementation details

- `MAXIMUM_GOSSIP_CLOCK_DISPARITY_MS = 500` (milliseconds) - hardcoded to match Ethereum's current value. Can be made configurable via environment variables in the future if needed.
- Uses millisecond precision for accurate boundary checking
- Both attestation and proposal validators now use the shared `isWithinClockTolerance()` helper
- Late messages within tolerance continue normal validation (proposer/attester checks still apply using the message's slot)

## Test plan

- [x] Unit tests for `isWithinClockTolerance()` with boundary cases (499ms, 500ms, 501ms)
- [x] Updated attestation validator tests for clock tolerance scenarios
- [x] Updated proposal validator tests for clock tolerance scenarios
- [x] All existing tests pass

---

Fixes A-319
