### PR TITLE
feat: not re-syncing at the same block

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -27,6 +27,7 @@ import { PrivateCircuitPublicInputs } from '@aztec/stdlib/kernel';
 import type { CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
 import { BlockHeader, PrivateCallExecutionResult } from '@aztec/stdlib/tx';
 
+import type { AnchorBlockStore } from '../../storage/anchor_block_store/anchor_block_store.js';
 import { ContractStore } from '../../storage/contract_store/index.js';
 import { Oracle } from './oracle.js';
 import type { PrivateExecutionOracle } from './private_execution_oracle.js';
@@ -211,9 +212,16 @@ export async function ensureContractSynced(
   aztecNode: AztecNode,
   contractStore: ContractStore,
   header: BlockHeader,
+  anchorBlockStore: AnchorBlockStore,
 ): Promise<void> {
+  if (anchorBlockStore.isContractSynced(contractAddress)) {
+    return;
+  }
+
   await Promise.all([
     contractStore.syncPrivateState(contractAddress, functionToInvokeAfterSync, utilityExecutor),
     verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
   ]);
+
+  anchorBlockStore.markContractSynced(contractAddress);
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -213,8 +213,9 @@ export async function ensureContractSynced(
   contractStore: ContractStore,
   header: BlockHeader,
   anchorBlockStore: AnchorBlockStore,
+  jobId: string,
 ): Promise<void> {
-  if (anchorBlockStore.isContractSynced(contractAddress)) {
+  if (anchorBlockStore.isContractSynced(contractAddress, jobId)) {
     return;
   }
 
@@ -223,5 +224,5 @@ export async function ensureContractSynced(
     verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
   ]);
 
-  anchorBlockStore.markContractSynced(contractAddress);
+  anchorBlockStore.markContractSynced(contractAddress, jobId);
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -548,6 +548,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       this.aztecNode,
       this.contractStore,
       this.anchorBlockHeader,
+      this.anchorBlockStore,
     );
 
     const targetArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -549,6 +549,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       this.contractStore,
       this.anchorBlockHeader,
       this.anchorBlockStore,
+      this.jobId,
     );
 
     const targetArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -302,6 +302,7 @@ export class PXE {
         this.node,
         this.contractStore,
         anchorBlockHeader,
+        this.anchorBlockStore,
       );
 
       const result = await contractFunctionSimulator.run(
@@ -970,6 +971,7 @@ export class PXE {
           this.node,
           this.contractStore,
           anchorBlockHeader,
+          this.anchorBlockStore,
         );
 
         const executionResult = await this.#simulateUtility(
@@ -1041,6 +1043,7 @@ export class PXE {
         this.node,
         this.contractStore,
         anchorBlockHeader,
+        this.anchorBlockStore,
       );
     });
 

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -303,6 +303,7 @@ export class PXE {
         this.contractStore,
         anchorBlockHeader,
         this.anchorBlockStore,
+        jobId,
       );
 
       const result = await contractFunctionSimulator.run(
@@ -972,6 +973,7 @@ export class PXE {
           this.contractStore,
           anchorBlockHeader,
           this.anchorBlockStore,
+          jobId,
         );
 
         const executionResult = await this.#simulateUtility(
@@ -1044,6 +1046,7 @@ export class PXE {
         this.contractStore,
         anchorBlockHeader,
         this.anchorBlockStore,
+        jobId,
       );
     });
 

--- a/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
@@ -1,16 +1,40 @@
 import type { AztecAsyncKVStore, AztecAsyncSingleton } from '@aztec/kv-store';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { BlockHeader } from '@aztec/stdlib/tx';
 
 export class AnchorBlockStore {
   #store: AztecAsyncKVStore;
   #synchronizedHeader: AztecAsyncSingleton<Buffer>;
+  // Contracts that have been synced for the current anchor block (contract class recency checked and private state
+  // synchronized). Cleared on block change.
+  #syncedContracts: Set<string> = new Set();
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
     this.#synchronizedHeader = this.#store.openSingleton('header');
   }
 
+  /** Check if a contract has been synced for the current anchor block. */
+  isContractSynced(contractAddress: AztecAddress): boolean {
+    return this.#syncedContracts.has(contractAddress.toString());
+  }
+
+  /** Mark a contract as synced for the current anchor block. */
+  markContractSynced(contractAddress: AztecAddress): void {
+    if (this.isContractSynced(contractAddress)) {
+      // This would indicate that a contract has been synced twice for the same anchor block which should never happen.
+      throw new Error(
+        `Contract ${contractAddress.toString()} has already been marked as synced for the current anchor block. This is a PXE bug.`,
+      );
+    }
+
+    this.#syncedContracts.add(contractAddress.toString());
+  }
+
   async setHeader(header: BlockHeader): Promise<void> {
+    // We have received a new anchor block so we wipe out the list of contracts that have been synced at the previous
+    // anchor block - with new state it's necessary to re-sync them.
+    this.#syncedContracts.clear();
     await this.#synchronizedHeader.set(header.toBuffer());
   }
 

--- a/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
@@ -13,16 +13,19 @@ export class AnchorBlockStore {
   // validated by subsequent executions. If we only tracked per-block, subsequent jobs would skip sync and never
   // validate those pending items.
   //
-  // Example flow that breaks if we only track per-block:
-  // 1. Job A calls `process_message.simulate()` which runs `ensureContractSynced` → marks contract as synced
-  // 2. Inside `process_message`, an event/note is enqueued to the capsule store via `enqueue_event_for_validation`
-  // 3. Job A commits, the enqueued item is now in the committed capsule store awaiting validation
-  // 4. Job B calls `getPrivateEvents()` which runs `ensureContractSynced`
+  // Example flow that breaks if we only track per-block (e.g. e2e_blacklist_token_contract):
+  // 1. Job A executes a mint transaction:
+  //    - `ensureContractSynced` → `sync_private_state` runs BEFORE the tx executes → marks contract as synced
+  //    - The mint transaction then creates a new shield note (emits a tagged log to the chain)
+  //    - Note: the note is created AFTER the sync already ran, so it wasn't discovered
+  // 2. Job A commits, the note now exists on-chain as a tagged log
+  // 3. Job B executes a transaction that calls `redeem_shield` to spend the minted tokens
+  // 4. `ensureContractSynced` runs for the token contract
   // 5. If we only tracked per-block, Job B would see the contract is "synced" and skip `sync_private_state`
-  // 6. The enqueued item from Job A would never be validated because `validate_enqueued_notes_and_events` is only
-  //    called inside `sync_private_state` (via `discover_new_messages`)
+  // 6. The note from Job A is never fetched from the chain because `sync_private_state` wasn't called
+  // 7. `redeem_shield` fails with "note not found"
   //
-  // By tracking per-job, Job B will run its own sync, which validates the pending items from Job A.
+  // By tracking per-job, Job B will run its own sync, which fetches the note from the chain.
   #syncedContracts: Set<string> = new Set();
 
   constructor(store: AztecAsyncKVStore) {

--- a/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
@@ -5,8 +5,24 @@ import { BlockHeader } from '@aztec/stdlib/tx';
 export class AnchorBlockStore {
   #store: AztecAsyncKVStore;
   #synchronizedHeader: AztecAsyncSingleton<Buffer>;
-  // Contracts that have been synced for the current anchor block (contract class recency checked and private state
-  // synchronized). Cleared on block change.
+
+  // Contracts that have been synced for the current anchor block AND job (contract class recency checked and private
+  // state synchronized). The key is "contractAddress:jobId". Cleared on block change.
+  //
+  // Note: We track per-job because a utility execution (job) may enqueue items to the capsule store that need to be
+  // validated by subsequent executions. If we only tracked per-block, subsequent jobs would skip sync and never
+  // validate those pending items.
+  //
+  // Example flow that breaks if we only track per-block:
+  // 1. Job A calls `process_message.simulate()` which runs `ensureContractSynced` → marks contract as synced
+  // 2. Inside `process_message`, an event/note is enqueued to the capsule store via `enqueue_event_for_validation`
+  // 3. Job A commits, the enqueued item is now in the committed capsule store awaiting validation
+  // 4. Job B calls `getPrivateEvents()` which runs `ensureContractSynced`
+  // 5. If we only tracked per-block, Job B would see the contract is "synced" and skip `sync_private_state`
+  // 6. The enqueued item from Job A would never be validated because `validate_enqueued_notes_and_events` is only
+  //    called inside `sync_private_state` (via `discover_new_messages`)
+  //
+  // By tracking per-job, Job B will run its own sync, which validates the pending items from Job A.
   #syncedContracts: Set<string> = new Set();
 
   constructor(store: AztecAsyncKVStore) {
@@ -14,21 +30,27 @@ export class AnchorBlockStore {
     this.#synchronizedHeader = this.#store.openSingleton('header');
   }
 
-  /** Check if a contract has been synced for the current anchor block. */
-  isContractSynced(contractAddress: AztecAddress): boolean {
-    return this.#syncedContracts.has(contractAddress.toString());
+  #keyFor(contractAddress: AztecAddress, jobId: string): string {
+    return `${contractAddress.toString()}:${jobId}`;
   }
 
-  /** Mark a contract as synced for the current anchor block. */
-  markContractSynced(contractAddress: AztecAddress): void {
-    if (this.isContractSynced(contractAddress)) {
-      // This would indicate that a contract has been synced twice for the same anchor block which should never happen.
+  /** Check if a contract has been synced for the current anchor block and job. */
+  isContractSynced(contractAddress: AztecAddress, jobId: string): boolean {
+    return this.#syncedContracts.has(this.#keyFor(contractAddress, jobId));
+  }
+
+  /** Mark a contract as synced for the current anchor block and job. */
+  markContractSynced(contractAddress: AztecAddress, jobId: string): void {
+    const key = this.#keyFor(contractAddress, jobId);
+    if (this.#syncedContracts.has(key)) {
+      // This would indicate that a contract has been synced twice for the same anchor block and job which should never
+      // happen.
       throw new Error(
-        `Contract ${contractAddress.toString()} has already been marked as synced for the current anchor block. This is a PXE bug.`,
+        `Contract ${contractAddress.toString()} has already been marked as synced for the current anchor block and job ${jobId}. This is a PXE bug.`,
       );
     }
 
-    this.#syncedContracts.add(contractAddress.toString());
+    this.#syncedContracts.add(key);
   }
 
   async setHeader(header: BlockHeader): Promise<void> {


### PR DESCRIPTION
Before this PR we performed private state sync and contracts update check multiple times for 1 contract if more than 1 private function was invoked. That's just wasteful and for this reason I have implemented a simple mechanism to prevent this.

How the mechanism work is that I store the info of if a given contract was synced in `AnchorBlockSource` and I wipe it when new anchor block is set.

For the AMM test with sponsored fpc it resulted in a drop of roundtrips from 94 to 84 and for the same test with private fpc it dropped from 151 to 118 (33 roundtrips!).

The larger drop for the fpc case is expected because we use the same tokens in the FPC as we supply to the AMM - hence more private functions are invoked on the same contracts and a larger reduction in roundtrips.

Note that I would expect the time savings to potentially be even larger than what the roundtrip reduction would imply because the private state sync can be quite heavy (you have to run the simulator, then you query node a few times to sync the logs then you try to process them in Noir etc.).

Isn't this great?