### PR TITLE
fix: n_tps fix for larger wallet count

### DIFF
--- a/yarn-project/end-to-end/src/spartan/n_tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps.test.ts
@@ -223,18 +223,6 @@ describe('sustained N TPS test', () => {
       benchScenario: process.env.BENCH_SCENARIO,
     });
     const spartanDir = `${getGitProjectRoot()}/spartan`;
-    logger.info('Installing chaos mesh chart', {
-      name: CHAOS_MESH_NAME,
-      namespace: config.NAMESPACE,
-      valuesFile: 'network-requirements.yaml',
-    });
-    const chaosMeshInstallation = installChaosMeshChart({
-      logger,
-      targetNamespace: config.NAMESPACE,
-      instanceName: CHAOS_MESH_NAME,
-      valuesFile: 'network-requirements.yaml',
-      helmChartDir: getChartDir(spartanDir, 'aztec-chaos-scenarios'),
-    });
 
     const rpcEndpoint = await getRPCEndpoint(config.NAMESPACE);
     endpoints.push(rpcEndpoint);
@@ -294,9 +282,23 @@ describe('sustained N TPS test', () => {
       .deployed();
     logger.info('Benchmark contract deployed', { address: benchmarkContract.address.toString() });
 
-    logger.info(`Awaiting chaos mesh installation`);
-    await chaosMeshInstallation;
+    logger.info('Installing chaos mesh chart', {
+      name: CHAOS_MESH_NAME,
+      namespace: config.NAMESPACE,
+      valuesFile: 'network-requirements.yaml',
+    });
+    await installChaosMeshChart({
+      logger,
+      targetNamespace: config.NAMESPACE,
+      instanceName: CHAOS_MESH_NAME,
+      valuesFile: 'network-requirements.yaml',
+      helmChartDir: getChartDir(spartanDir, 'aztec-chaos-scenarios'),
+    });
     logger.info('Chaos mesh installation complete');
+
+    logger.info('Waiting for network to stabilize after chaos mesh installation...');
+    await sleep(30 * 1000);
+    logger.info('Network stabilization wait complete');
 
     logger.info(`Test setup complete`);
   });

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -116,6 +116,56 @@ export async function deploySponsoredTestAccountsWithTokens(
   };
 }
 
+async function deployAccountWithDiagnostics(
+  account: { getDeployMethod: () => Promise<{ send: (opts: any) => any }>; address: any },
+  paymentMethod: SponsoredFeePaymentMethod,
+  aztecNode: AztecNode,
+  logger: Logger,
+  accountLabel: string,
+): Promise<void> {
+  const deployMethod = await account.getDeployMethod();
+  const sentTx = deployMethod.send({ from: AztecAddress.ZERO, fee: { paymentMethod } });
+  const txHash = await sentTx.getTxHash();
+
+  try {
+    await sentTx.wait({ timeout: 2400 });
+    logger.info(`${accountLabel} deployed at ${account.address}`);
+  } catch (error) {
+    const blockNumber = await aztecNode.getBlockNumber();
+    let receipt;
+    try {
+      receipt = await aztecNode.getTxReceipt(txHash);
+    } catch {
+      receipt = 'unavailable';
+    }
+    logger.error(`${accountLabel} deployment failed`, {
+      txHash: txHash.toString(),
+      receipt: JSON.stringify(receipt),
+      currentBlockNumber: blockNumber,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+async function deployAccountsInBatches(
+  accounts: { getDeployMethod: () => Promise<{ send: (opts: any) => any }>; address: any }[],
+  paymentMethod: SponsoredFeePaymentMethod,
+  aztecNode: AztecNode,
+  logger: Logger,
+  labelPrefix: string,
+  batchSize = 2,
+): Promise<void> {
+  for (let i = 0; i < accounts.length; i += batchSize) {
+    const batch = accounts.slice(i, i + batchSize);
+    await Promise.all(
+      batch.map((account, idx) =>
+        deployAccountWithDiagnostics(account, paymentMethod, aztecNode, logger, `${labelPrefix}${i + idx + 1}`),
+      ),
+    );
+  }
+}
+
 export async function deploySponsoredTestAccounts(
   wallet: TestWallet,
   aztecNode: AztecNode,
@@ -129,15 +179,9 @@ export async function deploySponsoredTestAccounts(
   await registerSponsoredFPC(wallet);
 
   const paymentMethod = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
-  const recipientDeployMethod = await recipientAccount.getDeployMethod();
-  await recipientDeployMethod.send({ from: AztecAddress.ZERO, fee: { paymentMethod } }).wait({ timeout: 2400 });
-  await Promise.all(
-    fundedAccounts.map(async a => {
-      const deployMethod = await a.getDeployMethod();
-      await deployMethod.send({ from: AztecAddress.ZERO, fee: { paymentMethod } }).wait({ timeout: 2400 }); // increase timeout on purpose in order to account for two empty epochs
-      logger.info(`Account deployed at ${a.address}`);
-    }),
-  );
+
+  await deployAccountWithDiagnostics(recipientAccount, paymentMethod, aztecNode, logger, 'Recipient account');
+  await deployAccountsInBatches(fundedAccounts, paymentMethod, aztecNode, logger, 'Funded account ', 2);
 
   return {
     aztecNode,


### PR DESCRIPTION
n_tps benchmark failed (again) for the `low_tps=2` [scenario](http://ci.aztec-labs.com/0a6933c1d859c05e). 
[Other scenarios](http://ci.aztec-labs.com/191edec389f40851) were successful. 

Logs imply that we were unable to fund 3 wallets, and the timeout kicked in. As per logs, there isa  +40min delay between sending txs and test timing up. 

```
06:25:41 [06:25:41.842] INFO: pxe:service Added contract SponsoredFPC at 0x2bce99adc7f9ecce287253249ed7e662502e28f7778ae5fd021a4475b51051c9 with class 0x20c546ed52e5d4163665e7a0c62453361c202a96c65e8ce60585415e6a628169
06:25:41 [06:25:41.899] INFO: pxe:service Added contract SponsoredFPC at 0x2bce99adc7f9ecce287253249ed7e662502e28f7778ae5fd021a4475b51051c9 with class 0x20c546ed52e5d4163665e7a0c62453361c202a96c65e8ce60585415e6a628169
06:25:41 [06:25:41.955] INFO: pxe:service Added contract SponsoredFPC at 0x2bce99adc7f9ecce287253249ed7e662502e28f7778ae5fd021a4475b51051c9 with class 0x20c546ed52e5d4163665e7a0c62453361c202a96c65e8ce60585415e6a628169
06:25:42 [06:25:42.012] INFO: e2e:k8s-utils command: kubectl delete workflownodes -l app.kubernetes.io/instance=network-shaping -n nightly-bench --ignore-not-found=true --wait=true --timeout=5m 
06:25:42 [06:25:42.263] INFO: e2e:k8s-utils helm command: helm upgrade --install network-shaping /home/aztec-dev/aztec-packages/spartan/aztec-chaos-scenarios --namespace nightly-bench --values /home/aztec-dev/aztec-packages/spartan/aztec-chaos-scenarios/values/network-requirements.yaml  --wait --timeout=10m --set-string global.targetNamespace='nightly-bench'
06:25:47 [06:25:47.602] INFO: wallet-sdk:base_wallet Sent transaction 0x0236134097869cca7dd866f358076b262eb5ef155ce423dbdf0e32ad2e9931a6
06:25:48 [06:25:48.095] INFO: wallet-sdk:base_wallet Sent transaction 0x1bc3577b8b12e27150f008044e7418597fef2d6c62e88102ed5f8e4bd0e87da5
06:25:48 [06:25:48.137] INFO: wallet-sdk:base_wallet Sent transaction 0x24b7bb256f4b493c3b5469cc0473d3e95a87db06fe17bf918fc9e084da42eed5
07:05:47 [07:05:47.671] INFO: e2e:spartan-test:sustained-tps Collecting benchmark metrics and cleaning up...
```

Changes:
1. Moved chaos mesh installation after the account deployments 
2. Batched account deployments 
3. Added more logs when deploying accounts 
