### PR TITLE
feat: Use monotonic time in sequencer to prevent NTP clock adjustment issues

### DIFF
--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -39,7 +39,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { hexToBuffer } from '@aztec/foundation/string';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { Deadline, TestDateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractsList, protocolContractsHash } from '@aztec/protocol-contracts';
@@ -826,13 +826,13 @@ describe('L1Publisher integration', () => {
       initialL2Slot = BigInt(await rollup.getSlotNumber());
     });
 
-    const getProposeTxTimeoutAt = (checkpoint: Checkpoint) => {
+    const getProposeTxDeadline = (checkpoint: Checkpoint): Deadline => {
       const { slotDuration: aztecSlotDuration } = l1Constants;
       const txTimeoutAt = new Date(
         (Number(getSlotStartBuildTimestamp(checkpoint.slot, l1Constants)) + Number(aztecSlotDuration)) * 1000,
       );
       logger.warn(`Setting tx timeout at ${txTimeoutAt.toISOString()} (${txTimeoutAt.getTime()})`);
-      return txTimeoutAt;
+      return Deadline.fromDate(txTimeoutAt, dateProvider);
     };
 
     const sendRequests = async () => {
@@ -850,7 +850,7 @@ describe('L1Publisher integration', () => {
 
     const enqueueProposeL2Checkpoint = async (checkpoint: Checkpoint) => {
       await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty(), {
-        txTimeoutAt: getProposeTxTimeoutAt(checkpoint),
+        txDeadline: getProposeTxDeadline(checkpoint),
       });
     };
 

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -10,6 +10,7 @@ import {
   getEpochNumberAtTimestamp,
   getSlotAtTimestamp,
   getSlotRangeForEpoch,
+  getSlotStartBuildTimestamp,
   getTimestampForSlot,
   getTimestampRangeForEpoch,
 } from '@aztec/stdlib/epoch-helpers';
@@ -17,6 +18,7 @@ import {
 import { createPublicClient, encodeAbiParameters, fallback, http, keccak256 } from 'viem';
 
 import { type EpochCacheConfig, getEpochCacheConfigEnvVars } from './config.js';
+import { SlotTimingContext } from './slot_timing_context.js';
 
 export type EpochAndSlot = {
   epoch: EpochNumber;
@@ -37,7 +39,7 @@ export type SlotTag = 'now' | 'next' | SlotNumber;
 export interface EpochCacheInterface {
   getCommittee(slot: SlotTag | undefined): Promise<EpochCommitteeInfo>;
   getEpochAndSlotNow(): EpochAndSlot;
-  getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint };
+  getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint; slotTimingContext: SlotTimingContext };
   getProposerIndexEncoding(epoch: EpochNumber, slot: SlotNumber, seed: bigint): `0x${string}`;
   computeProposerIndex(slot: SlotNumber, epoch: EpochNumber, seed: bigint, size: bigint): bigint;
   getCurrentAndNextSlot(): { currentSlot: SlotNumber; nextSlot: SlotNumber };
@@ -149,10 +151,24 @@ export class EpochCache implements EpochCacheInterface {
     return { epoch, ts, slot };
   }
 
-  public getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint } {
-    const now = this.nowInSeconds();
+  public getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint; slotTimingContext: SlotTimingContext } {
+    const wallClockNowMs = this.dateProvider.now();
+    const now = BigInt(Math.floor(wallClockNowMs / 1000));
+    const monotonicNow = this.dateProvider.monotonic();
+
     const nextSlotTs = now + BigInt(this.l1constants.ethereumSlotDuration);
-    return { ...this.getEpochAndSlotAtTimestamp(nextSlotTs), now };
+    const epochAndSlot = this.getEpochAndSlotAtTimestamp(nextSlotTs);
+
+    // Create SlotTimingContext with proper timing anchoring
+    const slotBuildTimestampSeconds = getSlotStartBuildTimestamp(epochAndSlot.slot, this.l1constants);
+    const slotTimingContext = new SlotTimingContext(
+      epochAndSlot.slot,
+      slotBuildTimestampSeconds,
+      wallClockNowMs,
+      monotonicNow,
+    );
+
+    return { ...epochAndSlot, now, slotTimingContext };
   }
 
   private getEpochAndSlotAtTimestamp(ts: bigint): EpochAndSlot {

--- a/yarn-project/epoch-cache/src/index.ts
+++ b/yarn-project/epoch-cache/src/index.ts
@@ -1,2 +1,3 @@
-export * from './epoch_cache.js';
 export * from './config.js';
+export * from './epoch_cache.js';
+export * from './slot_timing_context.js';

--- a/yarn-project/epoch-cache/src/slot_timing_context.ts
+++ b/yarn-project/epoch-cache/src/slot_timing_context.ts
@@ -1,0 +1,47 @@
+import type { SlotNumber } from '@aztec/foundation/branded-types';
+import { type DateProvider, Deadline, type MonotonicTimestampMs } from '@aztec/foundation/timer';
+
+/**
+ * Encapsulates timing information for a specific slot using monotonic time.
+ * Monotonic time is immune to NTP adjustments and wall-clock jumps.
+ */
+export class SlotTimingContext {
+  public readonly slot: SlotNumber;
+  public readonly slotStartBuildTimestamp: MonotonicTimestampMs;
+
+  constructor(
+    slot: SlotNumber,
+    slotBuildStartTimestampSeconds: number, // Wall-clock timestamp (seconds) when slot building should start
+    wallClockNowMs: number, // Current wall-clock time in milliseconds
+    monotonicNow: MonotonicTimestampMs,
+  ) {
+    this.slot = slot;
+
+    // Calculate the delta between wall-clock slot build start and current wall-clock time (in ms)
+    const slotBuildStartTimestampMs = slotBuildStartTimestampSeconds * 1000;
+    const wallClockDeltaMs = slotBuildStartTimestampMs - wallClockNowMs;
+
+    // Apply the same delta to monotonic time to get the monotonic slot start timestamp
+    this.slotStartBuildTimestamp = Math.floor(monotonicNow + wallClockDeltaMs) as MonotonicTimestampMs;
+  }
+
+  /**
+   * Returns the number of seconds elapsed since the slot build start time.
+   * Uses monotonic time, immune to wall-clock adjustments.
+   */
+  public getSecondsIntoSlot(dateProvider: DateProvider): number {
+    const monotonicNow = dateProvider.monotonic();
+    const elapsedMs = monotonicNow - this.slotStartBuildTimestamp;
+    const elapsedSeconds = elapsedMs / 1000;
+    return Number(elapsedSeconds.toFixed(3));
+  }
+
+  /**
+   * Creates a deadline at a specified number of seconds into the slot.
+   * The deadline is expressed as a monotonic timestamp.
+   */
+  public createDeadline(secondsIntoSlot: number): Deadline {
+    const deadlineMs = Math.floor(this.slotStartBuildTimestamp + secondsIntoSlot * 1000);
+    return Deadline.at(deadlineMs as MonotonicTimestampMs);
+  }
+}

--- a/yarn-project/foundation/src/timer/date.test.ts
+++ b/yarn-project/foundation/src/timer/date.test.ts
@@ -1,5 +1,61 @@
 import { sleep } from '../sleep/index.js';
 import { TestDateProvider } from './date.js';
+import { Deadline } from './deadline.js';
+import type { MonotonicTimestampMs } from './monotonic_timestamp.js';
+
+/**
+ * Standard tolerance for time-based assertions in tests (in milliseconds).
+ * Accounts for test execution overhead, timing drift, and sleep precision.
+ */
+const TIME_TOLERANCE_MS = 100;
+
+// Custom Jest matchers for time comparisons with tolerance
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Asserts that a timestamp is close to the expected time, with tolerance after.
+       * Checks that: expected <= actual < expected + TIME_TOLERANCE_MS
+       */
+      toBeCloseToTimeWithToleranceAfter(expected: number): R;
+      /**
+       * Asserts that a timestamp is close to the expected time, with tolerance before.
+       * Checks that: expected - TIME_TOLERANCE_MS < actual <= expected
+       */
+      toBeCloseToTimeWithToleranceBefore(expected: number): R;
+    }
+  }
+}
+
+expect.extend({
+  toBeCloseToTimeWithToleranceAfter(received: number, expected: number) {
+    const pass = received >= expected && received < expected + TIME_TOLERANCE_MS;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected ${received} not to be within [${expected}, ${expected + TIME_TOLERANCE_MS})`
+          : `expected ${received} to be within [${expected}, ${expected + TIME_TOLERANCE_MS}) but it was ${
+              received < expected ? 'too early' : 'too late'
+            }`,
+    };
+  },
+  toBeCloseToTimeWithToleranceBefore(received: number, expected: number) {
+    const lowerBound = expected - TIME_TOLERANCE_MS;
+    const pass = received > lowerBound && received <= expected;
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected ${received} not to be within (${lowerBound}, ${expected}]`
+          : `expected ${received} to be within (${lowerBound}, ${expected}] but it was ${
+              received <= lowerBound ? 'too early' : 'too late'
+            }`,
+    };
+  },
+});
 
 describe('TestDateProvider', () => {
   let dateProvider: TestDateProvider;
@@ -10,16 +66,14 @@ describe('TestDateProvider', () => {
   it('should return the current datetime', () => {
     const currentTime = Date.now();
     const result = dateProvider.now();
-    expect(result).toBeGreaterThanOrEqual(currentTime);
-    expect(result).toBeLessThan(currentTime + 100);
+    expect(result).toBeCloseToTimeWithToleranceAfter(currentTime);
   });
 
   it('should return the overridden datetime', () => {
     const overriddenTime = Date.now() + 1000;
     dateProvider.setTime(overriddenTime);
     const result = dateProvider.now();
-    expect(result).toBeGreaterThanOrEqual(overriddenTime);
-    expect(result).toBeLessThan(overriddenTime + 100);
+    expect(result).toBeCloseToTimeWithToleranceAfter(overriddenTime);
   });
 
   it('should keep ticking after overriding', async () => {
@@ -27,7 +81,162 @@ describe('TestDateProvider', () => {
     dateProvider.setTime(overriddenTime);
     await sleep(510);
     const result = dateProvider.now();
-    expect(result).toBeGreaterThanOrEqual(overriddenTime + 500);
-    expect(result).toBeLessThan(overriddenTime + 600);
+    expect(result).toBeCloseToTimeWithToleranceAfter(overriddenTime + 500);
+  });
+
+  describe('monotonic time', () => {
+    it('should advance monotonic time when setTime is called', () => {
+      const initialMonotonic = dateProvider.monotonic();
+
+      // Advance wall-clock time by 5 seconds
+      const futureTime = Date.now() + 5000;
+      dateProvider.setTime(futureTime);
+
+      const newMonotonic = dateProvider.monotonic();
+      // Monotonic should have advanced by approximately 5 seconds
+      expect(newMonotonic - initialMonotonic).toBeCloseToTimeWithToleranceAfter(5000);
+    });
+
+    it('should only advance monotonic time when advanceMonotonic is called', () => {
+      const initialWallClock = dateProvider.now();
+      const initialMonotonic = dateProvider.monotonic();
+
+      // Advance only monotonic time by 3 seconds
+      dateProvider.advanceMonotonic(3000);
+
+      // Wall-clock should be roughly the same (within timing tolerance)
+      expect(dateProvider.now() - initialWallClock).toBeLessThan(TIME_TOLERANCE_MS);
+      // Monotonic should have advanced by 3 seconds
+      const newMonotonic = dateProvider.monotonic();
+      expect(newMonotonic - initialMonotonic).toBeCloseToTimeWithToleranceAfter(3000);
+    });
+
+    it('should only advance wall-clock when setTimeWithoutMonotonic is called', () => {
+      const initialMonotonic = dateProvider.monotonic();
+
+      // Advance only wall-clock time by 10 seconds
+      const futureTime = Date.now() + 10000;
+      dateProvider.setTimeWithoutMonotonic(futureTime);
+
+      // Monotonic should be roughly the same (within timing tolerance)
+      const newMonotonic = dateProvider.monotonic();
+      expect(newMonotonic - initialMonotonic).toBeLessThan(TIME_TOLERANCE_MS);
+      // Wall-clock should show the new time
+      expect(dateProvider.now()).toBeGreaterThanOrEqual(futureTime);
+    });
+
+    it('should maintain separate offsets for wall-clock and monotonic time', () => {
+      // First, set wall-clock to a specific time (advances both)
+      const time1 = Date.now() + 5000;
+      dateProvider.setTime(time1);
+
+      // Then, advance only monotonic
+      dateProvider.advanceMonotonic(2000);
+
+      // Then, set wall-clock without affecting monotonic
+      const time2 = Date.now() + 20000;
+      dateProvider.setTimeWithoutMonotonic(time2);
+
+      // Wall-clock should reflect time2
+      expect(dateProvider.now()).toBeGreaterThanOrEqual(time2);
+      // Monotonic should be approximately 5000 + 2000 + small elapsed time
+      const monotonicValue = dateProvider.monotonic();
+      expect(monotonicValue).toBeGreaterThan(7000);
+    });
+  });
+});
+
+describe('Deadline', () => {
+  let dateProvider: TestDateProvider;
+  beforeEach(() => {
+    dateProvider = new TestDateProvider();
+  });
+
+  it('should create deadline from monotonic timestamp', () => {
+    const timestamp = dateProvider.monotonic();
+    const deadline = Deadline.at(timestamp);
+    expect(Deadline.toMs(deadline)).toBe(timestamp);
+  });
+
+  it('should correctly detect expired deadlines', () => {
+    const currentMonotonic = dateProvider.monotonic();
+
+    // Create a deadline in the past
+    const pastDeadline = Deadline.at((currentMonotonic - 1000) as MonotonicTimestampMs);
+    expect(Deadline.hasExpired(pastDeadline, dateProvider)).toBe(true);
+
+    // Create a deadline in the future
+    const futureDeadline = Deadline.at((currentMonotonic + 10000) as MonotonicTimestampMs);
+    expect(Deadline.hasExpired(futureDeadline, dateProvider)).toBe(false);
+  });
+
+  it('should be immune to wall-clock jumps', () => {
+    const currentMonotonic = dateProvider.monotonic();
+
+    // Create a deadline 5 seconds in the future (monotonic)
+    const deadline = Deadline.at((currentMonotonic + 5000) as MonotonicTimestampMs);
+
+    // Deadline should not be expired
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(false);
+
+    // Jump wall-clock forward by 10 seconds (simulating NTP correction)
+    const futureWallClock = Date.now() + 10000;
+    dateProvider.setTimeWithoutMonotonic(futureWallClock);
+
+    // Deadline should STILL not be expired because it uses monotonic time
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(false);
+
+    // Advance monotonic time by 4.9 seconds (just before deadline)
+    dateProvider.advanceMonotonic(4900);
+
+    // Deadline should NOT be expired yet
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(false);
+
+    // Advance well past the deadline
+    dateProvider.advanceMonotonic(200);
+
+    // Now deadline should be expired
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(true);
+  });
+
+  it('should use strictly greater than for expiration check', () => {
+    // Create a deadline 1 second in the future
+    const currentMonotonic = dateProvider.monotonic();
+    const deadline = Deadline.at((currentMonotonic + 1000) as MonotonicTimestampMs);
+
+    // Not expired yet
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(false);
+
+    // Advance to just before deadline (accounting for timing drift)
+    dateProvider.advanceMonotonic(900);
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(false);
+
+    // Advance well past the deadline
+    dateProvider.advanceMonotonic(200);
+    expect(Deadline.hasExpired(deadline, dateProvider)).toBe(true);
+  });
+
+  it('should return correct remaining time', () => {
+    const currentMonotonic = dateProvider.monotonic();
+
+    // Create a deadline 5 seconds in the future
+    const deadline = Deadline.at((currentMonotonic + 5000) as MonotonicTimestampMs);
+
+    // Remaining time should be approximately 5 seconds
+    const remaining = Deadline.remainingMs(deadline, dateProvider);
+    expect(remaining).toBeCloseToTimeWithToleranceBefore(5000);
+
+    // Advance monotonic time by 3 seconds
+    dateProvider.advanceMonotonic(3000);
+
+    // Remaining time should be approximately 2 seconds
+    const remaining2 = Deadline.remainingMs(deadline, dateProvider);
+    expect(remaining2).toBeCloseToTimeWithToleranceBefore(2000);
+
+    // Advance past the deadline
+    dateProvider.advanceMonotonic(3000);
+
+    // Remaining time should be 0 (not negative)
+    expect(Deadline.remainingMs(deadline, dateProvider)).toBe(0);
   });
 });

--- a/yarn-project/foundation/src/timer/date.ts
+++ b/yarn-project/foundation/src/timer/date.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../log/pino-logger.js';
+import type { MonotonicTimestampMs } from './monotonic_timestamp.js';
 
 /** Returns current datetime. */
 export class DateProvider {
@@ -13,11 +14,17 @@ export class DateProvider {
   public nowAsDate(): Date {
     return new Date(this.now());
   }
+
+  /** Monotonic time in milliseconds (immune to NTP adjustments) */
+  public monotonic(): MonotonicTimestampMs {
+    return performance.now() as MonotonicTimestampMs;
+  }
 }
 
 /** Returns current datetime and allows to override it. */
 export class TestDateProvider extends DateProvider {
   private offset = 0;
+  private monotonicOffset = 0;
 
   constructor(private readonly logger = createLogger('foundation:test-date-provider')) {
     super();
@@ -27,8 +34,30 @@ export class TestDateProvider extends DateProvider {
     return Date.now() + this.offset;
   }
 
+  public override monotonic(): MonotonicTimestampMs {
+    return (performance.now() + this.monotonicOffset) as MonotonicTimestampMs;
+  }
+
+  /** Set wall-clock time. Also advances monotonic time by same delta (simulates real time passing). */
   public setTime(timeMs: number) {
-    this.offset = timeMs - Date.now();
+    const now = Date.now();
+    const delta = timeMs - now - this.offset;
+    this.offset = timeMs - now;
+    this.monotonicOffset += delta;
     this.logger.warn(`Time set to ${new Date(timeMs).toISOString()}`, { offset: this.offset, timeMs });
+  }
+
+  /** Advance only monotonic time (for testing clock jump scenarios). */
+  public advanceMonotonic(ms: number) {
+    this.monotonicOffset += ms;
+  }
+
+  /** Set wall-clock WITHOUT advancing monotonic (simulate NTP correction). */
+  public setTimeWithoutMonotonic(timeMs: number) {
+    this.offset = timeMs - Date.now();
+    this.logger.warn(`Wall-clock time set to ${new Date(timeMs).toISOString()} (monotonic unchanged)`, {
+      offset: this.offset,
+      timeMs,
+    });
   }
 }

--- a/yarn-project/foundation/src/timer/deadline.ts
+++ b/yarn-project/foundation/src/timer/deadline.ts
@@ -1,0 +1,59 @@
+import { sleep } from '../sleep/index.js';
+import { DateProvider } from './date.js';
+import type { MonotonicTimestampMs } from './monotonic_timestamp.js';
+
+declare const DeadlineBrand: unique symbol;
+/**
+ * A deadline expressed as a monotonic timestamp.
+ * Immune to wall-clock jumps.
+ */
+export type Deadline = number & { [DeadlineBrand]: never };
+
+export const Deadline = {
+  /** Create a deadline at a specific monotonic timestamp */
+  at(timestamp: MonotonicTimestampMs): Deadline {
+    return timestamp as unknown as Deadline;
+  },
+
+  /** Convert a wall-clock Date to a monotonic Deadline */
+  fromDate(date: Date, dateProvider: DateProvider): Deadline {
+    const remainingMs = Math.max(0, date.getTime() - dateProvider.now());
+    return Math.floor(dateProvider.monotonic() + remainingMs) as unknown as Deadline;
+  },
+
+  /** Convert a monotonic Deadline back to a wall-clock Date */
+  toDate(deadline: Deadline, dateProvider: DateProvider): Date {
+    return new Date(dateProvider.now() + Deadline.remainingMs(deadline, dateProvider));
+  },
+
+  /** Check if a deadline has expired (strictly past the deadline) */
+  hasExpired(deadline: Deadline, dateProvider: DateProvider): boolean {
+    return dateProvider.monotonic() > Deadline.toMs(deadline);
+  },
+
+  /** Convert a Deadline to its underlying millisecond value */
+  toMs(deadline: Deadline): number {
+    return deadline as unknown as number;
+  },
+
+  /** Create a new deadline that is `ms` before the given deadline */
+  subtract(deadline: Deadline, ms: number): Deadline {
+    return (Deadline.toMs(deadline) - ms) as unknown as Deadline;
+  },
+
+  /** Get remaining time until deadline in milliseconds (0 if already expired) */
+  remainingMs(deadline: Deadline, dateProvider: DateProvider): number {
+    const remaining = Deadline.toMs(deadline) - dateProvider.monotonic();
+    return Math.max(0, Math.floor(remaining));
+  },
+
+  /** Wait until the deadline has expired. Loops to handle wall-clock jumps during sleep. */
+  async waitUntilExpired(deadline: Deadline, dateProvider: DateProvider): Promise<void> {
+    while (!Deadline.hasExpired(deadline, dateProvider)) {
+      const sleepMs = Deadline.remainingMs(deadline, dateProvider);
+      if (sleepMs > 0) {
+        await sleep(sleepMs);
+      }
+    }
+  },
+};

--- a/yarn-project/foundation/src/timer/index.ts
+++ b/yarn-project/foundation/src/timer/index.ts
@@ -1,4 +1,6 @@
 export * from './date.js';
+export * from './deadline.js';
 export { elapsed, elapsedSync } from './elapsed.js';
+export type { MonotonicTimestampMs } from './monotonic_timestamp.js';
 export { TimeoutTask, executeTimeout, timeoutPromise } from './timeout.js';
 export { Timer } from './timer.js';

--- a/yarn-project/foundation/src/timer/monotonic_timestamp.ts
+++ b/yarn-project/foundation/src/timer/monotonic_timestamp.ts
@@ -1,0 +1,7 @@
+declare const MonotonicTimestampMsBrand: unique symbol;
+/**
+ * A monotonic timestamp in milliseconds.
+ * Unlike Date.now(), monotonic time is immune to NTP adjustments.
+ * Values are relative to an arbitrary origin (typically process start).
+ */
+export type MonotonicTimestampMs = number & { [MonotonicTimestampMsBrand]: never };

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -4,7 +4,7 @@
  * Used when running testbench commands
  */
 import { MockL2BlockSource } from '@aztec/archiver/test';
-import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { type EpochCacheInterface, SlotTimingContext } from '@aztec/epoch-cache';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import { createLogger } from '@aztec/foundation/log';
@@ -96,7 +96,13 @@ function mockEpochCache(): EpochCacheInterface {
       nextSlot: SlotNumber.ZERO,
     }),
     getProposerAttesterAddressInSlot: () => Promise.resolve(undefined),
-    getEpochAndSlotInNextL1Slot: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n, now: 0n }),
+    getEpochAndSlotInNextL1Slot: () => ({
+      epoch: EpochNumber.ZERO,
+      slot: SlotNumber.ZERO,
+      ts: 0n,
+      now: 0n,
+      slotTimingContext: new SlotTimingContext(SlotNumber.ZERO, 0, 0, 0 as any),
+    }),
     isInCommittee: () => Promise.resolve(false),
     getRegisteredValidators: () => Promise.resolve([]),
     filterInCommittee: () => Promise.resolve([]),

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -1,6 +1,7 @@
 import { createArchiverStore } from '@aztec/archiver';
 import type { L1ContractsConfig } from '@aztec/ethereum/config';
 import type { Logger } from '@aztec/foundation/log';
+import { DateProvider } from '@aztec/foundation/timer';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { type ProverClientConfig, createProverClient } from '@aztec/prover-client';
 import { ProverBrokerConfig, createAndStartProvingBroker } from '@aztec/prover-client/broker';
@@ -53,6 +54,7 @@ export async function rerunEpochProvingJob(
     metrics,
     deadline,
     { skipEpochCheck: true },
+    new DateProvider(),
   );
 
   log.info(`Rerunning epoch proving job for epoch ${jobData.epochNumber}`);

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -4,6 +4,7 @@ import { fromEntries, times, timesParallel } from '@aztec/foundation/collection'
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { toArray } from '@aztec/foundation/iterable';
 import { sleep } from '@aztec/foundation/sleep';
+import { DateProvider } from '@aztec/foundation/timer';
 import type { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { CommitteeAttestation, type L2BlockSource } from '@aztec/stdlib/block';
@@ -75,6 +76,7 @@ describe('epoch-proving-job', () => {
       metrics,
       opts.deadline,
       { parallelBlockLimit: opts.parallelBlockLimit ?? 32, skipSubmitProof: opts.skipSubmitProof },
+      new DateProvider(),
     );
   };
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -5,7 +5,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
-import { Timer } from '@aztec/foundation/timer';
+import { DateProvider, Deadline, Timer } from '@aztec/foundation/timer';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractsHash } from '@aztec/protocol-contracts';
 import { buildFinalBlobChallenges } from '@aztec/prover-client/helpers';
@@ -62,6 +62,7 @@ export class EpochProvingJob implements Traceable {
     private metrics: ProverNodeJobMetrics,
     private deadline: Date | undefined,
     private config: EpochProvingJobOptions,
+    private dateProvider: DateProvider,
   ) {
     validateEpochProvingJobData(data);
     this.uuid = crypto.randomUUID();
@@ -400,7 +401,7 @@ export class EpochProvingJob implements Traceable {
   }
 
   private async processTxs(publicProcessor: PublicProcessor, txs: Tx[]): Promise<ProcessedTx[]> {
-    const { deadline } = this;
+    const deadline = this.deadline ? Deadline.fromDate(this.deadline, this.dateProvider) : undefined;
     const [processedTxs, failedTxs] = await publicProcessor.process(txs, { deadline });
 
     if (failedTxs.length) {

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -384,6 +384,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.jobMetrics,
       deadline,
       { parallelBlockLimit, skipSubmitProof: proverNodeDisableProofPublish, ...opts },
+      this.dateProvider,
     );
   }
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -32,7 +32,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature, type ViemSignature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { bufferToHex } from '@aztec/foundation/string';
-import { DateProvider, Timer } from '@aztec/foundation/timer';
+import { DateProvider, Deadline, Timer } from '@aztec/foundation/timer';
 import { EmpireBaseAbi, ErrorsAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { type ProposerSlashAction, encodeSlashConsensusVotes } from '@aztec/slasher';
 import { CommitteeAttestationsAndSigners, type ValidateCheckpointResult } from '@aztec/stdlib/block';
@@ -104,6 +104,7 @@ export class SequencerPublisher {
   private interrupted = false;
   private metrics: SequencerPublisherMetrics;
   public epochCache: EpochCache;
+  private dateProvider: DateProvider;
 
   protected governanceLog = createLogger('sequencer:publisher:governance');
   protected slashingLog = createLogger('sequencer:publisher:slashing');
@@ -163,6 +164,7 @@ export class SequencerPublisher {
     this.log = deps.log ?? createLogger('sequencer:publisher');
     this.ethereumSlotDuration = BigInt(config.ethereumSlotDuration);
     this.epochCache = deps.epochCache;
+    this.dateProvider = deps.dateProvider;
     this.lastActions = deps.lastActions;
 
     this.blobClient = deps.blobClient;
@@ -903,7 +905,7 @@ export class SequencerPublisher {
     checkpoint: Checkpoint,
     attestationsAndSigners: CommitteeAttestationsAndSigners,
     attestationsAndSignersSignature: Signature,
-    opts: { txTimeoutAt?: Date; forcePendingCheckpointNumber?: CheckpointNumber } = {},
+    opts: { txDeadline?: Deadline; forcePendingCheckpointNumber?: CheckpointNumber } = {},
   ): Promise<void> {
     const checkpointHeader = checkpoint.header;
 
@@ -1208,17 +1210,15 @@ export class SequencerPublisher {
   private async addProposeTx(
     checkpoint: Checkpoint,
     encodedData: L1ProcessArgs,
-    opts: { txTimeoutAt?: Date; forcePendingCheckpointNumber?: CheckpointNumber } = {},
+    opts: { txDeadline?: Deadline; forcePendingCheckpointNumber?: CheckpointNumber } = {},
     timestamp: bigint,
   ): Promise<void> {
     const slot = checkpoint.header.slotNumber;
     const timer = new Timer();
     const kzg = Blob.getViemKzgInstance();
-    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(
-      encodedData,
-      timestamp,
-      opts,
-    );
+    const { rollupData, simulationResult, blobEvaluationGas } = await this.prepareProposeTx(encodedData, timestamp, {
+      forcePendingCheckpointNumber: opts.forcePendingCheckpointNumber,
+    });
     const startBlock = await this.l1TxUtils.getBlockNumber();
     const gasLimit = this.l1TxUtils.bumpGasLimit(
       BigInt(Math.ceil((Number(simulationResult.gasUsed) * 64) / 63)) +
@@ -1234,6 +1234,9 @@ export class SequencerPublisher {
       }),
     );
 
+    // Convert monotonic Deadline to wall-clock Date for L1 utilities
+    const txTimeoutAt = opts.txDeadline ? Deadline.toDate(opts.txDeadline, this.dateProvider) : undefined;
+
     return this.addRequest({
       action: 'propose',
       request: {
@@ -1241,7 +1244,7 @@ export class SequencerPublisher {
         data: rollupData,
       },
       lastValidL2Slot: checkpoint.header.slotNumber,
-      gasConfig: { ...opts, gasLimit },
+      gasConfig: { txTimeoutAt, gasLimit },
       blobConfig: {
         blobs: encodedData.blobs.map(b => b.data),
         kzg,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -4,7 +4,7 @@ import {
   NUM_FIRST_BLOCK_END_BLOB_FIELDS,
 } from '@aztec/blob-lib/encoding';
 import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
-import type { EpochCache } from '@aztec/epoch-cache';
+import { type EpochCache, SlotTimingContext } from '@aztec/epoch-cache';
 import {
   BlockNumber,
   CheckpointNumber,
@@ -79,6 +79,7 @@ describe('CheckpointProposalJob', () => {
   let blockSink: MockProxy<L2BlockSink>;
   let slasherClient: MockProxy<SlasherClientInterface>;
   let dateProvider: TestDateProvider;
+  let slotTimingContext: SlotTimingContext;
   let metrics: MockProxy<SequencerMetrics>;
   let job: TestCheckpointProposalJob;
 
@@ -151,6 +152,14 @@ describe('CheckpointProposalJob', () => {
     // Set time to be at the start of the slot (slot 1 starts at l1GenesisTime + slotDuration - ethereumSlotDuration)
     const slotStartTime = Number(l1GenesisTime) + newSlotNumber * slotDuration - ethereumSlotDuration;
     dateProvider.setTime(slotStartTime * 1000); // Convert to milliseconds
+
+    // Create slotTimingContext anchored to the current time
+    slotTimingContext = new SlotTimingContext(
+      SlotNumber(newSlotNumber),
+      slotStartTime,
+      dateProvider.now(),
+      dateProvider.monotonic(),
+    );
 
     epochCache = mockDeep<EpochCache>();
     epochCache.getCommittee.mockResolvedValue({
@@ -521,6 +530,7 @@ describe('CheckpointProposalJob', () => {
       publisher,
       attestorAddress,
       undefined, // invalidateBlock
+      slotTimingContext,
       validatorClient,
       globalVariableBuilder,
       p2p,

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1,6 +1,6 @@
 import { NUM_CHECKPOINT_END_MARKER_FIELDS, getNumBlockEndBlobFields } from '@aztec/blob-lib/encoding';
 import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
-import type { EpochCache } from '@aztec/epoch-cache';
+import type { EpochCache, SlotTimingContext } from '@aztec/epoch-cache';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
@@ -8,8 +8,8 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { filter } from '@aztec/foundation/iterator';
 import type { Logger } from '@aztec/foundation/log';
-import { sleep, sleepUntil } from '@aztec/foundation/sleep';
-import { type DateProvider, Timer } from '@aztec/foundation/timer';
+import { sleep } from '@aztec/foundation/sleep';
+import { type DateProvider, Deadline, Timer } from '@aztec/foundation/timer';
 import { type TypedEventEmitter, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
@@ -22,7 +22,6 @@ import {
   MaliciousCommitteeAttestationsAndSigners,
 } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
-import { getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { Gas } from '@aztec/stdlib/gas';
 import type {
   PublicProcessorLimits,
@@ -69,6 +68,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly publisher: SequencerPublisher,
     private readonly attestorAddress: EthAddress,
     private readonly invalidateCheckpoint: InvalidateCheckpointRequest | undefined,
+    private readonly slotTimingContext: SlotTimingContext,
     private readonly validatorClient: ValidatorClient,
     private readonly globalsBuilder: GlobalVariableBuilder,
     private readonly p2pClient: P2P,
@@ -85,7 +85,7 @@ export class CheckpointProposalJob implements Traceable {
     private readonly dateProvider: DateProvider,
     private readonly metrics: SequencerMetrics,
     private readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
-    private readonly setStateFn: (state: SequencerState, slot?: SlotNumber) => void,
+    private readonly setStateFn: (state: SequencerState, slotTimingContext?: SlotTimingContext) => void,
     protected readonly log: Logger,
     public readonly tracer: Tracer,
   ) {}
@@ -155,7 +155,7 @@ export class CheckpointProposalJob implements Traceable {
       const feeRecipient = this.validatorClient.getFeeRecipientForAttestor(this.attestorAddress);
 
       // Start the checkpoint
-      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.slot);
+      this.setStateFn(SequencerState.INITIALIZING_CHECKPOINT, this.slotTimingContext);
       this.metrics.incOpenSlot(this.slot, this.proposer?.toString() ?? 'unknown');
 
       // Enqueues checkpoint invalidation (constant for the whole slot)
@@ -246,7 +246,7 @@ export class CheckpointProposalJob implements Traceable {
 
       // Assemble and broadcast the checkpoint proposal, including the last block that was not
       // broadcasted yet, and wait to collect the committee attestations.
-      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.slot);
+      this.setStateFn(SequencerState.ASSEMBLING_CHECKPOINT, this.slotTimingContext);
       const checkpoint = await checkpointBuilder.completeCheckpoint();
 
       // Do not collect attestations nor publish to L1 in fisherman mode
@@ -283,7 +283,7 @@ export class CheckpointProposalJob implements Traceable {
       const blockProposedAt = this.dateProvider.now();
       await this.p2pClient.broadcastCheckpointProposal(proposal);
 
-      this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.slot);
+      this.setStateFn(SequencerState.COLLECTING_ATTESTATIONS, this.slotTimingContext);
       const attestations = await this.waitForAttestations(proposal);
       const blockAttestedAt = this.dateProvider.now();
 
@@ -321,12 +321,10 @@ export class CheckpointProposalJob implements Traceable {
       }
 
       // Enqueue publishing the checkpoint to L1
-      this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.slot);
-      const aztecSlotDuration = this.l1Constants.slotDuration;
-      const slotStartBuildTimestamp = this.getSlotStartBuildTimestamp();
-      const txTimeoutAt = new Date((slotStartBuildTimestamp + aztecSlotDuration) * 1000);
+      this.setStateFn(SequencerState.PUBLISHING_CHECKPOINT, this.slotTimingContext);
+      const txDeadline = this.slotTimingContext.createDeadline(this.l1Constants.slotDuration);
       await this.publisher.enqueueProposeCheckpoint(checkpoint, attestations, attestationsSignature, {
-        txTimeoutAt,
+        txDeadline,
         forcePendingCheckpointNumber: this.invalidateCheckpoint?.forcePendingCheckpointNumber,
       });
 
@@ -370,7 +368,7 @@ export class CheckpointProposalJob implements Traceable {
       const indexWithinCheckpoint = blocksBuilt;
       const blockNumber = BlockNumber(initialBlockNumber + blocksBuilt);
 
-      const secondsIntoSlot = this.getSecondsIntoSlot();
+      const secondsIntoSlot = this.slotTimingContext.getSecondsIntoSlot(this.dateProvider);
       const timingInfo = this.timetable.canStartNextBlock(secondsIntoSlot);
 
       if (!timingInfo.canStart) {
@@ -387,10 +385,8 @@ export class CheckpointProposalJob implements Traceable {
         blockTimestamp: timestamp,
         // Create an empty block if we haven't already and this is the last one
         forceCreate: timingInfo.isLastBlock && blocksBuilt === 0 && this.config.buildCheckpointIfEmpty,
-        // Build deadline is only set if we are enforcing the timetable
-        buildDeadline: timingInfo.deadline
-          ? new Date((this.getSlotStartBuildTimestamp() + timingInfo.deadline) * 1000)
-          : undefined,
+        // Build deadline is only set if we are enforcing the timetable (monotonic time based)
+        buildDeadline: timingInfo.deadline ? this.slotTimingContext.createDeadline(timingInfo.deadline) : undefined,
         blockNumber,
         indexWithinCheckpoint,
         txHashesAlreadyIncluded,
@@ -471,7 +467,7 @@ export class CheckpointProposalJob implements Traceable {
   /** Sleeps until it is time to produce the next block in the slot */
   @trackSpan('CheckpointProposalJob.waitUntilNextSubslot')
   private async waitUntilNextSubslot(nextSubslotStart: number) {
-    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.slot);
+    this.setStateFn(SequencerState.WAITING_UNTIL_NEXT_BLOCK, this.slotTimingContext);
     this.log.verbose(`Waiting until time for the next block at ${nextSubslotStart}s into slot`, { slot: this.slot });
     await this.waitUntilTimeInSlot(nextSubslotStart);
   }
@@ -485,7 +481,7 @@ export class CheckpointProposalJob implements Traceable {
       blockTimestamp: bigint;
       blockNumber: BlockNumber;
       indexWithinCheckpoint: number;
-      buildDeadline: Date | undefined;
+      buildDeadline: Deadline | undefined;
       txHashesAlreadyIncluded: Set<string>;
       remainingBlobFields: number;
     },
@@ -530,7 +526,7 @@ export class CheckpointProposalJob implements Traceable {
         `Building block ${blockNumber} at index ${indexWithinCheckpoint} for slot ${this.slot} with ${availableTxs} available txs`,
         { slot: this.slot, blockNumber, indexWithinCheckpoint },
       );
-      this.setStateFn(SequencerState.CREATING_BLOCK, this.slot);
+      this.setStateFn(SequencerState.CREATING_BLOCK, this.slotTimingContext);
 
       // Calculate blob fields limit for txs (remaining capacity - this block's end overhead)
       const blockEndOverhead = getNumBlockEndBlobFields(indexWithinCheckpoint === 0);
@@ -615,27 +611,27 @@ export class CheckpointProposalJob implements Traceable {
     forceCreate?: boolean;
     blockNumber: BlockNumber;
     indexWithinCheckpoint: number;
-    buildDeadline: Date | undefined;
+    buildDeadline: Deadline | undefined;
   }): Promise<{ canStartBuilding: boolean; availableTxs: number }> {
     const minTxs = this.config.minTxsPerBlock;
     const { indexWithinCheckpoint, blockNumber, buildDeadline, forceCreate } = opts;
 
-    // Deadline is undefined if we are not enforcing the timetable, meaning we'll exit immediately when out of time
+    // Create a deadline for when we must start building (minExecutionTime before build deadline).
+    // Deadline is undefined if we are not enforcing the timetable, meaning we'll exit immediately when out of time.
     const startBuildingDeadline = buildDeadline
-      ? new Date(buildDeadline.getTime() - this.timetable.minExecutionTime * 1000)
+      ? Deadline.subtract(buildDeadline, this.timetable.minExecutionTime * 1000)
       : undefined;
 
     let availableTxs = await this.p2pClient.getPendingTxCount();
 
     while (!forceCreate && availableTxs < minTxs) {
       // If we're past deadline, or we have no deadline, give up
-      const now = this.dateProvider.nowAsDate();
-      if (startBuildingDeadline === undefined || now >= startBuildingDeadline) {
+      if (startBuildingDeadline === undefined || Deadline.hasExpired(startBuildingDeadline, this.dateProvider)) {
         return { canStartBuilding: false, availableTxs: availableTxs };
       }
 
       // Wait a bit before checking again
-      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.slot);
+      this.setStateFn(SequencerState.WAITING_FOR_TXS, this.slotTimingContext);
       this.log.verbose(
         `Waiting for enough txs to build block ${blockNumber} at index ${indexWithinCheckpoint} in slot ${this.slot} (have ${availableTxs} but need ${minTxs})`,
         { blockNumber, slot: this.slot, indexWithinCheckpoint },
@@ -820,18 +816,8 @@ export class CheckpointProposalJob implements Traceable {
   /** Waits until a specific time within the current slot */
   @trackSpan('CheckpointProposalJob.waitUntilTimeInSlot')
   protected async waitUntilTimeInSlot(targetSecondsIntoSlot: number): Promise<void> {
-    const slotStartTimestamp = this.getSlotStartBuildTimestamp();
-    const targetTimestamp = slotStartTimestamp + targetSecondsIntoSlot;
-    await sleepUntil(new Date(targetTimestamp * 1000), this.dateProvider.nowAsDate());
-  }
-
-  private getSlotStartBuildTimestamp(): number {
-    return getSlotStartBuildTimestamp(this.slot, this.l1Constants);
-  }
-
-  private getSecondsIntoSlot(): number {
-    const slotStartTimestamp = this.getSlotStartBuildTimestamp();
-    return Number((this.dateProvider.now() / 1000 - slotStartTimestamp).toFixed(3));
+    const deadline = this.slotTimingContext.createDeadline(targetSecondsIntoSlot);
+    await Deadline.waitUntilExpired(deadline, this.dateProvider);
   }
 
   public getPublisher() {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,5 +1,5 @@
 import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
-import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
+import { type EpochCache, type EpochCommitteeInfo, SlotTimingContext } from '@aztec/epoch-cache';
 import type { RollupContract } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { omit, times, timesParallel } from '@aztec/foundation/collection';
@@ -21,7 +21,7 @@ import {
   type ValidateCheckpointNegativeResult,
 } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
-import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { type L1RollupConstants, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import {
   type SequencerConfig,
@@ -112,6 +112,21 @@ describe('sequencer', () => {
     return TestUtils.makeTx(seed, chainId);
   };
 
+  /**
+   * Creates a SlotTimingContext using the actual dateProvider and l1Constants values.
+   * This ensures the monotonic slotStartBuildTimestamp is properly anchored to the current time,
+   * so tests that manipulate time with dateProvider.setTime() work correctly.
+   */
+  const createSlotTimingContext = (slot: SlotNumber) => {
+    const slotBuildStartTimestampSeconds = getSlotStartBuildTimestamp(
+      slot,
+      l1Constants as Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration'>,
+    );
+    const wallClockNowMs = dateProvider.now();
+    const monotonicNow = dateProvider.monotonic();
+    return new SlotTimingContext(slot, slotBuildStartTimestampSeconds, wallClockNowMs, monotonicNow);
+  };
+
   /** Creates a single tx, makes a block from it, and mocks it as pending */
   const setupSingleTxBlock = async (seed?: number) => {
     const tx = await makeTx(seed);
@@ -128,7 +143,7 @@ describe('sequencer', () => {
       attestationsAndSigners,
       getSignatures()[0].signature,
       {
-        txTimeoutAt: expect.any(Date),
+        txDeadline: expect.any(Number),
       },
     );
   };
@@ -161,6 +176,8 @@ describe('sequencer', () => {
       slot: SlotNumber(1),
       ts: 1000n,
       now: 1000n,
+      // Create SlotTimingContext at call time so it uses current dateProvider values
+      slotTimingContext: createSlotTimingContext(SlotNumber(1)),
     }));
     epochCache.getCommittee.mockResolvedValue({
       committee,
@@ -468,10 +485,23 @@ describe('sequencer', () => {
         .mockResolvedValueOnce({ attestorAddress: publishers[1].getSenderAddress(), publisher: publishers[1] });
 
       // Configure epoch cache to return different slots
+      // Use mockImplementationOnce so SlotTimingContext is created at call time with current dateProvider values
       epochCache.getEpochAndSlotInNextL1Slot
         .mockReset()
-        .mockReturnValueOnce({ epoch: EpochNumber(1), slot: SlotNumber(1), ts: 1000n, now: 1000n })
-        .mockReturnValueOnce({ epoch: EpochNumber(1), slot: SlotNumber(2), ts: 1000n, now: 1000n });
+        .mockImplementationOnce(() => ({
+          epoch: EpochNumber(1),
+          slot: SlotNumber(1),
+          ts: 1000n,
+          now: 1000n,
+          slotTimingContext: createSlotTimingContext(SlotNumber(1)),
+        }))
+        .mockImplementationOnce(() => ({
+          epoch: EpochNumber(1),
+          slot: SlotNumber(2),
+          ts: 1000n,
+          now: 1000n,
+          slotTimingContext: createSlotTimingContext(SlotNumber(2)),
+        }));
 
       sequencer.updateConfig({ enforceTimeTable: false, maxTxsPerBlock: 4 });
 
@@ -488,7 +518,7 @@ describe('sequencer', () => {
           expect.any(Checkpoint),
           attestationsAndSigners,
           getSignatures()[0].signature,
-          { txTimeoutAt: expect.any(Date) },
+          { txDeadline: expect.any(Number) },
         );
       }
     });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -1,6 +1,6 @@
 import { getKzg } from '@aztec/blob-lib';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
-import type { EpochCache } from '@aztec/epoch-cache';
+import type { EpochCache, SlotTimingContext } from '@aztec/epoch-cache';
 import { NoCommitteeError, type RollupContract } from '@aztec/ethereum/contracts';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { merge, omit, pick } from '@aztec/foundation/collection';
@@ -14,7 +14,7 @@ import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import type { L2Block, L2BlockSink, L2BlockSource, ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
-import { getSlotAtTimestamp, getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
+import { getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
 import {
   type ResolvedSequencerConfig,
   type SequencerConfig,
@@ -199,10 +199,10 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   @trackSpan('Sequencer.work')
   protected async work() {
     this.setState(SequencerState.SYNCHRONIZING, undefined);
-    const { slot, ts, now, epoch } = this.epochCache.getEpochAndSlotInNextL1Slot();
+    const { slot, ts, now, epoch, slotTimingContext } = this.epochCache.getEpochAndSlotInNextL1Slot();
 
     // Check if we are synced and it's our slot, grab a publisher, check previous block invalidation, etc
-    const checkpointProposalJob = await this.prepareCheckpointProposal(epoch, slot, ts, now);
+    const checkpointProposalJob = await this.prepareCheckpointProposal(epoch, slot, ts, now, slotTimingContext);
     if (!checkpointProposalJob) {
       return;
     }
@@ -238,6 +238,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     slot: SlotNumber,
     ts: bigint,
     now: bigint,
+    slotTimingContext: SlotTimingContext,
   ): Promise<CheckpointProposalJob | undefined> {
     // Check we have not already processed this slot (cheapest check)
     // We only check this if enforce timetable is set, since we want to keep processing the same slot if we are not
@@ -260,7 +261,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     // Check all components are synced to latest as seen by the archiver (queries all subsystems)
     const syncedTo = await this.checkSync({ ts, slot });
     if (!syncedTo) {
-      await this.tryVoteWhenSyncFails({ slot, ts });
+      await this.tryVoteWhenSyncFails({ slot, ts, slotTimingContext });
       return undefined;
     }
 
@@ -269,7 +270,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     const isEscapeHatchOpen = await this.epochCache.isEscapeHatchOpen(epoch);
 
     if (isEscapeHatchOpen) {
-      this.setState(SequencerState.PROPOSER_CHECK, slot);
+      this.setState(SequencerState.PROPOSER_CHECK, slotTimingContext);
       const [canPropose, proposer] = await this.checkCanPropose(slot);
       if (canPropose) {
         await this.tryVoteWhenEscapeHatchOpen({ slot, proposer });
@@ -297,7 +298,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     };
 
     // Check that we are a proposer for the next slot
-    this.setState(SequencerState.PROPOSER_CHECK, slot);
+    this.setState(SequencerState.PROPOSER_CHECK, slotTimingContext);
     const [canPropose, proposer] = await this.checkCanPropose(slot);
 
     // If we are not a proposer check if we should invalidate an invalid checkpoint, and bail
@@ -385,6 +386,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       publisher,
       attestorAddress,
       invalidateCheckpoint,
+      slotTimingContext,
     );
   }
 
@@ -397,6 +399,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     publisher: SequencerPublisher,
     attestorAddress: EthAddress,
     invalidateCheckpoint: InvalidateCheckpointRequest | undefined,
+    slotTimingContext: SlotTimingContext,
   ): CheckpointProposalJob {
     return new CheckpointProposalJob(
       epoch,
@@ -407,6 +410,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       publisher,
       attestorAddress,
       invalidateCheckpoint,
+      slotTimingContext,
       this.validatorClient,
       this.globalsBuilder,
       this.p2pClient,
@@ -432,12 +436,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
   /**
    * Internal helper for setting the sequencer state and checks if we have enough time left in the slot to transition to the new state.
    * @param proposedState - The new state to transition to.
-   * @param slotNumber - The current slot number.
+   * @param slotTimingContext - The slot timing context for monotonic time calculations.
    * @param force - Whether to force the transition even if the sequencer is stopped.
    */
   protected setState(
     proposedState: SequencerState,
-    slotNumber: SlotNumber | undefined,
+    slotTimingContext: SlotTimingContext | undefined,
     opts: { force?: boolean } = {},
   ): void {
     if (this.state === SequencerState.STOPPING && proposedState !== SequencerState.STOPPED && !opts.force) {
@@ -449,8 +453,9 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
     let secondsIntoSlot = undefined;
-    if (slotNumber !== undefined) {
-      secondsIntoSlot = this.getSecondsIntoSlot(slotNumber);
+    const slotNumber = slotTimingContext?.slot;
+    if (slotTimingContext !== undefined) {
+      secondsIntoSlot = slotTimingContext.getSecondsIntoSlot(this.dateProvider);
       this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
     }
 
@@ -589,8 +594,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
    * This allows the sequencer to participate in governance/slashing votes even when it cannot build blocks.
    */
   @trackSpan('Seqeuencer.tryVoteWhenSyncFails', ({ slot }) => ({ [Attributes.SLOT_NUMBER]: slot }))
-  protected async tryVoteWhenSyncFails(args: { slot: SlotNumber; ts: bigint }): Promise<void> {
-    const { slot } = args;
+  protected async tryVoteWhenSyncFails(args: {
+    slot: SlotNumber;
+    ts: bigint;
+    slotTimingContext: SlotTimingContext;
+  }): Promise<void> {
+    const { slot, slotTimingContext } = args;
 
     // Prevent duplicate attempts in the same slot
     if (this.lastSlotForFallbackVote === slot) {
@@ -599,7 +608,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     // Check if we're past the max time for initializing a proposal
-    const secondsIntoSlot = this.getSecondsIntoSlot(slot);
+    const secondsIntoSlot = slotTimingContext.getSecondsIntoSlot(this.dateProvider);
     const maxAllowedTime = this.timetable.getMaxAllowedTime(SequencerState.INITIALIZING_CHECKPOINT);
 
     // If we haven't exceeded the time limit for initializing a proposal, don't proceed with voting
@@ -829,15 +838,6 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
         avgPriorityFeeDeltaGwei: s.avgPriorityFeeDeltaGwei.toFixed(2),
       })),
     });
-  }
-
-  private getSlotStartBuildTimestamp(slotNumber: SlotNumber): number {
-    return getSlotStartBuildTimestamp(slotNumber, this.l1Constants);
-  }
-
-  private getSecondsIntoSlot(slotNumber: SlotNumber): number {
-    const slotStartTimestamp = this.getSlotStartBuildTimestamp(slotNumber);
-    return Number((this.dateProvider.now() / 1000 - slotStartTimestamp).toFixed(3));
   }
 
   public get aztecSlotDuration() {

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
@@ -14,7 +14,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { Deadline, type MonotonicTimestampMs, TestDateProvider } from '@aztec/foundation/timer';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { GasFees } from '@aztec/stdlib/gas';
 import { MerkleTreeId, merkleTreeIds } from '@aztec/stdlib/trees';
@@ -296,7 +296,7 @@ describe('PublicProcessor C++ Timeout Race Condition', () => {
 
       // Calculate deadline RIGHT BEFORE process() to ensure we get the full timeout.
       // Use a 20ms deadline - enough for C++ to start but short enough to timeout mid-simulation.
-      const deadline = new Date(dateProvider.now() + 20);
+      const deadline = Deadline.at((dateProvider.monotonic() + 20) as MonotonicTimestampMs);
 
       // Process the transaction with the short deadline
       // PublicProcessor flow on timeout:

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -2,7 +2,7 @@ import { CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE, CONTRACT_CLASS_REGISTRY_CONTRACT_
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { Deadline, type MonotonicTimestampMs, TestDateProvider } from '@aztec/foundation/timer';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
 import { bufferAsFields } from '@aztec/stdlib/abi';
 import { PublicDataWrite, PublicTxResult, RevertCode } from '@aztec/stdlib/avm';
@@ -28,6 +28,7 @@ describe('public_processor', () => {
   let merkleTree: MockProxy<MerkleTreeWriteOperations>;
   let contractsDB: PublicContractsDB;
   let publicTxSimulator: MockProxy<PublicTxSimulator>;
+  let dateProvider: TestDateProvider;
 
   let mockedEnqueuedCallsResult: PublicTxResult;
 
@@ -95,12 +96,13 @@ describe('public_processor', () => {
       return Promise.resolve(mockedEnqueuedCallsResult);
     });
 
+    dateProvider = new TestDateProvider();
     processor = new PublicProcessor(
       globalVariables,
       new GuardedMerkleTreeOperations(merkleTree),
       contractsDB,
       publicTxSimulator,
-      new TestDateProvider(),
+      dateProvider,
       getTelemetryClient(),
     );
   });
@@ -234,7 +236,7 @@ describe('public_processor', () => {
       });
 
       // We allocate a deadline of 2s, so only 2 txs should fit
-      const deadline = new Date(Date.now() + 2000);
+      const deadline = Deadline.at((dateProvider.monotonic() + 2000) as MonotonicTimestampMs);
       const [processed, failed] = await processor.process(txs, { deadline });
 
       expect(processed.length).toBe(2);

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -3,7 +3,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { DateProvider, Timer, elapsed, executeTimeout } from '@aztec/foundation/timer';
+import { DateProvider, Deadline, Timer, elapsed, executeTimeout } from '@aztec/foundation/timer';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
 import { computeFeePayerBalanceLeafSlot, computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
@@ -168,7 +168,7 @@ export class PublicProcessor implements Traceable {
       }
 
       // Bail if we've hit the deadline
-      if (deadline && this.dateProvider.now() > +deadline) {
+      if (deadline && Deadline.hasExpired(deadline, this.dateProvider)) {
         this.log.warn(`Stopping tx processing due to timeout.`);
         break;
       }
@@ -370,7 +370,7 @@ export class PublicProcessor implements Traceable {
   }
 
   @trackSpan('PublicProcessor.processTx', tx => ({ [Attributes.TX_HASH]: tx.getTxHash().toString() }))
-  private async processTx(tx: Tx, deadline: Date | undefined): Promise<[ProcessedTx, NestedProcessReturnValues[]]> {
+  private async processTx(tx: Tx, deadline: Deadline | undefined): Promise<[ProcessedTx, NestedProcessReturnValues[]]> {
     const [time, [processedTx, returnValues]] = await elapsed(() => this.processTxWithinDeadline(tx, deadline));
 
     this.log.verbose(
@@ -427,7 +427,7 @@ export class PublicProcessor implements Traceable {
   /** Processes the given tx within deadline. Returns timeout if deadline is hit. */
   private async processTxWithinDeadline(
     tx: Tx,
-    deadline: Date | undefined,
+    deadline: Deadline | undefined,
   ): Promise<[ProcessedTx, NestedProcessReturnValues[] | undefined]> {
     const innerProcessFn: () => Promise<[ProcessedTx, NestedProcessReturnValues[] | undefined]> = tx.hasPublicCalls()
       ? () => this.processTxWithPublicCalls(tx)
@@ -450,13 +450,13 @@ export class PublicProcessor implements Traceable {
     }
 
     const txHash = tx.getTxHash();
-    const timeout = +deadline - this.dateProvider.now();
+    const timeout = Deadline.remainingMs(deadline, this.dateProvider);
     if (timeout <= 0) {
       throw new PublicProcessorTimeoutError();
     }
 
     this.log.debug(`Processing tx ${txHash.toString()} within ${timeout}ms`, {
-      deadline: deadline.toISOString(),
+      deadlineMs: Deadline.toMs(deadline),
       now: new Date(this.dateProvider.now()).toISOString(),
       txHash,
     });

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -1,5 +1,6 @@
 import type { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { Deadline } from '@aztec/foundation/timer';
 
 import type { L2Block } from '../block/l2_block.js';
 import type { ChainConfig, SequencerConfig } from '../config/chain-config.js';
@@ -39,7 +40,7 @@ export interface PublicProcessorLimits {
   maxBlockSize?: number;
   maxBlockGas?: Gas;
   maxBlobFields?: number;
-  deadline?: Date;
+  deadline?: Deadline;
 }
 
 export interface PublicProcessorValidator {

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@aztec/accounts": "workspace:^",
     "@aztec/archiver": "workspace:^",
+    "@aztec/epoch-cache": "workspace:^",
     "@aztec/aztec-node": "workspace:^",
     "@aztec/aztec.js": "workspace:^",
     "@aztec/bb-prover": "workspace:^",

--- a/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
+++ b/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
@@ -1,4 +1,10 @@
-import type { EpochAndSlot, EpochCacheInterface, EpochCommitteeInfo, SlotTag } from '@aztec/epoch-cache';
+import {
+  type EpochAndSlot,
+  type EpochCacheInterface,
+  type EpochCommitteeInfo,
+  type SlotTag,
+  SlotTimingContext,
+} from '@aztec/epoch-cache';
 import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
@@ -24,12 +30,13 @@ export class MockEpochCache implements EpochCacheInterface {
     };
   }
 
-  getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint } {
+  getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint; slotTimingContext: SlotTimingContext } {
     return {
       epoch: EpochNumber.ZERO,
       slot: SlotNumber(0),
       ts: 0n,
       now: 0n,
+      slotTimingContext: new SlotTimingContext(SlotNumber.ZERO, 0, 0, 0 as any),
     };
   }
 

--- a/yarn-project/txe/tsconfig.json
+++ b/yarn-project/txe/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../constants"
     },
     {
+      "path": "../epoch-cache"
+    },
+    {
       "path": "../foundation"
     },
     {

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -6,7 +6,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import { createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
-import { DateProvider, Timer } from '@aztec/foundation/timer';
+import { DateProvider, Deadline, Timer } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
 import { TxProvider } from '@aztec/p2p';
 import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
@@ -437,6 +437,14 @@ export class BlockProposalHandler {
     return new Date(nextSlotTimestampSeconds * 1000);
   }
 
+  /** Creates a monotonic deadline for re-execution (immune to NTP clock adjustments). */
+  private createReexecutionDeadline(
+    slot: SlotNumber,
+    config: { l1GenesisTime: bigint; slotDuration: number },
+  ): Deadline {
+    return Deadline.fromDate(this.getReexecutionDeadline(slot, config), this.dateProvider);
+  }
+
   private getReexecuteFailureReason(err: any) {
     if (err instanceof ReExStateMismatchError) {
       return 'state_mismatch';
@@ -499,7 +507,7 @@ export class BlockProposalHandler {
     );
 
     // Build the new block
-    const deadline = this.getReexecutionDeadline(slot, config);
+    const deadline = this.createReexecutionDeadline(slot, config);
     const result = await checkpointBuilder.buildBlock(txs, blockNumber, blockHeader.globalVariables.timestamp, {
       deadline,
       expectedEndState: blockHeader.state,


### PR DESCRIPTION
## Summary

This PR replaces wall-clock time (`Date.now()`) with monotonic time (`performance.now()`) in the sequencer's timing-critical paths. This prevents issues where NTP clock adjustments could cause the sequencer to prematurely abort block building or incorrectly calculate deadlines.

## Problem

When the system clock is adjusted (e.g., by NTP), `Date.now()` can jump forward or backward. This causes issues in the sequencer:
- A forward jump could make deadlines appear to have already passed, causing premature aborts
- A backward jump could make the sequencer think it has more time than it actually does

## Solution

Use `performance.now()` which provides monotonic time that only moves forward at a steady rate, regardless of system clock adjustments. The key changes:

1. **New types for type safety:**
   - `MonotonicTimestampMs` - branded type for monotonic timestamps
   - `Deadline` - branded type with helper methods (`at`, `hasExpired`, `toMs`, `remainingMs`)

2. **Extended DateProvider:**
   - Added `monotonic()` method returning `MonotonicTimestampMs`
   - Extended `TestDateProvider` with `advanceMonotonic()` and `setTimeWithoutMonotonic()` for testing

3. **New SlotTimingContext class:**
   - Anchors monotonic time to wall-clock slot boundaries
   - Provides `getSecondsIntoSlot()` and `createDeadline()` methods
   - Returned by `EpochCache.getEpochAndSlotInNextL1Slot()`

4. **Updated timing throughout sequencer:**
   - `CheckpointProposalJob` uses `SlotTimingContext` for all timing calculations
   - `PublicProcessorLimits.deadline` changed from `Date` to `Deadline`
   - `SequencerPublisher` uses `txDeadline: Deadline` instead of `txTimeoutAt: Date`
   - Deadline-to-Date conversion happens at L1 utility boundaries

5. **Updated unit tests** to use new types and mocks for `SlotTimingContext` and `Deadline`

Fixes A-274
