### PR TITLE
fix: missing exports in aztec.js

### DIFF
--- a/yarn-project/aztec.js/src/api/wallet.ts
+++ b/yarn-project/aztec.js/src/api/wallet.ts
@@ -11,6 +11,8 @@ export {
   type Wallet,
   type PrivateEvent,
   type PrivateEventFilter,
+  type ContractMetadata,
+  type ContractClassMetadata,
   FunctionCallSchema,
   ExecutionPayloadSchema,
   GasSettingsOptionSchema,
@@ -23,6 +25,8 @@ export {
   EventMetadataDefinitionSchema,
   PrivateEventSchema,
   PrivateEventFilterSchema,
+  ContractClassMetadataSchema,
+  ContractMetadataSchema,
   WalletSchema,
 } from '../wallet/wallet.js';
 


### PR DESCRIPTION
These exports were missed in https://github.com/AztecProtocol/aztec-packages/pull/19457
