### PR TITLE
fix: pass --watch flag to swc in tsc.sh watch mode

### DIFF
--- a/yarn-project/scripts/tsc.sh
+++ b/yarn-project/scripts/tsc.sh
@@ -30,17 +30,17 @@ $no_emit && tsgo_cmd+=" --noEmit" || tsgo_cmd+=" --emitDeclarationOnly"
 $watch && tsgo_cmd+=" --watch"
 for arg in "${extra_args[@]+"${extra_args[@]}"}"; do tsgo_cmd+=" $arg"; done
 
-swc_cmd="cd {} && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
-$watch && swc_cmd+=" --watch"
+swc_args="src -d dest --config-file=$root/.swcrc --strip-leading-paths"
+$watch && swc_args+=" --watch"
 
 # In watch mode, run with full output
 if $watch; then
   if $skip_swc; then
     exec $tsgo_cmd
   elif [[ -d "src" ]]; then
-    parallel --halt now,fail=1 ::: "$tsgo_cmd" "cd . && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
+    parallel --halt now,fail=1 ::: "$tsgo_cmd" "cd . && $swc $swc_args"
   else
-    { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"; done; } | parallel --halt now,fail=1 --line-buffered
+    { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc $swc_args"; done; } | parallel --halt now,fail=1 --line-buffered
   fi
   exit 0
 fi
@@ -67,8 +67,8 @@ run_parallel() {
 if $skip_swc; then
   run_parallel ::: "$tsgo_cmd"
 elif [[ -d "src" ]]; then
-  run_parallel ::: "$tsgo_cmd" "cd . && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"
+  run_parallel ::: "$tsgo_cmd" "cd . && $swc $swc_args"
 else
-  { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc src -d dest --config-file=$root/.swcrc --strip-leading-paths"; done; } | run_parallel
+  { echo "$tsgo_cmd"; dirname */src | while read d; do echo "cd $d && $swc $swc_args"; done; } | run_parallel
 fi
 echo "Typescript build succeeded"

--- a/yarn-project/scripts/tsc.test.sh
+++ b/yarn-project/scripts/tsc.test.sh
@@ -311,8 +311,82 @@ test_quiet_success_output() {
   fi
 }
 
+test_watch_mode_emits_js() {
+  log "\nTest 8: Watch mode emits JS on file change"
+  clean_build_artifacts
+
+  # Start watch mode in background
+  (cd "$test_root/pkg-a" && ../scripts/tsc.sh -w) &
+  watch_pid=$!
+
+  # Wait for initial build
+  local timeout=10
+  while [[ ! -f "$test_root/pkg-a/dest/index.js" && $timeout -gt 0 ]]; do
+    sleep 0.5
+    ((timeout--))
+  done
+
+  check_file "$test_root/pkg-a/dest/index.js" "Initial JS file generated in watch mode"
+
+  if [[ -f "$test_root/pkg-a/dest/index.js" ]]; then
+    # Record original content
+    local original_content
+    original_content=$(cat "$test_root/pkg-a/dest/index.js")
+
+    # Wait a bit for swc to be ready for changes
+    sleep 1
+
+    # Modify the source file
+    cat > "$test_root/pkg-a/src/index.ts" << 'EOF'
+export interface Config {
+  name: string;
+  value: number;
+}
+
+export function createConfig(name: string, value: number): Config {
+  return { name, value };
+}
+
+export const DEFAULT_VALUE = 42;
+
+// New function added in watch mode
+export function newFunction(): string {
+  return "watch mode works";
+}
+EOF
+
+    # Wait for rebuild
+    sleep 3
+
+    # Check if JS was updated with new function
+    if grep -q "newFunction" "$test_root/pkg-a/dest/index.js" 2>/dev/null; then
+      pass "Watch mode rebuilt JS with changes"
+    else
+      fail "Watch mode did not rebuild JS (swc --watch missing?)"
+    fi
+  fi
+
+  # Cleanup: kill watch process
+  kill $watch_pid 2>/dev/null || true
+  wait $watch_pid 2>/dev/null || true
+
+  # Restore original source
+  cat > "$test_root/pkg-a/src/index.ts" << 'EOF'
+export interface Config {
+  name: string;
+  value: number;
+}
+
+export function createConfig(name: string, value: number): Config {
+  return { name, value };
+}
+
+export const DEFAULT_VALUE = 42;
+EOF
+}
+
 test_quiet_error_output() {
-  log "\nTest 8: Quiet error output (only failed command output shown)"
+  log "\nTest 9: Quiet error output (only failed command output shown)"
   clean_build_artifacts
 
   # Introduce a type error
@@ -380,6 +454,7 @@ main() {
   test_no_emit
   test_type_error_detection
   test_quiet_success_output
+  test_watch_mode_emits_js
   test_quiet_error_output
 
   log "\n=== Results ==="


### PR DESCRIPTION
## Summary

- Fixed bug where `yarn build -w` would check for type errors but not emit JS changes
- The swc commands in watch mode were constructed inline without the `--watch` flag
- Extracted `swc_args` variable and use it consistently across all swc invocations
- Added test case that verifies watch mode properly rebuilds JS when source files change

## Test plan

- Run `./scripts/tsc.test.sh` - all 28 tests pass including new watch mode test
- Run `yarn build -w` from yarn-project root, modify a file, verify JS is rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)