### PR TITLE
feat(avm)!: external sload

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -1696,13 +1696,19 @@ fn handle_storage_read(
     destinations: &[ValueOrArray],
     inputs: &[ValueOrArray],
 ) {
-    assert_eq!(inputs.len(), 1); // output
+    assert_eq!(inputs.len(), 2); // slot, contract_address
     assert_eq!(destinations.len(), 1); // return value
 
     let slot_offset_maybe = inputs[0];
     let slot_offset = match slot_offset_maybe {
         ValueOrArray::MemoryAddress(slot_offset) => slot_offset,
-        _ => panic!("ForeignCall address input should be a single value"),
+        _ => panic!("ForeignCall slot input should be a single value"),
+    };
+
+    let contract_address_offset_maybe = inputs[1];
+    let contract_address_offset = match contract_address_offset_maybe {
+        ValueOrArray::MemoryAddress(contract_address_offset) => contract_address_offset,
+        _ => panic!("ForeignCall contract_address input should be a single value"),
     };
 
     let dest_offset_maybe = destinations[0];
@@ -1716,11 +1722,13 @@ fn handle_storage_read(
         addressing_mode: Some(
             AddressingModeBuilder::default()
                 .direct_operand(&slot_offset)
+                .direct_operand(&contract_address_offset)
                 .direct_operand(&dest_offset)
                 .build(),
         ),
         operands: vec![
             AvmOperand::U16 { value: slot_offset.to_u32() as u16 },
+            AvmOperand::U16 { value: contract_address_offset.to_u32() as u16 },
             AvmOperand::U16 { value: dest_offset.to_u32() as u16 },
         ],
         ..Default::default()

--- a/barretenberg/cpp/pil/vm2/opcodes/sload.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/sload.pil
@@ -4,17 +4,19 @@ include "../trees/public_data_check.pil";
 // SLOAD opcode: Reads a value from storage at the provided slot
 //
 // This opcode interacts with the public data check gadget to read a value at the specified slot.
-// The execution trace reads the slot from memory into register[0], performs FF tag validation,
-// and writes the value retrieved from the tree to memory via register[1].
+// The execution trace reads the slot from memory into register[0], the contract address from
+// memory into register[1], performs FF tag validation, and writes the value retrieved from the
+// tree to memory via register[2].
 // The value written to memory is checked to have tag FF.
 //
 // Register usage:
 // - register[0]: Contains the storage slot to read from
-// - register[1]: Contains the retrieved value to be written to memory
+// - register[1]: Contains the contract address to read from
+// - register[2]: Contains the retrieved value to be written to memory
 //
 // The opcode leverages the public_data_check gadget to verify the storage read operation
 // against the current public data tree root. The public_data_check gadget silos the slot
-// with the current contract address.
+// with the contract address.
 //
 namespace execution; // this is a virtual gadget that shares rows with the execution trace
 
@@ -23,9 +25,9 @@ namespace execution; // this is a virtual gadget that shares rows with the execu
 
     #[STORAGE_READ]
     sel_execute_sload {
-        contract_address, // From context
-        register[0],
-        register[1],
+        register[1], // Contract address from memory
+        register[0], // Slot
+        register[2], // Value (output)
         prev_public_data_tree_root // From context
     } in public_data_check.sel {
         public_data_check.address,
@@ -35,7 +37,7 @@ namespace execution; // this is a virtual gadget that shares rows with the execu
     };
 
     #[SLOAD_FF_OUTPUT_TAG]
-    sel_execute_sload * (constants.MEM_TAG_FF - mem_tag_reg[1]) = 0;
+    sel_execute_sload * (constants.MEM_TAG_FF - mem_tag_reg[2]) = 0;
 
     // This opcode is infallible and sel_opcode_error is constrained to be zero
     // in execution.pil (see #[INFALLIBLE_OPCODES_SUCCESS]).

--- a/barretenberg/cpp/pil/vm2/opcodes/sload.pil
+++ b/barretenberg/cpp/pil/vm2/opcodes/sload.pil
@@ -25,13 +25,13 @@ namespace execution; // this is a virtual gadget that shares rows with the execu
 
     #[STORAGE_READ]
     sel_execute_sload {
-        register[1], // Contract address from memory
         register[0], // Slot
+        register[1], // Contract address from memory
         register[2], // Value (output)
         prev_public_data_tree_root // From context
     } in public_data_check.sel {
-        public_data_check.address,
         public_data_check.slot,
+        public_data_check.address,
         public_data_check.value,
         public_data_check.root
     };

--- a/barretenberg/cpp/src/barretenberg/vm2/common/instruction_spec.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/instruction_spec.cpp
@@ -72,7 +72,7 @@ const std::unordered_map<WireOpCode, std::array<uint8_t, NUM_OP_DC_SELECTORS>>& 
         { WireOpCode::MOV_16, { 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
 
         // World State
-        { WireOpCode::SLOAD, { 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+        { WireOpCode::SLOAD, { 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
         { WireOpCode::SSTORE, { 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
         { WireOpCode::NOTEHASHEXISTS, { 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
         { WireOpCode::EMITNOTEHASH, { 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
@@ -336,7 +336,7 @@ const std::unordered_map<WireOpCode, WireInstructionSpec>& get_wire_instruction_
         // World State
         { WireOpCode::SLOAD,
           { .exec_opcode = ExecutionOpCode::SLOAD,
-            .size_in_bytes = 6,
+            .size_in_bytes = 8,
             .op_dc_selectors = get_wire_opcode_dc_selectors().at(WireOpCode::SLOAD) } },
         { WireOpCode::SSTORE,
           { .exec_opcode = ExecutionOpCode::SSTORE,
@@ -637,9 +637,11 @@ const std::unordered_map<ExecutionOpCode, ExecInstructionSpec>& get_exec_instruc
             .gas_cost = { .opcode_gas = AVM_MOV_BASE_L2_GAS, .base_da = 0, .dyn_l2 = 0, .dyn_da = 0 },
             .register_info = RegisterInfo().add_input(/*src*/).add_output(/*dst*/) } },
         { ExecutionOpCode::SLOAD,
-          { .num_addresses = 2,
+          { .num_addresses = 3,
             .gas_cost = { .opcode_gas = AVM_SLOAD_BASE_L2_GAS, .base_da = 0, .dyn_l2 = 0, .dyn_da = 0 },
-            .register_info = RegisterInfo().add_input(/*slot*/ ValueTag::FF).add_output(/*dst*/) } },
+            .register_info = RegisterInfo()
+                                 .add_inputs({ /*slot*/ ValueTag::FF, /*contract_address*/ ValueTag::FF })
+                                 .add_output(/*dst*/) } },
         { ExecutionOpCode::SSTORE,
           { .num_addresses = 2,
             .gas_cost = { .opcode_gas = AVM_SSTORE_BASE_L2_GAS,

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/avm_fixed_vk.hpp
@@ -95,9 +95,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x0000000000000000000000000000000000000000000000000000000000000002")), // precomputed_first_row
             Commitment(
-                uint256_t("0x2333e362e64fb1f107caced2abe6b15c83432eb7a32de2ecf30977a614985279"),
+                uint256_t("0x00d3b534945cae272828a9621e350a4f42efe4258f3432b2ba7a535a6f8bd68f"),
                 uint256_t(
-                    "0x0807a4fd784c9f8c30579a87a35c1841f81dfdf26bbb80ed89be6f5e972ebf76")), // precomputed_instr_size
+                    "0x07924546f2d14918d809f440d770e88525d4787c828e1efcb6154e1c2b257da9")), // precomputed_instr_size
             Commitment(
                 uint256_t("0x11b710f896157a9557278a1f776cd6c7e1e7e256a572bd080797daaf1d6307d1"),
                 uint256_t(
@@ -210,13 +210,13 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x0c76ef320d793294cfbf1519c7a124b640859b99d43d051dc828f0053081a4f0")), // precomputed_rw_reg_0_
             Commitment(
-                uint256_t("0x2af2a42cc4fee5dbce68325a3264b898a726408414a0a6c789294bc54229a4de"),
+                uint256_t("0x23d96c05f4bc75a456d34d051f876ef99ad7b22c4e21908b13b9f576a9d4c620"),
                 uint256_t(
-                    "0x1852c4482c0f7af7895dff6d6342c39e440dd4b87c6c58e1dbe65b9ad2cfac44")), // precomputed_rw_reg_1_
+                    "0x008b8cb54710e5387557d73f2122ddd02a393ced7c57987776b55d6292964d89")), // precomputed_rw_reg_1_
             Commitment(
-                uint256_t("0x0ea6ee40df0431b45fcc37d168b9a8acee572cea67f79f7c3ef7371fd4a45330"),
+                uint256_t("0x039eae92cc21bf3c73b8406d17e8a06154a76ea489dfa0fb6049b9750a40b388"),
                 uint256_t(
-                    "0x2e25f8abaf300ceaea6edb0d6e54539b4bedbdc034216e8e09c770b393d6a97a")), // precomputed_rw_reg_2_
+                    "0x1e2e477b3a65fc69df47516f7d306b81d3205d1e1983aadafe99f6aea755d944")), // precomputed_rw_reg_2_
             Commitment::infinity(),                                                         // precomputed_rw_reg_3_
             Commitment::infinity(),                                                         // precomputed_rw_reg_4_
             Commitment::infinity(),                                                         // precomputed_rw_reg_5_
@@ -257,9 +257,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x04a79156fabb49e693ddcf07815f53d163489149958311b79a4fcfd2703bf3fd")), // precomputed_sel_mem_op_reg_1_
             Commitment(
-                uint256_t("0x2f9e1bd2b45c3be1bdf33b898ac4cc0dba2d96bcf77f0fdb24b666a954a2cccd"),
+                uint256_t("0x252ca1bf6e5e141f715b94f7c186675aed430fe49c8ec06e46160e41c9086c97"),
                 uint256_t(
-                    "0x1821245ac9715620427cfcb8f268d1b8b0c6af808c87d1047fab5ba3f0b2253d")), // precomputed_sel_mem_op_reg_2_
+                    "0x29d3d381d379ce261c1e66817822d796c6e605c276bf1f5993715ee56a5c7b82")), // precomputed_sel_mem_op_reg_2_
             Commitment(
                 uint256_t("0x1530ccb47d1198320c163380a82ca8cbaf87b2d40ede856d21c60535e2251262"),
                 uint256_t(
@@ -334,9 +334,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x07aa17a6a67bcafb019d4adc0192a41f801563508f1ba7c64cd056731e2a7e01")), // precomputed_sel_op_dc_3
             Commitment(
-                uint256_t("0x09c2810761dfd6879fd4ce6643fba632c0021351df5f3222fee25527be52566d"),
+                uint256_t("0x074d234606a4d5bb93e0b2ad331eb61bdeaf87a7813bcc2b06494251154d9fb8"),
                 uint256_t(
-                    "0x17880a4bed3382c66329a6cfcc49c70a33b3cc6bfcc500139cac203c074c22e2")), // precomputed_sel_op_dc_4
+                    "0x13e4734b603d75d2e71ba58a0fcf7532b2007296d22365242432bd708f5ed76a")), // precomputed_sel_op_dc_4
             Commitment(
                 uint256_t("0x0ddf9e9dd8363fd4119ac1d79553829192ac465e7ee6656f099e40e5a8b709b0"),
                 uint256_t(
@@ -366,9 +366,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x1945936772c40110b3ba7682c358ec4772d42e9b6152a4f8706fda2c4bbe85ff")), // precomputed_sel_op_is_address_1_
             Commitment(
-                uint256_t("0x1f5b1e92050dcf9e5704486a2988ccaf207fc251d61c16e2b19e121669ce35ec"),
+                uint256_t("0x06ea2e61015bf705c8e4f76bcccf8549ff3c66d1aaaaba0eefa491c2629922b2"),
                 uint256_t(
-                    "0x1b320fadc737d6a4fd0e0743d2b8b67ea39dd23782151d9f22d9d4bfaf9ef504")), // precomputed_sel_op_is_address_2_
+                    "0x08381a2b896ad123189cf793ad2a205484c9c269572b8041261b60a358e8eee3")), // precomputed_sel_op_is_address_2_
             Commitment(
                 uint256_t("0x3052e46c51289f5e76d606f7b57dd4f535602a065abdb0c6e9d02355ea1a31aa"),
                 uint256_t(
@@ -422,9 +422,9 @@ class AvmFixedVKCommitments {
                 uint256_t(
                     "0x20361a4e1e73f07142325b1271d5fb172cb32252b44996dbed0264117cdb7b01")), // precomputed_sel_tag_check_reg_0_
             Commitment(
-                uint256_t("0x018c380ccea19d9a50cbe3ed00c7461bda1f7e994f5dc2e7f6ed79642884b0aa"),
+                uint256_t("0x061fc7f3ab86d2e539fa6acfa1a57c36ae3cdeb3f94f27fd4621e0b290a3e367"),
                 uint256_t(
-                    "0x2019fb9538f8286cd319ddd6ee82904e932b858a2d1cdf18b4393134df1c8666")), // precomputed_sel_tag_check_reg_1_
+                    "0x2d6b6d6a6af0eb44678a40ac35a86dd3b2ba2529151d23589c1e65ff502dd888")), // precomputed_sel_tag_check_reg_1_
             Commitment(
                 uint256_t("0x1530ccb47d1198320c163380a82ca8cbaf87b2d40ede856d21c60535e2251262"),
                 uint256_t(

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/storage_load.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/storage_load.test.cpp
@@ -59,9 +59,11 @@ TEST(SLoadConstrainingTest, PositiveTest)
     TestTraceContainer trace({
         { { C::execution_sel_execute_sload, 1 },
           { C::execution_register_0_, /*slot=*/42 },
-          { C::execution_register_1_, /*dst=*/27 },
+          { C::execution_register_1_, /*contract_address=*/1 },
+          { C::execution_register_2_, /*value=*/27 },
           { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::FF) },
+          { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_subtrace_operation_id, AVM_EXEC_OP_ID_SLOAD } },
     });
     check_relation<sload>(trace);
@@ -72,9 +74,11 @@ TEST(SLoadConstrainingTest, NegativeInvalidOutputTag)
     TestTraceContainer trace({
         { { C::execution_sel_execute_sload, 1 },
           { C::execution_register_0_, /*slot=*/42 },
-          { C::execution_register_1_, /*dst=*/27 },
+          { C::execution_register_1_, /*contract_address=*/1 },
+          { C::execution_register_2_, /*value=*/27 },
           { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::FF) },
-          { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::U32) },
+          { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::FF) },
+          { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::U32) },
           { C::execution_subtrace_operation_id, AVM_EXEC_OP_ID_SLOAD } },
     });
     EXPECT_THROW_WITH_MESSAGE(check_relation<sload>(trace), "SLOAD_FF_OUTPUT_TAG");
@@ -85,9 +89,11 @@ TEST(SLoadConstrainingTest, NegativeSloadSuccess)
     TestTraceContainer trace({
         { { C::execution_sel_execute_sload, 1 },
           { C::execution_register_0_, /*slot=*/42 },
-          { C::execution_register_1_, /*dst=*/27 },
+          { C::execution_register_1_, /*contract_address=*/1 },
+          { C::execution_register_2_, /*value=*/27 },
           { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::FF) },
+          { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_subtrace_operation_id, AVM_EXEC_OP_ID_SLOAD },
           { C::execution_sel_opcode_error, 1 } },
     });
@@ -132,11 +138,12 @@ TEST(SLoadConstrainingTest, Interactions)
     TestTraceContainer trace({
         { { C::execution_sel_execute_sload, 1 },
           { C::execution_register_0_, slot },
-          { C::execution_register_1_, value },
+          { C::execution_register_1_, FF(contract_address) },
+          { C::execution_register_2_, value },
           { C::execution_mem_tag_reg_0_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_mem_tag_reg_1_, static_cast<uint8_t>(MemoryTag::FF) },
+          { C::execution_mem_tag_reg_2_, static_cast<uint8_t>(MemoryTag::FF) },
           { C::execution_subtrace_operation_id, AVM_EXEC_OP_ID_SLOAD },
-          { C::execution_contract_address, contract_address },
           { C::execution_prev_public_data_tree_root, trees.public_data_tree.root } },
     });
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sload.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sload.hpp
@@ -22,9 +22,9 @@ struct lookup_sload_storage_read_settings_ {
     static constexpr Column COUNTS = Column::lookup_sload_storage_read_counts;
     static constexpr Column INVERSES = Column::lookup_sload_storage_read_inv;
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = {
-        ColumnAndShifts::execution_contract_address,
-        ColumnAndShifts::execution_register_0_,
         ColumnAndShifts::execution_register_1_,
+        ColumnAndShifts::execution_register_0_,
+        ColumnAndShifts::execution_register_2_,
         ColumnAndShifts::execution_prev_public_data_tree_root
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sload.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sload.hpp
@@ -22,14 +22,14 @@ struct lookup_sload_storage_read_settings_ {
     static constexpr Column COUNTS = Column::lookup_sload_storage_read_counts;
     static constexpr Column INVERSES = Column::lookup_sload_storage_read_inv;
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = {
-        ColumnAndShifts::execution_register_1_,
         ColumnAndShifts::execution_register_0_,
+        ColumnAndShifts::execution_register_1_,
         ColumnAndShifts::execution_register_2_,
         ColumnAndShifts::execution_prev_public_data_tree_root
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
-        ColumnAndShifts::public_data_check_address,
         ColumnAndShifts::public_data_check_slot,
+        ColumnAndShifts::public_data_check_address,
         ColumnAndShifts::public_data_check_value,
         ColumnAndShifts::public_data_check_root
     };

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sload_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sload_impl.hpp
@@ -20,7 +20,7 @@ void sloadImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
     { // SLOAD_FF_OUTPUT_TAG
         using View = typename std::tuple_element_t<0, ContainerOverSubrelations>::View;
         auto tmp = static_cast<View>(in.get(C::execution_sel_execute_sload)) *
-                   (CView(constants_MEM_TAG_FF) - static_cast<View>(in.get(C::execution_mem_tag_reg_1_)));
+                   (CView(constants_MEM_TAG_FF) - static_cast<View>(in.get(C::execution_mem_tag_reg_2_)));
         std::get<0>(evals) += (tmp * scaling_factor);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.cpp
@@ -1113,13 +1113,18 @@ void Execution::xor_op(ContextInterface& context, MemoryAddress a_addr, MemoryAd
  *
  * @param context The context.
  * @param slot_addr The resolved address of the slot value.
+ * @param contract_address_addr The resolved address of the contract address to read from.
  * @param dst_addr The resolved address of the output memory value.
  *
  * @throws RegisterValidationException if the tags of the input values do not match the expected tags:
  *        - the slot tag is not FF.
+ *        - the contract_address tag is not FF.
  * @throws OutOfGasException if the gas limit is exceeded.
  */
-void Execution::sload(ContextInterface& context, MemoryAddress slot_addr, MemoryAddress dst_addr)
+void Execution::sload(ContextInterface& context,
+                      MemoryAddress slot_addr,
+                      MemoryAddress contract_address_addr,
+                      MemoryAddress dst_addr)
 {
     BB_BENCH_NAME("Execution::sload");
     constexpr auto opcode = ExecutionOpCode::SLOAD;
@@ -1127,11 +1132,12 @@ void Execution::sload(ContextInterface& context, MemoryAddress slot_addr, Memory
     auto& memory = context.get_memory();
 
     const auto& slot = memory.get(slot_addr);
-    set_and_validate_inputs(opcode, { slot });
+    const auto& contract_address = memory.get(contract_address_addr);
+    set_and_validate_inputs(opcode, { slot, contract_address });
 
     get_gas_tracker().consume_gas();
 
-    auto value = MemoryValue::from<FF>(merkle_db.storage_read(context.get_address(), slot.as<FF>()));
+    auto value = MemoryValue::from<FF>(merkle_db.storage_read(contract_address.as<AztecAddress>(), slot.as<FF>()));
 
     memory.set(dst_addr, value);
     set_output(opcode, value);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.hpp
@@ -160,7 +160,10 @@ class Execution : public ExecutionInterface {
     void and_op(ContextInterface& context, MemoryAddress a_addr, MemoryAddress b_addr, MemoryAddress dst_addr);
     void or_op(ContextInterface& context, MemoryAddress a_addr, MemoryAddress b_addr, MemoryAddress dst_addr);
     void xor_op(ContextInterface& context, MemoryAddress a_addr, MemoryAddress b_addr, MemoryAddress dst_addr);
-    void sload(ContextInterface& context, MemoryAddress slot_addr, MemoryAddress dst_addr);
+    void sload(ContextInterface& context,
+               MemoryAddress slot_addr,
+               MemoryAddress contract_address_addr,
+               MemoryAddress dst_addr);
     void sstore(ContextInterface& context, MemoryAddress src_addr, MemoryAddress slot_addr);
     void note_hash_exists(ContextInterface& context,
                           MemoryAddress unique_note_hash_addr,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/execution.test.cpp
@@ -622,20 +622,22 @@ TEST_F(ExecutionSimulationTest, DebugLog)
 TEST_F(ExecutionSimulationTest, Sload)
 {
     MemoryAddress slot_addr = 27;
+    MemoryAddress contract_address_addr = 28;
     MemoryAddress dst_addr = 10;
     AztecAddress address = 0xdeadbeef;
     auto slot = MemoryValue::from<FF>(42);
+    auto contract_address = MemoryValue::from<AztecAddress>(address);
 
     EXPECT_CALL(context, get_memory());
 
     EXPECT_CALL(memory, get(slot_addr)).WillOnce(ReturnRef(slot));
-    EXPECT_CALL(context, get_address).WillOnce(ReturnRef(address));
+    EXPECT_CALL(memory, get(contract_address_addr)).WillOnce(ReturnRef(contract_address));
     EXPECT_CALL(merkle_db, storage_read(address, slot.as<FF>())).WillOnce(Return(7));
 
     EXPECT_CALL(memory, set(dst_addr, MemoryValue::from<FF>(7)));
     EXPECT_CALL(gas_tracker, consume_gas(Gas{ 0, 0 }));
 
-    execution.sload(context, slot_addr, dst_addr);
+    execution.sload(context, slot_addr, contract_address_addr, dst_addr);
 }
 
 TEST_F(ExecutionSimulationTest, SStore)

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/lib/serialization.cpp
@@ -131,7 +131,8 @@ const std::unordered_map<WireOpCode, std::vector<OperandType>>& get_wire_opcode_
         { WireOpCode::MOV_16, { OperandType::INDIRECT8, OperandType::UINT16, OperandType::UINT16 } },
 
         // Side Effects - Public Storage
-        { WireOpCode::SLOAD, { OperandType::INDIRECT8, OperandType::UINT16, OperandType::UINT16 } },
+        { WireOpCode::SLOAD,
+          { OperandType::INDIRECT8, OperandType::UINT16, OperandType::UINT16, OperandType::UINT16 } },
         { WireOpCode::SSTORE, { OperandType::INDIRECT8, OperandType::UINT16, OperandType::UINT16 } },
         // Side Effects - Notes, Nullfiers, Logs, Messages
         { WireOpCode::NOTEHASHEXISTS,

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
@@ -846,19 +846,26 @@ TEST(ExecutionTraceGenTest, SLoad)
     ExecutionTraceBuilder builder;
 
     uint16_t slot_offset = 1234;
+    uint16_t contract_address_offset = 2345;
     uint16_t dst_offset = 4567;
 
     FF slot = 42;
+    FF contract_address = 0xdeadbeef;
     FF dst_value = 27;
 
-    const auto instr =
-        InstructionBuilder(WireOpCode::SLOAD).operand<uint16_t>(slot_offset).operand<uint16_t>(dst_offset).build();
+    const auto instr = InstructionBuilder(WireOpCode::SLOAD)
+                           .operand<uint16_t>(slot_offset)
+                           .operand<uint16_t>(contract_address_offset)
+                           .operand<uint16_t>(dst_offset)
+                           .build();
 
     ExecutionEvent ex_event = {
         .wire_instruction = instr,
-        .inputs = { MemoryValue::from<FF>(slot) },
+        .inputs = { MemoryValue::from<FF>(slot), MemoryValue::from<FF>(contract_address) },
         .output = MemoryValue::from<FF>(dst_value),
         .addressing_event = { .resolution_info = { { .resolved_operand = MemoryValue::from<uint16_t>(slot_offset) },
+                                                   { .resolved_operand =
+                                                         MemoryValue::from<uint16_t>(contract_address_offset) },
                                                    { .resolved_operand = MemoryValue::from<uint16_t>(dst_offset) } } },
     };
 
@@ -871,11 +878,14 @@ TEST(ExecutionTraceGenTest, SLoad)
                     AllOf(ROW_FIELD_EQ(execution_sel, 1),
                           ROW_FIELD_EQ(execution_sel_execute_sload, 1),
                           ROW_FIELD_EQ(execution_rop_0_, slot_offset),
-                          ROW_FIELD_EQ(execution_rop_1_, dst_offset),
+                          ROW_FIELD_EQ(execution_rop_1_, contract_address_offset),
+                          ROW_FIELD_EQ(execution_rop_2_, dst_offset),
                           ROW_FIELD_EQ(execution_register_0_, slot),
-                          ROW_FIELD_EQ(execution_register_1_, dst_value),
+                          ROW_FIELD_EQ(execution_register_1_, contract_address),
+                          ROW_FIELD_EQ(execution_register_2_, dst_value),
                           ROW_FIELD_EQ(execution_mem_tag_reg_0_, MEM_TAG_FF), // Memory tag for slot
-                          ROW_FIELD_EQ(execution_mem_tag_reg_1_, MEM_TAG_FF), // Memory tag for dst
+                          ROW_FIELD_EQ(execution_mem_tag_reg_1_, MEM_TAG_FF), // Memory tag for contract_address
+                          ROW_FIELD_EQ(execution_mem_tag_reg_2_, MEM_TAG_FF), // Memory tag for dst
                           ROW_FIELD_EQ(execution_subtrace_operation_id, AVM_EXEC_OP_ID_SLOAD))));
 }
 

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -737,11 +737,13 @@ impl PublicContext {
     /// * `N` - the number of consecutive slots to return, starting from the
     ///         `storage_slot`.
     ///
-    pub fn raw_storage_read<let N: u32>(_self: Self, storage_slot: Field) -> [Field; N] {
+    pub fn raw_storage_read<let N: u32>(self: Self, storage_slot: Field) -> [Field; N] {
         let mut out = [0; N];
         for i in 0..N {
             // Safety: AVM opcodes are constrained by the AVM itself
-            out[i] = unsafe { avm::storage_read(storage_slot + i as Field) };
+            out[i] = unsafe {
+                avm::storage_read(storage_slot + i as Field, self.this_address().to_field())
+            };
         }
         out
     }

--- a/noir-projects/aztec-nr/aztec/src/oracle/avm.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/avm.nr
@@ -110,8 +110,8 @@ pub unconstrained fn revert(revertdata: [Field]) {
     revert_opcode(revertdata)
 }
 
-pub unconstrained fn storage_read(storage_slot: Field) -> Field {
-    storage_read_opcode(storage_slot)
+pub unconstrained fn storage_read(storage_slot: Field, contract_address: Field) -> Field {
+    storage_read_opcode(storage_slot, contract_address)
 }
 
 pub unconstrained fn storage_write(storage_slot: Field, value: Field) {
@@ -219,7 +219,7 @@ unconstrained fn call_static_opcode<let N: u32>(
 unconstrained fn success_copy_opcode() -> bool {}
 
 #[oracle(avmOpcodeStorageRead)]
-unconstrained fn storage_read_opcode(storage_slot: Field) -> Field {}
+unconstrained fn storage_read_opcode(storage_slot: Field, contract_address: Field) -> Field {}
 
 #[oracle(avmOpcodeStorageWrite)]
 unconstrained fn storage_write_opcode(storage_slot: Field, value: Field) {}

--- a/yarn-project/simulator/docs/avm/opcodes/sload.md
+++ b/yarn-project/simulator/docs/avm/opcodes/sload.md
@@ -7,12 +7,12 @@ Load value from public storage
 Opcode `0x2F`
 
 ```javascript
-M[dstOffset] = storage[contractAddress][M[slotOffset]]
+M[dstOffset] = storage[M[contractAddressOffset]][M[slotOffset]]
 ```
 
 ## Details
 
-Reads from public storage at the specified slot. Performs a read of the Public Data Tree. The contractAddress is the address of the currently executing contract and does not come from the bytecode. Both slot and result have type tag FIELD. Gas cost varies based on whether the slot is warm (recently accessed) or cold (first access in this transaction).
+Reads from public storage at the specified slot. Performs a read of the Public Data Tree. The contractAddress is read from memory at the specified offset. Slot, contract address, and result all have type tag FIELD. Gas cost varies based on whether the slot is warm (recently accessed) or cold (first access in this transaction).
 
 ## Gas Costs
 
@@ -29,6 +29,7 @@ Reads from public storage at the specified slot. Performs a read of the Public D
 | Name | Type | Description |
 |------|------|-------------|
 | `slotOffset` | Memory offset | Memory offset of the storage slot to read from |
+| `contractAddressOffset` | Memory offset | Memory offset of the contract address to read from |
 | `dstOffset` | Memory offset | Memory offset where the loaded value will be written |
 
 ## Wire Formats
@@ -41,13 +42,14 @@ See [Wire Format](../wire-format.md) page for an explanation of wire format vari
 title: "SLOAD"
 config:
   packet:
-    bitsPerRow: 48
+    bitsPerRow: 64
 ---
 packet-beta
 0-7: "Opcode (0x2F)"
 8-15: "Addressing modes"
 16-31: "Operand: slotOffset"
-32-47: "Operand: dstOffset"
+32-47: "Operand: contractAddressOffset"
+48-63: "Operand: dstOffset"
 ```
 
 ## Addressing Modes
@@ -55,7 +57,7 @@ See [Addressing](../addressing.md) page for a detailed explanation.
 
 8-bit bitmask: 2 bits per memory offset operand (indirect flag + relative flag)
 
-Memory offset operands (`slotOffset`, `dstOffset`) are encoded as follows:
+Memory offset operands (`slotOffset`, `contractAddressOffset`, `dstOffset`) are encoded as follows:
 
 ```mermaid
 ---
@@ -68,10 +70,10 @@ config:
 packet-beta
   0: "slotOffset is indirect"
   1: "slotOffset is relative"
-  2: "dstOffset is indirect"
-  3: "dstOffset is relative"
-  4: "Unused"
-  5: "Unused"
+  2: "contractAddressOffset is indirect"
+  3: "contractAddressOffset is relative"
+  4: "dstOffset is indirect"
+  5: "dstOffset is relative"
   6: "Unused"
   7: "Unused"
 ```
@@ -79,6 +81,7 @@ packet-beta
 ## Tag Checks
 
 - `T[slotOffset] == FIELD`
+- `T[contractAddressOffset] == FIELD`
 
 ## Tag Updates
 
@@ -86,7 +89,7 @@ packet-beta
 
 ## Error Conditions
 
-- **INVALID_TAG**: Slot operand is not FIELD
+- **INVALID_TAG**: Slot or contract address operand is not FIELD
 - **MEMORY_ACCESS_OUT_OF_RANGE**: Memory offset operand exceeds addressable memory
 
 ---

--- a/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
@@ -105,9 +105,15 @@ describe('Storage Instructions', () => {
         SLoad.opcode, // opcode
         0x01, // indirect
         ...Buffer.from('1234', 'hex'), // slotOffset
+        ...Buffer.from('5678', 'hex'), // contractAddressOffset
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
-      const inst = new SLoad(/*addressing_mode=*/ 0x01, /*slotOffset=*/ 0x1234, /*dstOffset=*/ 0x3456);
+      const inst = new SLoad(
+        /*addressing_mode=*/ 0x01,
+        /*slotOffset=*/ 0x1234,
+        /*contractAddressOffset=*/ 0x5678,
+        /*dstOffset=*/ 0x3456,
+      );
 
       expect(SLoad.fromBuffer(buf)).toEqual(inst);
       expect(inst.toBuffer()).toEqual(buf);
@@ -118,17 +124,22 @@ describe('Storage Instructions', () => {
       const expectedResult = new Fr(1n);
       persistableState.readStorage.mockResolvedValueOnce(expectedResult);
 
-      const a = new Field(1n);
-      const b = new Field(2n);
+      const slot = new Field(1n);
+      const contractAddressField = new Field(address.toBigInt());
 
-      context.machineState.memory.set(0, a);
-      context.machineState.memory.set(1, b);
+      context.machineState.memory.set(0, slot);
+      context.machineState.memory.set(1, contractAddressField);
 
-      await new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1).execute(context);
+      await new SLoad(
+        /*addressing_mode=*/ 0,
+        /*slotOffset=*/ 0,
+        /*contractAddressOffset=*/ 1,
+        /*dstOffset=*/ 2,
+      ).execute(context);
 
-      expect(persistableState.readStorage).toHaveBeenCalledWith(address, new Fr(a.toBigInt()));
+      expect(persistableState.readStorage).toHaveBeenCalledWith(address, new Fr(slot.toBigInt()));
 
-      const actual = context.machineState.memory.get(1);
+      const actual = context.machineState.memory.get(2);
       expect(actual).toEqual(new Field(expectedResult));
     });
   });

--- a/yarn-project/simulator/src/public/avm/opcodes/storage.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/storage.ts
@@ -5,7 +5,9 @@ import { Opcode, OperandType } from '../serialization/instruction_serialization.
 import { Addressing } from './addressing_mode.js';
 import { Instruction } from './instruction.js';
 
-abstract class BaseStorageInstruction extends Instruction {
+export class SStore extends Instruction {
+  static readonly type: string = 'SSTORE';
+  static readonly opcode = Opcode.SSTORE;
   // Informs (de)serialization. See Instruction.deserialize.
   public static readonly wireFormat: OperandType[] = [
     OperandType.UINT8,
@@ -15,20 +17,11 @@ abstract class BaseStorageInstruction extends Instruction {
   ];
 
   constructor(
-    protected addressingMode: number,
-    protected aOffset: number,
-    protected bOffset: number,
+    private addressingMode: number,
+    private srcOffset: number,
+    private slotOffset: number,
   ) {
     super();
-  }
-}
-
-export class SStore extends BaseStorageInstruction {
-  static readonly type: string = 'SSTORE';
-  static readonly opcode = Opcode.SSTORE;
-
-  constructor(addressingMode: number, srcOffset: number, slotOffset: number) {
-    super(addressingMode, srcOffset, slotOffset);
   }
 
   public async execute(context: AvmContext): Promise<void> {
@@ -43,7 +36,7 @@ export class SStore extends BaseStorageInstruction {
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
     );
 
-    const operands = [this.aOffset, this.bOffset];
+    const operands = [this.srcOffset, this.slotOffset];
     const [srcOffset, slotOffset] = addressing.resolve(operands, memory);
     // We read before tag checking since it's needed for gas cost calculation
     const slot = memory.get(slotOffset).toFr();
@@ -60,12 +53,25 @@ export class SStore extends BaseStorageInstruction {
   }
 }
 
-export class SLoad extends BaseStorageInstruction {
+export class SLoad extends Instruction {
   static readonly type: string = 'SLOAD';
   static readonly opcode = Opcode.SLOAD;
+  // Informs (de)serialization. See Instruction.deserialize.
+  public static readonly wireFormat: OperandType[] = [
+    OperandType.UINT8,
+    OperandType.UINT8,
+    OperandType.UINT16,
+    OperandType.UINT16,
+    OperandType.UINT16,
+  ];
 
-  constructor(addressingMode: number, slotOffset: number, dstOffset: number) {
-    super(addressingMode, slotOffset, dstOffset);
+  constructor(
+    private addressingMode: number,
+    private slotOffset: number,
+    private contractAddressOffset: number,
+    private dstOffset: number,
+  ) {
+    super();
   }
 
   public async execute(context: AvmContext): Promise<void> {
@@ -76,12 +82,14 @@ export class SLoad extends BaseStorageInstruction {
       this.baseGasCost(addressing.indirectOperandsCount(), addressing.relativeOperandsCount()),
     );
 
-    const operands = [this.aOffset, this.bOffset];
-    const [slotOffset, dstOffset] = addressing.resolve(operands, memory);
+    const operands = [this.slotOffset, this.contractAddressOffset, this.dstOffset];
+    const [slotOffset, contractAddressOffset, dstOffset] = addressing.resolve(operands, memory);
     memory.checkTag(TypeTag.FIELD, slotOffset);
+    memory.checkTag(TypeTag.FIELD, contractAddressOffset);
 
     const slot = memory.get(slotOffset).toFr();
-    const value = await context.persistableState.readStorage(context.environment.address, slot);
+    const contractAddress = memory.get(contractAddressOffset).toAztecAddress();
+    const value = await context.persistableState.readStorage(contractAddress, slot);
     memory.set(dstOffset, new Field(value));
   }
 }

--- a/yarn-project/simulator/src/public/fixtures/opcode_spammer.ts
+++ b/yarn-project/simulator/src/public/fixtures/opcode_spammer.ts
@@ -966,34 +966,63 @@ export const SPAM_CONFIGS: Partial<Record<Opcode, SpamConfig[]>> = {
   [Opcode.SLOAD]: [
     {
       label: 'Cold read (slot not written)',
-      setup: [{ offset: 0, value: new Field(Fr.random()) }], // random slot
-      targetInstructions: () => [new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
+      setup: [
+        { offset: 0, value: new Field(Fr.random()) }, // random slot
+        () => [
+          // Get current contract address into offset 1
+          new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*varEnum=*/ 0).as(
+            Opcode.GETENVVAR_16,
+            GetEnvVar.wireFormat16,
+          ),
+        ],
+      ],
+      targetInstructions: () => [
+        new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*contractAddressOffset=*/ 1, /*dstOffset=*/ 2),
+      ],
     },
     {
       label: 'Warm read (from tree)',
       // Uses pre-inserted storage from insertWarmTreeEntries() which is called after contract deployment
-      setup: [{ offset: 0, value: new Field(WARM_STORAGE_SLOT) }], // pre-inserted slot
-      targetInstructions: () => [new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 1)],
+      setup: [
+        { offset: 0, value: new Field(WARM_STORAGE_SLOT) }, // pre-inserted slot
+        () => [
+          // Get current contract address into offset 1
+          new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 1, /*varEnum=*/ 0).as(
+            Opcode.GETENVVAR_16,
+            GetEnvVar.wireFormat16,
+          ),
+        ],
+      ],
+      targetInstructions: () => [
+        new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*contractAddressOffset=*/ 1, /*dstOffset=*/ 2),
+      ],
     },
     {
       label: 'Warm read (SSTORE first, unique slot per SLOAD)',
-      // Memory layout: slot (incremented), value, constant 1, revertSize, loaded value
+      // Memory layout: slot (incremented), value, constant 1, contract address (from GETENVVAR), revertSize, loaded value
       setup: [
         { offset: 0, value: new Field(Fr.random()) }, // slot (will be incremented)
         { offset: 1, value: new Field(Fr.random()) }, // value to store
         { offset: 2, value: new Field(1n) }, // constant 1 for ADD
-        { offset: 3, value: new Uint32(0n) }, // revertSize
+        () => [
+          // Get current contract address into offset 3
+          new GetEnvVar(/*addressing_mode=*/ 0, /*dstOffset=*/ 3, /*varEnum=*/ 0).as(
+            Opcode.GETENVVAR_16,
+            GetEnvVar.wireFormat16,
+          ),
+        ],
+        { offset: 4, value: new Uint32(0n) }, // revertSize
       ],
       targetInstructions: () => [
         new SStore(/*addressing_mode=*/ 0, /*srcOffset=*/ 1, /*slotOffset=*/ 0),
-        new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*dstOffset=*/ 4),
+        new SLoad(/*addressing_mode=*/ 0, /*slotOffset=*/ 0, /*contractAddressOffset=*/ 3, /*dstOffset=*/ 5),
         new Add(/*addressing_mode=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 2, /*dstOffset=*/ 0).as(
           Opcode.ADD_8,
           Add.wireFormat8,
         ), // slot++
       ],
       cleanupInstructions: () => [
-        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 3, /*returnOffset=*/ 0).as(
+        new Revert(/*addressing_mode=*/ 0, /*retSizeOffset=*/ 4, /*returnOffset=*/ 0).as(
           Opcode.REVERT_8,
           Revert.wireFormat8,
         ),

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -35,7 +35,7 @@ export interface IAvmExecutionOracle {
   avmOpcodeEmitNoteHash(noteHash: Fr): Promise<void>;
   avmOpcodeNullifierExists(innerNullifier: Fr, targetAddress: AztecAddress): Promise<boolean>;
   avmOpcodeStorageWrite(slot: Fr, value: Fr): Promise<void>;
-  avmOpcodeStorageRead(slot: Fr): Promise<Fr>;
+  avmOpcodeStorageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr>;
 }
 
 /**

--- a/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
@@ -101,8 +101,8 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
     ]);
   }
 
-  async avmOpcodeStorageRead(slot: Fr): Promise<Fr> {
-    const leafSlot = await computePublicDataTreeLeafSlot(this.contractAddress, slot);
+  async avmOpcodeStorageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr> {
+    const leafSlot = await computePublicDataTreeLeafSlot(contractAddress, slot);
 
     const lowLeafResult = await this.forkedWorldTrees.getPreviousValueIndex(
       MerkleTreeId.PUBLIC_DATA_TREE,
@@ -119,7 +119,7 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
             )) as PublicDataTreeLeafPreimage
           ).leaf.value;
 
-    this.logger.debug('AVM storage read', { slot, value });
+    this.logger.debug('AVM storage read', { slot, contractAddress, value });
 
     return value;
   }

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -822,10 +822,11 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle) {
+  async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
     const slot = fromSingle(foreignSlot);
+    const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
 
-    const value = (await this.handlerAsAvm().avmOpcodeStorageRead(slot)).value;
+    const value = (await this.handlerAsAvm().avmOpcodeStorageRead(slot, contractAddress)).value;
 
     return toForeignCallResult([toSingle(new Fr(value))]);
   }


### PR DESCRIPTION
Makes the `SLOAD` opcode take in an address. In aztec-nr, the public context is modified to use the current address, for backwards compatibility. It's up to the aztec-nr team to decide how to expose this.

Fixes https://linear.app/aztec-labs/issue/AVM-211/consider-taking-contractaddress-in-sload .