### PR TITLE
fix(ethereum): use proposal's pendingThrough timestamp for voting power

### DIFF
--- a/yarn-project/ethereum/src/contracts/governance.ts
+++ b/yarn-project/ethereum/src/contracts/governance.ts
@@ -174,6 +174,13 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
     return this.governanceContract.read.powerAt([this.client.account.address, now.timestamp]);
   }
 
+  /** Returns the user's voting power for a specific proposal, checked at pendingThrough timestamp. */
+  public async getPowerForProposal(proposalId: bigint): Promise<bigint> {
+    const proposal = await this.getProposal(proposalId);
+    const pendingThrough = proposal.creation + proposal.config.votingDelay;
+    return this.governanceContract.read.powerAt([this.client.account.address, pendingThrough]);
+  }
+
   public async vote({
     proposalId,
     voteAmount,
@@ -190,7 +197,7 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
     const l1TxUtils = createL1TxUtilsFromViemWallet(this.client, { logger });
     const retryDelaySeconds = 12;
 
-    voteAmount = voteAmount ?? (await this.getPower());
+    voteAmount = voteAmount ?? (await this.getPowerForProposal(proposalId));
 
     let success = false;
     for (let i = 0; i < retries; i++) {


### PR DESCRIPTION
## Summary
- Fixed a bug in the governance CLI where voting without an explicit `--vote-amount` would fail with `Governance__CheckpointedUintLib__NotInPast` error
- Added `getPowerForProposal(proposalId)` method that correctly uses the proposal's `pendingThrough` timestamp (creation + votingDelay) to determine voting power
- Updated `vote()` method to use `getPowerForProposal()` instead of the broken `getPower()` which was incorrectly using the current block timestamp

## Background
The governance contract checks voting power at `pendingThrough` timestamp (when proposal transitions from Pending to Active). The CLI's `getPower()` method was calling `powerAt(now.timestamp)` which always failed because the contract requires `_time < block.timestamp` (strictly less than).

## Test plan
- [x] Tested on local Anvil network with full governance flow (deposit → propose → vote → execute)
- [x] Verified voting works without explicit `--vote-amount` flag