### PR TITLE
fix: enforce poseidon2 encryption nonce bounds

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/poseidon2.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/poseidon2.nr
@@ -30,7 +30,7 @@ pub fn poseidon2_encrypt<let L: u32>(
     shared_secret: Point,
     encryption_nonce: Field,
 ) -> [Field; ((L + 2) / 3) * 3 + 1] {
-    // TODO: assert(encryption_nonce < 2^128), assert(L < 2^120);
+    assert(encryption_nonce < TWO_POW_128);
     let mut s =
         [0, shared_secret.x, shared_secret.y, encryption_nonce + (L as Field) * TWO_POW_128];
 
@@ -82,6 +82,7 @@ pub fn poseidon2_decrypt<let L: u32>(
     shared_secret: Point,
     encryption_nonce: Field,
 ) -> Option<[Field; L]> {
+    assert(encryption_nonce < TWO_POW_128);
     let mut s =
         [0, shared_secret.x, shared_secret.y, encryption_nonce + (L as Field) * TWO_POW_128];
 


### PR DESCRIPTION
Reason:
Previously poseidon2 encryption packed (encryption_nonce, L) into a single field element assuming a 128-bit nonce, but this was only documented in a TODO comment and never enforced. Callers could pass arbitrary field elements as nonces, breaking the intended 128-bit nonce invariant and making the encoding less clearly injective from a security/analysis point of view.

Overview of changes:
- Add an assertion in poseidon2_encrypt to ensure encryption_nonce < 2^128 (TWO_POW_128).
- Add the same assertion in poseidon2_decrypt to mirror the invariant at decryption time and keep both sides in sync with the documented design.
- Remove the obsolete TODO that referenced these missing checks.