### PR TITLE
refactor: clarifying state sync naming

### DIFF
--- a/boxes/boxes/react/src/pages/contract.tsx
+++ b/boxes/boxes/react/src/pages/contract.tsx
@@ -3,7 +3,7 @@ import { Contract } from '@aztec/aztec.js/contracts';
 import { FunctionType } from '@aztec/stdlib/abi';
 import { useNumber } from '../hooks/useNumber';
 
-const IGNORE_FUNCTIONS = ['constructor', 'sync_private_state'];
+const IGNORE_FUNCTIONS = ['constructor', 'sync_state'];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);

--- a/boxes/boxes/vite/src/pages/contract.tsx
+++ b/boxes/boxes/vite/src/pages/contract.tsx
@@ -3,7 +3,7 @@ import { Contract } from "@aztec/aztec.js/contracts";
 import { FunctionType } from "@aztec/aztec.js/abi";
 import { useNumber } from "../hooks/useNumber";
 
-const IGNORE_FUNCTIONS = ["constructor", "sync_private_state"];
+const IGNORE_FUNCTIONS = ["constructor", "sync_state"];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -16,7 +16,7 @@ use crate::macros::{
 };
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
-/// the `sync_private_state` utility function.
+/// the `sync_state` utility function.
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     // Functions that don't have #[external(...)], #[contract_library_method], or #[test] are not allowed in contracts.
@@ -34,9 +34,8 @@ pub comptime fn aztec(m: Module) -> Quoted {
     // We generate ABI exports for all the external functions in the contract.
     let fn_abi_exports = create_fn_abi_exports(m);
 
-    // We generate `_compute_note_hash_and_nullifier`, `sync_private_state` and `process_message`
-    // functions only if they are not already implemented. If they are implemented we just insert empty
-    // quotes.
+    // We generate `_compute_note_hash_and_nullifier`, `sync_state` and `process_message` functions only if they are
+    // not already implemented. If they are implemented we just insert empty quotes.
     let contract_library_method_compute_note_hash_and_nullifier = if !m.functions().any(|f| {
         f.name() == quote { _compute_note_hash_and_nullifier }
     }) {
@@ -44,10 +43,10 @@ pub comptime fn aztec(m: Module) -> Quoted {
     } else {
         quote {}
     };
-    let sync_private_state_fn_and_abi_export = if !m.functions().any(|f| {
-        f.name() == quote { sync_private_state }
+    let sync_state_fn_and_abi_export = if !m.functions().any(|f| {
+        f.name() == quote { sync_state }
     }) {
-        generate_sync_private_state()
+        generate_sync_state()
     } else {
         quote {}
     };
@@ -69,7 +68,7 @@ pub comptime fn aztec(m: Module) -> Quoted {
         $fn_abi_exports
         $contract_library_method_compute_note_hash_and_nullifier
         $public_dispatch
-        $sync_private_state_fn_and_abi_export
+        $sync_state_fn_and_abi_export
         $process_message_fn_and_abi_export
     }
 }
@@ -231,9 +230,9 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
             /// (non-siloed) and inner nullifier (non-siloed) assuming the note has been inserted into the note hash
             /// tree with `note_nonce`.
             ///
-            /// The signature of this function notably matches the `aztec::messages::discovery::ComputeNoteHashAndNullifier` type,
-            /// and so it can be used to call functions from that module such as `discover_new_messages`, 
-            /// `do_process_message` and `attempt_note_discovery`.
+            /// The signature of this function notably matches the
+            /// `aztec::messages::discovery::ComputeNoteHashAndNullifier` type, and so it can be used to call functions
+            /// from that module such as `do_sync_state` and `attempt_note_discovery`.
             ///
             /// This function is automatically injected by the `#[aztec]` macro.
             #[contract_library_method]
@@ -276,20 +275,20 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
     }
 }
 
-comptime fn generate_sync_private_state() -> Quoted {
+comptime fn generate_sync_state() -> Quoted {
     quote {
-        pub struct sync_private_state_parameters {}
+        pub struct sync_state_parameters {}
 
         #[abi(functions)]
-        pub struct sync_private_state_abi {
-            parameters: sync_private_state_parameters,
+        pub struct sync_state_abi {
+            parameters: sync_state_parameters,
         }
 
         #[aztec::macros::internals_functions_generation::abi_attributes::abi_utility]
-        unconstrained fn sync_private_state() {
+        unconstrained fn sync_state() {
             let address = aztec::context::UtilityContext::new().this_address();
             
-            aztec::messages::discovery::discover_new_messages(address, _compute_note_hash_and_nullifier);
+            aztec::messages::discovery::do_sync_state(address, _compute_note_hash_and_nullifier);
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -12,7 +12,7 @@ use crate::{
         logs::note::MAX_NOTE_PACKED_LEN,
         processing::{
             get_private_logs, pending_tagged_log::PendingTaggedLog,
-            validate_enqueued_notes_and_events,
+            validate_and_store_enqueued_notes_and_events,
         },
     },
     utils::array,
@@ -62,20 +62,21 @@ pub struct NoteHashAndNullifier {
 /// ```
 pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /* owner */ AztecAddress, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /* randomness */ Field, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 
-/// Performs the message discovery process, in which private logs are downloaded and inspected to find new private
+/// Performs the state synchronization process, in which private logs are downloaded and inspected to find new private
 /// notes, partial notes and events, etc., and pending partial notes are processed to search for their completion logs.
 /// This is the mechanism via which a contract updates its knowledge of its private state.
 ///
-/// Note that the state is synchronized up to the latest block synchronized by PXE. That should be close to the chain
-/// tip as block synchronization is performed before contract function simulation is done.
+/// Note that the state is synchronized up to the latest block synchronized by PXE (referred to as "anchor block").
+/// That should be close to the chain tip as block synchronization is performed before contract function simulation is
+/// done.
 ///
 /// Receives the address of the contract on which discovery is performed along with its
 /// `compute_note_hash_and_nullifier` function.
-pub unconstrained fn discover_new_messages<Env>(
+pub unconstrained fn do_sync_state<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
 ) {
-    debug_log("Performing message discovery");
+    debug_log("Performing state synchronization");
 
     // First we process all private logs, which can contain different kinds of messages e.g. private notes, partial
     // notes, private events, etc.
@@ -107,5 +108,5 @@ pub unconstrained fn discover_new_messages<Env>(
 
     // Finally we validate all notes and events that were found as part of the previous processes, resulting in them
     // being added to PXE's database and retrievable via oracles (get_notes) and our TS API (PXE::getPrivateEvents).
-    validate_enqueued_notes_and_events(contract_address);
+    validate_and_store_enqueued_notes_and_events(contract_address);
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -162,7 +162,7 @@ impl MessageEncryption for AES128 {
         recipient: AztecAddress,
     ) -> [Field; MESSAGE_CIPHERTEXT_LEN] {
         // AES 128 operates on bytes, not fields, so we need to convert the fields to bytes.
-        // (This process is then reversed when processing the message in `do_process_message`)
+        // (This process is then reversed when processing the message in `process_message_ciphertext`)
         let plaintext_bytes = fields_to_bytes(plaintext);
 
         // *****************************************************************************

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
@@ -1,8 +1,9 @@
 use crate::{event::EventSelector, messages::logs::event::MAX_EVENT_SERIALIZED_LEN};
 use protocol_types::{address::AztecAddress, traits::Serialize};
 
-/// Intermediate struct used to perform batch event validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle
-/// expects for values of this type to be stored in a `CapsuleArray` at the given `base_slot`.
+/// Intermediate struct used to perform batch event validation by PXE. The
+/// `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in
+/// a `CapsuleArray` at the given `base_slot`.
 #[derive(Serialize)]
 pub(crate) struct EventValidationRequest {
     pub contract_address: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -61,9 +61,9 @@ pub(crate) unconstrained fn get_private_logs(
 /// via `get_notes` oracle. The note will be scoped to `contract_address`, meaning other contracts will not be able to
 /// access it unless authorized.
 ///
-/// In order for the note validation and insertion to occur, `validate_enqueued_notes_and_events` must be later called.
-/// For optimal performance, accumulate as many note validation requests as possible and then validate them all at the
-/// end (which results in PXE minimizing the number of network round-trips).
+/// In order for the note validation and insertion to occur, `validate_and_store_enqueued_notes_and_events` must be
+/// later called. For optimal performance, accumulate as many note validation requests as possible and then validate
+/// them all at the end (which results in PXE minimizing the number of network round-trips).
 ///
 /// The `packed_note` is what `getNotes` will later return. PXE indexes notes by `storage_slot`, so this value
 /// is typically used to filter notes that correspond to different state variables. `note_hash` and `nullifier` are
@@ -111,9 +111,9 @@ pub(crate) unconstrained fn enqueue_note_for_validation(
 /// Enqueues an event for validation by PXE, so that it can be efficiently validated and then inserted into the event
 /// store.
 ///
-/// In order for the event validation and insertion to occur, `validate_enqueued_notes_and_events` must be later
-/// called. For optimal performance, accumulate as many event validation requests as possible and then validate them
-/// all at the end (which results in PXE minimizing the number of network round-trips).
+/// In order for the event validation and insertion to occur, `validate_and_store_enqueued_notes_and_events` must be
+/// later called. For optimal performance, accumulate as many event validation requests as possible and then validate
+/// them all at the end (which results in PXE minimizing the number of network round-trips).
 pub(crate) unconstrained fn enqueue_event_for_validation(
     contract_address: AztecAddress,
     event_type_id: EventSelector,
@@ -143,8 +143,10 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
 /// queryable via `get_notes` oracle and our TS API (PXE::getPrivateEvents).
 ///
 /// This automatically clears both validation request queues, so no further work needs to be done by the caller.
-pub(crate) unconstrained fn validate_enqueued_notes_and_events(contract_address: AztecAddress) {
-    oracle::message_processing::validate_enqueued_notes_and_events(
+pub(crate) unconstrained fn validate_and_store_enqueued_notes_and_events(
+    contract_address: AztecAddress,
+) {
+    oracle::message_processing::validate_and_store_enqueued_notes_and_events(
         contract_address,
         NOTE_VALIDATION_REQUESTS_ARRAY_BASE_SLOT,
         EVENT_VALIDATION_REQUESTS_ARRAY_BASE_SLOT,

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
@@ -1,8 +1,9 @@
 use crate::messages::logs::note::MAX_NOTE_PACKED_LEN;
 use protocol_types::{address::AztecAddress, traits::Serialize};
 
-/// Intermediate struct used to perform batch note validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle
-/// expects for values of this type to be stored in a `CapsuleArray`.
+/// Intermediate struct used to perform batch note validation by PXE. The
+/// `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in
+/// a `CapsuleArray`.
 #[derive(Serialize)]
 pub(crate) struct NoteValidationRequest {
     pub contract_address: AztecAddress,

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -11,20 +11,20 @@ unconstrained fn fetch_tagged_logs_oracle(pending_tagged_log_array_base_slot: Fi
 
 // This must be a single oracle and not one for notes and one for events because the entire point is to validate
 // all notes and events in one go, minimizing node round-trips.
-pub(crate) unconstrained fn validate_enqueued_notes_and_events(
+pub(crate) unconstrained fn validate_and_store_enqueued_notes_and_events(
     contract_address: AztecAddress,
     note_validation_requests_array_base_slot: Field,
     event_validation_requests_array_base_slot: Field,
 ) {
-    validate_enqueued_notes_and_events_oracle(
+    validate_and_store_enqueued_notes_and_events_oracle(
         contract_address,
         note_validation_requests_array_base_slot,
         event_validation_requests_array_base_slot,
     );
 }
 
-#[oracle(utilityValidateEnqueuedNotesAndEvents)]
-unconstrained fn validate_enqueued_notes_and_events_oracle(
+#[oracle(utilityValidateAndStoreEnqueuedNotesAndEvents)]
+unconstrained fn validate_and_store_enqueued_notes_and_events_oracle(
     contract_address: AztecAddress,
     note_validation_requests_array_base_slot: Field,
     event_validation_requests_array_base_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called and
 /// if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 8;
+pub global ORACLE_VERSION: Field = 9;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -18,7 +18,7 @@ use crate::{
         },
         encoding::MESSAGE_PLAINTEXT_LEN,
         logs::{event::encode_private_event_message, note::encode_private_note_message},
-        processing::{MessageContext, validate_enqueued_notes_and_events},
+        processing::{MessageContext, validate_and_store_enqueued_notes_and_events},
     },
     note::{
         HintedNote,
@@ -947,7 +947,7 @@ impl TestEnvironment {
                 message_context,
             );
 
-            validate_enqueued_notes_and_events(context.this_address());
+            validate_and_store_enqueued_notes_and_events(context.this_address());
         });
     }
 }

--- a/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 // in a simulation. This avoids the need of generating real signatures during simulation.
 // It will also consider all authwits sent to it as valid and emit the hash in an offchain effect
 // for later verification. In order to properly mimic our account contract it imports the PublickKeyNote
-// struct so the #[aztec] macro can generate a `sync_private_state` implementation that can process the *real*
+// struct so the #[aztec] macro can generate a `sync_state` implementation that can process the *real*
 // public key of the overridden contract
 #[aztec]
 pub contract SimulatedAccount {
@@ -39,9 +39,9 @@ pub contract SimulatedAccount {
         true
     }
 
-    /// Since this contract normally emulates an account that uses a note to store the public key,
-    /// we completely bypass message discovery here to avoid losing time on useless processing
-    /// and also enabling the emulation of different accounts with differently sized public key notes.
+    /// Since this contract normally emulates an account that uses a note to store the public key, we completely bypass
+    /// state synchronization here to avoid losing time on useless processing and also enabling the emulation of
+    /// different accounts with differently sized public key notes.
     #[external("utility")]
-    unconstrained fn sync_private_state() {}
+    unconstrained fn sync_state() {}
 }

--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -159,7 +159,7 @@ const deployedContractCss = css({
   },
 });
 
-const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_private_state', 'public_dispatch'];
+const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_state', 'public_dispatch'];
 
 export function ContractComponent() {
   const [currentContract, setCurrentContract] = useState<Contract | null>(null);

--- a/playground/src/constants.ts
+++ b/playground/src/constants.ts
@@ -7,7 +7,7 @@ export const PREDEFINED_CONTRACTS = {
   CUSTOM_UPLOAD: 'custom_upload',
 };
 
-export const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_private_state', 'public_dispatch'];
+export const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_state', 'public_dispatch'];
 
 export const TX_TIMEOUT = 180;
 

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/event_validation_request.ts
@@ -8,7 +8,7 @@ import { TxHash } from '@aztec/stdlib/tx';
 const MAX_EVENT_SERIALIZED_LEN = 12;
 
 /**
- * Intermediate struct used to perform batch event validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle
+ * Intermediate struct used to perform batch event validation by PXE. The `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle
  * expects for values of this type to be stored in a `CapsuleArray`.
  */
 export class EventValidationRequest {

--- a/yarn-project/pxe/src/contract_function_simulator/noir-structs/note_validation_request.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/noir-structs/note_validation_request.ts
@@ -7,7 +7,7 @@ import { TxHash } from '@aztec/stdlib/tx';
 export const MAX_NOTE_PACKED_LEN = 10;
 
 /**
- * Intermediate struct used to perform batch note validation by PXE. The `utilityValidateEnqueuedNotesAndEvents` oracle
+ * Intermediate struct used to perform batch note validation by PXE. The `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle
  * expects for values of this type to be stored in a `CapsuleArray`.
  */
 export class NoteValidationRequest {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -117,7 +117,7 @@ export interface IUtilityExecutionOracle {
     numberOfElements: number,
   ): Promise<Fr[]>;
   utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr): Promise<void>;
-  utilityValidateEnqueuedNotesAndEvents(
+  utilityValidateAndStoreEnqueuedNotesAndEvents(
     contractAddress: AztecAddress,
     noteValidationRequestsArrayBaseSlot: Fr,
     eventValidationRequestsArrayBaseSlot: Fr,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -491,12 +491,12 @@ export class Oracle {
     return [];
   }
 
-  async utilityValidateEnqueuedNotesAndEvents(
+  async utilityValidateAndStoreEnqueuedNotesAndEvents(
     [contractAddress]: ACVMField[],
     [noteValidationRequestsArrayBaseSlot]: ACVMField[],
     [eventValidationRequestsArrayBaseSlot]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityValidateEnqueuedNotesAndEvents(
+    await this.handlerAsUtility().utilityValidateAndStoreEnqueuedNotesAndEvents(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(noteValidationRequestsArrayBaseSlot),
       Fr.fromString(eventValidationRequestsArrayBaseSlot),

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -453,8 +453,8 @@ describe('Private Execution test suite', () => {
         returnTypes: functionArtifact.returnTypes,
       };
     });
-    contractStore.syncPrivateState.mockImplementation(async (contractAddress, _functionSelector, _executor) => {
-      await contractStore.getFunctionCall('sync_private_state', [], contractAddress);
+    contractStore.syncState.mockImplementation(async (contractAddress, _functionSelector, _executor) => {
+      await contractStore.getFunctionCall('sync_state', [], contractAddress);
     });
 
     capsuleStore.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
@@ -745,7 +745,7 @@ describe('Private Execution test suite', () => {
         contractAddress: parentAddress,
       });
 
-      expect(contractStore.getFunctionCall).toHaveBeenCalledWith('sync_private_state', [], childAddress);
+      expect(contractStore.getFunctionCall).toHaveBeenCalledWith('sync_state', [], childAddress);
     });
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -213,7 +213,7 @@ export async function ensureContractSynced(
   header: BlockHeader,
 ): Promise<void> {
   await Promise.all([
-    contractStore.syncPrivateState(contractAddress, functionToInvokeAfterSync, utilityExecutor),
+    contractStore.syncState(contractAddress, functionToInvokeAfterSync, utilityExecutor),
     verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
   ]);
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -381,7 +381,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param noteValidationRequestsArrayBaseSlot - The base slot of capsule array containing note validation requests.
    * @param eventValidationRequestsArrayBaseSlot - The base slot of capsule array containing event validation requests.
    */
-  public async utilityValidateEnqueuedNotesAndEvents(
+  public async utilityValidateAndStoreEnqueuedNotesAndEvents(
     contractAddress: AztecAddress,
     noteValidationRequestsArrayBaseSlot: Fr,
     eventValidationRequestsArrayBaseSlot: Fr,
@@ -403,7 +403,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
     const noteStorePromises = noteValidationRequests.map(request =>
-      noteService.storeNote(
+      noteService.validateAndStoreNote(
         request.contractAddress,
         request.owner,
         request.storageSlot,
@@ -419,7 +419,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
     const eventService = new EventService(this.anchorBlockStore, this.aztecNode, this.privateEventStore, this.jobId);
     const eventStorePromises = eventValidationRequests.map(request =>
-      eventService.storeEvent(
+      eventService.validateAndStoreEvent(
         request.contractAddress,
         request.eventTypeId,
         request.randomness,

--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -41,7 +41,7 @@ export class PXEDebugUtils {
     }
 
     // We need to manually trigger private state sync to have a guarantee that all the notes are available.
-    const call = await this.contractStore.getFunctionCall('sync_private_state', [], filter.contractAddress);
+    const call = await this.contractStore.getFunctionCall('sync_state', [], filter.contractAddress);
     await this.#pxe.simulateUtility(call);
 
     return this.noteStore.getNotes(filter, randomBytes(8).toString('hex'));

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -14,7 +14,7 @@ import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_sto
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 import { EventService } from './event_service.js';
 
-describe('storeEvent', () => {
+describe('validateAndStoreEvent', () => {
   let blockNumber: BlockNumber;
   let eventSelector: EventSelector;
   let randomness: Fr;
@@ -88,7 +88,7 @@ describe('storeEvent', () => {
       eventCommitment?: Fr;
     } = {},
   ) {
-    await eventService.storeEvent(
+    await eventService.validateAndStoreEvent(
       contractAddress,
       eventSelector,
       randomness,

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -16,7 +16,7 @@ export class EventService {
     private readonly jobId: string,
   ) {}
 
-  public async storeEvent(
+  public async validateAndStoreEvent(
     contractAddress: AztecAddress,
     selector: EventSelector,
     randomness: Fr,

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -197,7 +197,7 @@ describe('NoteService', () => {
     expect(getNotesSpy).toHaveBeenCalledWith(expect.objectContaining({ contractAddress }), 'test');
   });
 
-  describe('storeNote', () => {
+  describe('validateAndStoreNote', () => {
     // Recipient is different from the owner because recipient refers to the
     // recipient of the message containing the note, while owner refers to the
     // owner of the note.
@@ -270,7 +270,7 @@ describe('NoteService', () => {
     });
 
     it('should store note if it exists in a tx effect', async () => {
-      await noteService.storeNote(
+      await noteService.validateAndStoreNote(
         contractAddress,
         owner,
         storageSlot,
@@ -302,7 +302,7 @@ describe('NoteService', () => {
 
     it('should throw if tx hash does not exist', async () => {
       await expect(
-        noteService.storeNote(
+        noteService.validateAndStoreNote(
           contractAddress,
           owner,
           storageSlot,
@@ -319,7 +319,7 @@ describe('NoteService', () => {
 
     it('should throw if note was not emitted in the tx', async () => {
       await expect(
-        noteService.storeNote(
+        noteService.validateAndStoreNote(
           contractAddress,
           owner,
           storageSlot,
@@ -338,7 +338,7 @@ describe('NoteService', () => {
       await setSyncedBlockNumber(BlockNumber(blockNumber - 1));
 
       await expect(
-        noteService.storeNote(
+        noteService.validateAndStoreNote(
           contractAddress,
           owner,
           storageSlot,
@@ -365,7 +365,7 @@ describe('NoteService', () => {
         return Promise.resolve([undefined]);
       });
 
-      await noteService.storeNote(
+      await noteService.validateAndStoreNote(
         contractAddress,
         owner,
         storageSlot,

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -112,7 +112,7 @@ export class NoteService {
     await this.noteStore.applyNullifiers(foundNullifiers, this.jobId);
   }
 
-  public async storeNote(
+  public async validateAndStoreNote(
     contractAddress: AztecAddress,
     owner: AztecAddress,
     storageSlot: Fr,

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -4,9 +4,9 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-export const ORACLE_VERSION = 8;
+export const ORACLE_VERSION = 9;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant in this file and in
 /// `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'f13e672b47b84b54c43610e22559dd16fb12a74983af8b5a87a0d45dff31b330';
+export const ORACLE_INTERFACE_HASH = '9866cc52510acaef75a3d47a0ed501fd9ff92b9d53b2c8a88c8a3ffd04ced81f';

--- a/yarn-project/pxe/src/storage/contract_store/contract_store.ts
+++ b/yarn-project/pxe/src/storage/contract_store/contract_store.ts
@@ -318,22 +318,21 @@ export class ContractStore {
     };
   }
 
-  // Synchronize target contract data
-  public async syncPrivateState(
+  public async syncState(
     contractAddress: AztecAddress,
     functionToInvokeAfterSync: FunctionSelector | null,
     utilityExecutor: (privateSyncCall: FunctionCall) => Promise<any>,
   ) {
     // Protocol contracts don't have private state to sync
     if (!isProtocolContract(contractAddress)) {
-      const syncPrivateStateFunctionCall = await this.getFunctionCall('sync_private_state', [], contractAddress);
-      if (functionToInvokeAfterSync && functionToInvokeAfterSync.equals(syncPrivateStateFunctionCall.selector)) {
+      const syncStateFunctionCall = await this.getFunctionCall('sync_state', [], contractAddress);
+      if (functionToInvokeAfterSync && functionToInvokeAfterSync.equals(syncStateFunctionCall.selector)) {
         throw new Error(
-          'Forbidden `sync_private_state` invocation. `sync_private_state` can only be invoked by PXE, manual execution can lead to inconsistencies.',
+          'Forbidden `sync_state` invocation. `sync_state` can only be invoked by PXE, manual execution can lead to inconsistencies.',
         );
       }
 
-      return utilityExecutor(syncPrivateStateFunctionCall);
+      return utilityExecutor(syncStateFunctionCall);
     }
   }
 }

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -461,7 +461,7 @@ describe('NoteStore', () => {
     });
 
     // This test ensures applyNullifiers is idempotent: the same nullifier can be applied multiple times
-    // without error. This relaxes constraints on usage of NoteService#storeNote, which can then be
+    // without error. This relaxes constraints on usage of NoteService#validateAndStoreNote, which can then be
     // run concurrently in a Promise.all context without risking unnecessarily defensive checks failing.
     it('applying nullifier a second time is a no-op', async () => {
       await noteStore.applyNullifiers([mkNullifier(note1)], 'test'); // First application should succeed
@@ -477,7 +477,7 @@ describe('NoteStore', () => {
     });
 
     it('can nullify a freshly added note in the same job without committing first', async () => {
-      // This test simulates the storeNote flow where a note is added and immediately nullified
+      // This test simulates the validateAndStoreNote flow where a note is added and immediately nullified
       // without committing first (when the note is discovered to already be nullified on chain)
       const freshNullifier = Fr.random();
       const freshNote = await mkNote({
@@ -489,7 +489,7 @@ describe('NoteStore', () => {
       // Add note to stage without committing
       await noteStore.addNotes([freshNote], SCOPE_1, 'fresh-job');
 
-      // Immediately nullify it in the same job (simulating storeNote when nullifier exists on chain)
+      // Immediately nullify it in the same job (simulating validateAndStoreNote when nullifier exists on chain)
       const nullifiers = [mkNullifier(freshNote)];
       await expect(noteStore.applyNullifiers(nullifiers, 'fresh-job')).resolves.toEqual([freshNote]);
 
@@ -506,9 +506,9 @@ describe('NoteStore', () => {
       });
     });
 
-    it('can handle concurrent note additions and nullifications (simulating Promise.all in storeNote)', async () => {
-      // This test simulates the scenario in utilityValidateEnqueuedNotesAndEvents where
-      // multiple storeNote calls run concurrently via Promise.all
+    it('can handle concurrent note additions and nullifications (simulating Promise.all in validateAndStoreNote)', async () => {
+      // This test simulates the scenario in utilityValidateAndStoreEnqueuedNotesAndEvents where
+      // multiple validateAndStoreNote calls run concurrently via Promise.all
       const NOTE_COUNT = 100;
       const noteNullifiers = Array.from({ length: NOTE_COUNT }, () => Fr.random());
       const notes = await Promise.all(
@@ -517,7 +517,7 @@ describe('NoteStore', () => {
         ),
       );
 
-      // Simulate concurrent storeNote calls where each note is added and immediately nullified
+      // Simulate concurrent validateAndStoreNote calls where each note is added and immediately nullified
       const concurrentStoreNoteCalls = notes.map(async note => {
         await noteStore.addNotes([note], SCOPE_1, 'concurrent-job');
         const nullifiers = [mkNullifier(note)];
@@ -566,7 +566,7 @@ describe('NoteStore', () => {
     });
 
     it('handles duplicate note storage requests gracefully (same note added and nullified twice)', async () => {
-      // This scenario can happen during concurrent note store calls via Promise.all in storeNote
+      // This scenario can happen during concurrent note store calls via Promise.all in validateAndStoreNote
       // when the same note is somehow processed twice (e.g., duplicate log entries)
       const duplicateNullifier = new Fr(9999n);
       const duplicateNote = await mkNote({
@@ -580,14 +580,14 @@ describe('NoteStore', () => {
       await noteStore.applyNullifiers([mkNullifier(duplicateNote)], 'duplicate-job');
 
       // Second attempt to store (duplicate): try to add the same note again - should not throw
-      // This simulates what happens in concurrent storeNote calls when the same note is processed twice
+      // This simulates what happens in concurrent validateAndStoreNote calls when the same note is processed twice
       await noteStore.addNotes([duplicateNote], SCOPE_2, 'duplicate-job');
       const notesAfterSecondAttempt = await noteStore.getNotes(
         { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE, scopes: [SCOPE_1, SCOPE_2] },
         'duplicate-job',
       );
 
-      // Check that the second attempt at calling storeNote didn't accidentally overwrite the first one
+      // Check that the second attempt at calling validateAndStoreNote didn't accidentally overwrite the first one
       // (causing the note to be "re-activated")
       expect(notesAfterSecondAttempt.filter(n => n.siloedNullifier.equals(duplicateNullifier))).toEqual([]);
 

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -173,7 +173,7 @@ export class NoteStore implements StagedStore {
    * The operation is atomic - if any nullifier is not found, the entire operation fails and no notes are modified.
    *
    * applyNullifiers is idempotent: the same nullifier can be applied multiple times without error.
-   * This relaxes constraints on usage of NoteService#storeNote, which can then be run concurrently in a Promise.all
+   * This relaxes constraints on usage of NoteService#validateAndStoreNote, which can then be run concurrently in a Promise.all
    * context without risking unnecessarily defensive checks failing.
    *
    * @param nullifiers - Array of nullifiers with their block numbers to process
@@ -339,7 +339,7 @@ export class NoteStore implements StagedStore {
   /**
    * Functions run withJobLock are forced to wait for each other, i.e. if they share a `jobId`, they run serially
    * instead of concurrently. This is needed because staged data is stored in memory, and concurrent async operations
-   * (e.g., Promise.all in `storeNote`) could otherwise interleave and corrupt state.
+   * (e.g., Promise.all in `validateAndStoreNote`) could otherwise interleave and corrupt state.
    */
   async #withJobLock<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
     let lock = this.#jobLocks.get(jobId);

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -301,7 +301,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       await this.executeUtilityCall(call);
     };
 
-    await this.contractStore.syncPrivateState(targetContractAddress, functionSelector, utilityExecutor);
+    await this.contractStore.syncState(targetContractAddress, functionSelector, utilityExecutor);
 
     const blockNumber = await this.txeGetNextBlockNumber();
 
@@ -645,7 +645,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
 
     // Sync notes before executing utility function to discover notes from previous transactions
-    await this.contractStore.syncPrivateState(targetContractAddress, functionSelector, async call => {
+    await this.contractStore.syncState(targetContractAddress, functionSelector, async call => {
       await this.executeUtilityCall(call);
     });
 

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -688,7 +688,7 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
-  public async utilityValidateEnqueuedNotesAndEvents(
+  public async utilityValidateAndStoreEnqueuedNotesAndEvents(
     foreignContractAddress: ForeignCallSingle,
     foreignNoteValidationRequestsArrayBaseSlot: ForeignCallSingle,
     foreignEventValidationRequestsArrayBaseSlot: ForeignCallSingle,
@@ -697,7 +697,7 @@ export class RPCTranslator {
     const noteValidationRequestsArrayBaseSlot = fromSingle(foreignNoteValidationRequestsArrayBaseSlot);
     const eventValidationRequestsArrayBaseSlot = fromSingle(foreignEventValidationRequestsArrayBaseSlot);
 
-    await this.handlerAsUtility().utilityValidateEnqueuedNotesAndEvents(
+    await this.handlerAsUtility().utilityValidateAndStoreEnqueuedNotesAndEvents(
       contractAddress,
       noteValidationRequestsArrayBaseSlot,
       eventValidationRequestsArrayBaseSlot,


### PR DESCRIPTION
Doing renamings based on the [slack discussion](https://aztecprotocol.slack.com/archives/C07R3GTKJ49/p1769185724841299?thread_ts=1769160393.167349&cid=C07R3GTKJ49) from Friday.