### PR TITLE
fix: dropping redundant call to `discover_new_messages(...)`

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -313,7 +313,6 @@ comptime fn generate_process_message() -> Quoted {
         ) {
             let address = aztec::context::UtilityContext::new().this_address();
 
-            aztec::messages::discovery::discover_new_messages(address, _compute_note_hash_and_nullifier);     
             aztec::messages::discovery::process_message::process_message_ciphertext(
                 address,
                 _compute_note_hash_and_nullifier,


### PR DESCRIPTION
The call to `discover_new_messages` in `process_message` utility function was redundant because PXE now automatically triggers private state sync before any private or utility function is simulated/executed. I originally thought this is a huge performance issue as I was not sure if we enter some kind of sync loop but it turns out to not be the case because the `process_message` utility function is never invoked in the sync process.

To figure this out I wrote an overview of how we sync:
1. `PXE` simulates `sync_private_state` utility function that just calls `aztec::messages::discovery::discover_new_messages(...)`,
2. `discover_new_messages` calls the `utilityFetchTaggedLogs` oracle that (now in parallel) triggers `syncTaggedLogs` and `syncNoteNullifiers`,
3. `syncTaggedLogs` then loads new tagged logs and stores them in capsule,
4. once the oracle handler returns `discover_new_messages` loads the capsule and calls `process_message_ciphertext` that then decrypts it and calls `process_message_plaintext` that then in the case of notes calls `process_private_note_msg` that calls `attempt_note_discovery` that brute forces the nonce and then `enqueue_note_for_validation` gets called which stores the note in capsule,
5. then `discover_new_messages` calls `validate_enqueued_notes_and_events` that validates the data stored in capsules and stores them in the relevant stores (note and event stores).

The flow feels a bit too complex.