### PR TITLE
chore: temporarily bump up github actions time-out 

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -122,6 +122,7 @@ jobs:
   # This task runs against a real testnet deployment. This uses resources on GCP (not AWS, thank free credit incentives).
   ci-network-scenario:
     runs-on: ubuntu-latest
+    timeout-minutes: 540
     # We either run after a release (tag starting with v), or when the ci-network-scenario label is present in a PR.
     # We exclude ci-release-pr test tags (v0.0.1-commit.*) which are only for testing the release process.
     needs: ci

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   deploy-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 540
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Currently github actions is stopping the scenario tests at 6 hours, we need to bump to 9 to run everything

- match aws shutdown time of 540 minutes for both ci3 and network test workflow.

