### PR TITLE
fix(e2e): use checkpointed chain tip for PXE in epochs and p2p tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -121,30 +121,35 @@ export class EpochsTestContext {
 
     // Set up system without any account nor protocol contracts
     // and with faster block times and shorter epochs.
-    const context = await setup(opts.numberOfAccounts ?? 0, {
-      automineL1Setup: true,
-      checkIntervalMs: 50,
-      archiverPollingIntervalMS: ARCHIVER_POLL_INTERVAL,
-      worldStateBlockCheckIntervalMS: WORLD_STATE_BLOCK_CHECK_INTERVAL,
-      aztecEpochDuration,
-      aztecSlotDuration,
-      ethereumSlotDuration,
-      aztecProofSubmissionEpochs,
-      aztecTargetCommitteeSize: opts.initialValidators?.length ?? 0,
-      minTxsPerBlock: 0,
-      realProofs: false,
-      startProverNode: true,
-      proverTestDelayMs: opts.proverTestDelayMs ?? 0,
-      // We use numeric incremental prover ids for simplicity, but we can switch to
-      // using the prover's eth address if the proverId is used for something in the rollup contract
-      // Use numeric EthAddress for deterministic prover id
-      proverId: EthAddress.fromNumber(1),
-      worldStateBlockHistory: WORLD_STATE_BLOCK_HISTORY,
-      exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
-      slasherFlavor: 'none',
-      l1PublishingTime,
-      ...opts,
-    });
+    const context = await setup(
+      opts.numberOfAccounts ?? 0,
+      {
+        automineL1Setup: true,
+        checkIntervalMs: 50,
+        archiverPollingIntervalMS: ARCHIVER_POLL_INTERVAL,
+        worldStateBlockCheckIntervalMS: WORLD_STATE_BLOCK_CHECK_INTERVAL,
+        aztecEpochDuration,
+        aztecSlotDuration,
+        ethereumSlotDuration,
+        aztecProofSubmissionEpochs,
+        aztecTargetCommitteeSize: opts.initialValidators?.length ?? 0,
+        minTxsPerBlock: 0,
+        realProofs: false,
+        startProverNode: true,
+        proverTestDelayMs: opts.proverTestDelayMs ?? 0,
+        // We use numeric incremental prover ids for simplicity, but we can switch to
+        // using the prover's eth address if the proverId is used for something in the rollup contract
+        // Use numeric EthAddress for deterministic prover id
+        proverId: EthAddress.fromNumber(1),
+        worldStateBlockHistory: WORLD_STATE_BLOCK_HISTORY,
+        exitDelaySeconds: DefaultL1ContractsConfig.exitDelaySeconds,
+        slasherFlavor: 'none',
+        l1PublishingTime,
+        ...opts,
+      },
+      // Use checkpointed chain tip for PXE to avoid issues with blocks being dropped due to pruned anchor blocks.
+      { syncChainTip: 'checkpointed' },
+    );
 
     this.context = context;
     this.proverNodes = context.proverNode ? [context.proverNode] : [];

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -351,14 +351,19 @@ export class P2PNetworkTest {
 
   async setup() {
     this.logger.info('Setting up subsystems from fresh');
-    this.context = await setup(0, {
-      ...this.setupOptions,
-      fundSponsoredFPC: true,
-      skipAccountDeployment: true,
-      slasherFlavor: this.setupOptions.slasherFlavor ?? this.deployL1ContractsArgs.slasherFlavor ?? 'none',
-      aztecTargetCommitteeSize: 0,
-      l1ContractsArgs: this.deployL1ContractsArgs,
-    });
+    this.context = await setup(
+      0,
+      {
+        ...this.setupOptions,
+        fundSponsoredFPC: true,
+        skipAccountDeployment: true,
+        slasherFlavor: this.setupOptions.slasherFlavor ?? this.deployL1ContractsArgs.slasherFlavor ?? 'none',
+        aztecTargetCommitteeSize: 0,
+        l1ContractsArgs: this.deployL1ContractsArgs,
+      },
+      // Use checkpointed chain tip for PXE to avoid issues with blocks being dropped due to pruned anchor blocks.
+      { syncChainTip: 'checkpointed' },
+    );
     this.ctx = this.context;
 
     const sponsoredFPCAddress = await getSponsoredFPCAddress();


### PR DESCRIPTION
## Summary

Fixes flaky test failures in `e2e_p2p` and `e2e_epochs` tests caused by transactions being lost when blocks are pruned due to failed checkpoint proposals.

## Problem

The CI test `e2e_p2p_valid_epoch_pruned_slash` (and potentially other epochs/p2p tests) was failing with a timeout error:

```
TimeoutError: Timeout awaiting isMined
  at retryUntil (../../foundation/dest/retry/index.js:90:19)
  at DeploySentTx.waitForReceipt (../../aztec.js/dest/contract/sent_tx.js:78:16)
```

### Root Cause

The failure sequence was:

1. **Block 2 was built at slot 16** with a deployment transaction
2. **Checkpoint proposal failed L1 validation** with `HeaderLib__InvalidSlotNumber(17,16)` - by the time the proposal was submitted, L1 had already moved to slot 17
3. **Block 2 was pruned** when the archiver detected slot 16 wasn't checkpointed:
   ```
   WARN: archiver:l1-sync - Pruning blocks after block 1 due to slot 16 not being checkpointed
   ```
4. **The deployment transaction was lost** because it was in the pruned block
5. **PXE was syncing to the "proposed" chain tip** (default behavior), so `waitForReceipt` kept waiting for a transaction that would never be mined

## Solution

Configure PXE to sync to the **checkpointed** chain tip instead of the **proposed** one in both test contexts:

- `P2PNetworkTest.setup()` - used by all `e2e_p2p` tests
- `EpochsTestContext.setup()` - used by all `e2e_epochs` tests

This uses the newly added `syncChainTip` PXE config option:
```typescript
{ syncChainTip: 'checkpointed' }
```

### Why This Fixes the Issue

With `syncChainTip: 'checkpointed'`:
- PXE only considers blocks that have been successfully submitted to L1 (checkpointed)
- Blocks that are proposed but not yet checkpointed are not visible to PXE
- When a checkpoint fails and blocks are pruned, PXE already wasn't tracking those blocks
- Transactions sent through PXE will use anchor blocks from the checkpointed chain, which are stable and won't be pruned

This provides a more stable view of the chain for tests that involve block pruning scenarios.

## Changes

- `end-to-end/src/e2e_p2p/p2p_network.ts`: Pass `{ syncChainTip: 'checkpointed' }` to `setup()`
- `end-to-end/src/e2e_epochs/epochs_test.ts`: Pass `{ syncChainTip: 'checkpointed' }` to `setup()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)