### PR TITLE
chore: old req/resp batch request vs new one

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -211,6 +211,7 @@ function bench_cmds {
   echo "$hash BENCH_OUTPUT=bench-out/native_world_state.bench.json yarn-project/scripts/run_test.sh world-state/src/native/native_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/kv_store.bench.json yarn-project/scripts/run_test.sh kv-store/src/bench/map_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx_pool.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts"
+  echo "$hash BENCH_OUTPUT=bench-out/p2p_client_proposal_tx_collector.bench.json yarn-project/scripts/run_test.sh p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx.bench.json yarn-project/scripts/run_test.sh stdlib/src/tx/tx_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=10:MEM=16g:LOG_LEVEL=silent BENCH_OUTPUT=bench-out/proving_broker.bench.json yarn-project/scripts/run_test.sh prover-client/src/test/proving_broker_testbench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=16:MEM=16g BENCH_OUTPUT=bench-out/avm_bulk_test.bench.json yarn-project/scripts/run_test.sh bb-prover/src/avm_proving_tests/avm_bulk.test.ts"

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_txs.test.ts
@@ -264,7 +264,7 @@ describe('p2p client integration', () => {
       expect.anything(), // maxRetryAttempts
     );
 
-    expect(sendRequestToPeerSpy).toHaveBeenCalledTimes(request.length);
+    expect(sendRequestToPeerSpy.mock.calls.length).toBeGreaterThanOrEqual(request.length);
   });
 
   it('will penalize peers that send invalid proofs', async () => {

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/README.md
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/README.md
@@ -1,0 +1,227 @@
+# ProposalTxCollector Benchmarks
+
+This benchmark suite measures **how quickly a proposer node can fetch missing transactions from P2P peers** when building a block proposal. It compares two alternative transaction-collection implementations under several controlled "who-has-which-txs" distributions.
+
+## Purpose
+
+When proposing a block, the node may have a block proposal containing a list of `txHashes`, but may be **missing the full `Tx` objects** locally. The node must fetch those missing txs from peers via the P2P req/resp layer.
+
+This benchmark answers:
+
+- How long does it take to fetch **N missing txs** (N ∈ **{10, 50, 100, 500}**)?
+- How do different **peer availability patterns** affect performance?
+- Which collector strategy performs better under each pattern?
+
+The suite compares two collectors:
+
+- **`BatchTxRequesterCollector`** (collector type: `batch-requester`)
+- **`SendBatchRequestCollector`** (collector type: `send-batch-request`)
+
+## Architecture
+
+The benchmark runs a small simulated network on localhost:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Test Process (Driver)                        │
+│   p2p_client.proposal_tx_collector_bench.test.ts                    │
+│   ┌─────────────────────────────────────────────────────────────┐   │
+│   │            WorkerClientManager                              │   │
+│   │         (src/testbench/worker_client_manager.ts)            │   │
+│   └─────────────────────────────────────────────────────────────┘   │
+│                              │ IPC                                  │
+│         ┌────────────────────┼────────────────────┐                 │
+│         ▼                    ▼                    ▼                 │
+│   ┌───────────┐        ┌───────────┐        ┌───────────┐           │
+│   │ Worker 0  │◄──────►│ Worker 1  │◄──────►│ Worker N-1│           │
+│   │ (Collector│  P2P   │(Responder)│  P2P   │(Responder)│           │
+│   │  Node)    │        │           │        │           │           │
+│   │ TxPool:[] │        │ TxPool:   │        │ TxPool:   │           │
+│   │           │        │ [txs...]  │        │ [txs...]  │           │
+│   └───────────┘        └───────────┘        └───────────┘           │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+- **N worker processes** are spawned using Node's **`child_process.fork()`**
+- Each worker runs a "light" **`P2PClient.Full`** node (enough to exercise the real P2P req/resp machinery)
+- Workers communicate with the test process via **IPC messages** defined in `p2p_client_testbench_worker.ts`
+
+### Why multiple processes?
+
+Using separate OS processes makes the setup closer to real networking behavior (independent event loops, scheduling, IPC boundaries), and avoids many artifacts you'd get by running everything in one process.
+
+### Worker roles
+
+The network is intentionally asymmetric:
+
+- **Worker 0 is the collector/proposer node**
+  - Starts with an **empty tx pool** (`[]`)
+  - Is the only worker instructed to run the collector for each `BENCH_REQRESP` command
+- **Workers 1..N-1 are responder peers**
+  - Locally generate and filter txs according to the distribution pattern
+  - Respond to req/resp queries made by Worker 0's collector
+
+This models a proposer that has only `txHashes` in a proposal and must fetch the full tx bodies from the network.
+
+## Transaction Distribution Patterns
+
+Each benchmark case generates `missingTxCount` mock txs and assigns them to peers using one of these patterns:
+
+### `uniform`
+
+**Every responder peer has every transaction.**
+
+- Simulates the best-case: high replication / high gossip success
+- Expectation: collector should quickly succeed; differences mostly reflect collector overhead and batching strategy
+
+### `sparse`
+
+**Each transaction exists on only a small subset of peers.**
+
+Each responder is bucketed and holds txs whose index falls into its bucket or the "next" bucket (striped by tx index).
+
+- Simulates partial propagation, churn, or uneven mempool convergence
+- Expectation: collector must query multiple peers and cope with "misses"
+
+### `pinned-only`
+
+**Only a single "pinned" peer has the transactions; all other peers have none.**
+
+- Simulates "I know exactly who has the txs" (or a topology where one peer is the source of truth)
+- Useful to test whether "pinned peer" fast-paths work as intended
+
+> **Guardrail:** the pinned peer index must be within `(0, numberOfPeers)` (Worker 0 cannot be pinned).
+
+## Collectors Under Test
+
+### `BatchTxRequesterCollector` (`batch-requester`)
+
+```typescript
+new BatchTxRequesterCollector(p2pService, logger, new DateProvider())
+```
+
+Uses the P2P service plus internal logic to fetch missing txs, coordinating requests in a batched or staged way.
+
+### `SendBatchRequestCollector` (`send-batch-request`)
+
+```typescript
+const maxPeers = 10;
+const maxRetryAttempts = Math.max(peerIds.length, 3);
+new SendBatchRequestCollector(p2pService, maxPeers, maxRetryAttempts)
+```
+
+Explicitly caps the number of peers it will involve (`maxPeers`) and uses a retry budget derived from peer count.
+
+## Test Parameters
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `PEERS_PER_RUN` | 30 | Number of worker processes spawned |
+| `MISSING_TX_COUNTS` | 10, 50, 100, 500 | Number of missing transactions to fetch |
+| `TIMEOUT_MS` | 30,000 ms | Collector timeout per case |
+| `TEST_TIMEOUT_MS` | 600,000 ms | Overall Jest timeout (10 minutes) |
+
+## Running
+
+From the p2p package:
+
+```bash
+cd yarn-project/p2p
+yarn test src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector_bench.test.ts
+```
+
+Or from repo root:
+
+```bash
+yarn test p2p_client.proposal_tx_collector_bench.test.ts
+```
+
+The benchmark is intentionally long due to spawning many processes and running multiple cases.
+
+## Output Formats
+
+### Default: Markdown table to stdout
+
+If no env vars are set, the suite prints a table:
+
+```
+| Collector           | Distribution | Missing | Duration (ms) | Fetched | Success |
+|---------------------|--------------|---------|---------------|---------|---------|
+| batch-requester     | pinned-only  |      10 |           123 |      10 |   Yes   |
+| send-batch-request  | pinned-only  |      10 |           145 |      10 |   Yes   |
+```
+
+Plus a comparison summary stating which collector was faster per `(distribution, missing)` pair.
+
+### JSON metrics (for CI/dashboards)
+
+```bash
+BENCH_OUTPUT=/path/results.json yarn test ...
+```
+
+Writes JSON metrics like:
+- `ProposalTxCollector/<collector>/<distribution>/missing_<N>/duration` (ms)
+- `ProposalTxCollector/<collector>/<distribution>/missing_<N>/fetched` (txs)
+
+### Markdown file output
+
+```bash
+BENCH_OUTPUT_MD=/path/results.md yarn test ...
+```
+
+Writes the pretty table + summary to disk.
+
+## Interpreting Results
+
+For each case the benchmark records:
+
+- `durationMs`: wall-clock time spent inside the collector call
+- `fetchedCount`: how many txs were returned by the collector
+- `success`: `fetchedCount === missingTxCount`
+
+**Guidelines:**
+
+- **Always check `Success` first.** A faster run that fetched fewer txs is not a win.
+- Compare collectors **within the same distribution + missing count** only.
+- Expect `pinned-only` to highlight pinned-peer behavior (fast if pinned peer is used effectively; slow if the algorithm wastes time sampling other peers).
+- Expect `sparse` to be the most "network-like" stress case, since many peers won't have each requested tx.
+
+## Determinism / Noise Reduction
+
+Inside each worker, the benchmark intentionally reduces variability:
+
+- **Unlimited rate limits** are installed so the req/resp rate limiter doesn't dominate results
+- **Deterministic tx generation** ensures all workers see the same tx set without large IPC payloads
+
+This makes the benchmark better for *comparing collectors* (A vs B), but it is **not** a perfect model of production networking conditions.
+
+## Limitations
+
+This benchmark does **not** measure:
+
+- Real internet latency, NAT traversal, or adversarial peers (everything runs on localhost)
+- End-to-end proposer behavior beyond tx fetching (block construction, proving, etc.)
+- Gossip-based mempool convergence—tx availability is injected directly into each worker's in-memory tx pool
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `p2p_client.proposal_tx_collector_bench.test.ts` | Test suite (cases, distributions, output formatting) |
+| `proposal_tx_collector_worker.ts` | Collector-specific worker implementation |
+| `proposal_tx_collector_worker_protocol.ts` | IPC message types and serialization |
+| `src/testbench/worker_client_manager.ts` | Worker process manager (forking, IPC, orchestration) |
+| `src/testbench/p2p_client_testbench_worker.ts` | General testbench worker implementation |
+| `src/test-helpers/testbench-utils.ts` | Shared mocks and utilities (InMemoryTxPool, InMemoryAttestationPool, etc.) |
+
+## Implementation Notes
+
+- Workers run TypeScript via `ts-node/esm` unless a compiled JS worker exists at `dest/testbench/p2p_client_testbench_worker.js`
+- Request/response rate limits are overridden so the benchmark is not throttled
+- Workers generate txs locally from a shared seed to avoid sending large tx payloads over IPC
+
+## Practical Tips
+
+- Run on an otherwise idle machine; CPU scheduling noise matters when spawning 30 node processes
+- If you see intermittent failures, increase `TIMEOUT_MS` or reduce `PEERS_PER_RUN` for local iteration
+- Use `BENCH_OUTPUT` in CI to track performance regressions over time

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector_bench.test.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector_bench.test.ts
@@ -1,0 +1,293 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+import {
+  type CollectorType,
+  type DistributionPattern,
+  WorkerClientManager,
+  testChainConfig,
+} from '../../../testbench/worker_client_manager.js';
+
+const TEST_TIMEOUT_MS = 600_000; // 10 minutes
+jest.setTimeout(TEST_TIMEOUT_MS);
+
+const COLLECTOR_TYPES: CollectorType[] = ['batch-requester', 'send-batch-request'];
+
+const PEERS_PER_RUN = 30;
+const TIMEOUT_MS = 30_000;
+
+const MISSING_TX_COUNTS = [10, 50, 100, 500] as const;
+type MissingTxCount = number;
+
+interface ScenarioBase {
+  name: string;
+  distribution: DistributionPattern;
+  blockNumber: number;
+  pinnedPeerIndex?: number; // index in worker list, if applicable
+}
+
+interface BenchmarkCase extends ScenarioBase {
+  peers: number;
+  missingTxCount: MissingTxCount;
+  timeoutMs: number;
+}
+
+interface BenchmarkResult {
+  missingTxCount: number;
+  distribution: DistributionPattern;
+  collector: CollectorType;
+  durationMs: number;
+  fetchedCount: number;
+  success: boolean;
+}
+
+interface JsonBenchmarkResult {
+  name: string;
+  value: number;
+  unit: string;
+}
+
+const BASE_SCENARIOS: readonly ScenarioBase[] = [
+  {
+    name: 'uniform distribution',
+    distribution: 'uniform',
+    blockNumber: 1,
+  },
+  {
+    name: 'sparse distribution',
+    distribution: 'sparse',
+    blockNumber: 2,
+  },
+  {
+    name: 'pinned-only distribution',
+    distribution: 'pinned-only',
+    blockNumber: 3,
+    pinnedPeerIndex: 1,
+  },
+];
+
+const CASES: readonly BenchmarkCase[] = BASE_SCENARIOS.flatMap(base =>
+  MISSING_TX_COUNTS.map(missingTxCount => ({
+    ...base,
+    peers: PEERS_PER_RUN,
+    missingTxCount,
+    timeoutMs: TIMEOUT_MS,
+  })),
+);
+
+describe('ProposalTxCollector Benchmarks', () => {
+  const results: BenchmarkResult[] = [];
+
+  let logger: Logger;
+  let workerManager: WorkerClientManager | undefined;
+
+  beforeAll(async () => {
+    logger = createLogger('p2p:bench');
+    const benchConfig = {
+      ...testChainConfig,
+      debugDisableColocationPenalty: true,
+      p2pDisableStatusHandshake: true,
+      bootstrapNodeEnrVersionCheck: false,
+      bootstrapNodesAsFullPeers: true,
+      maxPeerCount: PEERS_PER_RUN + 1,
+      peerCheckIntervalMS: 1000,
+      dialTimeoutMs: 10_000,
+      individualRequestTimeoutMs: 30_000,
+    };
+    workerManager = new WorkerClientManager(logger, benchConfig);
+    await workerManager.makeWorkerClients(PEERS_PER_RUN, {
+      bootstrapMode: 'all',
+      batchSize: 5,
+      batchDelayMs: 500,
+    });
+    await sleep(5000);
+  });
+
+  afterAll(async () => {
+    try {
+      if (workerManager) {
+        await workerManager.cleanup();
+      }
+    } finally {
+      await outputResults(results);
+    }
+  });
+
+  beforeEach(() => {
+    logger.info(`Starting test ${expect.getState().currentTestName}`);
+  });
+
+  describe.each(CASES)('$name (missing=$missingTxCount)', benchCase => {
+    it.each(COLLECTOR_TYPES)('collector: %s', async collectorType => {
+      if (!workerManager) {
+        throw new Error('Worker manager not initialized');
+      }
+
+      const { missingTxCount, peers, distribution, timeoutMs, blockNumber } = benchCase;
+      const pinnedPeerIndex = distribution === 'pinned-only' ? benchCase.pinnedPeerIndex : undefined;
+      const seed = blockNumber * 1_000_000;
+
+      logger.info(
+        `Case=${benchCase.name}, missing=${missingTxCount}, collector=${collectorType}, peers=${peers}, timeoutMs=${timeoutMs}`,
+      );
+
+      try {
+        const result = await workerManager.runReqRespBenchmark({
+          txCount: missingTxCount,
+          distribution,
+          collectorType,
+          timeoutMs,
+          pinnedPeerIndex,
+          blockNumber,
+          seed,
+        });
+
+        results.push({
+          missingTxCount,
+          distribution,
+          collector: collectorType,
+          durationMs: result.durationMs,
+          fetchedCount: result.fetchedCount,
+          success: result.fetchedCount === missingTxCount,
+        });
+
+        logger.info(
+          `${collectorType}: fetched ${result.fetchedCount}/${missingTxCount} in ${result.durationMs.toFixed(0)}ms`,
+        );
+      } catch (err: any) {
+        logger.error(`${collectorType} failed: ${err?.message ?? String(err)}`);
+
+        results.push({
+          missingTxCount,
+          distribution,
+          collector: collectorType,
+          durationMs: timeoutMs,
+          fetchedCount: 0,
+          success: false,
+        });
+
+        throw err;
+      }
+    });
+  });
+});
+
+/* eslint-disable no-console */
+function toPrettyString(benchResults: BenchmarkResult[]): string {
+  if (benchResults.length === 0) {
+    return 'No benchmark results to display';
+  }
+
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push('='.repeat(80));
+  lines.push('ProposalTxCollector Benchmark Results');
+  lines.push('='.repeat(80));
+  lines.push('');
+  lines.push('| Collector           | Distribution | Missing | Duration (ms) | Fetched | Success |');
+  lines.push('|---------------------|--------------|---------|---------------|---------|---------|');
+
+  const sorted = [...benchResults].sort((a, b) => {
+    if (a.distribution !== b.distribution) {
+      return a.distribution.localeCompare(b.distribution);
+    }
+    if (a.missingTxCount !== b.missingTxCount) {
+      return a.missingTxCount - b.missingTxCount;
+    }
+    return a.collector.localeCompare(b.collector);
+  });
+
+  for (const r of sorted) {
+    lines.push(
+      `| ${r.collector.padEnd(19)} | ${r.distribution.padEnd(12)} | ${String(r.missingTxCount).padStart(7)} | ` +
+        `${r.durationMs.toFixed(0).padStart(13)} | ${String(r.fetchedCount).padStart(7)} | ${r.success ? '  Yes  ' : '  No   '} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push('## Comparison Summary');
+  lines.push('');
+
+  const keys = [...new Set(sorted.map(r => `${r.distribution}:${r.missingTxCount}`))];
+
+  for (const key of keys) {
+    const [distRaw, missingRaw] = key.split(':');
+    const dist = distRaw as DistributionPattern;
+    const missing = Number(missingRaw);
+
+    const batch = sorted.find(
+      r => r.distribution === dist && r.missingTxCount === missing && r.collector === 'batch-requester',
+    );
+    const send = sorted.find(
+      r => r.distribution === dist && r.missingTxCount === missing && r.collector === 'send-batch-request',
+    );
+
+    if (!batch || !send) {
+      continue;
+    }
+
+    if (!batch.success || !send.success) {
+      lines.push(
+        `- ${dist} (missing=${missing}): cannot compare reliably (success: batch=${batch.success}, send=${send.success})`,
+      );
+      continue;
+    }
+
+    const faster = batch.durationMs <= send.durationMs ? 'BatchTxRequester' : 'SendBatchRequest';
+    const slower = faster === 'BatchTxRequester' ? 'SendBatchRequest' : 'BatchTxRequester';
+
+    const delta = Math.abs(send.durationMs - batch.durationMs);
+    const pct = (delta / Math.max(batch.durationMs, send.durationMs)) * 100;
+
+    lines.push(`- ${dist} (missing=${missing}): ${faster} is ${pct.toFixed(1)}% faster than ${slower}`);
+  }
+
+  lines.push('');
+  lines.push('='.repeat(80));
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function toBenchmarkJSON(benchResults: BenchmarkResult[], indent = 2): string {
+  const metrics: JsonBenchmarkResult[] = [];
+
+  for (const result of benchResults) {
+    const baseName = `ProposalTxCollector/${result.collector}/${result.distribution}/missing_${result.missingTxCount}`;
+    metrics.push(
+      {
+        name: `${baseName}/duration`,
+        unit: 'ms',
+        value: result.durationMs,
+      },
+      {
+        name: `${baseName}/fetched`,
+        unit: 'txs',
+        value: result.fetchedCount,
+      },
+    );
+  }
+
+  return JSON.stringify(metrics, null, indent);
+}
+
+async function outputResults(benchResults: BenchmarkResult[]): Promise<void> {
+  if (process.env.BENCH_OUTPUT) {
+    await mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
+    await writeFile(process.env.BENCH_OUTPUT, toBenchmarkJSON(benchResults));
+    return;
+  }
+
+  if (process.env.BENCH_OUTPUT_MD) {
+    await mkdir(path.dirname(process.env.BENCH_OUTPUT_MD), { recursive: true });
+    await writeFile(process.env.BENCH_OUTPUT_MD, toPrettyString(benchResults));
+    return;
+  }
+
+  console.log(toPrettyString(benchResults));
+}

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
@@ -1,0 +1,317 @@
+import { MockL2BlockSource } from '@aztec/archiver/test';
+import { SecretValue } from '@aztec/foundation/config';
+import { createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+import { DateProvider, Timer, executeTimeout } from '@aztec/foundation/timer';
+import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
+import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
+import { P2PClientType } from '@aztec/stdlib/p2p';
+import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
+
+import { peerIdFromString } from '@libp2p/peer-id';
+
+import type { P2PConfig } from '../../../config.js';
+import { RateLimitStatus } from '../../../services/reqresp/rate-limiter/rate_limiter.js';
+import {
+  BatchTxRequesterCollector,
+  SendBatchRequestCollector,
+} from '../../../services/tx_collection/proposal_tx_collector.js';
+import { AlwaysTrueCircuitVerifier } from '../../../test-helpers/reqresp-nodes.js';
+import {
+  BENCHMARK_CONSTANTS,
+  InMemoryAttestationPool,
+  InMemoryTxPool,
+  UNLIMITED_RATE_LIMIT_QUOTA,
+  calculateInternalTimeout,
+  createMockEpochCache,
+  createMockWorldStateSynchronizer,
+} from '../../../test-helpers/testbench-utils.js';
+import { createP2PClient } from '../../index.js';
+import type { P2PClient } from '../../p2p_client.js';
+import {
+  type WorkerCommand,
+  type WorkerResponse,
+  deserializeBlockProposal,
+  deserializeTx,
+  deserializeTxHash,
+} from './proposal_tx_collector_worker_protocol.js';
+
+let client: P2PClient | undefined;
+let txPool: InMemoryTxPool | undefined;
+let attestationPool: InMemoryAttestationPool | undefined;
+let logger = createLogger('p2p:proposal-bench');
+let kvStore: Awaited<ReturnType<typeof openTmpStore>> | undefined;
+let ipcDisconnected = false;
+
+function ensureClient(): P2PClient {
+  if (!client || !txPool) {
+    throw new Error('Worker client not started');
+  }
+  return client;
+}
+
+function isIpcDisconnectError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EPIPE' || code === 'ERR_IPC_CHANNEL_CLOSED';
+}
+
+function sendMessage(message: WorkerResponse): Promise<void> {
+  const send = process.send;
+  if (!send || !process.connected || ipcDisconnected) {
+    return Promise.resolve();
+  }
+
+  return new Promise(resolve => {
+    const fallbackTimeout = setTimeout(() => resolve(), 2000);
+    try {
+      send.call(process, message, undefined, undefined, err => {
+        clearTimeout(fallbackTimeout);
+        if (!err) {
+          resolve();
+          return;
+        }
+        if (isIpcDisconnectError(err)) {
+          ipcDisconnected = true;
+          resolve();
+          return;
+        }
+        logger.warn('Failed to send IPC message', { error: err?.message ?? String(err) });
+        resolve();
+      });
+    } catch (err: any) {
+      clearTimeout(fallbackTimeout);
+      if (isIpcDisconnectError(err)) {
+        ipcDisconnected = true;
+        resolve();
+        return;
+      }
+      logger.warn('Failed to send IPC message', { error: err?.message ?? String(err) });
+      resolve();
+    }
+  });
+}
+
+async function startClient(config: P2PConfig, clientIndex: number) {
+  txPool = new InMemoryTxPool();
+  attestationPool = new InMemoryAttestationPool();
+  const epochCache = createMockEpochCache();
+  const worldState = createMockWorldStateSynchronizer();
+  const l2BlockSource = new MockL2BlockSource();
+  const proofVerifier = new AlwaysTrueCircuitVerifier();
+  kvStore = await openTmpStore(`proposal-bench-${clientIndex}`);
+  logger = createLogger(`p2p:proposal-bench:${clientIndex}`);
+
+  const telemetry = getTelemetryClient();
+  const deps = {
+    txPool,
+    attestationPool,
+    store: kvStore,
+    logger,
+  };
+
+  client = await createP2PClient(
+    P2PClientType.Full,
+    config as P2PConfig & DataStoreConfig,
+    l2BlockSource as L2BlockSource & ContractDataSource,
+    proofVerifier as ClientProtocolCircuitVerifier,
+    worldState,
+    epochCache,
+    'proposal-tx-collector-bench-worker',
+    new DateProvider(),
+    telemetry as TelemetryClient,
+    deps,
+  );
+
+  await client.start();
+  installUnlimitedRateLimits();
+
+  for (let i = 0; i < 120; i++) {
+    if (client.isReady()) {
+      return;
+    }
+    await sleep(500);
+  }
+
+  throw new Error('Timed out waiting for P2P client readiness');
+}
+
+function installSamplerOverrides(peerList: ReturnType<typeof peerIdFromString>[]) {
+  const reqResp = (ensureClient() as any).p2pService.reqresp as any;
+  const sampler = reqResp.connectionSampler as any;
+
+  sampler.getPeerListSortedByConnectionCountAsc = (excluding?: Set<string>) => {
+    if (!excluding || excluding.size === 0) {
+      return peerList;
+    }
+    return peerList.filter(peerId => !excluding.has(peerId.toString()));
+  };
+  sampler.samplePeersBatch = (numberToSample: number, excluding?: Map<string, boolean>) => {
+    const filtered = peerList.filter(peerId => !excluding?.has(peerId.toString()));
+    return filtered.slice(0, Math.min(numberToSample, filtered.length));
+  };
+  sampler.getPeer = (excluding?: Map<string, boolean>) => {
+    const filtered = peerList.filter(peerId => !excluding?.has(peerId.toString()));
+    return filtered[0];
+  };
+}
+
+function installUnlimitedRateLimits() {
+  const reqResp = (ensureClient() as any).p2pService.reqresp as any;
+  const rateLimiter = reqResp.rateLimiter as any;
+
+  rateLimiter.getRateLimits = () => UNLIMITED_RATE_LIMIT_QUOTA;
+  rateLimiter.allow = () => RateLimitStatus.Allowed;
+}
+
+async function runCollector(cmd: Extract<WorkerCommand, { type: 'RUN_COLLECTOR' }>) {
+  const { collectorType, txHashes, blockProposal, pinnedPeerId, peerIds, timeoutMs } = cmd;
+  const reqResp = (ensureClient() as any).p2pService.reqresp as any;
+  const peerList = peerIds.map(peerId => peerIdFromString(peerId));
+
+  installSamplerOverrides(peerList);
+  installUnlimitedRateLimits();
+
+  const p2pService = {
+    reqResp,
+    connectionSampler: {
+      getPeerListSortedByConnectionCountAsc: () => peerList,
+    },
+    txValidator: () => Promise.resolve(true),
+  };
+
+  const parsedTxHashes = txHashes.map(deserializeTxHash);
+  const parsedProposal = deserializeBlockProposal(blockProposal);
+  const pinnedPeer = pinnedPeerId ? peerIdFromString(pinnedPeerId) : undefined;
+
+  const timer = new Timer();
+  let fetchedCount = 0;
+
+  const internalTimeoutMs = calculateInternalTimeout(timeoutMs);
+
+  try {
+    if (collectorType === 'batch-requester') {
+      const collector = new BatchTxRequesterCollector(p2pService, logger, new DateProvider());
+      const fetched = await executeTimeout(
+        (_signal: AbortSignal) => collector.collectTxs(parsedTxHashes, parsedProposal, pinnedPeer, internalTimeoutMs),
+        timeoutMs,
+        () => new Error(`Collector timed out after ${timeoutMs}ms`),
+      );
+      fetchedCount = fetched.length;
+    } else {
+      const collector = new SendBatchRequestCollector(
+        p2pService,
+        BENCHMARK_CONSTANTS.FIXED_MAX_PEERS,
+        BENCHMARK_CONSTANTS.FIXED_MAX_RETRY_ATTEMPTS,
+      );
+      const fetched = await executeTimeout(
+        (_signal: AbortSignal) => collector.collectTxs(parsedTxHashes, parsedProposal, pinnedPeer, internalTimeoutMs),
+        timeoutMs,
+        () => new Error(`Collector timed out after ${timeoutMs}ms`),
+      );
+      fetchedCount = fetched.length;
+    }
+  } catch (err: any) {
+    logger.warn(`Collector error: ${err?.message ?? String(err)}`);
+  }
+
+  return { durationMs: timer.ms(), fetchedCount };
+}
+
+async function stopClient() {
+  if (!client) {
+    return;
+  }
+  await client.stop();
+  if (kvStore?.close) {
+    await kvStore.close();
+  }
+  client = undefined;
+  txPool = undefined;
+  attestationPool = undefined;
+}
+
+process.on('disconnect', () => {
+  ipcDisconnected = true;
+  void stopClient().finally(() => process.exit(0));
+});
+
+process.on('error', err => {
+  if (isIpcDisconnectError(err)) {
+    ipcDisconnected = true;
+    return;
+  }
+  logger.warn('Worker process error', { error: err?.message ?? String(err) });
+});
+
+process.on('message', (msg: WorkerCommand) => {
+  void (async () => {
+    if (!msg || typeof msg !== 'object') {
+      return;
+    }
+
+    const requestId = msg.requestId;
+
+    try {
+      switch (msg.type) {
+        case 'START': {
+          const rawConfig = msg.config;
+          const config: P2PConfig = {
+            ...rawConfig,
+            peerIdPrivateKey: rawConfig.peerIdPrivateKey ? new SecretValue(rawConfig.peerIdPrivateKey) : undefined,
+          } as P2PConfig;
+
+          await startClient(config, msg.clientIndex);
+          const peerId = (ensureClient() as any).p2pService.node.peerId.toString();
+          await sendMessage({ type: 'READY', requestId, peerId });
+          break;
+        }
+        case 'SET_TXS': {
+          if (!txPool) {
+            throw new Error('Tx pool not initialized');
+          }
+          const txs = msg.txs.map(deserializeTx);
+          const count = msg.mode === 'append' ? txPool.appendTxs(txs) : txPool.setTxs(txs);
+          await sendMessage({ type: 'TXS_SET', requestId, count });
+          break;
+        }
+        case 'SET_BLOCK_PROPOSAL': {
+          if (!attestationPool) {
+            throw new Error('Attestation pool not initialized');
+          }
+          const proposal = deserializeBlockProposal(msg.blockProposal);
+          await attestationPool.addBlockProposal(proposal);
+          await sendMessage({ type: 'BLOCK_PROPOSAL_SET', requestId, archiveRoot: proposal.archive.toString() });
+          break;
+        }
+        case 'RUN_COLLECTOR': {
+          const { durationMs, fetchedCount } = await runCollector(msg);
+          await sendMessage({ type: 'COLLECTOR_RESULT', requestId, durationMs, fetchedCount });
+          break;
+        }
+        case 'GET_PEER_COUNT': {
+          const peers = await ensureClient().getPeers();
+          await sendMessage({ type: 'PEER_COUNT', requestId, count: peers.length });
+          break;
+        }
+        case 'STOP': {
+          await stopClient();
+          await sendMessage({ type: 'STOPPED', requestId });
+          process.exit(0);
+          break;
+        }
+        default: {
+          const _exhaustive: never = msg;
+          throw new Error(`Unknown command: ${(msg as { type?: string }).type}`);
+        }
+      }
+    } catch (err: any) {
+      await sendMessage({ type: 'ERROR', requestId, error: err?.message ?? String(err) });
+      if (msg.type === 'START') {
+        process.exit(1);
+      }
+    }
+  })();
+});

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker_protocol.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker_protocol.ts
@@ -1,0 +1,43 @@
+import { BlockProposal } from '@aztec/stdlib/p2p';
+import { Tx, TxHash } from '@aztec/stdlib/tx';
+
+import type { P2PConfig } from '../../../config.js';
+
+export type SerializedP2PConfig = Omit<P2PConfig, 'peerIdPrivateKey'> & { peerIdPrivateKey?: string };
+
+export type CollectorType = 'batch-requester' | 'send-batch-request';
+
+export type WorkerCommand =
+  | { type: 'START'; requestId: string; clientIndex: number; config: SerializedP2PConfig }
+  | { type: 'SET_TXS'; requestId: string; txs: string[]; mode?: 'replace' | 'append' }
+  | { type: 'SET_BLOCK_PROPOSAL'; requestId: string; blockProposal: string }
+  | {
+      type: 'RUN_COLLECTOR';
+      requestId: string;
+      collectorType: CollectorType;
+      txHashes: string[];
+      blockProposal: string;
+      pinnedPeerId?: string;
+      peerIds: string[];
+      timeoutMs: number;
+    }
+  | { type: 'GET_PEER_COUNT'; requestId: string }
+  | { type: 'STOP'; requestId: string };
+
+export type WorkerResponse =
+  | { type: 'READY'; requestId: string; peerId: string }
+  | { type: 'TXS_SET'; requestId: string; count: number }
+  | { type: 'BLOCK_PROPOSAL_SET'; requestId: string; archiveRoot: string }
+  | { type: 'COLLECTOR_RESULT'; requestId: string; durationMs: number; fetchedCount: number }
+  | { type: 'PEER_COUNT'; requestId: string; count: number }
+  | { type: 'STOPPED'; requestId: string }
+  | { type: 'ERROR'; requestId: string; error: string };
+
+export const serializeTx = (tx: Tx) => tx.toBuffer().toString('hex');
+export const deserializeTx = (hex: string) => Tx.fromBuffer(Buffer.from(hex, 'hex'));
+
+export const serializeTxHash = (txHash: TxHash) => txHash.toString();
+export const deserializeTxHash = (hex: string) => TxHash.fromString(hex);
+
+export const serializeBlockProposal = (proposal: BlockProposal) => proposal.toBuffer().toString('hex');
+export const deserializeBlockProposal = (hex: string) => BlockProposal.fromBuffer(Buffer.from(hex, 'hex'));

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
@@ -166,4 +166,91 @@ describe('BatchConnectionSampler', () => {
     expect(samplerWithMorePeers.getPeerForRequest(0)).toBe(peers[0]);
     expect(samplerWithMorePeers.getPeerForRequest(1)).toBe(peers[1]);
   });
+
+  it('skips failed peer-index combinations and tries next peer', () => {
+    mockRandomSampler.random.mockImplementation(() => 0);
+
+    // 6 requests across 3 peers (2 per peer)
+    // Peer 0: 0,1  Peer 1: 2,3  Peer 2: 4,5
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 6, /* maxPeers */ 3);
+
+    // Initially, request 0 goes to peer 0
+    expect(sampler.getPeerForRequest(0)).toBe(peers[0]);
+
+    // Mark peer 0 as failed for index 0
+    sampler.markPeerFailedForIndex(peers[0], 0);
+
+    // Now request 0 should go to the next peer (peer 1)
+    expect(sampler.getPeerForRequest(0)).toBe(peers[1]);
+
+    // Mark peer 1 as also failed for index 0
+    sampler.markPeerFailedForIndex(peers[1], 0);
+
+    // Now request 0 should go to peer 2
+    expect(sampler.getPeerForRequest(0)).toBe(peers[2]);
+
+    // Request 1 should still go to peer 0 (only index 0 was failed)
+    expect(sampler.getPeerForRequest(1)).toBe(peers[0]);
+  });
+
+  it('samples new peer when all batch peers have failed for an index', () => {
+    mockRandomSampler.random.mockImplementation(() => 0);
+
+    // 4 requests across 2 peers (peers[0] and peers[1])
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
+    expect(sampler.activePeerCount).toBe(2);
+
+    // Mark both batch peers as failed for index 0
+    sampler.markPeerFailedForIndex(peers[0], 0);
+    sampler.markPeerFailedForIndex(peers[1], 0);
+
+    // Should sample a new peer (peers[2]) and return it
+    mockRandomSampler.random.mockImplementation(() => 2);
+    expect(sampler.getPeerForRequest(0)).toBe(peers[2]);
+    expect(sampler.activePeerCount).toBe(3); // New peer was added to batch
+
+    // Other indices still work with original peers
+    expect(sampler.getPeerForRequest(1)).toBe(peers[0]);
+    expect(sampler.getPeerForRequest(2)).toBe(peers[1]);
+  });
+
+  it('returns undefined when all peers exhausted and no new peers available', () => {
+    mockRandomSampler.random.mockImplementation(() => 0);
+
+    // 4 requests across 2 peers
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
+
+    // Mark both peers as failed for index 0
+    sampler.markPeerFailedForIndex(peers[0], 0);
+    sampler.markPeerFailedForIndex(peers[1], 0);
+
+    // No more peers available to sample
+    libp2p.getPeers.mockReturnValue([peers[0], peers[1]]); // Only return already-used peers
+
+    // No peer available for index 0
+    expect(sampler.getPeerForRequest(0)).toBeUndefined();
+  });
+
+  it('failed peer-index tracking survives peer replacement', () => {
+    mockRandomSampler.random.mockImplementation(() => 0);
+
+    // 4 requests across 2 peers
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
+
+    // Mark peer 0 as failed for index 0
+    sampler.markPeerFailedForIndex(peers[0], 0);
+
+    // Request 0 now goes to peer 1
+    expect(sampler.getPeerForRequest(0)).toBe(peers[1]);
+
+    // Replace peer 0 with peer 2
+    mockRandomSampler.random.mockImplementation(() => 2);
+    sampler.removePeerAndReplace(peers[0]);
+
+    // Request 0 should still go to peer 1 (the replacement peer 2 is now in slot 0,
+    // but peer 0's failure record should not affect the new peer)
+    // Actually, the failure is tracked by peer ID, so peer 2 is a fresh peer
+    // Request 0's primary is now peer 2 (in slot 0), which hasn't failed
+    expect(sampler.getPeerForRequest(0)).toBe(peers[2]);
+  });
 });

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -20,6 +20,8 @@ import type { ConnectionSampler } from './connection_sampler.js';
 export class BatchConnectionSampler {
   private readonly batch: PeerId[] = [];
   private readonly requestsPerPeer: number;
+  /** Tracks peer-index combinations that returned empty/invalid responses */
+  private readonly failedPeerIndices: Map<string, Set<number>> = new Map();
 
   constructor(
     private readonly connectionSampler: ConnectionSampler,
@@ -44,10 +46,12 @@ export class BatchConnectionSampler {
   }
 
   /**
-   * Gets the peer responsible for handling a specific request index
+   * Gets the peer responsible for handling a specific request index.
+   * If the primary peer has previously failed for this index, tries other peers.
+   * If all batch peers have failed, attempts to sample a new peer.
    *
    * @param index - The request index
-   * @returns The peer assigned to handle this request
+   * @returns The peer assigned to handle this request, or undefined if no peer available
    */
   getPeerForRequest(index: number): PeerId | undefined {
     if (this.batch.length === 0) {
@@ -55,8 +59,65 @@ export class BatchConnectionSampler {
     }
 
     // Calculate which peer bucket this index belongs to
-    const peerIndex = Math.floor(index / this.requestsPerPeer) % this.batch.length;
-    return this.batch[peerIndex];
+    const primaryPeerIndex = Math.floor(index / this.requestsPerPeer) % this.batch.length;
+
+    // Try peers starting from primary, wrapping around
+    for (let offset = 0; offset < this.batch.length; offset++) {
+      const peerIndex = (primaryPeerIndex + offset) % this.batch.length;
+      const peer = this.batch[peerIndex];
+      const peerKey = peer.toString();
+
+      const failedIndices = this.failedPeerIndices.get(peerKey);
+      if (!failedIndices || !failedIndices.has(index)) {
+        return peer;
+      }
+    }
+
+    // All batch peers have failed for this index - try to sample a new peer
+    const newPeer = this.sampleNewPeer();
+    if (newPeer) {
+      return newPeer;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Attempts to sample a new peer that isn't already in the batch.
+   * If successful, adds the peer to the batch.
+   *
+   * @returns The new peer if one was sampled, undefined otherwise
+   */
+  private sampleNewPeer(): PeerId | undefined {
+    // Exclude all current batch peers
+    const excluding = new Map(this.batch.map(p => [p.toString(), true] as const));
+    const newPeer = this.connectionSampler.getPeer(excluding);
+
+    if (newPeer) {
+      this.batch.push(newPeer);
+      this.logger.trace('Sampled new peer for exhausted index', { newPeer: newPeer.toString() });
+      return newPeer;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Marks that a peer returned an empty/invalid response for a specific request index.
+   * The peer will not be assigned this index again.
+   *
+   * @param peerId - The peer that failed
+   * @param index - The request index that failed
+   */
+  markPeerFailedForIndex(peerId: PeerId, index: number): void {
+    const peerKey = peerId.toString();
+    let failedIndices = this.failedPeerIndices.get(peerKey);
+    if (!failedIndices) {
+      failedIndices = new Set();
+      this.failedPeerIndices.set(peerKey, failedIndices);
+    }
+    failedIndices.add(index);
+    this.logger.trace('Marked peer failed for index', { peerId: peerKey, index });
   }
 
   /**

--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -489,7 +489,7 @@ describe('ReqResp', () => {
       const batchSize = 12;
       nodes = await createNodes(peerScoring, 3);
 
-      const requesterLoggerSpy = jest.spyOn((nodes[0].req as any).logger, 'debug');
+      const requesterLoggerSpy = jest.spyOn((nodes[0].req as any).logger, 'warn');
 
       await startNodes(nodes);
       await sleep(500);

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -219,6 +219,14 @@ export class ReqResp implements ReqRespInterface {
     const responseValidator = this.subProtocolValidators[subProtocol] ?? DEFAULT_SUB_PROTOCOL_VALIDATORS[subProtocol];
     const responses: InstanceType<SubProtocolMap[SubProtocol]['response']>[] = new Array(requests.length);
     const requestBuffers = requests.map(req => req.toBuffer());
+    const isEmptyResponse = (value: unknown): boolean => {
+      // Some responses serialize to a non-empty buffer even when they contain no items (e.g., empty TxArray).
+      if (!value || typeof value !== 'object') {
+        return false;
+      }
+      const length = (value as { length?: number }).length;
+      return typeof length === 'number' && length === 0;
+    };
 
     const requestFunction = async (signal: AbortSignal) => {
       // Track which requests still need to be processed
@@ -259,7 +267,9 @@ export class ReqResp implements ReqRespInterface {
         for (const requestIndex of pendingRequestIndices) {
           const peer = batchSampler.getPeerForRequest(requestIndex);
           if (!peer) {
-            break;
+            // No peer available for this specific index (all peers exhausted for it)
+            // Skip this index for now - it stays in pendingRequestIndices for retry
+            continue;
           }
           const peerAsString = peer.toString();
           if (!requestBatches.has(peerAsString)) {
@@ -278,6 +288,12 @@ export class ReqResp implements ReqRespInterface {
           });
         }
 
+        // If no requests could be assigned (all peers exhausted for all indices), exit early
+        if (requestBatches.size === 0) {
+          this.logger.warn('No peers available for any pending request indices, stopping batch request');
+          break;
+        }
+
         // Make parallel requests for each peer's batch
         // A batch entry will look something like this:
         // PeerId0: [0, 1, 2, 3]
@@ -289,38 +305,61 @@ export class ReqResp implements ReqRespInterface {
         const batchResults = await Promise.all(
           Array.from(requestBatches.entries()).map(async ([peerAsString, { peerId: peer, indices }]) => {
             try {
+              const markIndexFailed = (index: number) => batchSampler.markPeerFailedForIndex(peer, index);
               // Requests all going to the same peer are sent synchronously
               const peerResults: { index: number; response: InstanceType<SubProtocolMap[SubProtocol]['response']> }[] =
                 [];
+              let shouldReplacePeer = false;
+              const handleFailure = (status: ReqRespStatus, index: number) => {
+                this.logger.warn(
+                  `Request to peer ${peerAsString} failed with status ${prettyPrintReqRespStatus(status)}`,
+                );
+                markIndexFailed(index);
+                return status === ReqRespStatus.RATE_LIMIT_EXCEEDED;
+              };
+
               for (const index of indices) {
-                this.logger.trace(`Sending request ${index} to peer ${peerAsString}`);
+                this.logger.info(`Sending request ${index} to peer ${peerAsString}`);
                 const response = await this.sendRequestToPeer(peer, subProtocol, requestBuffers[index]);
 
                 // Check the status of the response buffer
                 if (response.status !== ReqRespStatus.SUCCESS) {
-                  this.logger.debug(
-                    `Request to peer ${peerAsString} failed with status ${prettyPrintReqRespStatus(response.status)}`,
-                  );
-
-                  // If we hit a rate limit or some failure, we remove the peer and return the results,
-                  // they will be split among remaining peers and the new sampled peer
-                  batchSampler.removePeerAndReplace(peer);
-                  return { peer, results: peerResults };
-                }
-
-                if (response && response.data.length > 0) {
-                  const object = responseFromBuffer(subProtocol, response.data);
-                  const isValid = await responseValidator(requests[index], object, peer);
-
-                  if (isValid) {
-                    peerResults.push({ index, response: object });
+                  shouldReplacePeer = handleFailure(response.status, index);
+                  if (shouldReplacePeer) {
+                    break;
                   }
+                  continue;
                 }
+
+                if (response.data.length === 0) {
+                  markIndexFailed(index);
+                  continue;
+                }
+
+                const object = responseFromBuffer(subProtocol, response.data);
+                if (isEmptyResponse(object)) {
+                  markIndexFailed(index);
+                  continue;
+                }
+
+                const isValid = await responseValidator(requests[index], object, peer);
+                if (!isValid) {
+                  markIndexFailed(index);
+                  continue;
+                }
+
+                peerResults.push({ index, response: object });
+              }
+
+              // If peer had a hard failure (rate limit), replace it for future iterations
+              if (shouldReplacePeer) {
+                this.logger.warn(`Peer ${peerAsString} hit a hard failure, removing from sampler`);
+                batchSampler.removePeerAndReplace(peer);
               }
 
               return { peer, results: peerResults };
             } catch (error) {
-              this.logger.debug(`Failed batch request to peer ${peerAsString}:`, error);
+              this.logger.warn(`Failed batch request to peer ${peerAsString}:`, error);
               batchSampler.removePeerAndReplace(peer);
               return { peer, results: [] };
             }
@@ -341,7 +380,7 @@ export class ReqResp implements ReqRespInterface {
       }
 
       if (retryAttempts >= maxRetryAttempts) {
-        this.logger.debug(`Max retry attempts ${maxRetryAttempts} reached for batch request`);
+        this.logger.warn(`Max retry attempts ${maxRetryAttempts} reached for batch request`);
       }
 
       return responses;
@@ -354,7 +393,7 @@ export class ReqResp implements ReqRespInterface {
         () => new CollectiveReqRespTimeoutError(),
       );
     } catch (e: any) {
-      this.logger.debug(`${e.message} | subProtocol: ${subProtocol}`);
+      this.logger.warn(`${e.message} | subProtocol: ${subProtocol}`);
       return [];
     }
   }

--- a/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
+++ b/yarn-project/p2p/src/services/tx_collection/fast_tx_collection.ts
@@ -12,11 +12,11 @@ import { type Tx, TxHash } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
 
-import { BatchTxRequester } from '../reqresp/batch-tx-requester/batch_tx_requester.js';
 import type { BatchTxRequesterLibP2PService } from '../reqresp/batch-tx-requester/interface.js';
 import { ReqRespSubProtocol } from '../reqresp/interface.js';
 import { chunkTxHashesRequest } from '../reqresp/protocols/tx.js';
 import type { TxCollectionConfig } from './config.js';
+import { BatchTxRequesterCollector, type ProposalTxCollector } from './proposal_tx_collector.js';
 import type { FastCollectionRequest, FastCollectionRequestInput } from './tx_collection.js';
 import type { TxCollectionSink } from './tx_collection_sink.js';
 import type { TxSource } from './tx_source.js';
@@ -24,6 +24,7 @@ import type { TxSource } from './tx_source.js';
 export class FastTxCollection {
   // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   protected requests: Set<FastCollectionRequest> = new Set();
+  private proposalTxCollector: ProposalTxCollector;
 
   constructor(
     private p2pService: BatchTxRequesterLibP2PService,
@@ -32,7 +33,10 @@ export class FastTxCollection {
     private config: TxCollectionConfig,
     private dateProvider: DateProvider = new DateProvider(),
     private log: Logger = createLogger('p2p:tx_collection_service'),
-  ) {}
+    proposalTxCollector?: ProposalTxCollector,
+  ) {
+    this.proposalTxCollector = proposalTxCollector ?? new BatchTxRequesterCollector(p2pService, log, dateProvider);
+  }
 
   public async stop() {
     this.requests.forEach(request => request.promise.reject(new AbortError(`Stopped collection service`)));
@@ -264,19 +268,7 @@ export class FastTxCollection {
       await this.txCollectionSink.collect(
         async txHashes => {
           if (request.type === 'proposal') {
-            const blockProposal = request.blockProposal;
-
-            const batchRequester = new BatchTxRequester(
-              txHashes,
-              blockProposal,
-              pinnedPeer,
-              timeoutMs,
-              this.p2pService,
-              this.log,
-              this.dateProvider,
-            );
-
-            return await BatchTxRequester.collectAllTxs(batchRequester.run());
+            return await this.proposalTxCollector.collectTxs(txHashes, request.blockProposal, pinnedPeer, timeoutMs);
           } else if (request.type === 'block') {
             const txs = await this.p2pService.reqResp.sendBatchRequest<ReqRespSubProtocol.TX>(
               ReqRespSubProtocol.TX,

--- a/yarn-project/p2p/src/services/tx_collection/index.ts
+++ b/yarn-project/p2p/src/services/tx_collection/index.ts
@@ -1,2 +1,7 @@
 export { TxCollection, type FastCollectionRequestInput } from './tx_collection.js';
 export { type TxSource, createNodeRpcTxSources, NodeRpcTxSource } from './tx_source.js';
+export {
+  type ProposalTxCollector,
+  BatchTxRequesterCollector,
+  SendBatchRequestCollector,
+} from './proposal_tx_collector.js';

--- a/yarn-project/p2p/src/services/tx_collection/proposal_tx_collector.ts
+++ b/yarn-project/p2p/src/services/tx_collection/proposal_tx_collector.ts
@@ -1,0 +1,96 @@
+import type { Logger } from '@aztec/foundation/log';
+import type { DateProvider } from '@aztec/foundation/timer';
+import type { BlockProposal } from '@aztec/stdlib/p2p';
+import type { Tx, TxHash } from '@aztec/stdlib/tx';
+
+import type { PeerId } from '@libp2p/interface';
+
+import { BatchTxRequester } from '../reqresp/batch-tx-requester/batch_tx_requester.js';
+import type { BatchTxRequesterLibP2PService } from '../reqresp/batch-tx-requester/interface.js';
+import { ReqRespSubProtocol } from '../reqresp/interface.js';
+import { chunkTxHashesRequest } from '../reqresp/protocols/tx.js';
+
+/**
+ * Strategy interface for collecting transactions for block proposals.
+ * Allows swapping between different tx collection implementations for benchmarking.
+ */
+export interface ProposalTxCollector {
+  /**
+   * Collect transactions for a block proposal.
+   * @param txHashes - The transaction hashes to collect
+   * @param blockProposal - The block proposal containing the transactions
+   * @param pinnedPeer - Optional peer that sent the proposal (expected to have all txs)
+   * @param timeoutMs - Timeout in milliseconds
+   * @returns The collected transactions
+   */
+  collectTxs(
+    txHashes: TxHash[],
+    blockProposal: BlockProposal,
+    pinnedPeer: PeerId | undefined,
+    timeoutMs: number,
+  ): Promise<Tx[]>;
+}
+
+/**
+ * Collects transactions using the BatchTxRequester implementation.
+ * This uses a smart/dumb peer strategy with parallel workers.
+ */
+export class BatchTxRequesterCollector implements ProposalTxCollector {
+  constructor(
+    private p2pService: BatchTxRequesterLibP2PService,
+    private log: Logger,
+    private dateProvider: DateProvider,
+  ) {}
+
+  async collectTxs(
+    txHashes: TxHash[],
+    blockProposal: BlockProposal,
+    pinnedPeer: PeerId | undefined,
+    timeoutMs: number,
+  ): Promise<Tx[]> {
+    const batchRequester = new BatchTxRequester(
+      txHashes,
+      blockProposal,
+      pinnedPeer,
+      timeoutMs,
+      this.p2pService,
+      this.log,
+      this.dateProvider,
+    );
+
+    return await BatchTxRequester.collectAllTxs(batchRequester.run());
+  }
+}
+
+const DEFAULT_MAX_PEERS = 10;
+const DEFAULT_MAX_RETRY_ATTEMPTS = 3;
+
+/**
+ * Collects transactions using the sendBatchRequest implementation from ReqResp.
+ * This is the original implementation that balances requests across peers.
+ */
+export class SendBatchRequestCollector implements ProposalTxCollector {
+  constructor(
+    private p2pService: BatchTxRequesterLibP2PService,
+    private maxPeers: number = DEFAULT_MAX_PEERS,
+    private maxRetryAttempts: number = DEFAULT_MAX_RETRY_ATTEMPTS,
+  ) {}
+
+  async collectTxs(
+    txHashes: TxHash[],
+    _blockProposal: BlockProposal,
+    pinnedPeer: PeerId | undefined,
+    timeoutMs: number,
+  ): Promise<Tx[]> {
+    const txs = await this.p2pService.reqResp.sendBatchRequest<ReqRespSubProtocol.TX>(
+      ReqRespSubProtocol.TX,
+      chunkTxHashesRequest(txHashes),
+      pinnedPeer,
+      timeoutMs,
+      this.maxPeers,
+      this.maxRetryAttempts,
+    );
+
+    return txs.flat();
+  }
+}

--- a/yarn-project/p2p/src/test-helpers/index.ts
+++ b/yarn-project/p2p/src/test-helpers/index.ts
@@ -4,3 +4,4 @@ export * from './make-enrs.js';
 export * from './make-test-p2p-clients.js';
 export * from './reqresp-nodes.js';
 export * from './mock-pubsub.js';
+export * from './testbench-utils.js';

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -1,6 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { type BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
-import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type {

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -1,0 +1,373 @@
+import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { type BlockNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { Logger } from '@aztec/foundation/log';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type {
+  BlockProposal,
+  CheckpointAttestation,
+  CheckpointProposal,
+  CheckpointProposalCore,
+} from '@aztec/stdlib/p2p';
+import { type BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
+
+import EventEmitter from 'events';
+
+import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_pool.js';
+import type { TxPool } from '../mem_pools/tx_pool/index.js';
+import { RateLimitStatus } from '../services/reqresp/rate-limiter/rate_limiter.js';
+
+/**
+ * In-memory TxPool implementation for testing.
+ * Provides basic tx storage without persistence.
+ */
+export class InMemoryTxPool extends EventEmitter implements TxPool {
+  private txsByHash = new Map<string, Tx>();
+  private logger: Logger | null = null;
+
+  setLogger(logger: Logger): void {
+    this.logger = logger;
+  }
+
+  setTxs(txs: Tx[]): number {
+    this.txsByHash.clear();
+    return this.appendTxs(txs);
+  }
+
+  appendTxs(txs: Tx[]): number {
+    let added = 0;
+    for (const tx of txs) {
+      const key = tx.getTxHash().toString();
+      if (!this.txsByHash.has(key)) {
+        added += 1;
+      }
+      this.txsByHash.set(key, tx);
+    }
+    return added;
+  }
+
+  clearTxs(): void {
+    this.txsByHash.clear();
+  }
+
+  resetState(): void {
+    this.txsByHash.clear();
+    this.removeAllListeners();
+  }
+
+  addTxs(txs: Tx[], opts?: { source?: string }): Promise<number> {
+    const newTxs: Tx[] = [];
+    let added = 0;
+    for (const tx of txs) {
+      const key = tx.getTxHash().toString();
+      if (!this.txsByHash.has(key)) {
+        newTxs.push(tx);
+        added += 1;
+      }
+      this.txsByHash.set(key, tx);
+    }
+    if (newTxs.length > 0) {
+      this.emit('txs-added', { txs: newTxs, source: opts?.source });
+    }
+    return Promise.resolve(added);
+  }
+
+  getTxByHash(hash: TxHash): Promise<Tx | undefined> {
+    return Promise.resolve(this.txsByHash.get(hash.toString()));
+  }
+
+  getTxsByHash(hashes: TxHash[]): Promise<(Tx | undefined)[]> {
+    const result = hashes.map(h => this.txsByHash.get(h.toString()));
+    const found = result.filter(tx => tx !== undefined).length;
+    this.logger?.debug(`[TxPool] getTxsByHash: requested ${hashes.length}, found ${found}`);
+    return Promise.resolve(result);
+  }
+
+  hasTxs(hashes: TxHash[]): Promise<boolean[]> {
+    return Promise.resolve(hashes.map(h => this.txsByHash.has(h.toString())));
+  }
+
+  hasTx(hash: TxHash): Promise<boolean> {
+    return Promise.resolve(this.txsByHash.has(hash.toString()));
+  }
+
+  getArchivedTxByHash(_hash: TxHash): Promise<Tx | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  async markAsMined(_txHashes: TxHash[], _blockHeader: BlockHeader): Promise<void> {}
+
+  async markMinedAsPending(_txHashes: TxHash[], _latestBlock: BlockNumber): Promise<void> {}
+
+  deleteTxs(txHashes: TxHash[], _opts?: { permanently?: boolean }): Promise<void> {
+    for (const txHash of txHashes) {
+      this.txsByHash.delete(txHash.toString());
+    }
+    return Promise.resolve();
+  }
+
+  getAllTxs(): Promise<Tx[]> {
+    return Promise.resolve([...this.txsByHash.values()]);
+  }
+
+  getAllTxHashes(): Promise<TxHash[]> {
+    return Promise.resolve([...this.txsByHash.keys()].map(key => TxHash.fromString(key)));
+  }
+
+  getPendingTxHashes(): Promise<TxHash[]> {
+    return Promise.resolve([...this.txsByHash.keys()].map(key => TxHash.fromString(key)));
+  }
+
+  getPendingTxCount(): Promise<number> {
+    return Promise.resolve(this.txsByHash.size);
+  }
+
+  getMinedTxHashes(): Promise<[tx: TxHash, blockNumber: BlockNumber][]> {
+    return Promise.resolve([]);
+  }
+
+  getTxStatus(hash: TxHash): Promise<'pending' | 'mined' | 'deleted' | undefined> {
+    return Promise.resolve(this.txsByHash.has(hash.toString()) ? 'pending' : undefined);
+  }
+
+  updateConfig(_config: { maxPendingTxCount?: number; archivedTxLimit?: number }): void {}
+
+  isEmpty(): Promise<boolean> {
+    return Promise.resolve(this.txsByHash.size === 0);
+  }
+
+  async markTxsAsNonEvictable(_txHashes: TxHash[]): Promise<void> {}
+
+  async clearNonEvictableTxs(): Promise<void> {}
+
+  cleanupDeletedMinedTxs(_blockNumber: BlockNumber): Promise<number> {
+    return Promise.resolve(0);
+  }
+}
+
+/**
+ * In-memory AttestationPool implementation for testing.
+ */
+export class InMemoryAttestationPool implements AttestationPool {
+  private proposals = new Map<string, BlockProposal>();
+
+  addBlockProposal(blockProposal: BlockProposal): Promise<void> {
+    this.proposals.set(blockProposal.archive.toString(), blockProposal);
+    return Promise.resolve();
+  }
+
+  getBlockProposal(id: string): Promise<BlockProposal | undefined> {
+    return Promise.resolve(this.proposals.get(id));
+  }
+
+  hasBlockProposal(idOrProposal: string | BlockProposal): Promise<boolean> {
+    const id = typeof idOrProposal === 'string' ? idOrProposal : idOrProposal.archive.toString();
+    return Promise.resolve(this.proposals.has(id));
+  }
+
+  canAddProposal(_block: BlockProposal): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  async addCheckpointProposal(_proposal: CheckpointProposal): Promise<void> {}
+
+  getCheckpointProposal(_id: string): Promise<CheckpointProposalCore | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  hasCheckpointProposal(_idOrProposal: string | CheckpointProposal): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  async addCheckpointAttestations(_attestations: CheckpointAttestation[]): Promise<void> {}
+
+  async deleteCheckpointAttestationsOlderThan(_slot: SlotNumber): Promise<void> {}
+
+  getCheckpointAttestationsForSlot(_slot: SlotNumber): Promise<CheckpointAttestation[]> {
+    return Promise.resolve([]);
+  }
+
+  getCheckpointAttestationsForSlotAndProposal(
+    _slot: SlotNumber,
+    _proposalId: string,
+  ): Promise<CheckpointAttestation[]> {
+    return Promise.resolve([]);
+  }
+
+  hasCheckpointAttestation(_attestation: CheckpointAttestation): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  canAddCheckpointProposal(_proposal: CheckpointProposal): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  canAddCheckpointAttestation(_attestation: CheckpointAttestation, _committeeSize: number): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  hasReachedCheckpointProposalCap(_slot: SlotNumber): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  hasReachedCheckpointAttestationCap(_slot: SlotNumber, _proposalId: string, _committeeSize: number): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  isEmpty(): Promise<boolean> {
+    return Promise.resolve(this.proposals.size === 0);
+  }
+
+  resetState(): void {
+    this.proposals.clear();
+  }
+}
+
+/**
+ * Creates a mock EpochCache for testing.
+ */
+export function createMockEpochCache(): EpochCacheInterface {
+  return {
+    getCommittee: () => Promise.resolve({ committee: [], seed: 1n, epoch: EpochNumber.ZERO, isEscapeHatchOpen: false }),
+    getProposerIndexEncoding: () => '0x' as `0x${string}`,
+    getEpochAndSlotNow: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n }),
+    computeProposerIndex: () => 0n,
+    getCurrentAndNextSlot: () => ({ currentSlot: SlotNumber.ZERO, nextSlot: SlotNumber.ZERO }),
+    getProposerAttesterAddressInSlot: () => Promise.resolve(undefined),
+    getEpochAndSlotInNextL1Slot: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n, now: 0n }),
+    isInCommittee: () => Promise.resolve(false),
+    getRegisteredValidators: () => Promise.resolve([]),
+    filterInCommittee: () => Promise.resolve([]),
+  };
+}
+
+/**
+ * Creates a mock WorldStateSynchronizer for testing.
+ */
+export function createMockWorldStateSynchronizer(): WorldStateSynchronizer {
+  return {
+    status: () =>
+      Promise.resolve({
+        syncSummary: {
+          latestBlockNumber: 0,
+          latestBlockHash: '',
+          finalizedBlockNumber: 0,
+          treesAreSynched: false,
+          oldestHistoricBlockNumber: 0,
+        },
+      }),
+  } as WorldStateSynchronizer;
+}
+
+/**
+ * Unlimited rate limit configuration for benchmarks.
+ */
+export const UNLIMITED_RATE_LIMIT_QUOTA = {
+  peerLimit: { quotaTimeMs: 1000, quotaCount: 10_000 },
+  globalLimit: { quotaTimeMs: 1000, quotaCount: 100_000 },
+};
+
+/**
+ * Installs unlimited rate limits on a ReqResp instance.
+ * Used in benchmarks to avoid rate limiting affecting results.
+ *
+ * Note: Uses `as any` because rateLimiter is private. This is acceptable
+ * in test code where we need to override internal behavior.
+ */
+export function installUnlimitedRateLimitsOnReqResp(reqResp: any): void {
+  const rateLimiter = reqResp.rateLimiter;
+  rateLimiter.getRateLimits = () => UNLIMITED_RATE_LIMIT_QUOTA;
+  rateLimiter.allow = () => RateLimitStatus.Allowed;
+}
+
+/**
+ * Distribution patterns for benchmark transaction distribution.
+ */
+export type DistributionPattern = 'uniform' | 'sparse' | 'pinned-only';
+
+/**
+ * Collector implementation types for benchmarking.
+ */
+export type CollectorType = 'batch-requester' | 'send-batch-request';
+
+/**
+ * Display names for collector types (for output/logging only).
+ */
+export const COLLECTOR_DISPLAY_NAMES: Record<CollectorType, string> = {
+  'batch-requester': 'batch-requester (new)',
+  'send-batch-request': 'send-batch-request (old)',
+};
+
+/**
+ * Benchmark timing constants.
+ */
+export const BENCHMARK_CONSTANTS = {
+  /** Time to wait for peers to connect before starting benchmark */
+  PEER_DISCOVERY_WAIT_MS: 10_000,
+  /** Maximum time to wait for peer connections */
+  MAX_PEER_WAIT_MS: 60_000,
+  /** Interval between peer connection checks */
+  PEER_CHECK_INTERVAL_MS: 500,
+  /** Default worker ready timeout */
+  WORKER_READY_TIMEOUT_MS: 30_000,
+  /** Graceful shutdown timeout before force kill */
+  GRACEFUL_SHUTDOWN_TIMEOUT_MS: 5_000,
+  /** Overall cleanup timeout */
+  CLEANUP_TIMEOUT_MS: 10_000,
+  /** Buffer time for internal timeout to ensure we return before outer timeout */
+  TIMEOUT_BUFFER_MS: 5_000,
+  /** Minimum internal timeout regardless of buffer */
+  MIN_INTERNAL_TIMEOUT_MS: 1_000,
+  /** Fixed max peers for fair benchmarking */
+  FIXED_MAX_PEERS: 10,
+  /** Fixed max retry attempts for fair benchmarking */
+  FIXED_MAX_RETRY_ATTEMPTS: 3,
+} as const;
+
+/**
+ * Filters transactions based on distribution pattern for benchmark responders.
+ *
+ * @param allTxs - All transactions to filter
+ * @param peerIndex - Index of the current peer (0 = aggregator)
+ * @param peerCount - Total number of peers
+ * @param distribution - Distribution pattern to apply
+ * @param pinnedPeerIndex - Index of the pinned peer (for pinned-only distribution)
+ * @returns Filtered transactions for this peer
+ */
+export function filterTxsByDistribution(
+  allTxs: Tx[],
+  peerIndex: number,
+  peerCount: number,
+  distribution: DistributionPattern,
+  pinnedPeerIndex: number = 1,
+): Tx[] {
+  if (peerIndex === 0) {
+    return [];
+  }
+
+  const responderCount = peerCount - 1;
+
+  switch (distribution) {
+    case 'uniform':
+      return allTxs;
+
+    case 'sparse': {
+      const responderIndex = peerIndex - 1;
+      return allTxs.filter((_, txIndex) => {
+        const bucket = txIndex % responderCount;
+        return bucket === responderIndex || bucket === (responderIndex + 1) % responderCount;
+      });
+    }
+
+    case 'pinned-only':
+      return peerIndex === pinnedPeerIndex ? allTxs : [];
+  }
+}
+
+/**
+ * Calculates the internal timeout for collector operations.
+ * Ensures we return before the outer timeout while maintaining a minimum.
+ */
+export function calculateInternalTimeout(timeoutMs: number): number {
+  return Math.max(timeoutMs - BENCHMARK_CONSTANTS.TIMEOUT_BUFFER_MS, BENCHMARK_CONSTANTS.MIN_INTERNAL_TIMEOUT_MS);
+}

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -1,126 +1,97 @@
 /**
  * A testbench worker that creates a p2p client and listens for commands from the parent.
  *
- * Used when running testbench commands
+ * Used when running testbench commands.
  */
 import { MockL2BlockSource } from '@aztec/archiver/test';
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
-import { createLogger } from '@aztec/foundation/log';
+import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
+import { DateProvider, Timer } from '@aztec/foundation/timer';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
+import { protocolContractsHash } from '@aztec/protocol-contracts';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { P2PClientType, P2PMessage } from '@aztec/stdlib/p2p';
-import { Tx, TxStatus } from '@aztec/stdlib/tx';
+import { type BlockProposal, P2PClientType, P2PMessage } from '@aztec/stdlib/p2p';
+import { ChonkProof } from '@aztec/stdlib/proofs';
+import { makeAztecAddress, makeBlockHeader, makeBlockProposal, mockTx } from '@aztec/stdlib/testing';
+import { Tx, TxHash } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import type { Message, PeerId } from '@libp2p/interface';
 import { TopicValidatorResult } from '@libp2p/interface';
-import EventEmitter from 'events';
+import { peerIdFromString } from '@libp2p/peer-id';
 
+import type { P2PClient } from '../client/p2p_client.js';
 import type { P2PConfig } from '../config.js';
 import { createP2PClient } from '../index.js';
-import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_pool.js';
 import type { MemPools } from '../mem_pools/interface.js';
-import type { TxPool } from '../mem_pools/tx_pool/index.js';
 import { LibP2PService } from '../services/libp2p/libp2p_service.js';
 import type { PeerManager } from '../services/peer-manager/peer_manager.js';
+import type { BatchTxRequesterLibP2PService } from '../services/reqresp/batch-tx-requester/interface.js';
+import { RateLimitStatus } from '../services/reqresp/rate-limiter/rate_limiter.js';
 import type { ReqResp } from '../services/reqresp/reqresp.js';
 import type { PeerDiscoveryService } from '../services/service.js';
+import {
+  BatchTxRequesterCollector,
+  SendBatchRequestCollector,
+} from '../services/tx_collection/proposal_tx_collector.js';
 import { AlwaysTrueCircuitVerifier } from '../test-helpers/reqresp-nodes.js';
+import {
+  BENCHMARK_CONSTANTS,
+  type CollectorType,
+  type DistributionPattern,
+  InMemoryAttestationPool,
+  InMemoryTxPool,
+  UNLIMITED_RATE_LIMIT_QUOTA,
+  createMockEpochCache,
+  createMockWorldStateSynchronizer,
+  filterTxsByDistribution,
+} from '../test-helpers/testbench-utils.js';
 import type { PubSubLibp2p } from '../util.js';
 
-// Simple mock implementation
-function mockTxPool(): TxPool {
-  // Mock all methods
-  const pool: Omit<TxPool, keyof EventEmitter> = {
-    isEmpty: () => Promise.resolve(false),
-    addTxs: () => Promise.resolve(1),
-    getTxByHash: () => Promise.resolve(undefined),
-    getArchivedTxByHash: () => Promise.resolve(undefined),
-    markAsMined: () => Promise.resolve(),
-    markMinedAsPending: () => Promise.resolve(),
-    deleteTxs: () => Promise.resolve(),
-    getAllTxs: () => Promise.resolve([]),
-    getAllTxHashes: () => Promise.resolve([]),
-    getPendingTxHashes: () => Promise.resolve([]),
-    getPendingTxCount: () => Promise.resolve(0),
-    getMinedTxHashes: () => Promise.resolve([]),
-    getTxStatus: () => Promise.resolve(TxStatus.PENDING),
-    getTxsByHash: () => Promise.resolve([]),
-    hasTxs: () => Promise.resolve([]),
-    hasTx: () => Promise.resolve(false),
-    updateConfig: () => {},
-    markTxsAsNonEvictable: () => Promise.resolve(),
-    clearNonEvictableTxs: () => Promise.resolve(),
-    cleanupDeletedMinedTxs: () => Promise.resolve(0),
-  };
-  return Object.assign(new EventEmitter(), pool);
+export type { DistributionPattern, CollectorType } from '../test-helpers/testbench-utils.js';
+export { COLLECTOR_DISPLAY_NAMES } from '../test-helpers/testbench-utils.js';
+
+export interface BenchReqRespCommand {
+  type: 'BENCH_REQRESP';
+  txCount: number;
+  peerCount: number;
+  distribution: DistributionPattern;
+  collectorType: CollectorType;
+  timeoutMs: number;
+  isAggregator: boolean;
+  peerIndex: number;
+  pinnedPeerIndex?: number;
+  pinnedPeerId?: string;
+  blockNumber: number;
+  seed: number;
 }
 
-function mockAttestationPool(): AttestationPool {
-  return {
-    isEmpty: () => Promise.resolve(false),
-    addBlockProposal: () => Promise.resolve(),
-    getBlockProposal: () => Promise.resolve(undefined),
-    hasBlockProposal: () => Promise.resolve(false),
-    canAddProposal: () => Promise.resolve(true),
-    // Checkpoint attestation methods
-    addCheckpointProposal: () => Promise.resolve(),
-    getCheckpointProposal: () => Promise.resolve(undefined),
-    hasCheckpointProposal: () => Promise.resolve(false),
-    addCheckpointAttestations: () => Promise.resolve(),
-    getCheckpointAttestationsForSlot: () => Promise.resolve([]),
-    getCheckpointAttestationsForSlotAndProposal: () => Promise.resolve([]),
-    deleteCheckpointAttestationsOlderThan: () => Promise.resolve(),
-    hasReachedCheckpointProposalCap: () => Promise.resolve(false),
-    hasReachedCheckpointAttestationCap: () => Promise.resolve(false),
-    canAddCheckpointProposal: () => Promise.resolve(true),
-    canAddCheckpointAttestation: () => Promise.resolve(true),
-    hasCheckpointAttestation: () => Promise.resolve(false),
-  };
+export interface BenchResultMessage {
+  type: 'BENCH_RESULT';
+  durationMs: number;
+  fetchedCount: number;
+  success: boolean;
+  error?: string;
 }
 
-function mockEpochCache(): EpochCacheInterface {
-  return {
-    getCommittee: () => Promise.resolve({ committee: [], seed: 1n, epoch: EpochNumber.ZERO, isEscapeHatchOpen: false }),
-    getProposerIndexEncoding: () => '0x' as `0x${string}`,
-    getEpochAndSlotNow: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n }),
-    computeProposerIndex: () => 0n,
-    getCurrentAndNextSlot: () => ({
-      currentSlot: SlotNumber.ZERO,
-      nextSlot: SlotNumber.ZERO,
-    }),
-    getProposerAttesterAddressInSlot: () => Promise.resolve(undefined),
-    getEpochAndSlotInNextL1Slot: () => ({ epoch: EpochNumber.ZERO, slot: SlotNumber.ZERO, ts: 0n, now: 0n }),
-    isInCommittee: () => Promise.resolve(false),
-    getRegisteredValidators: () => Promise.resolve([]),
-    filterInCommittee: () => Promise.resolve([]),
-  };
+export interface BenchReadyMessage {
+  type: 'BENCH_READY';
 }
 
-function mockWorldStateSynchronizer(): WorldStateSynchronizer {
-  return {
-    status: () =>
-      Promise.resolve({
-        syncSummary: {
-          latestBlockNumber: 0,
-          latestBlockHash: '',
-          finalizedBlockNumber: 0,
-          treesAreSynched: false,
-          oldestHistoricBlockNumber: 0,
-        },
-      }),
-  } as WorldStateSynchronizer;
-}
+const txCache = new Map<number, Tx[]>();
 
 class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends LibP2PService<T> {
   private disableTxValidation: boolean;
-  private gossipMessageCount: number = 0;
+  private gossipMessageCount = 0;
 
   constructor(
     clientType: T,
@@ -189,10 +160,163 @@ class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends Li
   }
 }
 
+async function generateDeterministicTxs(txCount: number, seed: number, config: P2PConfig): Promise<Tx[]> {
+  const cached = txCache.get(seed) ?? [];
+  if (cached.length >= txCount) {
+    return cached.slice(0, txCount);
+  }
+
+  const includeByTimestampBase = BigInt(seed);
+  for (let i = cached.length; i < txCount; i++) {
+    const txSeed = seed * 10000 + i;
+    const tx = await mockTx(txSeed, {
+      chainId: new Fr(config.l1ChainId),
+      version: new Fr(config.rollupVersion),
+      vkTreeRoot: getVKTreeRoot(),
+      protocolContractsHash,
+      feePayer: makeAztecAddress(txSeed + 1),
+      chonkProof: ChonkProof.empty(),
+      numberOfNonRevertiblePublicCallRequests: 0,
+      numberOfRevertiblePublicCallRequests: 0,
+      numberOfRevertibleNullifiers: 0,
+      hasPublicTeardownCallRequest: false,
+      publicCalldataSize: 0,
+    });
+    tx.data.includeByTimestamp = includeByTimestampBase + BigInt(i);
+    await tx.recomputeHash();
+    cached.push(tx);
+  }
+
+  txCache.set(seed, cached);
+  return cached.slice(0, txCount);
+}
+
+async function createBlockProposal(blockNumber: number, txHashes: TxHash[], seed: number): Promise<BlockProposal> {
+  const archiveRoot = new Fr(BigInt(seed) * 1000000n + BigInt(blockNumber));
+  return await makeBlockProposal({
+    signer: Secp256k1Signer.random(),
+    blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(blockNumber) }),
+    archiveRoot,
+    txHashes,
+  });
+}
+
+function installUnlimitedRateLimits(client: P2PClient): void {
+  const reqResp = (client as any).p2pService.reqresp as any;
+  const rateLimiter = reqResp.rateLimiter as any;
+
+  rateLimiter.getRateLimits = () => UNLIMITED_RATE_LIMIT_QUOTA;
+  rateLimiter.allow = () => RateLimitStatus.Allowed;
+}
+
+async function runAggregatorBenchmark(
+  client: P2PClient,
+  blockProposal: BlockProposal,
+  collectorType: CollectorType,
+  timeoutMs: number,
+  pinnedPeerId: string | undefined,
+  pinnedPeerIndex: number | undefined,
+  logger: Logger,
+  expectedPeerCount: number,
+): Promise<BenchResultMessage> {
+  let timer = new Timer();
+  try {
+    installUnlimitedRateLimits(client);
+
+    const txHashes = blockProposal.txHashes;
+    logger.info(`[BENCH] Using block proposal with archive ${blockProposal.archive.toString().slice(0, 10)}...`);
+
+    const p2pService = (client as any).p2pService;
+    const reqResp = p2pService.reqresp;
+    const connectionSampler =
+      typeof reqResp.getConnectionSampler === 'function' ? reqResp.getConnectionSampler() : reqResp.connectionSampler;
+
+    const minPeersRequired = Math.max(1, expectedPeerCount - 1);
+    const maxWaitMs = BENCHMARK_CONSTANTS.MAX_PEER_WAIT_MS;
+    const waitInterval = BENCHMARK_CONSTANTS.PEER_CHECK_INTERVAL_MS;
+    let waited = 0;
+
+    while (waited < maxWaitMs) {
+      const connectedPeers = connectionSampler.getPeerListSortedByConnectionCountAsc();
+      if (connectedPeers.length >= minPeersRequired) {
+        logger.info(`[BENCH] Aggregator has ${connectedPeers.length} connected peers, starting benchmark`);
+        break;
+      }
+      logger.debug(`[BENCH] Waiting for peers: ${connectedPeers.length}/${minPeersRequired} (waited ${waited}ms)`);
+      await sleep(waitInterval);
+      waited += waitInterval;
+    }
+
+    const connectedPeers = connectionSampler.getPeerListSortedByConnectionCountAsc();
+    logger.info(`[BENCH] Aggregator has ${connectedPeers.length} connected peers`);
+    logger.info(
+      `[BENCH] Requesting ${txHashes.length} tx hashes: ${txHashes
+        .slice(0, 3)
+        .map(h => h.toString())
+        .join(', ')}...`,
+    );
+
+    const mockService: BatchTxRequesterLibP2PService = {
+      reqResp,
+      connectionSampler,
+      txValidator: () => Promise.resolve(true),
+    };
+
+    let pinnedPeer: PeerId | undefined;
+    if (pinnedPeerId) {
+      pinnedPeer = peerIdFromString(pinnedPeerId);
+    } else if (pinnedPeerIndex !== undefined) {
+      if (pinnedPeerIndex > 0 && pinnedPeerIndex <= connectedPeers.length) {
+        pinnedPeer = connectedPeers[pinnedPeerIndex - 1];
+      }
+    }
+
+    timer = new Timer();
+    if (collectorType === 'batch-requester') {
+      const collector = new BatchTxRequesterCollector(mockService, logger, new DateProvider());
+      const fetchedTxs = await collector.collectTxs(txHashes, blockProposal, pinnedPeer, timeoutMs);
+      const durationMs = timer.ms();
+      return {
+        type: 'BENCH_RESULT',
+        durationMs,
+        fetchedCount: fetchedTxs.length,
+        success: fetchedTxs.length === txHashes.length,
+      };
+    }
+
+    const collector = new SendBatchRequestCollector(
+      mockService,
+      BENCHMARK_CONSTANTS.FIXED_MAX_PEERS,
+      BENCHMARK_CONSTANTS.FIXED_MAX_RETRY_ATTEMPTS,
+    );
+    const fetchedTxs = await collector.collectTxs(txHashes, blockProposal, pinnedPeer, timeoutMs);
+    const durationMs = timer.ms();
+    return {
+      type: 'BENCH_RESULT',
+      durationMs,
+      fetchedCount: fetchedTxs.length,
+      success: fetchedTxs.length === txHashes.length,
+    };
+  } catch (err: any) {
+    return {
+      type: 'BENCH_RESULT',
+      durationMs: timer.ms(),
+      fetchedCount: 0,
+      success: false,
+      error: err?.message ?? String(err),
+    };
+  }
+}
+
+let workerClient: P2PClient | null = null;
+let workerTxPool: InMemoryTxPool | null = null;
+let workerAttestationPool: InMemoryAttestationPool | null = null;
+let workerConfig: P2PConfig | null = null;
+let workerLogger: Logger | null = null;
+let kvStore: Awaited<ReturnType<typeof openTmpStore>> | null = null;
+
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 process.on('message', async msg => {
-  // Note: peerIdPrivateKey comes as a raw string (not SecretValue) because
-  // SecretValue's private fields can't be serialized via IPC
   const {
     type,
     config: rawConfig,
@@ -202,47 +326,47 @@ process.on('message', async msg => {
     config: Omit<P2PConfig, 'peerIdPrivateKey'> & { peerIdPrivateKey?: string };
     clientIndex: number;
   };
+
   try {
     if (type === 'START') {
-      // Re-wrap the peerIdPrivateKey with SecretValue
       const config: P2PConfig = {
         ...rawConfig,
         peerIdPrivateKey: rawConfig.peerIdPrivateKey ? new SecretValue(rawConfig.peerIdPrivateKey) : undefined,
       } as P2PConfig;
 
-      const txPool = mockTxPool();
-      const attestationPool = mockAttestationPool();
-      const epochCache = mockEpochCache();
-      const worldState = mockWorldStateSynchronizer();
+      workerConfig = config;
+      workerTxPool = new InMemoryTxPool();
+      workerAttestationPool = new InMemoryAttestationPool();
+      const epochCache = createMockEpochCache();
+      const worldState = createMockWorldStateSynchronizer();
       const l2BlockSource = new MockL2BlockSource();
 
       const proofVerifier = new AlwaysTrueCircuitVerifier();
-      const kvStore = await openTmpStore(`test-${clientIndex}`);
-      const logger = createLogger(`p2p:${clientIndex}`);
+      kvStore = await openTmpStore(`test-${clientIndex}`);
+      workerLogger = createLogger(`p2p:${clientIndex}`);
+      workerTxPool.setLogger(workerLogger);
       const telemetry = getTelemetryClient();
 
       const deps = {
-        txPool,
-        attestationPool,
+        txPool: workerTxPool,
+        attestationPool: workerAttestationPool,
         store: kvStore,
-        logger,
+        logger: workerLogger,
       };
 
       const client = await createP2PClient(
         P2PClientType.Full,
         config as P2PConfig & DataStoreConfig,
         l2BlockSource,
-        proofVerifier,
+        proofVerifier as ClientProtocolCircuitVerifier,
         worldState,
         epochCache,
         'test-p2p-bench-worker',
         undefined,
-        telemetry,
+        telemetry as TelemetryClient,
         deps,
       );
 
-      // Create test service with validation disabled
-      // Note: Parameter order must match LibP2PService constructor
       const testService = new TestLibP2PService(
         P2PClientType.Full,
         config,
@@ -255,41 +379,113 @@ process.on('message', async msg => {
         epochCache,
         proofVerifier,
         worldState,
-        telemetry,
-        logger,
-        true, // disable validation
+        telemetry as TelemetryClient,
+        workerLogger,
+        true,
       );
 
-      // Replace the existing p2pService with our test version
       (client as any).p2pService = testService;
 
       await client.start();
-      // Wait until the client is ready
       for (let i = 0; i < 100; i++) {
         const isReady = client.isReady();
-        logger.debug(`Client ${clientIndex} isReady: ${isReady}`);
+        workerLogger.debug(`Client ${clientIndex} isReady: ${isReady}`);
         if (isReady) {
           break;
         }
         await sleep(1000);
       }
 
-      // Listen for commands from parent
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      process.on('message', async (cmd: any) => {
-        switch (cmd.type) {
-          case 'STOP':
-            await client.stop();
-            process.exit(0);
-            break;
-          case 'SEND_TX':
-            await client.sendTx(Tx.fromBuffer(Buffer.from(cmd.tx)));
-            process.send!({ type: 'TX_SENT' });
-            break;
-        }
-      });
+      workerClient = client;
+      const peerId = (client as any).p2pService.node.peerId.toString();
+      process.send!({ type: 'READY', peerId });
+      return;
+    }
 
-      process.send!({ type: 'READY' });
+    const cmd = msg as any;
+    switch (cmd.type) {
+      case 'STOP':
+        if (workerClient) {
+          await workerClient.stop();
+        }
+        if (kvStore?.close) {
+          await kvStore.close();
+        }
+        process.exit(0);
+        break;
+
+      case 'SEND_TX':
+        if (workerClient) {
+          await workerClient.sendTx(Tx.fromBuffer(Buffer.from(cmd.tx)));
+          process.send!({ type: 'TX_SENT' });
+        }
+        break;
+
+      case 'BENCH_REQRESP': {
+        const benchCmd = cmd as BenchReqRespCommand;
+        if (!workerClient || !workerTxPool || !workerAttestationPool || !workerConfig || !workerLogger) {
+          process.send!({
+            type: 'BENCH_RESULT',
+            durationMs: 0,
+            fetchedCount: 0,
+            success: false,
+            error: 'Worker not initialized',
+          } as BenchResultMessage);
+          break;
+        }
+
+        // Reset state before each benchmark run to avoid cross-run contamination
+        workerTxPool.resetState();
+        workerAttestationPool.resetState();
+
+        installUnlimitedRateLimits(workerClient);
+
+        const allTxs = await generateDeterministicTxs(benchCmd.txCount, benchCmd.seed, workerConfig);
+        const txHashes = allTxs.map(tx => tx.getTxHash());
+        const blockProposal = await createBlockProposal(benchCmd.blockNumber, txHashes, benchCmd.seed);
+
+        await workerAttestationPool.addBlockProposal(blockProposal);
+        workerLogger.debug(
+          `[BENCH] Added block proposal with archive ${blockProposal.archive.toString().slice(0, 10)}...`,
+        );
+
+        if (benchCmd.isAggregator) {
+          workerTxPool.clearTxs();
+
+          workerLogger.info(
+            `[BENCH] Aggregator starting benchmark: txCount=${benchCmd.txCount}, collector=${benchCmd.collectorType}, distribution=${benchCmd.distribution}`,
+          );
+
+          const result = await runAggregatorBenchmark(
+            workerClient,
+            blockProposal,
+            benchCmd.collectorType,
+            benchCmd.timeoutMs,
+            benchCmd.pinnedPeerId,
+            benchCmd.pinnedPeerIndex,
+            workerLogger,
+            benchCmd.peerCount,
+          );
+
+          process.send!(result);
+        } else {
+          const myTxs = filterTxsByDistribution(
+            allTxs,
+            benchCmd.peerIndex,
+            benchCmd.peerCount,
+            benchCmd.distribution,
+            benchCmd.pinnedPeerIndex,
+          );
+          workerTxPool.setTxs(myTxs);
+
+          workerLogger.info(
+            `[BENCH] Peer ${benchCmd.peerIndex} populated tx pool with ${myTxs.length}/${benchCmd.txCount} txs (${benchCmd.distribution})`,
+          );
+
+          process.send!({ type: 'BENCH_READY' } as BenchReadyMessage);
+        }
+        break;
+      }
     }
   } catch (err: any) {
     process.send!({ type: 'ERROR', error: err.message });

--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -1,10 +1,10 @@
-import { SecretValue } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Logger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { ChainConfig } from '@aztec/stdlib/config';
 
 import { type ChildProcess, fork } from 'child_process';
+import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -12,9 +12,19 @@ import { type P2PConfig, getP2PDefaultConfig } from '../config.js';
 import { generatePeerIdPrivateKeys } from '../test-helpers/generate-peer-id-private-keys.js';
 import { getPorts } from '../test-helpers/get-ports.js';
 import { makeEnr, makeEnrs } from '../test-helpers/make-enrs.js';
+import { BENCHMARK_CONSTANTS } from '../test-helpers/testbench-utils.js';
+import type {
+  BenchReqRespCommand,
+  BenchResultMessage,
+  CollectorType,
+  DistributionPattern,
+} from './p2p_client_testbench_worker.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const workerPath = path.join(__dirname, '../../dest/testbench/p2p_client_testbench_worker.js');
+const p2pRoot = path.resolve(__dirname, '../..');
+const workerTsPath = path.join(__dirname, 'p2p_client_testbench_worker.ts');
+const workerJsPath = path.join(p2pRoot, 'dest/testbench/p2p_client_testbench_worker.js');
+const tsconfigPath = path.join(p2pRoot, 'tsconfig.json');
 
 const testChainConfig: ChainConfig = {
   l1ChainId: 31337,
@@ -24,11 +34,32 @@ const testChainConfig: ChainConfig = {
   },
 };
 
+export interface ReqRespBenchmarkConfig {
+  txCount: number;
+  distribution: DistributionPattern;
+  collectorType: CollectorType;
+  timeoutMs: number;
+  pinnedPeerIndex?: number;
+  blockNumber?: number;
+  seed?: number;
+}
+
+export interface ReqRespBenchmarkResult {
+  txCount: number;
+  distribution: DistributionPattern;
+  collector: CollectorType;
+  durationMs: number;
+  fetchedCount: number;
+  success: boolean;
+  error?: string;
+}
+
 class WorkerClientManager {
   public processes: ChildProcess[] = [];
   public peerIdPrivateKeys: string[] = [];
   public peerEnrs: string[] = [];
   public ports: number[] = [];
+  public peerIds: string[] = [];
   private p2pConfig: Partial<P2PConfig>;
   private logger: Logger;
   private messageReceivedByClient: number[] = [];
@@ -46,39 +77,55 @@ class WorkerClientManager {
   }
 
   /**
-   * Creates a client configuration object
+   * Creates a client configuration object for IPC.
+   * Note: We send the raw peerIdPrivateKey string instead of SecretValue
+   * because SecretValue.toJSON() returns '[Redacted]', losing the value.
+   * The worker must re-wrap it in SecretValue.
    */
   private createClientConfig(
     clientIndex: number,
     port: number,
     otherNodes: string[],
-  ): P2PConfig & Partial<ChainConfig> {
+  ): Omit<P2PConfig, 'peerIdPrivateKey'> & { peerIdPrivateKey: string } & Partial<ChainConfig> {
     return {
       ...getP2PDefaultConfig(),
       p2pEnabled: true,
-      peerIdPrivateKey: new SecretValue(this.peerIdPrivateKeys[clientIndex]),
+      peerIdPrivateKey: this.peerIdPrivateKeys[clientIndex],
       listenAddress: '127.0.0.1',
       p2pIp: '127.0.0.1',
       p2pPort: port,
       bootstrapNodes: [...otherNodes],
       ...this.p2pConfig,
-    };
+    } as Omit<P2PConfig, 'peerIdPrivateKey'> & { peerIdPrivateKey: string } & Partial<ChainConfig>;
   }
 
   /**
-   * Spawns a worker process and returns a promise that resolves when the worker is ready
+   * Spawns a worker process and returns a promise that resolves when the worker is ready.
+   * Config uses raw string for peerIdPrivateKey (not SecretValue) for IPC serialization.
    */
   private spawnWorkerProcess(
-    config: P2PConfig & Partial<ChainConfig>,
+    config: Omit<P2PConfig, 'peerIdPrivateKey'> & { peerIdPrivateKey: string } & Partial<ChainConfig>,
     clientIndex: number,
   ): [ChildProcess, Promise<void>] {
-    const childProcess = fork(workerPath);
-    // Extract the raw peerIdPrivateKey value since SecretValue can't be serialized via IPC
-    const serializedConfig = {
-      ...config,
-      peerIdPrivateKey: config.peerIdPrivateKey?.getValue(),
+    const useCompiled = existsSync(workerJsPath);
+    const workerPath = useCompiled ? workerJsPath : workerTsPath;
+
+    const execArgv = [...process.execArgv];
+    if (!useCompiled && !execArgv.includes('ts-node/esm')) {
+      execArgv.push('--loader', 'ts-node/esm');
+    }
+
+    const env = {
+      ...process.env,
+      TS_NODE_PROJECT: tsconfigPath,
     };
-    childProcess.send({ type: 'START', config: serializedConfig, clientIndex });
+
+    const childProcess = fork(workerPath, {
+      cwd: p2pRoot,
+      execArgv,
+      env,
+    });
+    childProcess.send({ type: 'START', config, clientIndex });
 
     // Handle unexpected child process exit
     childProcess.on('exit', (code, signal) => {
@@ -95,74 +142,131 @@ class WorkerClientManager {
 
     // Create ready signal promise
     const readySignal = new Promise<void>((resolve, reject) => {
-      // Set a timeout to avoid hanging indefinitely
-      const timeout = setTimeout(() => {
-        reject(new Error(`Timeout waiting for worker ${clientIndex} to be ready`));
-      }, 30000); // 30 second timeout
+      let resolved = false;
 
-      childProcess.once('message', (msg: any) => {
-        clearTimeout(timeout);
-        if (msg.type === 'READY') {
-          resolve();
+      const timeout = setTimeout(() => {
+        if (resolved) {
+          return;
         }
-        // For future use
-        if (msg.type === 'ERROR') {
+        resolved = true;
+        childProcess.off('message', messageHandler);
+        childProcess.off('exit', exitHandler);
+        reject(new Error(`Timeout waiting for worker ${clientIndex} to be ready`));
+      }, BENCHMARK_CONSTANTS.WORKER_READY_TIMEOUT_MS);
+
+      const messageHandler = (msg: any) => {
+        if (resolved) {
+          return;
+        }
+        // Only handle READY or ERROR messages; ignore others (e.g., GOSSIP_RECEIVED)
+        if (msg.type === 'READY') {
+          resolved = true;
+          clearTimeout(timeout);
+          childProcess.off('message', messageHandler);
+          childProcess.off('exit', exitHandler);
+          if (typeof msg.peerId === 'string') {
+            this.peerIds[clientIndex] = msg.peerId;
+          }
+          resolve();
+        } else if (msg.type === 'ERROR') {
+          resolved = true;
+          clearTimeout(timeout);
+          childProcess.off('message', messageHandler);
+          childProcess.off('exit', exitHandler);
           reject(new Error(msg.error));
         }
-      });
+        // Ignore other message types and keep waiting for READY/ERROR
+      };
 
-      // Also resolve/reject if process exits before sending message
-      childProcess.once('exit', code => {
+      const exitHandler = (code: number | null) => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
         clearTimeout(timeout);
+        childProcess.off('message', messageHandler);
         if (code === 0) {
           resolve();
         } else {
           reject(new Error(`Worker ${clientIndex} exited with code ${code} before becoming ready`));
         }
-      });
+      };
+
+      childProcess.on('message', messageHandler);
+      childProcess.once('exit', exitHandler);
     });
 
     return [childProcess, readySignal];
   }
 
   /**
-   * Creates a number of worker clients in separate processes
-   * All are configured to connect to each other and overrided with the test specific config
+   * Creates a number of worker clients in separate processes.
+   * All are configured to connect to each other and overridden with the test-specific config.
    *
    * @param numberOfClients - The number of clients to create
+   * @param options - Optional overrides for seeding/bootstrapping strategy
    * @returns The ENRs of the created clients
    */
-  async makeWorkerClients(numberOfClients: number) {
+  async makeWorkerClients(
+    numberOfClients: number,
+    options: {
+      bootstrapMode?: 'subset' | 'all';
+      seedPeerLimit?: number;
+      batchSize?: number;
+      batchDelayMs?: number;
+    } = {},
+  ) {
     try {
+      const bootstrapMode = options.bootstrapMode ?? (this.p2pConfig.bootstrapNodesAsFullPeers ? 'all' : 'subset');
+      const seedPeerLimit = options.seedPeerLimit ?? 10;
+      const batchSize = options.batchSize ?? (bootstrapMode === 'all' ? Math.min(5, numberOfClients) : numberOfClients);
+      const batchDelayMs = options.batchDelayMs ?? (bootstrapMode === 'all' ? 500 : 0);
+
       this.messageReceivedByClient = new Array(numberOfClients).fill(0);
       this.peerIdPrivateKeys = generatePeerIdPrivateKeys(numberOfClients);
       this.ports = await getPorts(numberOfClients);
       this.peerEnrs = await makeEnrs(this.peerIdPrivateKeys, this.ports, testChainConfig);
+      this.peerIds = new Array(numberOfClients);
 
       this.processes = [];
       const readySignals: Promise<void>[] = [];
 
-      for (let i = 0; i < numberOfClients; i++) {
-        this.logger.info(`Creating client ${i}`);
+      for (let batchStart = 0; batchStart < numberOfClients; batchStart += batchSize) {
+        const batchEnd = Math.min(batchStart + batchSize, numberOfClients);
+        const batchPromises: Promise<void>[] = [];
 
-        // Maximum seed with 10 other peers to allow peer discovery to connect them at a smoother rate
-        const otherNodes = this.peerEnrs.filter((_, ind) => ind < Math.min(i, 10));
+        for (let i = batchStart; i < batchEnd; i++) {
+          this.logger.info(`Creating client ${i}`);
 
-        const config = this.createClientConfig(i, this.ports[i], otherNodes);
-        const [childProcess, readySignal] = this.spawnWorkerProcess(config, i);
+          const otherNodes =
+            bootstrapMode === 'all'
+              ? this.peerEnrs.filter((_, ind) => ind !== i)
+              : this.peerEnrs.filter((_, ind) => ind < Math.min(i, seedPeerLimit));
 
-        readySignals.push(readySignal);
-        this.processes.push(childProcess);
+          const config = this.createClientConfig(i, this.ports[i], otherNodes);
+          const [childProcess, readySignal] = this.spawnWorkerProcess(config, i);
+
+          readySignals.push(readySignal);
+          batchPromises.push(readySignal);
+          this.processes.push(childProcess);
+        }
+
+        await Promise.all(batchPromises);
+
+        if (batchEnd < numberOfClients && batchDelayMs > 0) {
+          await sleep(batchDelayMs);
+        }
       }
 
-      // Wait for peers to all connect with each other
-      await sleep(10000);
+      await sleep(BENCHMARK_CONSTANTS.PEER_DISCOVERY_WAIT_MS);
 
-      // Wait for all peers to be booted up with timeout
       await Promise.race([
         Promise.all(readySignals),
         new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Timeout waiting for all workers to be ready')), 30000),
+          setTimeout(
+            () => reject(new Error('Timeout waiting for all workers to be ready')),
+            BENCHMARK_CONSTANTS.WORKER_READY_TIMEOUT_MS,
+          ),
         ),
       ]);
 
@@ -220,11 +324,13 @@ class WorkerClientManager {
 
       this.processes[clientIndex] = childProcess;
 
-      // Wait for the process to be ready with a timeout
       await Promise.race([
         readySignal,
         new Promise((_, reject) =>
-          setTimeout(() => reject(new Error(`Timeout waiting for client ${clientIndex} to be ready`)), 30000),
+          setTimeout(
+            () => reject(new Error(`Timeout waiting for client ${clientIndex} to be ready`)),
+            BENCHMARK_CONSTANTS.WORKER_READY_TIMEOUT_MS,
+          ),
         ),
       ]);
     } catch (error) {
@@ -244,15 +350,14 @@ class WorkerClientManager {
     }
 
     return new Promise<void>(resolve => {
-      // Set a timeout for the graceful exit
       const forceKillTimeout = setTimeout(() => {
         this.logger.warn(`Process ${index} didn't exit gracefully, force killing...`);
         try {
-          process.kill('SIGKILL'); // Force kill
+          process.kill('SIGKILL');
         } catch (e) {
           this.logger.error(`Error force killing process ${index}:`, e);
         }
-      }, 5000); // 5 second timeout for graceful exit
+      }, BENCHMARK_CONSTANTS.GRACEFUL_SHUTDOWN_TIMEOUT_MS);
 
       // Listen for process exit
       process.once('exit', () => {
@@ -285,7 +390,6 @@ class WorkerClientManager {
     // Create array of promises for each process termination
     const terminationPromises = this.processes.map((process, index) => this.terminateProcess(process, index));
 
-    // Wait for all processes to terminate with a timeout
     try {
       await Promise.race([
         Promise.all(terminationPromises),
@@ -302,7 +406,7 @@ class WorkerClientManager {
               }
             });
             resolve();
-          }, 10000); // 10 second timeout for all processes
+          }, BENCHMARK_CONSTANTS.CLEANUP_TIMEOUT_MS);
         }),
       ]);
     } catch (error) {
@@ -310,8 +414,161 @@ class WorkerClientManager {
     }
 
     this.processes = [];
+    this.peerIds = [];
     this.logger.info('All worker processes cleaned up');
+  }
+
+  /**
+   * Run a req/resp benchmark across all worker clients.
+   *
+   * This sends a BENCH_REQRESP command to all workers:
+   * - Aggregator (client 0) runs the collector and returns timing results
+   * - Responders (clients 1..N) populate their tx pools based on distribution
+   *
+   * All workers generate the same txs deterministically from a shared seed,
+   * then filter based on their peerIndex and distribution pattern.
+   */
+  async runReqRespBenchmark(config: ReqRespBenchmarkConfig): Promise<ReqRespBenchmarkResult> {
+    const peerCount = this.processes.length;
+    if (peerCount < 2) {
+      throw new Error('Need at least 2 peers to run req/resp benchmark');
+    }
+
+    const seed = config.seed ?? Date.now();
+    const blockNumber = config.blockNumber ?? 1;
+    const pinnedPeerId = config.pinnedPeerIndex !== undefined ? this.peerIds[config.pinnedPeerIndex] : undefined;
+
+    this.logger.info(
+      `Starting req/resp benchmark: txCount=${config.txCount}, distribution=${config.distribution}, collector=${config.collectorType}`,
+    );
+
+    const readyPromises: Promise<void>[] = [];
+
+    for (let i = 1; i < peerCount; i++) {
+      const cmd: BenchReqRespCommand = {
+        type: 'BENCH_REQRESP',
+        txCount: config.txCount,
+        peerCount,
+        distribution: config.distribution,
+        collectorType: config.collectorType,
+        timeoutMs: config.timeoutMs,
+        isAggregator: false,
+        peerIndex: i,
+        pinnedPeerIndex: config.pinnedPeerIndex,
+        pinnedPeerId,
+        blockNumber,
+        seed,
+      };
+
+      this.processes[i].send(cmd);
+      readyPromises.push(this.waitForBenchReady(i, 30000));
+    }
+
+    await Promise.all(readyPromises);
+    this.logger.info('All responder peers ready, starting aggregator benchmark...');
+
+    const aggregatorCmd: BenchReqRespCommand = {
+      type: 'BENCH_REQRESP',
+      txCount: config.txCount,
+      peerCount,
+      distribution: config.distribution,
+      collectorType: config.collectorType,
+      timeoutMs: config.timeoutMs,
+      isAggregator: true,
+      peerIndex: 0,
+      pinnedPeerIndex: config.pinnedPeerIndex,
+      pinnedPeerId,
+      blockNumber,
+      seed,
+    };
+
+    this.processes[0].send(aggregatorCmd);
+    const result = await this.waitForBenchResult(0, config.timeoutMs + 30000);
+
+    this.logger.info(
+      `Benchmark complete: fetched=${result.fetchedCount}/${config.txCount}, duration=${result.durationMs.toFixed(0)}ms, success=${result.success}`,
+    );
+
+    return {
+      txCount: config.txCount,
+      distribution: config.distribution,
+      collector: config.collectorType,
+      durationMs: result.durationMs,
+      fetchedCount: result.fetchedCount,
+      success: result.success,
+      error: result.error,
+    };
+  }
+
+  private waitForBenchReady(clientIndex: number, timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+
+      const handler = (msg: any) => {
+        if (resolved) {
+          return;
+        }
+        if (msg.type === 'BENCH_READY') {
+          resolved = true;
+          clearTimeout(timeout);
+          this.processes[clientIndex].off('message', handler);
+          resolve();
+        } else if (msg.type === 'ERROR') {
+          resolved = true;
+          clearTimeout(timeout);
+          this.processes[clientIndex].off('message', handler);
+          reject(new Error(`Client ${clientIndex} error: ${msg.error}`));
+        }
+      };
+
+      const timeout = setTimeout(() => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        this.processes[clientIndex].off('message', handler);
+        reject(new Error(`Timeout waiting for BENCH_READY from client ${clientIndex}`));
+      }, timeoutMs);
+
+      this.processes[clientIndex].on('message', handler);
+    });
+  }
+
+  private waitForBenchResult(clientIndex: number, timeoutMs: number): Promise<BenchResultMessage> {
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+
+      const handler = (msg: any) => {
+        if (resolved) {
+          return;
+        }
+        if (msg.type === 'BENCH_RESULT') {
+          resolved = true;
+          clearTimeout(timeout);
+          this.processes[clientIndex].off('message', handler);
+          resolve(msg as BenchResultMessage);
+        } else if (msg.type === 'ERROR') {
+          resolved = true;
+          clearTimeout(timeout);
+          this.processes[clientIndex].off('message', handler);
+          reject(new Error(`Client ${clientIndex} error: ${msg.error}`));
+        }
+      };
+
+      const timeout = setTimeout(() => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        this.processes[clientIndex].off('message', handler);
+        reject(new Error(`Timeout waiting for BENCH_RESULT from client ${clientIndex}`));
+      }, timeoutMs);
+
+      this.processes[clientIndex].on('message', handler);
+    });
   }
 }
 
 export { WorkerClientManager, testChainConfig };
+export type { DistributionPattern, CollectorType } from './p2p_client_testbench_worker.js';
+export { COLLECTOR_DISPLAY_NAMES } from './p2p_client_testbench_worker.js';


### PR DESCRIPTION
NOTE:
batch-requester is the new one

```    ================================================================================
    ProposalTxCollector Benchmark Results
    ================================================================================

    | Collector           | Distribution | Missing | Duration (ms) | Fetched | Success |
    |---------------------|--------------|---------|---------------|---------|---------|
    | batch-requester     | pinned-only  |      10 |            99 |      10 |   Yes   |
    | send-batch-request  | pinned-only  |      10 |           112 |      10 |   Yes   |
    | batch-requester     | pinned-only  |      50 |           190 |      50 |   Yes   |
    | send-batch-request  | pinned-only  |      50 |           589 |      50 |   Yes   |
    | batch-requester     | pinned-only  |     100 |           366 |     100 |   Yes   |
    | send-batch-request  | pinned-only  |     100 |          1163 |     100 |   Yes   |
    | batch-requester     | pinned-only  |     500 |          2186 |     500 |   Yes   |
    | send-batch-request  | pinned-only  |     500 |          6048 |     500 |   Yes   |
    | batch-requester     | sparse       |      10 |           111 |      10 |   Yes   |
    | send-batch-request  | sparse       |      10 |            49 |       3 |   No    |
    | batch-requester     | sparse       |      50 |           204 |      50 |   Yes   |
    | send-batch-request  | sparse       |      50 |           229 |      12 |   No    |
    | batch-requester     | sparse       |     100 |           330 |     100 |   Yes   |
    | send-batch-request  | sparse       |     100 |           358 |      20 |   No    |
    | batch-requester     | sparse       |     500 |          1240 |     500 |   Yes   |
    | send-batch-request  | sparse       |     500 |          1569 |      89 |   No    |
    | batch-requester     | uniform      |      10 |           156 |      10 |   Yes   |
    | send-batch-request  | uniform      |      10 |           104 |      10 |   Yes   |
    | batch-requester     | uniform      |      50 |           303 |      50 |   Yes   |
    | send-batch-request  | uniform      |      50 |           520 |      50 |   Yes   |
    | batch-requester     | uniform      |     100 |           498 |     100 |   Yes   |
    | send-batch-request  | uniform      |     100 |           989 |     100 |   Yes   |
    | batch-requester     | uniform      |     500 |          1351 |     500 |   Yes   |
    | send-batch-request  | uniform      |     500 |          5290 |     500 |   Yes   |

    ## Comparison Summary

    - pinned-only (missing=10): BatchTxRequester is 11.7% faster than SendBatchRequest
    - pinned-only (missing=50): BatchTxRequester is 67.7% faster than SendBatchRequest
    - pinned-only (missing=100): BatchTxRequester is 68.5% faster than SendBatchRequest
    - pinned-only (missing=500): BatchTxRequester is 63.9% faster than SendBatchRequest
    - sparse (missing=10): cannot compare reliably (success: batch=true, send=false)
    - sparse (missing=50): cannot compare reliably (success: batch=true, send=false)
    - sparse (missing=100): cannot compare reliably (success: batch=true, send=false)
    - sparse (missing=500): cannot compare reliably (success: batch=true, send=false)
    - uniform (missing=10): SendBatchRequest is 33.4% faster than BatchTxRequester
    - uniform (missing=50): BatchTxRequester is 41.7% faster than SendBatchRequest
    - uniform (missing=100): BatchTxRequester is 49.6% faster than SendBatchRequest
    - uniform (missing=500): BatchTxRequester is 74.5% faster than SendBatchRequest

    ================================================================================
```


While implementing benchmarks, I discovered a couple of bugs in the old reqreps batch requeter, which this PR also fixes. Without the fixes, the old code is basically useless.

REF: A-116