### PR TITLE
refactor!: Use siloed values for settled nullifier read requests

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -22,3 +22,6 @@ pub mod gas;
 
 mod note_existence_request;
 pub use note_existence_request::NoteExistenceRequest;
+
+mod nullifier_existence_request;
+pub use nullifier_existence_request::NullifierExistenceRequest;

--- a/noir-projects/aztec-nr/aztec/src/context/note_existence_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/note_existence_request.nr
@@ -15,6 +15,10 @@ impl NoteExistenceRequest {
     /// requests are created using the unsiloed note hash (i.e. from
     /// [crate::note::note_interface::NoteHash::compute_note_hash]) and address of the contract that created the note.
     pub fn for_pending(unsiloed_note_hash: Field, contract_address: AztecAddress) -> Self {
+        // The kernel doesn't take options; it takes a note_hash and an address, and infers whether the request is
+        // siloed based on whether the address is zero or non-zero. When passing the value to the kernel, we use
+        // `maybe_addr.unwrap_or(Address::ZERO)`. Therefore, passing a zero address to `for_pending` is not allowed
+        // since it would be interpreted by the kernel as a settled request.
         assert(
             !contract_address.is_zero(),
             "Can't read a transient note with a zero contract address",

--- a/noir-projects/aztec-nr/aztec/src/context/nullifier_existence_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/nullifier_existence_request.nr
@@ -1,0 +1,46 @@
+use protocol_types::address::aztec_address::AztecAddress;
+
+/// A request to assert the existence of a nullifier.
+///
+/// Used by [crate::context::private_context::PrivateContext::assert_nullifier_exists].
+pub struct NullifierExistenceRequest {
+    nullifier: Field,
+    maybe_contract_address: Option<AztecAddress>,
+}
+
+impl NullifierExistenceRequest {
+    /// Creates an existence request for a pending nullifier.
+    ///
+    /// Pending nullifiers have not been siloed with the contract address. These requests are created using the unsiloed
+    /// value and address of the contract that emitted the nullifier.
+    pub fn for_pending(unsiloed_nullifier: Field, contract_address: AztecAddress) -> Self {
+        // The kernel doesn't take options; it takes a nullifier and an address, and infers whether the request is
+        // siloed based on whether the address is zero or non-zero. When passing the value to the kernel, we use
+        // `maybe_addr.unwrap_or(Address::ZERO)`. Therefore, passing a zero address to `for_pending` is not allowed
+        // since it would be interpreted by the kernel as a settled request.
+        assert(
+            !contract_address.is_zero(),
+            "Can't read a pending nullifier with a zero contract address",
+        );
+        Self {
+            nullifier: unsiloed_nullifier,
+            maybe_contract_address: Option::some(contract_address),
+        }
+    }
+
+    /// Creates an existence request for a settled nullifier.
+    ///
+    /// Unlike pending nullifiers, settled nullifiers have been siloed with their contract addresses before adding to
+    /// the nullifier tree, and their existence request is created using the siloed value.
+    pub fn for_settled(siloed_nullifier: Field) -> Self {
+        Self { nullifier: siloed_nullifier, maybe_contract_address: Option::none() }
+    }
+
+    pub(crate) fn nullifier(self) -> Field {
+        self.nullifier
+    }
+
+    pub(crate) fn maybe_contract_address(self) -> Option<AztecAddress> {
+        self.maybe_contract_address
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -1,5 +1,7 @@
 use crate::{
-    context::{inputs::PrivateContextInputs, NoteExistenceRequest, ReturnsHash},
+    context::{
+        inputs::PrivateContextInputs, NoteExistenceRequest, NullifierExistenceRequest, ReturnsHash,
+    },
     hash::{hash_args, hash_calldata_array},
     keys::constants::{NULLIFIER_INDEX, NUM_KEY_TYPES, OUTGOING_INDEX, sk_generators},
     messaging::process_l1_to_l2_message,
@@ -13,7 +15,8 @@ use crate::{
         execution_cache,
         key_validation_request::get_key_validation_request,
         logs::notify_created_contract_class_log,
-        notes::{notify_created_nullifier, notify_nullified_note},
+        notes::notify_nullified_note,
+        nullifiers::notify_created_nullifier,
     },
 };
 use dep::protocol_types::{
@@ -803,13 +806,17 @@ impl PrivateContext {
     /// an additional invocation of the kernel reset circuit.
     pub fn assert_nullifier_exists(
         &mut self,
-        unsiloed_nullifier: Field,
-        contract_address: AztecAddress,
+        nullifier_existence_request: NullifierExistenceRequest,
     ) {
+        let nullifier = nullifier_existence_request.nullifier();
+        let contract_address =
+            nullifier_existence_request.maybe_contract_address().unwrap_or(AztecAddress::zero());
+
         let request = Scoped::new(
-            Counted::new(unsiloed_nullifier, self.next_counter()),
+            Counted::new(nullifier, self.next_counter()),
             contract_address,
         );
+
         self.nullifier_read_requests.push(request);
     }
 

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
@@ -3,7 +3,7 @@ use crate::history::{
     nullifier_inclusion::{ProveNoteIsNullified, ProveNullifierInclusion},
     test,
 };
-use crate::oracle::{notes::notify_created_nullifier, random::random};
+use crate::oracle::{nullifiers::notify_created_nullifier, random::random};
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use dep::protocol_types::{
     constants::DOM_SEP__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator, traits::ToField,

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
@@ -3,7 +3,7 @@ use crate::history::{
     nullifier_non_inclusion::{ProveNoteNotNullified, ProveNullifierNonInclusion},
     test,
 };
-use crate::oracle::{notes::notify_created_nullifier, random::random};
+use crate::oracle::{nullifiers::notify_created_nullifier, random::random};
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use dep::protocol_types::{
     constants::DOM_SEP__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator, traits::ToField,

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -35,6 +35,7 @@ pub mod history;
 pub mod keys;
 mod messaging;
 pub mod note;
+pub mod nullifier;
 pub mod oracle;
 pub mod state_vars;
 mod capsules;

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
@@ -5,6 +5,7 @@ use dep::protocol_types::{
 
 use crate::{
     context::{PrivateContext, PublicContext},
+    nullifier::utils::compute_nullifier_existence_request,
     oracle::get_contract_instance::{
         get_contract_instance, get_contract_instance_deployer_avm,
         get_contract_instance_initialization_hash_avm,
@@ -39,7 +40,9 @@ pub fn assert_is_initialized_public(context: PublicContext) {
 // Used by `create_init_check` (you won't find it through searching)
 pub fn assert_is_initialized_private(context: &mut PrivateContext) {
     let init_nullifier = compute_unsiloed_contract_initialization_nullifier(context.this_address());
-    context.assert_nullifier_exists(init_nullifier, context.this_address());
+    let nullifier_existence_request =
+        compute_nullifier_existence_request(init_nullifier, context.this_address());
+    context.assert_nullifier_exists(nullifier_existence_request);
 }
 
 fn compute_unsiloed_contract_initialization_nullifier(address: AztecAddress) -> Field {

--- a/noir-projects/aztec-nr/aztec/src/nullifier/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/nullifier/mod.nr
@@ -1,0 +1,3 @@
+//! Nullifier-related utilities.
+
+pub mod utils;

--- a/noir-projects/aztec-nr/aztec/src/nullifier/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/nullifier/utils.nr
@@ -1,0 +1,26 @@
+use crate::{context::NullifierExistenceRequest, oracle::nullifiers::is_nullifier_pending};
+
+use protocol_types::{address::aztec_address::AztecAddress, hash::compute_siloed_nullifier};
+
+/// Returns the [NullifierExistenceRequest] used to prove a nullifier exists.
+pub fn compute_nullifier_existence_request(
+    unsiloed_nullifier: Field,
+    contract_address: AztecAddress,
+) -> NullifierExistenceRequest {
+    let pending_read_request =
+        NullifierExistenceRequest::for_pending(unsiloed_nullifier, contract_address);
+
+    let siloed_nullifier = compute_siloed_nullifier(contract_address, unsiloed_nullifier);
+    let settled_read_request = NullifierExistenceRequest::for_settled(siloed_nullifier);
+
+    // Safety: This is a hint to check whether we are reading a pending or settled nullifier. The chosen read request
+    // will be validated by the kernel. Failure to provide a correct hint will cause the read request validation to fail.
+    let should_use_pending_read_request =
+        unsafe { is_nullifier_pending(unsiloed_nullifier, contract_address) };
+
+    if should_use_pending_read_request {
+        pending_read_request
+    } else {
+        settled_read_request
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -23,6 +23,7 @@ pub mod key_validation_request;
 pub mod logs;
 pub mod message_processing;
 pub mod notes;
+pub mod nullifiers;
 pub mod offchain_effect;
 pub mod version;
 pub mod random;

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -37,13 +37,6 @@ pub fn notify_nullified_note(nullifier: Field, note_hash: Field, counter: u32) {
     unsafe { notify_nullified_note_oracle_wrapper(nullifier, note_hash, counter) };
 }
 
-/// Notifies the simulator that a non-note nullifier has been created, so that it can be used for note nonces.
-pub fn notify_created_nullifier(nullifier: Field) {
-    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to
-    // call.
-    unsafe { notify_created_nullifier_oracle_wrapper(nullifier) };
-}
-
 unconstrained fn notify_created_note_oracle_wrapper<let N: u32>(
     owner: AztecAddress,
     storage_slot: Field,
@@ -85,13 +78,6 @@ unconstrained fn notify_nullified_note_oracle_wrapper(
 
 #[oracle(privateNotifyNullifiedNote)]
 unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) {}
-
-unconstrained fn notify_created_nullifier_oracle_wrapper(nullifier: Field) {
-    notify_created_nullifier_oracle(nullifier);
-}
-
-#[oracle(privateNotifyCreatedNullifier)]
-unconstrained fn notify_created_nullifier_oracle(_nullifier: Field) {}
 
 #[oracle(utilityGetNotes)]
 unconstrained fn get_notes_oracle<Note, let M: u32, let MaxNotes: u32>(
@@ -193,17 +179,6 @@ where
 
     notes_array
 }
-
-/// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
-/// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before the
-/// current transaction is included in a block. While this might seem of little use at first, certain design patterns
-/// benefit from this abstraction (see e.g. `PrivateMutable`).
-pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
-    check_nullifier_exists_oracle(inner_nullifier)
-}
-
-#[oracle(utilityCheckNullifierExists)]
-unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}
 
 // TODO: Oracles below are generic private log oracles and are not specific to notes. Move them somewhere else.
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
@@ -1,0 +1,46 @@
+//! Nullifier creation, existence checks, etc.
+
+use protocol_types::address::aztec_address::AztecAddress;
+
+/// Notifies the simulator that a nullifier has been created, so that its correct status (pending or settled) can be
+/// determined when reading nullifiers in subsequent private function calls.
+/// The first non-revertible nullifier emitted is also used to compute note nonces.
+pub fn notify_created_nullifier(inner_nullifier: Field) {
+    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to
+    // call.
+    unsafe { notify_created_nullifier_oracle(inner_nullifier) };
+}
+
+#[oracle(privateNotifyCreatedNullifier)]
+unconstrained fn notify_created_nullifier_oracle(_inner_nullifier: Field) {}
+
+/// Returns true if the nullifier has been emitted in the same transaction, i.e. if [notify_created_nullifier] has been
+/// called for this inner nullifier from the contract with the specified address.
+///
+/// Note that despite sharing pending transaction information with the app, this is not a privacy leak:
+/// anyone in the network can always determine in which transaction a inner nullifier was emitted by a
+/// given contract by simply inspecting transaction effects. What _would_ constitute a leak would be to
+/// share the list of inner pending nullifiers, as that would reveal their preimages.
+pub unconstrained fn is_nullifier_pending(
+    inner_nullifier: Field,
+    contract_address: AztecAddress,
+) -> bool {
+    is_nullifier_pending_oracle(inner_nullifier, contract_address)
+}
+
+#[oracle(privateIsNullifierPending)]
+unconstrained fn is_nullifier_pending_oracle(
+    _inner_nullifier: Field,
+    _contract_address: AztecAddress,
+) -> bool {}
+
+/// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
+/// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before the
+/// current transaction is included in a block. While this might seem of little use at first, certain design patterns
+/// benefit from this abstraction (see e.g. `PrivateMutable`).
+pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
+    check_nullifier_exists_oracle(inner_nullifier)
+}
+
+#[oracle(utilityCheckNullifierExists)]
+unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called and
 /// if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 7;
+pub global ORACLE_VERSION: Field = 8;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -7,7 +7,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
         NoteMessage,
     },
-    oracle::notes::check_nullifier_exists,
+    oracle::nullifiers::check_nullifier_exists,
     state_vars::owned_state_variable::OwnedStateVariable,
 };
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -7,7 +7,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
         NoteMessage,
     },
-    oracle::notes::check_nullifier_exists,
+    oracle::nullifiers::check_nullifier_exists,
     state_vars::owned_state_variable::OwnedStateVariable,
 };
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
@@ -7,7 +7,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
         NoteMessage,
     },
-    oracle::notes::check_nullifier_exists,
+    oracle::nullifiers::check_nullifier_exists,
     state_vars::state_variable::StateVariable,
 };
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
@@ -7,7 +7,7 @@ use crate::{
         note_interface::{NoteHash, NoteType},
         NoteMessage,
     },
-    oracle::notes::check_nullifier_exists,
+    oracle::nullifiers::check_nullifier_exists,
     state_vars::state_variable::StateVariable,
 };
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
@@ -6,7 +6,8 @@ use dep::protocol_types::{
 use crate::{
     context::{PrivateContext, UtilityContext},
     keys::getters::{get_nsk_app, get_public_keys},
-    oracle::notes::check_nullifier_exists,
+    nullifier::utils::compute_nullifier_existence_request,
+    oracle::nullifiers::check_nullifier_exists,
     state_vars::owned_state_variable::OwnedStateVariable,
 };
 
@@ -124,7 +125,9 @@ impl SingleUseClaim<&mut PrivateContext> {
         let has_been_claimed = unsafe { check_nullifier_exists(nullifier) };
         assert(has_been_claimed, "cannot prove claim exists");
 
-        self.context.assert_nullifier_exists(nullifier, self.context.this_address())
+        let nullifier_existence_request =
+            compute_nullifier_existence_request(nullifier, self.context.this_address());
+        self.context.assert_nullifier_exists(nullifier_existence_request)
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/private_context.nr
@@ -1,4 +1,4 @@
-use crate::oracle::notes::check_nullifier_exists;
+use crate::oracle::nullifiers::check_nullifier_exists;
 use crate::test::helpers::test_environment::{PrivateContextOptions, TestEnvironment};
 use protocol_types::{
     abis::function_selector::FunctionSelector, address::AztecAddress, traits::FromField,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/utility_context.nr
@@ -1,6 +1,6 @@
 use crate::test::helpers::test_environment::TestEnvironment;
 
-use crate::oracle::notes::check_nullifier_exists;
+use crate::oracle::nullifiers::check_nullifier_exists;
 use protocol_types::{address::AztecAddress, traits::FromField};
 
 #[test]

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -35,7 +35,7 @@ pub contract Orderbook {
     use crate::{config::Config, order::Order};
     use aztec::{
         macros::{events::event, functions::{external, initializer, only_self}, storage::storage},
-        oracle::notes::check_nullifier_exists,
+        oracle::nullifiers::check_nullifier_exists,
         protocol_types::{address::AztecAddress, traits::{FromField, ToField}},
         state_vars::{Map, PublicImmutable},
     };

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry/src/main.nr
@@ -4,6 +4,7 @@ use aztec::macros::aztec;
 pub contract ContractInstanceRegistry {
     use aztec::{
         macros::{events::event, functions::{external, view}, storage::storage},
+        nullifier::utils::compute_nullifier_existence_request,
         protocol_types::{
             address::{AztecAddress, PartialAddress},
             constants::{
@@ -104,10 +105,11 @@ pub contract ContractInstanceRegistry {
         universal_deploy: bool,
     ) {
         // contract class must be published in order to publish an instance
-        self.context.assert_nullifier_exists(
+        let nullifier_existence_request = compute_nullifier_existence_request(
             contract_class_id.to_field(),
             CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
         );
+        self.context.assert_nullifier_exists(nullifier_existence_request);
 
         let deployer = if universal_deploy {
             AztecAddress::zero()

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
@@ -7,13 +7,13 @@ use super::{
 
 use dep::types::{
     merkle_tree::LeafPreimage,
-    side_effect::{Counted, Ordered, Readable, Scoped},
+    side_effect::{Counted, Readable, Scoped},
     utils::arrays::ClaimedLengthArray,
 };
 
 pub struct ReadRequestValidator<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> {
     pub read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    pub pending_values: ClaimedLengthArray<Value, PendingValueLen>,
+    pub pending_values: ClaimedLengthArray<Scoped<Counted<Value>>, PendingValueLen>,
     pub tree_root: Field,
     pub propagated_read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
     pub hints: ReadRequestHints<ReadRequestLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SettledReadLeafPreimage>,
@@ -21,7 +21,7 @@ pub struct ReadRequestValidator<let ReadRequestLen: u32, Value, let PendingValue
 
 impl<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> ReadRequestValidator<ReadRequestLen, Value, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SettledReadLeafPreimage>
 where
-    Value: Readable + Ordered,
+    Value: Readable,
     SettledReadLeafPreimage: LeafPreimage + Readable,
 {
     // Generic parameters are used because generic arrays cannot have zero length.
@@ -29,17 +29,17 @@ where
     // item, while `_ReadAmount` will be set to zero.
     pub fn validate<let PendingReadAmount: u32, let SettledReadAmount: u32>(self) {
         if PendingReadAmount != 0 {
-            // Assert that `PendingReadAmount` equals the number of hints.
-            // This allows us to skip validation of unused hints (i.e., those with index >= `PendingReadAmount`),
-            // as we do when `PendingReadAmount` is 0.
-            //
-            // Since all hints are consumed in `validate_pending_read_requests`, it becomes impossible to skip
-            // propagating a read request by referencing a hint index >= `PendingReadAmount`.
-            assert_eq(
-                PendingReadAmount,
-                self.hints.pending_read_hints.len(),
-                "pending_read_hints length does not match PendingReadAmount",
+            // `PendingReadAmount` is not used in validation and propagation when it's larger than 0. However, it should
+            // still match `PendingReadHintsLen` to ensure consistency and avoid confusion.
+            std::static_assert(
+                PendingReadAmount == self.hints.pending_read_hints.len(),
+                "PendingReadAmount should match the length of the hints array",
             );
+
+            // Since all hints are consumed in `validate_pending_read_requests`, it is not possible to skip propagating
+            // a read request by referencing a hint.
+            // This allows us to skip validation of unused hints (because there are none), unlike the case where
+            // `PendingReadAmount` is 0.
             validate_pending_read_requests(
                 self.read_requests,
                 self.pending_values,
@@ -47,8 +47,8 @@ where
             );
         } else {
             // Validate unused hints: Ensure that all index hints are set to `ReadRequestLen`.
-            // This guarantees that the hints cannot be used in `verify_propagated_read_requests` to skip propagating a
-            // read request by pointing to a valid `read_request_index`.
+            // This guarantees that the hints cannot be used in `validate_propagated_read_requests` to skip propagating
+            // a read request by pointing to a valid `read_request_index`.
             for hint in self.hints.pending_read_hints {
                 assert_eq(
                     hint.read_request_index,
@@ -59,17 +59,17 @@ where
         }
 
         if SettledReadAmount != 0 {
-            // Assert that `SettledReadAmount` equals the number of hints.
-            // This allows us to skip validation of unused hints (i.e., those with index >= `SettledReadAmount`),
-            // as we do when `SettledReadAmount` is 0.
-            //
-            // Since all hints are consumed in `validate_settled_read_requests`, it becomes impossible to skip
-            // propagating a read request by referencing a hint index >= `SettledReadAmount`.
-            assert_eq(
-                SettledReadAmount,
-                self.hints.settled_read_hints.len(),
-                "settled_read_hints length does not match SettledReadAmount",
+            // `SettledReadAmount` is not used in validation and propagation when it's larger than 0. However, it should
+            // still match `SettledReadHintsLen` to ensure consistency and avoid confusion.
+            std::static_assert(
+                SettledReadAmount == self.hints.settled_read_hints.len(),
+                "SettledReadAmount should match the length of the hints array",
             );
+
+            // Since all hints are consumed in `validate_settled_read_requests`, it is not possible to skip propagating
+            // a read request by referencing a hint.
+            // This allows us to skip validation of unused hints (because there are none), unlike the case where
+            // `SettledReadAmount` is 0.
             validate_settled_read_requests(
                 self.read_requests,
                 self.hints.settled_read_hints,
@@ -77,8 +77,8 @@ where
             );
         } else {
             // Validate unused hints: Ensure that all index hints are set to `ReadRequestLen`.
-            // This guarantees that the hints cannot be used in `verify_propagated_read_requests` to skip propagating a
-            // read request by pointing to a valid `read_request_index`.
+            // This guarantees that the hints cannot be used in `validate_propagated_read_requests` to skip propagating
+            // a read request by pointing to a valid `read_request_index`.
             for hint in self.hints.settled_read_hints {
                 assert_eq(
                     hint.read_request_index,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/mod.nr
@@ -11,7 +11,7 @@ use super::{
 use dep::types::{
     address::AztecAddress,
     merkle_tree::{LeafPreimage, MembershipWitness},
-    side_effect::{Counted, Ordered, Readable, Scoped},
+    side_effect::{Counted, Readable, Scoped},
     tests::{merkle_tree_utils::SingleSubtreeMerkleTree, utils::pad_end},
     traits::{Empty, FromField},
     utils::arrays::ClaimedLengthArray,
@@ -21,28 +21,23 @@ pub use read_request_hints_builder::ReadRequestHintsBuilder;
 #[derive(Eq)]
 struct TestValue {
     value: Field,
-    counter: u32,
 }
 
 impl Empty for TestValue {
     fn empty() -> Self {
-        TestValue { value: 0, counter: 0 }
+        TestValue { value: 0 }
     }
 }
 
-impl Ordered for TestValue {
-    fn counter(self) -> u32 {
-        self.counter
+impl TestValue {
+    pub fn count(self, counter: u32) -> Counted<TestValue> {
+        Counted::new(self, counter)
     }
 }
 
 impl Readable for TestValue {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
-        assert_eq(
-            read_request.innermost(),
-            self.value,
-            "Hinted test value does not match read request",
-        );
+    fn assert_match_read_request(self, read_request: Field) {
+        assert_eq(read_request, self.value, "Hinted test value does not match read request");
     }
 }
 
@@ -68,9 +63,9 @@ impl Empty for TestLeafPreimage {
 }
 
 impl Readable for TestLeafPreimage {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
+    fn assert_match_read_request(self, read_request: Field) {
         assert_eq(
-            read_request.innermost(),
+            read_request,
             self.value,
             "Hinted test leaf preimage does not match read request",
         );
@@ -91,7 +86,7 @@ global TEST_CONTRACT_ADDRESS: AztecAddress = AztecAddress::from_field(123);
 
 struct TestBuilder {
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, READ_REQUEST_LEN>,
-    pending_values: ClaimedLengthArray<TestValue, PENDING_VALUE_LEN>,
+    pending_values: ClaimedLengthArray<Scoped<Counted<TestValue>>, PENDING_VALUE_LEN>,
     tree: SingleSubtreeMerkleTree<TEST_SUBTREE_WIDTH, TEST_SUBTREE_HEIGHT, TEST_TREE_HEIGHT>,
     tree_root: Field,
     leaf_preimages: [TestLeafPreimage; TEST_SUBTREE_WIDTH],
@@ -105,10 +100,10 @@ impl TestBuilder {
     pub fn new() -> Self {
         let pending_values = ClaimedLengthArray {
             array: pad_end([
-                TestValue { value: 55, counter: 5 },
-                TestValue { value: 66, counter: 6 },
-                TestValue { value: 77, counter: 7 },
-                TestValue { value: 88, counter: 8 },
+                TestValue { value: 55 }.count(5).scope(TEST_CONTRACT_ADDRESS),
+                TestValue { value: 66 }.count(6).scope(TEST_CONTRACT_ADDRESS),
+                TestValue { value: 77 }.count(7).scope(TEST_CONTRACT_ADDRESS),
+                TestValue { value: 88 }.count(8).scope(TEST_CONTRACT_ADDRESS),
             ]),
             length: 4,
         };
@@ -149,13 +144,18 @@ impl TestBuilder {
 
     pub fn add_pending_read(&mut self, pending_value_index: u32) {
         let pending_value = self.pending_values.array[pending_value_index];
-        let read_request_index = self.add_read_request(pending_value.value);
+        let read_request_index = self.add_read_request(pending_value.innermost().value);
         self.hints.add_pending_read_hint(read_request_index, pending_value_index);
     }
 
     pub fn add_settled_read(&mut self, leaf_preimage_index: u32) {
         let leaf_preimage = self.leaf_preimages[leaf_preimage_index];
-        let read_request_index = self.add_read_request(leaf_preimage.value);
+        // Settled reads use zero contract address because the value is already siloed to match the tree.
+        let read_request_index = self.read_requests.length;
+        let read_request =
+            Counted::new(leaf_preimage.value, self.counter).scope(AztecAddress::zero());
+        self.read_requests.push(read_request);
+        self.counter += 1;
 
         let leaf_index = leaf_preimage_index as Field;
         let membership_witness =

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/pending_read_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/pending_read_tests.nr
@@ -82,13 +82,23 @@ fn mismatch_pending_value_being_read() {
     builder.validate();
 }
 
+#[test(should_fail_with = "Contract address of the pending value does not match read request")]
+fn mismatch_pending_value_contract_address() {
+    let mut builder = TestBuilder::new_all_pending();
+
+    // Change the contract address of the pending value to be different from the read request.
+    builder.pending_values.array[1].contract_address.inner += 1;
+
+    builder.validate();
+}
+
 #[test(should_fail_with = "Cannot read a pending value beyond claimed length")]
 fn read_pending_value_at_claimed_length() {
     let mut builder = TestBuilder::new_all_pending();
 
     // Set a random value at the claimed length.
     let pending_value_index = builder.pending_values.length;
-    builder.pending_values.array[pending_value_index].value = 9999;
+    builder.pending_values.array[pending_value_index].inner.inner.value = 9999;
     // Change the read request to be reading the random value.
     let mut hint = builder.hints.pending_read_hints.pop();
     builder.read_requests.array[hint.read_request_index].inner.inner = 9999;
@@ -105,7 +115,7 @@ fn read_pending_value_beyond_claimed_length() {
 
     // Set a random value at the claimed length.
     let pending_value_index = builder.pending_values.length + 1;
-    builder.pending_values.array[pending_value_index].value = 9999;
+    builder.pending_values.array[pending_value_index].inner.inner.value = 9999;
     // Change the read request to be reading the random value.
     let mut hint = builder.hints.pending_read_hints.pop();
     builder.read_requests.array[hint.read_request_index].inner.inner = 9999;
@@ -122,7 +132,8 @@ fn read_request_counter_equals_pending_value_counter() {
 
     // Change the counter of the read request to be equal to the counter of the pending value.
     let hint = builder.hints.pending_read_hints.get(1);
-    let pending_value_counter = builder.pending_values.array[hint.pending_value_index].counter;
+    let pending_value_counter =
+        builder.pending_values.array[hint.pending_value_index].inner.counter;
     builder.read_requests.array[hint.read_request_index].inner.counter = pending_value_counter;
 
     builder.validate();
@@ -134,7 +145,8 @@ fn read_request_counter_less_than_pending_value_counter() {
 
     // Change the counter of the read request to be less than the counter of the pending value.
     let hint = builder.hints.pending_read_hints.get(1);
-    let pending_value_counter = builder.pending_values.array[hint.pending_value_index].counter;
+    let pending_value_counter =
+        builder.pending_values.array[hint.pending_value_index].inner.counter;
     builder.read_requests.array[hint.read_request_index].inner.counter = pending_value_counter - 1;
 
     builder.validate();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/read_request_validator_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/read_request_validator_tests.nr
@@ -54,14 +54,14 @@ fn clears_partial_read_requests() {
     );
 }
 
-#[test(should_fail_with = "pending_read_hints length does not match PendingReadAmount")]
+#[test(should_fail_with = "PendingReadAmount should match the length of the hints array")]
 fn validate_amount_less_than_pending_read_hints() {
     let builder = TestBuilder::new_mixed();
     // Validate 1 less than the `pending_read_hints` array length.
     builder.validate_with_amount::<PENDING_READ_HINTS_LEN - 1, SETTLED_READ_HINTS_LEN>();
 }
 
-#[test(should_fail_with = "pending_read_hints length does not match PendingReadAmount")]
+#[test(should_fail_with = "PendingReadAmount should match the length of the hints array")]
 fn validate_amount_greater_than_pending_read_hints() {
     let builder = TestBuilder::new_mixed();
     // Validate 1 more than the `pending_read_hints` array length.
@@ -111,14 +111,14 @@ fn validate_with_zero_pending_read_amount_hints_non_empty() {
     builder.validate_with_amount::<0, SETTLED_READ_HINTS_LEN>();
 }
 
-#[test(should_fail_with = "settled_read_hints length does not match SettledReadAmount")]
+#[test(should_fail_with = "SettledReadAmount should match the length of the hints array")]
 fn validate_with_fewer_settled_read_amount_fails() {
     let mut builder = TestBuilder::new_mixed();
     // Validate 1 less than the `settled_read_hints` array length.
     builder.validate_with_amount::<PENDING_READ_HINTS_LEN, SETTLED_READ_HINTS_LEN - 1>();
 }
 
-#[test(should_fail_with = "settled_read_hints length does not match SettledReadAmount")]
+#[test(should_fail_with = "SettledReadAmount should match the length of the hints array")]
 fn validate_with_more_settled_read_amount_fails() {
     let mut builder = TestBuilder::new_mixed();
     // Validate 1 more than the `settled_read_hints` array length.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/settled_read_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/settled_read_tests.nr
@@ -60,6 +60,17 @@ fn duplicate_settled_read_requests() {
     assert_array_eq(builder.propagated_read_requests.array, []);
 }
 
+#[test(should_fail_with = "Settled read request must have zero contract address")]
+fn with_non_zero_contract_address() {
+    let mut builder = TestBuilder::new();
+
+    // Add a read request with a non-zero contract address.
+    builder.add_settled_read(1);
+    builder.read_requests.array[0].contract_address.inner = 99;
+
+    builder.validate();
+}
+
 #[test(should_fail_with = "Hinted test leaf preimage does not match read request")]
 fn hint_points_to_wrong_leaf_preimage() {
     let mut builder = TestBuilder::new();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
@@ -14,33 +14,33 @@ impl PendingReadHint {
     }
 }
 
-// Validates that "pending" read requests (reads of values emitted earlier in the same transaction) are valid.
-//
-// Context:
-// - Pending values are those produced within the current transaction. This array contains values that may be emitted
-//   before or after the read requests were made.
-// - Each `PendingReadHint` provides indices to link a read request with its corresponding pending value.
-// - Unused hints must be marked with `read_request_index == ReadRequestLen`.
-//
-// Invariants checked:
-// 1. If a hint is active (its `read_request_index` is not `ReadRequestLen`):
-//    - The `pending_value_index` must be within the claimed length.
-//    - The pending value must match the corresponding read request.
-//    - The pending value must be emitted before the read request (i.e., the pending value's counter is less than the
-//      read request's counter).
-// 2. If a hint is inactive (its `read_request_index == ReadRequestLen`):
-//    - It is ignored (no validation performed).
-//
-// More info here:
-// - https://discourse.aztec.network/t/to-read-or-not-to-read/178
-// - https://discourse.aztec.network/t/spending-notes-which-havent-yet-been-inserted/180
+/// Validates that "pending" read requests (reads of values emitted earlier in the same transaction) are valid.
+///
+/// Context:
+/// - Pending values are those produced within the current transaction. This array contains values that may be emitted
+///   before or after the read requests were made.
+/// - Each `PendingReadHint` provides indices to link a read request with its corresponding pending value.
+/// - Unused hints must be marked with `read_request_index == ReadRequestLen`.
+///
+/// Invariants checked:
+/// 1. If a hint is active (its `read_request_index` is NOT `ReadRequestLen`):
+///    - The `pending_value_index` must be within the claimed length.
+///    - The pending value must match the corresponding read request.
+///    - The pending value must be emitted before the read request (i.e., the pending value's counter is less than the
+///      read request's counter).
+/// 2. If a hint is inactive (its `read_request_index` is `ReadRequestLen`):
+///    - It is ignored (no validation performed).
+///
+/// More info here:
+/// - https://discourse.aztec.network/t/to-read-or-not-to-read/178
+/// - https://discourse.aztec.network/t/spending-notes-which-havent-yet-been-inserted/180
 pub fn validate_pending_read_requests<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32>(
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    pending_values: ClaimedLengthArray<Value, PendingValueLen>,
+    pending_values: ClaimedLengthArray<Scoped<Counted<Value>>, PendingValueLen>,
     hints: [PendingReadHint; PendingReadHintsLen],
 )
 where
-    Value: Readable + Ordered,
+    Value: Readable,
 {
     for hint in hints {
         let read_request_index = hint.read_request_index;
@@ -53,8 +53,18 @@ where
 
             let read_request = read_requests.array[read_request_index];
             let pending_value = pending_values.array[hint.pending_value_index];
-            pending_value.assert_match_read_request(read_request);
 
+            // Validate that the pending value matches the read request.
+            pending_value.innermost().assert_match_read_request(read_request.innermost());
+
+            // Validate that the pending value has the same contract address as the read request.
+            assert_eq(
+                pending_value.contract_address,
+                read_request.contract_address,
+                "Contract address of the pending value does not match read request",
+            );
+
+            // Validate that the pending value was emitted before the read request.
             assert(
                 pending_value.counter() < read_request.counter(),
                 "Pending value must be emitted before the read request",

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
@@ -24,19 +24,19 @@ where
     }
 }
 
-// Validates "settled" read requests (reads of values already committed in a tree) against the provided tree root.
-//
-// Context:
-// - A settled read requires proving membership of a leaf in the tree corresponding to a past state.
-// - Each hint links a read request to a leaf preimage and provides its membership witness.
-// - Unused hints must be marked with `read_request_index == ReadRequestLen`.
-//
-// Invariants checked:
-// 1. If a hint is active (its `read_request_index` is not `ReadRequestLen`):
-//    - The leaf preimage must match the corresponding read request.
-//    - The membership witness must prove that the leaf exists in the tree with the given root.
-// 2. If a hint is inactive (its `read_request_index == ReadRequestLen`):
-//    - It is ignored (no validation performed).
+/// Validates "settled" read requests (reads of values already committed in a tree) against the provided tree root.
+///
+/// Context:
+/// - A settled read requires proving membership of a leaf in the tree corresponding to a past state.
+/// - Each hint links a read request to a leaf preimage and provides its membership witness.
+/// - Unused hints must be marked with `read_request_index == ReadRequestLen`.
+///
+/// Invariants checked:
+/// 1. If a hint is active (its `read_request_index` is NOT `ReadRequestLen`):
+///    - The leaf preimage must match the corresponding read request.
+///    - The membership witness must prove that the leaf exists in the tree with the given root.
+/// 2. If a hint is inactive (its `read_request_index` is ` ReadRequestLen`):
+///    - It is ignored (no validation performed).
 pub fn validate_settled_read_requests<let ReadRequestLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage>(
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
     hints: [SettledReadHint<TreeHeight, SettledReadLeafPreimage>; SettledReadHintsLen],
@@ -49,10 +49,22 @@ where
         let read_request_index = hint.read_request_index;
         if read_request_index != ReadRequestLen {
             let read_request = read_requests.array[read_request_index];
+            // To read a settled value, the app should have siloed the value with the contract address so that it
+            // matches the siloed value stored in the tree.
+            // While the contract address could technically be ignored here, we assert that it is zero to prevent
+            // misconfigured hints from causing a pending read request to be incorrectly validated as a settled read
+            // request.
+            assert(
+                read_request.contract_address.is_zero(),
+                "Settled read request must have zero contract address",
+            );
+
             let leaf_preimage = hint.leaf_preimage;
 
-            leaf_preimage.assert_match_read_request(read_request);
+            // Validate that the leaf preimage value matches the read request.
+            leaf_preimage.assert_match_read_request(read_request.innermost());
 
+            // Validate that the leaf preimage exists in the tree.
             let leaf = leaf_preimage.as_leaf();
             let witness = hint.membership_witness;
             assert(

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
@@ -169,8 +169,8 @@ impl TestBuilder {
 
     pub fn read_settled_nullifier(&mut self, preimage_index: u32) {
         let preimage = self.nullifier_preimages[preimage_index];
-        let nullifier_value = self.pre_existing_nullifier_values[preimage_index];
-        let read_request_index = self.previous_kernel.add_nullifier_read_request(nullifier_value);
+        let read_request_index =
+            self.previous_kernel.add_read_request_for_settled_nullifier(preimage.nullifier);
         let leaf_index = preimage_index as Field;
         let membership_witness = MembershipWitness {
             leaf_index,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/read_request_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/read_request_tests.nr
@@ -53,7 +53,7 @@ fn wrong_hint_for_pending_note_hash_read_request() {
     builder.failed();
 }
 
-#[test(should_fail_with = "Contract address of the note hash does not match read request")]
+#[test(should_fail_with = "Contract address of the pending value does not match read request")]
 fn mismatch_pending_note_hash_contract_address() {
     let mut builder = TestBuilder::new();
 
@@ -174,7 +174,7 @@ fn wrong_hint_for_pending_nullifier_read_request() {
     builder.failed();
 }
 
-#[test(should_fail_with = "Contract address of the nullifier does not match read request")]
+#[test(should_fail_with = "Contract address of the pending value does not match read request")]
 fn mismatch_pending_nullifier_contract_address() {
     let mut builder = TestBuilder::new();
 
@@ -204,20 +204,36 @@ fn wrong_hint_for_settled_nullifier_read_request() {
     builder.failed();
 }
 
+#[test(should_fail_with = "Settled read request must have zero contract address")]
+fn non_zero_contract_address_for_settled_nullifier_read_request() {
+    let mut builder = TestBuilder::new();
+
+    builder.read_settled_nullifier(1);
+
+    // Change the contract address to a non-zero value.
+    let mut request = builder.previous_kernel.nullifier_read_requests.pop();
+    request.contract_address = AztecAddress::from_field(1);
+    builder.previous_kernel.nullifier_read_requests.push(request);
+
+    builder.failed();
+}
+
 #[test(should_fail_with = "Membership check failed: leaf for read request not found in tree")]
 fn settled_nullifier_read_request_non_existing_leaf() {
     let mut builder = TestBuilder::new();
 
     builder.read_settled_nullifier(1);
-    // Change the read request to read a value that does not exist in the nullifier tree.
+
+    // Change the read request to read a siloed value that does not exist in the nullifier tree.
+    let siloed_nonexistent_nullifier =
+        compute_siloed_nullifier(builder.previous_kernel.contract_address, 99);
     let mut read_request = builder.previous_kernel.nullifier_read_requests.pop();
-    read_request.inner.inner = 99;
+    read_request.inner.inner = siloed_nonexistent_nullifier;
     builder.previous_kernel.nullifier_read_requests.push(read_request);
 
-    // Change the hint to a different value.
+    // Change the hint's preimage to match the read request value.
     let mut hint = builder.nullifier_read_request_hints.settled_read_hints.pop();
-    hint.leaf_preimage.nullifier =
-        compute_siloed_nullifier(builder.previous_kernel.contract_address, 99);
+    hint.leaf_preimage.nullifier = siloed_nonexistent_nullifier;
     builder.nullifier_read_request_hints.settled_read_hints.push(hint);
 
     builder.failed();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
@@ -1,18 +1,9 @@
-use crate::side_effect::{Counted, Readable, Scoped};
+use crate::side_effect::Readable;
 
 pub type NoteHash = Field;
 
-impl Readable for Scoped<Counted<NoteHash>> {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
-        assert_eq(
-            self.innermost(),
-            read_request.innermost(),
-            "Value of the note hash does not match read request",
-        );
-        assert_eq(
-            self.contract_address,
-            read_request.contract_address,
-            "Contract address of the note hash does not match read request",
-        );
+impl Readable for NoteHash {
+    fn assert_match_read_request(self, read_request: Field) {
+        assert_eq(self, read_request, "Value of the note hash does not match read request");
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
@@ -1,6 +1,6 @@
 global NOTE_HASH_LEAF_PREIMAGE_LENGTH: u32 = 1;
 
-use crate::{merkle_tree::LeafPreimage, side_effect::{Counted, Readable, Scoped}, traits::Empty};
+use crate::{merkle_tree::LeafPreimage, side_effect::Readable, traits::Empty};
 
 pub struct NoteHashLeafPreimage {
     pub value: Field,
@@ -23,14 +23,10 @@ impl LeafPreimage for NoteHashLeafPreimage {
 }
 
 impl Readable for NoteHashLeafPreimage {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
-        assert(
-            read_request.contract_address.is_zero(),
-            "Settled read request must have zero contract address",
-        );
+    fn assert_match_read_request(self, read_request: Field) {
         assert_eq(
             self.value,
-            read_request.innermost(),
+            read_request,
             "Value of the note hash leaf does not match read request",
         );
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
@@ -27,17 +27,8 @@ impl Scoped<Counted<Nullifier>> {
     }
 }
 
-impl Readable for Scoped<Counted<Nullifier>> {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
-        assert_eq(
-            self.innermost().value,
-            read_request.innermost(),
-            "Value of the nullifier does not match read request",
-        );
-        assert_eq(
-            self.contract_address,
-            read_request.contract_address,
-            "Contract address of the nullifier does not match read request",
-        );
+impl Readable for Nullifier {
+    fn assert_match_read_request(self, read_request: Field) {
+        assert_eq(self.value, read_request, "Value of the nullifier does not match read request");
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
@@ -62,12 +62,10 @@ impl IndexedTreeLeafPreimage<Field> for NullifierLeafPreimage {
 }
 
 impl Readable for NullifierLeafPreimage {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>) {
-        let siloed_value =
-            compute_siloed_nullifier(read_request.contract_address, read_request.innermost());
+    fn assert_match_read_request(self, read_request: Field) {
         assert_eq(
             self.nullifier,
-            siloed_value,
+            read_request,
             "Value of the nullifier leaf does not match read request",
         );
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/mod.nr
@@ -9,5 +9,5 @@ pub trait Ordered {
 }
 
 pub trait Readable {
-    fn assert_match_read_request(self, read_request: Scoped<Counted<Field>>);
+    fn assert_match_read_request(self, read_request: Field);
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -946,6 +946,14 @@ impl FixtureBuilder {
         self.add_nullifier_read_request(value)
     }
 
+    pub fn add_read_request_for_settled_nullifier(&mut self, siloed_nullifier: Field) -> u32 {
+        let read_request_index = self.nullifier_read_requests.len();
+        let read_request =
+            Counted::new(siloed_nullifier, self.next_counter()).scope(AztecAddress::zero());
+        self.nullifier_read_requests.push(read_request);
+        read_request_index
+    }
+
     pub fn append_nullifier_read_requests(&mut self, num_reads: u32) {
         let index_offset = self.nullifier_read_requests.len();
         for i in 0..self.nullifier_read_requests.max_len() {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -155,6 +155,7 @@ export interface IPrivateExecutionOracle {
   ): void;
   privateNotifyNullifiedNote(innerNullifier: Fr, noteHash: Fr, counter: number): Promise<void>;
   privateNotifyCreatedNullifier(innerNullifier: Fr): Promise<void>;
+  privateIsNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean>;
   privateNotifyCreatedContractClassLog(log: ContractClassLog, counter: number): void;
   privateCallPrivateFunction(
     targetContractAddress: AztecAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -346,6 +346,14 @@ export class Oracle {
     return [];
   }
 
+  async privateIsNullifierPending([innerNullifier]: ACVMField[], [contractAddress]: ACVMField[]): Promise<ACVMField[]> {
+    const isPending = await this.handlerAsPrivate().privateIsNullifierPending(
+      Fr.fromString(innerNullifier),
+      AztecAddress.fromString(contractAddress),
+    );
+    return [toACVMField(isPending)];
+  }
+
   async utilityCheckNullifierExists([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
     const exists = await this.handlerAsUtility().utilityCheckNullifierExists(Fr.fromString(innerNullifier));
     return [toACVMField(exists)];

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -473,6 +473,19 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   }
 
   /**
+   * Check if a nullifier has been emitted in the same transaction, i.e. if privateNotifyCreatedNullifier has been
+   * called for this inner nullifier from the contract with the specified address.
+   * @param innerNullifier - The inner nullifier to check.
+   * @param contractAddress - Address of the contract that emitted the nullifier.
+   * @returns A boolean indicating whether the nullifier is pending or not.
+   */
+  public async privateIsNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean> {
+    const siloedNullifier = await siloNullifier(contractAddress, innerNullifier);
+    const isNullifierPending = this.noteCache.getNullifiers(contractAddress).has(siloedNullifier.toBigInt());
+    return Promise.resolve(isNullifierPending);
+  }
+
+  /**
    * Emit a contract class log.
    * This fn exists because we only carry a poseidon hash through the kernels, and need to
    * keep the preimage in ts for later.

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -4,9 +4,9 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-export const ORACLE_VERSION = 7;
+export const ORACLE_VERSION = 8;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant in this file and in
 /// `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'a1b2bceb2072b7ce271ff1c6a124003ddfef2e7f3e50359d1e444049d7a58f51';
+export const ORACLE_INTERFACE_HASH = 'f13e672b47b84b54c43610e22559dd16fb12a74983af8b5a87a0d45dff31b330';

--- a/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.test.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.test.ts
@@ -5,6 +5,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Tuple } from '@aztec/foundation/serialize';
 
 import { AztecAddress } from '../../aztec-address/index.js';
+import { siloNullifier } from '../../hash/hash.js';
 import { ClaimedLengthArray } from '../claimed_length_array.js';
 import { Nullifier, type ScopedNullifier } from '../nullifier.js';
 import { buildNullifierReadRequestHints } from './build_nullifier_read_request_hints.js';
@@ -20,8 +21,11 @@ describe('buildNullifierReadRequestHints', () => {
 
   const innerNullifier = (index: number) => index + 1;
 
-  const makeReadRequest = (value: number, counter = 2) =>
+  const makePendingReadRequest = (value: number, counter = 2) =>
     new ReadRequest(new Fr(value), counter).scope(contractAddress);
+
+  const makeSettledReadRequest = async (value: number, counter = 2) =>
+    new ReadRequest(await siloNullifier(contractAddress, new Fr(value)), counter).scope(AztecAddress.ZERO);
 
   const makeNullifier = (value: number, counter = 1) =>
     new Nullifier(new Fr(value), Fr.ZERO, counter).scope(contractAddress);
@@ -61,21 +65,21 @@ describe('buildNullifierReadRequestHints', () => {
     readRequestIndex?: number;
     hintIndex?: number;
   }) => {
-    nullifierReadRequests[readRequestIndex] = makeReadRequest(innerNullifier(nullifierIndex));
+    nullifierReadRequests[readRequestIndex] = makePendingReadRequest(innerNullifier(nullifierIndex));
     expectedHints.readRequestActions[readRequestIndex] = ReadRequestAction.readAsPending(hintIndex);
     expectedHints.pendingReadHints[hintIndex] = new PendingReadHint(readRequestIndex, nullifierIndex);
     numReadRequests++;
     numPendingReads++;
   };
 
-  const readSettledNullifier = ({
+  const readSettledNullifier = async ({
     readRequestIndex = numReadRequests,
     hintIndex = numSettledReads,
   }: {
     readRequestIndex?: number;
     hintIndex?: number;
   } = {}) => {
-    nullifierReadRequests[readRequestIndex] = makeReadRequest(settledNullifierInnerValue);
+    nullifierReadRequests[readRequestIndex] = await makeSettledReadRequest(settledNullifierInnerValue);
     expectedHints.readRequestActions[readRequestIndex] = ReadRequestAction.readAsSettled(hintIndex);
     expectedHints.settledReadHints[hintIndex] = new SettledReadHint(readRequestIndex, {} as any, {} as any);
     numReadRequests++;
@@ -84,7 +88,7 @@ describe('buildNullifierReadRequestHints', () => {
 
   const readFutureNullifier = (nullifierIndex: number) => {
     const readRequestIndex = numReadRequests;
-    nullifierReadRequests[readRequestIndex] = makeReadRequest(futureNullifiers[nullifierIndex].value.toNumber());
+    nullifierReadRequests[readRequestIndex] = makePendingReadRequest(futureNullifiers[nullifierIndex].value.toNumber());
     numReadRequests++;
   };
 
@@ -120,17 +124,17 @@ describe('buildNullifierReadRequestHints', () => {
   });
 
   it('builds hints for settled nullifier read requests', async () => {
-    readSettledNullifier();
-    readSettledNullifier();
+    await readSettledNullifier();
+    await readSettledNullifier();
     const hints = await buildHints();
     expect(hints).toEqual(expectedHints);
   });
 
   it('builds hints for mixed pending and settled and future nullifier read requests', async () => {
     readPendingNullifier({ nullifierIndex: 2 });
-    readSettledNullifier();
+    await readSettledNullifier();
     readFutureNullifier(0);
-    readSettledNullifier();
+    await readSettledNullifier();
     readPendingNullifier({ nullifierIndex: 1 });
     readFutureNullifier(BlockNumber(1));
     readPendingNullifier({ nullifierIndex: 1 });

--- a/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
+++ b/yarn-project/stdlib/src/kernel/hints/build_nullifier_read_request_hints.ts
@@ -6,7 +6,6 @@ import {
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { MembershipWitness } from '@aztec/foundation/trees';
 
-import { siloNullifier } from '../../hash/hash.js';
 import type { NullifierLeafPreimage } from '../../trees/nullifier_leaf.js';
 import type { ClaimedLengthArray } from '../claimed_length_array.js';
 import type { ScopedNullifier } from '../nullifier.js';
@@ -74,7 +73,6 @@ export async function buildNullifierReadRequestHintsFromResetActions<PENDING ext
   resetActions: ReadRequestResetActions<typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX>,
   maxPending: PENDING = MAX_NULLIFIER_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NULLIFIER_READ_REQUESTS_PER_TX as SETTLED,
-  siloed = false,
 ) {
   const builder = new NullifierReadRequestHintsBuilder(maxPending, maxSettled);
 
@@ -90,12 +88,7 @@ export async function buildNullifierReadRequestHintsFromResetActions<PENDING ext
     }
   }
 
-  // Compute siloed values in parallel (if not already siloed)
-  const siloedValues = siloed
-    ? settledRequests.map(({ readRequest }) => readRequest.value)
-    : await Promise.all(
-        settledRequests.map(({ readRequest }) => siloNullifier(readRequest.contractAddress, readRequest.value)),
-      );
+  const siloedValues = settledRequests.map(({ readRequest }) => readRequest.value);
 
   // Fetch all membership witnesses in parallel
   const membershipWitnesses = await Promise.all(siloedValues.map(value => oracle.getNullifierMembershipWitness(value)));
@@ -121,7 +114,6 @@ export async function buildNullifierReadRequestHints<PENDING extends number, SET
   futureNullifiers: ScopedNullifier[],
   maxPending: PENDING = MAX_NULLIFIER_READ_REQUESTS_PER_TX as PENDING,
   maxSettled: SETTLED = MAX_NULLIFIER_READ_REQUESTS_PER_TX as SETTLED,
-  siloed = false,
 ) {
   const resetActions = getNullifierReadRequestResetActions(nullifierReadRequests, nullifiers, futureNullifiers);
   return await buildNullifierReadRequestHintsFromResetActions(
@@ -130,6 +122,5 @@ export async function buildNullifierReadRequestHints<PENDING extends number, SET
     resetActions,
     maxPending,
     maxSettled,
-    siloed,
   );
 }

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -512,6 +512,15 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
+  async privateIsNullifierPending(foreignInnerNullifier: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
+    const innerNullifier = fromSingle(foreignInnerNullifier);
+    const contractAddress = addressFromSingle(foreignContractAddress);
+
+    const isPending = await this.handlerAsPrivate().privateIsNullifierPending(innerNullifier, contractAddress);
+
+    return toForeignCallResult([toSingle(new Fr(isPending))]);
+  }
+
   async utilityCheckNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 


### PR DESCRIPTION
Changing the settled nullifier read request to be siloed in the app circuit. 
It’s more consistent (the settled note hash read request is already siloed in the app), and cheaper overall. Because we only silo it when requesting a nullifier to be read, instead of siloing N times (N >= actual number of read requests) in the reset kernel.