### PR TITLE
refactor: constrain deposit timing of escape hatch

### DIFF
--- a/l1-contracts/src/core/EscapeHatch.sol
+++ b/l1-contracts/src/core/EscapeHatch.sol
@@ -135,10 +135,14 @@ contract EscapeHatch is IEscapeHatch {
    *
    * @dev Transfers BOND_SIZE tokens from the caller
    *
+   * @custom:reverts EscapeHatch__HatchTooEarly if called during early period when exit would revert
    * @custom:reverts EscapeHatch__AlreadyInCandidateSet if caller is already in the candidate set
    * @custom:reverts EscapeHatch__InvalidStatus if caller has a non-NONE status
    */
   function joinCandidateSet() external override(IEscapeHatchCore) {
+    // Ensure exit path is viable (reverts with EscapeHatch__HatchTooEarly during early period)
+    getSetTimestamp(getCurrentHatch() + Hatch.wrap(LAG_IN_HATCHES));
+
     address candidate = msg.sender;
 
     require(!$activeCandidates.contains(candidate), Errors.EscapeHatch__AlreadyInCandidateSet(candidate));
@@ -619,7 +623,12 @@ contract EscapeHatch is IEscapeHatch {
    * @return The timestamp at which the candidate set was frozen for this hatch
    */
   function getSetTimestamp(Hatch _hatch) public view override(IEscapeHatch) returns (uint32) {
-    Epoch freezeEpoch = _getFirstEpoch(_hatch - Hatch.wrap(LAG_IN_HATCHES)) - Epoch.wrap(LAG_IN_EPOCHS_FOR_SET_SIZE);
+    require(Hatch.unwrap(_hatch) >= LAG_IN_HATCHES, Errors.EscapeHatch__HatchTooEarly(_hatch));
+
+    Epoch firstEpoch = _getFirstEpoch(_hatch - Hatch.wrap(LAG_IN_HATCHES));
+    require(Epoch.unwrap(firstEpoch) >= LAG_IN_EPOCHS_FOR_SET_SIZE, Errors.EscapeHatch__HatchTooEarly(_hatch));
+
+    Epoch freezeEpoch = firstEpoch - Epoch.wrap(LAG_IN_EPOCHS_FOR_SET_SIZE);
     return Timestamp.unwrap(ROLLUP.getTimestampForEpoch(freezeEpoch)).toUint32();
   }
 
@@ -634,8 +643,12 @@ contract EscapeHatch is IEscapeHatch {
    * @return The timestamp at which the RANDAO seed is sampled for this hatch
    */
   function getSeedTimestamp(Hatch _hatch) public view override(IEscapeHatch) returns (uint32) {
+    require(Hatch.unwrap(_hatch) >= LAG_IN_HATCHES, Errors.EscapeHatch__HatchTooEarly(_hatch));
+
     Hatch samplingHatch = _hatch - Hatch.wrap(LAG_IN_HATCHES);
     Epoch firstEpoch = _getFirstEpoch(samplingHatch);
+    require(Epoch.unwrap(firstEpoch) >= LAG_IN_EPOCHS_FOR_RANDAO, Errors.EscapeHatch__HatchTooEarly(_hatch));
+
     Epoch seedEpoch = firstEpoch - Epoch.wrap(LAG_IN_EPOCHS_FOR_RANDAO);
     return Timestamp.unwrap(ROLLUP.getTimestampForEpoch(seedEpoch)).toUint32();
   }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -109,6 +109,7 @@ library Errors {
   error EscapeHatch__InvalidConfiguration();
   error EscapeHatch__SetUnstable(Hatch hatch);
   error EscapeHatch__AlreadyValidated(Hatch hatch);
+  error EscapeHatch__HatchTooEarly(Hatch hatch);
 
   // ProposedHeaderLib
   error HeaderLib__InvalidHeaderSize(uint256 expected, uint256 actual); // 0xf3ccb247

--- a/l1-contracts/test/escape-hatch/base.sol
+++ b/l1-contracts/test/escape-hatch/base.sol
@@ -153,7 +153,10 @@ contract EscapeHatchBase is TestBase {
   }
 
   function _warpForwardEpochs(uint256 _numEpochs) internal {
-    vm.warp(block.timestamp + _numEpochs * EPOCH_DURATION);
+    // Use proper epoch calculation from current rollup (handles both real and fake rollup)
+    Epoch currentEpoch = _getCurrentEpoch();
+    Epoch targetEpoch = Epoch.wrap(Epoch.unwrap(currentEpoch) + _numEpochs);
+    _warpToEpoch(Epoch.unwrap(targetEpoch));
   }
 
   function _getHatchForEpoch(uint256 _epochNumber) internal view returns (Hatch) {
@@ -168,11 +171,15 @@ contract EscapeHatchBase is TestBase {
     return IValidatorSelection(_getRollup()).getCurrentEpoch();
   }
 
-  /// @notice Warps to a safe epoch where selectCandidates() won't underflow
-  /// @dev Must be at epoch >= FREQUENCY so that baseEpoch (first epoch of current hatch) is large enough
-  ///      to subtract LAG_IN_EPOCHS_FOR_SET_SIZE and LAG_IN_EPOCHS_FOR_RANDAO without underflow
+  /// @notice Ensures we're at a safe epoch where joinCandidateSet won't revert with HatchTooEarly
+  /// @dev Only warps forward if needed - never goes backward in time.
+  ///      Must be at an epoch where getSetTimestamp() won't revert.
+  ///      This happens when currentHatch >= lagInHatches and the freeze epoch is valid.
   function _warpToSafeEpoch() internal {
-    _warpToEpoch(config.frequency);
+    uint256 safeEpoch = (config.lagInHatches) * config.frequency;
+    if (Epoch.unwrap(_getCurrentEpoch()) < safeEpoch) {
+      _warpToEpoch(safeEpoch);
+    }
   }
 
   // ============ Fuzz Config Helpers ============
@@ -221,7 +228,8 @@ contract EscapeHatchBase is TestBase {
   }
 
   /// @notice Modifier that bounds a fuzzed config, stores it, and deploys a new EscapeHatch
-  /// @dev Use this when you want to test with various valid configurations
+  /// @dev Use this when you want to test with various valid configurations.
+  ///      Automatically warps to safe epoch to avoid HatchTooEarly errors.
   modifier givenValidConfig(EscapeHatchConfig memory _config) {
     config = _boundValidConfig(_config);
 
@@ -239,6 +247,9 @@ contract EscapeHatchBase is TestBase {
     );
 
     vm.label(address(escapeHatch), "FuzzedEscapeHatch");
+
+    // Warp to safe epoch to avoid HatchTooEarly errors
+    _warpToSafeEpoch();
     _;
   }
 

--- a/l1-contracts/test/escape-hatch/e2e/candidateExit.t.sol
+++ b/l1-contracts/test/escape-hatch/e2e/candidateExit.t.sol
@@ -104,7 +104,7 @@ contract EscapeHatchCandidateExitTest is EscapeHatchIntegrationBase {
     _joinCandidateSet(CANDIDATE2);
 
     // Warp to start of known window (start of hatch 1)
-    _warpToEpoch(DEFAULT_FREQUENCY);
+    _warpForwardEpochs(DEFAULT_FREQUENCY);
 
     Hatch currentHatch = escapeHatch.getHatch(rollup.getCurrentEpoch());
     // The next selection (during currentHatch + 1) prepares targetHatch = currentHatch + 1 + lagInHatches
@@ -172,7 +172,7 @@ contract EscapeHatchCandidateExitTest is EscapeHatchIntegrationBase {
     _joinCandidateSet(CANDIDATE2);
 
     // Warp to start of hatch 1 to avoid underflows in freeze timestamp calculations
-    _warpToEpoch(DEFAULT_FREQUENCY);
+    _warpForwardEpochs(DEFAULT_FREQUENCY);
 
     // Calculate flux window boundaries and determine selected candidate
     uint256 freezeTimestamp;

--- a/l1-contracts/test/escape-hatch/e2e/earlyExit.t.sol
+++ b/l1-contracts/test/escape-hatch/e2e/earlyExit.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {EscapeHatchBase} from "../base.sol";
+import {IEscapeHatchCore, Status, CandidateInfo, Hatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Epoch} from "@aztec/shared/libraries/TimeMath.sol";
+
+/**
+ * @title EscapeHatchEarlyExitTest
+ * @notice Audit finding: Exit initiation blocked during early system startup
+ *
+ * @dev Severity: Low
+ *      Category: Liveness
+ *
+ *      Summary:
+ *      The exit initiation flow in EscapeHatch is blocked during early system startup due to
+ *      deterministic underflow in epoch arithmetic. Because `initiateExit()` always invokes
+ *      `selectCandidates()` first, any revert in the selection logic prevents candidates from
+ *      transitioning into the EXITING state.
+ *
+ *      Root Cause:
+ *      `getSetTimestamp(hatch)` computes:
+ *        freezeEpoch = firstEpoch(hatch - LAG_IN_HATCHES) - LAG_IN_EPOCHS_FOR_SET_SIZE
+ *
+ *      During hatch 0, when `selectCandidates()` computes the target hatch (currentHatch + LAG_IN_HATCHES),
+ *      the resulting epoch arithmetic subtracts lag values from epoch 0, causing underflow.
+ *
+ *      Impact:
+ *      - Candidates who join during the early period cannot initiate exit immediately
+ *      - User bonds remain locked until the rollup advances past the early period
+ *      - The lock is temporary - once the system progresses past the bootstrap window,
+ *        exit becomes possible (this happens fairly quickly as epochs advance)
+ *      - Still violates the principle: if you can join, you should be able to exit
+ *
+ *      Fix:
+ *      Block `joinCandidateSet()` when `getSetTimestamp()` would revert. This ensures that
+ *      if a user can join, they can also exit - the simplest invariant to maintain.
+ *
+ *      Test Structure:
+ *      1. test_cannotJoinDuringEarlyPeriod - The fix: joining is blocked during early period
+ *      2. test_joinAndExitWorksAfterEarlyPeriod - Normal operation after early period
+ */
+contract EscapeHatchEarlyExitTest is EscapeHatchBase {
+  /**
+   * @notice The fix: Cannot join during early period when exit would be impossible
+   *
+   * @dev During early operation, `getSetTimestamp()` would revert due to epoch arithmetic
+   *      constraints, making exit impossible. The fix blocks joining in this state.
+   */
+  function test_cannotJoinDuringEarlyPeriod() public {
+    // Verify we're at early operation (epoch 0, hatch 0)
+    Epoch currentEpoch = _getCurrentEpoch();
+    Hatch currentHatch = escapeHatch.getCurrentHatch();
+    assertEq(Epoch.unwrap(currentEpoch), 0, "Should be at epoch 0");
+    assertEq(Hatch.unwrap(currentHatch), 0, "Should be at hatch 0");
+
+    // The target hatch that would be checked
+    Hatch targetHatch = currentHatch + Hatch.wrap(escapeHatch.getLagInHatches());
+
+    // Verify that getSetTimestamp reverts with the correct error
+    vm.expectRevert(abi.encodeWithSelector(Errors.EscapeHatch__HatchTooEarly.selector, targetHatch));
+    escapeHatch.getSetTimestamp(targetHatch);
+
+    // The fix: joining should be blocked when exit would be impossible
+    _mintAndApprove(CANDIDATE1, DEFAULT_BOND_SIZE);
+    vm.expectRevert(abi.encodeWithSelector(Errors.EscapeHatch__HatchTooEarly.selector, targetHatch));
+    vm.prank(CANDIDATE1);
+    escapeHatch.joinCandidateSet();
+  }
+
+  /**
+   * @notice Normal operation: Join and exit works after the early period
+   *
+   * @dev Once the system advances past the early period, the epoch arithmetic no longer
+   *      causes issues and both join and exit work as expected.
+   */
+  function test_joinAndExitWorksAfterEarlyPeriod() public {
+    _warpToSafeEpoch();
+
+    // Verify we're past the early period
+    Hatch currentHatch = escapeHatch.getCurrentHatch();
+    Hatch targetHatch = currentHatch + Hatch.wrap(escapeHatch.getLagInHatches());
+
+    // getSetTimestamp should work now
+    uint32 freezeTs = escapeHatch.getSetTimestamp(targetHatch);
+    assertTrue(freezeTs > 0, "Should return valid timestamp after early period");
+
+    // Join succeeds
+    _joinCandidateSet(CANDIDATE1);
+
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.ACTIVE), "Should be ACTIVE");
+
+    // Exit succeeds
+    vm.prank(CANDIDATE1);
+    escapeHatch.initiateExit();
+
+    info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.EXITING), "Should be EXITING");
+  }
+
+  /**
+   * @notice Fuzz test: If join succeeds, immediate exit must also succeed
+   *
+   * @dev Tests across various epochs that the invariant holds:
+   *      - Either both join AND exit work (normal operation)
+   *      - Or join is blocked (early period)
+   *      - Never: join succeeds but exit fails
+   *
+   * @param _epoch The epoch to test at (bounded to reasonable range)
+   */
+  function test_joinSuccessImpliesExitSuccess(uint256 _epoch) public {
+    _epoch = bound(_epoch, 0, config.frequency * 4);
+    _warpToEpoch(_epoch);
+
+    _mintAndApprove(CANDIDATE1, DEFAULT_BOND_SIZE);
+
+    vm.startPrank(CANDIDATE1);
+    try escapeHatch.joinCandidateSet() {
+      // Join succeeded - exit MUST also succeed for the fix to be valid
+      escapeHatch.initiateExit();
+
+      CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+      assertEq(uint8(info.status), uint8(Status.EXITING), "If join succeeds, exit must succeed");
+    } catch {
+      // Join failed (early period) - invariant trivially holds
+    }
+    vm.stopPrank();
+  }
+}

--- a/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
+++ b/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
@@ -92,8 +92,10 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
 
   /**
    * @notice Have a candidate join the escape hatch set
+   * @dev Automatically ensures we're at a safe epoch to avoid HatchTooEarly errors
    */
   function _joinCandidateSet(address _candidate) internal {
+    _warpToSafeEpoch();
     vm.prank(testERC20.owner());
     testERC20.mint(_candidate, DEFAULT_BOND_SIZE);
     vm.prank(_candidate);
@@ -103,14 +105,14 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
   }
 
   /**
-   * @notice Warp to safe epoch and select candidates with randomness
-   * @dev Sets random prevrandao before warping to ensure varied candidate selection
+   * @notice Warp forward and select candidates with randomness
+   * @dev Sets random prevrandao before warping to ensure varied candidate selection.
+   *      Warps forward by DEFAULT_FREQUENCY epochs to ensure candidates are in the snapshot.
    * @return The prepared hatch number
    */
   function _selectCandidateForHatch() internal returns (Hatch) {
     _setRandomPrevrandao();
-    _warpToEpoch(DEFAULT_FREQUENCY);
-    _warpForwardEpochs(3);
+    _warpForwardEpochs(DEFAULT_FREQUENCY);
     escapeHatch.selectCandidates();
 
     Hatch currentHatch = escapeHatch.getHatch(rollup.getCurrentEpoch());
@@ -266,6 +268,17 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
   }
 
   // ============ Time Helpers ============
+
+  /**
+   * @notice Ensures we're at a safe epoch where joinCandidateSet won't revert with HatchTooEarly
+   * @dev Only warps forward if needed - never goes backwards in time
+   */
+  function _warpToSafeEpoch() internal {
+    uint256 safeEpoch = DEFAULT_LAG_IN_HATCHES * DEFAULT_FREQUENCY;
+    if (Epoch.unwrap(rollup.getCurrentEpoch()) < safeEpoch) {
+      _warpToEpoch(safeEpoch);
+    }
+  }
 
   function _warpToEpoch(uint256 _epochNumber) internal {
     Timestamp ts = rollup.getTimestampForEpoch(Epoch.wrap(_epochNumber));

--- a/l1-contracts/test/escape-hatch/unit/getters.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/getters.t.sol
@@ -67,8 +67,7 @@ contract EscapeHatchGettersTest is EscapeHatchBase {
     assertEq(escapeHatch.getDesignatedProposer(Hatch.wrap(1)), address(0), "Should be zero without selection");
 
     _joinCandidateSetWithConfig(CANDIDATE1);
-    _warpToSafeEpoch();
-    _warpForwardEpochs(3);
+    _warpForwardEpochs(config.frequency);
 
     escapeHatch.selectCandidates();
 
@@ -134,8 +133,7 @@ contract EscapeHatchGettersTest is EscapeHatchBase {
     assertEq(info.exitableAt, 0, "exitableAt should be 0 for ACTIVE");
 
     // PROPOSING: after selection
-    _warpToSafeEpoch();
-    _warpForwardEpochs(3);
+    _warpForwardEpochs(config.frequency);
     escapeHatch.selectCandidates();
 
     // Record which hatch the candidate was selected for (currentHatch + lagInHatches)
@@ -187,17 +185,15 @@ contract EscapeHatchGettersTest is EscapeHatchBase {
     // Bound future time jump to reasonable range (1 second to 10 years)
     _futureTimeJump = bound(_futureTimeJump, 1, 365 days * 10);
 
-    // ============ PART 1: DETERMINISM AT EXACT FREEZE TIMESTAMP ============
-    // Join one candidate early (at timestamp ~1)
+    // Join candidates at safe epoch
     _joinCandidateSetWithConfig(CANDIDATE1);
 
-    // Calculate a valid targetHatch that won't underflow:
-    // - targetHatch >= lagInHatches (so samplingHatch doesn't underflow)
-    // - samplingHatch's firstEpoch >= LAG_IN_EPOCHS_FOR_SET_SIZE (so freezeEpoch doesn't underflow)
-    uint256 lagInEpochs = escapeHatch.LAG_IN_EPOCHS_FOR_SET_SIZE();
-    uint256 minSamplingHatch = (lagInEpochs / config.frequency) + 1;
-    uint256 minTargetHatch = config.lagInHatches + minSamplingHatch;
-    Hatch targetHatch = Hatch.wrap(minTargetHatch);
+    // Warp forward so candidates are in snapshot for next hatch
+    _warpForwardEpochs(config.frequency);
+
+    // Calculate target hatch based on current position
+    Hatch currentHatch = escapeHatch.getCurrentHatch();
+    Hatch targetHatch = currentHatch + Hatch.wrap(config.lagInHatches);
     uint256 freezeTs = escapeHatch.getSetTimestamp(targetHatch);
 
     // Warp to EXACTLY the freeze timestamp
@@ -232,7 +228,7 @@ contract EscapeHatchGettersTest is EscapeHatchBase {
     uint256 snapshotCountAfterAdd = escapeHatch.getCandidateCountForHatch(targetHatch);
     assertEq(snapshotCountAfterAdd, 2, "Snapshot count should still be 2 after adding CANDIDATE3");
 
-    // ============ PART 3: FUZZED TIME JUMP ============
+    // ============ PART 3: FUZZED TIME JUMP - IMMUTABILITY ============
     // Jump arbitrarily far into the future - snapshot must remain immutable
     vm.warp(block.timestamp + _futureTimeJump);
 
@@ -280,15 +276,16 @@ contract EscapeHatchGettersTest is EscapeHatchBase {
   {
     // it should return the candidate address from the snapshot at the given index
 
-    // Join candidates at different times
+    // Join candidates at safe epoch
     _joinCandidateSetWithConfig(CANDIDATE1);
     _joinCandidateSetWithConfig(CANDIDATE2);
 
-    // Calculate a valid targetHatch
-    uint256 lagInEpochs = escapeHatch.LAG_IN_EPOCHS_FOR_SET_SIZE();
-    uint256 minSamplingHatch = (lagInEpochs / config.frequency) + 1;
-    uint256 minTargetHatch = config.lagInHatches + minSamplingHatch;
-    Hatch targetHatch = Hatch.wrap(minTargetHatch);
+    // Warp forward to ensure candidates are in snapshot for next hatch
+    _warpForwardEpochs(config.frequency);
+
+    // Calculate target hatch based on current position
+    Hatch currentHatch = escapeHatch.getCurrentHatch();
+    Hatch targetHatch = currentHatch + Hatch.wrap(config.lagInHatches);
     uint256 freezeTs = escapeHatch.getSetTimestamp(targetHatch);
 
     // Warp past freeze timestamp

--- a/l1-contracts/test/escape-hatch/unit/isHatchOpen.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/isHatchOpen.t.sol
@@ -61,9 +61,7 @@ contract EscapeHatchIsHatchOpenTest is EscapeHatchBase {
 
     _joinCandidateSetWithConfig(CANDIDATE1);
 
-    _warpToSafeEpoch();
-
-    _warpForwardEpochs(3);
+    _warpForwardEpochs(config.frequency);
 
     // Select candidates - prepares hatch LAG_IN_HATCHES ahead
     escapeHatch.selectCandidates();

--- a/l1-contracts/test/escape-hatch/unit/joinCandidateSet.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/joinCandidateSet.t.sol
@@ -4,13 +4,41 @@ pragma solidity >=0.8.27;
 
 import {EscapeHatchBase, EscapeHatchConfig} from "../base.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {IEscapeHatchCore, Status, CandidateInfo, Hatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
+import {IEscapeHatchCore, Status, CandidateInfo, Hatch, Epoch} from "@aztec/core/interfaces/IEscapeHatch.sol";
 import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
 
 contract EscapeHatchJoinCandidateSetTest is EscapeHatchBase {
+  function test_GivenSystemIsInEarlyPeriod() external {
+    // it should revert {EscapeHatch__HatchTooEarly}
+
+    // At epoch 0, targetHatch = 1 (LAG_IN_HATCHES = 1)
+    // getSetTimestamp(1) computes firstEpoch = _getFirstEpoch(1-1) = epoch 0
+    // Since epoch 0 < LAG_IN_EPOCHS_FOR_SET_SIZE (2), it reverts
+    Epoch currentEpoch = _getCurrentEpoch();
+    Hatch currentHatch = escapeHatch.getCurrentHatch();
+    assertEq(Epoch.unwrap(currentEpoch), 0, "Should be at epoch 0");
+    assertEq(Hatch.unwrap(currentHatch), 0, "Should be at hatch 0");
+
+    Hatch targetHatch = currentHatch + Hatch.wrap(escapeHatch.getLagInHatches());
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.EscapeHatch__HatchTooEarly.selector, targetHatch));
+    escapeHatch.getSetTimestamp(targetHatch);
+
+    _mintAndApprove(CANDIDATE1, DEFAULT_BOND_SIZE);
+    vm.expectRevert(abi.encodeWithSelector(Errors.EscapeHatch__HatchTooEarly.selector, targetHatch));
+    vm.prank(CANDIDATE1);
+    escapeHatch.joinCandidateSet();
+  }
+
+  modifier givenSystemIsPastEarlyPeriod() {
+    assertGt(Hatch.unwrap(escapeHatch.getCurrentHatch()), 0);
+    _;
+  }
+
   function test_GivenCallerIsAlreadyInCandidateSet(EscapeHatchConfig memory _config)
     external
     givenValidConfig(_config)
+    givenSystemIsPastEarlyPeriod
   {
     // it should revert {EscapeHatch__AlreadyInCandidateSet}
     _joinCandidateSetWithConfig(CANDIDATE1);
@@ -30,6 +58,7 @@ contract EscapeHatchJoinCandidateSetTest is EscapeHatchBase {
   function test_GivenCallerHasNon_NONEStatus(EscapeHatchConfig memory _config)
     external
     givenValidConfig(_config)
+    givenSystemIsPastEarlyPeriod
     givenCallerIsNotInCandidateSet
   {
     // it should revert {EscapeHatch__InvalidStatus}
@@ -75,6 +104,7 @@ contract EscapeHatchJoinCandidateSetTest is EscapeHatchBase {
   function test_RevertGiven_CallerHasInsufficientBondTokenBalance(EscapeHatchConfig memory _config)
     external
     givenValidConfig(_config)
+    givenSystemIsPastEarlyPeriod
     givenCallerIsNotInCandidateSet
     givenCallerHasNONEStatus
   {
@@ -98,6 +128,7 @@ contract EscapeHatchJoinCandidateSetTest is EscapeHatchBase {
   function test_RevertGiven_CallerHasNotApprovedBondToken(EscapeHatchConfig memory _config)
     external
     givenValidConfig(_config)
+    givenSystemIsPastEarlyPeriod
     givenCallerIsNotInCandidateSet
     givenCallerHasNONEStatus
     givenCallerHasSufficientBondTokenBalance
@@ -113,6 +144,7 @@ contract EscapeHatchJoinCandidateSetTest is EscapeHatchBase {
   function test_GivenCallerHasApprovedBondToken(EscapeHatchConfig memory _config)
     external
     givenValidConfig(_config)
+    givenSystemIsPastEarlyPeriod
     givenCallerIsNotInCandidateSet
     givenCallerHasNONEStatus
     givenCallerHasSufficientBondTokenBalance

--- a/l1-contracts/test/escape-hatch/unit/joinCandidateSet.tree
+++ b/l1-contracts/test/escape-hatch/unit/joinCandidateSet.tree
@@ -1,18 +1,21 @@
 EscapeHatchJoinCandidateSetTest
-├── given caller is already in candidate set
-│   └── it should revert {EscapeHatch__AlreadyInCandidateSet}
-└── given caller is not in candidate set
-    ├── given caller has non-NONE status
-    │   └── it should revert {EscapeHatch__InvalidStatus}
-    └── given caller has NONE status
-        ├── given caller has insufficient bond token balance
-        │   └── it should revert
-        └── given caller has sufficient bond token balance
-            ├── given caller has not approved bond token
+├── given system is in early period
+│   └── it should revert {EscapeHatch__HatchTooEarly}
+└── given system is past early period
+    ├── given caller is already in candidate set
+    │   └── it should revert {EscapeHatch__AlreadyInCandidateSet}
+    └── given caller is not in candidate set
+        ├── given caller has non-NONE status
+        │   └── it should revert {EscapeHatch__InvalidStatus}
+        └── given caller has NONE status
+            ├── given caller has insufficient bond token balance
             │   └── it should revert
-            └── given caller has approved bond token
-                ├── it should add caller to active candidates
-                ├── it should set caller status to ACTIVE
-                ├── it should set caller amount to BOND_SIZE
-                ├── it should transfer BOND_SIZE from caller
-                └── it should emit CandidateJoined event
+            └── given caller has sufficient bond token balance
+                ├── given caller has not approved bond token
+                │   └── it should revert
+                └── given caller has approved bond token
+                    ├── it should add caller to active candidates
+                    ├── it should set caller status to ACTIVE
+                    ├── it should set caller amount to BOND_SIZE
+                    ├── it should transfer BOND_SIZE from caller
+                    └── it should emit CandidateJoined event

--- a/l1-contracts/test/escape-hatch/unit/leaveCandidateSet.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/leaveCandidateSet.t.sol
@@ -27,7 +27,7 @@ contract EscapeHatchLeaveCandidateSetTest is EscapeHatchBase {
     vm.prank(CANDIDATE1);
     escapeHatch.leaveCandidateSet();
 
-    _warpToSafeEpoch();
+    _warpForwardEpochs(config.frequency);
 
     escapeHatch.selectCandidates();
     vm.expectRevert(
@@ -189,9 +189,11 @@ contract EscapeHatchLeaveCandidateSetTest is EscapeHatchBase {
 
     _deployWithFakeRollup();
 
-    _joinCandidateSetWithConfig(CANDIDATE1);
+    // Warp to safe epoch using FakeRollup timing (after deploying FakeRollup)
     _warpToSafeEpoch();
-    _warpForwardEpochs(3);
+
+    _joinCandidateSetWithConfig(CANDIDATE1);
+    _warpForwardEpochs(config.frequency);
     escapeHatch.selectCandidates();
 
     Epoch currentEpoch = _getCurrentEpoch();

--- a/l1-contracts/test/escape-hatch/unit/selectCandidates.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/selectCandidates.t.sol
@@ -183,14 +183,11 @@ contract EscapeHatchSelectCandidatesTest is EscapeHatchBase {
     // it should set proposer exitableAt to end of proof window
     // it should emit CandidateSelected event
 
-    // Add a candidate before warping to ensure they're in the snapshot
+    // Add a candidate and warp forward to ensure they're in the snapshot
     _joinCandidateSetWithConfig(CANDIDATE1);
 
-    // Warp to safe epoch to avoid underflow in selectCandidates
-    _warpToSafeEpoch();
-
-    // Warp forward a bit more to ensure snapshot is stable
-    _warpForwardEpochs(3);
+    // Warp forward to ensure candidate is in snapshot for selection
+    _warpForwardEpochs(config.frequency);
 
     Epoch currentEpoch = _getCurrentEpoch();
     Hatch currentHatch = escapeHatch.getHatch(currentEpoch);
@@ -262,15 +259,12 @@ contract EscapeHatchSelectCandidatesTest is EscapeHatchBase {
     // With 2 candidates, we first prepare a hatch (selecting one), then the other can exit.
     // For the second hatch, if the exiting candidate is selected, we test our scenario.
 
-    // Join both candidates at epoch 0
+    // Join both candidates
     _joinCandidateSetWithConfig(CANDIDATE1);
     _joinCandidateSetWithConfig(CANDIDATE2);
 
-    // Warp to safe epoch (hatch 1) to avoid underflow
-    _warpToSafeEpoch();
-
-    // Warp forward a bit more to ensure snapshot is stable
-    _warpForwardEpochs(3);
+    // Warp forward to ensure candidates are in snapshot for selection
+    _warpForwardEpochs(config.frequency);
 
     // Get current state
     Epoch currentEpoch = _getCurrentEpoch();

--- a/l1-contracts/test/escape-hatch/unit/validateProofSubmission.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/validateProofSubmission.t.sol
@@ -13,14 +13,14 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
   function _setupProposerWithFakeRollup() internal returns (Hatch) {
     _deployWithFakeRollup();
 
+    // Warp to safe epoch to avoid HatchTooEarly when joining
+    _warpToSafeEpoch();
+
     // Add candidate and set up as proposer
     _joinCandidateSetWithConfig(CANDIDATE1);
 
-    // Warp to safe epoch to avoid underflow in selectCandidates
-    _warpToSafeEpoch();
-
-    // Warp forward a bit more to ensure snapshot is stable
-    _warpForwardEpochs(3);
+    // Warp forward to ensure candidate is in snapshot
+    _warpForwardEpochs(config.frequency);
 
     // Select candidates
     escapeHatch.selectCandidates();


### PR DESCRIPTION
Constrain the time where it is possible to deposit into the escape hatch such that it is only allowed at a point where it would be possible to instantly call exit. This is to avoid a period (even if short) where it is possible to deposit into the escape hatch, but not start an exit. 