### PR TITLE
feat: support JSON input files for bb verify command

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -43,7 +43,8 @@ void write_standalone_vk(std::vector<uint8_t> bytecode,
     if (is_stdout) {
         write_bytes_to_stdout(response.bytes);
     } else if (flags.output_format == "json") {
-        std::string json_content = build_json_output(response.fields, "vk", flags);
+        // Note: Chonk VK doesn't have a hash, so we pass an empty string
+        std::string json_content = VkJson::build(response.fields, "", flags.scheme);
         write_file(output_path / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
         info("VK (JSON) saved to ", output_path / "vk.json");
     } else {
@@ -111,7 +112,8 @@ void ChonkAPI::prove(const Flags& flags,
             write_bytes_to_stdout(to_buffer(proof_fields));
         } else if (flags.output_format == "json") {
             vinfo("writing Chonk proof (JSON) in directory ", output_dir);
-            std::string json_content = build_json_output(proof_fields, "proof", flags);
+            // Note: Chonk proof doesn't have a vk_hash, so we pass an empty string
+            std::string json_content = ProofJson::build(proof_fields, "", flags.scheme);
             write_file(output_dir / "proof.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
             info("Proof (JSON) saved to ", output_dir / "proof.json");
         } else {

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -27,7 +27,7 @@ void write_vk_outputs(const bbapi::CircuitComputeVk::Response& vk_response,
 {
     if (flags.output_format == "json") {
         std::string json_content =
-            build_json_output(vk_response.fields, "vk", flags, bytes_to_hex_string(vk_response.hash));
+            VkJson::build(vk_response.fields, bytes_to_hex_string(vk_response.hash), flags.scheme);
         write_file(output_dir / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
         info("VK (JSON) saved to ", output_dir / "vk.json");
     } else {
@@ -44,11 +44,11 @@ void write_proof_outputs(const bbapi::CircuitProve::Response& prove_response,
 {
     if (flags.output_format == "json") {
         std::string vk_hash = bytes_to_hex_string(prove_response.vk.hash);
-        std::string proof_json = build_json_output(prove_response.proof, "proof", flags, vk_hash);
+        std::string proof_json = ProofJson::build(prove_response.proof, vk_hash, flags.scheme);
         write_file(output_dir / "proof.json", std::vector<uint8_t>(proof_json.begin(), proof_json.end()));
         info("Proof (JSON) saved to ", output_dir / "proof.json");
 
-        std::string pi_json = build_json_output(prove_response.public_inputs, "public_inputs", flags);
+        std::string pi_json = PublicInputsJson::build(prove_response.public_inputs, flags.scheme);
         write_file(output_dir / "public_inputs.json", std::vector<uint8_t>(pi_json.begin(), pi_json.end()));
         info("Public inputs (JSON) saved to ", output_dir / "public_inputs.json");
     } else {
@@ -120,28 +120,28 @@ bool UltraHonkAPI::verify(const Flags& flags,
 {
     BB_BENCH_NAME("UltraHonkAPI::verify");
 
-    // Read input files, supporting both binary and JSON formats (auto-detected by content)
+    // Read and parse input files (auto-detect JSON vs binary format)
     std::vector<uint256_t> public_inputs;
     std::vector<uint256_t> proof;
     std::vector<uint8_t> vk_bytes;
 
     auto public_inputs_content = read_file(public_inputs_path);
     if (auto json = try_parse_json(public_inputs_content)) {
-        public_inputs = parse_json_fields(*json);
+        public_inputs = PublicInputsJson::parse(*json);
     } else {
         public_inputs = many_from_buffer<uint256_t>(public_inputs_content);
     }
 
     auto proof_content = read_file(proof_path);
     if (auto json = try_parse_json(proof_content)) {
-        proof = parse_json_fields(*json);
+        proof = ProofJson::parse(*json);
     } else {
         proof = many_from_buffer<uint256_t>(proof_content);
     }
 
     auto vk_content = read_file(vk_path);
     if (auto json = try_parse_json(vk_content)) {
-        vk_bytes = parse_json_fields_to_bytes(*json);
+        vk_bytes = VkJson::parse_to_bytes(*json);
     } else {
         vk_bytes = std::move(vk_content);
     }

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -119,10 +119,35 @@ bool UltraHonkAPI::verify(const Flags& flags,
                           const std::filesystem::path& vk_path)
 {
     BB_BENCH_NAME("UltraHonkAPI::verify");
-    // Read input files
-    auto public_inputs = many_from_buffer<uint256_t>(read_file(public_inputs_path));
-    auto proof = many_from_buffer<uint256_t>(read_file(proof_path));
-    auto vk_bytes = read_vk_file(vk_path);
+
+    // Read input files, supporting both binary and JSON formats (auto-detected by content)
+    std::vector<uint256_t> public_inputs;
+    std::vector<uint256_t> proof;
+    std::vector<uint8_t> vk_bytes;
+
+    auto public_inputs_content = read_file(public_inputs_path);
+    if (is_json_content(public_inputs_content)) {
+        std::string json_str(public_inputs_content.begin(), public_inputs_content.end());
+        public_inputs = parse_json_fields(json_str);
+    } else {
+        public_inputs = many_from_buffer<uint256_t>(public_inputs_content);
+    }
+
+    auto proof_content = read_file(proof_path);
+    if (is_json_content(proof_content)) {
+        std::string json_str(proof_content.begin(), proof_content.end());
+        proof = parse_json_fields(json_str);
+    } else {
+        proof = many_from_buffer<uint256_t>(proof_content);
+    }
+
+    auto vk_content = read_file(vk_path);
+    if (is_json_content(vk_content)) {
+        std::string json_str(vk_content.begin(), vk_content.end());
+        vk_bytes = parse_json_fields_to_bytes(json_str);
+    } else {
+        vk_bytes = std::move(vk_content);
+    }
 
     // Convert flags to ProofSystemSettings
     bbapi::ProofSystemSettings settings{ .ipa_accumulation = flags.ipa_accumulation,

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -126,25 +126,22 @@ bool UltraHonkAPI::verify(const Flags& flags,
     std::vector<uint8_t> vk_bytes;
 
     auto public_inputs_content = read_file(public_inputs_path);
-    if (is_json_content(public_inputs_content)) {
-        std::string json_str(public_inputs_content.begin(), public_inputs_content.end());
-        public_inputs = parse_json_fields(json_str);
+    if (auto json = try_parse_json(public_inputs_content)) {
+        public_inputs = parse_json_fields(*json);
     } else {
         public_inputs = many_from_buffer<uint256_t>(public_inputs_content);
     }
 
     auto proof_content = read_file(proof_path);
-    if (is_json_content(proof_content)) {
-        std::string json_str(proof_content.begin(), proof_content.end());
-        proof = parse_json_fields(json_str);
+    if (auto json = try_parse_json(proof_content)) {
+        proof = parse_json_fields(*json);
     } else {
         proof = many_from_buffer<uint256_t>(proof_content);
     }
 
     auto vk_content = read_file(vk_path);
-    if (is_json_content(vk_content)) {
-        std::string json_str(vk_content.begin(), vk_content.end());
-        vk_bytes = parse_json_fields_to_bytes(json_str);
+    if (auto json = try_parse_json(vk_content)) {
+        vk_bytes = parse_json_fields_to_bytes(*json);
     } else {
         vk_bytes = std::move(vk_content);
     }

--- a/barretenberg/cpp/src/barretenberg/api/json_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/json_output.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
 #include "barretenberg/api/api.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/version.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
+#include <filesystem>
 #include <iomanip>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -78,6 +82,104 @@ std::string build_json_output(const std::vector<T>& fields,
     std::stringstream ss;
     ss << oh.get();
     return ss.str();
+}
+
+/**
+ * @brief Check if file content appears to be JSON
+ *
+ * @details Detects JSON by checking if content starts with '{' (after skipping whitespace).
+ * This is more robust than relying on file extension.
+ */
+inline bool is_json_content(const std::vector<uint8_t>& content)
+{
+    for (const auto& byte : content) {
+        if (std::isspace(byte)) {
+            continue;
+        }
+        return byte == '{';
+    }
+    return false;
+}
+
+/**
+ * @brief Parse a hex string (with or without 0x prefix) to uint256_t
+ */
+inline uint256_t hex_string_to_uint256(const std::string& hex_str)
+{
+    std::string str = hex_str;
+    // Remove 0x prefix if present
+    if (str.size() >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
+        str = str.substr(2);
+    }
+    // Pad to 64 characters (32 bytes) if needed
+    if (str.size() < 64) {
+        str.insert(0, 64 - str.size(), '0');
+    }
+    return uint256_t(str);
+}
+
+/**
+ * @brief Parse JSON file content and extract fields as uint256_t vector
+ *
+ * @param json_content Raw JSON string content
+ * @return Vector of field elements
+ */
+inline std::vector<uint256_t> parse_json_fields(const std::string& json_content)
+{
+    auto json = nlohmann::json::parse(json_content);
+
+    if (!json.contains("fields") || !json["fields"].is_array()) {
+        throw_or_abort("JSON missing 'fields' array");
+    }
+
+    std::vector<uint256_t> result;
+    result.reserve(json["fields"].size());
+    for (const auto& field : json["fields"]) {
+        result.push_back(hex_string_to_uint256(field.get<std::string>()));
+    }
+    return result;
+}
+
+/**
+ * @brief Parse JSON file and extract the vk_hash field
+ *
+ * @param json_content Raw JSON string content
+ * @return vk_hash as a hex string, or empty string if not present
+ */
+inline std::string parse_json_vk_hash(const std::string& json_content)
+{
+    auto json = nlohmann::json::parse(json_content);
+    if (json.contains("vk_hash") && json["vk_hash"].is_string()) {
+        return json["vk_hash"].get<std::string>();
+    }
+    return "";
+}
+
+/**
+ * @brief Parse JSON file and extract fields as raw bytes
+ *
+ * @details Converts field elements back to their 32-byte big-endian representation.
+ * This is the inverse of the serialization used for VK output.
+ *
+ * @param json_content Raw JSON string content
+ * @return Vector of bytes (each field element is 32 bytes)
+ */
+inline std::vector<uint8_t> parse_json_fields_to_bytes(const std::string& json_content)
+{
+    auto fields = parse_json_fields(json_content);
+    std::vector<uint8_t> result;
+    result.reserve(fields.size() * 32);
+
+    for (const auto& field : fields) {
+        // Serialize each uint256_t as 32 bytes big-endian
+        for (int i = 3; i >= 0; --i) {
+            uint64_t limb = field.data[i];
+            for (int j = 7; j >= 0; --j) {
+                result.push_back(static_cast<uint8_t>((limb >> (j * 8)) & 0xFF));
+            }
+        }
+    }
+    return result;
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/api/json_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/json_output.hpp
@@ -6,7 +6,6 @@
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
-#include <filesystem>
 #include <iomanip>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -30,62 +29,6 @@ inline std::string bytes_to_hex_string(const std::vector<uint8_t>& bytes)
 }
 
 /**
- * @brief Serializable structure for JSON output (msgpack-compatible)
- */
-struct JsonOutput {
-    std::vector<std::string> fields;
-    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
-    std::string file_kind; // "vk", "proof", or "public_inputs"
-    std::string bb_version;
-    std::string scheme;
-    std::string verifier_target; // Optional
-
-    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
-};
-
-/**
- * @brief Build JSON output string using msgpack serialization
- *
- * @tparam T Field element type (must have operator<< that outputs 0x-prefixed hex)
- * @param fields Vector of field elements to serialize
- * @param file_kind Type identifier: "vk", "proof", or "public_inputs"
- * @param flags API flags containing scheme and verifier_target
- * @param vk_hash Optional hash string for VK or proof files
- * @return JSON string
- */
-template <typename T>
-std::string build_json_output(const std::vector<T>& fields,
-                              const std::string& file_kind,
-                              const API::Flags& flags,
-                              const std::string& vk_hash = "")
-{
-    std::vector<std::string> hex_fields;
-    hex_fields.reserve(fields.size());
-    for (const auto& field : fields) {
-        std::stringstream ss;
-        ss << field; // T's operator<< outputs "0x" prefix
-        hex_fields.push_back(ss.str());
-    }
-
-    JsonOutput output{
-        .fields = std::move(hex_fields),
-        .vk_hash = vk_hash,
-        .file_kind = file_kind,
-        .bb_version = BB_VERSION,
-        .scheme = flags.scheme,
-        .verifier_target = flags.verifier_target,
-    };
-
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, output);
-    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
-
-    std::stringstream ss;
-    ss << oh.get();
-    return ss.str();
-}
-
-/**
  * @brief Try to parse file content as JSON
  *
  * @details Attempts to parse the content as JSON.
@@ -95,7 +38,7 @@ inline std::optional<nlohmann::json> try_parse_json(const std::vector<uint8_t>& 
 {
     // Quick check: JSON objects must start with '{' (after whitespace)
     for (const auto& byte : content) {
-        if (std::isspace(byte)) {
+        if (std::isspace(static_cast<unsigned char>(byte)) != 0) {
             continue;
         }
         if (byte != '{') {
@@ -131,64 +74,150 @@ inline uint256_t hex_string_to_uint256(const std::string& hex_str)
 }
 
 /**
- * @brief Extract fields from parsed JSON as uint256_t vector
- *
- * @param json Parsed JSON object
- * @return Vector of field elements
+ * @brief Serializable structure for VK JSON output (msgpack-compatible)
  */
-inline std::vector<uint256_t> parse_json_fields(const nlohmann::json& json)
-{
-    if (!json.contains("fields") || !json["fields"].is_array()) {
-        throw_or_abort("JSON missing 'fields' array");
+struct VkJson {
+    std::vector<std::string> vk;
+    std::string hash;
+    std::string bb_version;
+    std::string scheme;
+
+    MSGPACK_FIELDS(vk, hash, bb_version, scheme);
+
+    template <typename T>
+    static std::string build(const std::vector<T>& fields, const std::string& hash, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        VkJson output{ .vk = std::move(hex_fields), .hash = hash, .bb_version = BB_VERSION, .scheme = scheme };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+        std::stringstream ss;
+        ss << oh.get();
+        return ss.str();
     }
 
-    std::vector<uint256_t> result;
-    result.reserve(json["fields"].size());
-    for (const auto& field : json["fields"]) {
-        result.push_back(hex_string_to_uint256(field.get<std::string>()));
-    }
-    return result;
-}
-
-/**
- * @brief Extract vk_hash from parsed JSON
- *
- * @param json Parsed JSON object
- * @return vk_hash as a hex string, or empty string if not present
- */
-inline std::string parse_json_vk_hash(const nlohmann::json& json)
-{
-    if (json.contains("vk_hash") && json["vk_hash"].is_string()) {
-        return json["vk_hash"].get<std::string>();
-    }
-    return "";
-}
-
-/**
- * @brief Extract fields from parsed JSON as raw bytes
- *
- * @details Converts field elements back to their 32-byte big-endian representation.
- * This is the inverse of the serialization used for VK output.
- *
- * @param json Parsed JSON object
- * @return Vector of bytes (each field element is 32 bytes)
- */
-inline std::vector<uint8_t> parse_json_fields_to_bytes(const nlohmann::json& json)
-{
-    auto fields = parse_json_fields(json);
-    std::vector<uint8_t> result;
-    result.reserve(fields.size() * 32);
-
-    for (const auto& field : fields) {
-        // Serialize each uint256_t as 32 bytes big-endian
-        for (int i = 3; i >= 0; --i) {
-            uint64_t limb = field.data[i];
-            for (int j = 7; j >= 0; --j) {
-                result.push_back(static_cast<uint8_t>((limb >> (j * 8)) & 0xFF));
+    static std::vector<uint8_t> parse_to_bytes(const nlohmann::json& json)
+    {
+        if (!json.contains("vk") || !json["vk"].is_array()) {
+            throw_or_abort("JSON missing 'vk' array");
+        }
+        std::vector<uint8_t> result;
+        result.reserve(json["vk"].size() * 32);
+        for (const auto& field : json["vk"]) {
+            auto value = hex_string_to_uint256(field.get<std::string>());
+            for (int i = 3; i >= 0; --i) {
+                uint64_t limb = value.data[i];
+                for (int j = 7; j >= 0; --j) {
+                    result.push_back(static_cast<uint8_t>((limb >> (j * 8)) & 0xFF));
+                }
             }
         }
+        return result;
     }
-    return result;
-}
+};
+
+/**
+ * @brief Serializable structure for proof JSON output (msgpack-compatible)
+ */
+struct ProofJson {
+    std::vector<std::string> proof;
+    std::string vk_hash;
+    std::string bb_version;
+    std::string scheme;
+
+    MSGPACK_FIELDS(proof, vk_hash, bb_version, scheme);
+
+    template <typename T>
+    static std::string build(const std::vector<T>& fields, const std::string& vk_hash, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        ProofJson output{
+            .proof = std::move(hex_fields), .vk_hash = vk_hash, .bb_version = BB_VERSION, .scheme = scheme
+        };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+        std::stringstream ss;
+        ss << oh.get();
+        return ss.str();
+    }
+
+    static std::vector<uint256_t> parse(const nlohmann::json& json)
+    {
+        if (!json.contains("proof") || !json["proof"].is_array()) {
+            throw_or_abort("JSON missing 'proof' array");
+        }
+        std::vector<uint256_t> result;
+        result.reserve(json["proof"].size());
+        for (const auto& field : json["proof"]) {
+            result.push_back(hex_string_to_uint256(field.get<std::string>()));
+        }
+        return result;
+    }
+};
+
+/**
+ * @brief Serializable structure for public inputs JSON output (msgpack-compatible)
+ */
+struct PublicInputsJson {
+    std::vector<std::string> public_inputs;
+    std::string bb_version;
+    std::string scheme;
+
+    MSGPACK_FIELDS(public_inputs, bb_version, scheme);
+
+    template <typename T> static std::string build(const std::vector<T>& fields, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        PublicInputsJson output{ .public_inputs = std::move(hex_fields), .bb_version = BB_VERSION, .scheme = scheme };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+        std::stringstream ss;
+        ss << oh.get();
+        return ss.str();
+    }
+
+    static std::vector<uint256_t> parse(const nlohmann::json& json)
+    {
+        if (!json.contains("public_inputs") || !json["public_inputs"].is_array()) {
+            throw_or_abort("JSON missing 'public_inputs' array");
+        }
+        std::vector<uint256_t> result;
+        result.reserve(json["public_inputs"].size());
+        for (const auto& field : json["public_inputs"]) {
+            result.push_back(hex_string_to_uint256(field.get<std::string>()));
+        }
+        return result;
+    }
+};
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/api/json_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/json_output.hpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -85,20 +86,31 @@ std::string build_json_output(const std::vector<T>& fields,
 }
 
 /**
- * @brief Check if file content appears to be JSON
+ * @brief Try to parse file content as JSON
  *
- * @details Detects JSON by checking if content starts with '{' (after skipping whitespace).
- * This is more robust than relying on file extension.
+ * @details Attempts to parse the content as JSON.
+ * Returns nullopt if parsing fails, allowing fallback to binary format.
  */
-inline bool is_json_content(const std::vector<uint8_t>& content)
+inline std::optional<nlohmann::json> try_parse_json(const std::vector<uint8_t>& content)
 {
+    // Quick check: JSON objects must start with '{' (after whitespace)
     for (const auto& byte : content) {
         if (std::isspace(byte)) {
             continue;
         }
-        return byte == '{';
+        if (byte != '{') {
+            return std::nullopt;
+        }
+        break;
     }
-    return false;
+
+    // Try to parse as JSON
+    try {
+        std::string str(content.begin(), content.end());
+        return nlohmann::json::parse(str);
+    } catch (...) {
+        return std::nullopt;
+    }
 }
 
 /**
@@ -119,15 +131,13 @@ inline uint256_t hex_string_to_uint256(const std::string& hex_str)
 }
 
 /**
- * @brief Parse JSON file content and extract fields as uint256_t vector
+ * @brief Extract fields from parsed JSON as uint256_t vector
  *
- * @param json_content Raw JSON string content
+ * @param json Parsed JSON object
  * @return Vector of field elements
  */
-inline std::vector<uint256_t> parse_json_fields(const std::string& json_content)
+inline std::vector<uint256_t> parse_json_fields(const nlohmann::json& json)
 {
-    auto json = nlohmann::json::parse(json_content);
-
     if (!json.contains("fields") || !json["fields"].is_array()) {
         throw_or_abort("JSON missing 'fields' array");
     }
@@ -141,14 +151,13 @@ inline std::vector<uint256_t> parse_json_fields(const std::string& json_content)
 }
 
 /**
- * @brief Parse JSON file and extract the vk_hash field
+ * @brief Extract vk_hash from parsed JSON
  *
- * @param json_content Raw JSON string content
+ * @param json Parsed JSON object
  * @return vk_hash as a hex string, or empty string if not present
  */
-inline std::string parse_json_vk_hash(const std::string& json_content)
+inline std::string parse_json_vk_hash(const nlohmann::json& json)
 {
-    auto json = nlohmann::json::parse(json_content);
     if (json.contains("vk_hash") && json["vk_hash"].is_string()) {
         return json["vk_hash"].get<std::string>();
     }
@@ -156,17 +165,17 @@ inline std::string parse_json_vk_hash(const std::string& json_content)
 }
 
 /**
- * @brief Parse JSON file and extract fields as raw bytes
+ * @brief Extract fields from parsed JSON as raw bytes
  *
  * @details Converts field elements back to their 32-byte big-endian representation.
  * This is the inverse of the serialization used for VK output.
  *
- * @param json_content Raw JSON string content
+ * @param json Parsed JSON object
  * @return Vector of bytes (each field element is 32 bytes)
  */
-inline std::vector<uint8_t> parse_json_fields_to_bytes(const std::string& json_content)
+inline std::vector<uint8_t> parse_json_fields_to_bytes(const nlohmann::json& json)
 {
-    auto fields = parse_json_fields(json_content);
+    auto fields = parse_json_fields(json);
     std::vector<uint8_t> result;
     result.reserve(fields.size() * 32);
 


### PR DESCRIPTION
## Summary

Adds support for reading JSON-formatted proof, public inputs, and VK files in the `bb verify` command. This complements the existing `--output_format json` feature by allowing the JSON files to be consumed for verification.

This enables users who receive JSON proof artifacts from third parties to verify the proof before using it in their circuits (e.g., for recursive verification).

### Format Detection

The format is **auto-detected by attempting to parse as JSON**. If parsing succeeds, the file is treated as JSON; otherwise it falls back to binary format. This is robust and works regardless of file extension.

### Usage

```bash
# Verify using JSON files
bb verify --scheme ultra_honk -p proof.json -i public_inputs.json -k vk.json

# Works even without .json extension (content-based detection)
bb verify --scheme ultra_honk -p my_proof -i my_inputs -k my_vk

# Mix and match: JSON proof with binary VK
bb verify --scheme ultra_honk -p proof.json -i public_inputs.json -k vk
```

## Test plan

- [x] Build passes
- [x] Tested verify with JSON files
- [x] Tested verify with binary files (no false positive JSON detection)
- [x] Tested verify with mixed JSON and binary files
- [x] acir_tests bb_prove tests pass