### PR TITLE
fix(avm): Make the TS simulator lazy read calldata / return data

### DIFF
--- a/yarn-project/simulator/src/public/avm/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/avm/apps_tests/token.test.ts
@@ -79,6 +79,6 @@ describe('AVM simulator apps tests: TokenContract', () => {
       /*isStaticCall=*/ true,
     );
     expect(balResult.reverted).toBe(false);
-    expect(balResult.output).toEqual([new Fr(expectedBalance)]);
+    expect(balResult.output.readAll()).toEqual([new Fr(expectedBalance)]);
   };
 });

--- a/yarn-project/simulator/src/public/avm/avm_context.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_context.test.ts
@@ -1,6 +1,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
+import { CallDataArray } from './calldata.js';
 import { initContext } from './fixtures/initializers.js';
 import { allSameExcept } from './fixtures/utils.js';
 
@@ -21,7 +22,7 @@ describe('Avm Context', () => {
     context.machineState.pc = 20;
 
     const newAddress = await AztecAddress.random();
-    const newCalldata = [new Fr(1), new Fr(2)];
+    const newCalldata = new CallDataArray([new Fr(1), new Fr(2)]);
     const allocatedGas = { l2Gas: 2, daGas: 3 }; // How much of the current call gas we pass to the nested call
     const newContext = await context.createNestedContractCallContext(newAddress, newCalldata, allocatedGas, 'CALL');
 
@@ -49,7 +50,7 @@ describe('Avm Context', () => {
     context.machineState.pc = 20;
 
     const newAddress = await AztecAddress.random();
-    const newCalldata = [new Fr(1), new Fr(2)];
+    const newCalldata = new CallDataArray([new Fr(1), new Fr(2)]);
     const allocatedGas = { l2Gas: 2, daGas: 3 };
     const newContext = await context.createNestedContractCallContext(
       newAddress,

--- a/yarn-project/simulator/src/public/avm/avm_context.ts
+++ b/yarn-project/simulator/src/public/avm/avm_context.ts
@@ -1,4 +1,3 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
@@ -6,6 +5,7 @@ import type { AvmExecutionEnvironment } from './avm_execution_environment.js';
 import { type Gas, gasToGasLeft } from './avm_gas.js';
 import { AvmMachineState } from './avm_machine_state.js';
 import type { AvmSimulatorInterface } from './avm_simulator_interface.js';
+import type { CallData } from './calldata.js';
 
 /**
  * An execution context includes the information necessary to initiate AVM
@@ -45,7 +45,7 @@ export class AvmContext {
    */
   public async createNestedContractCallContext(
     address: AztecAddress,
-    calldata: Fr[],
+    calldata: CallData,
     allocatedGas: Gas,
     callType: 'CALL' | 'STATICCALL',
   ): Promise<AvmContext> {

--- a/yarn-project/simulator/src/public/avm/avm_contract_call_result.ts
+++ b/yarn-project/simulator/src/public/avm/avm_contract_call_result.ts
@@ -6,6 +6,7 @@ import { inspect } from 'util';
 
 import { createSimulationError } from '../../common/errors.js';
 import type { Gas as AvmGas } from './avm_gas.js';
+import type { ReturnData } from './calldata.js';
 import type { AvmRevertReason } from './errors.js';
 
 /**
@@ -14,14 +15,14 @@ import type { AvmRevertReason } from './errors.js';
 export class AvmContractCallResult {
   constructor(
     public reverted: boolean,
-    public output: Fr[],
+    public output: ReturnData,
     public gasLeft: AvmGas,
     public revertReason?: AvmRevertReason,
     public totalInstructions: number = 0, // including nested calls
   ) {}
 
   toString(): string {
-    let resultsStr = `reverted: ${this.reverted}, output: ${this.output}, gasLeft: ${inspect(
+    let resultsStr = `reverted: ${this.reverted}, output: ${this.output.bestEffortReadAll()}, gasLeft: ${inspect(
       this.gasLeft,
     )}, totalInstructions: ${this.totalInstructions}`;
     if (this.revertReason) {
@@ -31,10 +32,12 @@ export class AvmContractCallResult {
   }
 
   finalize(): AvmFinalizedCallResult {
-    const revertReason = this.revertReason ? createSimulationError(this.revertReason, this.output) : undefined;
+    const revertReason = this.revertReason
+      ? createSimulationError(this.revertReason, this.output.bestEffortReadAll())
+      : undefined;
     return new AvmFinalizedCallResult(
       this.reverted,
-      this.output,
+      this.output.bestEffortReadAll(),
       Gas.from(this.gasLeft),
       revertReason,
       this.totalInstructions,

--- a/yarn-project/simulator/src/public/avm/avm_contract_call_result.ts
+++ b/yarn-project/simulator/src/public/avm/avm_contract_call_result.ts
@@ -1,4 +1,3 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { SimulationError } from '@aztec/stdlib/errors';
 import { Gas } from '@aztec/stdlib/gas';
 
@@ -22,7 +21,7 @@ export class AvmContractCallResult {
   ) {}
 
   toString(): string {
-    let resultsStr = `reverted: ${this.reverted}, output: ${this.output.bestEffortReadAll()}, gasLeft: ${inspect(
+    let resultsStr = `reverted: ${this.reverted}, output: ${this.output.bestEffortReadAll(10)}${this.output.length() > 10 ? ' ...' : ''}, gasLeft: ${inspect(
       this.gasLeft,
     )}, totalInstructions: ${this.totalInstructions}`;
     if (this.revertReason) {
@@ -37,7 +36,7 @@ export class AvmContractCallResult {
       : undefined;
     return new AvmFinalizedCallResult(
       this.reverted,
-      this.output.bestEffortReadAll(),
+      this.output,
       Gas.from(this.gasLeft),
       revertReason,
       this.totalInstructions,
@@ -52,14 +51,14 @@ export class AvmContractCallResult {
 export class AvmFinalizedCallResult {
   constructor(
     public reverted: boolean,
-    public output: Fr[],
+    public output: ReturnData,
     public gasLeft: Gas,
     public revertReason?: SimulationError,
     public totalInstructions: number = 0, // including nested calls
   ) {}
 
   toString(): string {
-    let resultsStr = `reverted: ${this.reverted}, output: ${this.output}, gasLeft: ${inspect(
+    let resultsStr = `reverted: ${this.reverted}, output: ${this.output.bestEffortReadAll(10)}${this.output.length() > 10 ? ' ...' : ''}, gasLeft: ${inspect(
       this.gasLeft,
     )}, totalInstructions: ${this.totalInstructions}`;
     if (this.revertReason) {

--- a/yarn-project/simulator/src/public/avm/avm_execution_environment.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_execution_environment.test.ts
@@ -1,12 +1,13 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 
+import { CallDataArray } from './calldata.js';
 import { initExecutionEnvironment } from './fixtures/initializers.js';
 import { allSameExcept } from './fixtures/utils.js';
 
 describe('Execution Environment', () => {
   const newAddress = AztecAddress.fromNumber(123456);
-  const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+  const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
 
   it('New call should fork execution environment correctly', () => {
     const executionEnvironment = initExecutionEnvironment();

--- a/yarn-project/simulator/src/public/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/public/avm/avm_execution_environment.ts
@@ -3,6 +3,8 @@ import type { PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { GlobalVariables } from '@aztec/stdlib/tx';
 
+import type { CallData } from './calldata.js';
+
 /**
  * Contains variables that remain constant during AVM execution
  * These variables are provided by the public kernel circuit
@@ -15,13 +17,13 @@ export class AvmExecutionEnvironment {
     public readonly transactionFee: Fr,
     public readonly globals: GlobalVariables,
     public readonly isStaticCall: boolean,
-    public readonly calldata: Fr[],
+    public readonly calldata: CallData,
     public readonly config: PublicSimulatorConfig,
   ) {}
 
   private deriveEnvironmentForNestedCallInternal(
     targetAddress: AztecAddress,
-    calldata: Fr[],
+    calldata: CallData,
     isStaticCall: boolean,
   ): AvmExecutionEnvironment {
     return new AvmExecutionEnvironment(
@@ -36,11 +38,14 @@ export class AvmExecutionEnvironment {
     );
   }
 
-  public deriveEnvironmentForNestedCall(targetAddress: AztecAddress, calldata: Fr[]): AvmExecutionEnvironment {
+  public deriveEnvironmentForNestedCall(targetAddress: AztecAddress, calldata: CallData): AvmExecutionEnvironment {
     return this.deriveEnvironmentForNestedCallInternal(targetAddress, calldata, /*isStaticCall=*/ false);
   }
 
-  public deriveEnvironmentForNestedStaticCall(targetAddress: AztecAddress, calldata: Fr[]): AvmExecutionEnvironment {
+  public deriveEnvironmentForNestedStaticCall(
+    targetAddress: AztecAddress,
+    calldata: CallData,
+  ): AvmExecutionEnvironment {
     return this.deriveEnvironmentForNestedCallInternal(targetAddress, calldata, /*isStaticCall=*/ true);
   }
 }

--- a/yarn-project/simulator/src/public/avm/avm_machine_state.ts
+++ b/yarn-project/simulator/src/public/avm/avm_machine_state.ts
@@ -2,6 +2,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 
 import type { Gas } from './avm_gas.js';
 import { TaggedMemory } from './avm_memory_types.js';
+import { type ReturnData, ReturnDataArray } from './calldata.js';
 import { type AvmRevertReason, OutOfGasError } from './errors.js';
 
 /**
@@ -39,7 +40,7 @@ export class AvmMachineState {
   /** program counter of the next instruction, byte based */
   public nextPc: number = 0;
   /** return/revertdata of the last nested call. */
-  public nestedReturndata: Fr[] = [];
+  public nestedReturndata: ReturnData = new ReturnDataArray([]);
   /** Tracks whether the last external call was successful */
   public nestedCallSuccess: boolean = false;
   /**
@@ -66,7 +67,7 @@ export class AvmMachineState {
   /** Signals that execution has reverted normally (this does not cover exceptional halts) */
   private reverted: boolean = false;
   /** Output data must NOT be modified once it is set */
-  private output: Fr[] = [];
+  private output: ReturnData = new ReturnDataArray([]);
 
   // Metrics only - not needed for execution
   /** instruction counter, including nested calls */
@@ -129,7 +130,7 @@ export class AvmMachineState {
    * Output data must NOT be modified once it is set
    * @param output
    */
-  public return(output: Fr[]) {
+  public return(output: ReturnData) {
     this.halted = true;
     this.output = output;
   }
@@ -139,7 +140,7 @@ export class AvmMachineState {
    * Output data must NOT be modified once it is set
    * @param output
    */
-  public revert(output: Fr[]) {
+  public revert(output: ReturnData) {
     this.halted = true;
     this.reverted = true;
     this.output = output;
@@ -153,7 +154,7 @@ export class AvmMachineState {
     return this.reverted;
   }
 
-  public getOutput(): Fr[] {
+  public getOutput(): ReturnData {
     return this.output;
   }
 

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -865,7 +865,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(false);
 
         // returns the storage slot for modified key
-        const mapSlotNumber = results.output.read(0).toBigInt();
+        const mapSlotNumber = results.output.read(0)!.toBigInt();
         const mapSlot = new Fr(mapSlotNumber);
 
         expect(await context.persistableState.readStorage(address, mapSlot)).toEqual(value0);
@@ -884,7 +884,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(false);
 
         // returns the storage slot for modified key
-        const mapSlotNumber = results.output.read(0).toBigInt();
+        const mapSlotNumber = results.output.read(0)!.toBigInt();
         const mapSlot = new Fr(mapSlotNumber);
 
         expect(await context.persistableState.readStorage(address, mapSlot)).toEqual(value0);

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -41,6 +41,7 @@ import type { AvmContext } from './avm_context.js';
 import type { AvmExecutionEnvironment } from './avm_execution_environment.js';
 import { type MemoryValue, TypeTag, type Uint8, type Uint64 } from './avm_memory_types.js';
 import { AvmSimulator } from './avm_simulator.js';
+import { type CallData, CallDataArray } from './calldata.js';
 import { AvmRevertReason } from './errors.js';
 import {
   initContext,
@@ -96,11 +97,11 @@ const siloAddress = (contractAddress: AztecAddress) => {
 };
 
 describe('AVM simulator: injected bytecode', () => {
-  let calldata: Fr[];
+  let calldata: CallData;
   let bytecode: Buffer;
 
   beforeAll(() => {
-    calldata = [new Fr(1), new Fr(2)];
+    calldata = new CallDataArray([new Fr(1), new Fr(2)]);
     bytecode = encodeToBytecode([
       new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 0).as(Opcode.SET_8, Set.wireFormat8),
       new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
@@ -119,7 +120,7 @@ describe('AVM simulator: injected bytecode', () => {
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(3)]);
+    expect(results.output.readAll()).toEqual([new Fr(3)]);
   });
 
   it('Should halt if runs out of gas', async () => {
@@ -130,7 +131,7 @@ describe('AVM simulator: injected bytecode', () => {
 
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
     expect(results.reverted).toBe(true);
-    expect(results.output).toEqual([]);
+    expect(results.output.readAll()).toEqual([]);
     expect(results.revertReason?.message).toEqual('Not enough L2GAS gas left');
     expect(results.gasLeft.l2Gas).toEqual(0);
     expect(results.gasLeft.daGas).toEqual(0);
@@ -148,7 +149,7 @@ describe('AVM simulator: injected bytecode', () => {
     ]);
     const results = await new AvmSimulator(context).executeBytecode(badBytecode);
     expect(results.reverted).toBe(true);
-    expect(results.output).toEqual([]);
+    expect(results.output.readAll()).toEqual([]);
     expect(results.revertReason?.message).toMatch(/Tag mismatch/);
     expect(results.gasLeft.l2Gas).toEqual(0);
     expect(results.gasLeft.daGas).toEqual(0);
@@ -166,62 +167,62 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const results = await new AvmSimulator(context).execute();
 
     expect(results.reverted).toBe(true);
-    expect(results.output).toEqual([]);
+    expect(results.output.readAll()).toEqual([]);
     expect(results.gasLeft).toEqual({ l2Gas: 0, daGas: 0 });
   });
 
   it('addition', async () => {
-    const calldata: Fr[] = [new Fr(1), new Fr(2)];
+    const calldata = new CallDataArray([new Fr(1), new Fr(2)]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('add_args_return');
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(3)]);
+    expect(results.output.readAll()).toEqual([new Fr(3)]);
   });
 
   it('addition via dispatch', async () => {
-    const calldata: Fr[] = [
+    const calldata = new CallDataArray([
       (await FunctionSelector.fromSignature('add_args_return(Field,Field)')).toField(),
       new Fr(1),
       new Fr(2),
-    ];
+    ]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('public_dispatch');
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(3)]);
+    expect(results.output.readAll()).toEqual([new Fr(3)]);
   });
 
   it('get_args_hash via dispatch', async () => {
     const selector = await FunctionSelector.fromSignature('get_args_hash(u8,[Field;3])');
     const args = [new Fr(8), new Fr(1), new Fr(2), new Fr(3)];
-    const dispatchCalldata = [selector.toField(), ...args];
+    const dispatchCalldata = new CallDataArray([selector.toField(), ...args]);
 
     const context = initContext({ env: initExecutionEnvironment({ calldata: dispatchCalldata }) });
     const bytecode = getAvmTestContractBytecode('public_dispatch');
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([await computeVarArgsHash(args)]);
+    expect(results.output.readAll()).toEqual([await computeVarArgsHash(args)]);
   });
 
   it('modulo and u1', async () => {
-    const calldata: Fr[] = [new Fr(2)];
+    const calldata = new CallDataArray([new Fr(2)]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('modulo2');
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(0)]);
+    expect(results.output.readAll()).toEqual([new Fr(0)]);
   });
 
   it('Should handle calldata oracle', async () => {
-    const calldata: Fr[] = [new Fr(1), new Fr(2), new Fr(3), /* with_selector: */ new Fr(0)];
+    const calldata = new CallDataArray([new Fr(1), new Fr(2), new Fr(3), /* with_selector: */ new Fr(0)]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('assert_calldata_copy');
@@ -237,7 +238,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
+    expect(results.output.readAll()).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
   });
 
   it('Should handle revert oracle', async () => {
@@ -247,20 +248,20 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
     expect(results.reverted).toBe(true);
-    expect(results.output).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
+    expect(results.output.readAll()).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
   });
 
   it('ec_add should not revert', async () => {
     // This test performs the same doubling as in elliptic_curve_add_and_double
     // But the optimizer is not able to optimize out the addition
-    const calldata: Fr[] = [
+    const calldata = new CallDataArray([
       new Fr(1), // P1x
       new Fr(17631683881184975370165255887551781615748388533673675138860n), // P1y
       new Fr(0), // P1inf
       new Fr(1), // P2x
       new Fr(17631683881184975370165255887551781615748388533673675138860n), // P2y
       new Fr(0), // P2inf
-    ];
+    ]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('elliptic_curve_add');
@@ -277,17 +278,17 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
     expect(results.reverted).toBe(false);
     const g3 = await Grumpkin.mul(Grumpkin.generator, new Fq(3));
-    expect(results.output).toEqual([g3.x, g3.y, Fr.ZERO]);
+    expect(results.output.readAll()).toEqual([g3.x, g3.y, Fr.ZERO]);
   });
 
   describe('msm', () => {
     it('low scalars', async () => {
-      const calldata: Fr[] = [
+      const calldata = new CallDataArray([
         /* scalar lo */ new Fr(3),
         /* scalar hi */ new Fr(0),
         /* scalar2 lo */ new Fr(20),
         /* scalar2 hi */ new Fr(0),
-      ];
+      ]);
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('variable_base_msm');
@@ -297,16 +298,16 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const g3 = await Grumpkin.mul(Grumpkin.generator, new Fq(3));
       const g20 = await Grumpkin.mul(Grumpkin.generator, new Fq(20));
       const expectedResult = await Grumpkin.add(g3, g20);
-      expect(results.output).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
+      expect(results.output.readAll()).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
     });
 
     it('with a zero', async () => {
-      const calldata: Fr[] = [
+      const calldata = new CallDataArray([
         /* scalar lo */ new Fr(3),
         /* scalar hi */ new Fr(0),
         /* scalar2 lo */ new Fr(0),
         /* scalar2 hi */ new Fr(0),
-      ];
+      ]);
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('variable_base_msm');
@@ -314,7 +315,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       expect(results.reverted).toBe(false);
       const expectedResult = await Grumpkin.mul(Grumpkin.generator, new Fq(3));
-      expect(results.output).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
+      expect(results.output.readAll()).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
     });
 
     const fqToLimbs = (fq: Fq): [bigint, bigint] => {
@@ -329,7 +330,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const scalar = new Fq(Fq.MODULUS - 1n);
       const scalar2 = new Fq(Fq.MODULUS - 2n);
 
-      const calldata: Fr[] = [...fqToLimbs(scalar), ...fqToLimbs(scalar2)].map(bigint => new Fr(bigint));
+      const calldata = new CallDataArray([...fqToLimbs(scalar), ...fqToLimbs(scalar2)].map(bigint => new Fr(bigint)));
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('variable_base_msm');
@@ -339,12 +340,12 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const g1 = await Grumpkin.mul(Grumpkin.generator, scalar);
       const g2 = await Grumpkin.mul(Grumpkin.generator, scalar2);
       const expectedResult = await Grumpkin.add(g1, g2);
-      expect(results.output).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
+      expect(results.output.readAll()).toEqual([expectedResult.x, expectedResult.y, Fr.ZERO]);
     });
   });
 
   it('pedersen commitment operations', async () => {
-    const calldata: Fr[] = [new Fr(100), new Fr(1)];
+    const calldata = new CallDataArray([new Fr(100), new Fr(1)]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('pedersen_commit');
@@ -356,41 +357,43 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     // TODO: Come back to the handling of infinities when we confirm how they're handled in bb
     const isInf = expectedResult[0] === new Fr(0) && expectedResult[1] === new Fr(0);
     expectedResult.push(new Fr(isInf));
-    expect(results.output).toEqual(expectedResult);
+    expect(results.output.readAll()).toEqual(expectedResult);
   });
 
   it('conditional move operations', async () => {
-    const calldata: Fr[] = [new Fr(27), new Fr(28), new Fr(1)];
+    const calldataArray: Fr[] = [new Fr(27), new Fr(28), new Fr(1)];
 
     const bytecode = getAvmTestContractBytecode('conditional_move');
 
+    let calldata = new CallDataArray(calldataArray);
     let context = initContext({ env: initExecutionEnvironment({ calldata }) });
     let results = await new AvmSimulator(context).executeBytecode(bytecode);
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(27)]);
+    expect(results.output.readAll()).toEqual([new Fr(27)]);
 
-    calldata[2] = new Fr(0);
+    calldataArray[2] = new Fr(0);
+    calldata = new CallDataArray(calldataArray);
     context = initContext({ env: initExecutionEnvironment({ calldata }) });
     results = await new AvmSimulator(context).executeBytecode(bytecode);
     expect(results.reverted).toBe(false);
-    expect(results.output).toEqual([new Fr(28)]);
+    expect(results.output.readAll()).toEqual([new Fr(28)]);
   });
 
   describe('U128 addition and overflows', () => {
     it('U128 addition', async () => {
-      const calldata: Fr[] = [
+      const calldata = new CallDataArray([
         // First U128
         new Fr(1),
         // Second U128
         new Fr(2),
-      ];
+      ]);
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('add_u128');
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(3)]);
+      expect(results.output.readAll()).toEqual([new Fr(3)]);
     });
 
     it('Expect failure on U128::add() overflow', async () => {
@@ -399,13 +402,17 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(true);
       expect(results.revertReason).toBeDefined();
       expect(
-        resolveAvmTestContractAssertionMessage('u128_addition_overflow', results.revertReason!, results.output),
+        resolveAvmTestContractAssertionMessage(
+          'u128_addition_overflow',
+          results.revertReason!,
+          results.output.readAll(),
+        ),
       ).toMatch('attempt to add with overflow');
     });
   });
 
   it('Assertion message', async () => {
-    const calldata: Fr[] = [new Fr(20)];
+    const calldata = new CallDataArray([new Fr(20)]);
     const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
     const bytecode = getAvmTestContractBytecode('assert_nullifier_exists');
@@ -413,9 +420,13 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
     expect(results.reverted).toBe(true);
     expect(results.revertReason).toBeDefined();
-    expect(results.output).toHaveLength(1); // Error selector for static string error
+    expect(results.output.length()).toBe(1); // Error selector for static string error
     expect(
-      resolveAvmTestContractAssertionMessage('assert_nullifier_exists', results.revertReason!, results.output),
+      resolveAvmTestContractAssertionMessage(
+        'assert_nullifier_exists',
+        results.revertReason!,
+        results.output.readAll(),
+      ),
     ).toMatch("Nullifier doesn't exist!");
   });
 
@@ -433,7 +444,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(res)]);
+      expect(results.output.readAll()).toEqual([new Fr(res)]);
     });
   });
 
@@ -471,14 +482,14 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     ['pedersen_hash_with_index', /*input=*/ randomMemoryFields(10), /*output=*/ indexedPedersenFromMemoryFields],
   ])('Hashes in noir contracts', (name: string, input: MemoryValue[], output: (msg: any[]) => Promise<Fr[]>) => {
     it(`Should execute contract function that performs ${name} on input of length ${input.length}`, async () => {
-      const calldata = input.map(e => e.toFr());
+      const calldata = new CallDataArray(input.map(e => e.toFr()));
 
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
       const bytecode = getAvmGadgetsTestContractArtifact(name).bytecode;
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual(await output(input));
+      expect(results.output.readAll()).toEqual(await output(input));
     });
   });
 
@@ -536,13 +547,13 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(false);
 
       const returnData = results.output;
-      expect(returnData).toEqual([value]);
+      expect(returnData.readAll()).toEqual([value]);
     });
   });
 
   describe('conversions', () => {
     it('to le bytes', async () => {
-      const calldata: Fr[] = [new Fr(0x11223344556677)];
+      const calldata = new CallDataArray([new Fr(0x11223344556677)]);
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('to_le_bytes');
@@ -551,6 +562,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(false);
       expect(
         results.output
+          .readAll()
           .reverse()
           .map(f => f.toNumber().toString(16).padStart(2, '0'))
           .join(''),
@@ -558,7 +570,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     });
 
     it('to le bits', async () => {
-      const calldata: Fr[] = [new Fr(0b1011101010100)];
+      const calldata = new CallDataArray([new Fr(0b1011101010100)]);
       const context = initContext({ env: initExecutionEnvironment({ calldata }) });
 
       const bytecode = getAvmTestContractBytecode('to_le_bits');
@@ -567,6 +579,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       expect(results.reverted).toBe(false);
       expect(
         results.output
+          .readAll()
           .reverse()
           .map(f => f.toNumber().toString())
           .join(''),
@@ -608,7 +621,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const createContext = (calldata: Fr[] = []) => {
       return initContext({
         persistableState,
-        env: initExecutionEnvironment({ address, sender, calldata }),
+        env: initExecutionEnvironment({ address, sender, calldata: new CallDataArray(calldata) }),
       });
     };
 
@@ -635,7 +648,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([expectFound ? Fr.ONE : Fr.ZERO]);
+        expect(results.output.readAll()).toEqual([expectFound ? Fr.ONE : Fr.ZERO]);
       });
     });
 
@@ -652,7 +665,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([exists ? Fr.ONE : Fr.ZERO]);
+        expect(results.output.readAll()).toEqual([exists ? Fr.ONE : Fr.ZERO]);
       });
     });
 
@@ -680,7 +693,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([expectFound ? Fr.ONE : Fr.ZERO]);
+        expect(results.output.readAll()).toEqual([expectFound ? Fr.ONE : Fr.ZERO]);
       });
     });
 
@@ -692,7 +705,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([]);
+      expect(results.output.readAll()).toEqual([]);
 
       expect(trace.traceNewNoteHash).toHaveBeenCalledTimes(1);
       const siloedNotehash = await siloNoteHash(address, value0);
@@ -708,7 +721,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([]);
+      expect(results.output.readAll()).toEqual([]);
 
       expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1);
       expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
@@ -793,7 +806,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0]);
+        expect(results.output.readAll()).toEqual([value0]);
       });
 
       it('Should set and read a value from storage (single)', async () => {
@@ -804,7 +817,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0]);
+        expect(results.output.readAll()).toEqual([value0]);
 
         expect(trace.tracePublicStorageWrite).toHaveBeenCalledTimes(1);
         expect(trace.tracePublicStorageWrite).toHaveBeenCalledWith(address, slot, value0, false);
@@ -839,7 +852,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0, value1]);
+        expect(results.output.readAll()).toEqual([value0, value1]);
       });
 
       it('Should set a value in storage (map)', async () => {
@@ -852,7 +865,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(false);
 
         // returns the storage slot for modified key
-        const mapSlotNumber = results.output[0].toBigInt();
+        const mapSlotNumber = results.output.read(0).toBigInt();
         const mapSlot = new Fr(mapSlotNumber);
 
         expect(await context.persistableState.readStorage(address, mapSlot)).toEqual(value0);
@@ -871,7 +884,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(false);
 
         // returns the storage slot for modified key
-        const mapSlotNumber = results.output[0].toBigInt();
+        const mapSlotNumber = results.output.read(0).toBigInt();
         const mapSlot = new Fr(mapSlotNumber);
 
         expect(await context.persistableState.readStorage(address, mapSlot)).toEqual(value0);
@@ -889,7 +902,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0]);
+        expect(results.output.readAll()).toEqual([value0]);
       });
     });
 
@@ -941,7 +954,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(callBytecode);
         expect(results.reverted).toBe(true);
-        expect(results.output).toEqual([]);
+        expect(results.output.readAll()).toEqual([]);
       });
 
       it(`Nested call`, async () => {
@@ -962,7 +975,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(callBytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0.add(value1)]);
+        expect(results.output.readAll()).toEqual([value0.add(value1)]);
       });
 
       it(`Nested static call`, async () => {
@@ -983,7 +996,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(callBytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0.add(value1)]);
+        expect(results.output.readAll()).toEqual([value0.add(value1)]);
       });
 
       it(`Nested call with not enough gas (expect failure)`, async () => {
@@ -1054,7 +1067,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.reverted).toBe(true); // The outer call should revert.
         expect(results.revertReason).toBeDefined();
         expect(
-          resolveAvmTestContractAssertionMessage('public_dispatch', results.revertReason!, results.output),
+          resolveAvmTestContractAssertionMessage('public_dispatch', results.revertReason!, results.output.readAll()),
         ).toMatch('Values are not equal');
       });
 
@@ -1114,7 +1127,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         const context = initContext({ persistableState });
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(true);
-        expect(results.output).toEqual([]);
+        expect(results.output.readAll()).toEqual([]);
         expect(results.revertReason?.message).toMatch('Reached the limit');
       });
     });
@@ -1125,7 +1138,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         env: initExecutionEnvironment({
           address,
           sender,
-          calldata: [],
+          calldata: new CallDataArray([]),
           config: PublicSimulatorConfig.from({ collectDebugLogs: true }),
         }),
       });
@@ -1133,7 +1146,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([]);
+      expect(results.output.readAll()).toEqual([]);
       expect(trace.traceDebugLog).toHaveBeenCalledTimes(6);
       expect(trace.traceDebugLog).toHaveBeenCalledWith(address, 'debug', 'just text', []);
       expect(trace.traceDebugLog).toHaveBeenCalledWith(address, 'debug', 'second: {1}', [
@@ -1217,7 +1230,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const createContext = (calldata: Fr[] = []) => {
       return initContext({
         persistableState,
-        env: initExecutionEnvironment({ address, sender, calldata }),
+        env: initExecutionEnvironment({ address, sender, calldata: new CallDataArray(calldata) }),
       });
     };
 
@@ -1229,7 +1242,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([]);
+        expect(results.output.readAll()).toEqual([]);
 
         expect(trace.traceNewNoteHash).toHaveBeenCalledTimes(1);
         expect(trace.traceNewNoteHash).toHaveBeenCalledWith(uniqueNoteHash0);
@@ -1243,7 +1256,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([/*exists=*/ Fr.ZERO]);
+        expect(results.output.readAll()).toEqual([/*exists=*/ Fr.ZERO]);
       });
       it('Note hash check properly returns exists=true', async () => {
         const leafIndex = (await treesDB.getTreeSnapshots()).noteHashTree.nextAvailableLeafIndex;
@@ -1255,7 +1268,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([/*exists=*/ Fr.ONE]);
+        expect(results.output.readAll()).toEqual([/*exists=*/ Fr.ONE]);
       });
     });
     describe('Nullifiers', () => {
@@ -1266,7 +1279,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([]);
+        expect(results.output.readAll()).toEqual([]);
 
         expect(trace.traceNewNullifier).toHaveBeenCalledTimes(1);
         expect(trace.traceNewNullifier).toHaveBeenCalledWith(siloedNullifier0);
@@ -1278,7 +1291,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([/*exists=*/ Fr.ZERO]);
+        expect(results.output.readAll()).toEqual([/*exists=*/ Fr.ZERO]);
       });
       it('Nullifier check properly returns exists=true', async () => {
         const calldata = [value0];
@@ -1288,7 +1301,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([/*exists=*/ Fr.ONE]);
+        expect(results.output.readAll()).toEqual([/*exists=*/ Fr.ONE]);
       });
     });
     describe('Public storage accesses', () => {
@@ -1312,7 +1325,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([Fr.zero()]);
+        expect(results.output.readAll()).toEqual([Fr.zero()]);
       });
 
       it('Should read value in storage (single) - written before, leaf exists', async () => {
@@ -1323,7 +1336,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0]);
+        expect(results.output.readAll()).toEqual([value0]);
       });
 
       it('Should set and read value in storage (single)', async () => {
@@ -1333,7 +1346,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
         expect(results.reverted).toBe(false);
-        expect(results.output).toEqual([value0]);
+        expect(results.output.readAll()).toEqual([value0]);
 
         expect(trace.tracePublicStorageWrite).toHaveBeenCalledTimes(1);
         expect(trace.tracePublicStorageWrite).toHaveBeenCalledWith(address, slot0, value0, false);
@@ -1342,7 +1355,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
   });
 
   it('should be able to execute contracts that only have private functions', async () => {
-    const context = initContext({ env: initExecutionEnvironment({ calldata: [] }) });
+    const context = initContext({ env: initExecutionEnvironment({ calldata: new CallDataArray([]) }) });
 
     // NoteGetter contract is a private only contract (no public functions)
     const counterDispatch = getContractFunctionArtifact(
@@ -1358,7 +1371,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       resolveContractAssertionMessage(
         'public_dispatch',
         results.revertReason!,
-        results.output,
+        results.output.readAll(),
         NoteGetterContract.artifact,
       ),
     ).toMatch('No public functions');
@@ -1397,7 +1410,7 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(0)]);
+      expect(results.output.readAll()).toEqual([new Fr(0)]);
     });
 
     it('Should handle shift amount equal to bit size (Uint128)', async () => {
@@ -1424,7 +1437,7 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(0)]);
+      expect(results.output.readAll()).toEqual([new Fr(0)]);
     });
   });
 
@@ -1453,7 +1466,7 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(0)]);
+      expect(results.output.readAll()).toEqual([new Fr(0)]);
     });
 
     it('Should handle shift amount equal to bit size (Uint128)', async () => {
@@ -1480,7 +1493,7 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(0)]);
+      expect(results.output.readAll()).toEqual([new Fr(0)]);
     });
 
     it('Should handle shift amount equal to bit size (Uint32)', async () => {
@@ -1507,7 +1520,7 @@ describe('AVM simulator: shift operations with huge amounts', () => {
       const results = await new AvmSimulator(context).executeBytecode(bytecode);
 
       expect(results.reverted).toBe(false);
-      expect(results.output).toEqual([new Fr(0)]);
+      expect(results.output.readAll()).toEqual([new Fr(0)]);
     });
   });
 });

--- a/yarn-project/simulator/src/public/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.ts
@@ -15,6 +15,7 @@ import { AvmExecutionEnvironment } from './avm_execution_environment.js';
 import type { Gas } from './avm_gas.js';
 import { AvmMachineState } from './avm_machine_state.js';
 import type { AvmSimulatorInterface } from './avm_simulator_interface.js';
+import { type CallData, ReturnDataArray } from './calldata.js';
 import { AvmRevertReason, InvalidProgramCounterError } from './errors.js';
 import type { Instruction } from './opcodes/instruction.js';
 import { revertReasonFromExceptionalHalt, revertReasonFromExplicitRevert } from './revert_reason.js';
@@ -49,7 +50,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
     // This will be used by the CALL opcode to create a new simulator. It is required to
     // avoid a dependency cycle.
     context.provideSimulator = AvmSimulator.build;
-    this.log = createLogger(`simulator:avm(calldata[0]: ${context.environment.calldata[0]})`);
+    this.log = createLogger(`simulator:avm(calldata[0]: ${context.environment.calldata.read(0)})`);
     // Turn on tallying if explicitly enabled or if trace logging
     if (enableTallying || this.log.isLevelEnabled('trace')) {
       this.tallyPrintFunction = this.printOpcodeTallies;
@@ -74,7 +75,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
     transactionFee: Fr,
     globals: GlobalVariables,
     isStaticCall: boolean,
-    calldata: Fr[],
+    calldata: CallData,
     allocatedGas: Gas,
     config: PublicSimulatorConfig,
   ) {
@@ -183,7 +184,9 @@ export class AvmSimulator implements AvmSimulatorInterface {
 
       const output = machineState.getOutput();
       const reverted = machineState.getReverted();
-      const revertReason = reverted ? await revertReasonFromExplicitRevert(output, this.context) : undefined;
+      const revertReason = reverted
+        ? await revertReasonFromExplicitRevert(output.bestEffortReadAll(), this.context)
+        : undefined;
       const results = new AvmContractCallResult(
         reverted,
         output,
@@ -220,7 +223,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
       // Note: "exceptional halts" cannot return data, hence [].
       const results = new AvmContractCallResult(
         /*reverted=*/ true,
-        /*output=*/ [],
+        /*output=*/ new ReturnDataArray([]),
         noGasLeft,
         revertReason,
         machineState.instrCounter,
@@ -250,7 +253,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
     this.log.warn(message);
     return new AvmContractCallResult(
       /*reverted=*/ true,
-      /*output=*/ [],
+      /*output=*/ new ReturnDataArray([]),
       /*gasLeft=*/ { l2Gas: 0, daGas: 0 }, // consumes all allocated gas
       revertReason,
     );

--- a/yarn-project/simulator/src/public/avm/calldata.test.ts
+++ b/yarn-project/simulator/src/public/avm/calldata.test.ts
@@ -1,0 +1,75 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+
+import { Field, TaggedMemory } from './avm_memory_types.js';
+import { LazyReaderArray, LazyReaderMemory } from './calldata.js';
+
+describe('LazyReader test suite', () => {
+  describe('LazyReaderArray', () => {
+    it('LazyReaderArray respects readCap in bestEffortReadAll', () => {
+      const data = [new Fr(1), new Fr(2), new Fr(3), new Fr(4), new Fr(5)];
+      const reader = new LazyReaderArray(data);
+      expect(reader.bestEffortReadAll(3)).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
+    });
+  });
+  describe('LazyReaderMemory', () => {
+    it('LazyReaderMemory respects readCap in bestEffortReadAll', () => {
+      const memory = new TaggedMemory();
+      memory.setSlice(10, [new Field(1n), new Field(2n), new Field(3n), new Field(4n), new Field(5n)]);
+      const reader = new LazyReaderMemory(memory, 10, 5);
+      expect(reader.bestEffortReadAll(3)).toEqual([new Fr(1), new Fr(2), new Fr(3)]);
+    });
+
+    it('LazyReaderMemory caps bestEffortReadAll at memory bounds', () => {
+      const memory = new TaggedMemory();
+      const nearEnd = TaggedMemory.MAX_MEMORY_SIZE - 2;
+      memory.set(nearEnd, new Field(42n));
+      memory.set(nearEnd + 1, new Field(43n));
+      // Request size 100, but only 2 elements fit before MAX_MEMORY_SIZE
+      const reader = new LazyReaderMemory(memory, nearEnd, 100);
+      expect(reader.bestEffortReadAll()).toHaveLength(2);
+    });
+
+    it('LazyReaderMemory caps bestEffortReadAll at default cap (10000)', () => {
+      const memory = new TaggedMemory();
+      memory.set(0, new Field(1n));
+      memory.set(14999, new Field(2n));
+      const reader = new LazyReaderMemory(memory, 0, 15000);
+      expect(reader.bestEffortReadAll()).toHaveLength(10000);
+    });
+
+    it('LazyReaderMemory slice applies offset correctly', () => {
+      const memory = new TaggedMemory();
+      // Data at memory positions 100-104
+      memory.setSlice(100, [new Field(10n), new Field(20n), new Field(30n), new Field(40n), new Field(50n)]);
+      const reader = new LazyReaderMemory(memory, 100, 5);
+      // slice(1, 4) should read memory positions 101-103
+      expect(reader.slice(1, 4)).toEqual([new Fr(20), new Fr(30), new Fr(40)]);
+    });
+
+    it('LazyReaderMemory slice trims result when end exceeds size', () => {
+      const memory = new TaggedMemory();
+      memory.setSlice(0, [new Field(1n), new Field(2n), new Field(3n), new Field(4n), new Field(5n)]);
+      const reader = new LazyReaderMemory(memory, 0, 5);
+      // Request slice(2, 10) but size is only 5, should return only elements 2-4
+      expect(reader.slice(2, 10)).toEqual([new Fr(3), new Fr(4), new Fr(5)]);
+    });
+
+    it('LazyReaderMemory slice returns empty when start >= size', () => {
+      const memory = new TaggedMemory();
+      memory.setSlice(0, [new Field(1n), new Field(2n), new Field(3n)]);
+      const reader = new LazyReaderMemory(memory, 0, 3);
+      // Start beyond size should return empty, like array.slice(5, 10) on a 3-element array
+      expect(reader.slice(5, 10)).toEqual([]);
+    });
+
+    it('LazyReaderMemory handles empty reader (size = 0)', () => {
+      const memory = new TaggedMemory();
+      memory.set(0, new Field(999n)); // Data exists but reader has size 0
+      const reader = new LazyReaderMemory(memory, 0, 0);
+      expect(reader.length()).toBe(0);
+      expect(reader.readAll()).toEqual([]);
+      expect(reader.bestEffortReadAll()).toEqual([]);
+      expect(reader.slice(0, 5)).toEqual([]);
+    });
+  });
+});

--- a/yarn-project/simulator/src/public/avm/calldata.ts
+++ b/yarn-project/simulator/src/public/avm/calldata.ts
@@ -8,7 +8,7 @@ const DEFAULT_BEST_EFFORT_READ_CAP = 10000;
 export interface LazyReader {
   bestEffortReadAll(readCap?: number): Fr[];
   readAll(): Fr[];
-  read(idx: number): Fr;
+  read(idx: number): Fr | undefined;
   slice(start: number, end: number): Fr[];
   length(): number;
 }
@@ -25,7 +25,10 @@ export class LazyReaderMemory implements LazyReader {
     return this.memory.getSlice(this.offset, size).map(word => word.toFr());
   }
 
-  public read(idx: number): Fr {
+  public read(idx: number): Fr | undefined {
+    if (idx >= this.size) {
+      return undefined;
+    }
     return this.memory.get(this.offset + idx).toFr();
   }
 
@@ -51,7 +54,7 @@ export class LazyReaderArray implements LazyReader {
     return this.array.slice(0, readCap);
   }
 
-  public read(idx: number): Fr {
+  public read(idx: number): Fr | undefined {
     return this.array[idx];
   }
 

--- a/yarn-project/simulator/src/public/avm/calldata.ts
+++ b/yarn-project/simulator/src/public/avm/calldata.ts
@@ -2,9 +2,10 @@ import type { Fr } from '@aztec/foundation/schemas';
 
 import { TaggedMemory } from './avm_memory_types.js';
 
-const DEFAULT_BEST_EFFORT_READ_CAP = 3000;
+// Allow reading up to 300 kB of return data when unspecified.
+const DEFAULT_BEST_EFFORT_READ_CAP = 10000;
 
-interface LazyReader {
+export interface LazyReader {
   bestEffortReadAll(readCap?: number): Fr[];
   readAll(): Fr[];
   read(idx: number): Fr;
@@ -12,7 +13,7 @@ interface LazyReader {
   length(): number;
 }
 
-class LazyReaderMemory implements LazyReader {
+export class LazyReaderMemory implements LazyReader {
   constructor(
     private memory: TaggedMemory,
     private offset: number,
@@ -29,7 +30,9 @@ class LazyReaderMemory implements LazyReader {
   }
 
   public slice(start: number, end: number): Fr[] {
-    return this.memory.getSlice(this.offset + start, end - start).map(word => word.toFr());
+    const clampedEnd = Math.min(end, this.size);
+    const length = Math.max(0, clampedEnd - start);
+    return this.memory.getSlice(this.offset + start, length).map(word => word.toFr());
   }
 
   public readAll(): Fr[] {
@@ -41,7 +44,7 @@ class LazyReaderMemory implements LazyReader {
   }
 }
 
-class LazyReaderArray implements LazyReader {
+export class LazyReaderArray implements LazyReader {
   constructor(private array: Fr[]) {}
 
   public bestEffortReadAll(readCap = DEFAULT_BEST_EFFORT_READ_CAP): Fr[] {

--- a/yarn-project/simulator/src/public/avm/calldata.ts
+++ b/yarn-project/simulator/src/public/avm/calldata.ts
@@ -1,0 +1,94 @@
+import type { Fr } from '@aztec/foundation/schemas';
+
+import { TaggedMemory } from './avm_memory_types.js';
+
+const DEFAULT_BEST_EFFORT_READ_CAP = 3000;
+
+interface LazyReader {
+  bestEffortReadAll(readCap?: number): Fr[];
+  readAll(): Fr[];
+  read(idx: number): Fr;
+  slice(start: number, end: number): Fr[];
+  length(): number;
+}
+
+class LazyReaderMemory implements LazyReader {
+  constructor(
+    private memory: TaggedMemory,
+    private offset: number,
+    private size: number,
+  ) {}
+
+  public bestEffortReadAll(readCap = DEFAULT_BEST_EFFORT_READ_CAP): Fr[] {
+    const size = Math.min(this.size, readCap, TaggedMemory.MAX_MEMORY_SIZE - this.offset);
+    return this.memory.getSlice(this.offset, size).map(word => word.toFr());
+  }
+
+  public read(idx: number): Fr {
+    return this.memory.get(this.offset + idx).toFr();
+  }
+
+  public slice(start: number, end: number): Fr[] {
+    return this.memory.getSlice(this.offset + start, end - start).map(word => word.toFr());
+  }
+
+  public readAll(): Fr[] {
+    return this.memory.getSlice(this.offset, this.size).map(word => word.toFr());
+  }
+
+  public length(): number {
+    return this.size;
+  }
+}
+
+class LazyReaderArray implements LazyReader {
+  constructor(private array: Fr[]) {}
+
+  public bestEffortReadAll(readCap = DEFAULT_BEST_EFFORT_READ_CAP): Fr[] {
+    return this.array.slice(0, readCap);
+  }
+
+  public read(idx: number): Fr {
+    return this.array[idx];
+  }
+
+  public slice(start: number, end: number): Fr[] {
+    return this.array.slice(start, end);
+  }
+
+  public readAll(): Fr[] {
+    return this.array;
+  }
+
+  public length(): number {
+    return this.array.length;
+  }
+}
+
+// Compile time branding to avoid swapping CallData and ReturnData by accident.
+declare const CallDataBrand: unique symbol;
+declare const ReturnDataBrand: unique symbol;
+
+export type CallData = LazyReader & {
+  readonly [CallDataBrand]: true;
+};
+
+export type ReturnData = LazyReader & {
+  readonly [ReturnDataBrand]: true;
+};
+
+export class CallDataArray extends LazyReaderArray implements CallData {
+  declare readonly [CallDataBrand]: true;
+}
+
+export class CallDataMemory extends LazyReaderMemory implements CallData {
+  declare readonly [CallDataBrand]: true;
+}
+
+export class ReturnDataArray extends LazyReaderArray implements ReturnData {
+  declare readonly [ReturnDataBrand]: true;
+}
+
+export class ReturnDataMemory extends LazyReaderMemory implements ReturnData {
+  declare readonly [ReturnDataBrand]: true;
+}

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -13,6 +13,7 @@ import { SimpleContractDataSource } from '../../fixtures/simple_contract_data_so
 import { PublicContractsDB, PublicTreesDB } from '../../public_db_sources.js';
 import { PublicPersistableStateManager } from '../../state_manager/state_manager.js';
 import { AvmSimulator } from '../avm_simulator.js';
+import { CallDataArray } from '../calldata.js';
 import { BaseAvmSimulationTester } from './base_avm_simulation_tester.js';
 import { initContext, initExecutionEnvironment } from './initializers.js';
 import {
@@ -89,7 +90,7 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
       collectCallMetadata: true,
     });
     const environment = initExecutionEnvironment({
-      calldata,
+      calldata: new CallDataArray(calldata),
       globals,
       address,
       sender,
@@ -105,7 +106,12 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
     if (result.reverted) {
       this.logger.error(`Error in ${fnName}:`);
       this.logger.error(
-        resolveContractAssertionMessage(fnName, result.revertReason!, result.output, contractArtifact)!,
+        resolveContractAssertionMessage(
+          fnName,
+          result.revertReason!,
+          result.output.bestEffortReadAll(),
+          contractArtifact,
+        )!,
       );
     } else {
       this.logger.info(`Simulation of function ${fnName} succeeded!`);

--- a/yarn-project/simulator/src/public/avm/fixtures/initializers.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/initializers.ts
@@ -19,6 +19,7 @@ import { AvmContext } from '../avm_context.js';
 import { AvmExecutionEnvironment } from '../avm_execution_environment.js';
 import { AvmMachineState } from '../avm_machine_state.js';
 import { AvmSimulator } from '../avm_simulator.js';
+import { CallDataArray } from '../calldata.js';
 import { DEFAULT_TIMESTAMP } from './utils.js';
 
 /**
@@ -70,7 +71,7 @@ export function initExecutionEnvironment(overrides?: Partial<AvmExecutionEnviron
     overrides?.transactionFee ?? Fr.zero(),
     overrides?.globals ?? GlobalVariables.empty(),
     overrides?.isStaticCall ?? false,
-    overrides?.calldata ?? [],
+    overrides?.calldata ?? new CallDataArray([]),
     overrides?.config ?? PublicSimulatorConfig.empty(),
   );
 }

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -230,7 +230,7 @@ describe('External Calls', () => {
 
       const retValues = context.machineState.nestedReturndata;
       expect(retValues.length()).toBe(1);
-      expect(retValues.read(0).toBigInt()).toBeLessThan(initialL2Gas);
+      expect(retValues.read(0)!.toBigInt()).toBeLessThan(initialL2Gas);
 
       expect(context.machineState.l2GasLeft).toBeLessThan(initialL2Gas);
       expect(context.machineState.daGasLeft).toBeLessThanOrEqual(initialDaGas);

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -107,7 +107,7 @@ describe('External Calls', () => {
       expect(successValue).toEqual(new Uint1(0n)); // failure, contract non-existent!
 
       const retValue = context.machineState.nestedReturndata;
-      expect(retValue).toEqual([]);
+      expect(retValue.readAll()).toEqual([]);
 
       // should charge for the CALL instruction itself, and all allocated gas should be consumed
       expect(context.machineState.l2GasLeft).toBeLessThan(initialL2Gas - l2Gas);
@@ -169,7 +169,7 @@ describe('External Calls', () => {
       expect(successValue).toEqual(new Uint1(1n));
 
       const retValue = context.machineState.nestedReturndata;
-      expect(retValue).toEqual([new Fr(1n), new Fr(2n)]);
+      expect(retValue.readAll()).toEqual([new Fr(1n), new Fr(2n)]);
 
       expect(context.machineState.l2GasLeft).toBeLessThan(initialL2Gas);
       expect(context.machineState.daGasLeft).toBeLessThanOrEqual(initialDaGas);
@@ -229,8 +229,8 @@ describe('External Calls', () => {
       expect(successValue).toEqual(new Uint1(1n));
 
       const retValues = context.machineState.nestedReturndata;
-      expect(retValues).toHaveLength(1);
-      expect(retValues[0].toBigInt()).toBeLessThan(initialL2Gas);
+      expect(retValues.length()).toBe(1);
+      expect(retValues.read(0).toBigInt()).toBeLessThan(initialL2Gas);
 
       expect(context.machineState.l2GasLeft).toBeLessThan(initialL2Gas);
       expect(context.machineState.daGasLeft).toBeLessThanOrEqual(initialDaGas);
@@ -335,7 +335,7 @@ describe('External Calls', () => {
 
       expect(context.machineState.getHalted()).toBe(true);
       expect(context.machineState.getReverted()).toBe(false);
-      expect(context.machineState.getOutput()).toEqual(returnData);
+      expect(context.machineState.getOutput().readAll()).toEqual(returnData);
     });
   });
 
@@ -368,7 +368,7 @@ describe('External Calls', () => {
 
       expect(context.machineState.getHalted()).toBe(true);
       expect(context.machineState.getReverted()).toBe(true);
-      expect(context.machineState.getOutput()).toEqual(returnData.map(f => f.toFr()));
+      expect(context.machineState.getOutput().readAll()).toEqual(returnData.map(f => f.toFr()));
     });
   });
 

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
@@ -1,6 +1,7 @@
 import type { AvmContext } from '../avm_context.js';
 import type { AvmContractCallResult } from '../avm_contract_call_result.js';
 import { type Field, TypeTag, Uint1 } from '../avm_memory_types.js';
+import { CallDataMemory, ReturnDataMemory } from '../calldata.js';
 import { Opcode, OperandType } from '../serialization/instruction_serialization.js';
 import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
@@ -45,8 +46,8 @@ abstract class ExternalCall extends Instruction {
     memory.checkTag(TypeTag.UINT32, argsSizeOffset);
 
     const calldataSize = memory.get(argsSizeOffset).toNumber();
-    // This is a DOS vector. CalldataSize is chosen by the bytecode, and can be arbitrarily large leading to a OOM here.
-    const calldata = memory.getSlice(argsOffset, calldataSize).map(f => f.toFr());
+
+    const calldata = new CallDataMemory(memory, argsOffset, calldataSize);
 
     const callAddress = memory.getAs<Field>(addrOffset);
     // If we are already in a static call, we propagate the environment.
@@ -73,8 +74,8 @@ abstract class ExternalCall extends Instruction {
     const success = !nestedCallResults.reverted;
 
     // Save return/revert data for later.
-    const fullReturnData = nestedCallResults.output;
-    context.machineState.nestedReturndata = fullReturnData;
+    const returnData = nestedCallResults.output;
+    context.machineState.nestedReturndata = returnData;
 
     // Track the success status directly
     context.machineState.nestedCallSuccess = success;
@@ -89,7 +90,7 @@ abstract class ExternalCall extends Instruction {
     // (in Noir code).
     if (!success) {
       context.machineState.collectedRevertInfo = {
-        revertDataRepresentative: fullReturnData,
+        revertDataRepresentative: returnData.bestEffortReadAll(),
         recursiveRevertReason: nestedCallResults.revertReason!,
       };
     }
@@ -195,7 +196,7 @@ export class Return extends Instruction {
     memory.checkTag(TypeTag.UINT32, returnSizeOffset);
     const returnSize = memory.get(returnSizeOffset).toNumber();
 
-    const output = memory.getSlice(returnOffset, returnSize).map(word => word.toFr());
+    const output = new ReturnDataMemory(memory, returnOffset, returnSize);
 
     context.machineState.return(output);
   }
@@ -243,7 +244,7 @@ export class Revert extends Instruction {
 
     memory.checkTag(TypeTag.UINT32, retSizeOffset);
     const retSize = memory.get(retSizeOffset).toNumber();
-    const output = memory.getSlice(returnOffset, retSize).map(word => word.toFr());
+    const output = new ReturnDataMemory(memory, returnOffset, retSize);
 
     context.machineState.revert(output);
   }

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
@@ -8,6 +8,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 
 import type { AvmContext } from '../avm_context.js';
 import { Field, TaggedMemory, TypeTag, Uint8, Uint16, Uint32, Uint64, Uint128 } from '../avm_memory_types.js';
+import { CallDataArray, ReturnDataArray } from '../calldata.js';
 import { MemorySliceOutOfRangeError } from '../errors.js';
 import { initContext, initExecutionEnvironment } from '../fixtures/initializers.js';
 import { Opcode } from '../serialization/instruction_serialization.js';
@@ -407,7 +408,7 @@ describe('Memory instructions', () => {
     });
 
     it('Writes nothing if size is 0', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(0)); // cdoffset
       context.machineState.memory.set(1, new Uint32(0)); // size
@@ -422,7 +423,7 @@ describe('Memory instructions', () => {
     });
 
     it('Copies all calldata', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(0)); // cdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
@@ -436,7 +437,7 @@ describe('Memory instructions', () => {
     });
 
     it('Copies slice of calldata', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(1)); // cdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
@@ -450,7 +451,7 @@ describe('Memory instructions', () => {
     });
 
     it('Should return error when memory slice calldatacopy target is out-of-range', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(0)); // cdStart = 0
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
@@ -466,7 +467,7 @@ describe('Memory instructions', () => {
     });
 
     it('Should pad with zeros when the calldata slice is out-of-range', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(2)); // cdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
@@ -483,7 +484,7 @@ describe('Memory instructions', () => {
     });
 
     it('Should charge dynamic gas', async () => {
-      const calldata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      const calldata = new CallDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context = initContext({ env: initExecutionEnvironment({ calldata }) });
       context.machineState.memory.set(0, new Uint32(0)); // cdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
@@ -515,7 +516,7 @@ describe('Memory instructions', () => {
 
     it('Writes size', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
 
       await new ReturndataSize(/*addressing_mode=*/ 0, /*dstOffset=*/ 10).execute(context);
 
@@ -546,7 +547,7 @@ describe('Memory instructions', () => {
 
     it('Writes nothing if size is 0', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(0)); // rdoffset
       context.machineState.memory.set(1, new Uint32(0)); // size
       context.machineState.memory.set(3, new Uint16(12)); // not overwritten
@@ -561,7 +562,7 @@ describe('Memory instructions', () => {
 
     it('Copies all returndata', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(0)); // rdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
 
@@ -575,7 +576,7 @@ describe('Memory instructions', () => {
 
     it('Copies slice of returndata', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(1)); // rdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
 
@@ -589,7 +590,7 @@ describe('Memory instructions', () => {
 
     it('Should return error when memory slice target is out-of-range', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(1)); // rdStart = 1
       context.machineState.memory.set(1, new Uint32(2)); // copySize = 2
 
@@ -605,7 +606,7 @@ describe('Memory instructions', () => {
 
     it('Should pad with zeros when returndata slice is out-of-range', async () => {
       context = initContext();
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(2)); // rdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
 
@@ -623,7 +624,7 @@ describe('Memory instructions', () => {
     it('Should charge dynamic gas', async () => {
       context = initContext();
       const size = 3;
-      context.machineState.nestedReturndata = [new Fr(1n), new Fr(2n), new Fr(3n)];
+      context.machineState.nestedReturndata = new ReturnDataArray([new Fr(1n), new Fr(2n), new Fr(3n)]);
       context.machineState.memory.set(0, new Uint32(0)); // rdoffset
       context.machineState.memory.set(1, new Uint32(size)); // size
 

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.ts
@@ -242,7 +242,7 @@ export class ReturndataSize extends Instruction {
     const operands = [this.dstOffset];
     const [dstOffset] = addressing.resolve(operands, memory);
 
-    memory.set(dstOffset, new Uint32(context.machineState.nestedReturndata.length));
+    memory.set(dstOffset, new Uint32(context.machineState.nestedReturndata.length()));
   }
 }
 

--- a/yarn-project/simulator/src/public/debug_fn_name.ts
+++ b/yarn-project/simulator/src/public/debug_fn_name.ts
@@ -1,20 +1,21 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
+import type { CallData } from './avm/calldata.js';
 import type { PublicContractsDBInterface } from './db_interfaces.js';
 
 export async function getPublicFunctionDebugName(
   db: PublicContractsDBInterface,
   contractAddress: AztecAddress,
-  calldata: Fr[],
+  calldata: CallData,
 ): Promise<string> {
   // Public function is dispatched and therefore the target function is passed in the first argument.
-  if (!calldata[0]) {
+  const selectorField = calldata.read(0);
+  if (!selectorField) {
     return `<calldata[0] undefined> (Contract Address: ${contractAddress})`;
   }
-  const fallbackName = `<calldata[0]:${calldata[0].toString()}> (Contract Address: ${contractAddress})`;
-  const selector = FunctionSelector.fromFieldOrUndefined(calldata[0]);
+  const fallbackName = `<calldata[0]:${selectorField.toString()}> (Contract Address: ${contractAddress})`;
+  const selector = FunctionSelector.fromFieldOrUndefined(selectorField);
   if (!selector) {
     return fallbackName;
   }
@@ -32,13 +33,14 @@ export async function getPublicFunctionDebugName(
 export async function getPublicFunctionSelectorAndName(
   db: PublicContractsDBInterface,
   contractAddress: AztecAddress,
-  calldata: Fr[],
+  calldata: CallData,
 ): Promise<{ functionSelector?: FunctionSelector; functionName?: string }> {
   // Public function is dispatched and therefore the target function is passed in the first argument.
-  if (!calldata[0]) {
+  const selectorField = calldata.read(0);
+  if (!selectorField) {
     return {};
   }
-  const selector = FunctionSelector.fromFieldOrUndefined(calldata[0]);
+  const selector = FunctionSelector.fromFieldOrUndefined(selectorField);
   if (!selector) {
     return {};
   }

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -28,6 +28,7 @@ import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
 import { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
+import { ReturnDataArray } from '../avm/calldata.js';
 import type { InstructionSet } from '../avm/serialization/bytecode_serialization.js';
 import { PublicContractsDB } from '../public_db_sources.js';
 import { CheckedPublicExecutionError } from '../public_errors.js';
@@ -152,7 +153,7 @@ describe('public_tx_simulator', () => {
             return Promise.resolve(
               new AvmFinalizedCallResult(
                 /*reverted=*/ false,
-                /*output=*/ [],
+                /*output=*/ new ReturnDataArray([]),
                 /*gasLeft=*/ allocatedGas.sub(enqueuedCallGasUsed),
               ),
             );
@@ -160,7 +161,7 @@ describe('public_tx_simulator', () => {
             return Promise.resolve(
               new AvmFinalizedCallResult(
                 /*reverted=*/ true,
-                /*output=*/ [],
+                /*output=*/ new ReturnDataArray([]),
                 /*gasLeft=*/ allocatedGas.sub(enqueuedCallGasUsed),
                 revertReason,
               ),
@@ -242,7 +243,7 @@ describe('public_tx_simulator', () => {
         return Promise.resolve(
           new AvmFinalizedCallResult(
             /*reverted=*/ false,
-            /*output=*/ [],
+            /*output=*/ new ReturnDataArray([]),
             /*gasLeft=*/ allocatedGas.sub(enqueuedCallGasUsed),
             /*revertReason=*/ undefined,
           ),
@@ -483,7 +484,7 @@ describe('public_tx_simulator', () => {
     simulateInternal.mockResolvedValueOnce(
       new AvmFinalizedCallResult(
         /*reverted=*/ true,
-        /*output=*/ [],
+        /*output=*/ new ReturnDataArray([]),
         /*gasLeft=*/ Gas.empty(),
         /*revertReason=*/ setupFailure,
       ),

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -19,6 +19,7 @@ import {
 import { strict as assert } from 'assert';
 
 import type { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
+import { CallDataArray } from '../avm/calldata.js';
 import { AvmSimulator } from '../avm/index.js';
 import { getPublicFunctionDebugName } from '../debug_fn_name.js';
 import { HintingMerkleWriteOperations, HintingPublicContractsDB } from '../hinting_db_sources.js';
@@ -357,7 +358,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
       transactionFee,
       this.globalVariables,
       request.isStaticCall,
-      calldata,
+      new CallDataArray(calldata),
       allocatedGas,
       this.config,
     );

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -298,7 +298,11 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
   ): Promise<AvmFinalizedCallResult> {
     const stateManager = context.state.getActiveStateManager();
     const contractAddress = callRequest.request.contractAddress;
-    const fnName = await getPublicFunctionDebugName(this.contractsDB, contractAddress, callRequest.calldata);
+    const fnName = await getPublicFunctionDebugName(
+      this.contractsDB,
+      contractAddress,
+      new CallDataArray(callRequest.calldata),
+    );
 
     const allocatedGas = context.getGasLeftAtPhase(phase);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -268,7 +268,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
 
       const enqueuedCallResult = await this.simulateEnqueuedCall(phase, context, callRequest);
 
-      returnValues.push(new NestedProcessReturnValues(enqueuedCallResult.output));
+      returnValues.push(new NestedProcessReturnValues(enqueuedCallResult.output.bestEffortReadAll()));
 
       if (enqueuedCallResult.reverted) {
         reverted = true;

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -523,13 +523,21 @@ export class PublicPersistableStateManager {
   }
 
   public async getPublicFunctionDebugName(avmEnvironment: AvmExecutionEnvironment): Promise<string> {
-    return await getPublicFunctionDebugName(this.contractsDB, avmEnvironment.address, avmEnvironment.calldata);
+    return await getPublicFunctionDebugName(
+      this.contractsDB,
+      avmEnvironment.address,
+      avmEnvironment.calldata.bestEffortReadAll(),
+    );
   }
 
   public async getPublicFunctionSelectorAndName(
     avmEnvironment: AvmExecutionEnvironment,
   ): Promise<{ functionSelector?: FunctionSelector; functionName?: string }> {
-    return await getPublicFunctionSelectorAndName(this.contractsDB, avmEnvironment.address, avmEnvironment.calldata);
+    return await getPublicFunctionSelectorAndName(
+      this.contractsDB,
+      avmEnvironment.address,
+      avmEnvironment.calldata.bestEffortReadAll(),
+    );
   }
 
   public async padTree(treeId: MerkleTreeId, leavesToInsert: number): Promise<void> {

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -523,21 +523,13 @@ export class PublicPersistableStateManager {
   }
 
   public async getPublicFunctionDebugName(avmEnvironment: AvmExecutionEnvironment): Promise<string> {
-    return await getPublicFunctionDebugName(
-      this.contractsDB,
-      avmEnvironment.address,
-      avmEnvironment.calldata.bestEffortReadAll(),
-    );
+    return await getPublicFunctionDebugName(this.contractsDB, avmEnvironment.address, avmEnvironment.calldata);
   }
 
   public async getPublicFunctionSelectorAndName(
     avmEnvironment: AvmExecutionEnvironment,
   ): Promise<{ functionSelector?: FunctionSelector; functionName?: string }> {
-    return await getPublicFunctionSelectorAndName(
-      this.contractsDB,
-      avmEnvironment.address,
-      avmEnvironment.calldata.bestEffortReadAll(),
-    );
+    return await getPublicFunctionSelectorAndName(this.contractsDB, avmEnvironment.address, avmEnvironment.calldata);
   }
 
   public async padTree(treeId: MerkleTreeId, leavesToInsert: number): Promise<void> {


### PR DESCRIPTION
Resolves https://linear.app/aztec-labs/issue/AVM-208/wrap-calldatareturndata-in-ts-simulator-in-a-lazy-reader-class

Adds an interface for lazily read calldata and returndata. Creates two classes that implement the interface, an array backed one and a memory backed one. Internal calls use the memory backed one and the top level calldata uses the array backed one. In the memory one, memory is accessed at read time, instead of at creation time like we did before.

This should fix the largest diff that we have right now between the TS and CPP versions of the simulator, that is the lazy behavior of calldata and returndata, unblocking the differential fuzzer.