### PR TITLE
chore: optimize as_str_quote

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -95,20 +95,17 @@ impl AsStrQuote for Quoted {
     // Used to convert an arbitrary quoted type into a quoted string, removing whitespace between tokens
     comptime fn as_str_quote(self) -> (Quoted, u32) {
         let tokens = self.tokens();
-        let mut acc: [u8] = @[];
-        let mut total_len: u32 = 0;
+        let mut string = CtString::new();
         for token in tokens {
             let token_as_fmt_str = f"{token}";
-            let token_as_str = unquote!(quote {$token_as_fmt_str});
-            let token_len = unquote!(quote { $token_as_str.as_bytes().len() });
-            let token_as_bytes = unquote!(quote { $token_as_str.as_bytes().as_vector() });
-            total_len += token_len;
-            acc = acc.append(token_as_bytes);
+            string = string.append_fmtstr(token_as_fmt_str);
         }
+        let string: str<_> = string.as_quoted_str!();
+        let array = string.as_bytes();
+        let total_len = array.len();
         let result = unquote!(
             quote {
-                let signature_as_array: [u8; $total_len] = $acc.as_array();
-                signature_as_array.as_str_unchecked()
+                string
             },
         );
         (quote { $result }, total_len)


### PR DESCRIPTION
`nargo check` on token_contract takes around 1.5 seconds on my machine. With some custom profiling of comptime code I found that as_str_quote took 400ms (across all invocations). This PR provides a more efficient way to implement it. This brings down the time for `nargo check` on token_contract to around 1.1 seconds. It's not much, but for LSP it's noticeable. And, well, this should make compiling any contract a bit faster. 

Note: I _think_ the new implementation is correct, but I'm not sure. It would maybe be nice to have some tests for this function.