### PR TITLE
fix(validator): validator integration test and fixes

### DIFF
--- a/yarn-project/.claude/rules/typescript-style.md
+++ b/yarn-project/.claude/rules/typescript-style.md
@@ -3,7 +3,7 @@
 ## Type Safety
 
 - Avoid `as Type` casts; prefer type guards
-- Never use `as any`
+- Never use `as any`; if a subclass need access to private members, change the visibility to `protected` instead of doing `this as any`
 - Use branded types for common domain types (`SlotNumber`, `BlockNumber`, `EpochNumber`, etc.)
 - Type guard functions follow `is<TypeName>` naming convention:
   ```typescript

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -68,7 +68,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
   public readonly events: ArchiverEmitter;
 
   /** A loop in which we will be continually fetching new checkpoints. */
-  private runningPromise: RunningPromise;
+  protected runningPromise: RunningPromise;
 
   /** L1 synchronizer that handles fetching checkpoints and messages from L1. */
   private readonly synchronizer: ArchiverL1Synchronizer;

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -157,7 +157,8 @@ export async function createArchiver(
   return archiver;
 }
 
-async function registerProtocolContracts(store: KVArchiverDataStore) {
+/** Registers protocol contracts in the archiver store. */
+export async function registerProtocolContracts(store: KVArchiverDataStore) {
   const blockNumber = 0;
   for (const name of protocolContractNames) {
     const provider = new BundledProtocolContractsProvider();

--- a/yarn-project/archiver/src/test/index.ts
+++ b/yarn-project/archiver/src/test/index.ts
@@ -2,3 +2,4 @@ export * from './mock_structs.js';
 export * from './mock_l2_block_source.js';
 export * from './mock_l1_to_l2_message_source.js';
 export * from './mock_archiver.js';
+export * from './noop_l1_archiver.js';

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -46,24 +46,40 @@ export function makeInboxMessage(
 }
 
 export function makeInboxMessages(
-  count: number,
+  totalCount: number,
   opts: {
     initialHash?: Buffer16;
     initialCheckpointNumber?: CheckpointNumber;
+    messagesPerCheckpoint?: number;
     overrideFn?: (msg: InboxMessage, index: number) => InboxMessage;
   } = {},
 ): InboxMessage[] {
-  const { initialHash = Buffer16.ZERO, overrideFn = msg => msg, initialCheckpointNumber = 1 } = opts;
+  const {
+    initialHash = Buffer16.ZERO,
+    overrideFn = msg => msg,
+    initialCheckpointNumber = CheckpointNumber(1),
+    messagesPerCheckpoint = 1,
+  } = opts;
+
   const messages: InboxMessage[] = [];
   let rollingHash = initialHash;
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < totalCount; i++) {
+    const msgIndex = i % messagesPerCheckpoint;
+    const checkpointNumber = CheckpointNumber.fromBigInt(
+      BigInt(initialCheckpointNumber) + BigInt(i) / BigInt(messagesPerCheckpoint),
+    );
     const leaf = Fr.random();
-    const checkpointNumber = CheckpointNumber(i + initialCheckpointNumber);
-    const message = overrideFn(makeInboxMessage(rollingHash, { leaf, checkpointNumber }), i);
+    const message = overrideFn(
+      makeInboxMessage(rollingHash, {
+        leaf,
+        checkpointNumber,
+        index: InboxLeaf.smallestIndexForCheckpoint(checkpointNumber) + BigInt(msgIndex),
+      }),
+      i,
+    );
     rollingHash = message.rollingHash;
     messages.push(message);
   }
-
   return messages;
 }
 

--- a/yarn-project/archiver/src/test/noop_l1_archiver.ts
+++ b/yarn-project/archiver/src/test/noop_l1_archiver.ts
@@ -1,0 +1,109 @@
+import type { BlobClientInterface } from '@aztec/blob-client/client';
+import type { RollupContract } from '@aztec/ethereum/contracts';
+import type { ViemPublicClient, ViemPublicDebugClient } from '@aztec/ethereum/types';
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { FunctionsOf } from '@aztec/foundation/types';
+import type { ArchiverEmitter } from '@aztec/stdlib/block';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { type TelemetryClient, type Tracer, getTelemetryClient } from '@aztec/telemetry-client';
+
+import { mock } from 'jest-mock-extended';
+import { EventEmitter } from 'node:events';
+
+import { Archiver } from '../archiver.js';
+import { ArchiverInstrumentation } from '../modules/instrumentation.js';
+import type { ArchiverL1Synchronizer } from '../modules/l1_synchronizer.js';
+import type { KVArchiverDataStore } from '../store/kv_archiver_store.js';
+
+/** Noop L1 synchronizer for testing without L1 connectivity. */
+class NoopL1Synchronizer implements FunctionsOf<ArchiverL1Synchronizer> {
+  public readonly tracer: Tracer;
+
+  constructor(tracer: Tracer) {
+    this.tracer = tracer;
+  }
+
+  setConfig(_config: unknown) {}
+  getL1BlockNumber(): bigint | undefined {
+    return 0n;
+  }
+  getL1Timestamp(): bigint | undefined {
+    return 0n;
+  }
+  testEthereumNodeSynced(): Promise<void> {
+    return Promise.resolve();
+  }
+  syncFromL1(_initialSyncComplete: boolean): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Archiver with mocked L1 connectivity for testing.
+ * Uses mock L1 clients and a noop synchronizer, enabling tests that
+ * don't require real Ethereum connectivity.
+ */
+export class NoopL1Archiver extends Archiver {
+  constructor(
+    dataStore: KVArchiverDataStore,
+    l1Constants: L1RollupConstants & { genesisArchiveRoot: Fr },
+    instrumentation: ArchiverInstrumentation,
+  ) {
+    // Create mocks for L1 clients
+    const publicClient = mock<ViemPublicClient>();
+    const debugClient = mock<ViemPublicDebugClient>();
+    const rollup = mock<RollupContract>();
+    const blobClient = mock<BlobClientInterface>();
+
+    // Mock methods called during start()
+    blobClient.testSources.mockResolvedValue();
+    publicClient.getBlockNumber.mockResolvedValue(1n);
+
+    const events = new EventEmitter() as ArchiverEmitter;
+    const synchronizer = new NoopL1Synchronizer(instrumentation.tracer);
+
+    super(
+      publicClient,
+      debugClient,
+      rollup,
+      {
+        registryAddress: EthAddress.ZERO,
+        governanceProposerAddress: EthAddress.ZERO,
+        slashFactoryAddress: EthAddress.ZERO,
+        slashingProposerAddress: EthAddress.ZERO,
+      },
+      dataStore,
+      {
+        pollingIntervalMs: 1000,
+        batchSize: 100,
+        skipValidateCheckpointAttestations: true,
+        maxAllowedEthClientDriftSeconds: 300,
+        ethereumAllowNoDebugHosts: true, // Skip trace validation
+      },
+      blobClient,
+      instrumentation,
+      { ...l1Constants, l1StartBlockHash: Buffer32.random() },
+      synchronizer as ArchiverL1Synchronizer,
+      events,
+    );
+  }
+
+  /** Override start to skip L1 validation checks. */
+  public override start(_blockUntilSynced?: boolean): Promise<void> {
+    // Just start the running promise without L1 checks
+    this.runningPromise.start();
+    return Promise.resolve();
+  }
+}
+
+/** Creates an archiver with mocked L1 connectivity for testing. */
+export async function createNoopL1Archiver(
+  dataStore: KVArchiverDataStore,
+  l1Constants: L1RollupConstants & { genesisArchiveRoot: Fr },
+  telemetry: TelemetryClient = getTelemetryClient(),
+): Promise<NoopL1Archiver> {
+  const instrumentation = await ArchiverInstrumentation.new(telemetry, () => dataStore.estimateSize());
+  return new NoopL1Archiver(dataStore, l1Constants, instrumentation);
+}

--- a/yarn-project/epoch-cache/src/test/index.ts
+++ b/yarn-project/epoch-cache/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from './test_epoch_cache.js';

--- a/yarn-project/epoch-cache/src/test/test_epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/test/test_epoch_cache.ts
@@ -1,0 +1,169 @@
+import { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
+import { getEpochAtSlot, getSlotAtTimestamp, getTimestampRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
+
+import type { EpochAndSlot, EpochCacheInterface, EpochCommitteeInfo, SlotTag } from '../epoch_cache.js';
+
+/** Default L1 constants for testing. */
+const DEFAULT_L1_CONSTANTS: L1RollupConstants = {
+  l1StartBlock: 0n,
+  l1GenesisTime: 0n,
+  slotDuration: 24,
+  epochDuration: 16,
+  ethereumSlotDuration: 12,
+  proofSubmissionEpochs: 2,
+};
+
+/**
+ * A test implementation of EpochCacheInterface that allows manual configuration
+ * of committee, proposer, slot, and escape hatch state for use in tests.
+ *
+ * Unlike the real EpochCache, this class doesn't require any RPC connections
+ * or mock setup. Simply use the setter methods to configure the test state.
+ */
+export class TestEpochCache implements EpochCacheInterface {
+  private committee: EthAddress[] = [];
+  private proposerAddress: EthAddress | undefined;
+  private currentSlot: SlotNumber = SlotNumber(0);
+  private escapeHatchOpen: boolean = false;
+  private seed: bigint = 0n;
+  private registeredValidators: EthAddress[] = [];
+  private l1Constants: L1RollupConstants;
+
+  constructor(l1Constants: Partial<L1RollupConstants> = {}) {
+    this.l1Constants = { ...DEFAULT_L1_CONSTANTS, ...l1Constants };
+  }
+
+  /**
+   * Sets the committee members. Used in validation and attestation flows.
+   * @param committee - Array of committee member addresses.
+   */
+  setCommittee(committee: EthAddress[]): this {
+    this.committee = committee;
+    return this;
+  }
+
+  /**
+   * Sets the proposer address returned by getProposerAttesterAddressInSlot.
+   * @param proposer - The address of the current proposer.
+   */
+  setProposer(proposer: EthAddress | undefined): this {
+    this.proposerAddress = proposer;
+    return this;
+  }
+
+  /**
+   * Sets the current slot number.
+   * @param slot - The slot number to set.
+   */
+  setCurrentSlot(slot: SlotNumber): this {
+    this.currentSlot = slot;
+    return this;
+  }
+
+  /**
+   * Sets whether the escape hatch is open.
+   * @param open - True if escape hatch should be open.
+   */
+  setEscapeHatchOpen(open: boolean): this {
+    this.escapeHatchOpen = open;
+    return this;
+  }
+
+  /**
+   * Sets the randomness seed used for proposer selection.
+   * @param seed - The seed value.
+   */
+  setSeed(seed: bigint): this {
+    this.seed = seed;
+    return this;
+  }
+
+  /**
+   * Sets the list of registered validators (all validators, not just committee).
+   * @param validators - Array of validator addresses.
+   */
+  setRegisteredValidators(validators: EthAddress[]): this {
+    this.registeredValidators = validators;
+    return this;
+  }
+
+  /**
+   * Sets the L1 constants used for epoch/slot calculations.
+   * @param constants - Partial constants to override defaults.
+   */
+  setL1Constants(constants: Partial<L1RollupConstants>): this {
+    this.l1Constants = { ...this.l1Constants, ...constants };
+    return this;
+  }
+
+  getL1Constants(): L1RollupConstants {
+    return this.l1Constants;
+  }
+
+  getCommittee(_slot?: SlotTag): Promise<EpochCommitteeInfo> {
+    const epoch = getEpochAtSlot(this.currentSlot, this.l1Constants);
+    return Promise.resolve({
+      committee: this.committee,
+      epoch,
+      seed: this.seed,
+      isEscapeHatchOpen: this.escapeHatchOpen,
+    });
+  }
+
+  getEpochAndSlotNow(): EpochAndSlot & { nowMs: bigint } {
+    const epoch = getEpochAtSlot(this.currentSlot, this.l1Constants);
+    const ts = getTimestampRangeForEpoch(epoch, this.l1Constants)[0];
+    return { epoch, slot: this.currentSlot, ts, nowMs: ts * 1000n };
+  }
+
+  getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint } {
+    const now = getTimestampRangeForEpoch(getEpochAtSlot(this.currentSlot, this.l1Constants), this.l1Constants)[0];
+    const nextSlotTs = now + BigInt(this.l1Constants.ethereumSlotDuration);
+    const nextSlot = getSlotAtTimestamp(nextSlotTs, this.l1Constants);
+    const epoch = getEpochAtSlot(nextSlot, this.l1Constants);
+    const ts = getTimestampRangeForEpoch(epoch, this.l1Constants)[0];
+    return { epoch, slot: nextSlot, ts, now };
+  }
+
+  getProposerIndexEncoding(epoch: EpochNumber, slot: SlotNumber, seed: bigint): `0x${string}` {
+    // Simple encoding for testing purposes
+    return `0x${epoch.toString(16).padStart(64, '0')}${slot.toString(16).padStart(64, '0')}${seed.toString(16).padStart(64, '0')}`;
+  }
+
+  computeProposerIndex(slot: SlotNumber, _epoch: EpochNumber, _seed: bigint, size: bigint): bigint {
+    if (size === 0n) {
+      return 0n;
+    }
+    return BigInt(slot) % size;
+  }
+
+  getCurrentAndNextSlot(): { currentSlot: SlotNumber; nextSlot: SlotNumber } {
+    return {
+      currentSlot: this.currentSlot,
+      nextSlot: SlotNumber(this.currentSlot + 1),
+    };
+  }
+
+  getProposerAttesterAddressInSlot(_slot: SlotNumber): Promise<EthAddress | undefined> {
+    return Promise.resolve(this.proposerAddress);
+  }
+
+  getRegisteredValidators(): Promise<EthAddress[]> {
+    return Promise.resolve(this.registeredValidators);
+  }
+
+  isInCommittee(_slot: SlotTag, validator: EthAddress): Promise<boolean> {
+    return Promise.resolve(this.committee.some(v => v.equals(validator)));
+  }
+
+  filterInCommittee(_slot: SlotTag, validators: EthAddress[]): Promise<EthAddress[]> {
+    const committeeSet = new Set(this.committee.map(v => v.toString()));
+    return Promise.resolve(validators.filter(v => committeeSet.has(v.toString())));
+  }
+
+  isEscapeHatchOpenAtSlot(_slot?: SlotTag): Promise<boolean> {
+    return Promise.resolve(this.escapeHatchOpen);
+  }
+}

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -24,24 +24,24 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
       if (slotNumber !== currentSlot && slotNumber !== nextSlot) {
         // Check if message is for previous slot and within clock tolerance
         if (!isWithinClockTolerance(slotNumber, currentSlot, this.epochCache)) {
-          this.logger.debug(`Penalizing peer for invalid slot number ${slotNumber}`, { currentSlot, nextSlot });
+          this.logger.warn(`Penalizing peer for invalid slot number ${slotNumber}`, { currentSlot, nextSlot });
           return { result: 'reject', severity: PeerErrorSeverity.HighToleranceError };
         }
-        this.logger.debug(`Ignoring proposal for previous slot ${slotNumber} within clock tolerance`);
+        this.logger.verbose(`Ignoring proposal for previous slot ${slotNumber} within clock tolerance`);
         return { result: 'ignore' };
       }
 
       // Signature validity
       const proposer = proposal.getSender();
       if (!proposer) {
-        this.logger.debug(`Penalizing peer for proposal with invalid signature`);
+        this.logger.warn(`Penalizing peer for proposal with invalid signature`);
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }
 
       // Transactions permitted check
       const embeddedTxCount = proposal.txs?.length ?? 0;
       if (!this.txsPermitted && (proposal.txHashes.length > 0 || embeddedTxCount > 0)) {
-        this.logger.debug(
+        this.logger.warn(
           `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when transactions are not permitted`,
         );
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
@@ -65,7 +65,7 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
       // Proposer check
       const expectedProposer = await this.epochCache.getProposerAttesterAddressInSlot(slotNumber);
       if (expectedProposer !== undefined && !proposer.equals(expectedProposer)) {
-        this.logger.debug(`Penalizing peer for invalid proposer for current slot ${slotNumber}`, {
+        this.logger.warn(`Penalizing peer for invalid proposer for current slot ${slotNumber}`, {
           expectedProposer,
           proposer: proposer.toString(),
         });

--- a/yarn-project/p2p/src/test-helpers/index.ts
+++ b/yarn-project/p2p/src/test-helpers/index.ts
@@ -4,3 +4,4 @@ export * from './make-enrs.js';
 export * from './make-test-p2p-clients.js';
 export * from './reqresp-nodes.js';
 export * from './mock-pubsub.js';
+export * from './test_tx_provider.js';

--- a/yarn-project/p2p/src/test-helpers/test_tx_provider.ts
+++ b/yarn-project/p2p/src/test-helpers/test_tx_provider.ts
@@ -1,0 +1,64 @@
+import type { BlockNumber } from '@aztec/foundation/branded-types';
+import type { L2Block } from '@aztec/stdlib/block';
+import type { ITxProvider } from '@aztec/stdlib/interfaces/server';
+import type { BlockProposal } from '@aztec/stdlib/p2p';
+import { type Tx, TxHash } from '@aztec/stdlib/tx';
+
+import type { PeerId } from '@libp2p/interface';
+
+/**
+ * Test transaction provider that can be seeded with transactions.
+ * Returns seeded txs when requested by hash, useful for testing block
+ * proposal handling without requiring a full P2P network.
+ */
+export class TestTxProvider implements ITxProvider {
+  private txs: Map<string, Tx> = new Map();
+
+  /** Seed transactions that will be returned when requested. */
+  seed(txs: Tx[]) {
+    for (const tx of txs) {
+      this.txs.set(tx.getTxHash().toString(), tx);
+    }
+  }
+
+  /** Clear all seeded transactions. */
+  clear() {
+    this.txs.clear();
+  }
+
+  /** Returns txs from the seeded collection given their hashes. */
+  getAvailableTxs(txHashes: TxHash[]): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
+    return this.getTxsByHashes(txHashes);
+  }
+
+  /** Get txs for a block proposal, returning any seeded txs that match the requested hashes. */
+  getTxsForBlockProposal(
+    blockProposal: BlockProposal,
+    _blockNumber: BlockNumber,
+    _opts: { pinnedPeer: PeerId | undefined; deadline: Date },
+  ): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
+    return this.getTxsByHashes(blockProposal.txHashes);
+  }
+
+  /** Get txs for a block, returning any seeded txs that match the tx effects in the block. */
+  getTxsForBlock(block: L2Block, _opts: { deadline: Date }): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
+    const txHashes = block.body.txEffects.map(txEffect => txEffect.txHash);
+    return this.getTxsByHashes(txHashes);
+  }
+
+  private getTxsByHashes(txHashes: TxHash[]): Promise<{ txs: Tx[]; missingTxs: TxHash[] }> {
+    const txs: Tx[] = [];
+    const missingTxs: TxHash[] = [];
+
+    for (const txHash of txHashes) {
+      const tx = this.txs.get(txHash.toString());
+      if (tx) {
+        txs.push(tx);
+      } else {
+        missingTxs.push(txHash);
+      }
+    }
+
+    return Promise.resolve({ txs, missingTxs });
+  }
+}

--- a/yarn-project/stdlib/src/p2p/block_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/block_proposal.ts
@@ -30,8 +30,15 @@ export class BlockProposalHash extends Buffer32 {
 }
 
 export type BlockProposalOptions = {
-  publishFullTxs: boolean;
-  /** Whether to generate an invalid block proposal for broadcasting. Use only for testing. */
+  /**
+   * Whether to include the tx objects along with the block proposal.
+   * Dramatically increases size of the payload but eliminates failed reexecutions due to missing txs.
+   */
+  publishFullTxs?: boolean;
+  /**
+   * Whether to generate an invalid block proposal for broadcasting.
+   * Use only for testing.
+   */
   broadcastInvalidBlockProposal?: boolean;
 };
 

--- a/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
+++ b/yarn-project/stdlib/src/p2p/checkpoint_proposal.ts
@@ -32,8 +32,15 @@ export class CheckpointProposalHash extends Buffer32 {
 }
 
 export type CheckpointProposalOptions = {
-  publishFullTxs: boolean;
-  /** Whether to generate an invalid checkpoint proposal for broadcasting. Use only for testing. */
+  /**
+   * Whether to include the tx objects along with the block proposal.
+   * Dramatically increases size of the payload but eliminates failed reexecutions due to missing txs.
+   */
+  publishFullTxs?: boolean;
+  /**
+   * Whether to generate an invalid checkpoint proposal for broadcasting.
+   * Use only for testing.
+   */
   broadcastInvalidCheckpointProposal?: boolean;
 };
 

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -97,12 +97,14 @@ export const mockTx = async (
     publicCalldataSize = 2,
     feePayer,
     chonkProof = ChonkProof.random(),
+    maxFeesPerGas = new GasFees(10, 10),
     maxPriorityFeesPerGas,
     gasUsed = Gas.empty(),
     chainId = Fr.ZERO,
     version = Fr.ZERO,
     vkTreeRoot = Fr.ZERO,
     protocolContractsHash = Fr.ZERO,
+    anchorBlockHeader = BlockHeader.empty(),
   }: {
     numberOfNonRevertiblePublicCallRequests?: number;
     numberOfRevertiblePublicCallRequests?: number;
@@ -111,12 +113,14 @@ export const mockTx = async (
     publicCalldataSize?: number;
     feePayer?: AztecAddress;
     chonkProof?: ChonkProof;
+    maxFeesPerGas?: GasFees;
     maxPriorityFeesPerGas?: GasFees;
     gasUsed?: Gas;
     chainId?: Fr;
     version?: Fr;
     vkTreeRoot?: Fr;
     protocolContractsHash?: Fr;
+    anchorBlockHeader?: BlockHeader;
   } = {},
 ) => {
   const totalPublicCallRequests =
@@ -126,10 +130,8 @@ export const mockTx = async (
   const isForPublic = totalPublicCallRequests > 0;
   const data = PrivateKernelTailCircuitPublicInputs.empty();
   const firstNullifier = new Nullifier(new Fr(seed + 1), Fr.ZERO, 0);
-  data.constants.txContext.gasSettings = GasSettings.default({
-    maxFeesPerGas: new GasFees(10, 10),
-    maxPriorityFeesPerGas,
-  });
+  data.constants.anchorBlockHeader = anchorBlockHeader;
+  data.constants.txContext.gasSettings = GasSettings.default({ maxFeesPerGas, maxPriorityFeesPerGas });
   data.feePayer = feePayer ?? (await AztecAddress.random());
   data.gasUsed = gasUsed;
   data.constants.txContext.chainId = chainId;

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -86,6 +86,8 @@
     "viem": "npm:@aztec/viem@2.38.2"
   },
   "devDependencies": {
+    "@aztec/archiver": "workspace:^",
+    "@aztec/world-state": "workspace:^",
     "@electric-sql/pglite": "^0.3.14",
     "@jest/globals": "^30.0.0",
     "@types/jest": "^30.0.0",

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -8,11 +8,10 @@ import { createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
-import { TxProvider } from '@aztec/p2p';
 import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
 import type { L2Block, L2BlockSink, L2BlockSource } from '@aztec/stdlib/block';
 import { getEpochAtSlot, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
-import type { ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type { ITxProvider, ValidatorClientFullConfig, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import {
   type L1ToL2MessageSource,
   computeCheckpointOutHash,
@@ -78,7 +77,7 @@ export class BlockProposalHandler {
     private worldState: WorldStateSynchronizer,
     private blockSource: L2BlockSource & L2BlockSink,
     private l1ToL2MessageSource: L1ToL2MessageSource,
-    private txProvider: TxProvider,
+    private txProvider: ITxProvider,
     private blockProposalValidator: BlockProposalValidator,
     private epochCache: EpochCache,
     private config: ValidatorClientFullConfig,
@@ -160,9 +159,9 @@ export class BlockProposalHandler {
       return { isValid: false, reason: 'parent_block_not_found' };
     }
 
-    // Check that the parent block's slot is less than the proposal's slot (should not happen, but we check anyway)
-    if (parentBlockHeader !== 'genesis' && parentBlockHeader.getSlot() >= slotNumber) {
-      this.log.warn(`Parent block slot is greater than or equal to proposal slot, skipping processing`, {
+    // Check that the parent block's slot is not greater than the proposal's slot.
+    if (parentBlockHeader !== 'genesis' && parentBlockHeader.getSlot() > slotNumber) {
+      this.log.warn(`Parent block slot is greater than proposal slot, skipping processing`, {
         parentBlockSlot: parentBlockHeader.getSlot().toString(),
         proposalSlot: slotNumber.toString(),
         ...proposalInfo,
@@ -475,6 +474,7 @@ export class BlockProposalHandler {
 
     // Fork before the block to be built
     const parentBlockNumber = BlockNumber(blockNumber - 1);
+    await this.worldState.syncImmediate(parentBlockNumber);
     using fork = await this.worldState.fork(parentBlockNumber);
 
     // Build checkpoint constants from proposal (excludes blockNumber and timestamp which are per-block)

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -68,7 +68,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     pendingTxs: Iterable<Tx> | AsyncIterable<Tx>,
     blockNumber: BlockNumber,
     timestamp: bigint,
-    opts: PublicProcessorLimits & { expectedEndState?: StateReference },
+    opts: PublicProcessorLimits & { expectedEndState?: StateReference } = {},
   ): Promise<BuildBlockInCheckpointResultWithTimer> {
     const blockBuildingTimer = new Timer();
     const slot = this.checkpointBuilder.constants.slotNumber;

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -1,0 +1,584 @@
+import { createArchiverStore, registerProtocolContracts } from '@aztec/archiver';
+import { type NoopL1Archiver, createNoopL1Archiver, makeInboxMessages } from '@aztec/archiver/test';
+import type { BlobClientInterface } from '@aztec/blob-client/client';
+import type { EpochCache } from '@aztec/epoch-cache';
+import { TestEpochCache } from '@aztec/epoch-cache/test';
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { timesAsync } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { Hex } from '@aztec/foundation/string';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
+import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
+import type { P2P, PeerId } from '@aztec/p2p';
+import { TestTxProvider } from '@aztec/p2p/test-helpers';
+import { protocolContractsHash } from '@aztec/protocol-contracts';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
+import { L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
+import { type L1RollupConstants, getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
+import { GasFees } from '@aztec/stdlib/gas';
+import { tryStop } from '@aztec/stdlib/interfaces/server';
+import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
+import type { BlockProposal } from '@aztec/stdlib/p2p';
+import { mockTx } from '@aztec/stdlib/testing';
+import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
+import { BlockHeader, type CheckpointGlobalVariables, Tx } from '@aztec/stdlib/tx';
+import { ServerWorldStateSynchronizer } from '@aztec/world-state';
+import { NativeWorldStateService } from '@aztec/world-state/native';
+import { getGenesisValues } from '@aztec/world-state/testing';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+import { generatePrivateKey } from 'viem/accounts';
+
+import { CheckpointBuilder, FullNodeCheckpointsBuilder } from './checkpoint_builder.js';
+import { ValidatorClient } from './validator.js';
+
+jest.setTimeout(60_000);
+
+describe('ValidatorClient Integration', () => {
+  // Constants for L1
+  const l1Constants: L1RollupConstants = {
+    l1GenesisTime: 0n,
+    slotDuration: 24,
+    epochDuration: 16,
+    ethereumSlotDuration: 12,
+    proofSubmissionEpochs: 2,
+    l1StartBlock: 0n,
+  };
+
+  const emptyL1ToL2Messages: Fr[] = [];
+  const emptyPreviousCheckpointOutHashes: Fr[] = [];
+
+  type ValidatorContext = {
+    worldStateDb: NativeWorldStateService;
+    archiver: NoopL1Archiver;
+    synchronizer: ServerWorldStateSynchronizer;
+    checkpointsBuilder: FullNodeCheckpointsBuilder;
+    p2pClient: MockProxy<P2P>;
+    validator: ValidatorClient;
+  };
+
+  let slotNumber: SlotNumber;
+  let timestamp: bigint;
+  let chainId: Fr;
+  let version: Fr;
+
+  let epochCache: TestEpochCache;
+  let rollupAddress: EthAddress;
+  let genesisArchiveRoot: Fr;
+  let prefilledPublicData: PublicDataTreeLeaf[];
+  let genesisBlockHeader: BlockHeader;
+  let proposerSigner: Secp256k1Signer;
+  let proposerPrivateKey: Hex<32>;
+  let validatorSigner: Secp256k1Signer;
+  let validatorPrivateKey: Hex<32>;
+  let dateProvider: TestDateProvider;
+  let txProvider: TestTxProvider;
+  let keyStoreManager: KeystoreManager;
+  let blobClient: MockProxy<BlobClientInterface>;
+  let logger: Logger;
+  let feePayerAddresses: AztecAddress[];
+
+  let attestor: ValidatorContext;
+  let proposer: ValidatorContext;
+
+  const mockPeerId = { toString: () => 'test-peer' } as PeerId;
+
+  /** Creates a new validator and dependencies */
+  const createValidatorContext = async (privateKey: Hex<32>): Promise<ValidatorContext> => {
+    // Create archiver store and NoopL1Archiver
+    const archiverStore = await createArchiverStore(
+      {
+        archiverStoreMapSizeKb: 1024 * 1024,
+        dataDirectory: undefined,
+        dataStoreMapSizeKb: 1024 * 1024,
+      },
+      { epochDuration: l1Constants.epochDuration },
+    );
+    await registerProtocolContracts(archiverStore);
+    const archiver = await createNoopL1Archiver(archiverStore, { ...l1Constants, genesisArchiveRoot });
+    await archiver.start();
+
+    // Create world state synchronizer
+    const wsConfig = {
+      l1Contracts: { rollupAddress },
+      worldStateBlockCheckIntervalMS: 20,
+      worldStateBlockRequestBatchSize: 10,
+      worldStateDbMapSizeKb: 1024 * 1024,
+      worldStateBlockHistory: 0,
+    };
+    const worldStateDb = await NativeWorldStateService.tmp(rollupAddress, true, prefilledPublicData);
+    const synchronizer = new ServerWorldStateSynchronizer(worldStateDb, archiver, wsConfig);
+    await synchronizer.start();
+
+    // Create real checkpoints builder
+    const checkpointsBuilder = new FullNodeCheckpointsBuilder(
+      {
+        l1GenesisTime: l1Constants.l1GenesisTime,
+        slotDuration: l1Constants.slotDuration,
+        l1ChainId: chainId.toNumber(),
+        rollupVersion: version.toNumber(),
+        txPublicSetupAllowList: [],
+      },
+      synchronizer,
+      archiver,
+      dateProvider,
+    );
+
+    // Create mock p2p client
+    const p2pClient = mock<P2P>();
+    p2pClient.getCheckpointAttestationsForSlot.mockResolvedValue([]);
+    p2pClient.broadcastCheckpointAttestations.mockResolvedValue();
+    p2pClient.getTxStatus.mockResolvedValue('pending');
+    p2pClient.hasTxsInPool.mockImplementation(txHashes => Promise.resolve(txHashes.map(() => true)));
+
+    // Create keystore with private key
+    const keyStore: KeyStore = {
+      schemaVersion: 1,
+      slasher: undefined,
+      prover: undefined,
+      remoteSigner: undefined,
+      validators: [
+        {
+          attester: [privateKey],
+          feeRecipient: AztecAddress.ZERO,
+          coinbase: undefined,
+          remoteSigner: undefined,
+          publisher: [],
+        },
+      ],
+    };
+    keyStoreManager = new KeystoreManager(keyStore);
+
+    // Create and start validator
+    const validator = await ValidatorClient.new(
+      {
+        validatorPrivateKeys: new SecretValue([privateKey]),
+        attestationPollingIntervalMs: 100,
+        disableValidator: false,
+        disabledValidators: [],
+        validatorReexecute: true,
+        slashBroadcastedInvalidBlockPenalty: 10n,
+        haSigningEnabled: false,
+        skipCheckpointProposalValidation: false,
+        skipPushProposedBlocksToArchiver: false,
+        nodeId: 'test-node',
+        pollingIntervalMs: 100,
+        signingTimeoutMs: 3000,
+      },
+      checkpointsBuilder,
+      synchronizer,
+      epochCache as unknown as EpochCache,
+      p2pClient,
+      archiver,
+      archiver,
+      txProvider,
+      keyStoreManager,
+      blobClient,
+      dateProvider,
+    );
+
+    await validator.start();
+
+    return {
+      worldStateDb,
+      archiver,
+      synchronizer,
+      checkpointsBuilder,
+      p2pClient,
+      validator,
+    };
+  };
+
+  type BlockProposalResult = { block: L2Block; proposal: BlockProposal };
+
+  /** Builds a new block proposal with the given txs and l1-to-l2 messages */
+  const buildBlockProposal = async (
+    checkpointBuilder: CheckpointBuilder,
+    blockNumber: BlockNumber,
+    txs: Tx[] = [],
+    l1ToL2Messages: Fr[] = [],
+  ): Promise<{ block: L2Block; proposal: BlockProposal }> => {
+    const inHash = computeInHashFromL1ToL2Messages(l1ToL2Messages);
+    const { block, usedTxs } = await checkpointBuilder.buildBlock(txs, blockNumber, timestamp, {});
+
+    const proposal = await proposer.validator.createBlockProposal(
+      block.header,
+      block.indexWithinCheckpoint,
+      inHash,
+      block.archive.root,
+      usedTxs,
+      proposerSigner.address,
+    );
+
+    logger.warn(`Built block proposal for block ${blockNumber}`, { ...block.toBlockInfo() });
+    return { block, proposal };
+  };
+
+  let txCount = 0;
+  /** Builds mock transactions with pre-funded fee payers. */
+  const buildTxs = async (numTxs: number, anchorBlockHeader?: BlockHeader): Promise<Tx[]> => {
+    const txs = await timesAsync(numTxs, () => {
+      const feePayer = feePayerAddresses[txCount % feePayerAddresses.length];
+      return mockTx(++txCount + 1000, {
+        chainId,
+        version,
+        numberOfNonRevertiblePublicCallRequests: 0,
+        numberOfRevertibleNullifiers: 0,
+        numberOfRevertiblePublicCallRequests: 0,
+        hasPublicTeardownCallRequest: false,
+        vkTreeRoot: getVKTreeRoot(),
+        protocolContractsHash,
+        anchorBlockHeader: anchorBlockHeader ?? genesisBlockHeader,
+        maxFeesPerGas: new GasFees(1e12, 1e12),
+        feePayer,
+      });
+    });
+    txProvider.seed(txs);
+    for (const tx of txs) {
+      logger.debug(`Built and seeded tx ${tx.getTxHash().toString()} with feePayer ${tx.data.feePayer.toString()}`);
+    }
+    return txs;
+  };
+
+  /**
+   * Builds a complete checkpoint with the specified number of blocks.
+   * @param getTxsForBlock - Callback to get txs for each block, receives block number and previously built blocks.
+   */
+  const buildCheckpoint = async (
+    checkpointNumber: CheckpointNumber,
+    slot: SlotNumber,
+    l1ToL2Messages: Fr[],
+    previousCheckpointOutHashes: Fr[],
+    startBlockNumber: BlockNumber,
+    blockCount: number,
+    getTxsForBlock: (blockNumber: BlockNumber, previousBlocks: BlockProposalResult[]) => Promise<Tx[]> | Tx[],
+  ): Promise<{
+    blocks: BlockProposalResult[];
+    checkpoint: Awaited<ReturnType<CheckpointBuilder['completeCheckpoint']>>;
+    proposal: Awaited<ReturnType<typeof proposer.validator.createCheckpointProposal>>;
+    l1ToL2Messages: Fr[];
+    globalVariables: CheckpointGlobalVariables;
+  }> => {
+    const globalVariables: CheckpointGlobalVariables = {
+      chainId: new Fr(1),
+      version: new Fr(1),
+      coinbase: EthAddress.random(),
+      feeRecipient: await AztecAddress.random(),
+      gasFees: GasFees.empty(),
+      slotNumber: slot,
+    };
+
+    using fork = await proposer.worldStateDb.fork();
+    const builder = await proposer.checkpointsBuilder.startCheckpoint(
+      checkpointNumber,
+      globalVariables,
+      l1ToL2Messages,
+      previousCheckpointOutHashes,
+      fork,
+    );
+
+    const blocks: BlockProposalResult[] = [];
+    for (let i = 0; i < blockCount; i++) {
+      const blockNumber = BlockNumber(startBlockNumber + i);
+      const txs = await getTxsForBlock(blockNumber, blocks);
+      const block = await buildBlockProposal(builder, blockNumber, txs, l1ToL2Messages);
+      blocks.push(block);
+    }
+
+    const checkpoint = await builder.completeCheckpoint();
+
+    const proposal = await proposer.validator.createCheckpointProposal(
+      checkpoint.header,
+      checkpoint.archive.root,
+      undefined,
+      proposerSigner.address,
+    );
+
+    return { blocks, checkpoint, proposal, l1ToL2Messages, globalVariables };
+  };
+
+  /** Validates blocks by calling the validator client in the attestor. */
+  const attestorValidateBlocks = async (blocks: BlockProposalResult[]) => {
+    for (const block of blocks) {
+      logger.warn(`Validating block proposal ${block.proposal.blockNumber}`);
+      expect(await attestor.validator.validateBlockProposal(block.proposal, mockPeerId)).toBe(true);
+    }
+  };
+
+  beforeEach(async () => {
+    // Setup common values
+    slotNumber = SlotNumber(1);
+    timestamp = getTimestampForSlot(slotNumber, l1Constants);
+    chainId = new Fr(1);
+    version = new Fr(1);
+
+    // Setup signers with explicit private keys
+    proposerPrivateKey = generatePrivateKey() as Hex<32>;
+    proposerSigner = new Secp256k1Signer(Buffer32.fromString(proposerPrivateKey));
+    validatorPrivateKey = generatePrivateKey() as Hex<32>;
+    validatorSigner = new Secp256k1Signer(Buffer32.fromString(validatorPrivateKey));
+
+    // Set up common dependencies
+    logger = createLogger('validator:test');
+    rollupAddress = EthAddress.random();
+    dateProvider = new TestDateProvider();
+    dateProvider.setTime(Number(timestamp) * 1000);
+    txProvider = new TestTxProvider();
+    blobClient = mock<BlobClientInterface>();
+    blobClient.canUpload.mockReturnValue(false);
+    epochCache = new TestEpochCache(l1Constants)
+      .setCommittee([validatorSigner.address])
+      .setProposer(proposerSigner.address)
+      .setCurrentSlot(slotNumber);
+
+    // Generate fee payer addresses and pre-fund them
+    feePayerAddresses = await Promise.all(Array.from({ length: 10 }, () => AztecAddress.random()));
+    const genesisValues = await getGenesisValues(feePayerAddresses);
+    genesisArchiveRoot = genesisValues.genesisArchiveRoot;
+    prefilledPublicData = genesisValues.prefilledPublicData;
+
+    // Create validator clients
+    logger.warn(`Setting up validator contexts`);
+    attestor = await createValidatorContext(validatorPrivateKey);
+    proposer = await createValidatorContext(proposerPrivateKey);
+    // Get genesis block header from world state (archiver.getBlockHeader(0) returns undefined by design)
+    genesisBlockHeader = proposer.worldStateDb.getInitialHeader();
+    logger.warn(`Setup complete`);
+  });
+
+  afterEach(async () => {
+    logger.warn(`Stopping validator contexts`);
+    for (const { validator, synchronizer, archiver, worldStateDb } of [attestor, proposer]) {
+      await tryStop(validator);
+      await tryStop(synchronizer);
+      await tryStop(archiver);
+      await tryStop(worldStateDb);
+    }
+  });
+
+  describe('happy path', () => {
+    it('validates multiple blocks and attests to checkpoint', async () => {
+      const { blocks, proposal } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        emptyL1ToL2Messages,
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        3,
+        () => buildTxs(2),
+      );
+
+      await attestorValidateBlocks(blocks);
+
+      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      expect(attestations).toBeDefined();
+      expect(attestations).toHaveLength(1);
+      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
+
+      // Verify blocks are in archiver and hashes match
+      await attestor.archiver.syncImmediate();
+      const attestorBlocks = await attestor.archiver.getBlocks(BlockNumber(1), 3);
+      expect(attestorBlocks.length).toBe(3);
+
+      const attestorBlockHashes = await Promise.all(attestorBlocks.map(b => b.header.hash()));
+      const expectedBlockHashes = await Promise.all(blocks.map(b => b.block.header.hash()));
+      expect(attestorBlockHashes).toEqual(expectedBlockHashes);
+    });
+
+    it('validates and attests with txs anchored to proposed blocks and non-empty l1-to-l2 messages', async () => {
+      // Create l1 to l2 messages and seed them into the archivers
+      const l1ToL2Messages = makeInboxMessages(4, { messagesPerCheckpoint: 4 });
+      await proposer.archiver.dataStore.addL1ToL2Messages(l1ToL2Messages);
+      await attestor.archiver.dataStore.addL1ToL2Messages(l1ToL2Messages);
+
+      // Build txs anchored to the previously proposed block
+      const { blocks, proposal } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        l1ToL2Messages.map(m => m.leaf),
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        3,
+        (_blockNumber: BlockNumber, previousBlocks: BlockProposalResult[]) =>
+          buildTxs(2, previousBlocks.at(-1)?.block.header),
+      );
+
+      await attestorValidateBlocks(blocks);
+
+      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      expect(attestations).toBeDefined();
+      expect(attestations).toHaveLength(1);
+      expect(attestations![0].getSender()).toEqual(validatorSigner.address);
+
+      // Verify blocks are in archiver and hashes match
+      await attestor.archiver.syncImmediate();
+      const attestorBlocks = await attestor.archiver.getBlocks(BlockNumber(1), 3);
+      expect(attestorBlocks.length).toBe(3);
+
+      const attestorBlockHashes = await Promise.all(attestorBlocks.map(b => b.header.hash()));
+      const expectedBlockHashes = await Promise.all(blocks.map(b => b.block.header.hash()));
+      expect(attestorBlockHashes).toEqual(expectedBlockHashes);
+    });
+
+    it('validates second checkpoint using previousCheckpointOutHashes', async () => {
+      // Build and publish the first checkpoint
+      const { blocks: blocks1, checkpoint: checkpoint1 } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        emptyL1ToL2Messages,
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        2,
+        () => buildTxs(2),
+      );
+
+      // Publish checkpoint 1 to both archivers
+      const publishedCheckpoint1 = PublishedCheckpoint.from({
+        checkpoint: checkpoint1,
+        l1: new L1PublishedData(1n, BigInt(Math.floor(Date.now() / 1000)), Buffer32.random().toString()),
+        attestations: [CommitteeAttestation.random()],
+      });
+      await attestor.archiver.addCheckpoints([publishedCheckpoint1]);
+      await proposer.archiver.addCheckpoints([publishedCheckpoint1]);
+
+      // Sync proposer's world state before building next checkpoint
+      await proposer.synchronizer.syncImmediate(BlockNumber(2));
+
+      // Advance to slot 2
+      const slot2 = SlotNumber(2);
+      dateProvider.setTime(Number(getTimestampForSlot(slot2, l1Constants)) * 1000);
+      epochCache.setCurrentSlot(slot2);
+
+      // Build second checkpoint referencing the first
+      const { blocks: blocks2, proposal: proposal2 } = await buildCheckpoint(
+        CheckpointNumber(2),
+        slot2,
+        emptyL1ToL2Messages,
+        [checkpoint1.getCheckpointOutHash()],
+        BlockNumber(3),
+        2,
+        () => buildTxs(2),
+      );
+
+      await attestorValidateBlocks(blocks2);
+
+      const attestations = await attestor.validator.attestToCheckpointProposal(proposal2, mockPeerId);
+      expect(attestations).toBeDefined();
+      expect(attestations).toHaveLength(1);
+
+      // Verify all blocks are in archiver
+      await attestor.archiver.syncImmediate();
+      const attestorBlocks = await attestor.archiver.getBlocks(BlockNumber(1), 4);
+      expect(attestorBlocks.length).toBe(4);
+
+      const attestorBlockHashes = await Promise.all(attestorBlocks.map(b => b.header.hash()));
+      const expectedBlockHashes = await Promise.all([...blocks1, ...blocks2].map(b => b.block.header.hash()));
+      expect(attestorBlockHashes).toEqual(expectedBlockHashes);
+    });
+  });
+
+  describe('failure conditions', () => {
+    it('refuses to attest to checkpoint if not all block proposals were processed', async () => {
+      // Build 3 blocks but only validate 2
+      const { blocks, proposal } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        emptyL1ToL2Messages,
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        3,
+        () => buildTxs(2),
+      );
+
+      // Only validate first 2 blocks
+      await attestorValidateBlocks(blocks.slice(0, 2));
+
+      // Attestation should fail because block 3 wasn't validated
+      // The validator will timeout waiting for block with matching archive
+      const attestations = await attestor.validator.attestToCheckpointProposal(proposal, mockPeerId);
+      expect(attestations).toBeUndefined();
+    });
+
+    it('refuses to attest to checkpoint with archive mismatch', async () => {
+      const { blocks, checkpoint } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        emptyL1ToL2Messages,
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        2,
+        () => buildTxs(2),
+      );
+
+      // Create a checkpoint proposal with wrong archive root
+      const badProposal = await proposer.validator.createCheckpointProposal(
+        checkpoint.header,
+        Fr.random(), // Wrong archive root
+        undefined,
+        proposerSigner.address,
+      );
+
+      await attestorValidateBlocks(blocks);
+
+      // Attestation should fail because archive doesn't match any block
+      const attestations = await attestor.validator.attestToCheckpointProposal(badProposal, mockPeerId);
+      expect(attestations).toBeUndefined();
+    });
+
+    it('refuses block proposal with wrong slot', async () => {
+      const { blocks } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        emptyL1ToL2Messages,
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        1,
+        () => buildTxs(2),
+      );
+
+      // Advance time to slot 2 but keep the proposal from slot 1
+      const slot2 = SlotNumber(2);
+      dateProvider.setTime(Number(getTimestampForSlot(slot2, l1Constants)) * 1000);
+      epochCache.setCurrentSlot(slot2);
+
+      // Block proposal validator should reject the old proposal
+      const isValid = await attestor.validator.validateBlockProposal(blocks[0].proposal, mockPeerId);
+      expect(isValid).toBe(false);
+    });
+
+    it('refuses block proposal with mismatching l1 to l2 messages', async () => {
+      const l1ToL2Messages = makeInboxMessages(4, { messagesPerCheckpoint: 4 });
+      await proposer.archiver.dataStore.addL1ToL2Messages(l1ToL2Messages);
+
+      const otherL1ToL2Messages = makeInboxMessages(4, { messagesPerCheckpoint: 4 });
+      await attestor.archiver.dataStore.addL1ToL2Messages(otherL1ToL2Messages);
+
+      const { blocks } = await buildCheckpoint(
+        CheckpointNumber(1),
+        slotNumber,
+        l1ToL2Messages.map(m => m.leaf),
+        emptyPreviousCheckpointOutHashes,
+        BlockNumber(1),
+        1,
+        () => buildTxs(2),
+      );
+
+      // Advance time to slot 2 but keep the proposal from slot 1
+      const slot2 = SlotNumber(2);
+      dateProvider.setTime(Number(getTimestampForSlot(slot2, l1Constants)) * 1000);
+      epochCache.setCurrentSlot(slot2);
+
+      // Block proposal validator should reject the old proposal
+      const isValid = await attestor.validator.validateBlockProposal(blocks[0].proposal, mockPeerId);
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -18,7 +18,7 @@ import { RunningPromise } from '@aztec/foundation/running-promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { KeystoreManager } from '@aztec/node-keystore';
-import type { P2P, PeerId, TxProvider } from '@aztec/p2p';
+import type { P2P, PeerId } from '@aztec/p2p';
 import { AuthRequest, AuthResponse, BlockProposalValidator, ReqRespSubProtocol } from '@aztec/p2p';
 import { OffenseType, WANT_TO_SLASH_EVENT, type Watcher, type WatcherEmitter } from '@aztec/slasher';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -26,11 +26,12 @@ import type { CommitteeAttestationsAndSigners, L2Block, L2BlockSink, L2BlockSour
 import { getEpochAtSlot } from '@aztec/stdlib/epoch-helpers';
 import type {
   CreateCheckpointProposalLastBlockData,
+  ITxProvider,
   Validator,
   ValidatorClientFullConfig,
   WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
-import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
+import { type L1ToL2MessageSource, accumulateCheckpointOutHashes } from '@aztec/stdlib/messaging';
 import type {
   BlockProposal,
   BlockProposalOptions,
@@ -184,7 +185,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     p2pClient: P2P,
     blockSource: L2BlockSource & L2BlockSink,
     l1ToL2MessageSource: L1ToL2MessageSource,
-    txProvider: TxProvider,
+    txProvider: ITxProvider,
     keyStoreManager: KeystoreManager,
     blobClient: BlobClientInterface,
     dateProvider: DateProvider = new DateProvider(),
@@ -642,13 +643,17 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         return { isValid: false, reason: 'archive_mismatch' };
       }
 
-      // Check that the accumulated out hash matches the value in the proposal.
-      const computedOutHash = computedCheckpoint.getCheckpointOutHash();
-      const proposalOutHash = proposal.checkpointHeader.epochOutHash;
-      if (!computedOutHash.equals(proposalOutHash)) {
+      // Check that the accumulated epoch out hash matches the value in the proposal.
+      // The epoch out hash is the accumulated hash of all checkpoint out hashes in the epoch.
+      const checkpointOutHash = computedCheckpoint.getCheckpointOutHash();
+      const computedEpochOutHash = accumulateCheckpointOutHashes([...previousCheckpointOutHashes, checkpointOutHash]);
+      const proposalEpochOutHash = proposal.checkpointHeader.epochOutHash;
+      if (!computedEpochOutHash.equals(proposalEpochOutHash)) {
         this.log.warn(`Epoch out hash mismatch`, {
-          proposalOutHash: proposalOutHash.toString(),
-          computedOutHash: computedOutHash.toString(),
+          proposalEpochOutHash: proposalEpochOutHash.toString(),
+          computedEpochOutHash: computedEpochOutHash.toString(),
+          checkpointOutHash: checkpointOutHash.toString(),
+          previousCheckpointOutHashes: previousCheckpointOutHashes.map(h => h.toString()),
           ...proposalInfo,
         });
         return { isValid: false, reason: 'out_hash_mismatch' };
@@ -739,7 +744,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     archive: Fr,
     txs: Tx[],
     proposerAddress: EthAddress | undefined,
-    options: BlockProposalOptions,
+    options: BlockProposalOptions = {},
   ): Promise<BlockProposal> {
     // TODO(palla/mbps): Prevent double proposals properly
     // if (this.previousProposal?.slotNumber === blockHeader.globalVariables.slotNumber) {
@@ -771,7 +776,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     archive: Fr,
     lastBlockInfo: CreateCheckpointProposalLastBlockData | undefined,
     proposerAddress: EthAddress | undefined,
-    options: CheckpointProposalOptions,
+    options: CheckpointProposalOptions = {},
   ): Promise<CheckpointProposal> {
     this.log.info(`Assembling checkpoint proposal for slot ${checkpointHeader.slotNumber}`);
     return await this.validationService.createCheckpointProposal(

--- a/yarn-project/validator-client/tsconfig.json
+++ b/yarn-project/validator-client/tsconfig.json
@@ -53,6 +53,12 @@
     },
     {
       "path": "../validator-ha-signer"
+    },
+    {
+      "path": "../archiver"
+    },
+    {
+      "path": "../world-state"
     }
   ],
   "include": ["src"]

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -2262,6 +2262,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/validator-client@workspace:validator-client"
   dependencies:
+    "@aztec/archiver": "workspace:^"
     "@aztec/blob-client": "workspace:^"
     "@aztec/blob-lib": "workspace:^"
     "@aztec/constants": "workspace:^"
@@ -2278,6 +2279,7 @@ __metadata:
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/validator-ha-signer": "workspace:^"
+    "@aztec/world-state": "workspace:^"
     "@electric-sql/pglite": "npm:^0.3.14"
     "@jest/globals": "npm:^30.0.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
- Adds a new integration tests for the validator client that tests building and validating blocks within a checkpoint, and attesting to a checkpoint proposal
- Fixes `block_proposal_handler` slot validation to allow multiple blocks in the same slot (checkpoint model)
- Fixes `block_proposal_handler` to call `syncImmediate` on world-state before attempting to re-execute
- Fixes validator epoch out hash computation to use accumulated hash instead of checkpoint out hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)