### PR TITLE
refactor: replace remaining ad-hoc thread range calculations with ThreadChunk

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -154,8 +154,6 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         // at least 1
         size_t num_used_threads = std::min(n_l / efficient_operations_per_thread, num_threads);
         num_used_threads = num_used_threads ? num_used_threads : 1;
-        size_t chunk_size = n_l / num_used_threads;
-        size_t last_chunk_size = (n_l % chunk_size) ? (n_l % num_used_threads) : chunk_size;
 
         // Opening point is the same for all
         const Fr u_l = multilinear_challenge[l];
@@ -163,11 +161,8 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
         auto A_l_fold = fold_polynomials[l].data();
 
-        parallel_for(num_used_threads, [&](size_t i) {
-            size_t current_chunk_size = (i == (num_used_threads - 1)) ? last_chunk_size : chunk_size;
-            for (std::ptrdiff_t j = (std::ptrdiff_t)(i * chunk_size);
-                 j < (std::ptrdiff_t)((i * chunk_size) + current_chunk_size);
-                 j++) {
+        parallel_for(num_used_threads, [&](ThreadChunk chunk) {
+            for (size_t j : chunk.range(n_l)) {
                 // fold(Aₗ)[j] = (1-uₗ)⋅even(Aₗ)[j] + uₗ⋅odd(Aₗ)[j]
                 //            = (1-uₗ)⋅Aₗ[2j]      + uₗ⋅Aₗ[2j+1]
                 //            = Aₗ₊₁[j]

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -190,4 +190,14 @@ void parallel_for(const Func& func)
     });
 }
 
+// Overload that allows specifying the number of threads explicitly while still using ThreadChunk
+template <typename Func>
+    requires std::invocable<Func, ThreadChunk>
+void parallel_for(size_t num_threads, const Func& func)
+{
+    parallel_for(num_threads, [&](size_t thread_index) {
+        func(ThreadChunk{ .thread_index = thread_index, .total_threads = num_threads });
+    });
+}
+
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -257,15 +257,12 @@ template <typename FF_> class DatabusLookupRelationImpl {
         auto& inverse_polynomial = BusData<bus_idx, Polynomials>::inverses(polynomials);
 
         size_t min_iterations_per_thread = 1 << 6; // min number of iterations for which we'll spin up a unique thread
-        size_t num_threads = bb::calculate_num_threads_pow2(circuit_size, min_iterations_per_thread);
-        size_t iterations_per_thread = circuit_size / num_threads; // actual iterations per thread
+        size_t num_threads = bb::calculate_num_threads(circuit_size, min_iterations_per_thread);
 
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            size_t start = thread_idx * iterations_per_thread;
-            size_t end = (thread_idx + 1) * iterations_per_thread;
+        parallel_for(num_threads, [&](ThreadChunk chunk) {
             bool is_read = false;
             bool nonzero_read_count = false;
-            for (size_t i = start; i < end; ++i) {
+            for (size_t i : chunk.range(circuit_size)) {
                 // Determine if the present row contains a databus operation
                 auto q_busread = polynomials.q_busread[i];
                 if constexpr (bus_idx == 0) { // calldata

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -221,13 +221,10 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         auto& inverse_polynomial = get_inverse_polynomial(polynomials);
 
         size_t min_iterations_per_thread = 1 << 6; // min number of iterations for which we'll spin up a unique thread
-        size_t num_threads = bb::calculate_num_threads_pow2(circuit_size, min_iterations_per_thread);
-        size_t iterations_per_thread = circuit_size / num_threads; // actual iterations per thread
+        size_t num_threads = bb::calculate_num_threads(circuit_size, min_iterations_per_thread);
 
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            size_t start = thread_idx * iterations_per_thread;
-            size_t end = (thread_idx + 1) * iterations_per_thread;
-            for (size_t i = start; i < end; ++i) {
+        parallel_for(num_threads, [&](ThreadChunk chunk) {
+            for (size_t i : chunk.range(circuit_size)) {
                 // We only compute the inverse if this row contains a lookup gate or data that has been looked up
                 if (polynomials.q_lookup.get(i) == 1 || polynomials.lookup_read_tags.get(i) == 1) {
                     // TODO(https://github.com/AztecProtocol/barretenberg/issues/940): avoid get_row if possible.


### PR DESCRIPTION
## Summary
- Add `parallel_for` overload that accepts explicit thread count with `ThreadChunk`
- Refactor `gemini_impl.hpp` to use `ThreadChunk::range()` instead of manual chunk calculation
- Refactor `logderiv_lookup_relation.hpp` to use `ThreadChunk` with `calculate_num_threads`
- Refactor `databus_lookup_relation.hpp` to use `ThreadChunk` with `calculate_num_threads`

## Why explicit thread counts?

The three files specify thread counts explicitly rather than using the no-argument `parallel_for(func)` (which uses `get_num_cpus()`):

- **gemini_impl.hpp**: Dynamically reduces thread count as `n_l` shrinks each folding round (halving each iteration). Using all CPUs when there's only 4 elements to process would be wasteful.
- **logderiv_lookup_relation.hpp** and **databus_lookup_relation.hpp**: Limit threads based on `min_iterations_per_thread = 64` to avoid spawning more threads than the work justifies for smaller circuits.

## Why `calculate_num_threads` instead of `calculate_num_threads_pow2`?

The original code used `calculate_num_threads_pow2` to ensure `circuit_size / num_threads` divides evenly, avoiding the need for remainder handling. However, this was only necessary because the ad-hoc range calculation (`start = thread_idx * iterations_per_thread`) couldn't handle remainders properly.

`ThreadChunk::range()` handles non-even division correctly by distributing remainder elements across threads (threads 0 to remainder-1 each get one extra element). This makes the power-of-2 constraint unnecessary and allows us to use `calculate_num_threads`, which can utilize more CPU cores on systems with non-power-of-2 thread counts.

## Benefits
- Cleaner, more readable code
- Consistent remainder handling (`ThreadChunk` distributes remainders evenly across threads rather than dumping leftovers on the last thread)
- Better load balancing across threads
- Can now use all available threads on systems with non-power-of-2 CPU counts

Closes https://github.com/AztecProtocol/barretenberg/issues/1277

## Test plan
- [x] CI passes
- [x] Existing tests verify correctness (`ultra_honk_tests`, `commitment_schemes_tests`, `common_tests`)