### PR TITLE
chore(docs): improve grammar, style, and consistency in resources docs

### DIFF
--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/community_calls.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/community_calls.md
@@ -1,0 +1,66 @@
+---
+title: Community Calls
+tags: [community, calls, office-hours]
+description: Join live calls to connect with the Aztec team and other builders.
+---
+
+**Build with us, live.**
+
+Every week you can join office hours, townhalls and ecosystem calls to get unblocked, learn from maintainers, and connect with other builders. Pick the call that fits your needs, add it to your calendar, and show up with questions.
+
+---
+
+## Ecosystem Call
+
+- **When:** Biweekly · time in shared calendar
+- **Where:** [Google Meet](https://meet.google.com/rqs-ckcy-vyc)
+- **For:** Founders, contributors and newcomers. Updates, demos, feedback, open roles.
+
+---
+
+## Noir Office Hours
+
+We offer two weekly sessions to accommodate different timezones.
+
+### Morning Session (Americas/Europe)
+
+- **When:** Tuesdays · 15:00 – 16:00 UTC
+- **Where:** [Google Meet](https://meet.google.com/hyh-bdqm-ijg)
+- **For:** Developers writing or debugging Noir. Bring your questions about syntax, tooling, and patterns.
+
+### Evening Session (Europe/Asia-Pacific)
+
+- **When:** Wednesdays · 01:00 – 01:30 UTC
+- **Where:** [Google Meet](https://meet.google.com/hyh-bdqm-ijg)
+- **For:** An informal session to hang out with the Aztec Labs Dev Rel team and other Noir devs. Bring questions, share a project, or just come listen.
+
+---
+
+## Aztec Developer Office Hours
+
+- **When:** Wednesdays · 01:30 – 02:30 UTC
+- **Where:** [Google Meet](https://meet.google.com/say-ognq-dpc)
+- **For:** Aztec-focused developer questions. The Aztec Labs team is available to answer anything: high-level, architectural, protocol, debugging, and more.
+
+---
+
+## Community Townhall
+
+- **When:** Thursdays · Time in shared calendar
+- **Where:** [Google Meet](https://discord.gg/aztec)
+- **For:** The entire community, from contributors to newcomers. Updates from the core team, open discussions, roadmap insights.
+
+---
+
+## Community
+
+- Follow discussions in the [Forum](https://forum.aztec.network)
+- Ask daily questions in [Discord](https://discord.gg/aztec)
+
+---
+
+## One calendar, all calls
+
+Save time, add everything with one click:
+
+[Subscribe to the Aztec & Noir Community Calendar](https://calendar.google.com/calendar/u/0?cid=ZGI5MTVjMGQ2MzQ5NWNlNTgzOTJmNjg5YjJjZDYyZjQ5MTgxNzk3YjUzYTBiYmUyNmUwOTBkNWQ5Y2E0YzIwZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/considerations/limitations.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/considerations/limitations.md
@@ -4,44 +4,44 @@ description: Understand the current limitations of the Aztec network and its imp
 sidebar_position: 6
 ---
 
-The Aztec stack is a work in progress. Packages have been released early, to gather feedback on the capabilities of the protocol and user experiences.
+The Aztec stack is a work in progress. Packages have been released early to gather feedback on the capabilities of the protocol and user experiences.
 
-## What to expect?
+## What to expect
 
-- Regular Breaking Changes;
-- Missing features;
-- Bugs;
-- An 'unpolished' UX;
-- Missing information.
+- Regular breaking changes
+- Missing features
+- Bugs
+- An "unpolished" UX
+- Missing information
 
-## Why participate?
+## Why participate
 
 Front-run the future!
 
 Help shape and define:
 
 - Previously-impossible smart contracts and applications
-- Network tooling;
-- Network standards;
-- Smart contract syntax;
-- Educational content;
-- Core protocol improvements;
+- Network tooling
+- Network standards
+- Smart contract syntax
+- Educational content
+- Core protocol improvements
 
 ## Limitations developers need to know about
 
-- It is a testing environment, it is insecure, and unaudited. It is only for testing purposes.
-- `msg_sender` is currently leaking when doing private -> public calls
-  - The `msg_sender` will always be set, if you call a public function from the private world, the `msg_sender` will be set to the private caller's address.
+- It is a testing environment, insecure and unaudited. It is only for testing purposes.
+- `msg_sender` is currently leaked when making private -> public calls.
+  - The `msg_sender` is always set. If you call a public function from the private world, the `msg_sender` is set to the private caller's address.
   - There are patterns that can mitigate this.
 - The initial `msg_sender` is `-1`, which can be problematic for some contracts.
-- The number of side-effects attached to a tx (when sending the tx to the mempool) is leaky. At this stage of development, this is _intentional_, so that we can gauge appropriate choices for privacy sets. We have always had clear plans to implement privacy sets so that side effects are much less leaky, and these will be in place come mainnet.
-- A transaction can only emit a limited number of side-effects (notes, nullifiers, logs, l2->l1 messages), see [circuit limitations](#circuit-limitations).
-  - We haven't settled on the final constants, since we're still in a testing phase. But users could find that certain compositions of nested private function calls (e.g. call stacks that are dynamic in size, based on runtime data) could accumulate so many side-effects as to exceed tx limits. Such txs would then be unprovable. We would love for you to open an issue if you encounter this, as it will help us decide on adequate sizes for our constants.
-- There are lots of features that we still want to implement. Checkout github and the forum for details. If you would like a feature, please open an issue on github!
+- The number of side-effects attached to a transaction (when sending the transaction to the mempool) is leaky. At this stage of development, this is _intentional_, so that we can gauge appropriate choices for privacy sets. We have clear plans to implement privacy sets so that side effects are much less leaky, and these will be in place for mainnet.
+- A transaction can only emit a limited number of side-effects (notes, nullifiers, logs, L2->L1 messages). See [circuit limitations](#circuit-limitations).
+  - We have not settled on the final constants, since we are still in a testing phase. You could find that certain compositions of nested private function calls (for example, call stacks that are dynamic in size, based on runtime data) could accumulate so many side-effects as to exceed transaction limits. Such transactions would then be unprovable. Please open an issue if you encounter this, as it will help us decide on adequate sizes for our constants.
+- There are many features that we still want to implement. Check out GitHub and the forum for details. If you would like a feature, please open an issue on GitHub.
 
 ## WARNING
 
-Do not use real, meaningful secrets in Aztec's testnets. Some privacy features are still being worked on, including ensuring a secure "zk" property. Since the Aztec stack is still being worked on, there are no guarantees that real secrets will remain secret.
+Do not use real, meaningful secrets in Aztec testnets. Some privacy features are still in development, including ensuring a secure "zk" property. Since the Aztec stack is still being developed, there are no guarantees that real secrets will remain secret.
 
 ## Limitations
 
@@ -49,49 +49,49 @@ There are plans to resolve all of the below.
 
 ### It is not audited
 
-None of the Aztec stack is audited. It's being iterated-on every day. It will not be audited for quite some time.
+None of the Aztec stack is audited. It is being iterated on every day. It will not be audited for quite some time.
 
 ### Under-constrained
 
-Some of our more-complex circuits are still being worked on, so they will still be be underconstrained.
+Some of our more complex circuits are still in development, so they are still under-constrained.
 
 #### What are the consequences?
 
-Sound proofs are really only needed as a protection against malicious behavior, which we're not testing for at this stage.
+Sound proofs are really only needed as a protection against malicious behavior, which we are not testing for at this stage.
 
-### Keys and Addresses are subject to change
+### Keys and addresses are subject to change
 
 The way in which keypairs and addresses are derived is still being iterated on as we receive feedback.
 
 #### What are the consequences?
 
-This will impact the kinds of apps that you can build with the Local Network, as it is today:
+This will impact the kinds of apps that you can build with the local network as it is today.
 
-Please open new discussions on [discourse](http://discourse.aztec.network) or open issues on [github](http://github.com/AztecProtocol/aztec-packages), if you have requirements that aren't-yet being met by the local network's current key derivation scheme.
+Please open new discussions on [Discourse](https://discourse.aztec.network) or open issues on [GitHub](https://github.com/AztecProtocol/aztec-packages) if you have requirements that are not yet being met by the local network's current key derivation scheme.
 
 ### No privacy-preserving queries to nodes
 
-Ethereum has a notion of a 'full node' which keeps-up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so rely on 3rd-party 'full-node-as-a-service' infrastructure providers, who service blockchain queries from their users.
+Ethereum has a notion of a "full node" which keeps up with the blockchain and stores the full chain state. Many users do not wish to run full nodes, so they rely on third-party "full-node-as-a-service" infrastructure providers who service blockchain queries from their users.
 
-This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a 3rd-party 'full node', that user might leak data about who they are, or about their historical network activity, or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a 3rd-party node without revealing what that data is, nor who is making the request.
+This pattern is likely to develop in Aztec as well, except there is a problem: privacy. If a privacy-seeking user makes a query to a third-party "full node", that user might leak data about who they are, about their historical network activity, or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a third-party node without revealing what that data is, nor who is making the request.
 
 ### No private data authentication
 
-Private data should not be returned to an app, unless the user authorizes such access to the app. An authorization layer is not-yet in place.
+Private data should not be returned to an app unless the user authorizes such access to the app. An authorization layer is not yet in place.
 
 #### What are the consequences?
 
-Any app can request and receive any private user data relating to any other private app. Obviously this sounds bad. But the local network is a sandbox, and no meaningful value or credentials should be stored there; only test values and test credentials.
+Any app can request and receive any private user data relating to any other private app. This sounds problematic, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
 
-An auth layer will be added in due course.
+An authorization layer will be added in due course.
 
 ### No bytecode validation
 
-For safety reasons, bytecode should not be executed unless the PXE/Wallet has validated that the user's intentions (the function signature and contract address) match the bytecode.
+For safety reasons, bytecode should not be executed unless the PXE (Private eXecution Environment) or wallet has validated that the user's intentions (the function signature and contract address) match the bytecode.
 
 #### What are the consequences?
 
-Without such 'bytecode validation', if the incorrect bytecode is executed, and that bytecode is malicious, it could read private data from some other contract and emit that private data to the world. Obviously this would be bad in production. But the local network is a sandbox, and no meaningful value or credentials should be stored there; only test values and test credentials.
+Without bytecode validation, if incorrect bytecode is executed and that bytecode is malicious, it could read private data from some other contract and emit that private data to the world. This would be problematic in production, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
 
 There are plans to add bytecode validation soon.
 
@@ -101,27 +101,27 @@ We are planning a full assessment of the protocol's hashes, including rigorous d
 
 #### What are the consequences?
 
-Collisions and other hash-related attacks might be possible in the local network. Obviously that would be bad in production. But it's unlikely to cause problems at this early stage of testing.
+Collisions and other hash-related attacks might be possible in the local network. This would be problematic in production, but it is unlikely to cause problems at this early stage of testing.
 
 ### `msg_sender` is leaked when making a private -> public call
 
-There are ongoing discussions [here](https://forum.aztec.network/t/what-is-msg-sender-when-calling-private-public-plus-a-big-foray-into-stealth-addresses/7527 (and some more recent discussions that need to be documented) around how to address this.
+There are ongoing discussions [here](https://forum.aztec.network/t/what-is-msg-sender-when-calling-private-public-plus-a-big-foray-into-stealth-addresses/7527) (and some more recent discussions that need to be documented) around how to address this.
 
-### New Privacy Standards are required
+### New privacy standards are required
 
-There are many [patterns](../../resources/considerations/privacy_considerations.md) which can leak privacy, even on Aztec. Standards haven't been developed yet, to encourage best practices when designing private smart contracts.
+There are many [patterns](../../resources/considerations/privacy_considerations.md) which can leak privacy, even on Aztec. Standards have not been developed yet to encourage best practices when designing private smart contracts.
 
 #### What are the consequences?
 
-For example, until community standards are developed to reduce the uniqueness of ['Tx Fingerprints'](../../resources/considerations/privacy_considerations.md#function-fingerprints-and-tx-fingerprints) app developers might accidentally forfeit some function privacy.
+For example, until community standards are developed to reduce the uniqueness of ["Tx Fingerprints"](../../resources/considerations/privacy_considerations.md#function-fingerprints-and-tx-fingerprints), app developers might accidentally forfeit some function privacy.
 
-## Smart Contract limitations
+## Smart contract limitations
 
-We will never be done with all the yummy features we want to add to aztec.nr. We have lots of features that we still want to implement. Please check out github, and please open new issues with any feature requests you might have.
+We will never be done with all the features we want to add to Aztec.nr. We have many features that we still want to implement. Please check out GitHub and open new issues with any feature requests you might have.
 
 ## Circuit limitations
 
-### Upper limits on function outputs and tx outputs
+### Upper limits on function outputs and transaction outputs
 
 Due to the rigidity of zk-SNARK circuits, there are upper bounds on the amount of computation a circuit can perform, and on the amount of data that can be passed into and out of a function.
 
@@ -211,12 +211,12 @@ When you write an Aztec.nr function, there will be upper bounds on the following
 
 Not only are there limits on a _per function_ basis, there are also limits on a _per transaction_ basis.
 
-**In particular, these _per-transaction_ limits will limit transaction call stack depths**. That means if a function call results in a cascade of nested function calls, and each of those function calls outputs lots of state reads and writes, or logs (etc.), then all of that accumulated output data might exceed the per-transaction limits that we currently have. This would cause such transactions to fail.
+**In particular, these _per-transaction_ limits will limit transaction call stack depths**. This means if a function call results in a cascade of nested function calls, and each of those function calls outputs many state reads and writes, or logs, then all of that accumulated output data might exceed the per-transaction limits that we currently have. This would cause such transactions to fail.
 
-There are plans to relax some of this rigidity, by providing many 'sizes' of circuit.
+There are plans to relax some of this rigidity by providing many "sizes" of circuit.
 
-> **In the mean time**, if you encounter a per-transaction limit when testing, please do open an issue to explain what you were trying to do; we'd love to hear about it. And if you're feeling adventurous, you could 'hack' the PXE to increase the limits. **However**, the limits cannot be increased indefinitely. So although we do anticipate that we'll be able to increase them a little bit, don't go mad and provide yourself with 1 million state transitions per transaction. That would be as unrealistic as artificially increasing Ethereum gas limits to 1 trillion.
+> **In the meantime**, if you encounter a per-transaction limit when testing, please open an issue to explain what you were trying to do - we would love to hear about it. And if you are feeling adventurous, you could modify the PXE to increase the limits. **However**, the limits cannot be increased indefinitely. Although we do anticipate that we will be able to increase them slightly, do not provide yourself with 1 million state transitions per transaction. That would be as unrealistic as artificially increasing Ethereum gas limits to 1 trillion.
 
-## There's more
+## There is more
 
-See the [GitHub issues (GitHub link)](https://github.com/AztecProtocol/aztec-packages/issues) for all known bugs fixes and features currently being worked on.
+See the [GitHub issues](https://github.com/AztecProtocol/aztec-packages/issues) for all known bug fixes and features currently being worked on.

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/considerations/privacy_considerations.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/considerations/privacy_considerations.md
@@ -5,13 +5,7 @@ sidebar_position: 5
 tags: [protocol, PXE]
 ---
 
-Privacy is important.
-
-Keeping information private is difficult.
-
-Once information is leaked, it cannot be unleaked.
-
----
+Privacy is a core value of Aztec Protocol. Keeping information private is difficult, and once information is leaked, it cannot be unleaked. This page outlines key privacy considerations that developers should understand when building applications on Aztec.
 
 ## What can Aztec keep private?
 
@@ -35,9 +29,9 @@ The bytecode of private functions does not need to be distributed to the world; 
 
 :::danger
 Privacy is not guaranteed without care.
-Although Aztec provides the tools for private smart contracts, information can still be leaked unless the dapp developer is careful.
+Although Aztec provides the tools for private smart contracts, information can still be leaked unless you are careful.
 Aztec is still under development, so real-world, meaningful, valuable secrets _should not_ be entrusted to the system.
-This page outlines some best practices to aid dapp developers.
+This page outlines some best practices to help you build privacy-preserving applications.
 :::
 
 ---
@@ -46,18 +40,18 @@ This page outlines some best practices to aid dapp developers.
 
 There are many caveats to the above. Since Aztec also enables interaction with the _public_ world (public L2 functions and L1 functions), private information can be accidentally leaked if developers aren't careful.
 
-### Crossing the private -> public boundary
+### Crossing the private to public boundary
 
 Any time a private function makes a call to a public function, information is leaked. Now, that might be perfectly fine in some use cases (it's up to the smart contract developer). Indeed, most interesting apps will require some public state. But let's have a look at some leaky patterns:
 
 - Calling a public function from a private function. The public function execution will be publicly visible.
-- Calling a public function from a private function, without revealing the `msg_sender` of that call. (Otherwise the `msg_sender` will be publicly visible).
+- Calling a public function from a private function and revealing the `msg_sender` of that call (the `msg_sender` will be publicly visible).
 - Passing arguments to a public function from a private function. All of those arguments will be publicly visible.
 - Calling an internal public function from a private function. The fact that the call originated from a private function of that same contract will be trivially known.
 - Emitting unencrypted events from a private function. The unencrypted event name and arguments will be publicly visible.
 - Sending L2->L1 messages from a private function. The entire message, and the resulting L1 function execution will all be publicly visible.
 
-### Crossing the public -> private boundary
+### Crossing the public to private boundary
 
 If a public function sends a message to be consumed by a private function, the act of consuming that message might be leaked if not following recommended patterns.
 
@@ -73,7 +67,7 @@ These minor details are information that can disclose much more information abou
 
 Suppose that every time Alice sends Bob a private token, 1 minute later a transaction is always submitted to the tx pool with the same kind of 'fingerprint'. Alice might deduce that these transactions are automated reactions by Bob. (Here, 'fingerprint' is an intentionally vague term. It could be a public function call, or a private tx proof with a particular number of nonzero public inputs, or some other discernible pattern that Alice sees).
 
-TL;DR: app developers should think about the _timing_ of user transactions, and how this might leak information.
+In short, you should think about the _timing_ of user transactions and how this might leak information.
 
 ### Function Fingerprints and Tx Fingerprints
 
@@ -93,25 +87,27 @@ A 'Function Fingerprint' is any data which is exposed by a function to the outsi
   - \# bytes of encrypted logs
   - \# public function calls
   - \# L2->L1 messages
-  - \# nonzero roots[^1]
+  - \# nonzero roots
 
-> Note: many of these were mentioned in the ["Crossing the private -> public boundary"](#crossing-the-private---public-boundary) section.
+> Note: many of these were mentioned in the ["Crossing the private to public boundary"](#crossing-the-private-to-public-boundary) section.
 
-> Note: the transaction effects submitted to L1 is [encoded (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/master/l1-contracts/src/core/libraries/Decoder.sol) but not garbled with other transactions: the distinct Tx Fingerprint of each tx can is publicly visible when a tx is submitted to the L2 tx pool.
+> Note: the transaction effects submitted to L1 are [encoded (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/master/l1-contracts/src/core/libraries/Decoder.sol) but not garbled with other transactions. The distinct Tx Fingerprint of each transaction is publicly visible when submitted to the L2 tx pool.
 
 #### Standardizing Fingerprints
 
-If each private function were to have a unique Fingerprint, then all private functions would be distinguishable from each-other, and all of the efforts of the Aztec protocol to enable 'private function execution' would have been pointless. Standards need to be developed, to encourage smart contract developers to adhere to a restricted set of Tx Fingerprints. For example, a standard might propose that the number of new note hashes, nullifiers, logs, etc. must always be equal, and must always equal a power of two. Such a standard would effectively group private functions/txs into 'privacy sets', where all functions/txs in a particular 'privacy set' would look indistinguishable from each-other, when executed.
+If each private function were to have a unique Fingerprint, then all private functions would be distinguishable from each other, and all of the efforts of the Aztec Protocol to enable private function execution would have been pointless.
+
+Standards need to be developed to encourage smart contract developers to adhere to a restricted set of Tx Fingerprints. For example, a standard might propose that the number of new note hashes, nullifiers, logs, etc. must always be equal, and must always equal a power of two. Such a standard would effectively group private functions and transactions into "privacy sets," where all functions and transactions in a particular privacy set would look indistinguishable from each other when executed.
 
 ### Data queries
 
 It's not just the broadcasting of transactions to the network that can leak data.
 
-Ethereum has a notion of a 'full node' which keeps-up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so rely on 3rd-party 'full-node-as-a-service' infrastructure providers, who service blockchain queries from their users.
+Ethereum has a notion of a "full node" which keeps up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so they rely on third-party "full-node-as-a-service" infrastructure providers, who service blockchain queries from their users.
 
-This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a 3rd-party 'full node', that user might leak data about who they are; about their historical network activity; or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a 3rd-party node without revealing what that data is, nor who is making the request.
+This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a third-party full node, that user might leak data about who they are, their historical network activity, or their future intentions. One solution to this problem is to always run a full node, but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a third-party node without revealing what that data is, nor who is making the request.
 
-App developers should be aware of this avenue for private data leakage. **Whenever an app requests information from a node, the entity running that node is unlikely to be your user!**
+You should be aware of this avenue for private data leakage. **Whenever an app requests information from a node, the entity running that node is unlikely to be your user.**
 
 #### What kind of queries can be leaky?
 
@@ -127,9 +123,9 @@ Naturally, the note hash tree is continuously changing as new transactions take 
 
 If a user runs their own node, there's no problem: they can query the latest sibling path for their note(s) from their own machine without leaking any information to the outside world.
 
-But if a user is not running their own node, they would need to query the very-latest sibling path of their note(s) from some 3rd-party node. In order to query the sibling path of a leaf, the leaf's index needs to be provided as an argument. Revealing the leaf's index to a 3rd-party trivially reveals exactly the note(s) you're about to read. And since those notes were created in some prior transaction, the 3rd-party will be able to link you with that prior transaction. Suppose then that the 3rd-party also serviced the creator of said prior transaction: the 3rd-party will slowly be able to link more and more transactions, and gain more and more insight into a network which is meant to be private!
+But if a user is not running their own node, they would need to query the very-latest sibling path of their note(s) from some third-party node. In order to query the sibling path of a leaf, the leaf's index needs to be provided as an argument. Revealing the leaf's index to a third party trivially reveals exactly the note(s) you're about to read. And since those notes were created in some prior transaction, the third party will be able to link you with that prior transaction. Suppose then that the third party also serviced the creator of said prior transaction: they will slowly be able to link more and more transactions, and gain more and more insight into a network which is meant to be private.
 
-We're researching cryptographic ways to enable users to retrieve sibling paths from 3rd-parties without revealing leaf indices.
+We're researching cryptographic ways to enable users to retrieve sibling paths from third parties without revealing leaf indices.
 
 > \* Note: due to the non-uniformity of Aztec transactions, the 'privacy set' of a transaction might not be the entire set of transactions that came before.
 

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/glossary.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/glossary.md
@@ -38,7 +38,7 @@ Read more and review the source code [here](https://github.com/AztecProtocol/azt
 
 ### Aztec.nr
 
-[Aztec.nr](https://github.com/AztecProtocol/aztec-packages/tree/next/noir-projects/aztec-nr) is a framework for writing Aztec smart contracts with Noir that abstracts away state management. It handles things like note generation, state trees etc. It's essentially a giant Noir library which abstracts the complexities of interacting with Aztec.
+[Aztec.nr](https://github.com/AztecProtocol/aztec-packages/tree/next/noir-projects/aztec-nr) is a Noir framework for writing Aztec smart contracts that abstracts away state management, handling note generation, state trees, and more.
 
 Read more and review the source code [here](https://aztec.nr).
 
@@ -62,7 +62,7 @@ In Aztec, a commitment refers to a cryptographic hash of a note. Rather than sto
 
 A Merkle tree is a binary tree data structure where adjacent nodes are hashed together recursively to produce a single node called the root hash.
 
-Merkle trees in Aztec are used to store cryptographic commitments. They are used across five Aztec Merkle trees: the note hash tree (stores commitments to private notes), the nullifier tree (stores nullifiers for spent notes), the public data tree (stores public state), the contract tree and the archive tree. All trees use domain-separated Poseidon2 hashing with specific tree identifiers and layer separation to ensure security and prevent cross-tree attacks.
+Merkle trees in Aztec are used to store cryptographic commitments. They are used across five Aztec Merkle trees: the note hash tree (stores commitments to private notes), the nullifier tree (stores nullifiers for spent notes), the public data tree (stores public state), the contract tree, and the archive tree. All trees use domain-separated Poseidon2 hashing with specific tree identifiers and layer separation to ensure security and prevent cross-tree attacks.
 
 ### `nargo`
 
@@ -82,7 +82,7 @@ You can find more info about the LSP [in the Noir docs](https://noir-lang.org/do
 
 ### Node
 
-A node is a computer running Aztec software that participates in the Aztec network. A specific type of node is a sequencer. Nodes run the public execution environment (AVM), validate proofs, and maintain the 5 state Merkle trees (note hash, nullifier, public state, contract and archive trees).
+A node is a computer running Aztec software that participates in the Aztec network. A specific type of node is a sequencer. Nodes run the public execution environment (AVM), validate proofs, and maintain the five state Merkle trees (note hash, nullifier, public state, L1-L2 message, and archive trees).
 
 The Aztec testnet rolls up to Ethereum Sepolia.
 
@@ -90,7 +90,7 @@ To run your own node see [here](/network/).
 
 ### Note
 
-In Aztec, a Note is like an envelope containing private data. A commitment (hash) of this note is stored in an append-only Merkle tree and stored by all the nodes in the network. Notes can be encrypted to be shared with other users. Data in a note may represent some variable's state at a point in time.
+In Aztec, a note is like an envelope containing private data. A commitment (hash) of this note is stored in an append-only Merkle tree maintained by all nodes in the network. Notes can be encrypted to be shared with other users. The data in a note represents a variable's state at a specific point in time.
 
 ### Note Discovery
 
@@ -114,7 +114,7 @@ Aztec achieves programmable privacy through its hybrid architecture that support
 
 The Prover in a ZK system is the entity proving they have knowledge of a valid witness that satisfies a statement. In the context of Aztec, this is the entity that creates the proof that some computation was executed correctly. Here, the statement would be "I know the inputs and outputs that satisfy the requirements for the computation, and I did the computation correctly."
 
-Aztec will be launched with a fully permissionless proving network (pieces of code that produce the proofs for valid rollup state transitions) that anyone can participate in.
+Aztec launched with a fully permissionless proving network that anyone can participate in. The proving network produces proofs for valid rollup state transitions.
 
 How this works will be discussed via a future RFP process on Discourse, similarly to the Sequencer RFP.
 
@@ -124,21 +124,20 @@ A key that is used to generate a proof. In the case of Aztec, these are compiled
 
 ### Private Execution Environment (PXE)
 
-The private execution environment is where private computation occurs. This is local such as your device or browser.
-
+The private execution environment is where private computation occurs. This is local to your device or browser.
 
 Read more [here](../foundational-topics/pxe/index.md).
 
 ### Local Network
 
-The local network is a development Aztec network that runs on your machine and interacts with a development Ethereum node. It allows you to develop and deploy Noir smart contracts but without having to interact with testnet or mainnet (when the time comes).
+The local network is a development Aztec network that runs on your machine and interacts with a development Ethereum node. It allows you to develop and deploy Noir smart contracts without interacting with testnet or mainnet.
 
 Included in the local network:
 
 - Local Ethereum network (Anvil)
 - Deployed Aztec protocol contracts (for L1 and L2)
 - A set of test accounts with some test tokens to pay fees
-- Development tools to compile contracts and interact with the network (aztec command and aztec-wallet)
+- Development tools to compile contracts and interact with the network (`aztec` and `aztec-wallet`)
 - All of this comes packaged in a Docker container to make it easy to install and run.
 
 ### Sequencer
@@ -147,14 +146,13 @@ A sequencer is a specialized node that is generally responsible for:
 
 - Selecting pending transactions from the mempool
 - Ordering transactions into a block
-- Verifying all private transaction proofs and execute all public transactions to check their validity
+- Verifying all private transaction proofs and executing all public transactions to check their validity
 - Computing the ROLLUP_BLOCK_REQUEST_DATA
 - Computing state updates for messages between L2 & L1
 - Broadcasting the ROLLUP_BLOCK_REQUEST_DATA to the prover network via the proof pool for parallelizable computation.
 - Building a rollup proof from completed proofs in the proof pool
 - Tagging the pending block with an upgrade signal to facilitate forks
 - Publishing completed block with proofs to Ethereum as an ETH transaction
-
 
 Aztec will be launched with a fully permissionless sequencer network that anyone can participate in.
 
@@ -175,6 +173,7 @@ A statement in Aztec's zero-knowledge context refers to the public assertion bei
 ### Verifier
 
 The entity responsible for verifying the validity of a ZK proof. In the context of Aztec, this is:
+
 - **The sequencers**: verify that private functions were executed correctly.
 - **The Ethereum L1 smart contract**: verifies batches of transactions were executed correctly.
 

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/migration_notes.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/resources/migration_notes.md
@@ -5,7 +5,7 @@ keywords: [local network, sandbox, aztec, notes, migration, updating, upgrading]
 tags: [migration, updating, sandbox, local network]
 ---
 
-Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
+Aztec is in active development. Each version may introduce breaking changes that affect compatibility with previous releases. This page documents common errors and challenges you might encounter when upgrading, along with guidance on how to resolve them.
 
 ## TBD
 
@@ -181,7 +181,7 @@ This function made it annoying to deal with invalid addresses in circuits. If yo
 
 ### [Aztec.nr] Note owner is now enshrined
 
-It turns out that in all the cases a note always have a logical owner.
+It turns out that in all cases a note always has a logical owner.
 For this reason we have decided to enshrine the concept of a note owner and you should drop the field from your note:
 
 ```diff
@@ -1211,7 +1211,7 @@ add_private_authwit_from_call_interface(
 ### Historical block renamed as anchor block
 
 A historical block term has been used as a term that denotes the block against which a private part of a tx has been executed.
-This name is ambiguous and for this reason we've introduce "anchor block".
+This name is ambiguous and for this reason we've introduced "anchor block".
 This naming change resulted in quite a few changes and if you've access private context's or utility context's block header you will need to update your code:
 
 ```diff
@@ -1240,7 +1240,7 @@ Updating a note used to require reading it first (via `get_note`, which nullifie
 **Key points:**
 
 1. `replace(self, new_note)` (old) → `replace(self, f)` (new), where `f` takes the current note and returns a transformed note.
-2. `initialize_or_replace(self, note)` (old) → `initialize_or_replace(self, f)` (new), where `f` takes an `Option` with the current none, or `none` if uninitialized.
+2. `initialize_or_replace(self, note)` (old) → `initialize_or_replace(self, f)` (new), where `f` takes an `Option` with the current note, or `none` if uninitialized.
 3. Previous note is automatically nullified before the new note is inserted.
 4. `NoteEmission<Note>` still requires `.emit()` or `.discard()`.
 
@@ -1468,7 +1468,7 @@ emit_event_in_private_log(
 This change affected arguments `prepare_private_balance_increase` and `mint_to_private` functions on the `Token` contract.
 Drop the `from` argument when calling these.
 
-Example n TypeScript test:
+Example in TypeScript test:
 
 ```diff
 - await token.methods.mint_to_private(fundedWallet.getAddress(), alice, mintAmount).send().wait();
@@ -1808,7 +1808,7 @@ This means that if your portal were hard-coding `1` it will now fail when insert
 Instead you can get the real version (which don't change for a deployment) by reading the `VERSION` on inbox and outbox, or using `getVersion()` on the rollup.
 
 New Deployments of the protocol do not preserve former state/across each other.
-This means that after a new deployment, any "portal" following the registry would try to send messages into this empty rollup to non-existant contracts.
+This means that after a new deployment, any "portal" following the registry would try to send messages into this empty rollup to non-existent contracts.
 To solve, the portal should be linked to a specific deployment, e.g., a specific inbox.
 This can be done by storing the inbox/outbox/version at the time of deployment or initialize and not update them.
 
@@ -1822,7 +1822,7 @@ It's common that we need block metadata of a block in which leaves where inserte
 For this reason we now return that information along with the indexes.
 This allows us to reduce the number of individual AztecNode queries.
 
-Along this change `findNullifiersIndexesWithBlock` and `findBlockNumbersForIndexes` functions wer removed as all its uses can now be replaced with the newly modified `findLeavesIndexes` function.
+Along with this change, `findNullifiersIndexesWithBlock` and `findBlockNumbersForIndexes` functions were removed as all their uses can now be replaced with the newly modified `findLeavesIndexes` function.
 
 ### [aztec.js] AztecNode.getPublicDataTreeWitness renamed as AztecNode.getPublicDataWitness
 
@@ -3200,7 +3200,7 @@ Extended syntax for more use cases:
 
 ```rust
 // The contract we're testing
-env.deploy_self("ContractName"); // We have to provide ContractName since nargo it's ready to support multi-contract files
+env.deploy_self("ContractName"); // We have to provide ContractName since nargo isn't ready to support multi-contract files
 
 // A contract in a workspace
 env.deploy("../path/to/workspace@package_name", "ContractName"); // This format allows locating the artifact in the root workspace target folder, regardless of internal code organization

--- a/docs/docs-developers/docs/resources/community_calls.md
+++ b/docs/docs-developers/docs/resources/community_calls.md
@@ -1,0 +1,66 @@
+---
+title: Community Calls
+tags: [community, calls, office-hours]
+description: Join live calls to connect with the Aztec team and other builders.
+---
+
+**Build with us, live.**
+
+Every week you can join office hours, townhalls and ecosystem calls to get unblocked, learn from maintainers, and connect with other builders. Pick the call that fits your needs, add it to your calendar, and show up with questions.
+
+---
+
+## Ecosystem Call
+
+- **When:** Biweekly · time in shared calendar
+- **Where:** [Google Meet](https://meet.google.com/rqs-ckcy-vyc)
+- **For:** Founders, contributors and newcomers. Updates, demos, feedback, open roles.
+
+---
+
+## Noir Office Hours
+
+We offer two weekly sessions to accommodate different timezones.
+
+### Morning Session (Americas/Europe)
+
+- **When:** Tuesdays · 15:00 – 16:00 UTC
+- **Where:** [Google Meet](https://meet.google.com/hyh-bdqm-ijg)
+- **For:** Developers writing or debugging Noir. Bring your questions about syntax, tooling, and patterns.
+
+### Evening Session (Europe/Asia-Pacific)
+
+- **When:** Wednesdays · 01:00 – 01:30 UTC
+- **Where:** [Google Meet](https://meet.google.com/hyh-bdqm-ijg)
+- **For:** An informal session to hang out with the Aztec Labs Dev Rel team and other Noir devs. Bring questions, share a project, or just come listen.
+
+---
+
+## Aztec Developer Office Hours
+
+- **When:** Wednesdays · 01:30 – 02:30 UTC
+- **Where:** [Google Meet](https://meet.google.com/say-ognq-dpc)
+- **For:** Aztec-focused developer questions. The Aztec Labs team is available to answer anything: high-level, architectural, protocol, debugging, and more.
+
+---
+
+## Community Townhall
+
+- **When:** Thursdays · Time in shared calendar
+- **Where:** [Google Meet](https://discord.gg/aztec)
+- **For:** The entire community, from contributors to newcomers. Updates from the core team, open discussions, roadmap insights.
+
+---
+
+## Community
+
+- Follow discussions in the [Forum](https://forum.aztec.network)
+- Ask daily questions in [Discord](https://discord.gg/aztec)
+
+---
+
+## One calendar, all calls
+
+Save time, add everything with one click:
+
+[Subscribe to the Aztec & Noir Community Calendar](https://calendar.google.com/calendar/u/0?cid=ZGI5MTVjMGQ2MzQ5NWNlNTgzOTJmNjg5YjJjZDYyZjQ5MTgxNzk3YjUzYTBiYmUyNmUwOTBkNWQ5Y2E0YzIwZEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)

--- a/docs/docs-developers/docs/resources/considerations/limitations.md
+++ b/docs/docs-developers/docs/resources/considerations/limitations.md
@@ -4,44 +4,44 @@ description: Understand the current limitations of the Aztec network and its imp
 sidebar_position: 6
 ---
 
-The Aztec stack is a work in progress. Packages have been released early, to gather feedback on the capabilities of the protocol and user experiences.
+The Aztec stack is a work in progress. Packages have been released early to gather feedback on the capabilities of the protocol and user experiences.
 
-## What to expect?
+## What to expect
 
-- Regular Breaking Changes;
-- Missing features;
-- Bugs;
-- An 'unpolished' UX;
-- Missing information.
+- Regular breaking changes
+- Missing features
+- Bugs
+- An "unpolished" UX
+- Missing information
 
-## Why participate?
+## Why participate
 
 Front-run the future!
 
 Help shape and define:
 
 - Previously-impossible smart contracts and applications
-- Network tooling;
-- Network standards;
-- Smart contract syntax;
-- Educational content;
-- Core protocol improvements;
+- Network tooling
+- Network standards
+- Smart contract syntax
+- Educational content
+- Core protocol improvements
 
 ## Limitations developers need to know about
 
-- It is a testing environment, it is insecure, and unaudited. It is only for testing purposes.
-- `msg_sender` is currently leaking when doing private -> public calls
-  - The `msg_sender` will always be set, if you call a public function from the private world, the `msg_sender` will be set to the private caller's address.
+- It is a testing environment, insecure and unaudited. It is only for testing purposes.
+- `msg_sender` is currently leaked when making private -> public calls.
+  - The `msg_sender` is always set. If you call a public function from the private world, the `msg_sender` is set to the private caller's address.
   - There are patterns that can mitigate this.
 - The initial `msg_sender` is `-1`, which can be problematic for some contracts.
-- The number of side-effects attached to a tx (when sending the tx to the mempool) is leaky. At this stage of development, this is _intentional_, so that we can gauge appropriate choices for privacy sets. We have always had clear plans to implement privacy sets so that side effects are much less leaky, and these will be in place come mainnet.
-- A transaction can only emit a limited number of side-effects (notes, nullifiers, logs, l2->l1 messages), see [circuit limitations](#circuit-limitations).
-  - We haven't settled on the final constants, since we're still in a testing phase. But users could find that certain compositions of nested private function calls (e.g. call stacks that are dynamic in size, based on runtime data) could accumulate so many side-effects as to exceed tx limits. Such txs would then be unprovable. We would love for you to open an issue if you encounter this, as it will help us decide on adequate sizes for our constants.
-- There are lots of features that we still want to implement. Checkout github and the forum for details. If you would like a feature, please open an issue on github!
+- The number of side-effects attached to a transaction (when sending the transaction to the mempool) is leaky. At this stage of development, this is _intentional_, so that we can gauge appropriate choices for privacy sets. We have clear plans to implement privacy sets so that side effects are much less leaky, and these will be in place for mainnet.
+- A transaction can only emit a limited number of side-effects (notes, nullifiers, logs, L2->L1 messages). See [circuit limitations](#circuit-limitations).
+  - We have not settled on the final constants, since we are still in a testing phase. You could find that certain compositions of nested private function calls (for example, call stacks that are dynamic in size, based on runtime data) could accumulate so many side-effects as to exceed transaction limits. Such transactions would then be unprovable. Please open an issue if you encounter this, as it will help us decide on adequate sizes for our constants.
+- There are many features that we still want to implement. Check out GitHub and the forum for details. If you would like a feature, please open an issue on GitHub.
 
 ## WARNING
 
-Do not use real, meaningful secrets in Aztec's testnets. Some privacy features are still being worked on, including ensuring a secure "zk" property. Since the Aztec stack is still being worked on, there are no guarantees that real secrets will remain secret.
+Do not use real, meaningful secrets in Aztec testnets. Some privacy features are still in development, including ensuring a secure "zk" property. Since the Aztec stack is still being developed, there are no guarantees that real secrets will remain secret.
 
 ## Limitations
 
@@ -49,49 +49,49 @@ There are plans to resolve all of the below.
 
 ### It is not audited
 
-None of the Aztec stack is audited. It's being iterated-on every day. It will not be audited for quite some time.
+None of the Aztec stack is audited. It is being iterated on every day. It will not be audited for quite some time.
 
 ### Under-constrained
 
-Some of our more-complex circuits are still being worked on, so they will still be be underconstrained.
+Some of our more complex circuits are still in development, so they are still under-constrained.
 
 #### What are the consequences?
 
-Sound proofs are really only needed as a protection against malicious behavior, which we're not testing for at this stage.
+Sound proofs are really only needed as a protection against malicious behavior, which we are not testing for at this stage.
 
-### Keys and Addresses are subject to change
+### Keys and addresses are subject to change
 
 The way in which keypairs and addresses are derived is still being iterated on as we receive feedback.
 
 #### What are the consequences?
 
-This will impact the kinds of apps that you can build with the Local Network, as it is today:
+This will impact the kinds of apps that you can build with the local network as it is today.
 
-Please open new discussions on [discourse](http://discourse.aztec.network) or open issues on [github](http://github.com/AztecProtocol/aztec-packages), if you have requirements that aren't-yet being met by the local network's current key derivation scheme.
+Please open new discussions on [Discourse](https://discourse.aztec.network) or open issues on [GitHub](https://github.com/AztecProtocol/aztec-packages) if you have requirements that are not yet being met by the local network's current key derivation scheme.
 
 ### No privacy-preserving queries to nodes
 
-Ethereum has a notion of a 'full node' which keeps-up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so rely on 3rd-party 'full-node-as-a-service' infrastructure providers, who service blockchain queries from their users.
+Ethereum has a notion of a "full node" which keeps up with the blockchain and stores the full chain state. Many users do not wish to run full nodes, so they rely on third-party "full-node-as-a-service" infrastructure providers who service blockchain queries from their users.
 
-This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a 3rd-party 'full node', that user might leak data about who they are, or about their historical network activity, or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a 3rd-party node without revealing what that data is, nor who is making the request.
+This pattern is likely to develop in Aztec as well, except there is a problem: privacy. If a privacy-seeking user makes a query to a third-party full node, that user might leak data about who they are, about their historical network activity, or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a third-party node without revealing what that data is, nor who is making the request.
 
 ### No private data authentication
 
-Private data should not be returned to an app, unless the user authorizes such access to the app. An authorization layer is not-yet in place.
+Private data should not be returned to an app unless the user authorizes such access to the app. An authorization layer is not yet in place.
 
 #### What are the consequences?
 
-Any app can request and receive any private user data relating to any other private app. Obviously this sounds bad. But the local network is a sandbox, and no meaningful value or credentials should be stored there; only test values and test credentials.
+Any app can request and receive any private user data relating to any other private app. This sounds problematic, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
 
-An auth layer will be added in due course.
+An authorization layer will be added in due course.
 
 ### No bytecode validation
 
-For safety reasons, bytecode should not be executed unless the PXE/Wallet has validated that the user's intentions (the function signature and contract address) match the bytecode.
+For safety reasons, bytecode should not be executed unless the PXE (Private eXecution Environment) or wallet has validated that the user's intentions (the function signature and contract address) match the bytecode.
 
 #### What are the consequences?
 
-Without such 'bytecode validation', if the incorrect bytecode is executed, and that bytecode is malicious, it could read private data from some other contract and emit that private data to the world. Obviously this would be bad in production. But the local network is a sandbox, and no meaningful value or credentials should be stored there; only test values and test credentials.
+Without bytecode validation, if incorrect bytecode is executed and that bytecode is malicious, it could read private data from some other contract and emit that private data to the world. This would be problematic in production, but the local network is a sandbox, and no meaningful value or credentials should be stored there - only test values and test credentials.
 
 There are plans to add bytecode validation soon.
 
@@ -101,27 +101,27 @@ We are planning a full assessment of the protocol's hashes, including rigorous d
 
 #### What are the consequences?
 
-Collisions and other hash-related attacks might be possible in the local network. Obviously that would be bad in production. But it's unlikely to cause problems at this early stage of testing.
+Collisions and other hash-related attacks might be possible in the local network. This would be problematic in production, but it is unlikely to cause problems at this early stage of testing.
 
 ### `msg_sender` is leaked when making a private -> public call
 
-There are ongoing discussions [here](https://forum.aztec.network/t/what-is-msg-sender-when-calling-private-public-plus-a-big-foray-into-stealth-addresses/7527 (and some more recent discussions that need to be documented) around how to address this.
+There are ongoing discussions [here](https://forum.aztec.network/t/what-is-msg-sender-when-calling-private-public-plus-a-big-foray-into-stealth-addresses/7527) (and some more recent discussions that need to be documented) around how to address this.
 
-### New Privacy Standards are required
+### New privacy standards are required
 
-There are many [patterns](../../resources/considerations/privacy_considerations.md) which can leak privacy, even on Aztec. Standards haven't been developed yet, to encourage best practices when designing private smart contracts.
+There are many [patterns](../../resources/considerations/privacy_considerations.md) which can leak privacy, even on Aztec. Standards have not been developed yet to encourage best practices when designing private smart contracts.
 
 #### What are the consequences?
 
-For example, until community standards are developed to reduce the uniqueness of ['Tx Fingerprints'](../../resources/considerations/privacy_considerations.md#function-fingerprints-and-tx-fingerprints) app developers might accidentally forfeit some function privacy.
+For example, until community standards are developed to reduce the uniqueness of ["Tx Fingerprints"](../../resources/considerations/privacy_considerations.md#function-fingerprints-and-tx-fingerprints), app developers might accidentally forfeit some function privacy.
 
-## Smart Contract limitations
+## Smart contract limitations
 
-We will never be done with all the yummy features we want to add to aztec.nr. We have lots of features that we still want to implement. Please check out github, and please open new issues with any feature requests you might have.
+We will never be done with all the features we want to add to Aztec.nr. We have many features that we still want to implement. Please check out GitHub and open new issues with any feature requests you might have.
 
 ## Circuit limitations
 
-### Upper limits on function outputs and tx outputs
+### Upper limits on function outputs and transaction outputs
 
 Due to the rigidity of zk-SNARK circuits, there are upper bounds on the amount of computation a circuit can perform, and on the amount of data that can be passed into and out of a function.
 
@@ -147,12 +147,12 @@ When you write an Aztec.nr function, there will be upper bounds on the following
 
 Not only are there limits on a _per function_ basis, there are also limits on a _per transaction_ basis.
 
-**In particular, these _per-transaction_ limits will limit transaction call stack depths**. That means if a function call results in a cascade of nested function calls, and each of those function calls outputs lots of state reads and writes, or logs (etc.), then all of that accumulated output data might exceed the per-transaction limits that we currently have. This would cause such transactions to fail.
+**In particular, these _per-transaction_ limits will limit transaction call stack depths**. This means if a function call results in a cascade of nested function calls, and each of those function calls outputs many state reads and writes, or logs, then all of that accumulated output data might exceed the per-transaction limits that we currently have. This would cause such transactions to fail.
 
-There are plans to relax some of this rigidity, by providing many 'sizes' of circuit.
+There are plans to relax some of this rigidity by providing many "sizes" of circuit.
 
-> **In the mean time**, if you encounter a per-transaction limit when testing, please do open an issue to explain what you were trying to do; we'd love to hear about it. And if you're feeling adventurous, you could 'hack' the PXE to increase the limits. **However**, the limits cannot be increased indefinitely. So although we do anticipate that we'll be able to increase them a little bit, don't go mad and provide yourself with 1 million state transitions per transaction. That would be as unrealistic as artificially increasing Ethereum gas limits to 1 trillion.
+> **In the meantime**, if you encounter a per-transaction limit when testing, please open an issue to explain what you were trying to do - we would love to hear about it. And if you are feeling adventurous, you could modify the PXE to increase the limits. **However**, the limits cannot be increased indefinitely. Although we do anticipate that we will be able to increase them slightly, do not provide yourself with 1 million state transitions per transaction. That would be as unrealistic as artificially increasing Ethereum gas limits to 1 trillion.
 
-## There's more
+## There is more
 
-See the [GitHub issues (GitHub link)](https://github.com/AztecProtocol/aztec-packages/issues) for all known bugs fixes and features currently being worked on.
+See the [GitHub issues](https://github.com/AztecProtocol/aztec-packages/issues) for all known bug fixes and features currently being worked on.

--- a/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
+++ b/docs/docs-developers/docs/resources/considerations/privacy_considerations.md
@@ -5,13 +5,7 @@ sidebar_position: 5
 tags: [protocol, PXE]
 ---
 
-Privacy is important.
-
-Keeping information private is difficult.
-
-Once information is leaked, it cannot be unleaked.
-
----
+Privacy is a core value of Aztec Protocol. Keeping information private is difficult, and once information is leaked, it cannot be unleaked. This page outlines key privacy considerations that developers should understand when building applications on Aztec.
 
 ## What can Aztec keep private?
 
@@ -35,9 +29,9 @@ The bytecode of private functions does not need to be distributed to the world; 
 
 :::danger
 Privacy is not guaranteed without care.
-Although Aztec provides the tools for private smart contracts, information can still be leaked unless the dapp developer is careful.
+Although Aztec provides the tools for private smart contracts, information can still be leaked unless you are careful.
 Aztec is still under development, so real-world, meaningful, valuable secrets _should not_ be entrusted to the system.
-This page outlines some best practices to aid dapp developers.
+This page outlines some best practices to help you build privacy-preserving applications.
 :::
 
 ---
@@ -46,18 +40,18 @@ This page outlines some best practices to aid dapp developers.
 
 There are many caveats to the above. Since Aztec also enables interaction with the _public_ world (public L2 functions and L1 functions), private information can be accidentally leaked if developers aren't careful.
 
-### Crossing the private -> public boundary
+### Crossing the private to public boundary
 
 Any time a private function makes a call to a public function, information is leaked. Now, that might be perfectly fine in some use cases (it's up to the smart contract developer). Indeed, most interesting apps will require some public state. But let's have a look at some leaky patterns:
 
 - Calling a public function from a private function. The public function execution will be publicly visible.
-- Calling a public function from a private function, without revealing the `msg_sender` of that call. (Otherwise the `msg_sender` will be publicly visible).
+- Calling a public function from a private function and revealing the `msg_sender` of that call (the `msg_sender` will be publicly visible).
 - Passing arguments to a public function from a private function. All of those arguments will be publicly visible.
 - Calling an internal public function from a private function. The fact that the call originated from a private function of that same contract will be trivially known.
 - Emitting unencrypted events from a private function. The unencrypted event name and arguments will be publicly visible.
 - Sending L2->L1 messages from a private function. The entire message, and the resulting L1 function execution will all be publicly visible.
 
-### Crossing the public -> private boundary
+### Crossing the public to private boundary
 
 If a public function sends a message to be consumed by a private function, the act of consuming that message might be leaked if not following recommended patterns.
 
@@ -73,7 +67,7 @@ These minor details are information that can disclose much more information abou
 
 Suppose that every time Alice sends Bob a private token, 1 minute later a transaction is always submitted to the tx pool with the same kind of 'fingerprint'. Alice might deduce that these transactions are automated reactions by Bob. (Here, 'fingerprint' is an intentionally vague term. It could be a public function call, or a private tx proof with a particular number of nonzero public inputs, or some other discernible pattern that Alice sees).
 
-TL;DR: app developers should think about the _timing_ of user transactions, and how this might leak information.
+In short, you should think about the _timing_ of user transactions and how this might leak information.
 
 ### Function Fingerprints and Tx Fingerprints
 
@@ -93,25 +87,27 @@ A 'Function Fingerprint' is any data which is exposed by a function to the outsi
   - \# bytes of encrypted logs
   - \# public function calls
   - \# L2->L1 messages
-  - \# nonzero roots[^1]
+  - \# nonzero roots
 
-> Note: many of these were mentioned in the ["Crossing the private -> public boundary"](#crossing-the-private---public-boundary) section.
+> Note: many of these were mentioned in the ["Crossing the private to public boundary"](#crossing-the-private-to-public-boundary) section.
 
-> Note: the transaction effects submitted to L1 is [encoded (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/master/l1-contracts/src/core/libraries/Decoder.sol) but not garbled with other transactions: the distinct Tx Fingerprint of each tx can is publicly visible when a tx is submitted to the L2 tx pool.
+> Note: the transaction effects submitted to L1 are [encoded (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/master/l1-contracts/src/core/libraries/Decoder.sol) but not garbled with other transactions. The distinct Tx Fingerprint of each transaction is publicly visible when submitted to the L2 tx pool.
 
 #### Standardizing Fingerprints
 
-If each private function were to have a unique Fingerprint, then all private functions would be distinguishable from each-other, and all of the efforts of the Aztec protocol to enable 'private function execution' would have been pointless. Standards need to be developed, to encourage smart contract developers to adhere to a restricted set of Tx Fingerprints. For example, a standard might propose that the number of new note hashes, nullifiers, logs, etc. must always be equal, and must always equal a power of two. Such a standard would effectively group private functions/txs into 'privacy sets', where all functions/txs in a particular 'privacy set' would look indistinguishable from each-other, when executed.
+If each private function were to have a unique Fingerprint, then all private functions would be distinguishable from each other, and all of the efforts of the Aztec Protocol to enable private function execution would have been pointless.
+
+Standards need to be developed to encourage smart contract developers to adhere to a restricted set of Tx Fingerprints. For example, a standard might propose that the number of new note hashes, nullifiers, logs, etc. must always be equal, and must always equal a power of two. Such a standard would effectively group private functions and transactions into "privacy sets," where all functions and transactions in a particular privacy set would look indistinguishable from each other when executed.
 
 ### Data queries
 
 It's not just the broadcasting of transactions to the network that can leak data.
 
-Ethereum has a notion of a 'full node' which keeps-up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so rely on 3rd-party 'full-node-as-a-service' infrastructure providers, who service blockchain queries from their users.
+Ethereum has a notion of a "full node" which keeps up with the blockchain and stores the full chain state. Many users don't wish to run full nodes, so they rely on third-party "full-node-as-a-service" infrastructure providers, who service blockchain queries from their users.
 
-This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a 3rd-party 'full node', that user might leak data about who they are; about their historical network activity; or about their future intentions. One solution to this problem is "always run a full node", but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a 3rd-party node without revealing what that data is, nor who is making the request.
+This pattern is likely to develop in Aztec as well, except there's a problem: privacy. If a privacy-seeking user makes a query to a third-party full node, that user might leak data about who they are, their historical network activity, or their future intentions. One solution to this problem is to always run a full node, but pragmatically, not everyone will. To protect less-advanced users' privacy, research is underway to explore how a privacy-seeking user may request and receive data from a third-party node without revealing what that data is, nor who is making the request.
 
-App developers should be aware of this avenue for private data leakage. **Whenever an app requests information from a node, the entity running that node is unlikely to be your user!**
+You should be aware of this avenue for private data leakage. **Whenever an app requests information from a node, the entity running that node is unlikely to be your user.**
 
 #### What kind of queries can be leaky?
 
@@ -127,9 +123,9 @@ Naturally, the note hash tree is continuously changing as new transactions take 
 
 If a user runs their own node, there's no problem: they can query the latest sibling path for their note(s) from their own machine without leaking any information to the outside world.
 
-But if a user is not running their own node, they would need to query the very-latest sibling path of their note(s) from some 3rd-party node. In order to query the sibling path of a leaf, the leaf's index needs to be provided as an argument. Revealing the leaf's index to a 3rd-party trivially reveals exactly the note(s) you're about to read. And since those notes were created in some prior transaction, the 3rd-party will be able to link you with that prior transaction. Suppose then that the 3rd-party also serviced the creator of said prior transaction: the 3rd-party will slowly be able to link more and more transactions, and gain more and more insight into a network which is meant to be private!
+But if a user is not running their own node, they would need to query the very-latest sibling path of their note(s) from some third-party node. In order to query the sibling path of a leaf, the leaf's index needs to be provided as an argument. Revealing the leaf's index to a third party trivially reveals exactly the note(s) you're about to read. And since those notes were created in some prior transaction, the third party will be able to link you with that prior transaction. Suppose then that the third party also serviced the creator of said prior transaction: they will slowly be able to link more and more transactions, and gain more and more insight into a network which is meant to be private.
 
-We're researching cryptographic ways to enable users to retrieve sibling paths from 3rd-parties without revealing leaf indices.
+We're researching cryptographic ways to enable users to retrieve sibling paths from third parties without revealing leaf indices.
 
 > \* Note: due to the non-uniformity of Aztec transactions, the 'privacy set' of a transaction might not be the entire set of transactions that came before.
 

--- a/docs/docs-developers/docs/resources/glossary.md
+++ b/docs/docs-developers/docs/resources/glossary.md
@@ -38,7 +38,7 @@ Read more and review the source code [here](https://github.com/AztecProtocol/azt
 
 ### Aztec.nr
 
-[Aztec.nr](https://github.com/AztecProtocol/aztec-packages/tree/next/noir-projects/aztec-nr) is a framework for writing Aztec smart contracts with Noir that abstracts away state management. It handles things like note generation, state trees etc. It's essentially a giant Noir library which abstracts the complexities of interacting with Aztec.
+[Aztec.nr](https://github.com/AztecProtocol/aztec-packages/tree/next/noir-projects/aztec-nr) is a Noir framework for writing Aztec smart contracts that abstracts away state management, handling note generation, state trees, and more.
 
 Read more and review the source code [here](https://aztec.nr).
 
@@ -62,7 +62,7 @@ In Aztec, a commitment refers to a cryptographic hash of a note. Rather than sto
 
 A Merkle tree is a binary tree data structure where adjacent nodes are hashed together recursively to produce a single node called the root hash.
 
-Merkle trees in Aztec are used to store cryptographic commitments. They are used across five Aztec Merkle trees: the note hash tree (stores commitments to private notes), the nullifier tree (stores nullifiers for spent notes), the public data tree (stores public state), the contract tree and the archive tree. All trees use domain-separated Poseidon2 hashing with specific tree identifiers and layer separation to ensure security and prevent cross-tree attacks.
+Merkle trees in Aztec are used to store cryptographic commitments. They are used across five Aztec Merkle trees: the note hash tree (stores commitments to private notes), the nullifier tree (stores nullifiers for spent notes), the public data tree (stores public state), the contract tree, and the archive tree. All trees use domain-separated Poseidon2 hashing with specific tree identifiers and layer separation to ensure security and prevent cross-tree attacks.
 
 ### `nargo`
 
@@ -82,7 +82,7 @@ You can find more info about the LSP [in the Noir docs](https://noir-lang.org/do
 
 ### Node
 
-A node is a computer running Aztec software that participates in the Aztec network. A specific type of node is a sequencer. Nodes run the public execution environment (AVM), validate proofs, and maintain the 5 state Merkle trees (note hash, nullifier, public state, contract and archive trees).
+A node is a computer running Aztec software that participates in the Aztec network. A specific type of node is a sequencer. Nodes run the public execution environment (AVM), validate proofs, and maintain the five state Merkle trees (note hash, nullifier, public state, L1-L2 message, and archive trees).
 
 The Aztec testnet rolls up to Ethereum Sepolia.
 
@@ -90,7 +90,7 @@ To run your own node see [here](/network/).
 
 ### Note
 
-In Aztec, a Note is like an envelope containing private data. A commitment (hash) of this note is stored in an append-only Merkle tree and stored by all the nodes in the network. Notes can be encrypted to be shared with other users. Data in a note may represent some variable's state at a point in time.
+In Aztec, a note is like an envelope containing private data. A commitment (hash) of this note is stored in an append-only Merkle tree maintained by all nodes in the network. Notes can be encrypted to be shared with other users. The data in a note represents a variable's state at a specific point in time.
 
 ### Note Discovery
 
@@ -114,7 +114,7 @@ Aztec achieves programmable privacy through its hybrid architecture that support
 
 The Prover in a ZK system is the entity proving they have knowledge of a valid witness that satisfies a statement. In the context of Aztec, this is the entity that creates the proof that some computation was executed correctly. Here, the statement would be "I know the inputs and outputs that satisfy the requirements for the computation, and I did the computation correctly."
 
-Aztec will be launched with a fully permissionless proving network (pieces of code that produce the proofs for valid rollup state transitions) that anyone can participate in.
+Aztec launched with a fully permissionless proving network that anyone can participate in. The proving network produces proofs for valid rollup state transitions.
 
 How this works will be discussed via a future RFP process on Discourse, similarly to the Sequencer RFP.
 
@@ -124,21 +124,20 @@ A key that is used to generate a proof. In the case of Aztec, these are compiled
 
 ### Private Execution Environment (PXE)
 
-The private execution environment is where private computation occurs. This is local such as your device or browser.
-
+The private execution environment is where private computation occurs. This is local to your device or browser.
 
 Read more [here](../foundational-topics/pxe/index.md).
 
 ### Local Network
 
-The local network is a development Aztec network that runs on your machine and interacts with a development Ethereum node. It allows you to develop and deploy Noir smart contracts but without having to interact with testnet or mainnet (when the time comes).
+The local network is a development Aztec network that runs on your machine and interacts with a development Ethereum node. It allows you to develop and deploy Noir smart contracts without interacting with testnet or mainnet.
 
 Included in the local network:
 
 - Local Ethereum network (Anvil)
 - Deployed Aztec protocol contracts (for L1 and L2)
 - A set of test accounts with some test tokens to pay fees
-- Development tools to compile contracts and interact with the network (aztec command and aztec-wallet)
+- Development tools to compile contracts and interact with the network (`aztec` and `aztec-wallet`)
 - All of this comes packaged in a Docker container to make it easy to install and run.
 
 ### Sequencer
@@ -147,14 +146,13 @@ A sequencer is a specialized node that is generally responsible for:
 
 - Selecting pending transactions from the mempool
 - Ordering transactions into a block
-- Verifying all private transaction proofs and execute all public transactions to check their validity
+- Verifying all private transaction proofs and executing all public transactions to check their validity
 - Computing the ROLLUP_BLOCK_REQUEST_DATA
 - Computing state updates for messages between L2 & L1
 - Broadcasting the ROLLUP_BLOCK_REQUEST_DATA to the prover network via the proof pool for parallelizable computation.
 - Building a rollup proof from completed proofs in the proof pool
 - Tagging the pending block with an upgrade signal to facilitate forks
 - Publishing completed block with proofs to Ethereum as an ETH transaction
-
 
 Aztec will be launched with a fully permissionless sequencer network that anyone can participate in.
 
@@ -175,6 +173,7 @@ A statement in Aztec's zero-knowledge context refers to the public assertion bei
 ### Verifier
 
 The entity responsible for verifying the validity of a ZK proof. In the context of Aztec, this is:
+
 - **The sequencers**: verify that private functions were executed correctly.
 - **The Ethereum L1 smart contract**: verifies batches of transactions were executed correctly.
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -5,7 +5,7 @@ keywords: [local network, sandbox, aztec, notes, migration, updating, upgrading]
 tags: [migration, updating, sandbox, local network]
 ---
 
-Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
+Aztec is in active development. Each version may introduce breaking changes that affect compatibility with previous versions. This page documents common errors and difficulties you might encounter when upgrading, along with guidance on how to resolve them.
 
 ## TBD
 
@@ -91,8 +91,8 @@ The `UnsafeContract` class and async helper functions (`getFeeJuice`, `getClassR
 ### [Aztec.nr] Renamed Router contract
 
 `Router` contract has been renamed as `PublicChecks` contract.
-The name of the contract became stale as its use changed from routing public calls through it to public functions to just having public functions on it that can be called by anyone.
-By having these "standard checks" on one contract results in the privacy set of apps that could use this becoming potentially large.
+The name of the contract became stale as its use changed from routing public calls through it to simply having public functions that can be called by anyone.
+Having these "standard checks" on one contract results in a potentially large privacy set for apps that use it.
 
 ### [Aztec Node] `getBlockByHash` and `getBlockHeaderByHash` removed
 
@@ -448,7 +448,7 @@ This function made it annoying to deal with invalid addresses in circuits. If yo
 
 ### [Aztec.nr] Note owner is now enshrined
 
-It turns out that in all the cases a note always have a logical owner.
+It turns out that in all cases a note always has a logical owner.
 For this reason we have decided to enshrine the concept of a note owner and you should drop the field from your note:
 
 ```diff
@@ -922,7 +922,7 @@ The method now only accepts:
 
 #### Return value of `getNotes` no longer contains a recipient and it contains some other additional info
 
-Return value of `getNotes` used to be defined as `Promise<UniqueNote[]>` and now it's defined as `Promise<UniqueNote[]>`.
+Return value of `getNotes` used to be defined as `Promise<UniqueNote[]>` and is now defined as `Promise<NoteDao[]>`.
 `NoteDao` is mostly a super-set of `UniqueNote` but it doesn't contain a `recipient`.
 Having the recipient in the return value has been redundant as the same outcome can be achieved by populating the `scopes` array in `NoteFilter` with the `recipient` value.
 
@@ -1509,7 +1509,7 @@ add_private_authwit_from_call_interface(
 ### Historical block renamed as anchor block
 
 A historical block term has been used as a term that denotes the block against which a private part of a tx has been executed.
-This name is ambiguous and for this reason we've introduce "anchor block".
+This name is ambiguous and for this reason we've introduced "anchor block".
 This naming change resulted in quite a few changes and if you've access private context's or utility context's block header you will need to update your code:
 
 ```diff
@@ -1538,7 +1538,7 @@ Updating a note used to require reading it first (via `get_note`, which nullifie
 **Key points:**
 
 1. `replace(self, new_note)` (old) → `replace(self, f)` (new), where `f` takes the current note and returns a transformed note.
-2. `initialize_or_replace(self, note)` (old) → `initialize_or_replace(self, f)` (new), where `f` takes an `Option` with the current none, or `none` if uninitialized.
+2. `initialize_or_replace(self, note)` (old) → `initialize_or_replace(self, f)` (new), where `f` takes an `Option` with the current note, or `none` if uninitialized.
 3. Previous note is automatically nullified before the new note is inserted.
 4. `NoteEmission<Note>` still requires `.emit()` or `.discard()`.
 
@@ -1766,7 +1766,7 @@ emit_event_in_private_log(
 This change affected arguments `prepare_private_balance_increase` and `mint_to_private` functions on the `Token` contract.
 Drop the `from` argument when calling these.
 
-Example n TypeScript test:
+Example in TypeScript test:
 
 ```diff
 - await token.methods.mint_to_private(fundedWallet.getAddress(), alice, mintAmount).send().wait();
@@ -2043,11 +2043,10 @@ The following renamings have taken place:
 - `discovery` moved to `messages`: given that what is discovered are messages
 - `default_aes128` removed
 
-Most contracts barely used these modules, the only frequent imports are the `encode_and_encrypt` functions:
+Most contracts barely used these modules directly. The frequently used `encode_and_encrypt` function imports remain unchanged:
 
-```diff
-- use dep::aztec::messages::logs::note::encode_and_encrypt_note;
-+ use dep::aztec::messages::logs::note::encode_and_encrypt_note;
+```rust
+use dep::aztec::messages::logs::note::encode_and_encrypt_note;
 ```
 
 ### [noir-contracts] Reference Noir contracts directory structure change
@@ -2106,7 +2105,7 @@ This means that if your portal were hard-coding `1` it will now fail when insert
 Instead you can get the real version (which don't change for a deployment) by reading the `VERSION` on inbox and outbox, or using `getVersion()` on the rollup.
 
 New Deployments of the protocol do not preserve former state/across each other.
-This means that after a new deployment, any "portal" following the registry would try to send messages into this empty rollup to non-existant contracts.
+This means that after a new deployment, any "portal" following the registry would try to send messages into this empty rollup to non-existent contracts.
 To solve, the portal should be linked to a specific deployment, e.g., a specific inbox.
 This can be done by storing the inbox/outbox/version at the time of deployment or initialize and not update them.
 
@@ -2116,11 +2115,11 @@ Both of these issues were in the token portal and the uniswap portal, so if you 
 
 ### [aztec.js] AztecNode.findLeavesIndexes returns indexes with block metadata
 
-It's common that we need block metadata of a block in which leaves where inserted when querying indexes of these tree leaves.
+It's common that we need block metadata of a block in which leaves were inserted when querying indexes of these tree leaves.
 For this reason we now return that information along with the indexes.
 This allows us to reduce the number of individual AztecNode queries.
 
-Along this change `findNullifiersIndexesWithBlock` and `findBlockNumbersForIndexes` functions wer removed as all its uses can now be replaced with the newly modified `findLeavesIndexes` function.
+Along with this change, `findNullifiersIndexesWithBlock` and `findBlockNumbersForIndexes` functions were removed as all their uses can now be replaced with the newly modified `findLeavesIndexes` function.
 
 ### [aztec.js] AztecNode.getPublicDataTreeWitness renamed as AztecNode.getPublicDataWitness
 
@@ -3498,7 +3497,7 @@ Extended syntax for more use cases:
 
 ```rust
 // The contract we're testing
-env.deploy_self("ContractName"); // We have to provide ContractName since nargo it's ready to support multi-contract files
+env.deploy_self("ContractName"); // We have to provide ContractName since nargo isn't ready to support multi-contract files
 
 // A contract in a workspace
 env.deploy("../path/to/workspace@package_name", "ContractName"); // This format allows locating the artifact in the root workspace target folder, regardless of internal code organization

--- a/docs/docs-words.txt
+++ b/docs/docs-words.txt
@@ -319,6 +319,8 @@ timelock
 Timelock
 timelocked
 tonelli
+townhall
+townhalls
 TORADIXLE
 Tpkm
 transactionfee


### PR DESCRIPTION
## Summary
- Review and fix documentation in `docs-developers/docs/resources/`
- Fix grammar errors, typos, and inconsistencies across 4 files
- Standardize style and terminology per CLAUDE.md guidelines
- Apply same fixes to devnet.6 versioned docs

## Process

These updates were generated using Claude Code's `/review-docs` command, which spawns parallel agents to review each documentation file against the standards defined in `CLAUDE.md`. The command:

```
/review-docs @../docs-developers/docs/resources/ review all of the files in here. spawn an agent for each page
```

Each agent checks for:
- Front-matter requirements (description field)
- Grammar and language issues
- Tone and voice consistency
- Technical accuracy
- Code example correctness
- Structure and organization
- Terminology consistency

## Changes

### glossary.md
- Fix grammar (missing Oxford commas, verb agreement)
- Improve conciseness (reduce redundant phrasing)
- Add code formatting for CLI tool names

### migration_notes.md
- Fix typos ("wer" → "were", "non-existant" → "non-existent")
- Fix grammar errors ("we've introduce" → "we've introduced")
- Fix misleading diff that showed no actual change (line 925)

### privacy_considerations.md
- Fix grammar error ("can is" → "is")
- Remove orphaned footnote reference
- Standardize terminology ("3rd-party" → "third-party")

### limitations.md
- Fix broken link syntax (missing closing parenthesis)
- Change HTTP links to HTTPS
- Expand contractions for professional tone
- Replace informal language ("yummy features")
- Fix typos ("be be", "bugs fixes")

## Test plan
- [ ] Verify spellcheck passes: `yarn spellcheck`
- [ ] Verify build succeeds: `yarn build`

🤖 Generated with [Claude Code](https://claude.ai/code)