### PR TITLE
refactor!: make the history fns take confirmed note

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion.nr
@@ -1,37 +1,55 @@
-use protocol_types::{abis::block_header::BlockHeader, merkle_tree::root::root_from_sibling_path};
+use protocol_types::{
+    abis::block_header::BlockHeader,
+    hash::{compute_siloed_note_hash, compute_unique_note_hash},
+    merkle_tree::root::root_from_sibling_path,
+};
 
 use crate::{
-    note::{
-        hinted_note::HintedNote, note_interface::NoteHash, utils::compute_settled_note_unique_hash,
-    },
+    note::{confirmed_note::ConfirmedNote, hinted_note::HintedNote, note_interface::NoteHash},
     oracle::get_membership_witness::get_note_hash_membership_witness,
 };
 
 mod test;
 
 pub trait ProveNoteInclusion {
-    fn prove_note_inclusion<Note>(header: BlockHeader, hinted_note: HintedNote<Note>)
+    fn prove_note_inclusion<Note>(
+        header: BlockHeader,
+        hinted_note: HintedNote<Note>,
+    ) -> ConfirmedNote<Note>
     where
         Note: NoteHash;
 }
 
 impl ProveNoteInclusion for BlockHeader {
-    fn prove_note_inclusion<Note>(self, hinted_note: HintedNote<Note>)
+    fn prove_note_inclusion<Note>(self, hinted_note: HintedNote<Note>) -> ConfirmedNote<Note>
     where
         Note: NoteHash,
     {
-        let note_hash = compute_settled_note_unique_hash(hinted_note);
+        let note_hash = hinted_note.note.compute_note_hash(
+            hinted_note.owner,
+            hinted_note.storage_slot,
+            hinted_note.randomness,
+        );
+
+        let siloed_note_hash = compute_siloed_note_hash(hinted_note.contract_address, note_hash);
+
+        let unique_note_hash = compute_unique_note_hash(
+            hinted_note.metadata.to_settled().note_nonce(),
+            siloed_note_hash,
+        );
 
         // Safety: The witness is only used as a "magical value" that makes the merkle proof below pass. Hence it's safe.
-        let witness = unsafe { get_note_hash_membership_witness(self, note_hash) };
+        let witness = unsafe { get_note_hash_membership_witness(self, unique_note_hash) };
 
         // Note inclusion is fairly straightforward, since all we need to prove is that a note exists in the note tree -
         // we don't even care _where_ in the tree it is stored. This is because entries in the note hash tree are
         // unique.
         assert_eq(
             self.state.partial.note_hash_tree.root,
-            root_from_sibling_path(note_hash, witness.index, witness.path),
+            root_from_sibling_path(unique_note_hash, witness.index, witness.path),
             "Proving note inclusion failed",
         );
+
+        ConfirmedNote::new(hinted_note, unique_note_hash)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/history/note_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_inclusion/test.nr
@@ -10,7 +10,7 @@ unconstrained fn succeeds_on_blocks_after_note_creation() {
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_inclusion(hinted_note);
+            let _ = header.prove_note_inclusion(hinted_note);
         },
     );
 }
@@ -23,7 +23,7 @@ unconstrained fn fails_on_blocks_before_note_creation() {
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_CREATED_AT - 1),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_inclusion(hinted_note);
+            let _ = header.prove_note_inclusion(hinted_note);
         },
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
@@ -23,7 +23,7 @@ impl ProveNoteValidity for BlockHeader {
     where
         Note: NoteHash,
     {
-        self.prove_note_inclusion(hinted_note);
-        self.prove_note_not_nullified(hinted_note, context);
+        let confirmed_note = self.prove_note_inclusion(hinted_note);
+        self.prove_note_not_nullified(confirmed_note, context);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion.nr
@@ -1,14 +1,15 @@
 use crate::{
     context::PrivateContext,
     note::{
-        hinted_note::HintedNote, note_interface::NoteHash,
-        utils::compute_settled_note_siloed_nullifier,
+        confirmed_note::ConfirmedNote, note_interface::NoteHash,
+        utils::compute_confirmed_note_hash_for_nullification,
     },
     oracle::get_nullifier_membership_witness::get_nullifier_membership_witness,
 };
 
 use protocol_types::{
-    abis::block_header::BlockHeader, merkle_tree::root::root_from_sibling_path, traits::Hash,
+    abis::block_header::BlockHeader, hash::compute_siloed_nullifier,
+    merkle_tree::root::root_from_sibling_path, traits::Hash,
 };
 
 mod test;
@@ -45,7 +46,7 @@ impl ProveNullifierInclusion for BlockHeader {
 pub trait ProveNoteIsNullified {
     fn prove_note_is_nullified<Note>(
         header: BlockHeader,
-        hinted_note: HintedNote<Note>,
+        confirmed_note: ConfirmedNote<Note>,
         context: &mut PrivateContext,
     )
     where
@@ -55,14 +56,23 @@ pub trait ProveNoteIsNullified {
 impl ProveNoteIsNullified for BlockHeader {
     fn prove_note_is_nullified<Note>(
         self,
-        hinted_note: HintedNote<Note>,
+        confirmed_note: ConfirmedNote<Note>,
         context: &mut PrivateContext,
     )
     where
         Note: NoteHash,
     {
-        let nullifier = compute_settled_note_siloed_nullifier(hinted_note, context);
+        let note_hash_for_nullification =
+            compute_confirmed_note_hash_for_nullification(confirmed_note);
+        let inner_nullifier = confirmed_note.note.compute_nullifier(
+            context,
+            confirmed_note.owner,
+            note_hash_for_nullification,
+        );
 
-        self.prove_nullifier_inclusion(nullifier);
+        let siloed_nullifier =
+            compute_siloed_nullifier(confirmed_note.contract_address, inner_nullifier);
+
+        self.prove_nullifier_inclusion(siloed_nullifier);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
@@ -1,4 +1,8 @@
-use crate::history::{nullifier_inclusion::{ProveNoteIsNullified, ProveNullifierInclusion}, test};
+use crate::history::{
+    note_inclusion::ProveNoteInclusion,
+    nullifier_inclusion::{ProveNoteIsNullified, ProveNullifierInclusion},
+    test,
+};
 use crate::oracle::{notes::notify_created_nullifier, random::random};
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use dep::protocol_types::{
@@ -13,7 +17,8 @@ unconstrained fn note_is_nullified_succeeds_on_blocks_after_note_nullification()
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_is_nullified(hinted_note, context);
+            let confirmed_note = header.prove_note_inclusion(hinted_note);
+            header.prove_note_is_nullified(confirmed_note, context);
         },
     );
 }
@@ -26,7 +31,8 @@ unconstrained fn note_is_nullified_fails_on_blocks_before_note_nullification() {
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT - 1),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_is_nullified(hinted_note, context);
+            let confirmed_note = header.prove_note_inclusion(hinted_note);
+            header.prove_note_is_nullified(confirmed_note, context);
         },
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
@@ -1,13 +1,14 @@
 use crate::{
     context::PrivateContext,
     note::{
-        hinted_note::HintedNote, note_interface::NoteHash,
-        utils::compute_settled_note_siloed_nullifier,
+        confirmed_note::ConfirmedNote, note_interface::NoteHash,
+        utils::compute_confirmed_note_hash_for_nullification,
     },
     oracle::get_nullifier_membership_witness::get_low_nullifier_membership_witness,
 };
 use protocol_types::{
     abis::block_header::BlockHeader,
+    hash::compute_siloed_nullifier,
     merkle_tree::root::root_from_sibling_path,
     traits::Hash,
     utils::field::{full_field_greater_than, full_field_less_than},
@@ -55,7 +56,7 @@ impl ProveNullifierNonInclusion for BlockHeader {
 pub trait ProveNoteNotNullified {
     fn prove_note_not_nullified<Note>(
         header: BlockHeader,
-        hinted_note: HintedNote<Note>,
+        confirmed_note: ConfirmedNote<Note>,
         context: &mut PrivateContext,
     )
     where
@@ -65,14 +66,24 @@ pub trait ProveNoteNotNullified {
 impl ProveNoteNotNullified for BlockHeader {
     fn prove_note_not_nullified<Note>(
         self,
-        hinted_note: HintedNote<Note>,
+        confirmed_note: ConfirmedNote<Note>,
         context: &mut PrivateContext,
     )
     where
         Note: NoteHash,
     {
-        let nullifier = compute_settled_note_siloed_nullifier(hinted_note, context);
+        let note_hash_for_nullification =
+            compute_confirmed_note_hash_for_nullification(confirmed_note);
 
-        self.prove_nullifier_non_inclusion(nullifier);
+        let inner_nullifier = confirmed_note.note.compute_nullifier(
+            context,
+            confirmed_note.owner,
+            note_hash_for_nullification,
+        );
+
+        let siloed_nullifier =
+            compute_siloed_nullifier(confirmed_note.contract_address, inner_nullifier);
+
+        self.prove_nullifier_non_inclusion(siloed_nullifier);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
@@ -1,4 +1,5 @@
 use crate::history::{
+    note_inclusion::ProveNoteInclusion,
     nullifier_non_inclusion::{ProveNoteNotNullified, ProveNullifierNonInclusion},
     test,
 };
@@ -16,7 +17,8 @@ unconstrained fn note_not_nullified_succeeds_in_blocks_before_note_nullification
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT - 1),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_not_nullified(hinted_note, context);
+            let confirmed_note = header.prove_note_inclusion(hinted_note);
+            header.prove_note_not_nullified(confirmed_note, context);
         },
     );
 }
@@ -29,7 +31,8 @@ unconstrained fn note_not_nullified_fails_in_blocks_after_note_nullification_fai
         PrivateContextOptions::new().at_anchor_block_number(test::NOTE_NULLIFIED_AT),
         |context| {
             let header = context.anchor_block_header;
-            header.prove_note_not_nullified(hinted_note, context);
+            let confirmed_note = header.prove_note_inclusion(hinted_note);
+            header.prove_note_not_nullified(confirmed_note, context);
         },
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/note/confirmed_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/confirmed_note.nr
@@ -3,13 +3,22 @@ use protocol_types::address::AztecAddress;
 
 /// A note that has been confirmed to exist.
 ///
-/// This struct contains the actual note content and all associated data related to it, including metadata.
+/// This struct contains the actual note content and all associated data related to it, including the note's metadata
+/// and the note hash that was used to prove its existence.
+///
+/// Only `ConfirmedNote`s can be nullified, since emitting a nullifier for a note that does not exist is a meaningless
+/// action, and in the vast majority of cases an error.
+///
+/// `ConfirmedNote`s can be obtained by reading notes from PXE via [crate::note::note_getter::get_note] and
+/// [crate::note::note_getter::get_notes], or by confirming a [crate::note::hinted_note::HintedNote] via
+/// [crate::history::note_inclusion::ProveNoteInclusion::prove_note_inclusion].
 ///
 /// ## Pending Notes
 ///
-/// A pending `ConfirmedNote` will **not** necessarily be inserted into the note hash tree: if it is nullified in the
-/// same transaction, both note hash and nullifier will be squashed (deleted) by the kernel, resulting in a _transient
-/// note_.
+/// A pending `ConfirmedNote` (i.e. one of [crate::note::note_metadata::NoteStageEnum::PENDING_SAME_PHASE] or
+/// [crate::note::note_metadata::NoteStageEnum::PENDING_PREVIOUS_PHASE]) will **not** necessarily be inserted into the
+/// note hash tree: if it is nullified in the same transaction, both note hash and nullifier will be squashed (deleted)
+/// by the kernel, resulting in a _transient note_.
 pub struct ConfirmedNote<Note> {
     pub note: Note,
 
@@ -20,14 +29,14 @@ pub struct ConfirmedNote<Note> {
 
     pub metadata: NoteMetadata,
 
-    /// The note hash used in the kernel read request.
+    /// The note hash used to prove existence.
     ///
     /// Whether this note hash is unsiloed or unique depends on the note's metadata.
-    pub(crate) read_request_note_hash: Field,
+    pub(crate) proven_note_hash: Field,
 }
 
 impl<Note> ConfirmedNote<Note> {
-    pub(crate) fn new(hinted_note: HintedNote<Note>, read_request_note_hash: Field) -> Self {
+    pub(crate) fn new(hinted_note: HintedNote<Note>, proven_note_hash: Field) -> Self {
         Self {
             note: hinted_note.note,
             contract_address: hinted_note.contract_address,
@@ -35,7 +44,7 @@ impl<Note> ConfirmedNote<Note> {
             randomness: hinted_note.randomness,
             storage_slot: hinted_note.storage_slot,
             metadata: hinted_note.metadata,
-            read_request_note_hash,
+            proven_note_hash,
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/hinted_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/hinted_note.nr
@@ -1,8 +1,14 @@
 use crate::note::note_metadata::NoteMetadata;
 use protocol_types::{address::AztecAddress, traits::{Deserialize, Packable, Serialize}};
 
-/// A container for a note and the corresponding metadata that can be used to prove the note's existence, regardless of
-/// whether the note is pending (created in the current transaction) or settled (created in a previous transaction).
+/// A hint for a note that might exist.
+///
+/// This contains the actual note content and all metadata that is required in order to prove note's existence,
+/// regardless of whether the note is pending or settled (see [crate::note::note_metadata::NoteMetadata]).
+///
+/// This value typically unconstrained (originating from oracles or as a contract function parameter), and can be
+/// converted into a [crate::note::confirmed_note::ConfirmedNote] via
+/// [crate::history::note_inclusion::ProveNoteInclusion::prove_note_inclusion].
 #[derive(Deserialize, Eq, Serialize, Packable)]
 pub struct HintedNote<Note> {
     pub note: Note,

--- a/noir-projects/aztec-nr/aztec/src/note/note_metadata.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_metadata.nr
@@ -12,22 +12,27 @@ use protocol_types::traits::{Deserialize, Packable, Serialize};
 // For now, we have `NoteMetadata` acting as a sort of tagged union.
 
 struct NoteStageEnum {
-    /// A note that was created in the transaction that is currently being executed, during the current execution phase,
-    /// i.e. non-revertible or revertible.
+    /// A note created in the current transaction during the current execution phase.
+    ///
+    /// Notes from the non-revertible phase will be in this stage if the transaction is still in the non-revertible
+    /// phase, notes from the revertible phase will be in this stage until the transaction ends.
     ///
     /// These notes are not yet in the note hash tree, though they will be inserted unless nullified in this transaction
     /// (becoming a transient note).
     PENDING_SAME_PHASE: u8,
-    /// A note that was created in the transaction that is currently being executed, during the previous execution
-    /// phase. Because there are only two phases and their order is always the same (first non-revertible and then
-    /// revertible) this implies that the note was created in the non-revertible phase, and that the current phase is
-    /// the revertible phase.
+    /// A note created in the current transaction during the previous execution phase.
+    ///
+    /// Because there are only two phases and their order is always the same (first non-revertible and then revertible)
+    /// this implies that the note was created in the non-revertible phase, and that the current phase is the revertible
+    /// phase.
     ///
     /// These notes are not yet in the note hash tree, though they will be inserted **even if nullified in this
     /// transaction**. This means that they must be nullified as if they were settled (i.e. using the unique note hash)
     /// in order to avoid double spends once they become settled.
     PENDING_PREVIOUS_PHASE: u8,
-    /// A note that was created in a prior transaction and is therefore already in the note hash tree.
+    /// A note created in a prior transaction.
+    ///
+    /// Settled notes have alrady been inserted into the note hash tree.
     SETTLED: u8,
 }
 

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -1,11 +1,9 @@
 use crate::{
-    context::{note_existence_request::NoteExistenceRequest, PrivateContext},
+    context::note_existence_request::NoteExistenceRequest,
     note::{confirmed_note::ConfirmedNote, hinted_note::HintedNote, note_interface::NoteHash},
 };
 
-use protocol_types::hash::{
-    compute_siloed_note_hash, compute_siloed_nullifier, compute_unique_note_hash,
-};
+use protocol_types::hash::{compute_siloed_note_hash, compute_unique_note_hash};
 
 /// Returns the [NoteExistenceRequest] used to prove a note exists.
 pub fn compute_note_existence_request<Note>(hinted_note: HintedNote<Note>) -> NoteExistenceRequest
@@ -63,47 +61,12 @@ pub fn compute_confirmed_note_hash_for_nullification<Note>(
     if confirmed_note.metadata.is_pending_previous_phase() {
         let siloed_note_hash = compute_siloed_note_hash(
             confirmed_note.contract_address,
-            confirmed_note.read_request_note_hash,
+            confirmed_note.proven_note_hash,
         );
         let note_nonce = confirmed_note.metadata.to_pending_previous_phase().note_nonce();
 
         compute_unique_note_hash(note_nonce, siloed_note_hash)
     } else {
-        confirmed_note.read_request_note_hash
+        confirmed_note.proven_note_hash
     }
-}
-
-/// Returns the siloed nullifier for a settled note.
-///
-/// This fails unless the note is settled (i.e. it has been inserted into the trees and therefore has a nonce).
-pub fn compute_settled_note_siloed_nullifier<Note>(
-    hinted_note: HintedNote<Note>,
-    context: &mut PrivateContext,
-) -> Field
-where
-    Note: NoteHash,
-{
-    let unique_note_hash = compute_settled_note_unique_hash(hinted_note);
-
-    let inner_nullifier =
-        hinted_note.note.compute_nullifier(context, hinted_note.owner, unique_note_hash);
-
-    compute_siloed_nullifier(hinted_note.contract_address, inner_nullifier)
-}
-
-pub fn compute_settled_note_unique_hash<Note>(hinted_note: HintedNote<Note>) -> Field
-where
-    Note: NoteHash,
-{
-    let note_hash = hinted_note.note.compute_note_hash(
-        hinted_note.owner,
-        hinted_note.storage_slot,
-        hinted_note.randomness,
-    );
-
-    let siloed_note_hash = compute_siloed_note_hash(hinted_note.contract_address, note_hash);
-    compute_unique_note_hash(
-        hinted_note.metadata.to_settled().note_nonce(),
-        siloed_note_hash,
-    )
 }

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -51,7 +51,7 @@ pub contract Claim {
         // 3) Prove that the note hash exists in the note hash tree
         // docs:start:prove_note_inclusion
         let header = self.context.get_anchor_block_header();
-        header.prove_note_inclusion(hinted_note);
+        let _ = header.prove_note_inclusion(hinted_note);
         // docs:end:prove_note_inclusion
 
         // 4) Compute and emit a nullifier which is unique to the note and this contract to ensure the reward can be

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -262,7 +262,7 @@ pub contract Test {
         };
 
         let header = self.context.get_anchor_block_header();
-        header.prove_note_inclusion(hinted_note);
+        let _ = header.prove_note_inclusion(hinted_note);
     }
 
     #[external("private")]


### PR DESCRIPTION
Small follow up to https://github.com/AztecProtocol/aztec-packages/pull/19768. This makes the `prove_note` fn convert the hinted note into a confirmed note, and has the prove nullified fns take confirmed notes - this prevents accidentally proving a non-existent note has or has not been nullfied (which is meaningless), and also lets us reuse a hash and remove two utils fn.