### PR TITLE
chore: (A-468) add pre/post flight health checks to tests

### DIFF
--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -17,7 +17,7 @@ import {
   createWalletAndAztecNodeClient,
   deploySponsoredTestAccountsWithTokens,
 } from './setup_test_wallets.js';
-import { setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
+import { ChainHealth, setupEnvironment, startPortForwardForEthereum, startPortForwardForRPC } from './utils.js';
 
 const config = { ...setupEnvironment(process.env) };
 
@@ -39,13 +39,16 @@ describe('token transfer test', () => {
   let wallet: TestWallet;
   let aztecNode: AztecNode;
   let cleanup: undefined | (() => Promise<void>);
+  const health = new ChainHealth(config.NAMESPACE, logger);
 
   afterAll(async () => {
+    await health.teardown();
     await cleanup?.();
     forwardProcesses.forEach(p => p.kill());
   });
 
   beforeAll(async () => {
+    await health.setup();
     logger.info('Starting port forward for PXE and Ethereum');
     const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
     const { process: ethereumProcess, port: ethereumPort } = await startPortForwardForEthereum(config.NAMESPACE);

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -10,6 +10,7 @@ import type { ChildProcess } from 'child_process';
 
 import { type AlertConfig, GrafanaClient } from '../quality_of_service/grafana_client.js';
 import {
+  ChainHealth,
   applyBootNodeFailure,
   applyNetworkShaping,
   applyValidatorKill,
@@ -56,8 +57,10 @@ describe('a test that passively observes the network in the presence of network 
   const forwardProcesses: ChildProcess[] = [];
   const podChaosInstances: string[] = [];
   const networkShapingInstance = `${NAMESPACE}-network-shaping`;
+  const health = new ChainHealth(NAMESPACE, debugLogger);
 
   beforeAll(async () => {
+    await health.setup();
     // Try Prometheus in a dedicated metrics namespace first; if not present, fall back to the network namespace
     let promPort = 0;
     let promProc: ChildProcess | undefined;
@@ -108,6 +111,7 @@ describe('a test that passively observes the network in the presence of network 
   });
 
   afterAll(async () => {
+    await health.teardown();
     if (alertChecker) {
       await alertChecker.runAlertCheck(qosAlerts);
     }

--- a/yarn-project/end-to-end/src/spartan/invalidate_blocks.test.ts
+++ b/yarn-project/end-to-end/src/spartan/invalidate_blocks.test.ts
@@ -13,6 +13,7 @@ import { jest } from '@jest/globals';
 import type { ChildProcess } from 'child_process';
 
 import {
+  ChainHealth,
   getL1DeploymentAddresses,
   getNodeClient,
   getPublicViemClient,
@@ -43,6 +44,7 @@ describe('invalidate blocks test', () => {
   let origMinTxsPerBlock: number | undefined;
   let origSlashProposeInvalidAttestationsPenalty: bigint | undefined;
   let origSlashAttestDescendantOfInvalidPenalty: bigint | undefined;
+  const health = new ChainHealth(config.NAMESPACE, logger);
 
   const waitForSequencersToApplyConfig = async (expected: Partial<AztecNodeAdminConfig>, description: string) => {
     const keys = Object.keys(expected) as (keyof AztecNodeAdminConfig)[];
@@ -55,6 +57,7 @@ describe('invalidate blocks test', () => {
   };
 
   beforeAll(async () => {
+    await health.setup();
     const deployAddresses = await getL1DeploymentAddresses(config);
     ({ client } = await getPublicViemClient(config, forwardProcesses));
     rollup = new RollupContract(client, deployAddresses.rollupAddress);
@@ -68,6 +71,7 @@ describe('invalidate blocks test', () => {
   });
 
   afterAll(async () => {
+    await health.teardown();
     const restoreConfig: Partial<AztecNodeAdminConfig> = {
       skipCollectingAttestations: false,
       minTxsPerBlock: origMinTxsPerBlock,

--- a/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
+++ b/yarn-project/end-to-end/src/spartan/mempool_limit.test.ts
@@ -37,7 +37,7 @@ import {
   deploySponsoredTestAccounts,
   deploySponsoredTestAccountsWithTokens,
 } from './setup_test_wallets.js';
-import { getExternalIP, getSequencersConfig, setupEnvironment, updateSequencersConfig } from './utils.js';
+import { ChainHealth, getExternalIP, getSequencersConfig, setupEnvironment, updateSequencersConfig } from './utils.js';
 
 const config = setupEnvironment(process.env);
 
@@ -63,8 +63,10 @@ describe('mempool limiter test', () => {
   }[] = [];
 
   const forwardProcesses: ChildProcess[] = [];
+  const health = new ChainHealth(config.NAMESPACE, debugLogger);
 
   beforeAll(async () => {
+    await health.setup();
     const rpcIP = await getExternalIP(config.NAMESPACE, 'rpc-aztec-node');
     rpcUrl = `http://${rpcIP}:8080`;
     node = createAztecNodeClient(rpcUrl);
@@ -174,6 +176,7 @@ describe('mempool limiter test', () => {
   });
 
   afterAll(async () => {
+    await health.teardown();
     if (originalMinTxsPerBlock !== undefined) {
       await updateSequencersConfig(config, {
         maxPendingTxCount: baselineMaxPendingTxCount,

--- a/yarn-project/end-to-end/src/spartan/prover-node.test.ts
+++ b/yarn-project/end-to-end/src/spartan/prover-node.test.ts
@@ -5,6 +5,7 @@ import type { ChildProcess } from 'child_process';
 
 import { AlertTriggeredError, GrafanaClient } from '../quality_of_service/grafana_client.js';
 import {
+  ChainHealth,
   applyProverBrokerKill,
   applyProverKill,
   deleteResourceByLabel,
@@ -57,7 +58,10 @@ describe('prover node recovery', () => {
   const forwardProcesses: ChildProcess[] = [];
   let alertChecker: GrafanaClient;
   let spartanDir: string;
+  const health = new ChainHealth(config.NAMESPACE, logger);
+
   beforeAll(async () => {
+    await health.setup();
     // Try Prometheus in a dedicated metrics namespace first; if not present, fall back to the network namespace
     let promPort = 0;
     let promProc: ChildProcess | undefined;
@@ -97,6 +101,7 @@ describe('prover node recovery', () => {
   });
 
   afterAll(async () => {
+    await health.teardown();
     const cleanup = async (instanceName: string) => {
       const label = `app.kubernetes.io/instance=${instanceName}`;
       await deleteResourceByLabel({ resource: 'podchaos', namespace: config.NAMESPACE, label }).catch(() => undefined);

--- a/yarn-project/end-to-end/src/spartan/proving.test.ts
+++ b/yarn-project/end-to-end/src/spartan/proving.test.ts
@@ -5,7 +5,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { jest } from '@jest/globals';
 import type { ChildProcess } from 'child_process';
 
-import { setupEnvironment, startPortForwardForRPC } from './utils.js';
+import { ChainHealth, setupEnvironment, startPortForwardForRPC } from './utils.js';
 
 jest.setTimeout(2_400_000); // 40 minutes
 
@@ -16,14 +16,18 @@ const SLEEP_MS = 1000;
 describe('proving test', () => {
   let aztecNode: AztecNode;
   const forwardProcesses: ChildProcess[] = [];
+  const health = new ChainHealth(config.NAMESPACE, logger);
+
   beforeAll(async () => {
+    await health.setup();
     const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
     forwardProcesses.push(aztecRpcProcess);
     const rpcUrl = `http://127.0.0.1:${aztecRpcPort}`;
     aztecNode = createAztecNodeClient(rpcUrl);
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await health.teardown();
     forwardProcesses.forEach(p => p.kill());
   });
 

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -17,6 +17,7 @@ import {
   performTransfers,
 } from './setup_test_wallets.js';
 import {
+  ChainHealth,
   applyProverFailure,
   getGitProjectRoot,
   setupEnvironment,
@@ -58,13 +59,16 @@ describe('reorg test', () => {
   let testAccounts: TestAccounts;
   let aztecNode: AztecNode;
   let cleanup: undefined | (() => Promise<void>);
+  const health = new ChainHealth(config.NAMESPACE, debugLogger);
 
   afterAll(async () => {
+    await health.teardown();
     await cleanup?.();
     forwardProcesses.forEach(p => p.kill());
   });
 
   beforeAll(async () => {
+    await health.setup();
     const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
     const { process: ethProcess, port: ethPort } = await startPortForwardForEthereum(config.NAMESPACE);
     forwardProcesses.push(aztecRpcProcess);

--- a/yarn-project/end-to-end/src/spartan/slash_inactivity.test.ts
+++ b/yarn-project/end-to-end/src/spartan/slash_inactivity.test.ts
@@ -15,6 +15,7 @@ import assert from 'assert';
 import type { ChildProcess } from 'child_process';
 
 import {
+  ChainHealth,
   getL1DeploymentAddresses,
   getPublicViemClient,
   getSequencersConfig,
@@ -41,8 +42,10 @@ describe('slash inactivity test', () => {
   let constants: Omit<L1RollupConstants, 'ethereumSlotDuration'>;
   let monitor: ChainMonitor;
   let offlineValidator: EthAddress;
+  const health = new ChainHealth(config.NAMESPACE, logger);
 
   beforeAll(async () => {
+    await health.setup();
     const deployAddresses = await getL1DeploymentAddresses(config);
     ({ client } = await getPublicViemClient(config, forwardProcesses));
     rollup = new RollupContract(client, deployAddresses.rollupAddress);
@@ -52,6 +55,7 @@ describe('slash inactivity test', () => {
   });
 
   afterAll(async () => {
+    await health.teardown();
     // Clear out the disabled validators so we don't affect other tests
     await updateSequencersConfig(config, { disabledValidators: [] });
     monitor.removeAllListeners();

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -14,7 +14,7 @@ import {
   createWalletAndAztecNodeClient,
   deploySponsoredTestAccountsWithTokens,
 } from './setup_test_wallets.js';
-import { setupEnvironment, startPortForwardForRPC } from './utils.js';
+import { ChainHealth, setupEnvironment, startPortForwardForRPC } from './utils.js';
 
 const config = setupEnvironment(process.env);
 
@@ -31,13 +31,16 @@ describe('token transfer test', () => {
   let wallet: TestWallet;
   let aztecNode: AztecNode;
   let cleanup: undefined | (() => Promise<void>);
+  const health = new ChainHealth(config.NAMESPACE, logger);
 
   afterAll(async () => {
+    await health.teardown();
     await cleanup?.();
     forwardProcesses.forEach(p => p.kill());
   });
 
   beforeAll(async () => {
+    await health.setup();
     const { process, port } = await startPortForwardForRPC(config.NAMESPACE);
     forwardProcesses.push(process);
     const rpcUrl = `http://127.0.0.1:${port}`;

--- a/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_governance_proposer.test.ts
@@ -16,6 +16,7 @@ import { parseEther, stringify } from 'viem/utils';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import {
+  ChainHealth,
   setupEnvironment,
   startPortForwardForEthereum,
   startPortForwardForRPC,
@@ -34,12 +35,15 @@ describe('spartan_upgrade_governance_proposer', () => {
   let nodeInfo: NodeInfo;
   let ETHEREUM_HOSTS: string[];
   const forwardProcesses: ChildProcess[] = [];
+  const health = new ChainHealth(config.NAMESPACE, debugLogger);
 
-  afterAll(() => {
+  afterAll(async () => {
+    await health.teardown();
     forwardProcesses.forEach(p => p.kill());
   });
 
   beforeAll(async () => {
+    await health.setup();
     const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
     const { process: ethereumProcess, port: ethereumPort } = await startPortForwardForEthereum(config.NAMESPACE);
     forwardProcesses.push(aztecRpcProcess);

--- a/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
@@ -27,6 +27,7 @@ import { mnemonicToAccount } from 'viem/accounts';
 
 import { MNEMONIC } from '../fixtures/fixtures.js';
 import {
+  ChainHealth,
   getSequencersConfig,
   rollAztecPods,
   setupEnvironment,
@@ -46,13 +47,16 @@ describe('spartan_upgrade_rollup_version', () => {
   let ETHEREUM_HOSTS: string[];
   let originalL1ContractAddresses: L1ContractAddresses;
   const forwardProcesses: ChildProcess[] = [];
+  const health = new ChainHealth(config.NAMESPACE, debugLogger);
   jest.setTimeout(3 * 60 * 60 * 1000); // Governance flow can take a while
 
-  afterAll(() => {
+  afterAll(async () => {
+    await health.teardown();
     forwardProcesses.forEach(p => p.kill());
   });
 
   beforeAll(async () => {
+    await health.setup();
     const { process: aztecRpcProcess, port: aztecRpcPort } = await startPortForwardForRPC(config.NAMESPACE);
     const { process: ethereumProcess, port: ethereumPort } = await startPortForwardForEthereum(config.NAMESPACE);
     forwardProcesses.push(aztecRpcProcess);

--- a/yarn-project/end-to-end/src/spartan/utils/health.ts
+++ b/yarn-project/end-to-end/src/spartan/utils/health.ts
@@ -1,0 +1,256 @@
+import { createAztecNodeClient } from '@aztec/aztec.js/node';
+import { createEthereumChain } from '@aztec/ethereum/chain';
+import { RollupContract } from '@aztec/ethereum/contracts';
+import type { ViemPublicClient } from '@aztec/ethereum/types';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import type { Logger } from '@aztec/foundation/log';
+
+import type { ChildProcess } from 'child_process';
+import { createPublicClient, fallback, http } from 'viem';
+
+import { startPortForwardForEthereum, startPortForwardForRPC } from './k8s.js';
+
+/**
+ * Snapshot of chain state captured during setup for comparison in teardown.
+ */
+export interface ChainHealthSnapshot {
+  blockNumber: number;
+  checkpointNumber: CheckpointNumber;
+  timestamp: number;
+}
+
+/**
+ * Pre-flight and post-flight health checks for the Aztec network.
+ *
+ * Use in beforeAll/afterAll to validate the chain is healthy before tests run
+ * and verify it continued progressing during the test.
+ *
+ * @example
+ * ```typescript
+ * const health = new ChainHealth(config.NAMESPACE, logger);
+ *
+ * beforeAll(async () => {
+ *   await health.setup();
+ * });
+ *
+ * afterAll(async () => {
+ *   await health.teardown();
+ * });
+ * ```
+ */
+export class ChainHealth {
+  private namespace: string;
+  private logger: Logger;
+  private snapshot?: ChainHealthSnapshot;
+
+  constructor(namespace: string, logger: Logger) {
+    this.namespace = namespace;
+    this.logger = logger;
+  }
+
+  /**
+   * Pre-flight health check. Validates chain is in a testable state and captures
+   * initial state for comparison in teardown.
+   *
+   * Checks performed:
+   * - Node is reachable and returns valid info
+   * - ENR exists
+   * - L1 is accessible
+   * - At least 1 L2 block has been mined
+   * - Committee exists
+   * - At least 1 checkpoint has been reached
+   *
+   * @throws Error if any health check fails
+   */
+  async setup(): Promise<void> {
+    const processes: ChildProcess[] = [];
+
+    try {
+      // Establish temporary connections
+      const { process: rpcProcess, port: rpcPort } = await startPortForwardForRPC(this.namespace);
+      processes.push(rpcProcess);
+
+      const { process: ethProcess, port: ethPort } = await startPortForwardForEthereum(this.namespace);
+      processes.push(ethProcess);
+
+      const nodeUrl = `http://127.0.0.1:${rpcPort}`;
+      const ethereumUrl = `http://127.0.0.1:${ethPort}`;
+
+      // Create clients
+      const node = createAztecNodeClient(nodeUrl);
+
+      // Check 1: Node is reachable
+      let nodeInfo;
+      try {
+        nodeInfo = await node.getNodeInfo();
+      } catch (err) {
+        throw new Error(`Health check failed: Node is not reachable at ${nodeUrl}. Error: ${err}`);
+      }
+
+      if (!nodeInfo) {
+        throw new Error('Health check failed: Node returned empty info');
+      }
+
+      // Check 2: ENR exists (P2P identity)
+      if (!nodeInfo.enr || !nodeInfo.enr.startsWith('enr:-')) {
+        throw new Error(`Health check failed: Invalid or missing ENR. Got: ${nodeInfo.enr}`);
+      }
+
+      // Check 3: L1 is accessible
+      const chain = createEthereumChain([ethereumUrl], nodeInfo.l1ChainId);
+      const ethereumClient: ViemPublicClient = createPublicClient({
+        chain: chain.chainInfo,
+        transport: fallback([http(ethereumUrl, { batch: false })]),
+      });
+
+      try {
+        await ethereumClient.getBlockNumber();
+      } catch (err) {
+        throw new Error(`Health check failed: L1 is not accessible at ${ethereumUrl}. Error: ${err}`);
+      }
+
+      // Check 4: At least 1 L2 block mined
+      let l2BlockNumber;
+      try {
+        l2BlockNumber = await node.getBlockNumber();
+      } catch (err) {
+        throw new Error(`Health check failed: Could not get L2 block number. Error: ${err}`);
+      }
+
+      if (l2BlockNumber < 1) {
+        throw new Error(`Health check failed: No L2 blocks mined yet. Block number: ${l2BlockNumber}`);
+      }
+
+      // Check 5: Committee exists
+      const rollup = new RollupContract(ethereumClient, nodeInfo.l1ContractAddresses.rollupAddress);
+
+      let committee;
+      try {
+        committee = await rollup.getCurrentEpochCommittee();
+      } catch (err) {
+        throw new Error(`Health check failed: Could not get committee. Error: ${err}`);
+      }
+
+      if (!committee || committee.length === 0) {
+        throw new Error('Health check failed: No committee exists. Validators may not be registered yet.');
+      }
+
+      // Check 6: At least 1 checkpoint reached
+      let checkpointNumber;
+      try {
+        checkpointNumber = await rollup.getCheckpointNumber();
+      } catch (err) {
+        throw new Error(`Health check failed: Could not get checkpoint number. Error: ${err}`);
+      }
+
+      if (checkpointNumber < CheckpointNumber(1)) {
+        throw new Error(
+          `Health check failed: No checkpoint reached yet. Checkpoint number: ${checkpointNumber}. ` +
+            'The proving pipeline may not have completed a proof yet.',
+        );
+      }
+
+      // Capture snapshot for teardown comparison
+      this.snapshot = {
+        blockNumber: l2BlockNumber,
+        checkpointNumber,
+        timestamp: Date.now(),
+      };
+
+      this.logger.info('Pre-flight health check passed');
+    } finally {
+      processes.forEach(p => p.kill());
+    }
+  }
+
+  /**
+   * Post-flight health check. Verifies the chain continued progressing during the test.
+   *
+   * For tests that ran longer than the threshold, checks:
+   * - Block number increased since setup
+   * - Checkpoint number increased since setup
+   *
+   * For shorter tests, skips the check.
+   *
+   * @throws Error if chain did not progress
+   */
+  async teardown(): Promise<void> {
+    if (!this.snapshot) {
+      this.logger.warn('Teardown called without setup - skipping chain progress check');
+      return;
+    }
+
+    const processes: ChildProcess[] = [];
+    // Minimum test duration to check chain progression
+    const PROGRESS_CHECK_THRESHOLD_SECONDS = 120;
+
+    try {
+      const elapsedSeconds = Math.round((Date.now() - this.snapshot.timestamp) / 1000);
+
+      // Skip progress check for short tests
+      if (elapsedSeconds <= PROGRESS_CHECK_THRESHOLD_SECONDS) {
+        this.logger.info('Post-flight health check passed (skipped progress check - test too short)');
+        return;
+      }
+
+      const { process: rpcProcess, port: rpcPort } = await startPortForwardForRPC(this.namespace);
+      processes.push(rpcProcess);
+
+      const { process: ethProcess, port: ethPort } = await startPortForwardForEthereum(this.namespace);
+      processes.push(ethProcess);
+
+      const nodeUrl = `http://127.0.0.1:${rpcPort}`;
+      const ethereumUrl = `http://127.0.0.1:${ethPort}`;
+      const node = createAztecNodeClient(nodeUrl);
+
+      // Check that block number increased
+      let currentBlockNumber;
+      try {
+        currentBlockNumber = await node.getBlockNumber();
+      } catch (err) {
+        throw new Error(`Teardown health check failed: Could not get block number. Error: ${err}`);
+      }
+
+      if (currentBlockNumber <= this.snapshot.blockNumber) {
+        throw new Error(
+          `Chain did not progress during test. ` +
+            `Block number at setup: ${this.snapshot.blockNumber}, ` +
+            `Block number at teardown: ${currentBlockNumber}, ` +
+            `Elapsed time: ${elapsedSeconds}s. ` +
+            `The chain may have stalled during the test.`,
+        );
+      }
+
+      // Check that checkpoint number increased
+      const nodeInfo = await node.getNodeInfo();
+      const chain = createEthereumChain([ethereumUrl], nodeInfo.l1ChainId);
+      const ethereumClient: ViemPublicClient = createPublicClient({
+        chain: chain.chainInfo,
+        transport: fallback([http(ethereumUrl, { batch: false })]),
+      });
+
+      const rollup = new RollupContract(ethereumClient, nodeInfo.l1ContractAddresses.rollupAddress);
+      let currentCheckpoint;
+      try {
+        currentCheckpoint = await rollup.getCheckpointNumber();
+      } catch (err) {
+        throw new Error(`Teardown health check failed: Could not get checkpoint number. Error: ${err}`);
+      }
+
+      if (currentCheckpoint <= this.snapshot.checkpointNumber) {
+        throw new Error(
+          `Proving pipeline did not progress during test. ` +
+            `Checkpoint at setup: ${this.snapshot.checkpointNumber}, ` +
+            `Checkpoint at teardown: ${currentCheckpoint}, ` +
+            `Elapsed time: ${elapsedSeconds}s. ` +
+            `The proving pipeline may have stalled during the test.`,
+        );
+      }
+
+      this.logger.info('Post-flight health check passed');
+    } finally {
+      processes.forEach(p => p.kill());
+      this.snapshot = undefined;
+    }
+  }
+}

--- a/yarn-project/end-to-end/src/spartan/utils/index.ts
+++ b/yarn-project/end-to-end/src/spartan/utils/index.ts
@@ -53,3 +53,6 @@ export {
 
 // Client utilities
 export { getPublicViemClient, getL1DeploymentAddresses, getNodeClient } from './clients.js';
+
+// Health checks
+export { ChainHealth, type ChainHealthSnapshot } from './health.js';

--- a/yarn-project/end-to-end/src/spartan/validator_nuke_and_suppression.test.ts
+++ b/yarn-project/end-to-end/src/spartan/validator_nuke_and_suppression.test.ts
@@ -14,6 +14,7 @@ import type { ChildProcess } from 'child_process';
 import { createPublicClient, fallback, http } from 'viem';
 
 import {
+  ChainHealth,
   applyValidatorFailure,
   applyValidatorKill,
   getExternalIP,
@@ -41,8 +42,10 @@ describe('validator suppression and nuke with slashing assertions', () => {
   let nodeRpcUrl: string;
   let spartanDir: string;
   const killReleases: string[] = [];
+  const health = new ChainHealth(config.NAMESPACE, logger);
 
   beforeAll(async () => {
+    await health.setup();
     const chaosReleases = ['validator-failure'];
     await Promise.all(
       chaosReleases.map(name =>
@@ -98,6 +101,7 @@ describe('validator suppression and nuke with slashing assertions', () => {
   });
 
   afterAll(async () => {
+    await health.teardown();
     // Ensure we don't leave validators disabled
     await updateSequencersConfig(config, { disabledValidators: [] }).catch(() => undefined);
     const chaosReleases = ['validator-failure', ...killReleases];


### PR DESCRIPTION
This PR is basically implementing a fast fail mechanism for our scenario tests.

preflight checks:
- Node is reachable and returns valid info
- ENR exists
- L1 is accessible
- At least 1 L2 block has been mined
- Committee exists
- At least 1 checkpoint has been reached

postflight checks:
- Block number increased since setup
- Checkpoint number increased since setup
- keeps track of state from pre-flight