### PR TITLE
chore: Update test chonk vk script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
       "name": "Debug chonk transaction",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-fast-no-avm/bin/bb",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/bb",
       "args": ["prove", "--scheme", "chonk", "--output_path", ".", "--ivc_inputs_path", "ivc-inputs.msgpack", "--print_bench"],
       "cwd": "${workspaceFolder}/yarn-project/end-to-end/example-app-ivc-inputs-out/ecdsar1+transfer_0_recursions+sponsored_fpc",
       "initCommands": [
@@ -48,7 +48,7 @@
       "name": "Debug acir test",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-fast-no-avm/bin/bb",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-fast/bin/bb",
       "args": ["prove", "--scheme", "ultra_honk", "--output_path", ".", "-b", "./target/program.json", "--write_vk"],
       // Can replace with any directory containing target/program.json and target/witness.gz
       "cwd": "${workspaceFolder}/barretenberg/acir_tests/acir_tests/embedded_curve_ops",
@@ -60,7 +60,7 @@
       "name": "Debug test_graph_for_arithmetic_gates",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/boomerang_value_detection_tests",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/boomerang_value_detection_tests",
       "args": ["--gtest_filter=BoomerangGoblinRecursiveVerifierTests.graph_description_basic"],
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
@@ -70,9 +70,9 @@
       "name": "Debug BB API Test",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm/bin/api_tests",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/api_tests",
       "args": ["--gtest_filter=ChonkAPITests.ProveAndVerifyFileBasedFlow"],
-      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug-no-avm",
+      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug",
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],

--- a/barretenberg/cpp/CLAUDE.md
+++ b/barretenberg/cpp/CLAUDE.md
@@ -133,16 +133,55 @@ The remote benchmark script:
 
 ## Verification Keys
 
-To check whether vks have changed first build barretenberg native code:
+**IMPORTANT**: When making barretenberg changes that could affect verification keys, you must verify that VKs haven't changed unexpectedly, or
+update them if the changes are intentional.
+
+### Checking if VKs have changed
+
+Prerequisites: Build barretenberg native code first.
 
 ```bash
 cd barretenberg/cpp
 ./bootstrap.sh build_native
 ```
-and then run:
+
+Run the VK check script from barretenberg/cpp/scripts:
+
 ```bash
 cd barretenberg/cpp/scripts
 ./test_chonk_standalone_vks_havent_changed.sh
 ```
 
-If the vks have changed, you can update them using the script `./test_chonk_standalone_vks_havent_changed.sh --update_inputs`. You can verify the validity of the inputs using the command `./test_chonk_standalone_vks_havent_changed.sh --prove_and_verify`. If one of the proof test fails, the inputs for which proving has failed are saved to `yarn-project/end-to-end/xample-app-ivc-inputs-out` under a folder with name equal to the flow for which the proof test failed.
+Expected result: Script exits successfully if VKs are unchanged, or shows that VKs have changed.
+
+### Updating VKs (when changes are intentional)
+
+**IMPORTANT**: Never update the VKs without asking permission first. When asking for permission, explain why you think the VK update is to be expected.
+
+If VKs have changed and this is expected due to your modifications, update the stored VKs:
+
+```bash
+cd barretenberg/cpp/scripts
+./test_chonk_standalone_vks_havent_changed.sh --update_inputs
+```
+
+### Verifying VK validity (proving the updated inputs)
+
+**IMPORTANT**: There is no need to verify the validity of the inputs after having updated them. The flag `update_inputs` verifies the new inputs.
+
+To verify the validity of the inputs pinned by the script `./test_chonk_standalone_vks_havent_changed.sh`, run:
+
+```bash
+cd barretenberg/cpp/scripts
+./test_chonk_standalone_vks_havent_changed.sh --prove_and_verify
+```
+
+Note: If a proof test fails for a specific flow, the inputs are saved to:
+`yarn-project/end-to-end/example-app-ivc-inputs-out/<flow_name>`
+
+Typical workflow
+
+1. Make barretenberg changes
+2. Build native code: `cd barretenberg/cpp && ./bootstrap.sh build_native`
+3. Check VKs: `cd scripts && ./test_chonk_standalone_vks_havent_changed.sh`
+4. If VKs changed intentionally: `./test_chonk_standalone_vks_havent_changed.sh --update_inputs`

--- a/barretenberg/cpp/CLAUDE.md
+++ b/barretenberg/cpp/CLAUDE.md
@@ -145,8 +145,4 @@ cd barretenberg/cpp/scripts
 ./test_chonk_standalone_vks_havent_changed.sh
 ```
 
-If the vks have changed, you can update them using the script `./test_chonk_standalone_vks_havent_changed.sh ` with one of the following flags:
-- `--update_fast`, this flag updates the vks without regenerating the msgpack inputs
-- `--update_inputs`, this flag updates the vks and the msgpack inputs
-
-Both flags run proof test on the msgpack inputs to ensure that we can prove with the new vks. In case a proof test fails, the inputs for which proving has failed are saved to `yarn-project/end-to-end/xample-app-ivc-inputs-out` under a folder with name equal to the flow for which the proof test failed.
+If the vks have changed, you can update them using the script `./test_chonk_standalone_vks_havent_changed.sh --update_inputs`. You can verify the validity of the inputs using the command `./test_chonk_standalone_vks_havent_changed.sh --prove_and_verify`. If one of the proof test fails, the inputs for which proving has failed are saved to `yarn-project/end-to-end/xample-app-ivc-inputs-out` under a folder with name equal to the flow for which the proof test failed.

--- a/barretenberg/cpp/CLAUDE.md
+++ b/barretenberg/cpp/CLAUDE.md
@@ -130,3 +130,23 @@ The remote benchmark script:
 - Automatically builds the target if needed
 - Returns performance metrics and timing data
 - Should be used instead of local benchmarks for performance validation
+
+## Verification Keys
+
+To check whether vks have changed first build barretenberg native code:
+
+```bash
+cd barretenberg/cpp
+./bootstrap.sh build_native
+```
+and then run:
+```bash
+cd barretenberg/cpp/scripts
+./test_chonk_standalone_vks_havent_changed.sh
+```
+
+If the vks have changed, you can update them using the script `./test_chonk_standalone_vks_havent_changed.sh ` with one of the following flags:
+- `--update_fast`, this flag updates the vks without regenerating the msgpack inputs
+- `--update_inputs`, this flag updates the vks and the msgpack inputs
+
+Both flags run proof test on the msgpack inputs to ensure that we can prove with the new vks. In case a proof test fails, the inputs for which proving has failed are saved to `yarn-project/end-to-end/xample-app-ivc-inputs-out` under a folder with name equal to the flow for which the proof test failed.

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -2,7 +2,7 @@
 source $(git rev-parse --show-toplevel)/ci3/source
 
 # export bb as it is needed when using exported functions
-export bb=$(./find-bb)
+export bb="$root/barretenberg/cpp/$(./native-preset-build-dir)/bin/bb"
 cd ..
 
 # NOTE: We pin the captured IVC inputs to a known master commit, exploiting that there won't be frequent changes.

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -51,7 +51,7 @@ function compress_and_upload {
 
 function check_circuit_vks {
   set -eu
-  local flow_folder="$inputs_tmp_dir/$1"
+  local flow_folder="$inputs_dir/$1"
   local output
   local exit_code=0
 
@@ -79,7 +79,7 @@ export -f check_circuit_vks
 
 function prove_and_verify_inputs {
   set -eu
-  local flow_folder="$inputs_tmp_dir/$1"
+  local flow_folder="$inputs_dir/$1"
   local proof_exit_code=0
 
   echo "Running proof test for $1..."
@@ -138,6 +138,8 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 EOF
   exit 0
 elif [[ "${1:-}" == "--update_inputs" ]]; then
+    export inputs_dir="../../yarn-project/end-to-end/example-app-ivc-inputs-out"
+
     # For easily rerunning the inputs generation
     set -eu
     trap 'rm -f bb-chonk-inputs.tar.gz' EXIT SIGINT
@@ -149,19 +151,21 @@ elif [[ "${1:-}" == "--update_inputs" ]]; then
     BOOTSTRAP_TO=yarn-project ../../bootstrap.sh # bootstrap aztec-packages from root
     ../../yarn-project/end-to-end/bootstrap.sh build_bench # build bench to generate IVC inputs
 
-    compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
+    compress_and_upload "$inputs_dir"
 
     prove_exit_code=0
-    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls ../../yarn-project/end-to-end/example-app-ivc-inputs-out) || prove_exit_code=$?
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_dir") || prove_exit_code=$?
 
     if [[ $prove_exit_code -eq 1 ]]; then
       echo "One or more flows failed the proof test after updating inputs. Please investigate."
       exit 1
     fi
+
+    echo "Inputs successfully updated."
     exit 0
 else
-  export inputs_tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$inputs_tmp_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
+  export inputs_dir=$(mktemp -d)
+  trap 'rm -rf "$inputs_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
 
   echo "Downloading pinned IVC inputs from: $pinned_chonk_inputs_url"
   if ! curl -s -f "$pinned_chonk_inputs_url" -o bb-chonk-inputs.tar.gz; then
@@ -171,17 +175,17 @@ else
   fi
 
   echo "Extracting IVC inputs..."
-  if ! tar -xzf bb-chonk-inputs.tar.gz -C "$inputs_tmp_dir"; then
+  if ! tar -xzf bb-chonk-inputs.tar.gz -C "$inputs_dir"; then
       echo_stderr "Error: Failed to extract IVC inputs archive"
       exit 1
   fi
 
-  ls "$inputs_tmp_dir"
+  ls "$inputs_dir"
 
   if [[ "${1:-}" == "--prove_and_verify" ]]; then
     # Prove and verify the current pinned inputs
     prove_exit_code=0
-    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_dir") || prove_exit_code=$?
 
     if [[ $prove_exit_code -ne 0 ]]; then
       echo "One or more flows failed the proof test after updating inputs. Please investigate."
@@ -192,9 +196,9 @@ else
     exit 0
   else
     exit_code=0
-    parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || true
+    parallel --joblog "$inputs_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_dir") || true
 
-    extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
+    extract_exit_code "$inputs_dir/joblog.log" || exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then
       echo "No VK changes detected. Short hash is: ${pinned_short_hash}"

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -57,10 +57,11 @@ function run_proof_test_on_inputs {
     $bb prove --scheme chonk --ivc_inputs_path "$inputs_path" > /dev/null 2>&1 || prove_exit_code=$?
 
     if [[ $prove_exit_code -ne 0 ]]; then
-      echo "Proof test failed. Please re-run the script with flag --update_inputs."
-      exit 1
+      return 1
     fi
 }
+
+export -f run_proof_test_on_inputs
 
 # For easily rerunning the inputs generation
 if [[ "${1:-}" == "--update_inputs" ]]; then
@@ -100,6 +101,7 @@ function check_circuit_vks {
   local flow_folder="$inputs_tmp_dir/$1"
   local output
   local exit_code=0
+  local proof_exit_code=0
 
   if [[ "${2:-}" == "--update_inputs" ]]; then
     output=$($bb check --vk_policy=rewrite --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
@@ -112,6 +114,18 @@ function check_circuit_vks {
     if echo "$output" | grep -q "VK mismatch detected\|Expected precomputed vk"; then
       echo_stderr "Error: VK change detected in $flow_folder!"
       if [[ "${2:-}" == "--update_inputs" ]]; then
+        # Test the new inputs before uploading
+        run_proof_test_on_inputs "$flow_folder/ivc-inputs.msgpack" || proof_exit_code=$?
+
+        if [[ $proof_exit_code -ne 0 ]]; then
+          echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."
+
+          flow="$(basename $flow_folder)"
+          cp "$flow_folder/ivc-inputs.msgpack" "$root/yarn-project/end-to-end/example-app-ivc-inputs-out/$flow/ivc-inputs.msgpack"
+          echo "Inputs copied in yarn-project for debugging"
+          exit 2
+        fi
+
         echo_stderr "Updating inputs with new VK."
       fi
       echo_stderr "$output"
@@ -130,44 +144,66 @@ function check_circuit_vks {
 
 export -f check_circuit_vks
 
+# Extract exit code from job logs of parallel execution
+function extract_exit_code {
+  local log_file="$1"
+  local exit_code=0
+
+  awk 'NR>1 { codes[$7]=1 } END {
+    has_other = 0;
+    has_one = 0;
+    for (code in codes) {
+      if (code != 0 && code != 1) has_other = 1;
+      if (code == 1) has_one = 1;
+    }
+    if (has_other) exit 2;
+    if (has_one) exit 1;
+    exit 0;
+  }' "$log_file" || exit_code=$?
+
+  if [[ $exit_code -eq 0 ]]; then
+    return 0
+  elif [[ $exit_code -eq 1 ]]; then
+    return 1
+  else
+    return 2
+  fi
+}
+
 # Run on one public and one private input.
 ls "$inputs_tmp_dir"
 
 if [[ "${1:-}" == "--update_fast" ]]; then
   exit_code=0
-  parallel -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") || exit_code=$?
+  parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") || true
+
+  extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
 
   if [[ $exit_code -eq 0 ]]; then
     echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
   elif [[ $exit_code -eq 1 ]]; then
-    # All flows that changed returned the same exit code (1)
-    # Test the new inputs before uploading
-    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
+    # All flows that changed returned exit code 0 or 1
+    echo "VK changes detected, uploading updated inputs..."
     compress_and_upload $inputs_tmp_dir
   else
-    # Mixed results (some 0, some 1) OR real errors (exit code >= 2)
-    # Test the new inputs before uploading
-    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
-    # Optimistically upload - real errors will persist on next run
-    echo "Mixed results detected (exit code: $exit_code). Uploading updated inputs..."
-    compress_and_upload $inputs_tmp_dir
+    # At least one real error
+    echo "Real error detected, please investigate."
   fi
 else
   exit_code=0
-  parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || exit_code=$?
+  parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || true
+
+  extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
 
   if [[ $exit_code -eq 0 ]]; then
-    run_proof_test_on_inputs "$inputs_tmp_dir/deploy_schnorr+sponsored_fpc/ivc-inputs.msgpack"
     echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
   elif [[ $exit_code -eq 1 ]]; then
     # All flows had VK changes
     echo "VK changes detected. Please re-run the script with --update_fast or --update_inputs"
     exit 1
   else
-    # Mixed results (some 0, some 1) OR real errors (exit code >= 2)
-    echo_stderr "Error: Mixed results or errors detected (exit code: $exit_code)."
-    echo_stderr "Some flows may have VK changes while others had errors."
-    echo_stderr "Please re-run with --update_inputs to update inputs, or investigate errors above."
+    # At least one real error
+    echo "Real error detected, please investigate."
     exit $exit_code
   fi
 fi

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="77e58648"
+pinned_short_hash="dbe74310"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="2b022426"
+pinned_short_hash="77e58648"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"
@@ -152,7 +152,7 @@ elif [[ "${1:-}" == "--update_inputs" ]]; then
     compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
 
     prove_exit_code=0
-    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls ../../yarn-project/end-to-end/example-app-ivc-inputs-out) || prove_exit_code=$?
 
     if [[ $prove_exit_code -eq 1 ]]; then
       echo "One or more flows failed the proof test after updating inputs. Please investigate."

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -50,84 +50,18 @@ function compress_and_upload {
     echo "Script updated with new pinned_short_hash: $short_hash"
 }
 
-function run_proof_test_on_inputs {
-    local inputs_path=$1
-    echo "Running proof test on inputs at: $inputs_path"
-    prove_exit_code=0
-    $bb prove --scheme chonk --ivc_inputs_path "$inputs_path" > /dev/null 2>&1 || prove_exit_code=$?
-
-    if [[ $prove_exit_code -ne 0 ]]; then
-      return 1
-    fi
-}
-
-export -f run_proof_test_on_inputs
-
-# For easily rerunning the inputs generation
-if [[ "${1:-}" == "--update_inputs" ]]; then
-    set -eu
-    trap 'rm -f bb-chonk-inputs.tar.gz' EXIT SIGINT
-    echo "Updating pinned IVC inputs..."
-
-    # Generate new inputs
-    echo "Running bootstrap to generate new IVC inputs..."
-
-    BOOTSTRAP_TO=yarn-project ../../bootstrap.sh # bootstrap aztec-packages from root
-    ../../yarn-project/end-to-end/bootstrap.sh build_bench # build bench to generate IVC inputs
-
-    compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
-
-    exit 0
-fi
-
-export inputs_tmp_dir=$(mktemp -d)
-trap 'rm -rf "$inputs_tmp_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
-
-echo "Downloading pinned IVC inputs from: $pinned_chonk_inputs_url"
-if ! curl -s -f "$pinned_chonk_inputs_url" -o bb-chonk-inputs.tar.gz; then
-    echo_stderr "Error: Failed to download pinned IVC inputs from $pinned_chonk_inputs_url"
-    echo_stderr "The pinned short hash '$pinned_short_hash' may be invalid or the file may not exist in S3."
-    exit 1
-fi
-
-echo "Extracting IVC inputs..."
-if ! tar -xzf bb-chonk-inputs.tar.gz -C "$inputs_tmp_dir"; then
-    echo_stderr "Error: Failed to extract IVC inputs archive"
-    exit 1
-fi
-
 function check_circuit_vks {
   set -eu
   local flow_folder="$inputs_tmp_dir/$1"
   local output
   local exit_code=0
-  local proof_exit_code=0
 
-  if [[ "${2:-}" == "--update_inputs" ]]; then
-    output=$($bb check --vk_policy=rewrite --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
-  else
-    output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
-  fi
+  output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
 
   if [[ $exit_code -ne 0 ]]; then
     # Check if this is actually a VK change
     if echo "$output" | grep -q "VK mismatch detected\|Expected precomputed vk"; then
       echo_stderr "Error: VK change detected in $flow_folder!"
-      if [[ "${2:-}" == "--update_inputs" ]]; then
-        # Test the new inputs before uploading
-        run_proof_test_on_inputs "$flow_folder/ivc-inputs.msgpack" || proof_exit_code=$?
-
-        if [[ $proof_exit_code -ne 0 ]]; then
-          echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."
-
-          flow="$(basename $flow_folder)"
-          cp "$flow_folder/ivc-inputs.msgpack" "$root/yarn-project/end-to-end/example-app-ivc-inputs-out/$flow/ivc-inputs.msgpack"
-          echo "Inputs copied in yarn-project for debugging"
-          exit 2
-        fi
-
-        echo_stderr "Updating inputs with new VK."
-      fi
       echo_stderr "$output"
       exit 1
     else
@@ -143,6 +77,26 @@ function check_circuit_vks {
 }
 
 export -f check_circuit_vks
+
+function prove_and_verify_inputs {
+  set -eu
+  local flow_folder="$inputs_tmp_dir/$1"
+  local proof_exit_code=0
+
+  # Test the new inputs before uploading
+      echo "Running proof test for $1..."
+  $bb prove --scheme chonk --ivc_inputs_path "$inputs_path" > /dev/null 2>&1 || prove_exit_code=$?
+
+  if [[ $proof_exit_code -ne 0 ]]; then
+    echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."
+
+    cp "$flow_folder/ivc-inputs.msgpack" "$root/yarn-project/end-to-end/example-app-ivc-inputs-out/$1/ivc-inputs.msgpack"
+    echo "Inputs copied in yarn-project for debugging"
+    exit 1
+  fi
+}
+
+export -f prove_and_verify_inputs
 
 # Extract exit code from job logs of parallel execution
 function extract_exit_code {
@@ -170,26 +124,56 @@ function extract_exit_code {
   fi
 }
 
-# Run on one public and one private input.
-ls "$inputs_tmp_dir"
+if [[ "${1:-}" == "--update_inputs" ]]; then
+    # For easily rerunning the inputs generation
+    set -eu
+    trap 'rm -f bb-chonk-inputs.tar.gz' EXIT SIGINT
+    echo "Updating pinned IVC inputs..."
 
-if [[ "${1:-}" == "--update_fast" ]]; then
-  exit_code=0
-  parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") || true
+    # Generate new inputs
+    echo "Running bootstrap to generate new IVC inputs..."
 
-  extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
+    BOOTSTRAP_TO=yarn-project ../../bootstrap.sh # bootstrap aztec-packages from root
+    ../../yarn-project/end-to-end/bootstrap.sh build_bench # build bench to generate IVC inputs
 
-  if [[ $exit_code -eq 0 ]]; then
-    echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
-  elif [[ $exit_code -eq 1 ]]; then
-    # All flows that changed returned exit code 0 or 1
-    echo "VK changes detected, uploading updated inputs..."
-    compress_and_upload $inputs_tmp_dir
-  else
-    # At least one real error
-    echo "Real error detected, please investigate."
-  fi
+    compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
+
+    prove_exit_code=0
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
+
+    if [[ $prove_exit_code -eq 1 ]]; then
+      echo "One or more flows failed the proof test after updating inputs. Please investigate."
+      exit 1
+    fi
+    exit 0
+elif [[ "${1:-}" == "--prove_and_verify_inputs" ]]; then
+    # Prove and verify the current pinned inputs
+    prove_exit_code=0
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
+
+    if [[ $prove_exit_code -eq 1 ]]; then
+      echo "One or more flows failed the proof test after updating inputs. Please investigate."
+      exit 1
+    fi
+    exit 0
 else
+  export inputs_tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$inputs_tmp_dir" bb-chonk-inputs.tar.gz' EXIT SIGINT
+
+  echo "Downloading pinned IVC inputs from: $pinned_chonk_inputs_url"
+  if ! curl -s -f "$pinned_chonk_inputs_url" -o bb-chonk-inputs.tar.gz; then
+      echo_stderr "Error: Failed to download pinned IVC inputs from $pinned_chonk_inputs_url"
+      echo_stderr "The pinned short hash '$pinned_short_hash' may be invalid or the file may not exist in S3."
+      exit 1
+  fi
+
+  echo "Extracting IVC inputs..."
+  if ! tar -xzf bb-chonk-inputs.tar.gz -C "$inputs_tmp_dir"; then
+      echo_stderr "Error: Failed to extract IVC inputs archive"
+      exit 1
+  fi
+
+  ls "$inputs_tmp_dir"
   exit_code=0
   parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || true
 

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,11 +13,10 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="82e925f8"
+pinned_short_hash="2b022426"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"
-echo "$script_path"
 
 function update_pinned_hash_in_script {
     local new_hash=$1
@@ -56,7 +55,7 @@ function check_circuit_vks {
   local output
   local exit_code=0
 
-  output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" 2>&1) || exit_code=$?
+  output=$($bb check --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack") || exit_code=$?
 
   if [[ $exit_code -ne 0 ]]; then
     # Check if this is actually a VK change
@@ -83,9 +82,8 @@ function prove_and_verify_inputs {
   local flow_folder="$inputs_tmp_dir/$1"
   local proof_exit_code=0
 
-  # Test the new inputs before uploading
-      echo "Running proof test for $1..."
-  $bb prove --scheme chonk --ivc_inputs_path "$inputs_path" > /dev/null 2>&1 || prove_exit_code=$?
+  echo "Running proof test for $1..."
+  $bb prove --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" > /dev/null 2>&1 || prove_exit_code=$?
 
   if [[ $proof_exit_code -ne 0 ]]; then
     echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."
@@ -124,7 +122,22 @@ function extract_exit_code {
   fi
 }
 
-if [[ "${1:-}" == "--update_inputs" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat << EOF
+  Usage: $(basename "$0") [OPTIONS]
+
+  Options:
+      none                       Test that Chonk standalone VKs haven't changed
+      --update_inputs            Generate new IVC inputs and upload to S3
+      --prove_and_verify         Prove and verify current pinned inputs
+      -h, --help                 Show this help message
+
+  Description:
+      Tests that Chonk standalone VKs haven't changed by comparing
+      generated VKs with pinned reference inputs.
+EOF
+  exit 0
+elif [[ "${1:-}" == "--update_inputs" ]]; then
     # For easily rerunning the inputs generation
     set -eu
     trap 'rm -f bb-chonk-inputs.tar.gz' EXIT SIGINT
@@ -138,16 +151,6 @@ if [[ "${1:-}" == "--update_inputs" ]]; then
 
     compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
 
-    prove_exit_code=0
-    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
-
-    if [[ $prove_exit_code -eq 1 ]]; then
-      echo "One or more flows failed the proof test after updating inputs. Please investigate."
-      exit 1
-    fi
-    exit 0
-elif [[ "${1:-}" == "--prove_and_verify_inputs" ]]; then
-    # Prove and verify the current pinned inputs
     prove_exit_code=0
     parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
 
@@ -174,20 +177,35 @@ else
   fi
 
   ls "$inputs_tmp_dir"
-  exit_code=0
-  parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || true
 
-  extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
+  if [[ "${1:-}" == "--prove_and_verify" ]]; then
+    # Prove and verify the current pinned inputs
+    prove_exit_code=0
+    parallel -v --line-buffer --tag prove_and_verify_inputs {} ::: $(ls "$inputs_tmp_dir") || prove_exit_code=$?
 
-  if [[ $exit_code -eq 0 ]]; then
-    echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
-  elif [[ $exit_code -eq 1 ]]; then
-    # All flows had VK changes
-    echo "VK changes detected. Please re-run the script with --update_fast or --update_inputs"
-    exit 1
+    if [[ $prove_exit_code -ne 0 ]]; then
+      echo "One or more flows failed the proof test after updating inputs. Please investigate."
+      exit 1
+    else
+      echo "All inputs were successfully proven and verified."
+    fi
+    exit 0
   else
-    # At least one real error
-    echo "Real error detected, please investigate."
-    exit $exit_code
+    exit_code=0
+    parallel --joblog "$inputs_tmp_dir/joblog.log" -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir") || true
+
+    extract_exit_code "$inputs_tmp_dir/joblog.log" || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+      echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
+    elif [[ $exit_code -eq 1 ]]; then
+      # All flows had VK changes
+      echo "VK changes detected. Please re-run the script with --update_fast or --update_inputs"
+      exit 1
+    else
+      # At least one real error
+      echo "Real error detected, please investigate."
+      exit $exit_code
+    fi
   fi
 fi

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="982e010b"
+pinned_short_hash="82e925f8"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
@@ -18,6 +18,9 @@ void create_sha256_compression_constraints(Builder& builder, const Sha256Compres
     std::array<field_ct, 8> hash_inputs; // previous  (or initial) hash state
     std::array<field_ct, 16> inputs;     // message block to compress
 
+    field_ct test = field_ct::from_witness(&builder, bb::fr::one());
+    test = test * test;
+
     // Get the witness assignment for each witness index.
     // It is assumed that the caller (Noir) separately constrains all 24 inputs (8 hash state + 16 message words) to 32
     // bits, e.g. via instantiating them as u32 types.

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/sha256_constraint.cpp
@@ -18,9 +18,6 @@ void create_sha256_compression_constraints(Builder& builder, const Sha256Compres
     std::array<field_ct, 8> hash_inputs; // previous  (or initial) hash state
     std::array<field_ct, 16> inputs;     // message block to compress
 
-    field_ct test = field_ct::from_witness(&builder, bb::fr::one());
-    test = test * test;
-
     // Get the witness assignment for each witness index.
     // It is assumed that the caller (Noir) separately constrains all 24 inputs (8 hash state + 16 message words) to 32
     // bits, e.g. via instantiating them as u32 types.

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -515,7 +515,7 @@ TYPED_TEST(MergeTests, DifferentTranscriptOriginTagFailure)
     // Catch the exception and verify it's the expected cross-transcript error
 #ifndef NDEBUG
     EXPECT_THROW_WITH_MESSAGE([[maybe_unused]] auto result =
-                                  verifier_2.verify_proof(proof_2_recursive, input_commitments_1),
+                                  verifier_2.reduce_to_pairing_check(proof_2_recursive, input_commitments_1),
                               "Tags from different transcripts were involved in the same computation");
 #endif
 }


### PR DESCRIPTION
Remove the flag `update_fast` from the script as it didn't work. Simplified the script as a result, added an helper, added `prove_and_verify` flag to verify the validity of the pinned inputs.
