### PR TITLE
chore: don't error if vite can't clean

### DIFF
--- a/boxes/boxes/vite/package.json
+++ b/boxes/boxes/vite/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "yarn clean && yarn compile && yarn codegen && tsc -b && vite build",
-    "clean": "rm -rf ./dist .tsbuildinfo ./codegenCache.json ./artifacts ./src/contracts/target ./test-results",
+    "clean": "rm -rf ./dist .tsbuildinfo ./codegenCache.json ./artifacts ./src/contracts/target ./test-results || true",
     "compile": "cd src/contracts && ${AZTEC:-aztec} compile --silence-warnings",
     "codegen": "${AZTEC:-aztec} codegen src/contracts/target -o artifacts",
     "serve": "vite",


### PR DESCRIPTION
We're snagging at this harmless error
```
[aztec-example-vite]: rm: cannot remove './test-results/.last-run.json': Permission denied
```
this is written as root currently