### PR TITLE
refactor: moving around contract sync utils

### DIFF
--- a/yarn-project/pxe/src/bin/check_oracle_version.ts
+++ b/yarn-project/pxe/src/bin/check_oracle_version.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/no-named-as-default-member */
 import { keccak256String } from '@aztec/foundation/crypto/keccak';
 
 import { readFileSync } from 'fs';

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -453,9 +453,6 @@ describe('Private Execution test suite', () => {
         returnTypes: functionArtifact.returnTypes,
       };
     });
-    contractStore.syncState.mockImplementation(async (contractAddress, _functionSelector, _executor) => {
-      await contractStore.getFunctionCall('sync_state', [], contractAddress);
-    });
 
     capsuleStore.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));
 
@@ -718,7 +715,9 @@ describe('Private Execution test suite', () => {
       expect(result.returnValues).toEqual([new Fr(privateIncrement)]);
 
       // First fetch of the function artifact is the parent contract
-      expect(contractStore.getFunctionArtifact.mock.calls[1]).toEqual([childAddress, childSelector]);
+      // Second fetch is for sync_state on the child contract (calls[1])
+      // Third fetch is for the actual child function (calls[2])
+      expect(contractStore.getFunctionArtifact.mock.calls[2]).toEqual([childAddress, childSelector]);
       expect(result.nestedExecutionResults).toHaveLength(1);
       expect(result.nestedExecutionResults[0].returnValues).toEqual([new Fr(privateIncrement)]);
       expect(result.publicInputs.privateCallRequests.array[0].callContext).toEqual(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -2,7 +2,6 @@ import { PRIVATE_CIRCUIT_PUBLIC_INPUTS_LENGTH, PRIVATE_CONTEXT_INPUTS_LENGTH } f
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import {
   type ACVMWitness,
   type CircuitSimulator,
@@ -14,20 +13,14 @@ import {
 import {
   type FunctionArtifact,
   type FunctionArtifactWithContractName,
-  type FunctionCall,
   type FunctionSelector,
   countArgumentsSize,
 } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
-import type { ContractInstance } from '@aztec/stdlib/contract';
-import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '@aztec/stdlib/delayed-public-mutable';
-import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { PrivateCircuitPublicInputs } from '@aztec/stdlib/kernel';
 import type { CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
-import { BlockHeader, PrivateCallExecutionResult } from '@aztec/stdlib/tx';
+import { PrivateCallExecutionResult } from '@aztec/stdlib/tx';
 
-import { ContractStore } from '../../storage/contract_store/index.js';
 import { Oracle } from './oracle.js';
 import type { PrivateExecutionOracle } from './private_execution_oracle.js';
 
@@ -145,75 +138,4 @@ export function extractPrivateCircuitPublicInputs(
     returnData.push(Fr.fromString(returnedField));
   }
   return PrivateCircuitPublicInputs.fromFields(returnData);
-}
-
-/**
- * Read the current class id of a contract from the execution data provider or AztecNode. If not found, class id
- * from the instance is used.
- * @param contractAddress - The address of the contract to read the class id for.
- * @param instance - The instance of the contract.
- * @param aztecNode - The Aztec node to query for storage.
- * @param header - The header of the block at which to load the DelayedPublicMutable storing the class id.
- * @returns The current class id.
- */
-export async function readCurrentClassId(
-  contractAddress: AztecAddress,
-  instance: ContractInstance,
-  aztecNode: AztecNode,
-  header: BlockHeader,
-) {
-  const blockHashFr = await header.hash();
-  const blockHash = L2BlockHash.fromField(blockHashFr);
-  const timestamp = header.globalVariables.timestamp;
-  const { delayedPublicMutableSlot } = await DelayedPublicMutableValuesWithHash.getContractUpdateSlots(contractAddress);
-  const delayedPublicMutableValues = await DelayedPublicMutableValues.readFromTree(delayedPublicMutableSlot, slot =>
-    aztecNode.getPublicStorageAt(blockHash, ProtocolContractAddress.ContractInstanceRegistry, slot),
-  );
-  let currentClassId = delayedPublicMutableValues.svc.getCurrentAt(timestamp)[0];
-  if (currentClassId.isZero()) {
-    currentClassId = instance.originalContractClassId;
-  }
-  return currentClassId;
-}
-
-/**
- * Verify that the current class id of a contract obtained from AztecNode is the same as the one in contract data
- * provider (i.e. PXE's own storage).
- * @param header - The header of the block at which to verify the current class id.
- */
-async function verifyCurrentClassId(
-  contractAddress: AztecAddress,
-  aztecNode: AztecNode,
-  contractStore: ContractStore,
-  header: BlockHeader,
-) {
-  const instance = await contractStore.getContractInstance(contractAddress);
-  if (!instance) {
-    throw new Error(`No contract instance found for address ${contractAddress.toString()}`);
-  }
-
-  const currentClassId = await readCurrentClassId(contractAddress, instance, aztecNode, header);
-  if (!instance.currentContractClassId.equals(currentClassId)) {
-    throw new Error(
-      `Contract ${contractAddress} is outdated, current class id is ${currentClassId}, local class id is ${instance.currentContractClassId}`,
-    );
-  }
-}
-
-/**
- * Ensures the contract's private state is synchronized and that the PXE holds the current class artifact for
- * the contract.
- */
-export async function ensureContractSynced(
-  contractAddress: AztecAddress,
-  functionToInvokeAfterSync: FunctionSelector | null,
-  utilityExecutor: (call: FunctionCall) => Promise<any>,
-  aztecNode: AztecNode,
-  contractStore: ContractStore,
-  header: BlockHeader,
-): Promise<void> {
-  await Promise.all([
-    contractStore.syncState(contractAddress, functionToInvokeAfterSync, utilityExecutor),
-    verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
-  ]);
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -31,6 +31,7 @@ import {
   type TxContext,
 } from '@aztec/stdlib/tx';
 
+import { ensureContractSynced } from '../../contract_sync/index.js';
 import { NoteService } from '../../notes/note_service.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { AnchorBlockStore } from '../../storage/anchor_block_store/anchor_block_store.js';
@@ -47,7 +48,7 @@ import { ExecutionTaggingIndexCache } from '../execution_tagging_index_cache.js'
 import type { HashedValuesCache } from '../hashed_values_cache.js';
 import { pickNotes } from '../pick_notes.js';
 import type { IPrivateExecutionOracle, NoteData } from './interfaces.js';
-import { ensureContractSynced, executePrivateFunction } from './private_execution.js';
+import { executePrivateFunction } from './private_execution.js';
 import { UtilityExecutionOracle } from './utility_execution_oracle.js';
 
 /**

--- a/yarn-project/pxe/src/contract_sync/index.ts
+++ b/yarn-project/pxe/src/contract_sync/index.ts
@@ -1,0 +1,100 @@
+import { ProtocolContractAddress, isProtocolContract } from '@aztec/protocol-contracts';
+import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
+import type { ContractInstance } from '@aztec/stdlib/contract';
+import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '@aztec/stdlib/delayed-public-mutable';
+import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import type { BlockHeader } from '@aztec/stdlib/tx';
+
+import type { ContractStore } from '../storage/contract_store/contract_store.js';
+
+/**
+ * Read the current class id of a contract from the execution data provider or AztecNode. If not found, class id
+ * from the instance is used.
+ * @param contractAddress - The address of the contract to read the class id for.
+ * @param instance - The instance of the contract.
+ * @param aztecNode - The Aztec node to query for storage.
+ * @param header - The header of the block at which to load the DelayedPublicMutable storing the class id.
+ * @returns The current class id.
+ */
+export async function readCurrentClassId(
+  contractAddress: AztecAddress,
+  instance: ContractInstance,
+  aztecNode: AztecNode,
+  header: BlockHeader,
+) {
+  const blockHashFr = await header.hash();
+  const blockHash = L2BlockHash.fromField(blockHashFr);
+  const timestamp = header.globalVariables.timestamp;
+  const { delayedPublicMutableSlot } = await DelayedPublicMutableValuesWithHash.getContractUpdateSlots(contractAddress);
+  const delayedPublicMutableValues = await DelayedPublicMutableValues.readFromTree(delayedPublicMutableSlot, slot =>
+    aztecNode.getPublicStorageAt(blockHash, ProtocolContractAddress.ContractInstanceRegistry, slot),
+  );
+  let currentClassId = delayedPublicMutableValues.svc.getCurrentAt(timestamp)[0];
+  if (currentClassId.isZero()) {
+    currentClassId = instance.originalContractClassId;
+  }
+  return currentClassId;
+}
+
+export async function syncState(
+  contractAddress: AztecAddress,
+  contractStore: ContractStore,
+  functionToInvokeAfterSync: FunctionSelector | null,
+  utilityExecutor: (privateSyncCall: FunctionCall) => Promise<any>,
+) {
+  // Protocol contracts don't have private state to sync
+  if (!isProtocolContract(contractAddress)) {
+    const syncStateFunctionCall = await contractStore.getFunctionCall('sync_state', [], contractAddress);
+    if (functionToInvokeAfterSync && functionToInvokeAfterSync.equals(syncStateFunctionCall.selector)) {
+      throw new Error(
+        'Forbidden `sync_state` invocation. `sync_state` can only be invoked by PXE, manual execution can lead to inconsistencies.',
+      );
+    }
+
+    return utilityExecutor(syncStateFunctionCall);
+  }
+}
+
+/**
+ * Verify that the current class id of a contract obtained from AztecNode is the same as the one in contract data
+ * provider (i.e. PXE's own storage).
+ * @param header - The header of the block at which to verify the current class id.
+ */
+async function verifyCurrentClassId(
+  contractAddress: AztecAddress,
+  aztecNode: AztecNode,
+  contractStore: ContractStore,
+  header: BlockHeader,
+) {
+  const instance = await contractStore.getContractInstance(contractAddress);
+  if (!instance) {
+    throw new Error(`No contract instance found for address ${contractAddress.toString()}`);
+  }
+
+  const currentClassId = await readCurrentClassId(contractAddress, instance, aztecNode, header);
+  if (!instance.currentContractClassId.equals(currentClassId)) {
+    throw new Error(
+      `Contract ${contractAddress} is outdated, current class id is ${currentClassId}, local class id is ${instance.currentContractClassId}`,
+    );
+  }
+}
+
+/**
+ * Ensures the contract's private state is synchronized and that the PXE holds the current class artifact for
+ * the contract.
+ */
+export async function ensureContractSynced(
+  contractAddress: AztecAddress,
+  functionToInvokeAfterSync: FunctionSelector | null,
+  utilityExecutor: (call: FunctionCall) => Promise<any>,
+  aztecNode: AztecNode,
+  contractStore: ContractStore,
+  header: BlockHeader,
+): Promise<void> {
+  await Promise.all([
+    syncState(contractAddress, contractStore, functionToInvokeAfterSync, utilityExecutor),
+    verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
+  ]);
+}

--- a/yarn-project/pxe/src/entrypoints/server/index.ts
+++ b/yarn-project/pxe/src/entrypoints/server/index.ts
@@ -7,3 +7,4 @@ export { NoteService } from '../../notes/note_service.js';
 export { ORACLE_VERSION } from '../../oracle_version.js';
 export { type PXECreationOptions } from '../pxe_creation_options.js';
 export { JobCoordinator } from '../../job_coordinator/job_coordinator.js';
+export { syncState } from '../../contract_sync/index.js';

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -59,8 +59,8 @@ import {
   ContractFunctionSimulator,
   generateSimulatedProvingResult,
 } from './contract_function_simulator/contract_function_simulator.js';
-import { ensureContractSynced, readCurrentClassId } from './contract_function_simulator/oracle/private_execution.js';
 import { ProxiedContractStoreFactory } from './contract_function_simulator/proxied_contract_data_source.js';
+import { ensureContractSynced, readCurrentClassId } from './contract_sync/index.js';
 import { PXEDebugUtils } from './debug/pxe_debug_utils.js';
 import { enrichPublicSimulationError, enrichSimulationError } from './error_enriching.js';
 import { PrivateEventFilterValidator } from './events/private_event_filter_validator.js';

--- a/yarn-project/pxe/src/storage/contract_store/contract_store.ts
+++ b/yarn-project/pxe/src/storage/contract_store/contract_store.ts
@@ -3,7 +3,6 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { toArray } from '@aztec/foundation/iterable';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
-import { isProtocolContract } from '@aztec/protocol-contracts';
 import {
   type ContractArtifact,
   type FunctionAbi,
@@ -316,23 +315,5 @@ export class ContractStore {
       isStatic: functionDao.isStatic,
       returnTypes: functionDao.returnTypes,
     };
-  }
-
-  public async syncState(
-    contractAddress: AztecAddress,
-    functionToInvokeAfterSync: FunctionSelector | null,
-    utilityExecutor: (privateSyncCall: FunctionCall) => Promise<any>,
-  ) {
-    // Protocol contracts don't have private state to sync
-    if (!isProtocolContract(contractAddress)) {
-      const syncStateFunctionCall = await this.getFunctionCall('sync_state', [], contractAddress);
-      if (functionToInvokeAfterSync && functionToInvokeAfterSync.equals(syncStateFunctionCall.selector)) {
-        throw new Error(
-          'Forbidden `sync_state` invocation. `sync_state` can only be invoked by PXE, manual execution can lead to inconsistencies.',
-        );
-      }
-
-      return utilityExecutor(syncStateFunctionCall);
-    }
   }
 }

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -22,6 +22,7 @@ import {
   SenderAddressBookStore,
   SenderTaggingStore,
   enrichPublicSimulationError,
+  syncState,
 } from '@aztec/pxe/server';
 import {
   ExecutionNoteCache,
@@ -301,7 +302,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       await this.executeUtilityCall(call);
     };
 
-    await this.contractStore.syncState(targetContractAddress, functionSelector, utilityExecutor);
+    await syncState(targetContractAddress, this.contractStore, functionSelector, utilityExecutor);
 
     const blockNumber = await this.txeGetNextBlockNumber();
 
@@ -645,7 +646,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
 
     // Sync notes before executing utility function to discover notes from previous transactions
-    await this.contractStore.syncState(targetContractAddress, functionSelector, async call => {
+    await syncState(targetContractAddress, this.contractStore, functionSelector, async call => {
       await this.executeUtilityCall(call);
     });
 


### PR DESCRIPTION
We had contract sync related functionality in a somewhat random place so I moved it to `pxe/src/contract_sync/index.ts`. I also moved the `syncState` function out of `ContractStore` because it doesn't seem to be something that contract store should be handling (stores should be concerned with DB not with utility function simulation).

I decided against introducing `ContractService` because the functionality is stateless. As a result of this wrapping the functionality in a class is somewhat pointless.

I am not super sure about the directory structure and having it all be in `index.ts` so I am open to suggestiom.

This was originally discussed in https://github.com/AztecProtocol/aztec-packages/pull/19840#discussion_r2717251981.