### PR TITLE
chore: flake postgres.test.ts more

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -366,3 +366,10 @@ tests:
     error_regex: "Encountered 1 failing test in test/staking_asset_handler/claim.t.sol:ClaimTest"
     owners:
       - *lasse
+
+  # http://ci.aztec-labs.com/143ea51c3e2f43ff
+  # happening since node 24 move
+  - regex: "validator-ha-signer/src/db/postgres.test.ts"
+    owners:
+      - *spyros
+


### PR DESCRIPTION
This needs to be investigated still. worst case we may have to move away from pglite as nothing else has manifested in node 24 instability (you would think it wouldn't be this bugridden a release)