### PR TITLE
fix!: poseidon2 start row vulnerability

### DIFF
--- a/barretenberg/cpp/pil/vm2/poseidon2_hash.pil
+++ b/barretenberg/cpp/pil/vm2/poseidon2_hash.pil
@@ -58,6 +58,14 @@ namespace poseidon2_hash;
     #[SELECTOR_ON_END]
     end * (1 - sel) = 0;
 
+    // Selector must be 1 in start row
+    // This gadget is looked up based on `start` destination selector and therefore we
+    // need to ensure that this computation is performed on the active (`sel == 1`) rows.
+    // Otherwise, a malicious prover could circumvent most of the constraints.
+    // (Same pattern as merkle_check.pil lines 117-123)
+    #[SELECTOR_ON_START]
+    start * (1 - sel) = 0;
+
     // Our latch condition can either be the designated end of the computation or the first row
     // The previous relation ensures they cannot both be 1
     pol LATCH_CONDITION = end + precomputed.first_row;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
@@ -438,68 +438,53 @@ TEST_F(Poseidon2MemoryConstrainingTest, PermutationMemoryInvalidAddressRange)
 }
 
 ///////////////////////////
-// Vulnerability Test: Missing start * (1 - sel) = 0 constraint
+// Regression Test: start * (1 - sel) = 0 constraint
 ///////////////////////////
 
-// This test demonstrates a SECURITY VULNERABILITY in poseidon2_hash.pil:
-// The `start` selector is not protected to only be active when `sel == 1`.
-// A malicious prover can set start=1 on inactive rows (sel=0) and claim
-// arbitrary hash results, bypassing poseidon2 constraints.
+// This test verifies that the SELECTOR_ON_START constraint in poseidon2_hash.pil
+// correctly prevents a malicious prover from setting start=1 on inactive rows (sel=0).
 //
-// Compare with merkle_check.pil which has the fix at lines 122-123:
-//   #[SELECTOR_ON_START_OR_END]
-//   (start + end) * (1 - sel) = 0;
+// Previously, this was a vulnerability where a prover could forge hash results by
+// creating rows with start=1, sel=0, and arbitrary inputs/outputs.
 //
-// poseidon2_hash.pil only protects `end` but NOT `start`.
-TEST_F(Poseidon2ConstrainingTest, VulnerabilityStartWithoutSel)
+// The fix adds:
+//   #[SELECTOR_ON_START]
+//   start * (1 - sel) = 0;
+//
+// This mirrors the existing protection for `end` and matches merkle_check.pil.
+TEST_F(Poseidon2ConstrainingTest, StartSelectorIsProtected)
 {
     // Create a trace where start=1 but sel=0
-    // This represents a forged row that a malicious prover could create
+    // This represents a forged row that a malicious prover would try to create
     TestTraceContainer trace({
         { { C::precomputed_first_row, 1 } },
         {
-            // VULNERABILITY: sel=0 but start=1 should be INVALID
-            // However, all relation checks pass because they're conditioned on sel
+            // ATTACK ATTEMPT: sel=0 but start=1
+            // This is now BLOCKED by SELECTOR_ON_START constraint
             { C::poseidon2_hash_sel, 0 },
             { C::poseidon2_hash_start, 1 },
             { C::poseidon2_hash_end, 0 },
-            // Arbitrary inputs - not constrained when sel=0
+            // Arbitrary inputs - attacker would try to claim fake hash
             { C::poseidon2_hash_input_0, FF(0xDEADBEEF) },
             { C::poseidon2_hash_input_1, FF(0xCAFEBABE) },
             { C::poseidon2_hash_input_2, FF(0x12345678) },
-            // FAKE OUTPUT - This is NOT a valid poseidon2 hash of the inputs!
-            // A malicious prover can set this to any value they want.
             { C::poseidon2_hash_output, FF(0x999999) },
-            // Required for multi-round lookups (e.g., from public_data_check.pil or class_id_derivation.pil)
             { C::poseidon2_hash_num_perm_rounds_rem, 2 },
             { C::poseidon2_hash_input_len, 4 },
             { C::poseidon2_hash_padding, 2 },
         },
     });
 
-    // VULNERABILITY DEMONSTRATION:
-    // All poseidon2_hash relation checks PASS even though this row has:
-    // - start=1 (would be matched by lookups using poseidon2_hash.start as destination)
-    // - Arbitrary inputs and fake output (not enforced because sel=0)
-    //
-    // This allows a prover to claim: poseidon2(0xDEADBEEF, 0xCAFEBABE, 0x12345678) = 0x999999999
-    // without actually computing the hash!
-    check_relation<poseidon2_hash>(trace);
-
-    // If the vulnerability is FIXED by adding:
-    //   #[SELECTOR_ON_START]
-    //   start * (1 - sel) = 0;
-    //
-    // Then this test should FAIL with "SELECTOR_ON_START" error.
-    // Currently it PASSES, demonstrating the vulnerability exists.
+    // FIX VERIFIED: The SELECTOR_ON_START constraint now catches this attack
+    EXPECT_THROW_WITH_MESSAGE(check_relation<poseidon2_hash>(trace, poseidon2_hash::SR_SELECTOR_ON_START),
+                              "SELECTOR_ON_START");
 }
 
-// This test demonstrates one way to exploit the vulnerability: claiming a FAKE class_id for REAL inputs.
-// The attacker proves that (real_artifact, real_private_root, real_bytecode) → FAKE_class_id
-// Here we use populate the class_id_derivation trace as the source trace initiating poseidon hashes.
-// We check relation on both class_id_derivation and poseidon2_hash, and check_interaction for both start and end
-// lookups.
-TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
+// This test verifies that the SELECTOR_ON_START fix blocks the class_id forgery attack.
+// Previously, an attacker could claim (real_artifact, real_private_root, real_bytecode) → FAKE_class_id
+// by forging a start row with sel=0, start=1.
+// Now the fix blocks this by requiring start=1 implies sel=1.
+TEST_F(Poseidon2ConstrainingTest, FakeClassIdAttackIsBlocked)
 {
     using simulation::ClassIdDerivation;
     using simulation::ClassIdDerivationEvent;
@@ -524,14 +509,12 @@ TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
     // in the second round. This gives them a valid end row with (real_bytecode, 0, 0).
     FF attacker_artifact = FF(0xAAAA);
     FF attacker_private_root = FF(0xBBBB);
-    // Use the REAL bytecode - this is the key!
-    FF attacker_bytecode = real_bytecode_commitment;
+    FF attacker_bytecode = real_bytecode_commitment; // Use the REAL bytecode
 
     // Compute the FAKE class_id using the attacker's chosen inputs + real bytecode
     FF fake_class_id =
         poseidon2.hash({ FF(DOM_SEP__CONTRACT_CLASS_ID), attacker_artifact, attacker_private_root, attacker_bytecode });
 
-    // Verify we got a DIFFERENT class_id
     ASSERT_NE(fake_class_id, real_class_id);
 
     // =========================================================================
@@ -544,9 +527,8 @@ TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
     attacker_klass.id = fake_class_id;
     attacker_klass.artifact_hash = attacker_artifact;
     attacker_klass.private_functions_root = attacker_private_root;
-    attacker_klass.public_bytecode_commitment = attacker_bytecode; // = real_bytecode!
+    attacker_klass.public_bytecode_commitment = attacker_bytecode;
 
-    // This generates valid events for the attacker's computation
     attacker_class_id_sim.assert_derivation(attacker_klass);
 
     // =========================================================================
@@ -556,29 +538,25 @@ TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
         { { C::precomputed_first_row, 1 }, { C::precomputed_zero, 0 } },
     });
 
-    // Process poseidon2_hash events - creates valid 2-round computation for attacker
     Poseidon2TraceBuilder poseidon2_builder;
     poseidon2_builder.process_hash(hash_event_emitter.dump_events(), trace);
 
-    // Process class_id_derivation events (we'll overwrite this row later)
     ClassIdDerivationTraceBuilder class_id_builder;
     class_id_builder.process(attacker_class_id_emitter.dump_events(), trace);
 
     // =========================================================================
-    // STEP 5: Verify the attacker's computation is valid
+    // STEP 5: Verify the attacker's computation is valid (before the attack)
     // =========================================================================
     check_relation<poseidon2_hash>(trace);
     check_relation<class_id_derivation>(trace);
 
     // =========================================================================
-    // STEP 6: ATTACK - Claim the REAL inputs produce the FAKE class_id
+    // STEP 6: ATTACK ATTEMPT - Claim the REAL inputs produce the FAKE class_id
     // =========================================================================
-    // Mutate the class_id_derivation row to have REAL inputs but FAKE class_id
     uint32_t class_id_row = 0;
     trace.set(class_id_row,
               { {
                   { C::class_id_derivation_sel, 1 },
-                  // FAKE class_id for REAL inputs!
                   { C::class_id_derivation_class_id, fake_class_id },
                   { C::class_id_derivation_artifact_hash, real_artifact_hash },
                   { C::class_id_derivation_private_functions_root, real_private_functions_root },
@@ -588,20 +566,17 @@ TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
               } });
 
     // =========================================================================
-    // STEP 7: Add FORGED start row to satisfy lookup 1
+    // STEP 7: Add FORGED start row (this is what the fix blocks)
     // =========================================================================
-    // Forge: (DOM_SEP, real_artifact, real_private_root) → fake_class_id
     uint32_t forged_row = trace.get_num_rows();
     trace.set(forged_row,
               { {
-                  { C::poseidon2_hash_sel, 0 },   // INACTIVE - constraints don't apply!
-                  { C::poseidon2_hash_start, 1 }, // But can be matched by start lookup!
+                  { C::poseidon2_hash_sel, 0 },   // INACTIVE
+                  { C::poseidon2_hash_start, 1 }, // FORGED start - now blocked by SELECTOR_ON_START!
                   { C::poseidon2_hash_end, 0 },
-                  // REAL first-round inputs
                   { C::poseidon2_hash_input_0, FF(DOM_SEP__CONTRACT_CLASS_ID) },
                   { C::poseidon2_hash_input_1, real_artifact_hash },
                   { C::poseidon2_hash_input_2, real_private_functions_root },
-                  // But FAKE output!
                   { C::poseidon2_hash_output, fake_class_id },
                   { C::poseidon2_hash_num_perm_rounds_rem, 2 },
                   { C::poseidon2_hash_input_len, 4 },
@@ -609,38 +584,22 @@ TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
               } });
 
     // =========================================================================
-    // STEP 8: Verify ALL relations pass
+    // STEP 8: FIX VERIFIED - The SELECTOR_ON_START constraint blocks the attack
     // =========================================================================
-    check_relation<poseidon2_hash>(trace);
+    // The forged row has start=1 but sel=0, which violates: start * (1 - sel) = 0
+    EXPECT_THROW_WITH_MESSAGE(check_relation<poseidon2_hash>(trace, poseidon2_hash::SR_SELECTOR_ON_START),
+                              "SELECTOR_ON_START");
+
+    // class_id_derivation relations still pass (the attack is blocked at the poseidon2_hash level)
     check_relation<class_id_derivation>(trace);
 
     // =========================================================================
-    // STEP 9: Verify BOTH lookups succeed
+    // ATTACK BLOCKED: The class_id forgery is no longer possible
     // =========================================================================
-    // Lookup 1 (into start): Matches the FORGED row
-    // - Source: (DOM_SEP, real_artifact, real_private_root, fake_class_id, 2)
-    // - Dest: FORGED row with sel=0, start=1
-    check_interaction<ClassIdDerivationTraceBuilder, lookup_class_id_derivation_class_id_poseidon2_0_settings>(trace);
-
-    // Lookup 2 (into end): Matches the attacker's VALID end row
-    // - Source: (real_bytecode, 0, 0, fake_class_id)
-    // - Dest: Attacker's valid end row (has real_bytecode because attacker used it!)
-    check_interaction<ClassIdDerivationTraceBuilder, lookup_class_id_derivation_class_id_poseidon2_1_settings>(trace);
-
-    // =========================================================================
-    // VULNERABILITY DEMONSTRATED: COMPLETE CLASS_ID FORGERY
-    // =========================================================================
-    // The attacker has successfully proven:
-    //   fake_class_id = poseidon2(DOM_SEP, real_artifact, real_private_root, real_bytecode)
-    //
-    // When the TRUE relationship is:
-    //   real_class_id = poseidon2(DOM_SEP, real_artifact, real_private_root, real_bytecode)
-    //
-    // IMPACT: The class_id derivation is COMPLETELY BROKEN. An attacker can claim
-    // ANY class_id for ANY contract inputs. This means:
-    // - A malicious prover can claim a legitimate contract has a different class_id
-    // - This breaks all security assumptions about contract identity
-    // - Could be used to bypass access control, redirect funds, or impersonate contracts
+    // Previously, an attacker could claim ANY class_id for ANY contract inputs.
+    // Now the SELECTOR_ON_START constraint ensures that start=1 requires sel=1,
+    // meaning all poseidon2 constraints must be satisfied on start rows.
+    // This makes it cryptographically infeasible to forge hash results.
 }
 
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
@@ -25,6 +25,15 @@
 #include "barretenberg/vm2/simulation/gadgets/poseidon2.hpp"
 #include "barretenberg/vm2/tracegen/test_trace_container.hpp"
 
+// Imports for class_id_derivation-based vulnerability test
+#include "barretenberg/vm2/common/aztec_constants.hpp"
+#include "barretenberg/vm2/common/aztec_types.hpp"
+#include "barretenberg/vm2/generated/relations/class_id_derivation.hpp"
+#include "barretenberg/vm2/generated/relations/lookups_class_id_derivation.hpp"
+#include "barretenberg/vm2/simulation/events/class_id_derivation_event.hpp"
+#include "barretenberg/vm2/simulation/gadgets/class_id_derivation.hpp"
+#include "barretenberg/vm2/tracegen/class_id_derivation_trace.hpp"
+
 namespace bb::avm2::constraining {
 
 using ::testing::ElementsAreArray;
@@ -426,6 +435,212 @@ TEST_F(Poseidon2MemoryConstrainingTest, PermutationMemoryInvalidAddressRange)
 
     check_relation<poseidon2_mem>(trace);
     check_all_interactions<Poseidon2TraceBuilder>(trace);
+}
+
+///////////////////////////
+// Vulnerability Test: Missing start * (1 - sel) = 0 constraint
+///////////////////////////
+
+// This test demonstrates a SECURITY VULNERABILITY in poseidon2_hash.pil:
+// The `start` selector is not protected to only be active when `sel == 1`.
+// A malicious prover can set start=1 on inactive rows (sel=0) and claim
+// arbitrary hash results, bypassing poseidon2 constraints.
+//
+// Compare with merkle_check.pil which has the fix at lines 122-123:
+//   #[SELECTOR_ON_START_OR_END]
+//   (start + end) * (1 - sel) = 0;
+//
+// poseidon2_hash.pil only protects `end` but NOT `start`.
+TEST_F(Poseidon2ConstrainingTest, VulnerabilityStartWithoutSel)
+{
+    // Create a trace where start=1 but sel=0
+    // This represents a forged row that a malicious prover could create
+    TestTraceContainer trace({
+        { { C::precomputed_first_row, 1 } },
+        {
+            // VULNERABILITY: sel=0 but start=1 should be INVALID
+            // However, all relation checks pass because they're conditioned on sel
+            { C::poseidon2_hash_sel, 0 },
+            { C::poseidon2_hash_start, 1 },
+            { C::poseidon2_hash_end, 0 },
+            // Arbitrary inputs - not constrained when sel=0
+            { C::poseidon2_hash_input_0, FF(0xDEADBEEF) },
+            { C::poseidon2_hash_input_1, FF(0xCAFEBABE) },
+            { C::poseidon2_hash_input_2, FF(0x12345678) },
+            // FAKE OUTPUT - This is NOT a valid poseidon2 hash of the inputs!
+            // A malicious prover can set this to any value they want.
+            { C::poseidon2_hash_output, FF(0x999999) },
+            // Required for multi-round lookups (e.g., from public_data_check.pil or class_id_derivation.pil)
+            { C::poseidon2_hash_num_perm_rounds_rem, 2 },
+            { C::poseidon2_hash_input_len, 4 },
+            { C::poseidon2_hash_padding, 2 },
+        },
+    });
+
+    // VULNERABILITY DEMONSTRATION:
+    // All poseidon2_hash relation checks PASS even though this row has:
+    // - start=1 (would be matched by lookups using poseidon2_hash.start as destination)
+    // - Arbitrary inputs and fake output (not enforced because sel=0)
+    //
+    // This allows a prover to claim: poseidon2(0xDEADBEEF, 0xCAFEBABE, 0x12345678) = 0x999999999
+    // without actually computing the hash!
+    check_relation<poseidon2_hash>(trace);
+
+    // If the vulnerability is FIXED by adding:
+    //   #[SELECTOR_ON_START]
+    //   start * (1 - sel) = 0;
+    //
+    // Then this test should FAIL with "SELECTOR_ON_START" error.
+    // Currently it PASSES, demonstrating the vulnerability exists.
+}
+
+// This test demonstrates one way to exploit the vulnerability: claiming a FAKE class_id for REAL inputs.
+// The attacker proves that (real_artifact, real_private_root, real_bytecode) → FAKE_class_id
+// Here we use populate the class_id_derivation trace as the source trace initiating poseidon hashes.
+// We check relation on both class_id_derivation and poseidon2_hash, and check_interaction for both start and end
+// lookups.
+TEST_F(Poseidon2ConstrainingTest, VulnerabilityFakeClassIdForRealInputs)
+{
+    using simulation::ClassIdDerivation;
+    using simulation::ClassIdDerivationEvent;
+    using tracegen::ClassIdDerivationTraceBuilder;
+    using class_id_derivation = bb::avm2::class_id_derivation<FF>;
+
+    // =========================================================================
+    // STEP 1: Define the REAL contract class that the attacker wants to target
+    // =========================================================================
+    FF real_artifact_hash = FF(0x1111);
+    FF real_private_functions_root = FF(0x2222);
+    FF real_bytecode_commitment = FF(0x3333);
+
+    // This is the REAL class_id that should be derived
+    FF real_class_id = poseidon2.hash(
+        { FF(DOM_SEP__CONTRACT_CLASS_ID), real_artifact_hash, real_private_functions_root, real_bytecode_commitment });
+
+    // =========================================================================
+    // STEP 2: Attacker creates a VALID computation using the REAL bytecode
+    // =========================================================================
+    // The attacker chooses arbitrary first-round inputs but uses the REAL bytecode
+    // in the second round. This gives them a valid end row with (real_bytecode, 0, 0).
+    FF attacker_artifact = FF(0xAAAA);
+    FF attacker_private_root = FF(0xBBBB);
+    // Use the REAL bytecode - this is the key!
+    FF attacker_bytecode = real_bytecode_commitment;
+
+    // Compute the FAKE class_id using the attacker's chosen inputs + real bytecode
+    FF fake_class_id =
+        poseidon2.hash({ FF(DOM_SEP__CONTRACT_CLASS_ID), attacker_artifact, attacker_private_root, attacker_bytecode });
+
+    // Verify we got a DIFFERENT class_id
+    ASSERT_NE(fake_class_id, real_class_id);
+
+    // =========================================================================
+    // STEP 3: Use ClassIdDerivation simulator to generate VALID trace for attacker's computation
+    // =========================================================================
+    EventEmitter<ClassIdDerivationEvent> attacker_class_id_emitter;
+    ClassIdDerivation attacker_class_id_sim(poseidon2, attacker_class_id_emitter);
+
+    ContractClassWithCommitment attacker_klass;
+    attacker_klass.id = fake_class_id;
+    attacker_klass.artifact_hash = attacker_artifact;
+    attacker_klass.private_functions_root = attacker_private_root;
+    attacker_klass.public_bytecode_commitment = attacker_bytecode; // = real_bytecode!
+
+    // This generates valid events for the attacker's computation
+    attacker_class_id_sim.assert_derivation(attacker_klass);
+
+    // =========================================================================
+    // STEP 4: Build the trace with the attacker's VALID computation
+    // =========================================================================
+    TestTraceContainer trace({
+        { { C::precomputed_first_row, 1 }, { C::precomputed_zero, 0 } },
+    });
+
+    // Process poseidon2_hash events - creates valid 2-round computation for attacker
+    Poseidon2TraceBuilder poseidon2_builder;
+    poseidon2_builder.process_hash(hash_event_emitter.dump_events(), trace);
+
+    // Process class_id_derivation events (we'll overwrite this row later)
+    ClassIdDerivationTraceBuilder class_id_builder;
+    class_id_builder.process(attacker_class_id_emitter.dump_events(), trace);
+
+    // =========================================================================
+    // STEP 5: Verify the attacker's computation is valid
+    // =========================================================================
+    check_relation<poseidon2_hash>(trace);
+    check_relation<class_id_derivation>(trace);
+
+    // =========================================================================
+    // STEP 6: ATTACK - Claim the REAL inputs produce the FAKE class_id
+    // =========================================================================
+    // Mutate the class_id_derivation row to have REAL inputs but FAKE class_id
+    uint32_t class_id_row = 0;
+    trace.set(class_id_row,
+              { {
+                  { C::class_id_derivation_sel, 1 },
+                  // FAKE class_id for REAL inputs!
+                  { C::class_id_derivation_class_id, fake_class_id },
+                  { C::class_id_derivation_artifact_hash, real_artifact_hash },
+                  { C::class_id_derivation_private_functions_root, real_private_functions_root },
+                  { C::class_id_derivation_public_bytecode_commitment, real_bytecode_commitment },
+                  { C::class_id_derivation_gen_index_contract_class_id, FF(DOM_SEP__CONTRACT_CLASS_ID) },
+                  { C::class_id_derivation_const_two, 2 },
+              } });
+
+    // =========================================================================
+    // STEP 7: Add FORGED start row to satisfy lookup 1
+    // =========================================================================
+    // Forge: (DOM_SEP, real_artifact, real_private_root) → fake_class_id
+    uint32_t forged_row = trace.get_num_rows();
+    trace.set(forged_row,
+              { {
+                  { C::poseidon2_hash_sel, 0 },   // INACTIVE - constraints don't apply!
+                  { C::poseidon2_hash_start, 1 }, // But can be matched by start lookup!
+                  { C::poseidon2_hash_end, 0 },
+                  // REAL first-round inputs
+                  { C::poseidon2_hash_input_0, FF(DOM_SEP__CONTRACT_CLASS_ID) },
+                  { C::poseidon2_hash_input_1, real_artifact_hash },
+                  { C::poseidon2_hash_input_2, real_private_functions_root },
+                  // But FAKE output!
+                  { C::poseidon2_hash_output, fake_class_id },
+                  { C::poseidon2_hash_num_perm_rounds_rem, 2 },
+                  { C::poseidon2_hash_input_len, 4 },
+                  { C::poseidon2_hash_padding, 2 },
+              } });
+
+    // =========================================================================
+    // STEP 8: Verify ALL relations pass
+    // =========================================================================
+    check_relation<poseidon2_hash>(trace);
+    check_relation<class_id_derivation>(trace);
+
+    // =========================================================================
+    // STEP 9: Verify BOTH lookups succeed
+    // =========================================================================
+    // Lookup 1 (into start): Matches the FORGED row
+    // - Source: (DOM_SEP, real_artifact, real_private_root, fake_class_id, 2)
+    // - Dest: FORGED row with sel=0, start=1
+    check_interaction<ClassIdDerivationTraceBuilder, lookup_class_id_derivation_class_id_poseidon2_0_settings>(trace);
+
+    // Lookup 2 (into end): Matches the attacker's VALID end row
+    // - Source: (real_bytecode, 0, 0, fake_class_id)
+    // - Dest: Attacker's valid end row (has real_bytecode because attacker used it!)
+    check_interaction<ClassIdDerivationTraceBuilder, lookup_class_id_derivation_class_id_poseidon2_1_settings>(trace);
+
+    // =========================================================================
+    // VULNERABILITY DEMONSTRATED: COMPLETE CLASS_ID FORGERY
+    // =========================================================================
+    // The attacker has successfully proven:
+    //   fake_class_id = poseidon2(DOM_SEP, real_artifact, real_private_root, real_bytecode)
+    //
+    // When the TRUE relationship is:
+    //   real_class_id = poseidon2(DOM_SEP, real_artifact, real_private_root, real_bytecode)
+    //
+    // IMPACT: The class_id derivation is COMPLETELY BROKEN. An attacker can claim
+    // ANY class_id for ANY contract inputs. This means:
+    // - A malicious prover can claim a legitimate contract has a different class_id
+    // - This breaks all security assumptions about contract identity
+    // - Could be used to bypass access control, redirect funds, or impersonate contracts
 }
 
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class poseidon2_hashImpl {
   public:
     using FF = FF_;
 
-    static constexpr std::array<size_t, 20> SUBRELATION_PARTIAL_LENGTHS = { 3, 4, 4, 3, 3, 3, 3, 4, 4, 4,
+    static constexpr std::array<size_t, 21> SUBRELATION_PARTIAL_LENGTHS = { 3, 4, 4, 3, 3, 3, 3, 3, 4, 4, 4,
                                                                             5, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
@@ -38,6 +38,7 @@ template <typename FF> class poseidon2_hash : public Relation<poseidon2_hashImpl
     // Subrelation indices constants, to be used in tests.
     static constexpr size_t SR_TRACE_CONTINUITY = 1;
     static constexpr size_t SR_SELECTOR_ON_END = 6;
+    static constexpr size_t SR_SELECTOR_ON_START = 7;
 
     static std::string get_subrelation_label(size_t index)
     {
@@ -46,6 +47,8 @@ template <typename FF> class poseidon2_hash : public Relation<poseidon2_hashImpl
             return "TRACE_CONTINUITY";
         case SR_SELECTOR_ON_END:
             return "SELECTOR_ON_END";
+        case SR_SELECTOR_ON_START:
+            return "SELECTOR_ON_START";
         }
         return std::to_string(index);
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash_impl.hpp
@@ -65,31 +65,37 @@ void poseidon2_hashImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                    (FF(1) - static_cast<View>(in.get(C::poseidon2_hash_sel)));
         std::get<6>(evals) += (tmp * scaling_factor);
     }
-    {
+    { // SELECTOR_ON_START
         using View = typename std::tuple_element_t<7, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_padding)) *
-                   (static_cast<View>(in.get(C::poseidon2_hash_padding)) - FF(1)) *
-                   (static_cast<View>(in.get(C::poseidon2_hash_padding)) - FF(2));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_start)) *
+                   (FF(1) - static_cast<View>(in.get(C::poseidon2_hash_sel)));
         std::get<7>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<8, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) *
-                   static_cast<View>(in.get(C::poseidon2_hash_start)) *
-                   (static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem)) * FF(3) -
-                    CView(poseidon2_hash_PADDED_LEN));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_padding)) *
+                   (static_cast<View>(in.get(C::poseidon2_hash_padding)) - FF(1)) *
+                   (static_cast<View>(in.get(C::poseidon2_hash_padding)) - FF(2));
         std::get<8>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<9, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
-                   ((static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem_shift)) -
-                     static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem))) +
-                    FF(1));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) *
+                   static_cast<View>(in.get(C::poseidon2_hash_start)) *
+                   (static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem)) * FF(3) -
+                    CView(poseidon2_hash_PADDED_LEN));
         std::get<9>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<10, ContainerOverSubrelations>::View;
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
+                   ((static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem_shift)) -
+                     static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem))) +
+                    FF(1));
+        std::get<10>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) *
                    ((CView(poseidon2_hash_NEXT_ROUND_COUNT) *
                          (static_cast<View>(in.get(C::poseidon2_hash_end)) *
@@ -97,73 +103,73 @@ void poseidon2_hashImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                           static_cast<View>(in.get(C::poseidon2_hash_num_perm_rounds_rem_inv))) -
                      FF(1)) +
                     static_cast<View>(in.get(C::poseidon2_hash_end)));
-        std::get<10>(evals) += (tmp * scaling_factor);
-    }
-    {
-        using View = typename std::tuple_element_t<11, ContainerOverSubrelations>::View;
-        auto tmp =
-            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
-            (static_cast<View>(in.get(C::poseidon2_hash_a_0)) - static_cast<View>(in.get(C::poseidon2_hash_input_0)));
         std::get<11>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<12, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
-                   ((static_cast<View>(in.get(C::poseidon2_hash_a_0_shift)) -
-                     static_cast<View>(in.get(C::poseidon2_hash_b_0))) -
-                    static_cast<View>(in.get(C::poseidon2_hash_input_0_shift)));
+        auto tmp =
+            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
+            (static_cast<View>(in.get(C::poseidon2_hash_a_0)) - static_cast<View>(in.get(C::poseidon2_hash_input_0)));
         std::get<12>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<13, ContainerOverSubrelations>::View;
-        auto tmp =
-            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
-            (static_cast<View>(in.get(C::poseidon2_hash_a_1)) - static_cast<View>(in.get(C::poseidon2_hash_input_1)));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
+                   ((static_cast<View>(in.get(C::poseidon2_hash_a_0_shift)) -
+                     static_cast<View>(in.get(C::poseidon2_hash_b_0))) -
+                    static_cast<View>(in.get(C::poseidon2_hash_input_0_shift)));
         std::get<13>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<14, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
-                   ((static_cast<View>(in.get(C::poseidon2_hash_a_1_shift)) -
-                     static_cast<View>(in.get(C::poseidon2_hash_b_1))) -
-                    static_cast<View>(in.get(C::poseidon2_hash_input_1_shift)));
+        auto tmp =
+            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
+            (static_cast<View>(in.get(C::poseidon2_hash_a_1)) - static_cast<View>(in.get(C::poseidon2_hash_input_1)));
         std::get<14>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<15, ContainerOverSubrelations>::View;
-        auto tmp =
-            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
-            (static_cast<View>(in.get(C::poseidon2_hash_a_2)) - static_cast<View>(in.get(C::poseidon2_hash_input_2)));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
+                   ((static_cast<View>(in.get(C::poseidon2_hash_a_1_shift)) -
+                     static_cast<View>(in.get(C::poseidon2_hash_b_1))) -
+                    static_cast<View>(in.get(C::poseidon2_hash_input_1_shift)));
         std::get<15>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<16, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
-                   ((static_cast<View>(in.get(C::poseidon2_hash_a_2_shift)) -
-                     static_cast<View>(in.get(C::poseidon2_hash_b_2))) -
-                    static_cast<View>(in.get(C::poseidon2_hash_input_2_shift)));
+        auto tmp =
+            static_cast<View>(in.get(C::poseidon2_hash_sel)) * static_cast<View>(in.get(C::poseidon2_hash_start)) *
+            (static_cast<View>(in.get(C::poseidon2_hash_a_2)) - static_cast<View>(in.get(C::poseidon2_hash_input_2)));
         std::get<16>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<17, ContainerOverSubrelations>::View;
-        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) *
-                   static_cast<View>(in.get(C::poseidon2_hash_start)) *
-                   (static_cast<View>(in.get(C::poseidon2_hash_a_3)) - CView(poseidon2_hash_IV));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
+                   ((static_cast<View>(in.get(C::poseidon2_hash_a_2_shift)) -
+                     static_cast<View>(in.get(C::poseidon2_hash_b_2))) -
+                    static_cast<View>(in.get(C::poseidon2_hash_input_2_shift)));
         std::get<17>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<18, ContainerOverSubrelations>::View;
-        auto tmp =
-            static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
-            (static_cast<View>(in.get(C::poseidon2_hash_a_3_shift)) - static_cast<View>(in.get(C::poseidon2_hash_b_3)));
+        auto tmp = static_cast<View>(in.get(C::poseidon2_hash_sel)) *
+                   static_cast<View>(in.get(C::poseidon2_hash_start)) *
+                   (static_cast<View>(in.get(C::poseidon2_hash_a_3)) - CView(poseidon2_hash_IV));
         std::get<18>(evals) += (tmp * scaling_factor);
     }
     {
         using View = typename std::tuple_element_t<19, ContainerOverSubrelations>::View;
         auto tmp =
+            static_cast<View>(in.get(C::poseidon2_hash_sel)) * (FF(1) - CView(poseidon2_hash_LATCH_CONDITION)) *
+            (static_cast<View>(in.get(C::poseidon2_hash_a_3_shift)) - static_cast<View>(in.get(C::poseidon2_hash_b_3)));
+        std::get<19>(evals) += (tmp * scaling_factor);
+    }
+    {
+        using View = typename std::tuple_element_t<20, ContainerOverSubrelations>::View;
+        auto tmp =
             static_cast<View>(in.get(C::poseidon2_hash_sel)) * CView(poseidon2_hash_LATCH_CONDITION) *
             (static_cast<View>(in.get(C::poseidon2_hash_output)) - static_cast<View>(in.get(C::poseidon2_hash_b_0)));
-        std::get<19>(evals) += (tmp * scaling_factor);
+        std::get<20>(evals) += (tmp * scaling_factor);
     }
 }
 


### PR DESCRIPTION
This allowed a malicious actor to use fake inputs to a hash. The test here shows that you could prove an incorrect class-id for a given preimage.

I believe this is a broad vulnerability that could be exploited in several ways, but here is the specific attack that is shown in the test:

**The attacker's valid computation:**
```
Input: (DOM_SEP, attacker_artifact, attacker_private_root, real_bytecode, 0, 0)
Output: fake_class_id
```

This creates two VALID poseidon2_hash rows:
- **Row 1 (start):** `(DOM_SEP, attacker_artifact, attacker_private_root)` → `fake_class_id`, sel=1, start=1
- **Row 2 (end):** `(real_bytecode, 0, 0)` → `fake_class_id`, sel=1, end=1

**The forged row:**
- **Row 3 (forged):** `(DOM_SEP, real_artifact, real_private_root)` → `fake_class_id`, sel=0, start=1

**The mutated class_id_derivation row claims:**
```
(real_artifact, real_private_root, real_bytecode) → fake_class_id
```

**How the lookups match:**

| Lookup | Source (class_id_derivation) | Destination | Matches |
|--------|------------------------------|-------------|---------|
| Lookup 1 (into start) | `(DOM_SEP, real_artifact, real_private_root, fake_class_id, 2)` | FORGED row 3 | ✓ |
| Lookup 2 (into end) | `(real_bytecode, 0, 0, fake_class_id)` | VALID row 2 | ✓ |

**The trick:** The attacker uses the **real bytecode** in their valid computation. This makes the valid end row have `(real_bytecode, 0, 0)` → `fake_class_id`, which matches lookup 2 from the mutated class_id_derivation.

Both rows output `fake_class_id`:
- **Forged start row:** claims `(real_artifact, real_private_root)` → `fake_class_id`
- **Valid end row:** legitimately computes `(real_bytecode)` → `fake_class_id` (as part of attacker's computation)

The attack "bridges" the forged first round with a valid second round by choosing the attacker's computation to end with the real bytecode.
