### PR TITLE
refactor: typing BlockHeader hash

### DIFF
--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -335,7 +335,7 @@ describe('KVArchiverDataStore', () => {
       await store.addCheckpoints(publishedCheckpoints);
       const lastCheckpoint = publishedCheckpoints[publishedCheckpoints.length - 1];
       const lastBlock = lastCheckpoint.checkpoint.blocks[0];
-      const blockHash = await lastBlock.header.hash();
+      const blockHash = (await lastBlock.header.hash()).toField();
       const archive = lastBlock.archive.root;
 
       // Verify block and header exist before removing
@@ -639,7 +639,7 @@ describe('KVArchiverDataStore', () => {
       // Check each block by its hash
       for (let i = 0; i < checkpoint.checkpoint.blocks.length; i++) {
         const block = checkpoint.checkpoint.blocks[i];
-        const blockHash = await block.header.hash();
+        const blockHash = (await block.header.hash()).toField();
         const retrievedBlock = await store.getCheckpointedBlockByHash(blockHash);
 
         expect(retrievedBlock).toBeDefined();
@@ -797,8 +797,8 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlocks([block1, block2]);
 
       // getBlockByHash should work for uncheckpointed blocks
-      const hash1 = await block1.header.hash();
-      const hash2 = await block2.header.hash();
+      const hash1 = (await block1.header.hash()).toField();
+      const hash2 = (await block2.header.hash()).toField();
 
       const retrieved1 = await store.getBlockByHash(hash1);
       expect(retrieved1!.equals(block1)).toBe(true);
@@ -874,7 +874,7 @@ describe('KVArchiverDataStore', () => {
       });
       await store.addProposedBlocks([block1]);
 
-      const hash = await block1.header.hash();
+      const hash = (await block1.header.hash()).toField();
 
       // getCheckpointedBlockByHash should return undefined
       expect(await store.getCheckpointedBlockByHash(hash)).toBeUndefined();
@@ -1666,7 +1666,7 @@ describe('KVArchiverDataStore', () => {
     it('retrieves a block by its hash', async () => {
       const expectedCheckpoint = publishedCheckpoints[5];
       const expectedBlock = expectedCheckpoint.checkpoint.blocks[0];
-      const blockHash = await expectedBlock.header.hash();
+      const blockHash = (await expectedBlock.header.hash()).toField();
       const retrievedBlock = await store.getCheckpointedBlockByHash(blockHash);
 
       expect(retrievedBlock).toBeDefined();
@@ -1707,7 +1707,7 @@ describe('KVArchiverDataStore', () => {
 
     it('retrieves a block header by its hash', async () => {
       const expectedBlock = publishedCheckpoints[7].checkpoint.blocks[0];
-      const blockHash = await expectedBlock.header.hash();
+      const blockHash = (await expectedBlock.header.hash()).toField();
       const retrievedHeader = await store.getBlockHeaderByHash(blockHash);
 
       expect(retrievedHeader).toBeDefined();
@@ -1833,7 +1833,7 @@ describe('KVArchiverDataStore', () => {
       const expectedTx: IndexedTxEffect = {
         data,
         l2BlockNumber: block.number,
-        l2BlockHash: L2BlockHash.fromField(await block.header.hash()),
+        l2BlockHash: await block.header.hash(),
         txIndexInBlock,
       };
       const actualTx = await store.getTxEffect(data.txHash);
@@ -2732,7 +2732,7 @@ describe('KVArchiverDataStore', () => {
 
     it('returns block hash on public log ids', async () => {
       const targetBlock = publishedCheckpoints[0].checkpoint.blocks[0];
-      const expectedBlockHash = L2BlockHash.fromField(await targetBlock.header.hash());
+      const expectedBlockHash = await targetBlock.header.hash();
 
       const logs = (await store.getPublicLogs({ fromBlock: targetBlock.number, toBlock: targetBlock.number + 1 })).logs;
 
@@ -2790,7 +2790,7 @@ describe('KVArchiverDataStore', () => {
       const targetTxIndex = randomInt(getTxsPerBlock(targetBlock));
       const numLogsInTx = targetBlock.body.txEffects[targetTxIndex].publicLogs.length;
       const targetLogIndex = numLogsInTx > 0 ? randomInt(numLogsInTx) : 0;
-      const targetBlockHash = L2BlockHash.fromField(await targetBlock.header.hash());
+      const targetBlockHash = await targetBlock.header.hash();
 
       const afterLog = new LogId(
         BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
@@ -2882,7 +2882,7 @@ describe('KVArchiverDataStore', () => {
       const targetTxIndex = randomInt(getTxsPerBlock(targetBlock));
       const numLogsInTx = targetBlock.body.txEffects[targetTxIndex].publicLogs.length;
       const targetLogIndex = numLogsInTx > 0 ? randomInt(numLogsInTx) : 0;
-      const targetBlockHash = L2BlockHash.fromField(await targetBlock.header.hash());
+      const targetBlockHash = await targetBlock.header.hash();
 
       const afterLog = new LogId(
         BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
@@ -2935,7 +2935,7 @@ describe('KVArchiverDataStore', () => {
       expect(result.logs).toHaveLength(1);
 
       const [{ id, log }] = result.logs;
-      const expectedBlockHash = L2BlockHash.fromField(await targetBlock.header.hash());
+      const expectedBlockHash = await targetBlock.header.hash();
 
       expect(id.blockHash.equals(expectedBlockHash)).toBe(true);
       expect(id.blockNumber).toEqual(targetBlock.number);
@@ -3320,7 +3320,7 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlocks([block1, block2]);
 
       // Verify block2 is retrievable by hash and archive before removal
-      const block2Hash = await block2.header.hash();
+      const block2Hash = (await block2.header.hash()).toField();
       const block2Archive = block2.archive.root;
 
       expect(await store.getBlockByHash(block2Hash)).toBeDefined();
@@ -3346,7 +3346,7 @@ describe('KVArchiverDataStore', () => {
       }
 
       // Verify block1's data is still intact
-      const block1Hash = await block1.header.hash();
+      const block1Hash = (await block1.header.hash()).toField();
       const block1Archive = block1.archive.root;
 
       expect(await store.getBlockByHash(block1Hash)).toBeDefined();

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1411,11 +1411,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
   #getInitialHeaderHash(): Promise<L2BlockHash> {
     if (!this.initialHeaderHashPromise) {
-      this.initialHeaderHashPromise = this.worldStateSynchronizer
-        .getCommitted()
-        .getInitialHeader()
-        .hash()
-        .then(hash => L2BlockHash.fromField(hash));
+      this.initialHeaderHashPromise = this.worldStateSynchronizer.getCommitted().getInitialHeader().hash();
     }
     return this.initialHeaderHashPromise;
   }

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -7,7 +7,6 @@ import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
-import { L2BlockHash } from '@aztec/stdlib/block';
 
 import { jest } from '@jest/globals';
 import 'jest-extended';
@@ -57,15 +56,15 @@ describe('e2e_simple', () => {
       const initialHeader = await aztecNode.getBlockHeader(BlockNumber.ZERO);
       expect(initialHeader).toBeDefined();
       const initialHeaderHash = await initialHeader!.hash();
-      const initialBlockByHash = await aztecNode.getBlock(L2BlockHash.fromField(initialHeaderHash));
+      const initialBlockByHash = await aztecNode.getBlock(initialHeaderHash);
       expect(initialBlockByHash).toBeDefined();
       const initialBlockHash = await initialBlockByHash!.hash();
-      expect(initialBlockHash.equals(initialHeaderHash)).toBeTrue();
+      expect(initialBlockHash.equals(initialHeaderHash.toField())).toBeTrue();
       expect(initialBlockByHash?.body.txEffects.length).toBe(0);
       const initialBlockByNumber = await aztecNode.getBlock(BlockNumber.ZERO);
       expect(initialBlockByNumber).toBeDefined();
       const initialBlockByNumberHash = await initialBlockByNumber!.hash();
-      expect(initialBlockByNumberHash.equals(initialHeaderHash)).toBeTrue();
+      expect(initialBlockByNumberHash.equals(initialHeaderHash.toField())).toBeTrue();
       expect(initialBlockByNumber?.body.txEffects.length).toBe(0);
     });
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -322,9 +322,10 @@ describe('KV TX pool', () => {
     // modify tx1 to return no archive indices
     tx1.data.constants.anchorBlockHeader.globalVariables.blockNumber = BlockNumber(1);
     const tx1HeaderHash = await tx1.data.constants.anchorBlockHeader.hash();
+    const tx1HeaderHashFr = tx1HeaderHash.toField();
     db.findLeafIndices.mockImplementation((tree, leaves) => {
       if (tree === MerkleTreeId.ARCHIVE) {
-        return Promise.resolve((leaves as Fr[]).map(l => (l.equals(tx1HeaderHash) ? undefined : 1n)));
+        return Promise.resolve((leaves as Fr[]).map(l => (l.equals(tx1HeaderHashFr) ? undefined : 1n)));
       }
       return Promise.resolve([]);
     });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.test.ts
@@ -27,11 +27,12 @@ describe('BlockHeaderTxValidator', () => {
     );
 
     const goodTx = await mockTxForRollup();
-    archiveSource.getArchiveIndices.mockImplementation(async (archives: Fr[]) => {
-      if (archives[0].equals(await goodTx.data.constants.anchorBlockHeader.hash())) {
-        return [1n];
+    const goodTxHeaderHash = (await goodTx.data.constants.anchorBlockHeader.hash()).toField();
+    archiveSource.getArchiveIndices.mockImplementation((archives: Fr[]) => {
+      if (archives[0].equals(goodTxHeaderHash)) {
+        return Promise.resolve([1n]);
       } else {
-        return [undefined];
+        return Promise.resolve([undefined]);
       }
     });
     await expect(txValidator.validateTx(goodTx)).resolves.toEqual({ result: 'valid' } satisfies TxValidationResult);

--- a/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
@@ -15,7 +15,9 @@ export class BlockHeaderTxValidator<T extends AnyTx> implements TxValidator<T> {
   }
 
   async validateTx(tx: T): Promise<TxValidationResult> {
-    const [index] = await this.#archiveSource.getArchiveIndices([await tx.data.constants.anchorBlockHeader.hash()]);
+    const [index] = await this.#archiveSource.getArchiveIndices([
+      (await tx.data.constants.anchorBlockHeader.hash()).toField(),
+    ]);
     if (index === undefined) {
       this.#log.verbose(`Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} for referencing an unknown block header`);
       return { result: 'invalid', reason: [TX_ERROR_BLOCK_HEADER] };

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -97,7 +97,7 @@ export const insertSideEffectsAndBuildBaseRollupHints = runInSpan(
 
     const { nullifierInsertionResult, publicDataInsertionResult } = await insertSideEffects(tx, db);
 
-    const blockHash = await tx.data.constants.anchorBlockHeader.hash();
+    const blockHash = (await tx.data.constants.anchorBlockHeader.hash()).toField();
     const anchorBlockArchiveSiblingPath = (
       await getMembershipWitnessFor(blockHash, MerkleTreeId.ARCHIVE, ARCHIVE_HEIGHT, db)
     ).siblingPath;

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -363,7 +363,7 @@ export class EpochProvingJob implements Traceable {
     this.epochCheckPromise = new RunningPromise(
       async () => {
         const blockHeaders = await l2BlockSource.getCheckpointedBlockHeadersForEpoch(this.epochNumber);
-        const blockHashes = await Promise.all(blockHeaders.map(header => header.hash()));
+        const blockHashes = await Promise.all(blockHeaders.map(async header => (await header.hash()).toField()));
         const thisBlocks = this.checkpoints.flatMap(checkpoint => checkpoint.blocks);
         const thisBlockHashes = await Promise.all(thisBlocks.map(block => block.hash()));
         if (

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -14,7 +14,6 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
@@ -267,13 +266,12 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       // This is a tagging secret we've not yet used in this tx, so first sync our store to make sure its indices
       // are up to date. We do this here because this store is not synced as part of the global sync because
       // that'd be wasteful as most tagging secrets are not used in each tx.
-      const anchorBlockHash = L2BlockHash.fromField(await this.anchorBlockHeader.hash());
       await syncSenderTaggingIndexes(
         secret,
         this.contractAddress,
         this.aztecNode,
         this.senderTaggingStore,
-        anchorBlockHash,
+        await this.anchorBlockHeader.hash(),
         this.jobId,
       );
 

--- a/yarn-project/pxe/src/contract_sync/index.ts
+++ b/yarn-project/pxe/src/contract_sync/index.ts
@@ -1,7 +1,6 @@
 import { ProtocolContractAddress, isProtocolContract } from '@aztec/protocol-contracts';
 import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
 import type { ContractInstance } from '@aztec/stdlib/contract';
 import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '@aztec/stdlib/delayed-public-mutable';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -24,8 +23,7 @@ export async function readCurrentClassId(
   aztecNode: AztecNode,
   header: BlockHeader,
 ) {
-  const blockHashFr = await header.hash();
-  const blockHash = L2BlockHash.fromField(blockHashFr);
+  const blockHash = await header.hash();
   const timestamp = header.globalVariables.timestamp;
   const { delayedPublicMutableSlot } = await DelayedPublicMutableValuesWithHash.getContractUpdateSlots(contractAddress);
   const delayedPublicMutableValues = await DelayedPublicMutableValues.readFromTree(delayedPublicMutableSlot, slot =>

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -2,7 +2,6 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
 import type { CompleteAddress } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, PendingTaggedLog, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
@@ -55,7 +54,7 @@ export class LogService {
 
   async #getPublicLogByTag(tag: Tag, contractAddress: AztecAddress): Promise<LogRetrievalResponse | null> {
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const anchorBlockHash = await anchorBlockHeader.hash();
     const allLogsPerTag = await getAllPublicLogsByTagsFromContract(
       this.aztecNode,
       contractAddress,
@@ -85,7 +84,7 @@ export class LogService {
 
   async #getPrivateLogByTag(siloedTag: SiloedTag): Promise<LogRetrievalResponse | null> {
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const anchorBlockHash = await anchorBlockHeader.hash();
     const allLogsPerTag = await getAllPrivateLogsByTags(this.aztecNode, [siloedTag], anchorBlockHash);
     const logsForTag = allLogsPerTag[0];
 
@@ -118,7 +117,7 @@ export class LogService {
     // We only load logs from block up to and including the anchor block number
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
     const anchorBlockNumber = anchorBlockHeader.getBlockNumber();
-    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const anchorBlockHash = await anchorBlockHeader.hash();
 
     // Determine recipients: use scopes if provided, otherwise get all accounts
     const recipients = scopes && scopes.length > 0 ? scopes : await this.keyStore.getAccounts();

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,7 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { DataInBlock } from '@aztec/stdlib/block';
-import { L2BlockHash } from '@aztec/stdlib/block';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import { type AztecNode, MAX_RPC_LEN } from '@aztec/stdlib/interfaces/client';
 import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
@@ -73,7 +72,7 @@ export class NoteService {
    * @param contractAddress - The contract whose notes should be checked and nullified.
    */
   public async syncNoteNullifiers(contractAddress: AztecAddress): Promise<void> {
-    const anchorBlockHash = L2BlockHash.fromField(await (await this.anchorBlockStore.getBlockHeader()).hash());
+    const anchorBlockHash = await (await this.anchorBlockStore.getBlockHeader()).hash();
 
     const contractNotes = await this.noteStore.getNotes({ contractAddress }, this.jobId);
 
@@ -145,7 +144,7 @@ export class NoteService {
     // logs up to the synced block making this only an additional safety check.
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
     const anchorBlockNumber = anchorBlockHeader.getBlockNumber();
-    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const anchorBlockHash = await anchorBlockHeader.hash();
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -18,7 +18,6 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractInstanceWithAddress,
@@ -399,7 +398,7 @@ export class PXE {
     config: PrivateKernelExecutionProverConfig,
   ): Promise<PrivateKernelExecutionProofOutput<PrivateKernelTailCircuitPublicInputs>> {
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-    const anchorBlockHash = L2BlockHash.fromField(await anchorBlockHeader.hash());
+    const anchorBlockHash = await anchorBlockHeader.hash();
     const kernelOracle = new PrivateKernelOracle(this.contractStore, this.keyStore, this.node, anchorBlockHash);
     const kernelTraceProver = new PrivateKernelExecutionProver(kernelOracle, proofCreator, !this.proverEnabled);
     this.log.debug(`Executing kernel trace prover (${JSON.stringify(config)})...`);

--- a/yarn-project/stdlib/src/block/block_hash.ts
+++ b/yarn-project/stdlib/src/block/block_hash.ts
@@ -48,7 +48,7 @@ export class L2BlockHash extends Buffer32 {
     return new L2BlockHash(reader.readBytes(L2BlockHash.SIZE));
   }
 
-  static override fromString(str: string): Buffer32 {
+  static override fromString(str: string): L2BlockHash {
     return new L2BlockHash(super.fromString(str).toBuffer());
   }
 
@@ -62,5 +62,9 @@ export class L2BlockHash extends Buffer32 {
 
   static override fromField(hash: Fr) {
     return new L2BlockHash(hash.toBuffer());
+  }
+
+  toField(): Fr {
+    return Fr.fromBuffer(this.toBuffer());
   }
 }

--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -89,8 +89,9 @@ export class L2Block {
    * Returns the block's hash (hash of block header).
    * @returns The block's hash.
    */
-  public hash(): Promise<Fr> {
-    return this.header.hash();
+  public async hash(): Promise<Fr> {
+    const blockHash = await this.header.hash();
+    return blockHash.toField();
   }
 
   /**

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -8,6 +8,7 @@ import times from 'lodash.times';
 
 import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
 import type { BlockHeader } from '../../tx/block_header.js';
+import { L2BlockHash } from '../block_hash.js';
 import type { CheckpointedL2Block } from '../checkpointed_l2_block.js';
 import type { L2Block } from '../l2_block.js';
 import { GENESIS_CHECKPOINT_HEADER_HASH, type L2BlockId, type L2BlockSource, type L2Tips } from '../l2_block_source.js';
@@ -45,7 +46,8 @@ describe('L2BlockStream', () => {
       checkpointNumber: checkpointNum,
     }) as CheckpointedL2Block;
 
-  const makeHeader = (number: number) => ({ hash: () => Promise.resolve(new Fr(number)) }) as BlockHeader;
+  const makeHeader = (number: number) =>
+    ({ hash: () => Promise.resolve(L2BlockHash.fromField(new Fr(number))) }) as BlockHeader;
 
   const makeBlockId = (number: number): L2BlockId => ({ number: BlockNumber(number), hash: makeHash(number) });
 

--- a/yarn-project/stdlib/src/tx/__snapshots__/block_header.test.ts.snap
+++ b/yarn-project/stdlib/src/tx/__snapshots__/block_header.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`BlockHeader computes empty hash 1`] = `Fr<0x2c920b5fcfe68d413eab3e0022eb918d64d62ca44d195d5c32b8b9c68bff2dfe>`;
+exports[`BlockHeader computes empty hash 1`] = `"0x2c920b5fcfe68d413eab3e0022eb918d64d62ca44d195d5c32b8b9c68bff2dfe"`;
 
-exports[`BlockHeader computes hash 1`] = `Fr<0x270685169636054e0491cba0834e8f7b809114c4f35542cb1094febfd8389519>`;
+exports[`BlockHeader computes hash 1`] = `"0x270685169636054e0491cba0834e8f7b809114c4f35542cb1094febfd8389519"`;

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -11,13 +11,14 @@ import type { FieldsOf } from '@aztec/foundation/types';
 import { inspect } from 'util';
 import { z } from 'zod';
 
+import { L2BlockHash } from '../block/block_hash.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { GlobalVariables } from './global_variables.js';
 import { StateReference } from './state_reference.js';
 
 /** A header of an L2 block. */
 export class BlockHeader {
-  private _cachedHash?: Promise<Fr>;
+  private _cachedHash?: Promise<L2BlockHash>;
 
   constructor(
     /** Snapshot of archive before the block is applied. */
@@ -161,16 +162,18 @@ export class BlockHeader {
     return BlockHeader.fromBuffer(hexToBuffer(str));
   }
 
-  hash(): Promise<Fr> {
+  hash(): Promise<L2BlockHash> {
     if (!this._cachedHash) {
-      this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH);
+      this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH).then(fr =>
+        L2BlockHash.fromField(fr),
+      );
     }
     return this._cachedHash;
   }
 
   /** Manually set the hash for this block header if already computed */
   setHash(hashed: Fr) {
-    this._cachedHash = Promise.resolve(hashed);
+    this._cachedHash = Promise.resolve(L2BlockHash.fromField(hashed));
   }
 
   static random(overrides: Partial<FieldsOf<BlockHeader>> & Partial<FieldsOf<GlobalVariables>> = {}): BlockHeader {

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -135,7 +135,9 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
 
     // the initial header _must_ be the first element in the archive tree
     // if this assertion fails, check that the hashing done in Header in yarn-project matches the initial header hash done in world_state.cpp
-    const indices = await committed.findLeafIndices(MerkleTreeId.ARCHIVE, [await this.initialHeader.hash()]);
+    const indices = await committed.findLeafIndices(MerkleTreeId.ARCHIVE, [
+      (await this.initialHeader.hash()).toField(),
+    ]);
     const initialHeaderIndex = indices[0];
     assert.strictEqual(initialHeaderIndex, 0n, 'Invalid initial archive state');
   }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -3,7 +3,7 @@ import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { L2Block, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
+import { L2Block, L2BlockHash, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -56,7 +56,7 @@ describe('ServerWorldStateSynchronizer', () => {
 
     merkleTreeRead = mock<MerkleTreeReadOperations>();
     merkleTreeRead.getInitialHeader.mockReturnValue({
-      hash: () => Promise.resolve(Fr.random()),
+      hash: () => Promise.resolve(L2BlockHash.fromField(Fr.random())),
     } as BlockHeader);
     merkleTreeRead.getLeafValue.mockResolvedValue(Fr.random());
 

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -6,6 +6,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -93,7 +94,8 @@ describe('world-state integration', () => {
   };
 
   const expectSynchedBlockHashMatches = async (number: number) => {
-    const syncedBlockHash = await db.getCommitted().getLeafValue(MerkleTreeId.ARCHIVE, BigInt(number));
+    const syncedBlockHashFr = await db.getCommitted().getLeafValue(MerkleTreeId.ARCHIVE, BigInt(number));
+    const syncedBlockHash = syncedBlockHashFr ? L2BlockHash.fromField(syncedBlockHashFr) : undefined;
     const archiverBlockHash = await archiver.getBlockHeader(number).then(h => h?.hash());
     expect(syncedBlockHash).toEqual(archiverBlockHash);
   };


### PR DESCRIPTION
When touching Aztec Node endpoints a while ago I had to use there `L2BlockHash` type in order to be able to accept a generic block arg on the input that could represent either a block number or block hash (when I used `Fr` for the block hash there were serialization issues as these 2 types were getting mixed up).

But after this I had quite a few ugly conversions in `PXE` between `L2BlockHash` and `Fr`. In this PR I drop some of those conversions.

This results in ugly conversions being in some other places but eventually we should use the type everywhere so this is a step in a good direction.

Admittedly a low-priority issue but such tech debt even a cheap model like Sonnet is able to tackle so no reason to keep it around.