### PR TITLE
fix(p2p): sync world state before accessing snapshot in eviction rules

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -6,7 +6,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { MerkleTreeReadOperations, ReadonlyWorldStateAccess } from '@aztec/stdlib/interfaces/server';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { ChonkProof } from '@aztec/stdlib/proofs';
 import type { TxAddedToPoolStats } from '@aztec/stdlib/stats';
 import { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
@@ -99,7 +99,7 @@ export class AztecKVTxPool
   constructor(
     store: AztecAsyncKVStore,
     archive: AztecAsyncKVStore,
-    worldState: ReadonlyWorldStateAccess,
+    worldState: WorldStateSynchronizer,
     telemetry: TelemetryClient = getTelemetryClient(),
     config: TxPoolOptions = {},
     log = createLogger('p2p:tx_pool'),

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.test.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
@@ -150,12 +151,12 @@ describe('EvictionManager', () => {
       });
 
       evictionManager.registerRule(mockRule1);
-      await evictionManager.evictAfterChainPrune(1);
+      await evictionManager.evictAfterChainPrune(BlockNumber(1));
 
       expect(mockRule1.evict).toHaveBeenCalledWith(
         {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         },
         txPool,
       );
@@ -259,7 +260,7 @@ describe('EvictionManager', () => {
     });
 
     it('handles evictAfterChainPrune with no rules gracefully', async () => {
-      await expect(evictionManager.evictAfterChainPrune(1)).resolves.not.toThrow();
+      await expect(evictionManager.evictAfterChainPrune(BlockNumber(1))).resolves.not.toThrow();
     });
   });
 });

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_manager.ts
@@ -1,4 +1,5 @@
 import { findIndexInSortedArray, insertIntoSortedArray } from '@aztec/foundation/array';
+import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -50,7 +51,7 @@ export class EvictionManager {
     await this.runEvictionRules(ctx);
   }
 
-  public async evictAfterChainPrune(blockNumber: number): Promise<void> {
+  public async evictAfterChainPrune(blockNumber: BlockNumber): Promise<void> {
     const ctx: EvictionContext = {
       event: EvictionEvent.CHAIN_PRUNED,
       blockNumber,

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_strategy.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/eviction_strategy.ts
@@ -1,3 +1,4 @@
+import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
@@ -24,7 +25,7 @@ export type EvictionContext =
     }
   | {
       event: typeof EvictionEvent.CHAIN_PRUNED;
-      blockNumber: number;
+      blockNumber: BlockNumber;
     }
   | {
       event: typeof EvictionEvent.BLOCK_MINED;

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.test.ts
@@ -1,6 +1,7 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { MerkleTreeReadOperations } from '@aztec/stdlib/interfaces/server';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { mockTx } from '@aztec/stdlib/testing';
 import { PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { BlockHeader, type Tx, type TxHash } from '@aztec/stdlib/tx';
@@ -18,6 +19,7 @@ import { FeePayerBalanceEvictionRule } from './fee_payer_balance_eviction_rule.j
 describe('FeePayerBalanceEvictionRule', () => {
   let txPool: MockProxy<TxPoolOperations>;
   let worldState: MockProxy<MerkleTreeReadOperations>;
+  let worldStateSynchronizer: MockProxy<WorldStateSynchronizer>;
   let rule: FeePayerBalanceEvictionRule;
 
   const setFeePayerBalance = (balance: bigint) => {
@@ -71,17 +73,19 @@ describe('FeePayerBalanceEvictionRule', () => {
       new PublicDataTreeLeafPreimage(PublicDataTreeLeaf.empty(), Fr.ONE, 1n),
     );
 
-    rule = new FeePayerBalanceEvictionRule({
-      getCommitted: () => worldState,
-      getSnapshot: () => worldState,
-    } as any);
+    worldStateSynchronizer = mock<WorldStateSynchronizer>();
+    worldStateSynchronizer.getCommitted.mockReturnValue(worldState);
+    worldStateSynchronizer.getSnapshot.mockReturnValue(worldState);
+    worldStateSynchronizer.syncImmediate.mockResolvedValue(BlockNumber(1));
+
+    rule = new FeePayerBalanceEvictionRule(worldStateSynchronizer);
   });
 
   describe('evict method', () => {
     it('returns empty result for CHAIN_PRUNED event', async () => {
       const context: EvictionContext = {
         event: EvictionEvent.CHAIN_PRUNED,
-        blockNumber: 1,
+        blockNumber: BlockNumber(1),
       };
 
       const result = await rule.evict(context, txPool);
@@ -92,6 +96,8 @@ describe('FeePayerBalanceEvictionRule', () => {
         txsEvicted: [],
       });
       expect(txPool.getPendingFeePayers).toHaveBeenCalledTimes(1);
+      // Ensure syncImmediate is called before accessing the world state snapshot
+      expect(worldStateSynchronizer.syncImmediate).toHaveBeenCalledWith(BlockNumber(1));
     });
 
     it('returns empty result for TXS_ADDED when no fee payers are provided', async () => {
@@ -122,7 +128,7 @@ describe('FeePayerBalanceEvictionRule', () => {
 
       const context: EvictionContext = {
         event: EvictionEvent.CHAIN_PRUNED,
-        blockNumber: 1,
+        blockNumber: BlockNumber(1),
       };
 
       const result = await rule.evict(context, txPool);
@@ -156,6 +162,8 @@ describe('FeePayerBalanceEvictionRule', () => {
       expect(result.txsEvicted).toEqual(expect.arrayContaining(txHashes(tx2)));
       expect(result.txsEvicted.map(txHash => txHash.toString())).not.toContain(tx1.getTxHash().toString());
       expect(txPool.deleteTxs).toHaveBeenCalledWith(expect.arrayContaining(txHashes(tx2)));
+      // Ensure syncImmediate is called before accessing the world state snapshot
+      expect(worldStateSynchronizer.syncImmediate).toHaveBeenCalledWith(blockHeader.getBlockNumber());
     });
 
     it('handles empty fee payer entries after BLOCK_MINED', async () => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { ReadonlyWorldStateAccess } from '@aztec/stdlib/interfaces/server';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { DatabasePublicStateSource, type MerkleTreeReadOperations } from '@aztec/stdlib/trees';
 import type { TxHash } from '@aztec/stdlib/tx';
 
@@ -22,7 +22,7 @@ export class FeePayerBalanceEvictionRule implements EvictionRule {
 
   private log = createLogger('p2p:mempool:tx_pool:fee_payer_balance_eviction_rule');
 
-  constructor(private worldState: ReadonlyWorldStateAccess) {}
+  constructor(private worldState: WorldStateSynchronizer) {}
 
   async evict(context: EvictionContext, txPool: TxPoolOperations): Promise<EvictionResult> {
     try {
@@ -31,11 +31,12 @@ export class FeePayerBalanceEvictionRule implements EvictionRule {
       }
 
       if (context.event === EvictionEvent.BLOCK_MINED) {
-        return await this.evictForFeePayers(
-          context.feePayers,
-          this.worldState.getSnapshot(context.block.getBlockNumber()),
-          txPool,
-        );
+        const blockNumber = context.block.getBlockNumber();
+        // Ensure world state is synced to this block before accessing the snapshot.
+        // This handles the race where a block is added to the archiver
+        // but the world state hasn't synced it yet.
+        await this.worldState.syncImmediate(blockNumber);
+        return await this.evictForFeePayers(context.feePayers, this.worldState.getSnapshot(blockNumber), txPool);
       }
 
       // TODO: fix this edge-case
@@ -49,6 +50,8 @@ export class FeePayerBalanceEvictionRule implements EvictionRule {
       // -----
       // Proposed fix: evict only if node is synched
       if (context.event === EvictionEvent.CHAIN_PRUNED) {
+        // Ensure world state is synced to this block before accessing the snapshot.
+        await this.worldState.syncImmediate(context.blockNumber);
         const feePayers = await txPool.getPendingFeePayers();
         return await this.evictForFeePayers(feePayers, this.worldState.getSnapshot(context.blockNumber), txPool);
       }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_mining_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_mining_rule.test.ts
@@ -38,7 +38,7 @@ describe('InvalidTxsAfterMiningRule', () => {
       it('returns empty result for CHAIN_PRUNED event', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const result = await rule.evict(context, txPool);

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_reorg_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_reorg_rule.test.ts
@@ -1,5 +1,6 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import type { ReadonlyWorldStateAccess } from '@aztec/stdlib/interfaces/server';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { MerkleTreeReadOperations } from '@aztec/stdlib/trees';
 import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
@@ -16,7 +17,7 @@ import { InvalidTxsAfterReorgRule } from './invalid_txs_after_reorg_rule.js';
 
 describe('InvalidTxsAfterReorgRule', () => {
   let txPool: MockProxy<TxPoolOperations>;
-  let worldState: MockProxy<ReadonlyWorldStateAccess>;
+  let worldState: MockProxy<WorldStateSynchronizer>;
   let db: MockProxy<MerkleTreeReadOperations>;
   let rule: InvalidTxsAfterReorgRule;
 
@@ -30,6 +31,7 @@ describe('InvalidTxsAfterReorgRule', () => {
 
     worldState = mock();
     worldState.getSnapshot.mockReturnValue(db);
+    worldState.syncImmediate.mockResolvedValue(BlockNumber(1));
 
     rule = new InvalidTxsAfterReorgRule(worldState);
   });
@@ -74,7 +76,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('handles no pending transactions', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         txPool.getPendingTxInfos.mockResolvedValue([]);
@@ -92,7 +94,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('evicts all transactions that reference pruned blocks', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const tx1Hash = TxHash.random();
@@ -113,12 +115,14 @@ describe('InvalidTxsAfterReorgRule', () => {
         // Both txs reference pruned blocks
         expect(result.txsEvicted).toContain(tx1Hash);
         expect(result.txsEvicted).toContain(tx2Hash);
+        // Ensure syncImmediate is called before accessing the world state snapshot
+        expect(worldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(1));
       });
 
       it('respects non-evictable transactions', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const evictableTxHash = TxHash.random().toString();
@@ -143,7 +147,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('handles large number of transactions efficiently', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const largeTxBlockRefs: TxBlockReference[] = [];
@@ -173,7 +177,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('handles error from deleteTxs operation', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const txHash = TxHash.random().toString();
@@ -198,7 +202,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('evicts transactions with valid header hash format', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const txHash = TxHash.random().toString();
@@ -220,7 +224,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('deduplicates block hashes when multiple txs reference the same block', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const sharedBlockHash = Fr.random();
@@ -250,7 +254,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('only evicts txs referencing pruned blocks, keeps txs referencing valid blocks', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const validBlockHash = Fr.random();
@@ -283,7 +287,7 @@ describe('InvalidTxsAfterReorgRule', () => {
       it('handles mix of shared and unique block hashes with some valid and some pruned', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const validSharedHash = Fr.random();

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_reorg_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_reorg_rule.ts
@@ -1,7 +1,7 @@
 import { findIndexInSortedArray, insertIntoSortedArray } from '@aztec/foundation/array';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
-import type { ReadonlyWorldStateAccess } from '@aztec/stdlib/interfaces/server';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { TxHash } from '@aztec/stdlib/tx';
 
@@ -26,7 +26,7 @@ export class InvalidTxsAfterReorgRule implements EvictionRule {
 
   private log = createLogger('p2p:mempool:tx_pool:invalid_txs_after_reorg_rule');
 
-  public constructor(private worldState: ReadonlyWorldStateAccess) {}
+  public constructor(private worldState: WorldStateSynchronizer) {}
 
   async evict(context: EvictionContext, txPool: TxPoolOperations): Promise<EvictionResult> {
     if (context.event !== EvictionEvent.CHAIN_PRUNED) {
@@ -46,6 +46,8 @@ export class InvalidTxsAfterReorgRule implements EvictionRule {
         insertIntoSortedArray(uniqueBlockHashes, blockHash, Fr.cmp, false);
       });
 
+      // Ensure world state is synced to this block before accessing the snapshot.
+      await this.worldState.syncImmediate(context.blockNumber);
       const db = this.worldState.getSnapshot(context.blockNumber);
       const blocksFromDb = await db.findLeafIndices(MerkleTreeId.ARCHIVE, uniqueBlockHashes);
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.test.ts
@@ -1,3 +1,4 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -58,7 +59,7 @@ describe('LowPriorityEvictionRule', () => {
       it('returns empty result for CHAIN_PRUNED event', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
-          blockNumber: 1,
+          blockNumber: BlockNumber(1),
         };
 
         const result = await rule.evict(context, txPool);


### PR DESCRIPTION
Eviction rules were calling `worldState.getSnapshot(blockNumber)` for blocks that may not have been synced yet, causing "Unable to find low leaf" errors when processing provisional blocks. Now calls `syncImmediate` before `getSnapshot` to ensure the world state is synced to the target block.

Also updates `EvictionContext.blockNumber` to use branded `BlockNumber` type.

Fixes the following error seen in logs:
```
13:31:06 local-network-1  | [13:31:06.959] ERROR: world-state:database Call FIND_LOW_LEAF failed: Error: Unable to find low leaf for block 5, failed to get block data.: [Error: Unable to find low leaf for block 5, failed to get block data.] {"treeId":"PUBLIC_DATA_TREE","forkId":0,"blockNumber":5,"includeUncommitted":false}
13:31:06 local-network-1  | [13:31:06.959] ERROR: p2p:mempool:tx_pool:fee_payer_balance_eviction_rule Failed to evict txs due to fee payer balance: {
13:31:06 local-network-1  |   err: [Error: Unable to find low leaf for block 5, failed to get block data.]
13:31:06 local-network-1  | }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)