### PR TITLE
fix: public data read

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion.nr
@@ -26,7 +26,15 @@ impl ProveNullifierNonInclusion for BlockHeader {
         // Safety: The witness is only used as a "magical value" that makes the proof below pass. Hence it's safe.
         let witness = unsafe { get_low_nullifier_membership_witness(self, nullifier) };
 
-        // 2) First we prove that the tree leaf in the witness is present in the nullifier tree. This is expected to be
+        // 2) Check that the leaf preimage is not empty.
+        // An empty leaf preimage would pass validation as a low leaf. However, it's not a valid low leaf. It's used to
+        // pad the nullifiers emitted from a tx so they can be inserted into the tree in a fixed-size batch.
+        assert(
+            !witness.leaf_preimage.is_empty(),
+            "The provided public data tree leaf preimage cannot be empty",
+        );
+
+        // 3) Prove that the tree leaf in the witness is present in the nullifier tree. This is expected to be
         // the 'low leaf', i.e. the leaf that would come immediately before the nullifier's leaf, if the nullifier were
         // to be in the tree.
         let low_nullifier_leaf = witness.leaf_preimage;
@@ -36,13 +44,13 @@ impl ProveNullifierNonInclusion for BlockHeader {
             "Proving nullifier non-inclusion failed: Could not prove low nullifier inclusion",
         );
 
-        // 3) Prove that the low leaf is indeed smaller than the nullifier
+        // 4) Prove that the low leaf is indeed smaller than the nullifier
         assert(
             full_field_less_than(low_nullifier_leaf.nullifier, nullifier),
             "Proving nullifier non-inclusion failed: low_nullifier.value < nullifier.value check failed",
         );
 
-        // 4) Prove that the low leaf is pointing "over" the nullifier, which means that the nullifier is not included
+        // 5) Prove that the low leaf is pointing "over" the nullifier, which means that the nullifier is not included
         // in the nullifier tree, since if it were it'd need to be between the low leaf and the next leaf. Note the
         // special case in which the low leaf is the largest of all entries, in which case there's no 'next' entry.
         assert(

--- a/noir-projects/aztec-nr/aztec/src/history/public_storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/public_storage.nr
@@ -1,11 +1,10 @@
 use dep::protocol_types::{
     abis::block_header::BlockHeader, address::AztecAddress, constants::DOM_SEP__PUBLIC_LEAF_INDEX,
-    hash::poseidon2_hash_with_separator, utils::field::full_field_less_than,
+    data::public_data_storage_read, hash::poseidon2_hash_with_separator,
+    merkle_tree::MembershipWitness, traits::ToField,
 };
-use dep::protocol_types::merkle_tree::root::root_from_sibling_path;
 
 use crate::oracle::get_public_data_witness::get_public_data_witness;
-use protocol_types::traits::{Hash, ToField};
 
 mod test;
 
@@ -33,39 +32,11 @@ impl PublicStorageHistoricalRead for BlockHeader {
         // Safety: The witness is only used as a "magical value" that makes the proof below pass. Hence it's safe.
         let witness = unsafe { get_public_data_witness(self, public_data_tree_index) };
 
-        // 3) The witness is made up of two parts: the preimage of the leaf and the proof that it exists in the tree.
-        // We first prove that the witness is indeed valid for the public data tree, i.e. that the preimage is of a
-        // value present in the tree. Note that `hash` returns not just the hash of the value but also the metadata
-        // (slot, next index and next slot).
-        assert_eq(
+        public_data_storage_read(
             self.state.partial.public_data_tree.root,
-            root_from_sibling_path(witness.leaf_preimage.hash(), witness.index, witness.path),
-            "Proving public value inclusion failed",
-        );
-
-        // 4) Now that we know the preimage is valid, we determine the value that's represented by this tree entry. Here
-        // we have two scenarios:
-        // 1. The tree entry is initialized, and the value is the same as the one in the witness
-        // 2. The entry was never initialized, and the value is default zero (the default)
-        // The code below is based on the same checks in `validate_public_data_reads` in `base_rollup_inputs`.
-        let preimage = witness.leaf_preimage;
-
-        let is_less_than_slot = full_field_less_than(preimage.slot, public_data_tree_index);
-        let is_next_greater_than = full_field_less_than(public_data_tree_index, preimage.next_slot);
-        let is_max = ((preimage.next_index == 0) & (preimage.next_slot == 0));
-        let is_in_range = is_less_than_slot & (is_next_greater_than | is_max);
-
-        let value = if is_in_range {
-            0
-        } else {
-            assert_eq(
-                preimage.slot,
-                public_data_tree_index,
-                "Public data tree index doesn't match witness",
-            );
-            preimage.value
-        };
-
-        value
+            public_data_tree_index,
+            MembershipWitness { leaf_index: witness.index, sibling_path: witness.path },
+            witness.leaf_preimage,
+        )
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_empty_tx_first_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_empty_tx_first_rollup.nr
@@ -7,7 +7,6 @@ use types::{
         append_only_tree_snapshot::AppendOnlyTreeSnapshot,
         checkpoint_constant_data::CheckpointConstantData, state_reference::StateReference,
     },
-    blob_data::SpongeBlob,
     constants::{ARCHIVE_HEIGHT, L1_TO_L2_MSG_SUBTREE_ROOT_SIBLING_PATH_LENGTH},
     proof::proof_data::UltraHonkProofData,
 };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier_leaf_preimage.nr
@@ -1,7 +1,6 @@
 use crate::{
-    hash::compute_siloed_nullifier,
     merkle_tree::{IndexedTreeLeafPreimage, LeafPreimage},
-    side_effect::{Counted, Readable, Scoped},
+    side_effect::Readable,
     traits::{Deserialize, Empty, Hash, Serialize},
 };
 
@@ -21,6 +20,9 @@ impl Empty for NullifierLeafPreimage {
 impl Hash for NullifierLeafPreimage {
     fn hash(self) -> Field {
         if self.is_empty() {
+            // Note: Empty leaf preimages are used to pad the nullifiers emitted from a transaction so they can be
+            // inserted into the tree in a fixed-size batch. The hash of these padded leaves must be 0 so that the
+            // tree root does not change when a batch contains no transaction nullifiers.
             0
         } else {
             crate::hash::poseidon2_hash(self.serialize())

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/mod.nr
@@ -1,6 +1,10 @@
+// TODO: Rename this module to public_data.
+
 pub mod public_data_tree_leaf;
 pub mod public_data_tree_leaf_preimage;
 pub mod hash;
+mod storage_read;
 
 pub use public_data_tree_leaf::PublicDataTreeLeaf;
 pub use public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage;
+pub use storage_read::public_data_storage_read;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/public_data_tree_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/public_data_tree_leaf_preimage.nr
@@ -12,6 +12,34 @@ pub struct PublicDataTreeLeafPreimage {
     pub next_index: Field,
 }
 
+/// An empty public data tree leaf preimage never actually exists in the tree.
+///
+/// Unlike the nullifier tree, where nullifiers are inserted in fixed-size batches (padded with empty preimages when
+/// a transaction doesn't fill a full batch), the AVM inserts public data leaves one by one, so no padding is needed.
+///
+/// The tree is initialized with non-empty leaf preimages (see table below). To insert an empty leaf preimage
+/// (slot = 0), we would need to find a valid low leaf satisfying: low_leaf.slot < 0 < low_leaf.next_slot.
+/// Since all slots in the tree are non-negative, no such low leaf exists, making insertion impossible.
+///
+/// In fact, slot 0 already exists in the initial tree state. The preimage { slot: 0, value: 0, next_slot: 1,
+/// next_index: 1 } can be used to prove membership and update the value at slot 0. However, it's practically
+/// impossible for a contract to produce a storage slot where `compute_public_data_leaf_slot` returns 0.
+///
+/// Note: Tree leaves beyond next_available_leaf_index contain zero hashes (the default empty leaf value in Merkle
+/// trees). These are NOT hashes of empty leaf preimages - the hash of an empty public data leaf preimage is
+/// 0x20be000d93b852c82d4e02c94e9e61fa3a0e79949aac3af4010620651d416134
+///
+/// Initial state of the Public Data Tree (initialized in content_addressed_indexed_tree.hpp with N = 128):
+///
+///   Index |  slot    value   next_index  next_slot
+///   ----- |  ----    -----   ----------  ---------
+///   0     |  0       0       1           1
+///   1     |  1       0       2           2
+///   2     |  2       0       3           3
+///   ...   |  ...     ...     ...         ...
+///   N-2   |  N-2     0       N-1         N-1
+///   N-1   |  N-1     0       0           0          (points to infinity)
+///
 impl Empty for PublicDataTreeLeafPreimage {
     fn empty() -> Self {
         Self { slot: 0, value: 0, next_slot: 0, next_index: 0 }
@@ -20,16 +48,10 @@ impl Empty for PublicDataTreeLeafPreimage {
 
 impl Hash for PublicDataTreeLeafPreimage {
     fn hash(self) -> Field {
-        if self.is_empty() {
-            0
-        } else {
-            crate::hash::poseidon2_hash([
-                self.slot,
-                self.value,
-                (self.next_index as Field),
-                self.next_slot,
-            ])
-        }
+        // The order must match what's defined in the cpp merkle tree implementation:
+        // `merkle_tree/indexed_tree/indexed_leaf.hpp` > PublicDataLeafValue > get_hash_inputs
+        // TODO: Change this to crate::hash::poseidon2_hash(self.serialize()) and cpp to use the same order.
+        crate::hash::poseidon2_hash([self.slot, self.value, self.next_index, self.next_slot])
     }
 }
 
@@ -72,11 +94,5 @@ impl IndexedTreeLeafPreimage<PublicDataTreeLeaf> for PublicDataTreeLeafPreimage 
             next_slot: low_leaf.next_slot,
             next_index: low_leaf.next_index,
         }
-    }
-}
-
-impl PublicDataTreeLeafPreimage {
-    pub fn is_empty(self) -> bool {
-        (self.slot == 0) & (self.value == 0) & (self.next_slot == 0) & (self.next_index == 0)
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/storage_read.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/storage_read.nr
@@ -1,0 +1,260 @@
+use crate::{
+    constants::PUBLIC_DATA_TREE_HEIGHT,
+    data::public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
+    merkle_tree::{conditionally_check_membership, MembershipWitness},
+};
+
+/// Read the value from public storage at the given `leaf_slot`.
+///
+/// Parameters:
+/// - `public_data_tree_root`: The root of the public data tree.
+/// - `public_data_leaf_slot`: The slot of the leaf in the public data tree.
+/// - `witness`: A hint to prove that the `leaf_preimage` exists in the tree.
+///
+/// The slot could either exist (has been initialized) in the tree or not:
+/// - If it's in the tree, `leaf_preimage` should be the preimage for the slot.
+/// - If it's not in the tree, `leaf_preimage` should be the preimage for the low leaf of the slot.
+///
+/// Returns:
+/// - `Field`: The value read from the public data tree.
+pub fn public_data_storage_read(
+    public_data_tree_root: Field,
+    public_data_leaf_slot: Field,
+    witness: MembershipWitness<PUBLIC_DATA_TREE_HEIGHT>,
+    leaf_preimage: PublicDataTreeLeafPreimage,
+) -> Field {
+    // Use the given `leaf_preimage` hint to determine whether we are reading a slot that's been written to the tree or
+    // not.
+    let is_slot_in_tree = leaf_preimage.slot == public_data_leaf_slot;
+
+    let (_, is_expected_leaf, is_leaf_in_tree) = conditionally_check_membership(
+        public_data_leaf_slot,
+        is_slot_in_tree,
+        leaf_preimage,
+        witness,
+        public_data_tree_root,
+    );
+
+    // In the case of the state existing in the tree, `is_leaf_in_tree = true`.
+    // In the case of the state not existing in the tree, the above membership check was done against the _low_ leaf,
+    // so rather confusingly, we still expect `is_leaf_in_tree = true` (because it's a different kind of leaf in this case).
+    assert(is_leaf_in_tree, "Proving public value inclusion failed");
+    assert(
+        is_expected_leaf,
+        "The provided public data tree leaf preimage is not the correct leaf for the requested slot",
+    );
+
+    // Note: An empty leaf preimage would pass validation as a low leaf. However, it is not a valid leaf and is never
+    // inserted into the tree, since we do not perform batch insertions with padded empty leaves in the public data
+    // tree, and the tree's genesis state contains only non-empty leaves.
+    // (See the comment in `PublicDataTreeLeafPreimage` for more details.)
+    // Therefore, even if an empty leaf preimage is provided, it will fail the membership check because
+    // `is_leaf_in_tree` will be false.
+
+    if is_slot_in_tree {
+        leaf_preimage.value
+    } else {
+        0
+    }
+}
+
+mod tests {
+    use crate::{
+        constants::PUBLIC_DATA_TREE_HEIGHT,
+        data::public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
+        merkle_tree::MembershipWitness,
+        tests::merkle_tree_utils::single_subtree_merkle_tree::SingleSubtreeMerkleTree,
+        traits::{Empty, Hash},
+    };
+    use super::public_data_storage_read;
+
+    struct TestBuilder {
+        public_data_tree_root: Field,
+        public_data_leaf_slot: Field,
+        witness: MembershipWitness<PUBLIC_DATA_TREE_HEIGHT>,
+        leaf_preimage: PublicDataTreeLeafPreimage,
+        public_data_tree: SingleSubtreeMerkleTree<4, 2, PUBLIC_DATA_TREE_HEIGHT>,
+    }
+
+    impl TestBuilder {
+        pub fn new() -> Self {
+            // Create a tree with 4 prefilled leaves.
+            // slot 0 -> slot 11 -> slot 22 -> slot 33 -> infinity
+            let prefilled_leaves = [
+                PublicDataTreeLeafPreimage { slot: 0, value: 0, next_slot: 11, next_index: 3 },
+                PublicDataTreeLeafPreimage { slot: 22, value: 123, next_slot: 33, next_index: 2 },
+                PublicDataTreeLeafPreimage { slot: 33, value: 789, next_slot: 0, next_index: 0 },
+                PublicDataTreeLeafPreimage { slot: 11, value: 456, next_slot: 22, next_index: 1 },
+            ];
+            let public_data_tree = SingleSubtreeMerkleTree::<4, 2, PUBLIC_DATA_TREE_HEIGHT>::new(
+                prefilled_leaves.map(|l| l.hash()),
+            );
+
+            let public_data_tree_root = public_data_tree.get_root();
+
+            // Default to reading from slot 22 (exists in tree at index 1).
+            let leaf_index = 1;
+            let public_data_leaf_slot = 22;
+            let leaf_preimage = prefilled_leaves[1];
+            let witness = MembershipWitness {
+                leaf_index,
+                sibling_path: public_data_tree.get_sibling_path(leaf_index),
+            };
+
+            Self {
+                public_data_tree_root,
+                public_data_leaf_slot,
+                witness,
+                leaf_preimage,
+                public_data_tree,
+            }
+        }
+
+        pub fn read_value(self) -> Field {
+            public_data_storage_read(
+                self.public_data_tree_root,
+                self.public_data_leaf_slot,
+                self.witness,
+                self.leaf_preimage,
+            )
+        }
+    }
+
+    #[test]
+    fn read_existing_slot() {
+        let builder = TestBuilder::new();
+
+        let value = builder.read_value();
+
+        // Slot 22 has value 123.
+        assert_eq(value, 123);
+    }
+
+    #[test]
+    fn read_non_existing_slot_using_low_leaf() {
+        let mut builder = TestBuilder::new();
+
+        // Read from slot 30, which doesn't exist in the tree.
+        // Use the leaf at slot 22 as the low leaf (22 < 30 < 33).
+        builder.public_data_leaf_slot = 30;
+        // The leaf preimage at index 1 (slot 22) is a valid low leaf for slot 30.
+        // The witness is already pointing to index 1.
+
+        let value = builder.read_value();
+
+        // Non-existing slot should return 0.
+        assert_eq(value, 0);
+    }
+
+    #[test]
+    fn read_non_existing_slot_greater_than_max() {
+        let mut builder = TestBuilder::new();
+
+        // Read from slot 600, which is greater than the max slot in the tree (33).
+        // Use the leaf at slot 33 as the low leaf (points to infinity).
+        builder.public_data_leaf_slot = 600;
+        let leaf_index = 2;
+        builder.witness = MembershipWitness {
+            leaf_index,
+            sibling_path: builder.public_data_tree.get_sibling_path(leaf_index),
+        };
+        builder.leaf_preimage =
+            PublicDataTreeLeafPreimage { slot: 33, value: 789, next_slot: 0, next_index: 0 };
+
+        let value = builder.read_value();
+
+        // Non-existing slot should return 0.
+        assert_eq(value, 0);
+    }
+
+    #[test(should_fail_with = "Proving public value inclusion failed")]
+    fn wrong_membership_witness_index() {
+        let mut builder = TestBuilder::new();
+
+        // Use the wrong leaf index for the witness.
+        builder.witness.leaf_index += 1;
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "Proving public value inclusion failed")]
+    fn wrong_tree_root() {
+        let mut builder = TestBuilder::new();
+
+        // Use a different tree root.
+        builder.public_data_tree_root = 12345;
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "The provided public data tree leaf preimage is not the correct leaf for the requested slot")]
+    fn wrong_leaf_preimage_for_existing_slot() {
+        let mut builder = TestBuilder::new();
+
+        // Slot 22 exists, but provide a different preimage (for slot 11).
+        let leaf_index = 3;
+        builder.witness = MembershipWitness {
+            leaf_index,
+            sibling_path: builder.public_data_tree.get_sibling_path(leaf_index),
+        };
+        builder.leaf_preimage =
+            PublicDataTreeLeafPreimage { slot: 11, value: 456, next_slot: 22, next_index: 1 };
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "The provided public data tree leaf preimage is not the correct leaf for the requested slot")]
+    fn invalid_low_leaf_slot_too_high() {
+        let mut builder = TestBuilder::new();
+
+        // Try to read slot 15. Provide low leaf at slot 22, which is > 15.
+        builder.public_data_leaf_slot = 15;
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "The provided public data tree leaf preimage is not the correct leaf for the requested slot")]
+    fn invalid_low_leaf_next_slot_too_low() {
+        let mut builder = TestBuilder::new();
+
+        // Try to read slot 25. Use low leaf at slot 11, whose next_slot = 22, which is < 25.
+        builder.public_data_leaf_slot = 25;
+        let leaf_index = 3;
+        builder.witness = MembershipWitness {
+            leaf_index,
+            sibling_path: builder.public_data_tree.get_sibling_path(leaf_index),
+        };
+        builder.leaf_preimage =
+            PublicDataTreeLeafPreimage { slot: 11, value: 456, next_slot: 22, next_index: 1 };
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "Proving public value inclusion failed")]
+    fn bypass_existing_slot_using_empty_leaf() {
+        let mut builder = TestBuilder::new();
+
+        // Slot 22 exists, but try to bypass it using an empty leaf at an unused index.
+        let leaf_index = builder.public_data_tree.get_next_available_index();
+        builder.witness = MembershipWitness {
+            leaf_index,
+            sibling_path: builder.public_data_tree.get_sibling_path(leaf_index),
+        };
+        builder.leaf_preimage = PublicDataTreeLeafPreimage::empty();
+
+        let _ = builder.read_value();
+    }
+
+    #[test(should_fail_with = "Proving public value inclusion failed")]
+    fn leaf_preimage_mismatch_value() {
+        let mut builder = TestBuilder::new();
+
+        // Provide a preimage with the correct slot but wrong value.
+        // The slot matches, so the function treats this as "slot exists in tree".
+        // But the preimage hash won't match the actual leaf in the tree, so membership fails.
+        builder.leaf_preimage =
+            PublicDataTreeLeafPreimage { slot: 22, value: 9999, next_slot: 33, next_index: 2 };
+
+        let _ = builder.read_value();
+    }
+}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/with_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/with_hash.nr
@@ -3,12 +3,12 @@ use crate::{
     address::aztec_address::AztecAddress,
     constants::PUBLIC_DATA_TREE_HEIGHT,
     data::{
-        hash::compute_public_data_leaf_slot,
+        hash::compute_public_data_leaf_slot, public_data_storage_read,
         public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
     },
     delayed_public_mutable::delayed_public_mutable_values::DelayedPublicMutableValues,
     hash::poseidon2_hash,
-    merkle_tree::{conditionally_check_membership, membership::MembershipWitness},
+    merkle_tree::MembershipWitness,
     traits::Packable,
 };
 
@@ -45,14 +45,16 @@ where
         storage_slot,
     );
 
+    let public_data_leaf_slot =
+        compute_public_data_leaf_slot(contract_address, storage_slot_of_hash);
+
     // We attempt to read the storage slot.
     // If it's never been written to, the returned value will be `0`.
     // Otherwise, the returned value will be a hash of the delayed_public_mutable wrapper that contains
     // the `current_value` that we seek.
-    let hash = public_storage_historical_read(
-        historical_header,
-        storage_slot_of_hash,
-        contract_address,
+    let hash = public_data_storage_read(
+        historical_header.state.partial.public_data_tree.root,
+        public_data_leaf_slot,
         witness,
         leaf_preimage,
     );
@@ -80,51 +82,6 @@ where
     // The actual item (of type T, of packed length N fields) is stored in contiguous fields from the `storage_slot`.
     // The _hash_ of the item is stored at the end, at slot: `storage_slot + N`.
     start_storage_slot + <T as Packable>::N as Field
-}
-
-/// Read the value from public storage at the given `storage_slot` for the given `contract_address`.
-/// `historical_header` is the header of the block whose state we are reading the value from.
-/// `witness` is a hint to prove that the `leaf_preimage` exists in the tree.
-///
-/// The slot could either exist (has been initialized) in the tree or not:
-/// - If it's in the tree, `leaf_preimage` should be the preimage for the slot.
-/// - If it's not in the tree, `leaf_preimage` should be the preimage for the low leaf of the slot.
-///
-/// TODO: Move this to abis/public_data/storage/read.nr
-fn public_storage_historical_read(
-    historical_header: BlockHeader,
-    storage_slot: Field,
-    contract_address: AztecAddress,
-    witness: MembershipWitness<PUBLIC_DATA_TREE_HEIGHT>,
-    leaf_preimage: PublicDataTreeLeafPreimage,
-) -> Field {
-    let public_data_leaf_slot = compute_public_data_leaf_slot(contract_address, storage_slot);
-
-    // Use the given `leaf_preimage` hint to determine whether we are reading a slot that's been written to the tree or not.
-    let is_slot_in_tree = leaf_preimage.slot == public_data_leaf_slot;
-
-    let (_, is_expected_leaf, is_leaf_in_tree) = conditionally_check_membership(
-        public_data_leaf_slot,
-        is_slot_in_tree,
-        leaf_preimage,
-        witness,
-        historical_header.state.partial.public_data_tree.root,
-    );
-
-    // In the case of the state existing in the tree, `is_leaf_in_tree = true`.
-    // In the case of the state not existing in the tree, the above membership check was done against the _low_ leaf,
-    // so rather confusingly, we still expect `is_leaf_in_tree = true` (because it's a different kind of leaf in this case).
-    assert(is_leaf_in_tree, "Proving public value inclusion failed");
-    assert(
-        is_expected_leaf,
-        "The provided public data tree leaf preimage is not the correct leaf for the requested contract_address and storage slot",
-    );
-
-    if is_slot_in_tree {
-        leaf_preimage.value
-    } else {
-        0
-    }
 }
 
 mod tests {
@@ -161,6 +118,7 @@ mod tests {
         delayed_public_mutable: DelayedPublicMutableValues<ContractClassId, TEST_INITIAL_DELAY>,
         witness: MembershipWitness<PUBLIC_DATA_TREE_HEIGHT>,
         leaf_preimage: PublicDataTreeLeafPreimage,
+        public_data_tree: SingleSubtreeMerkleTree<4, 2, 40>,
     }
 
     impl TestBuilder {
@@ -177,7 +135,7 @@ mod tests {
             let current_timestamp = timestamp_of_change + 50;
             let delayed_public_mutable = DelayedPublicMutableValues::new(
                 ScheduledValueChange::new(
-                    ContractClassId::from_field(0),
+                    ContractClassId::from_field(13),
                     ContractClassId::from_field(96),
                     timestamp_of_change,
                 ),
@@ -245,6 +203,7 @@ mod tests {
                 delayed_public_mutable,
                 witness,
                 leaf_preimage,
+                public_data_tree,
             }
         }
 
@@ -279,7 +238,7 @@ mod tests {
 
         let current_value = builder.read_current_value();
 
-        assert_eq(current_value, ContractClassId::from_field(0));
+        assert_eq(current_value, ContractClassId::from_field(13));
     }
 
     #[test]
@@ -317,7 +276,7 @@ mod tests {
         let _ = builder.read_current_value();
     }
 
-    #[test(should_fail_with = "The provided public data tree leaf preimage is not the correct leaf for the requested contract_address and storage slot")]
+    #[test(should_fail_with = "The provided public data tree leaf preimage is not the correct leaf for the requested slot")]
     fn invalid_low_leaf() {
         let mut builder = TestBuilder::new();
 
@@ -334,6 +293,24 @@ mod tests {
         builder.delayed_public_mutable.svc.post = ContractClassId::from_field(999);
 
         let _ = builder.read_current_value();
+    }
+
+    #[test(should_fail_with = "Proving public value inclusion failed")]
+    fn bypass_updated_value_using_empty_low_leaf() {
+        let mut builder = TestBuilder::new();
+
+        // Use an empty leaf as the low leaf.
+        let leaf_index = builder.public_data_tree.get_next_available_index();
+        let witness = MembershipWitness {
+            leaf_index,
+            sibling_path: builder.public_data_tree.get_sibling_path(leaf_index),
+        };
+        builder.witness = witness;
+        builder.leaf_preimage = PublicDataTreeLeafPreimage::empty();
+
+        let current_value = builder.read_current_value();
+
+        assert_eq(current_value, ContractClassId::empty());
     }
 
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
@@ -24,7 +24,6 @@ pub mod type_serialization;
 pub mod type_packing;
 pub mod tuple_serialization;
 
-pub mod delayed_public_mutable;
 pub mod blob_data;
 
 pub mod proof;
@@ -32,6 +31,8 @@ pub mod data;
 pub mod storage;
 pub mod validate;
 pub mod meta;
+
+pub mod delayed_public_mutable;
 
 pub mod tests;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/types/test_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/types/test_leaf_preimage.nr
@@ -1,5 +1,8 @@
-use crate::{merkle_tree::leaf_preimage::{IndexedTreeLeafPreimage, LeafPreimage}, traits::Empty};
-use std::hash::pedersen_hash;
+use crate::{
+    hash::poseidon2_hash,
+    merkle_tree::leaf_preimage::{IndexedTreeLeafPreimage, LeafPreimage},
+    traits::Empty,
+};
 
 pub struct TestLeafPreimage {
     pub value: Field,
@@ -18,7 +21,7 @@ impl LeafPreimage for TestLeafPreimage {
     }
 
     fn as_leaf(self) -> Field {
-        pedersen_hash([self.value])
+        poseidon2_hash([self.value])
     }
 }
 


### PR DESCRIPTION
Fix a bug that we could use an empty low leaf to ignore public data that's actually been updated.