### PR TITLE
feat: not waiting for contract class recency check

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -85,7 +85,7 @@ import { ExecutionNoteCache } from './execution_note_cache.js';
 import { ExecutionTaggingIndexCache } from './execution_tagging_index_cache.js';
 import { HashedValuesCache } from './hashed_values_cache.js';
 import { Oracle } from './oracle/oracle.js';
-import { executePrivateFunction, verifyCurrentClassId } from './oracle/private_execution.js';
+import { executePrivateFunction } from './oracle/private_execution.js';
 import { PrivateExecutionOracle } from './oracle/private_execution_oracle.js';
 import { UtilityExecutionOracle } from './oracle/utility_execution_oracle.js';
 
@@ -137,12 +137,6 @@ export class ContractFunctionSimulator {
     jobId: string,
   ): Promise<PrivateExecutionResult> {
     const simulatorSetupTimer = new Timer();
-
-    await this.contractStore.syncPrivateState(contractAddress, selector, privateSyncCall =>
-      this.runUtility(privateSyncCall, [], anchorBlockHeader, scopes, jobId),
-    );
-
-    await verifyCurrentClassId(contractAddress, this.aztecNode, this.contractStore, anchorBlockHeader);
 
     const entryPointArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(contractAddress, selector);
 
@@ -268,8 +262,6 @@ export class ContractFunctionSimulator {
     scopes: AztecAddress[] | undefined,
     jobId: string,
   ): Promise<Fr[]> {
-    await verifyCurrentClassId(call.to, this.aztecNode, this.contractStore, anchorBlockHeader);
-
     const entryPointArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(call.to, call.selector);
 
     if (entryPointArtifact.functionType !== FunctionType.UTILITY) {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -14,6 +14,7 @@ import {
 import {
   type FunctionArtifact,
   type FunctionArtifactWithContractName,
+  type FunctionCall,
   type FunctionSelector,
   countArgumentsSize,
 } from '@aztec/stdlib/abi';
@@ -180,7 +181,7 @@ export async function readCurrentClassId(
  * provider (i.e. PXE's own storage).
  * @param header - The header of the block at which to verify the current class id.
  */
-export async function verifyCurrentClassId(
+async function verifyCurrentClassId(
   contractAddress: AztecAddress,
   aztecNode: AztecNode,
   contractStore: ContractStore,
@@ -197,4 +198,22 @@ export async function verifyCurrentClassId(
       `Contract ${contractAddress} is outdated, current class id is ${currentClassId}, local class id is ${instance.currentContractClassId}`,
     );
   }
+}
+
+/**
+ * Ensures the contract's private state is synchronized and that the PXE holds the current class artifact for
+ * the contract.
+ */
+export async function ensureContractSynced(
+  contractAddress: AztecAddress,
+  functionToInvokeAfterSync: FunctionSelector | null,
+  utilityExecutor: (call: FunctionCall) => Promise<any>,
+  aztecNode: AztecNode,
+  contractStore: ContractStore,
+  header: BlockHeader,
+): Promise<void> {
+  await Promise.all([
+    contractStore.syncPrivateState(contractAddress, functionToInvokeAfterSync, utilityExecutor),
+    verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
+  ]);
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -47,7 +47,7 @@ import { ExecutionTaggingIndexCache } from '../execution_tagging_index_cache.js'
 import type { HashedValuesCache } from '../hashed_values_cache.js';
 import { pickNotes } from '../pick_notes.js';
 import type { IPrivateExecutionOracle, NoteData } from './interfaces.js';
-import { executePrivateFunction, verifyCurrentClassId } from './private_execution.js';
+import { ensureContractSynced, executePrivateFunction } from './private_execution.js';
 import { UtilityExecutionOracle } from './utility_execution_oracle.js';
 
 /**
@@ -528,9 +528,14 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     isStaticCall = isStaticCall || this.callContext.isStaticCall;
 
-    await verifyCurrentClassId(targetContractAddress, this.aztecNode, this.contractStore, this.anchorBlockHeader);
-
-    await this.contractStore.syncPrivateState(targetContractAddress, functionSelector, this.utilityExecutor);
+    await ensureContractSynced(
+      targetContractAddress,
+      functionSelector,
+      this.utilityExecutor,
+      this.aztecNode,
+      this.contractStore,
+      this.anchorBlockHeader,
+    );
 
     const targetArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(
       targetContractAddress,

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -59,7 +59,7 @@ import {
   ContractFunctionSimulator,
   generateSimulatedProvingResult,
 } from './contract_function_simulator/contract_function_simulator.js';
-import { readCurrentClassId } from './contract_function_simulator/oracle/private_execution.js';
+import { ensureContractSynced, readCurrentClassId } from './contract_function_simulator/oracle/private_execution.js';
 import { ProxiedContractStoreFactory } from './contract_function_simulator/proxied_contract_data_source.js';
 import { PXEDebugUtils } from './debug/pxe_debug_utils.js';
 import { enrichPublicSimulationError, enrichSimulationError } from './error_enriching.js';
@@ -294,6 +294,15 @@ export class PXE {
 
     try {
       const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+
+      await ensureContractSynced(
+        contractAddress,
+        functionSelector,
+        privateSyncCall => this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
+        this.node,
+        this.contractStore,
+        anchorBlockHeader,
+      );
 
       const result = await contractFunctionSimulator.run(
         txRequest,
@@ -953,8 +962,14 @@ export class PXE {
         const functionTimer = new Timer();
         const contractFunctionSimulator = this.#getSimulatorForTx();
 
-        await this.contractStore.syncPrivateState(call.to, call.selector, privateSyncCall =>
-          this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
+        const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+        await ensureContractSynced(
+          call.to,
+          call.selector,
+          privateSyncCall => this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
+          this.node,
+          this.contractStore,
+          anchorBlockHeader,
         );
 
         const executionResult = await this.#simulateUtility(
@@ -1013,15 +1028,19 @@ export class PXE {
     await this.#putInJobQueue(async jobId => {
       await this.blockStateSynchronizer.sync();
 
-      anchorBlockNumber = (await this.anchorBlockStore.getBlockHeader()).getBlockNumber();
+      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+      anchorBlockNumber = anchorBlockHeader.getBlockNumber();
 
       const contractFunctionSimulator = this.#getSimulatorForTx();
 
-      await this.contractStore.syncPrivateState(
+      await ensureContractSynced(
         filter.contractAddress,
         null,
         async privateSyncCall =>
           await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
+        this.node,
+        this.contractStore,
+        anchorBlockHeader,
       );
     });
 

--- a/yarn-project/stdlib/src/delayed_public_mutable/delayed_public_mutable_values.ts
+++ b/yarn-project/stdlib/src/delayed_public_mutable/delayed_public_mutable_values.ts
@@ -68,23 +68,22 @@ export class DelayedPublicMutableValues {
   }
 
   static async readFromTree(delayedPublicMutableSlot: Fr, readStorage: (storageSlot: Fr) => Promise<Fr>) {
-    const fields = [];
-    for (let i = 0; i < DELAYED_PUBLIC_MUTABLE_VALUES_LEN; i++) {
-      fields.push(await readStorage(delayedPublicMutableSlot.add(new Fr(i))));
-    }
-    return DelayedPublicMutableValues.fromFields(fields);
+    const fieldPromises = Array.from({ length: DELAYED_PUBLIC_MUTABLE_VALUES_LEN }).map((_, i) =>
+      readStorage(delayedPublicMutableSlot.add(new Fr(i))),
+    );
+    return DelayedPublicMutableValues.fromFields(await Promise.all(fieldPromises));
   }
 
   isEmpty(): boolean {
     return this.svc.isEmpty() && this.sdc.isEmpty();
   }
 
-  async writeToTree(delayedPublicMutableSlot: Fr, storageWrite: (storageSlot: Fr, value: Fr) => Promise<void>) {
-    const fields = this.toFields();
+  writeToTree(delayedPublicMutableSlot: Fr, storageWrite: (storageSlot: Fr, value: Fr) => Promise<void>) {
+    const fieldPromises = this.toFields().map((field, i) =>
+      storageWrite(delayedPublicMutableSlot.add(new Fr(i)), field),
+    );
 
-    for (let i = 0; i < fields.length; i++) {
-      await storageWrite(delayedPublicMutableSlot.add(new Fr(i)), fields[i]);
-    }
+    return Promise.all(fieldPromises);
   }
 
   async hash(): Promise<Fr> {


### PR DESCRIPTION
Before this PR in every utility and private call we blocked until we verified that the given contract class is the current contract class. This has slowed execution so in this PR I do that at the same time with private state sync. If the class is outdated an error is thrown and the whole job fails - at that point the executor should handle wiping out the staged data.

When implementing this I've noticed that we performed 1 redundant contract updates check so I addressed that. This resulted in a significant drop in roundtrips.

The parallelization of private state sync a the check itself did not result in a drop in roundtrips but that is to be expected - the check gets a response from node faster than the private state sync starts querying stuff from it (at least that's my theory but I am pretty confident here that it's the case).

When implementing this I realized that the caching mechanism of if we performed the contract sync now makes even more sense because before I thought this is relevant only for the contracts update check but of course it's relevant also for the private state sync. For this reason I implemented that mechanism in a PR up the stack. Before that PR we performed private state sync and contracts update check multiple times for 1 contract if more than 1 private function was invoked - that's just stupid.

Closes https://linear.app/aztec-labs/issue/F-137/postpone-or-not-check-contract-upgrades