### PR TITLE
feat: reorg resistant `get*LogsByTag*` endpoints

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -700,15 +700,44 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return this.contractDataSource.getContract(address);
   }
 
-  public getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]> {
+  public async getPrivateLogsByTags(
+    tags: SiloedTag[],
+    page?: number,
+    referenceBlock?: L2BlockHash,
+  ): Promise<TxScopedL2Log[][]> {
+    if (referenceBlock) {
+      const initialBlockHash = await this.#getInitialHeaderHash();
+      if (!referenceBlock.equals(initialBlockHash)) {
+        const blockHashFr = Fr.fromBuffer(referenceBlock.toBuffer());
+        const header = await this.blockSource.getBlockHeaderByHash(blockHashFr);
+        if (!header) {
+          throw new Error(
+            `Block ${referenceBlock.toString()} not found in the node. This might indicate a reorg has occurred.`,
+          );
+        }
+      }
+    }
     return this.logsSource.getPrivateLogsByTags(tags, page);
   }
 
-  public getPublicLogsByTagsFromContract(
+  public async getPublicLogsByTagsFromContract(
     contractAddress: AztecAddress,
     tags: Tag[],
     page?: number,
+    referenceBlock?: L2BlockHash,
   ): Promise<TxScopedL2Log[][]> {
+    if (referenceBlock) {
+      const initialBlockHash = await this.#getInitialHeaderHash();
+      if (!referenceBlock.equals(initialBlockHash)) {
+        const blockHashFr = Fr.fromBuffer(referenceBlock.toBuffer());
+        const header = await this.blockSource.getBlockHeaderByHash(blockHashFr);
+        if (!header) {
+          throw new Error(
+            `Block ${referenceBlock.toString()} not found in the node. This might indicate a reorg has occurred.`,
+          );
+        }
+      }
+    }
     return this.logsSource.getPublicLogsByTagsFromContract(contractAddress, tags, page);
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -14,6 +14,7 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
@@ -265,7 +266,15 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       // This is a tagging secret we've not yet used in this tx, so first sync our store to make sure its indices
       // are up to date. We do this here because this store is not synced as part of the global sync because
       // that'd be wasteful as most tagging secrets are not used in each tx.
-      await syncSenderTaggingIndexes(secret, this.contractAddress, this.aztecNode, this.senderTaggingStore, this.jobId);
+      const anchorBlockHash = L2BlockHash.fromField(await this.anchorBlockHeader.hash());
+      await syncSenderTaggingIndexes(
+        secret,
+        this.contractAddress,
+        this.aztecNode,
+        this.senderTaggingStore,
+        anchorBlockHash,
+        this.jobId,
+      );
 
       const lastUsedIndex = await this.senderTaggingStore.getLastUsedIndex(secret, this.jobId);
       // If lastUsedIndex is undefined, we've never used this secret, so start from 0

--- a/yarn-project/pxe/src/logs/log_service.test.ts
+++ b/yarn-project/pxe/src/logs/log_service.test.ts
@@ -1,10 +1,13 @@
+import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { Tag } from '@aztec/stdlib/logs';
-import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
+import { makeBlockHeader, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -56,6 +59,10 @@ describe('LogService', () => {
       aztecNode.getPrivateLogsByTags.mockReset();
       aztecNode.getPublicLogsByTagsFromContract.mockReset();
       aztecNode.getTxEffect.mockReset();
+
+      // Set up anchor block header (required for bulkRetrieveLogs)
+      const header = makeBlockHeader(randomInt(1000), { blockNumber: BlockNumber(INITIAL_L2_BLOCK_NUM) });
+      await anchorBlockStore.setHeader(header);
     });
 
     it('returns no logs if none are found', async () => {

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -2,6 +2,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { CompleteAddress } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, PendingTaggedLog, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
@@ -53,7 +54,14 @@ export class LogService {
   }
 
   async #getPublicLogByTag(tag: Tag, contractAddress: AztecAddress): Promise<LogRetrievalResponse | null> {
-    const allLogsPerTag = await getAllPublicLogsByTagsFromContract(this.aztecNode, contractAddress, [tag]);
+    const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const allLogsPerTag = await getAllPublicLogsByTagsFromContract(
+      this.aztecNode,
+      contractAddress,
+      [tag],
+      anchorBlockHash,
+    );
     const logsForTag = allLogsPerTag[0];
 
     if (logsForTag.length === 0) {
@@ -76,7 +84,9 @@ export class LogService {
   }
 
   async #getPrivateLogByTag(siloedTag: SiloedTag): Promise<LogRetrievalResponse | null> {
-    const allLogsPerTag = await getAllPrivateLogsByTags(this.aztecNode, [siloedTag]);
+    const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const allLogsPerTag = await getAllPrivateLogsByTags(this.aztecNode, [siloedTag], anchorBlockHash);
     const logsForTag = allLogsPerTag[0];
 
     if (logsForTag.length === 0) {
@@ -106,7 +116,9 @@ export class LogService {
     this.log.verbose('Searching for tagged logs', { contract: contractAddress });
 
     // We only load logs from block up to and including the anchor block number
-    const anchorBlockNumber = (await this.anchorBlockStore.getBlockHeader()).getBlockNumber();
+    const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+    const anchorBlockNumber = anchorBlockHeader.getBlockNumber();
+    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
 
     // Determine recipients: use scopes if provided, otherwise get all accounts
     const recipients = scopes && scopes.length > 0 ? scopes : await this.keyStore.getAccounts();
@@ -127,6 +139,7 @@ export class LogService {
               this.aztecNode,
               this.recipientTaggingStore,
               anchorBlockNumber,
+              anchorBlockHash,
               this.jobId,
             ),
           ),

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -1,5 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -11,6 +12,8 @@ import { getAllPrivateLogsByTags } from './get_all_logs_by_tags.js';
 
 // We don't bother testing getAllPublicLogsByTagsFromContract because both of the functions are a simple wrapper around
 // getAllPages function so just testing the private logs function is enough.
+
+const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
 
 describe('getAllPrivateLogsByTags', () => {
   let aztecNode: MockProxy<AztecNode>;
@@ -29,17 +32,17 @@ describe('getAllPrivateLogsByTags', () => {
   it('returns empty arrays when no logs found', async () => {
     aztecNode.getPrivateLogsByTags.mockResolvedValue(tags.map(() => []));
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
 
     expect(result).toEqual([[], [], []]);
-    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(tags, 0);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledWith(tags, 0, MOCK_ANCHOR_BLOCK_HASH);
   });
 
   it('returns logs when all fit in a single page', async () => {
     const logsPerTag = tags.map((tag, i) => Array(i + 1).fill(randomTxScopedPrivateL2Log({ tag: tag.value })));
     aztecNode.getPrivateLogsByTags.mockResolvedValue(logsPerTag);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
 
     expect(result.map(logs => logs.length)).toEqual([1, 2, 3]);
     expect(aztecNode.getPrivateLogsByTags).toHaveBeenCalledTimes(1);
@@ -55,17 +58,17 @@ describe('getAllPrivateLogsByTags', () => {
 
     aztecNode.getPrivateLogsByTags.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, tags);
+    const result = await getAllPrivateLogsByTags(aztecNode, tags, MOCK_ANCHOR_BLOCK_HASH);
 
     expect(result.map(logs => logs.length)).toEqual([MAX_LOGS_PER_TAG + 5, 1, 0]);
-    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(1, tags, 0);
-    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, tags, 1);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(1, tags, 0, MOCK_ANCHOR_BLOCK_HASH);
+    expect(aztecNode.getPrivateLogsByTags).toHaveBeenNthCalledWith(2, tags, 1, MOCK_ANCHOR_BLOCK_HASH);
   });
 
   it('handles empty tags array', async () => {
     aztecNode.getPrivateLogsByTags.mockResolvedValue([]);
 
-    const result = await getAllPrivateLogsByTags(aztecNode, []);
+    const result = await getAllPrivateLogsByTags(aztecNode, [], MOCK_ANCHOR_BLOCK_HASH);
 
     expect(result).toEqual([]);
   });

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -1,4 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2BlockHash } from '@aztec/stdlib/block';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
@@ -34,10 +35,16 @@ async function getAllPages<T>(numTags: number, fetchPage: (page: number) => Prom
  * Fetches all private logs for the given tags, automatically paginating through all pages.
  * @param aztecNode - The Aztec node to query.
  * @param tags - The siloed tags to search for.
+ * @param anchorBlockHash - reference block for the Aztec node query, throws if block is not found there (typically
+ * because of reorgs).
  * @returns An array of log arrays, one per tag, containing all logs across all pages.
  */
-export function getAllPrivateLogsByTags(aztecNode: AztecNode, tags: SiloedTag[]): Promise<TxScopedL2Log[][]> {
-  return getAllPages(tags.length, page => aztecNode.getPrivateLogsByTags(tags, page));
+export function getAllPrivateLogsByTags(
+  aztecNode: AztecNode,
+  tags: SiloedTag[],
+  anchorBlockHash: L2BlockHash,
+): Promise<TxScopedL2Log[][]> {
+  return getAllPages(tags.length, page => aztecNode.getPrivateLogsByTags(tags, page, anchorBlockHash));
 }
 
 /**
@@ -45,12 +52,17 @@ export function getAllPrivateLogsByTags(aztecNode: AztecNode, tags: SiloedTag[])
  * @param aztecNode - The Aztec node to query.
  * @param contractAddress - The contract address to search logs for.
  * @param tags - The tags to search for.
+ * @param anchorBlockHash - reference block for the Aztec node query, throws if block is not found there (typically
+ * because of reorgs).
  * @returns An array of log arrays, one per tag, containing all logs across all pages.
  */
 export function getAllPublicLogsByTagsFromContract(
   aztecNode: AztecNode,
   contractAddress: AztecAddress,
   tags: Tag[],
+  anchorBlockHash: L2BlockHash,
 ): Promise<TxScopedL2Log[][]> {
-  return getAllPages(tags.length, page => aztecNode.getPublicLogsByTagsFromContract(contractAddress, tags, page));
+  return getAllPages(tags.length, page =>
+    aztecNode.getPublicLogsByTagsFromContract(contractAddress, tags, page, anchorBlockHash),
+  );
 }

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
@@ -3,6 +3,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { makeBlockHeader, makeL2Tips, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -15,7 +16,8 @@ import { loadPrivateLogsForSenderRecipientPair } from './load_private_logs_for_s
 
 // In this test suite we don't care about the anchor block behavior as that is sufficiently tested by
 // the loadLogsForRange test suite, so we use a high block number to ensure it occurs after all logs.
-const NON_INTERFERING_ANCHOR_BLOCK_NUMBER = BlockNumber(100);
+const FAR_FUTURE_BLOCK_NUMBER = BlockNumber(100);
+const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
 
 describe('loadPrivateLogsForSenderRecipientPair', () => {
   let secret: DirectionalAppTaggingSecret;
@@ -63,7 +65,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       app,
       aztecNode,
       taggingStore,
-      NON_INTERFERING_ANCHOR_BLOCK_NUMBER,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
       'test',
     );
 
@@ -97,7 +100,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       app,
       aztecNode,
       taggingStore,
-      NON_INTERFERING_ANCHOR_BLOCK_NUMBER,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
       'test',
     );
 
@@ -131,7 +135,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       app,
       aztecNode,
       taggingStore,
-      NON_INTERFERING_ANCHOR_BLOCK_NUMBER,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
       'test',
     );
 
@@ -182,7 +187,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
       app,
       aztecNode,
       taggingStore,
-      NON_INTERFERING_ANCHOR_BLOCK_NUMBER,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
       'test',
     );
 

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
@@ -1,5 +1,6 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, TxScopedL2Log } from '@aztec/stdlib/logs';
 
@@ -21,6 +22,7 @@ export async function loadPrivateLogsForSenderRecipientPair(
   aztecNode: AztecNode,
   taggingStore: RecipientTaggingStore,
   anchorBlockNumber: BlockNumber,
+  anchorBlockHash: L2BlockHash,
   jobId: string,
 ): Promise<TxScopedL2Log[]> {
   // # Explanation of how the algorithm works
@@ -92,7 +94,15 @@ export async function loadPrivateLogsForSenderRecipientPair(
 
   while (true) {
     // Get private logs with their block timestamps and corresponding tagging indexes
-    const privateLogsWithIndexes = await loadLogsForRange(secret, app, aztecNode, start, end, anchorBlockNumber);
+    const privateLogsWithIndexes = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      start,
+      end,
+      anchorBlockNumber,
+      anchorBlockHash,
+    );
 
     if (privateLogsWithIndexes.length === 0) {
       break;

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
@@ -1,6 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -12,7 +13,8 @@ import { loadLogsForRange } from './load_logs_for_range.js';
 
 // In tests where the anchor block behavior is not under examination, we use a high block number to ensure it occurs
 // after all logs.
-const NON_INTERFERING_ANCHOR_BLOCK_NUMBER = BlockNumber(100);
+const FAR_FUTURE_BLOCK_NUMBER = BlockNumber(100);
+const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
 
 describe('loadLogsForRange', () => {
   // App contract address and secret to be used on the input of the loadLogsForRange function.
@@ -46,7 +48,9 @@ describe('loadLogsForRange', () => {
       return Promise.resolve(tags.map((_tag: SiloedTag) => []));
     });
 
-    expect(await loadLogsForRange(secret, app, aztecNode, 0, 10, NON_INTERFERING_ANCHOR_BLOCK_NUMBER)).toHaveLength(0);
+    expect(
+      await loadLogsForRange(secret, app, aztecNode, 0, 10, FAR_FUTURE_BLOCK_NUMBER, MOCK_ANCHOR_BLOCK_HASH),
+    ).toHaveLength(0);
   });
 
   it('handles multiple logs at different indexes', async () => {
@@ -74,7 +78,15 @@ describe('loadLogsForRange', () => {
       );
     });
 
-    const result = await loadLogsForRange(secret, app, aztecNode, 0, 10, NON_INTERFERING_ANCHOR_BLOCK_NUMBER);
+    const result = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      0,
+      10,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
+    );
 
     expect(result).toHaveLength(2);
     const resultByIndex = result.sort((a, b) => a.taggingIndex - b.taggingIndex);
@@ -106,7 +118,15 @@ describe('loadLogsForRange', () => {
       );
     });
 
-    const result = await loadLogsForRange(secret, app, aztecNode, 0, 10, NON_INTERFERING_ANCHOR_BLOCK_NUMBER);
+    const result = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      0,
+      10,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0].taggingIndex).toBe(index);
@@ -139,7 +159,15 @@ describe('loadLogsForRange', () => {
       );
     });
 
-    const result = await loadLogsForRange(secret, app, aztecNode, 0, 10, NON_INTERFERING_ANCHOR_BLOCK_NUMBER);
+    const result = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      0,
+      10,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
+    );
 
     expect(result).toHaveLength(2);
 
@@ -173,7 +201,15 @@ describe('loadLogsForRange', () => {
       );
     });
 
-    const result = await loadLogsForRange(secret, app, aztecNode, start, end, NON_INTERFERING_ANCHOR_BLOCK_NUMBER);
+    const result = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      start,
+      end,
+      FAR_FUTURE_BLOCK_NUMBER,
+      MOCK_ANCHOR_BLOCK_HASH,
+    );
 
     // Should only include log at start (inclusive), not at end (exclusive)
     expect(result).toHaveLength(1);
@@ -202,7 +238,15 @@ describe('loadLogsForRange', () => {
       );
     });
 
-    const result = await loadLogsForRange(secret, app, aztecNode, 0, 10, BlockNumber(anchorBlockNumber));
+    const result = await loadLogsForRange(
+      secret,
+      app,
+      aztecNode,
+      0,
+      10,
+      BlockNumber(anchorBlockNumber),
+      MOCK_ANCHOR_BLOCK_HASH,
+    );
 
     // Should only include logs from blocks at or before the anchor block number
     expect(result).toHaveLength(2);

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
@@ -1,5 +1,6 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, PreTag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -18,6 +19,7 @@ export async function loadLogsForRange(
   start: number,
   end: number,
   anchorBlockNumber: BlockNumber,
+  anchorBlockHash: L2BlockHash,
 ): Promise<Array<{ log: TxScopedL2Log; taggingIndex: number }>> {
   // Derive tags for the window
   const preTags: PreTag[] = Array(end - start)
@@ -29,7 +31,7 @@ export async function loadLogsForRange(
 
   // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
   // pagination here.
-  const logs = await getAllPrivateLogsByTags(aztecNode, siloedTags);
+  const logs = await getAllPrivateLogsByTags(aztecNode, siloedTags, anchorBlockHash);
 
   // Pair logs with their corresponding tagging indexes
   const logsWithIndexes: Array<{ log: TxScopedL2Log; taggingIndex: number }> = [];

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -2,6 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 import { TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
@@ -11,6 +12,8 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag, UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../index.js';
 import { syncSenderTaggingIndexes } from './sync_sender_tagging_indexes.js';
+
+const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
 
 describe('syncSenderTaggingIndexes', () => {
   // Contract address and secret to be used on the input of the syncSenderTaggingIndexes function.
@@ -45,7 +48,7 @@ describe('syncSenderTaggingIndexes', () => {
       return Promise.resolve(tags.map((_tag: SiloedTag) => []));
     });
 
-    await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
+    await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Highest used and finalized indexes should stay undefined
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBeUndefined();
@@ -88,7 +91,7 @@ describe('syncSenderTaggingIndexes', () => {
         ),
       );
 
-      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
+      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
       // Verify the highest finalized index is updated to 3
       expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(finalizedIndexStep1);
@@ -120,7 +123,7 @@ describe('syncSenderTaggingIndexes', () => {
         ),
       );
 
-      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
+      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
       // Verify the highest finalized index was not updated
       expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(finalizedIndexStep1);
@@ -203,7 +206,7 @@ describe('syncSenderTaggingIndexes', () => {
         }
       });
 
-      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
+      await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
       expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(newHighestFinalizedIndex);
       expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBe(newHighestUsedIndex);
@@ -266,7 +269,7 @@ describe('syncSenderTaggingIndexes', () => {
     });
 
     // Sync tagged logs
-    await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, 'test');
+    await syncSenderTaggingIndexes(secret, contractAddress, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that both highest finalized and highest used were set to the pending and finalized index
     expect(await taggingStore.getLastFinalizedIndex(secret, 'test')).toBe(pendingAndFinalizedIndex);

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
@@ -1,4 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
 
@@ -26,6 +27,7 @@ export async function syncSenderTaggingIndexes(
   app: AztecAddress,
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
+  anchorBlockHash: L2BlockHash,
   jobId: string,
 ): Promise<void> {
   // # Explanation of how syncing works
@@ -57,7 +59,7 @@ export async function syncSenderTaggingIndexes(
   while (true) {
     // Load and store indexes for the current window. These indexes may already exist in the database if txs using
     // them were previously sent from this PXE. Any duplicates are handled by the tagging data provider.
-    await loadAndStoreNewTaggingIndexes(secret, app, start, end, aztecNode, taggingStore, jobId);
+    await loadAndStoreNewTaggingIndexes(secret, app, start, end, aztecNode, taggingStore, anchorBlockHash, jobId);
 
     // Retrieve all indexes within the current window from storage and update their status accordingly.
     const pendingTxHashes = await taggingStore.getTxHashesOfPendingIndexes(secret, start, end, jobId);

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -10,6 +11,8 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 
 import { SenderTaggingStore } from '../../../storage/tagging_store/sender_tagging_store.js';
 import { loadAndStoreNewTaggingIndexes } from './load_and_store_new_tagging_indexes.js';
+
+const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
 
 describe('loadAndStoreNewTaggingIndexes', () => {
   // App contract address and secret to be used on the input of the loadAndStoreNewTaggingIndexes function.
@@ -46,7 +49,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       return Promise.resolve(tags.map((_tag: SiloedTag) => []));
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that no pending indexes were stored
     expect(await taggingStore.getLastUsedIndex(secret, 'test')).toBeUndefined();
@@ -66,7 +69,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       return Promise.resolve(tags.map((t: SiloedTag) => (t.equals(tag) ? [makeLog(txHash, tag.value)] : [])));
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that the pending index was stored for this txHash
     const txHashesInRange = await taggingStore.getTxHashesOfPendingIndexes(secret, index, index + 1, 'test');
@@ -97,7 +100,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that only the highest index (7) was stored for this txHash and secret
     const txHashesAtIndex2 = await taggingStore.getTxHashesOfPendingIndexes(secret, index2, index2 + 1, 'test');
@@ -133,7 +136,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that both txHashes have their respective indexes stored
     const txHashesAtIndex1 = await taggingStore.getTxHashesOfPendingIndexes(secret, index1, index1 + 1, 'test');
@@ -161,7 +164,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify that both txHashes have the same index stored
     const txHashesAtIndex = await taggingStore.getTxHashesOfPendingIndexes(secret, index, index + 1, 'test');
@@ -207,7 +210,7 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(secret, app, 0, 10, aztecNode, taggingStore, MOCK_ANCHOR_BLOCK_HASH, 'test');
 
     // Verify txHash1 has highest index 8 (should not be at index 1)
     const txHashesAtIndex1 = await taggingStore.getTxHashesOfPendingIndexes(secret, 1, 2, 'test');
@@ -255,7 +258,16 @@ describe('loadAndStoreNewTaggingIndexes', () => {
       );
     });
 
-    await loadAndStoreNewTaggingIndexes(secret, app, start, end, aztecNode, taggingStore, 'test');
+    await loadAndStoreNewTaggingIndexes(
+      secret,
+      app,
+      start,
+      end,
+      aztecNode,
+      taggingStore,
+      MOCK_ANCHOR_BLOCK_HASH,
+      'test',
+    );
 
     // Verify that the log at start (inclusive) was processed
     const txHashesAtStart = await taggingStore.getTxHashesOfPendingIndexes(secret, start, start + 1, 'test');

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -1,4 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -28,6 +29,7 @@ export async function loadAndStoreNewTaggingIndexes(
   end: number,
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
+  anchorBlockHash: L2BlockHash,
   jobId: string,
 ) {
   // We compute the tags for the current window of indexes
@@ -38,7 +40,7 @@ export async function loadAndStoreNewTaggingIndexes(
     preTagsForWindow.map(async preTag => SiloedTag.compute(await Tag.compute(preTag), app)),
   );
 
-  const txsForTags = await getTxsContainingTags(siloedTagsForWindow, aztecNode);
+  const txsForTags = await getTxsContainingTags(siloedTagsForWindow, aztecNode, anchorBlockHash);
   const highestIndexMap = getTxHighestIndexMap(txsForTags, preTagsForWindow);
 
   // Now we iterate over the map, reconstruct the preTags and tx hash and store them in the db.
@@ -50,10 +52,14 @@ export async function loadAndStoreNewTaggingIndexes(
 
 // Returns txs that used the given tags. A tag might have been used in multiple txs and for this reason we return
 // an array for each tag.
-async function getTxsContainingTags(tags: SiloedTag[], aztecNode: AztecNode): Promise<TxHash[][]> {
+async function getTxsContainingTags(
+  tags: SiloedTag[],
+  aztecNode: AztecNode,
+  anchorBlockHash: L2BlockHash,
+): Promise<TxHash[][]> {
   // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
   // pagination here.
-  const allLogs = await getAllPrivateLogsByTags(aztecNode, tags);
+  const allLogs = await getAllPrivateLogsByTags(aztecNode, tags, anchorBlockHash);
   return allLogs.map(logs => logs.map(log => log.txHash));
 }
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -23,6 +23,7 @@ import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
+import { L2BlockHash } from '../block/block_hash.js';
 import { type BlockParameter, BlockParameterSchema } from '../block/block_parameter.js';
 import { CheckpointedL2Block } from '../block/checkpointed_l2_block.js';
 import { type DataInBlock, dataInBlockSchemaFor } from '../block/in_block.js';
@@ -347,10 +348,14 @@ export interface AztecNode
    * array implies no logs match that tag.
    * @param tags - The tags to search for.
    * @param page - The page number (0-indexed) for pagination.
+   * @param referenceBlock - Optional block hash used to ensure the block still exists before logs are retrieved.
+   * This block is expected to represent the latest block to which the client has synced (called anchor block in PXE).
+   * If specified and the block is not found, an error is thrown. This helps detect reorgs, which could result in
+   * undefined behavior in the client's code.
    * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
    * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPrivateLogsByTags(tags: SiloedTag[], page?: number): Promise<TxScopedL2Log[][]>;
+  getPrivateLogsByTags(tags: SiloedTag[], page?: number, referenceBlock?: L2BlockHash): Promise<TxScopedL2Log[][]>;
 
   /**
    * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
@@ -358,6 +363,10 @@ export interface AztecNode
    * @param contractAddress - The contract address to search logs for.
    * @param tags - The tags to search for.
    * @param page - The page number (0-indexed) for pagination.
+   * @param referenceBlock - Optional block hash used to ensure the block still exists before logs are retrieved.
+   * This block is expected to represent the latest block to which the client has synced (called anchor block in PXE).
+   * If specified and the block is not found, an error is thrown. This helps detect reorgs, which could result in
+   * undefined behavior in the client's code.
    * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
    * for a tag, the caller should fetch the next page to check for more logs.
    */
@@ -365,6 +374,7 @@ export interface AztecNode
     contractAddress: AztecAddress,
     tags: Tag[],
     page?: number,
+    referenceBlock?: L2BlockHash,
   ): Promise<TxScopedL2Log[][]>;
 
   /**
@@ -631,12 +641,17 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getPrivateLogsByTags: z
     .function()
-    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)))
+    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)), optional(L2BlockHash.schema))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 
   getPublicLogsByTagsFromContract: z
     .function()
-    .args(schemas.AztecAddress, z.array(Tag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)))
+    .args(
+      schemas.AztecAddress,
+      z.array(Tag.schema).max(MAX_RPC_LEN),
+      optional(z.number().gte(0)),
+      optional(L2BlockHash.schema),
+    )
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 
   sendTx: z.function().args(Tx.schema).returns(z.void()),


### PR DESCRIPTION
As discussed [here](https://github.com/AztecProtocol/aztec-packages/pull/19776#discussion_r2711994201) makes sense to add anchor block hash on the input of `getPrivateLogsByTags` and `getPublicLogsByTagsFromContract` to prevent undefined behavior in the case of reorgs.

PXE should handle this even without this check but makes sense to have it just to be safe.

The other discussed in the PR linked above was adding a test that verifies pages are stable upon new block additions. Those tests were added in [this PR](https://github.com/AztecProtocol/aztec-packages/pull/19837).