### PR TITLE
fix: allow passing noir deps to npm_install_deps

### DIFF
--- a/ci3/npm_install_deps
+++ b/ci3/npm_install_deps
@@ -2,6 +2,7 @@
 # In CI we leverage fast caching of node_modules folders using zstd.
 # Note this cache pull won't restore .yarn, which means a subsequent "yarn install" may still be slow.
 # This doesn't matter in CI however.
+# Takes optional extra dependencies (files, directories, or patterns) to include in the cache hash.
 NO_CD=1 source ${root:-$(git rev-parse --show-toplevel)}/ci3/source
 # We assume that `yarn.lock` sits within the root directory of the git repository we're currently in.
 #
@@ -16,11 +17,12 @@ fi
 
 yarn_lock_path=$(realpath yarn.lock --relative-to=$REPO_PATH)
 package_json_path=$(realpath package.json --relative-to=$REPO_PATH)
+extra_deps=("$@")
 
 # We only use the node module cache in CI.
 # The checking for ci-started makes sure we really *are* on a CI machine (it's created in bootstrap_ec2).
 if [ "$CI" -eq 1 ] && [ -f $HOME/ci-started ] && [ "${NO_CACHE:-0}" -eq 0 ]; then
-  nm_hash=$(cache_content_hash "^$yarn_lock_path" "^$package_json_path")
+  nm_hash=$(cache_content_hash "^$yarn_lock_path" "^$package_json_path" "${extra_deps[@]}")
   if ! cache_download node-modules-$nm_hash.zst; then
     denoise "retry 'find . -type d -iname node_modules -not -path \"*/node_modules/*\" | xargs rm -rf && yarn install --immutable'"
     cache_upload node-modules-$nm_hash.zst $(find . -type d -iname node_modules -not -path "*/node_modules/*")

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -131,7 +131,7 @@ export -f compile_project format lint get_projects compile_all hash
 function build {
   echo_header "yarn-project build"
   denoise "./bootstrap.sh clean-lite"
-  npm_install_deps
+  npm_install_deps ../noir
   denoise "compile_all"
 }
 


### PR DESCRIPTION
ci3/npm_install_deps now allows expressing a dependency on noir. this bit us with noirjs bumps