### PR TITLE
chore!: Make PublicImmutable is_initialized pub

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -172,7 +172,7 @@ impl<T> PublicImmutable<T, PublicContext> {
         WithHash::public_storage_read(self.context, self.storage_slot)
     }
 
-    fn is_initialized(self) -> bool {
+    pub fn is_initialized(self) -> bool {
         let nullifier = self.compute_initialization_nullifier();
 
         // Safety: it is safe to assume that the state variable has been initialized if the initialization nullifier


### PR DESCRIPTION
Making `PublicImmutable` `is_initialized` public
