### PR TITLE
refactor: PrivateEventStore

### DIFF
--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -278,6 +278,51 @@ describe('PrivateEventStore', () => {
     expect(events).toEqual([expectedEvent]);
   });
 
+  it('finds event under each scope it was stored with', async () => {
+    const scope1 = await AztecAddress.random();
+    const scope2 = await AztecAddress.random();
+    const eventCommitment = Fr.random();
+
+    const event = {
+      contractAddress,
+      scope: scope1,
+      txHash,
+      l2BlockNumber,
+      l2BlockHash,
+      txIndexInBlock: 0,
+      eventIndexInTx: 0,
+    };
+
+    await privateEventStore.storePrivateEventLog(eventSelector, randomness, msgContent, eventCommitment, event, 'test');
+    await privateEventStore.storePrivateEventLog(
+      eventSelector,
+      randomness,
+      msgContent,
+      eventCommitment,
+      { ...event, scope: scope2 },
+      'test',
+    );
+
+    await privateEventStore.commit('test');
+
+    const filter = { contractAddress, fromBlock: l2BlockNumber, toBlock: l2BlockNumber + 1 };
+
+    const eventsScope1 = await privateEventStore.getPrivateEvents(eventSelector, { ...filter, scopes: [scope1] });
+    expect(eventsScope1).toHaveLength(1);
+    expect(eventsScope1[0].packedEvent).toEqual(msgContent);
+
+    const eventsScope2 = await privateEventStore.getPrivateEvents(eventSelector, { ...filter, scopes: [scope2] });
+    expect(eventsScope2).toHaveLength(1);
+    expect(eventsScope2[0].packedEvent).toEqual(msgContent);
+
+    // Querying with both scopes returns the event once
+    const eventsBoth = await privateEventStore.getPrivateEvents(eventSelector, {
+      ...filter,
+      scopes: [scope1, scope2],
+    });
+    expect(eventsBoth).toHaveLength(1);
+  });
+
   it('returns empty array when no events match criteria', async () => {
     const events = await privateEventStore.getPrivateEvents(eventSelector, {
       contractAddress,

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -1,15 +1,16 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
-import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
-import { type InTx, TxHash } from '@aztec/stdlib/tx';
+import type { InTx, TxHash } from '@aztec/stdlib/tx';
 
 import type { StagedStore } from '../../job_coordinator/job_coordinator.js';
 import type { PackedPrivateEvent } from '../../pxe.js';
+import { StoredPrivateEvent } from './stored_private_event.js';
 
 export type PrivateEventStoreFilter = {
   contractAddress: AztecAddress;
@@ -17,20 +18,6 @@ export type PrivateEventStoreFilter = {
   toBlock: number;
   scopes: AztecAddress[];
   txHash?: TxHash;
-};
-
-type PrivateEventEntry = {
-  randomness: Fr; // Note that this value is currently not being returned on queries and is therefore temporarily unused
-  msgContent: Buffer;
-  l2BlockNumber: number;
-  l2BlockHash: Buffer;
-  txHash: Buffer;
-  /** The index of the tx within the block, used for ordering events */
-  txIndexInBlock: number;
-  /** The index of the event within the tx (based on nullifier position), used for ordering events */
-  eventIndexInTx: number;
-  /** The lookup key for #eventsByContractScopeSelector, used for cleanup during rollback */
-  lookupKey: string;
 };
 
 type PrivateEventMetadata = InTx & {
@@ -49,104 +36,29 @@ export class PrivateEventStore implements StagedStore {
   readonly storeName: string = 'private_event';
 
   #store: AztecAsyncKVStore;
-  /** Map storing the actual private event log entries, keyed by siloedEventCommitment */
-  #eventLogs: AztecAsyncMap<string, PrivateEventEntry>;
-  /** Multi-map from contractAddress_scope_eventSelector to siloedEventCommitment for efficient lookup */
-  #eventsByContractScopeSelector: AztecAsyncMultiMap<string, string>;
+  /** Actual private event log entries, keyed by siloedEventCommitment */
+  #events: AztecAsyncMap<string, Buffer>;
+  /** Multi-map from contractAddress_eventSelector to siloedEventCommitment for efficient lookup */
+  #eventsByContractAndEventSelector: AztecAsyncMultiMap<string, string>;
   /** Multi-map from block number to siloedEventCommitment for rollback support */
   #eventsByBlockNumber: AztecAsyncMultiMap<number, string>;
-  /** Map from siloedEventCommitment to boolean indicating if log has been seen. */
-  #seenLogs: AztecAsyncMap<string, boolean>;
 
-  /** jobId => eventId (event siloed nullifier)  => PrivateEventEntry */
-  #eventLogsInJobStage: Map<string, Map<string, PrivateEventEntry>>;
+  /** jobId => eventId (event siloed nullifier) => StoredPrivateEvent */
+  #eventsForJob: Map<string, Map<string, StoredPrivateEvent>>;
+
+  /** Per-job locks to prevent concurrent writes from affecting each other. */
+  #jobLocks: Map<string, Semaphore>;
 
   logger = createLogger('private_event_store');
 
   constructor(store: AztecAsyncKVStore) {
     this.#store = store;
-    this.#eventLogs = this.#store.openMap('private_event_logs');
-    this.#eventsByContractScopeSelector = this.#store.openMultiMap('events_by_contract_scope_selector');
-    this.#seenLogs = this.#store.openMap('seen_logs');
+    this.#events = this.#store.openMap('private_event_logs');
+    this.#eventsByContractAndEventSelector = this.#store.openMultiMap('events_by_contract_selector');
     this.#eventsByBlockNumber = this.#store.openMultiMap('events_by_block_number');
 
-    this.#eventLogsInJobStage = new Map();
-  }
-
-  #keyFor(contractAddress: AztecAddress, scope: AztecAddress, eventSelector: EventSelector): string {
-    return `${contractAddress.toString()}_${scope.toString()}_${eventSelector.toString()}`;
-  }
-
-  async commit(jobId: string): Promise<void> {
-    await Promise.all(
-      [...this.#getEventLogsInJobStage(jobId).entries()].map(async ([eventId, eventEntry]) => {
-        this.logger.verbose('storing private event log (KV store)', eventEntry);
-
-        await Promise.all([
-          this.#eventLogs.set(eventId, eventEntry),
-          this.#eventsByContractScopeSelector.set(eventEntry.lookupKey, eventId),
-          this.#eventsByBlockNumber.set(eventEntry.l2BlockNumber, eventId),
-          this.#seenLogs.set(eventId, true),
-        ]);
-      }),
-    );
-
-    return this.discardStaged(jobId);
-  }
-
-  discardStaged(jobId: string): Promise<void> {
-    this.#eventLogsInJobStage.delete(jobId);
-    return Promise.resolve();
-  }
-
-  #getEventLogsInJobStage(jobId: string): Map<string, PrivateEventEntry> {
-    let jobStage = this.#eventLogsInJobStage.get(jobId);
-    if (jobStage === undefined) {
-      jobStage = new Map();
-      this.#eventLogsInJobStage.set(jobId, jobStage);
-    }
-    return jobStage;
-  }
-
-  async #isSeenLog(jobId: string, eventId: string): Promise<boolean> {
-    const eventLogsInJobStage = this.#getEventLogsInJobStage(jobId).get(eventId);
-    return !!eventLogsInJobStage || !!(await this.#seenLogs.getAsync(eventId));
-  }
-
-  #addEventLogToStage(jobId: string, eventId: string, eventEntry: PrivateEventEntry) {
-    this.#getEventLogsInJobStage(jobId).set(eventId, eventEntry);
-  }
-
-  async #getEventSiloedNullifiers(
-    contractAddress: AztecAddress,
-    scope: AztecAddress,
-    eventSelector: EventSelector,
-    jobId?: string,
-  ): Promise<string[]> {
-    const key = this.#keyFor(contractAddress, scope, eventSelector);
-    const eventSiloedNullifiersInStorage: string[] = [];
-    for await (const eventId of this.#eventsByContractScopeSelector.getValuesAsync(key)) {
-      eventSiloedNullifiersInStorage.push(eventId);
-    }
-
-    if (!jobId) {
-      return eventSiloedNullifiersInStorage;
-    }
-
-    const eventSiloedNullifiersInJobStage = new Set(
-      [...this.#getEventLogsInJobStage(jobId).entries()]
-        .filter(([_, entry]) => entry.lookupKey === key)
-        .map(([idx, _]) => idx),
-    );
-    return [...new Set(eventSiloedNullifiersInStorage).union(eventSiloedNullifiersInJobStage)];
-  }
-
-  async #getEventLogBySiloedNullifier(eventId: string, jobId?: string): Promise<PrivateEventEntry | undefined> {
-    if (jobId) {
-      return this.#getEventLogsInJobStage(jobId).get(eventId) ?? (await this.#eventLogs.getAsync(eventId));
-    } else {
-      return await this.#eventLogs.getAsync(eventId);
-    }
+    this.#eventsForJob = new Map();
+    this.#jobLocks = new Map();
   }
 
   /**
@@ -168,39 +80,43 @@ export class PrivateEventStore implements StagedStore {
     siloedEventCommitment: Fr,
     metadata: PrivateEventMetadata,
     jobId: string,
-  ): Promise<void> {
-    const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
-
-    return this.#store.transactionAsync(async () => {
-      const key = this.#keyFor(contractAddress, scope, eventSelector);
-
-      // The siloed event commitment is guaranteed to be unique as it's inserted into the nullifier tree. For this
-      // reason we use it as id.
+  ) {
+    return this.#withJobLock(jobId, async () => {
+      const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
       const eventId = siloedEventCommitment.toString();
 
-      const hasBeenSeen = await this.#isSeenLog(jobId, eventId);
-      if (hasBeenSeen) {
-        this.logger.verbose('Ignoring duplicate event log', { txHash: txHash.toString(), siloedEventCommitment });
-        return;
-      }
-
       this.logger.verbose('storing private event log (job stage)', {
+        eventId,
         contractAddress,
         scope,
         msgContent,
         l2BlockNumber,
       });
 
-      this.#addEventLogToStage(jobId, eventId, {
-        randomness,
-        msgContent: serializeToBuffer(msgContent),
-        l2BlockNumber,
-        l2BlockHash: l2BlockHash.toBuffer(),
-        txHash: txHash.toBuffer(),
-        txIndexInBlock,
-        eventIndexInTx,
-        lookupKey: key,
-      });
+      const existing = await this.#readEvent(eventId, jobId);
+
+      if (existing) {
+        // If we already stored this event, we still want to make sure to track it for the given scope
+        existing.addScope(scope.toString());
+        this.#writeEvent(eventId, existing, jobId);
+      } else {
+        this.#writeEvent(
+          eventId,
+          new StoredPrivateEvent(
+            randomness,
+            msgContent,
+            l2BlockNumber,
+            l2BlockHash,
+            txHash,
+            txIndexInBlock,
+            eventIndexInTx,
+            contractAddress,
+            eventSelector,
+            new Set([scope.toString()]),
+          ),
+          jobId,
+        );
+      }
     });
   }
 
@@ -215,64 +131,78 @@ export class PrivateEventStore implements StagedStore {
    * @returns - The event log contents, augmented with metadata about the transaction and block in which the event was
    * included.
    */
-  public async getPrivateEvents(
+  public getPrivateEvents(
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
   ): Promise<PackedPrivateEvent[]> {
-    const events: Array<{
-      l2BlockNumber: number;
-      txIndexInBlock: number;
-      eventIndexInTx: number;
-      event: PackedPrivateEvent;
-    }> = [];
+    return this.#store.transactionAsync(async () => {
+      const events: Array<{
+        l2BlockNumber: number;
+        txIndexInBlock: number;
+        eventIndexInTx: number;
+        event: PackedPrivateEvent;
+      }> = [];
 
-    for (const scope of filter.scopes) {
-      const eventIds = await this.#getEventSiloedNullifiers(filter.contractAddress, scope, eventSelector);
+      const key = this.#keyFor(filter.contractAddress, eventSelector);
+      const targetScopes = new Set(filter.scopes.map(s => s.toString()));
+
+      const eventIds: string[] = await toArray(this.#eventsByContractAndEventSelector.getValuesAsync(key));
 
       for (const eventId of eventIds) {
-        const entry = await this.#getEventLogBySiloedNullifier(eventId);
+        const eventBuffer = await this.#events.getAsync(eventId);
 
-        if (!entry || entry.l2BlockNumber < filter.fromBlock || entry.l2BlockNumber >= filter.toBlock) {
+        // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
+        if (!eventBuffer) {
+          this.logger.verbose(
+            `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
+          );
           continue;
         }
 
-        // Convert buffer back to Fr array
-        const reader = BufferReader.asReader(entry.msgContent);
-        const numFields = entry.msgContent.length / Fr.SIZE_IN_BYTES;
-        const msgContent = reader.readArray(numFields, Fr);
-        const txHash = TxHash.fromBuffer(entry.txHash);
-        const l2BlockHash = L2BlockHash.fromBuffer(entry.l2BlockHash);
+        const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
 
-        if (filter.txHash && !txHash.equals(filter.txHash)) {
+        // Filter by block range
+        if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
+          continue;
+        }
+
+        // Filter by scopes
+        if (storedPrivateEvent.scopes.intersection(targetScopes).size === 0) {
+          continue;
+        }
+
+        // Filter by txHash
+        if (filter.txHash && !storedPrivateEvent.txHash.equals(filter.txHash)) {
           continue;
         }
 
         events.push({
-          l2BlockNumber: entry.l2BlockNumber,
-          txIndexInBlock: entry.txIndexInBlock,
-          eventIndexInTx: entry.eventIndexInTx,
+          l2BlockNumber: storedPrivateEvent.l2BlockNumber,
+          txIndexInBlock: storedPrivateEvent.txIndexInBlock,
+          eventIndexInTx: storedPrivateEvent.eventIndexInTx,
           event: {
-            packedEvent: msgContent,
-            l2BlockNumber: BlockNumber(entry.l2BlockNumber),
-            txHash,
-            l2BlockHash,
+            packedEvent: storedPrivateEvent.msgContent,
+            l2BlockNumber: BlockNumber(storedPrivateEvent.l2BlockNumber),
+            txHash: storedPrivateEvent.txHash,
+            l2BlockHash: storedPrivateEvent.l2BlockHash,
             eventSelector,
           },
         });
       }
-    }
 
-    // Sort by block number, then by tx index within block, then by event index within tx
-    events.sort((a, b) => {
-      if (a.l2BlockNumber !== b.l2BlockNumber) {
-        return a.l2BlockNumber - b.l2BlockNumber;
-      }
-      if (a.txIndexInBlock !== b.txIndexInBlock) {
-        return a.txIndexInBlock - b.txIndexInBlock;
-      }
-      return a.eventIndexInTx - b.eventIndexInTx;
+      // Sort by block number, then by tx index within block, then by event index within tx
+      events.sort((a, b) => {
+        if (a.l2BlockNumber !== b.l2BlockNumber) {
+          return a.l2BlockNumber - b.l2BlockNumber;
+        }
+        if (a.txIndexInBlock !== b.txIndexInBlock) {
+          return a.txIndexInBlock - b.txIndexInBlock;
+        }
+        return a.eventIndexInTx - b.eventIndexInTx;
+      });
+
+      return events.map(ev => ev.event);
     });
-    return events.map(ev => ev.event);
   }
 
   /**
@@ -296,23 +226,23 @@ export class PrivateEventStore implements StagedStore {
     let removedCount = 0;
 
     for (let block = blockNumber + 1; block <= synchedBlockNumber; block++) {
-      const eventIds: string[] = [];
-      for await (const eventId of this.#eventsByBlockNumber.getValuesAsync(block)) {
-        eventIds.push(eventId);
-      }
+      const eventIds: string[] = await toArray(this.#eventsByBlockNumber.getValuesAsync(block));
 
       if (eventIds.length > 0) {
         await this.#eventsByBlockNumber.delete(block);
 
         for (const eventId of eventIds) {
-          const entry = await this.#eventLogs.getAsync(eventId);
-          if (!entry) {
-            throw new Error(`Event log not found for eventId ${eventId}`);
+          const buffer = await this.#events.getAsync(eventId);
+          if (!buffer) {
+            throw new Error(`Event not found for eventId ${eventId}`);
           }
 
-          await this.#eventLogs.delete(eventId);
-          await this.#seenLogs.delete(eventId);
-          await this.#eventsByContractScopeSelector.deleteValue(entry.lookupKey, eventId);
+          const entry = StoredPrivateEvent.fromBuffer(buffer);
+          await this.#events.delete(eventId);
+          await this.#eventsByContractAndEventSelector.deleteValue(
+            this.#keyFor(entry.contractAddress, entry.eventSelector),
+            eventId,
+          );
 
           removedCount++;
         }
@@ -320,5 +250,114 @@ export class PrivateEventStore implements StagedStore {
     }
 
     this.logger.verbose(`Rolled back ${removedCount} private events after block ${blockNumber}`);
+  }
+
+  /**
+   * Commits in memory job data to persistent storage.
+   *
+   * Called by JobCoordinator when a job completes successfully.
+   *
+   * Note: JobCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync here
+   * (and using one would throw on IndexedDB as it does not support nested txs).
+   *
+   * @param jobId - The jobId identifying which staged data to commit
+   */
+  commit(jobId: string): Promise<void> {
+    return this.#withJobLock(jobId, async () => {
+      for (const [eventId, entry] of this.#getEventsForJob(jobId).entries()) {
+        const lookupKey = this.#keyFor(entry.contractAddress, entry.eventSelector);
+        this.logger.verbose('storing private event log', { eventId, lookupKey });
+
+        await Promise.all([
+          this.#events.set(eventId, entry.toBuffer()),
+          this.#eventsByContractAndEventSelector.set(lookupKey, eventId),
+          this.#eventsByBlockNumber.set(entry.l2BlockNumber, eventId),
+        ]);
+      }
+
+      this.#clearJobData(jobId);
+    });
+  }
+
+  /**
+   * Discards in memory job data without persisting it.
+   */
+  discardStaged(jobId: string): Promise<void> {
+    return this.#withJobLock(jobId, () => Promise.resolve(this.#clearJobData(jobId)));
+  }
+
+  /**
+   * Reads an event from in-memory job data first, falling back to persistent storage if not found.
+   *
+   * Returns undefined if the event does not exist in the store overall.
+   */
+  async #readEvent(eventId: string, jobId: string): Promise<StoredPrivateEvent | undefined> {
+    const eventForJob = this.#getEventsForJob(jobId).get(eventId);
+    if (eventForJob) {
+      return eventForJob;
+    }
+
+    const buffer = await this.#events.getAsync(eventId);
+    return buffer ? StoredPrivateEvent.fromBuffer(buffer) : undefined;
+  }
+
+  /**
+   * Writes an event to in-memory job data.
+   *
+   * Writes are only allowed in a job context. Events modified during a job will only be persisted when `commit` is
+   * called.
+   */
+  #writeEvent(eventId: string, entry: StoredPrivateEvent, jobId: string) {
+    this.#getEventsForJob(jobId).set(eventId, entry);
+  }
+
+  /**
+   * Get in-memory data only visible to @param jobId
+   */
+  #getEventsForJob(jobId: string): Map<string, StoredPrivateEvent> {
+    let eventsForJob = this.#eventsForJob.get(jobId);
+    if (eventsForJob === undefined) {
+      eventsForJob = new Map();
+      this.#eventsForJob.set(jobId, eventsForJob);
+    }
+    return eventsForJob;
+  }
+
+  /**
+   * Clear data structures supporting a specific job.
+   */
+  #clearJobData(jobId: string) {
+    this.#eventsForJob.delete(jobId);
+    this.#jobLocks.delete(jobId);
+  }
+
+  /**
+   * Ensures a function can only run once it acquires a unique per-job lock, and handles proper lock release after it
+   * runs.
+   *
+   * This primitive allows concurrent writes on this store without risking data corruption due to unsound write
+   * interleaving.
+   */
+  async #withJobLock<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
+    let lock = this.#jobLocks.get(jobId);
+    if (!lock) {
+      lock = new Semaphore(1);
+      this.#jobLocks.set(jobId, lock);
+    }
+    await lock.acquire();
+    try {
+      return await fn();
+    } finally {
+      lock.release();
+    }
+  }
+
+  /**
+   * Returns a string key based on @param contractAddress and @param eventSelector.
+   *
+   * The returned key is meant to be used when interacting with index #eventsByContractAndEventSelector.
+   */
+  #keyFor(contractAddress: AztecAddress, eventSelector: EventSelector): string {
+    return `${contractAddress.toString()}_${eventSelector.toString()}`;
   }
 }

--- a/yarn-project/pxe/src/storage/private_event_store/stored_private_event.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/stored_private_event.test.ts
@@ -1,0 +1,124 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EventSelector } from '@aztec/stdlib/abi';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
+import { TxHash } from '@aztec/stdlib/tx';
+
+import { StoredPrivateEvent } from './stored_private_event.js';
+
+describe('StoredPrivateEvent', () => {
+  const makeEvent = async (
+    overrides: {
+      randomness?: Fr;
+      msgContent?: Fr[];
+      l2BlockNumber?: number;
+      l2BlockHash?: L2BlockHash;
+      txHash?: TxHash;
+      txIndexInBlock?: number;
+      eventIndexInTx?: number;
+      contractAddress?: AztecAddress;
+      eventSelector?: EventSelector;
+      scopes?: Set<string>;
+    } = {},
+  ) => {
+    return new StoredPrivateEvent(
+      overrides.randomness ?? Fr.random(),
+      overrides.msgContent ?? [Fr.random(), Fr.random(), Fr.random()],
+      overrides.l2BlockNumber ?? 42,
+      overrides.l2BlockHash ?? L2BlockHash.random(),
+      overrides.txHash ?? TxHash.random(),
+      overrides.txIndexInBlock ?? 3,
+      overrides.eventIndexInTx ?? 1,
+      overrides.contractAddress ?? (await AztecAddress.random()),
+      overrides.eventSelector ?? EventSelector.random(),
+      overrides.scopes ?? new Set(['scope1', 'scope2']),
+    );
+  };
+
+  describe('toBuffer/fromBuffer', () => {
+    it('round-trips all fields correctly', async () => {
+      const event = await makeEvent();
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.randomness).toEqual(event.randomness);
+      expect(restored.msgContent).toEqual(event.msgContent);
+      expect(restored.l2BlockNumber).toBe(event.l2BlockNumber);
+      expect(restored.l2BlockHash).toEqual(event.l2BlockHash);
+      expect(restored.txHash).toEqual(event.txHash);
+      expect(restored.txIndexInBlock).toBe(event.txIndexInBlock);
+      expect(restored.eventIndexInTx).toBe(event.eventIndexInTx);
+      expect(restored.contractAddress).toEqual(event.contractAddress);
+      expect(restored.eventSelector).toEqual(event.eventSelector);
+      expect(restored.scopes).toEqual(event.scopes);
+    });
+
+    it('handles empty msgContent', async () => {
+      const event = await makeEvent({ msgContent: [] });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.msgContent).toEqual([]);
+    });
+
+    it('handles single msgContent field', async () => {
+      const content = [Fr.random()];
+      const event = await makeEvent({ msgContent: content });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.msgContent).toEqual(content);
+    });
+
+    it('handles many msgContent fields', async () => {
+      const content = Array.from({ length: 20 }, () => Fr.random());
+      const event = await makeEvent({ msgContent: content });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.msgContent).toEqual(content);
+    });
+
+    it('handles empty scopes', async () => {
+      const event = await makeEvent({ scopes: new Set<string>() });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.scopes.size).toBe(0);
+    });
+
+    it('handles single scope', async () => {
+      const event = await makeEvent({ scopes: new Set(['only-scope']) });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.scopes).toEqual(new Set(['only-scope']));
+    });
+
+    it('handles many scopes', async () => {
+      const scopes = new Set(Array.from({ length: 10 }, (_, i) => `scope-${i}`));
+      const event = await makeEvent({ scopes });
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+
+      expect(restored.scopes).toEqual(scopes);
+    });
+  });
+
+  describe('addScope', () => {
+    it('adds a new scope', async () => {
+      const event = await makeEvent({ scopes: new Set(['existing']) });
+      event.addScope('new-scope');
+
+      expect(event.scopes).toEqual(new Set(['existing', 'new-scope']));
+    });
+
+    it('does not duplicate an existing scope', async () => {
+      const event = await makeEvent({ scopes: new Set(['existing']) });
+      event.addScope('existing');
+
+      expect(event.scopes.size).toBe(1);
+    });
+
+    it('persists added scopes through serialization', async () => {
+      const event = await makeEvent({ scopes: new Set(['initial']) });
+      event.addScope('added');
+
+      const restored = StoredPrivateEvent.fromBuffer(event.toBuffer());
+      expect(restored.scopes).toEqual(new Set(['initial', 'added']));
+    });
+  });
+});

--- a/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
@@ -1,0 +1,73 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
+import { EventSelector } from '@aztec/stdlib/abi';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
+import { TxHash } from '@aztec/stdlib/tx';
+
+/** Serializable private event entry with scope tracking. */
+export class StoredPrivateEvent {
+  constructor(
+    readonly randomness: Fr,
+    readonly msgContent: Fr[],
+    readonly l2BlockNumber: number,
+    readonly l2BlockHash: L2BlockHash,
+    readonly txHash: TxHash,
+    readonly txIndexInBlock: number,
+    readonly eventIndexInTx: number,
+    readonly contractAddress: AztecAddress,
+    readonly eventSelector: EventSelector,
+    readonly scopes: Set<string>,
+  ) {}
+
+  addScope(scope: string) {
+    this.scopes.add(scope);
+  }
+
+  toBuffer(): Buffer {
+    const scopesArray = [...this.scopes];
+    return serializeToBuffer(
+      this.randomness,
+      this.msgContent.length,
+      ...this.msgContent,
+      this.l2BlockNumber,
+      this.l2BlockHash,
+      this.txHash,
+      this.txIndexInBlock,
+      this.eventIndexInTx,
+      this.contractAddress,
+      this.eventSelector.toBuffer(),
+      scopesArray.length,
+      ...scopesArray,
+    );
+  }
+
+  static fromBuffer(buffer: Buffer): StoredPrivateEvent {
+    const reader = BufferReader.asReader(buffer);
+
+    const randomness = Fr.fromBuffer(reader);
+    const msgContentLength = reader.readNumber();
+    const msgContent = reader.readArray(msgContentLength, Fr);
+    const l2BlockNumber = reader.readNumber();
+    const l2BlockHash = L2BlockHash.fromBuffer(reader);
+    const txHash = TxHash.fromBuffer(reader);
+    const txIndexInBlock = reader.readNumber();
+    const eventIndexInTx = reader.readNumber();
+    const contractAddress = AztecAddress.fromBuffer(reader);
+    const eventSelector = EventSelector.fromBuffer(reader);
+    const scopes = reader.readVector({ fromBuffer: (r: BufferReader) => r.readString() });
+
+    return new StoredPrivateEvent(
+      randomness,
+      msgContent,
+      l2BlockNumber,
+      l2BlockHash,
+      txHash,
+      txIndexInBlock,
+      eventIndexInTx,
+      contractAddress,
+      eventSelector,
+      new Set(scopes),
+    );
+  }
+}


### PR DESCRIPTION
Refactors PrivateEventStore, and fixes a bug I found in the process of doing so. Improvements:

- Fixes a bug introduced since we changed to indexing events by commitment. We were incorrectly skipping indexing events by scope when they were found in the `#seenLogs` (by commitment), which means we were losing track of any scopes for the event after the first time they were stored. There's a new test covering against regressions on that one. The same test also covers de-duplication (F-207).
- Applies a number of patterns that were used in a similar refactor of NoteStore.
- Removes #seenLogs, which only provided premature optimization of a single db write.  
- Simplifies indexes meant for reading: events were indexed by `<contractAddress, eventSelector, scope>`. The per scope indexing adds a lot of code complexity for almost no performance gains. So now we only index by `<contractAddress, eventSelector>` and filter scopes in-loop.
- Implements job level locks when storing. Since now scopes are stored together with each event entry, we need to be careful with lost updates.
- General cleanups: renames, function ordering for easier understanding of the code, docs. 

Closes F-203
Closes F-207