### PR TITLE
fix(archiver): use checkpointed block number in isEpochComplete

### DIFF
--- a/yarn-project/archiver/README.md
+++ b/yarn-project/archiver/README.md
@@ -97,6 +97,15 @@ Blocks added via `addBlock()` are considered "provisional" until they appear in 
 
 When `handleCheckpoints()` processes incoming checkpoints, it compares archive roots of local blocks against the checkpoint's blocks. If they differ, local blocks are pruned and replaced with the checkpoint's blocks. After checkpoint sync, `pruneUncheckpointedBlocks()` removes any remaining provisional blocks from slots that have ended. Both cases emit `L2PruneUncheckpointed`.
 
+### Querying Block Data
+
+When querying the archiver, be aware of the distinction between proposed and checkpointed blocks:
+
+- `getBlockHeader('latest')` / `getBlockNumber()`: Returns the latest block **including** proposed blocks
+- `getCheckpointedL2BlockNumber()`: Returns only the count of **checkpointed** blocks (synced from L1)
+
+Use checkpointed queries when the result must reflect L1 state (e.g., determining if an epoch is complete for proving). Use `'latest'` when you need the most recent block regardless of L1 confirmation (e.g., serving RPC queries to users).
+
 ### Edge Cases
 
 #### L1 Reorgs

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -323,8 +323,11 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   }
 
   public async isEpochComplete(epochNumber: EpochNumber): Promise<boolean> {
-    // The epoch is complete if the current L2 block is the last one in the epoch (or later)
-    const header = await this.getBlockHeader('latest');
+    // The epoch is complete if the current checkpointed L2 block is the last one in the epoch (or later).
+    // We use the checkpointed block number (synced from L1) instead of 'latest' to avoid returning true
+    // prematurely when proposed blocks have been pushed to the archiver but not yet checkpointed on L1.
+    const checkpointedBlockNumber = await this.getCheckpointedL2BlockNumber();
+    const header = checkpointedBlockNumber > 0 ? await this.getBlockHeader(checkpointedBlockNumber) : undefined;
     const slot = header ? header.globalVariables.slotNumber : undefined;
     const [_startSlot, endSlot] = getSlotRangeForEpoch(epochNumber, this.l1Constants);
     if (slot && slot >= endSlot) {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -756,21 +756,27 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   public async getTxReceipt(txHash: TxHash): Promise<TxReceipt> {
-    let txReceipt = new TxReceipt(txHash, TxStatus.DROPPED, undefined, 'Tx dropped by P2P node.');
-
     // We first check if the tx is in pending (instead of first checking if it is mined) because if we first check
     // for mined and then for pending there could be a race condition where the tx is mined between the two checks
     // and we would incorrectly return a TxReceipt with status DROPPED
-    if ((await this.p2pClient.getTxStatus(txHash)) === 'pending') {
-      txReceipt = new TxReceipt(txHash, TxStatus.PENDING, undefined, undefined);
-    }
+    const txStatus = await this.p2pClient.getTxStatus(txHash);
+    const isKnownToPool = txStatus === 'pending' || txStatus === 'mined';
 
+    // Then get the actual tx from the archiver, which tracks every tx in a mined block.
     const settledTxReceipt = await this.blockSource.getSettledTxReceipt(txHash);
-    if (settledTxReceipt) {
-      txReceipt = settledTxReceipt;
-    }
 
-    return txReceipt;
+    if (settledTxReceipt) {
+      // If the archiver has the receipt then return it.
+      return settledTxReceipt;
+    } else if (isKnownToPool) {
+      // If the tx is in the pool but not in the archiver, it's pending.
+      // This handles race conditions between archiver and p2p, where the archiver
+      // has pruned the block in which a tx was mined, but p2p has not caught up yet.
+      return new TxReceipt(txHash, TxStatus.PENDING, undefined, undefined);
+    } else {
+      // Otherwise, if we don't know the tx, we consider it dropped.
+      return new TxReceipt(txHash, TxStatus.DROPPED, undefined, 'Tx dropped by P2P node');
+    }
   }
 
   public getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {

--- a/yarn-project/aztec/src/local-network/local-network.ts
+++ b/yarn-project/aztec/src/local-network/local-network.ts
@@ -51,7 +51,6 @@ export async function deployContractsToL1(
   aztecNodeConfig: AztecNodeConfig,
   privateKey: Hex,
   opts: {
-    assumeProvenThroughBlockNumber?: number;
     genesisArchiveRoot?: Fr;
     feeJuicePortalInitialBalance?: bigint;
   } = {},
@@ -149,7 +148,6 @@ export async function createLocalNetwork(config: Partial<LocalNetworkConfig> = {
       aztecNodeConfig,
       aztecNodeConfig.validatorPrivateKeys.getValue()[0],
       {
-        assumeProvenThroughBlockNumber: Number.MAX_SAFE_INTEGER,
         genesisArchiveRoot,
         feeJuicePortalInitialBalance: fundingNeeded,
       },
@@ -181,9 +179,13 @@ export async function createLocalNetwork(config: Partial<LocalNetworkConfig> = {
 
   let epochTestSettler: EpochTestSettler | undefined;
   if (!aztecNodeConfig.p2pEnabled) {
-    epochTestSettler = new EpochTestSettler(cheatcodes!, rollupAddress!, node.getBlockSource(), {
-      pollingIntervalMs: 200,
-    });
+    epochTestSettler = new EpochTestSettler(
+      cheatcodes!,
+      rollupAddress!,
+      node.getBlockSource(),
+      logger.createChild('epoch-settler'),
+      { pollingIntervalMs: 200 },
+    );
     await epochTestSettler.start();
   }
 

--- a/yarn-project/aztec/src/testing/epoch_test_settler.ts
+++ b/yarn-project/aztec/src/testing/epoch_test_settler.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/aztec.js/fields';
 import { type EthCheatCodes, RollupCheatCodes } from '@aztec/ethereum/test';
 import { type EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import type { Logger } from '@aztec/foundation/log';
 import { EpochMonitor } from '@aztec/prover-node';
 import type { EthAddress, L2BlockSource } from '@aztec/stdlib/block';
 import { computeL2ToL1MembershipWitnessFromMessagesInEpoch } from '@aztec/stdlib/messaging';
@@ -13,6 +14,7 @@ export class EpochTestSettler {
     cheatcodes: EthCheatCodes,
     rollupAddress: EthAddress,
     private l2BlockSource: L2BlockSource,
+    private log: Logger,
     private options: { pollingIntervalMs: number; provingDelayMs?: number },
   ) {
     this.rollupCheatCodes = new RollupCheatCodes(cheatcodes, { rollupAddress });
@@ -30,9 +32,14 @@ export class EpochTestSettler {
 
   async handleEpochReadyToProve(epoch: EpochNumber): Promise<boolean> {
     const blocks = await this.l2BlockSource.getBlocksForEpoch(epoch);
+    this.log.info(
+      `Settling epoch ${epoch} with blocks ${blocks[0]?.header.getBlockNumber()} to ${blocks.at(-1)?.header.getBlockNumber()}`,
+      { blocks: blocks.map(b => b.toBlockInfo()) },
+    );
     const messagesInEpoch: Fr[][][][] = [];
     let previousSlotNumber = SlotNumber.ZERO;
     let checkpointIndex = -1;
+
     for (const block of blocks) {
       const slotNumber = block.header.globalVariables.slotNumber;
       if (slotNumber !== previousSlotNumber) {
@@ -47,11 +54,15 @@ export class EpochTestSettler {
     if (firstMessage) {
       const { root: outHash } = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, firstMessage);
       await this.rollupCheatCodes.insertOutbox(epoch, outHash.toBigInt());
+    } else {
+      this.log.info(`No L2 to L1 messages in epoch ${epoch}`);
     }
 
-    // Mark the blocks as proven.
-    for (const block of blocks) {
-      await this.rollupCheatCodes.markAsProven(block.number);
+    const lastCheckpoint = blocks.at(-1)?.checkpointNumber;
+    if (lastCheckpoint !== undefined) {
+      await this.rollupCheatCodes.markAsProven(lastCheckpoint);
+    } else {
+      this.log.warn(`No checkpoint found for epoch ${epoch}`);
     }
 
     return true;

--- a/yarn-project/cli/src/cmds/l1/assume_proven_through.ts
+++ b/yarn-project/cli/src/cmds/l1/assume_proven_through.ts
@@ -1,23 +1,20 @@
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
 import { RollupCheatCodes } from '@aztec/ethereum/test';
-import { BlockNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { LogFn } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 
 export async function assumeProvenThrough(
-  blockNumberOrLatest: number | undefined,
+  checkpointOrLatest: CheckpointNumber | undefined,
   l1RpcUrls: string[],
   nodeUrl: string,
   log: LogFn,
 ) {
   const aztecNode = createAztecNodeClient(nodeUrl);
   const rollupAddress = await aztecNode.getNodeInfo().then(i => i.l1ContractAddresses.rollupAddress);
-  const blockNumber: BlockNumber = blockNumberOrLatest
-    ? BlockNumber(blockNumberOrLatest)
-    : await aztecNode.getBlockNumber();
 
   const rollupCheatCodes = RollupCheatCodes.create(l1RpcUrls, { rollupAddress }, new DateProvider());
 
-  await rollupCheatCodes.markAsProven(blockNumber);
-  log(`Assumed proven through block ${blockNumber}`);
+  await rollupCheatCodes.markAsProven(checkpointOrLatest);
+  log(`Assumed proven through checkpoint ${checkpointOrLatest ?? 'latest'}`);
 }

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -1,3 +1,4 @@
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 
@@ -497,14 +498,14 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
   program
     .command('set-proven-through', { hidden: true })
     .description(
-      'Instructs the L1 rollup contract to assume all blocks until the given number are automatically proven.',
+      'Instructs the L1 rollup contract to assume all blocks until the given checkpoint are automatically proven.',
     )
-    .argument('[blockNumber]', 'The target block number, defaults to the latest pending block number.', parseBigint)
+    .argument('[checkpoint]', 'The target checkpoint, defaults to the latest pending checkpoint.', parseBigint)
     .addOption(l1RpcUrlsOption)
     .addOption(nodeOption)
-    .action(async (blockNumber, options) => {
+    .action(async (checkpoint, options) => {
       const { assumeProvenThrough } = await import('./assume_proven_through.js');
-      await assumeProvenThrough(blockNumber, options.l1RpcUrls, options.nodeUrl, log);
+      await assumeProvenThrough(CheckpointNumber.fromBigInt(checkpoint), options.l1RpcUrls, options.nodeUrl, log);
     });
 
   program

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -247,7 +247,7 @@ describe('e2e_fees failures', () => {
           },
         })
         .wait(),
-    ).rejects.toThrow(/Transaction (0x)?[0-9a-fA-F]{64} was dropped\. Reason: Tx dropped by P2P node\./);
+    ).rejects.toThrow(/Transaction (0x)?[0-9a-fA-F]{64} was dropped/i);
   });
 
   it('includes transaction that error in teardown', async () => {

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -466,7 +466,7 @@ describe('e2e_synching', () => {
       // If it breaks here, first place you should look is the pruning.
       await publisher.enqueueProposeCheckpoint(checkpoint, CommitteeAttestationsAndSigners.empty(), Signature.empty());
 
-      await cheatCodes.rollup.markAsProven(provenThrough);
+      await cheatCodes.rollup.markAsProven(CheckpointNumber.fromBlockNumber(BlockNumber(provenThrough)));
     }
 
     await alternativeSync(
@@ -579,8 +579,8 @@ describe('e2e_synching', () => {
           expect(await worldState.getLatestBlockNumber()).toEqual(Number(pendingBlockNumber));
 
           // We prune the last token and schnorr contract
-          const provenThrough = pendingBlockNumber - 2n;
-          await opts.cheatCodes!.rollup.markAsProven(provenThrough);
+          const provenThrough = BlockNumber.fromBigInt(pendingBlockNumber - 2n);
+          await opts.cheatCodes!.rollup.markAsProven(CheckpointNumber.fromBlockNumber(provenThrough));
 
           const timeliness = (await rollup.read.getEpochDuration()) * 2n;
           const blockLog = await rollup.read.getCheckpoint([(await rollup.read.getProvenCheckpointNumber()) + 1n]);
@@ -661,8 +661,9 @@ describe('e2e_synching', () => {
             client: opts.deployL1ContractsValues!.l1Client,
           });
 
-          const pendingBlockNumber = await rollup.read.getPendingCheckpointNumber();
-          await opts.cheatCodes!.rollup.markAsProven(pendingBlockNumber - BigInt(variant.blockCount) / 2n);
+          const pendingCheckpointNumber = CheckpointNumber.fromBigInt(await rollup.read.getPendingCheckpointNumber());
+          const offset = CheckpointNumber.fromBlockNumber(BlockNumber(variant.blockCount / 2));
+          await opts.cheatCodes!.rollup.markAsProven(CheckpointNumber(pendingCheckpointNumber - offset));
 
           const aztecNode = await AztecNodeService.createAndSync(opts.config!);
           const sequencer = aztecNode.getSequencer();
@@ -726,8 +727,9 @@ describe('e2e_synching', () => {
             client: opts.deployL1ContractsValues!.l1Client,
           });
 
-          const pendingBlockNumber = await rollup.read.getPendingCheckpointNumber();
-          await opts.cheatCodes!.rollup.markAsProven(pendingBlockNumber - BigInt(variant.blockCount) / 2n);
+          const pendingCheckpointNumber = CheckpointNumber.fromBigInt(await rollup.read.getPendingCheckpointNumber());
+          const offset = CheckpointNumber.fromBlockNumber(BlockNumber(variant.blockCount / 2));
+          await opts.cheatCodes!.rollup.markAsProven(CheckpointNumber(pendingCheckpointNumber - offset));
 
           const timeliness = (await rollup.read.getEpochDuration()) * 2n;
           const blockLog = await rollup.read.getCheckpoint([(await rollup.read.getProvenCheckpointNumber()) + 1n]);

--- a/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/rollup_cheat_codes.ts
@@ -176,7 +176,7 @@ export class RollupCheatCodes {
    * Marks the specified checkpoint (or latest if none) as proven
    * @param maybeCheckpointNumber - The checkpoint number to mark as proven (defaults to latest pending)
    */
-  public markAsProven(maybeCheckpointNumber?: number | bigint) {
+  public markAsProven(maybeCheckpointNumber?: CheckpointNumber) {
     return this.ethCheatCodes.execWithPausedAnvil(async () => {
       const tipsBefore = await this.getTips();
       const { pending, proven } = tipsBefore;


### PR DESCRIPTION
When proposed blocks are pushed to the archiver before being checkpointed on L1, `isEpochComplete` was returning true prematurely because it used `getBlockHeader('latest')` which includes proposed blocks. However, `getBlocksForEpoch` only returns blocks from synced checkpoints, leading to incomplete epoch proving.

This fix changes `isEpochComplete` to use `getCheckpointedL2BlockNumber` instead of 'latest', ensuring the epoch is only marked complete when checkpointed blocks reach the end of the epoch.

Also fixes:
- EpochTestSettler now marks the last checkpoint as proven instead of iterating over blocks
- Updates markAsProven to use CheckpointNumber type for type safety
- Updates CLI command and tests to use CheckpointNumber consistently
