### PR TITLE
fix(archiver): remove proposed blocks after removed checkpoints

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1076,7 +1076,7 @@ describe('Archiver Sync', () => {
       expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
       const blockAlreadySyncedFromCheckpoint = cp1.blocks[cp1.blocks.length - 1];
 
-      // Now try and add one of the blocks via the addBlocks method. It should throw
+      // Now try and add one of the blocks via the addProposedBlocks method. It should throw
       await expect(archiver.addBlock(blockAlreadySyncedFromCheckpoint)).rejects.toThrow();
     }, 10_000);
 
@@ -1141,8 +1141,8 @@ describe('Archiver Sync', () => {
       const { checkpoint: cp3 } = await fake.addCheckpoint(CheckpointNumber(3), { l1BlockNumber: 5010n });
 
       // Add blocks from BOTH checkpoints locally (matching the L1 checkpoints)
-      await archiverStore.addBlocks(cp2.blocks, { force: true });
-      await archiverStore.addBlocks(cp3.blocks, { force: true });
+      await archiverStore.addProposedBlocks(cp2.blocks, { force: true });
+      await archiverStore.addProposedBlocks(cp3.blocks, { force: true });
 
       // Verify all blocks are visible locally
       const lastBlockInCheckpoint3 = cp3.blocks[cp3.blocks.length - 1].number;

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -215,7 +215,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     // Process each block individually to properly resolve/reject each promise
     for (const { block, resolve, reject } of queuedItems) {
       try {
-        await this.updater.addBlocks([block]);
+        await this.updater.addProposedBlocks([block]);
         this.log.debug(`Added block ${block.number} to store`);
         resolve();
       } catch (err: any) {
@@ -358,8 +358,8 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     return this.initialSyncComplete;
   }
 
-  public unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number): Promise<boolean> {
-    return this.updater.unwindCheckpoints(from, checkpointsToUnwind);
+  public removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<boolean> {
+    return this.updater.removeCheckpointsAfter(checkpointNumber);
   }
 
   /** Used by TXE to add checkpoints directly without syncing from L1. */
@@ -367,7 +367,7 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     checkpoints: PublishedCheckpoint[],
     pendingChainValidationStatus?: ValidateCheckpointResult,
   ): Promise<boolean> {
-    await this.updater.setNewCheckpointData(checkpoints, pendingChainValidationStatus);
+    await this.updater.addCheckpoints(checkpoints, pendingChainValidationStatus);
     return true;
   }
 
@@ -487,13 +487,12 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     if (targetL2BlockNumber >= currentL2Block) {
       throw new Error(`Target L2 block ${targetL2BlockNumber} must be less than current L2 block ${currentL2Block}`);
     }
-    const blocksToUnwind = currentL2Block - targetL2BlockNumber;
     const targetL2Block = await this.store.getCheckpointedBlock(targetL2BlockNumber);
     if (!targetL2Block) {
       throw new Error(`Target L2 block ${targetL2BlockNumber} not found`);
     }
     const targetL1BlockNumber = targetL2Block.l1.blockNumber;
-    const targetCheckpointNumber = CheckpointNumber.fromBlockNumber(targetL2BlockNumber);
+    const targetCheckpointNumber = targetL2Block.checkpointNumber;
     const targetL1Block = await this.publicClient.getBlock({
       blockNumber: targetL1BlockNumber,
       includeTransactions: false,
@@ -502,9 +501,11 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
       throw new Error(`Missing L1 block ${targetL1BlockNumber}`);
     }
     const targetL1BlockHash = Buffer32.fromString(targetL1Block.hash);
-    this.log.info(`Unwinding ${blocksToUnwind} checkpoints from L2 block ${currentL2Block}`);
-    await this.updater.unwindCheckpoints(CheckpointNumber.fromBlockNumber(currentL2Block), blocksToUnwind);
-    this.log.info(`Unwinding L1 to L2 messages to checkpoint ${targetCheckpointNumber}`);
+    this.log.info(
+      `Removing checkpoints after checkpoint ${targetCheckpointNumber} (target block ${targetL2BlockNumber})`,
+    );
+    await this.updater.removeCheckpointsAfter(targetCheckpointNumber);
+    this.log.info(`Rolling back L1 to L2 messages to checkpoint ${targetCheckpointNumber}`);
     await this.store.rollbackL1ToL2MessagesToCheckpoint(targetCheckpointNumber);
     this.log.info(`Setting L1 syncpoints to ${targetL1BlockNumber}`);
     await this.store.setCheckpointSynchedL1BlockNumber(targetL1BlockNumber);

--- a/yarn-project/archiver/src/errors.ts
+++ b/yarn-project/archiver/src/errors.ts
@@ -88,3 +88,15 @@ export class BlockNotFoundError extends Error {
     super(`Failed to find expected block number ${blockNumber}`);
   }
 }
+
+export class CannotOverwriteCheckpointedBlockError extends Error {
+  constructor(
+    public readonly blockNumber: number,
+    public readonly lastCheckpointedBlock: number,
+  ) {
+    super(
+      `Cannot add block ${blockNumber}: would overwrite checkpointed data (checkpointed up to block ${lastCheckpointedBlock})`,
+    );
+    this.name = 'CannotOverwriteCheckpointedBlockError';
+  }
+}

--- a/yarn-project/archiver/src/modules/data_store_updater.test.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.test.ts
@@ -59,7 +59,7 @@ describe('ArchiverDataStoreUpdater', () => {
   });
 
   describe('contract data', () => {
-    it('stores contract class and instance data when blocks are added via addBlocks', async () => {
+    it('stores contract class and instance data when blocks are added via addProposedBlocks', async () => {
       // Create block with contract class and instance logs
       const block = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),
@@ -68,7 +68,7 @@ describe('ArchiverDataStoreUpdater', () => {
       block.body.txEffects[0].contractClassLogs = [contractClassLog];
       block.body.txEffects[0].privateLogs = [PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload())];
 
-      await updater.addBlocks([block]);
+      await updater.addProposedBlocks([block]);
 
       // Verify contract class was stored
       const retrievedClass = await store.getContractClass(contractClassId);
@@ -94,7 +94,7 @@ describe('ArchiverDataStoreUpdater', () => {
         PrivateLog.fromBuffer(getSampleContractInstancePublishedEventPayload()),
       ];
 
-      await updater.addBlocks([localBlock]);
+      await updater.addProposedBlocks([localBlock]);
 
       // Verify contract data was stored
       const timestamp = localBlock.header.globalVariables.timestamp + 1n;
@@ -118,8 +118,8 @@ describe('ArchiverDataStoreUpdater', () => {
       );
       const publishedCheckpoint = makePublishedCheckpoint(checkpointWithConflict, 10);
 
-      // setCheckpointData should detect the conflict and prune the local block
-      await updater.setNewCheckpointData([publishedCheckpoint]);
+      // This should detect the conflict and prune the local block
+      await updater.addCheckpoints([publishedCheckpoint]);
 
       // Verify the contract data from the local block was removed
       expect(await store.getContractClass(contractClassId)).toBeUndefined();
@@ -138,15 +138,15 @@ describe('ArchiverDataStoreUpdater', () => {
       const checkpoint = new Checkpoint(block.archive, CheckpointHeader.random(), [block], CheckpointNumber(1));
       const publishedCheckpoint = makePublishedCheckpoint(checkpoint, 10);
 
-      await updater.setNewCheckpointData([publishedCheckpoint]);
+      await updater.addCheckpoints([publishedCheckpoint]);
 
       // Verify contract data was stored
       const timestamp = block.header.globalVariables.timestamp + 1n;
       expect(await store.getContractClass(contractClassId)).toBeDefined();
       expect(await store.getContractInstance(instanceAddress, timestamp)).toBeDefined();
 
-      // Unwind the checkpoint
-      await updater.unwindCheckpoints(CheckpointNumber(1), 1);
+      // Remove the checkpoint
+      await updater.removeCheckpointsAfter(CheckpointNumber(0));
 
       // Verify the contract data was removed
       expect(await store.getContractClass(contractClassId)).toBeUndefined();
@@ -163,13 +163,13 @@ describe('ArchiverDataStoreUpdater', () => {
         slotNumber: SlotNumber(100),
       });
 
-      await updater.addBlocks([block]);
+      await updater.addProposedBlocks([block]);
 
       // Create checkpoint with the SAME block (same archive root)
       const checkpoint = new Checkpoint(block.archive, CheckpointHeader.random(), [block], CheckpointNumber(1));
       const publishedCheckpoint = makePublishedCheckpoint(checkpoint, 10);
 
-      await updater.setNewCheckpointData([publishedCheckpoint]);
+      await updater.addCheckpoints([publishedCheckpoint]);
 
       // Verify logs are NOT duplicated
       const publicLogs = await store.getPublicLogs({ fromBlock: block.number, toBlock: block.number + 1 });
@@ -184,7 +184,7 @@ describe('ArchiverDataStoreUpdater', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         slotNumber: SlotNumber(100),
       });
-      await updater.addBlocks([localBlock]);
+      await updater.addProposedBlocks([localBlock]);
       const publicLogsBefore = await store.getPublicLogs({});
       expect(publicLogsBefore.logs.map(l => l.log)).toEqual(localBlock.body.txEffects.flatMap(tx => tx.publicLogs));
 
@@ -202,7 +202,7 @@ describe('ArchiverDataStoreUpdater', () => {
         [checkpointBlock],
         CheckpointNumber(1),
       );
-      await updater.setNewCheckpointData([makePublishedCheckpoint(checkpoint, 10)]);
+      await updater.addCheckpoints([makePublishedCheckpoint(checkpoint, 10)]);
 
       // Verify checkpoint block is stored
       const storedBlock = await store.getBlock(BlockNumber(1));
@@ -211,19 +211,19 @@ describe('ArchiverDataStoreUpdater', () => {
       expect(publicLogsAfter.logs.map(l => l.log)).toEqual(checkpointBlock.body.txEffects.flatMap(tx => tx.publicLogs));
     });
 
-    it('removes logs when unwinding blocks', async () => {
+    it('removes logs when removing uncheckpointed blocks', async () => {
       // Add local provisional block
       const localBlock = await L2Block.random(BlockNumber(1), {
         checkpointNumber: CheckpointNumber(1),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         slotNumber: SlotNumber(100),
       });
-      await updater.addBlocks([localBlock]);
+      await updater.addProposedBlocks([localBlock]);
       const publicLogsBefore = await store.getPublicLogs({});
       expect(publicLogsBefore.logs.map(l => l.log)).toEqual(localBlock.body.txEffects.flatMap(tx => tx.publicLogs));
 
-      // Unwind the block
-      await updater.removeBlocksAfter(BlockNumber.ZERO);
+      // Remove the uncheckpointed block
+      await updater.removeUncheckpointedBlocksAfter(BlockNumber.ZERO);
 
       // Verify logs are removed
       const publicLogsAfter = await store.getPublicLogs({});

--- a/yarn-project/archiver/src/modules/data_store_updater.ts
+++ b/yarn-project/archiver/src/modules/data_store_updater.ts
@@ -1,4 +1,4 @@
-import { BlockNumber, type CheckpointNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import {
@@ -47,17 +47,21 @@ export class ArchiverDataStoreUpdater {
   constructor(private store: KVArchiverDataStore) {}
 
   /**
-   * Adds blocks to the store with contract class/instance extraction from logs.
+   * Adds proposed blocks to the store with contract class/instance extraction from logs.
+   * These are uncheckpointed blocks that have been proposed by the sequencer but not yet included in a checkpoint on L1.
    * Extracts ContractClassPublished, ContractInstancePublished, ContractInstanceUpdated events,
    * and individually broadcasted functions from the block logs.
    *
-   * @param blocks - The L2 blocks to add.
+   * @param blocks - The proposed L2 blocks to add.
    * @param pendingChainValidationStatus - Optional validation status to set.
    * @returns True if the operation is successful.
    */
-  public addBlocks(blocks: L2Block[], pendingChainValidationStatus?: ValidateCheckpointResult): Promise<boolean> {
+  public addProposedBlocks(
+    blocks: L2Block[],
+    pendingChainValidationStatus?: ValidateCheckpointResult,
+  ): Promise<boolean> {
     return this.store.transactionAsync(async () => {
-      await this.store.addBlocks(blocks);
+      await this.store.addProposedBlocks(blocks);
 
       const opResults = await Promise.all([
         // Update the pending chain validation status if provided
@@ -65,7 +69,7 @@ export class ArchiverDataStoreUpdater {
         // Add any logs emitted during the retrieved blocks
         this.store.addLogs(blocks),
         // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
-        ...blocks.map(block => this.addBlockDataToDB(block)),
+        ...blocks.map(block => this.addContractDataToDb(block)),
       ]);
 
       return opResults.every(Boolean);
@@ -74,7 +78,7 @@ export class ArchiverDataStoreUpdater {
 
   /**
    * Reconciles local blocks with incoming checkpoints from L1.
-   * Adds checkpoints to the store with contract class/instance extraction from logs.
+   * Adds new checkpoints to the store with contract class/instance extraction from logs.
    * Prunes any local blocks that conflict with checkpoint data (by comparing archive roots).
    * Extracts ContractClassPublished, ContractInstancePublished, ContractInstanceUpdated events,
    * and individually broadcasted functions from the checkpoint block logs.
@@ -83,7 +87,7 @@ export class ArchiverDataStoreUpdater {
    * @param pendingChainValidationStatus - Optional validation status to set.
    * @returns Result with information about any pruned blocks.
    */
-  public setNewCheckpointData(
+  public addCheckpoints(
     checkpoints: PublishedCheckpoint[],
     pendingChainValidationStatus?: ValidateCheckpointResult,
   ): Promise<ReconcileCheckpointsResult> {
@@ -93,7 +97,7 @@ export class ArchiverDataStoreUpdater {
 
       await this.store.addCheckpoints(checkpoints);
 
-      // Filter out blocks that were already inserted via addBlocks() to avoid duplicating logs/contract data
+      // Filter out blocks that were already inserted via addProposedBlocks() to avoid duplicating logs/contract data
       const newBlocks = checkpoints
         .flatMap((ch: PublishedCheckpoint) => ch.checkpoint.blocks)
         .filter(b => lastAlreadyInsertedBlockNumber === undefined || b.number > lastAlreadyInsertedBlockNumber);
@@ -104,7 +108,7 @@ export class ArchiverDataStoreUpdater {
         // Add any logs emitted during the retrieved blocks
         this.store.addLogs(newBlocks),
         // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
-        ...newBlocks.map(block => this.addBlockDataToDB(block)),
+        ...newBlocks.map(block => this.addContractDataToDb(block)),
       ]);
 
       return { prunedBlocks, lastAlreadyInsertedBlockNumber };
@@ -185,80 +189,80 @@ export class ArchiverDataStoreUpdater {
   }
 
   /**
-   * Removes all blocks strictly after the specified block number and cleans up associated contract data.
+   * Removes all uncheckpointed blocks strictly after the specified block number and cleans up associated contract data.
    * This handles removal of provisionally added blocks along with their contract classes/instances.
+   * Verifies that each block being removed is not part of a stored checkpoint.
    *
    * @param blockNumber - Remove all blocks with number greater than this.
    * @returns The removed blocks.
+   * @throws Error if any block to be removed is checkpointed.
    */
-  public removeBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
+  public removeUncheckpointedBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
     return this.store.transactionAsync(async () => {
-      // First get the blocks to be removed so we can clean up contract data
-      const removedBlocks = await this.store.removeBlocksAfter(blockNumber);
+      // Verify we're only removing uncheckpointed blocks
+      const lastCheckpointedBlockNumber = await this.store.getCheckpointedL2BlockNumber();
+      if (blockNumber < lastCheckpointedBlockNumber) {
+        throw new Error(
+          `Cannot remove blocks after ${blockNumber} because checkpointed blocks exist up to ${lastCheckpointedBlockNumber}`,
+        );
+      }
 
-      // Clean up contract data and logs for the removed blocks
-      await Promise.all([
-        this.store.deleteLogs(removedBlocks),
-        ...removedBlocks.map(block => this.removeBlockDataFromDB(block)),
-      ]);
-
-      return removedBlocks;
+      return await this.removeBlocksAfter(blockNumber);
     });
   }
 
   /**
-   * Unwinds checkpoints from the store with reverse contract extraction.
+   * Removes all blocks strictly after the given block number along with any logs and contract data.
+   * Does not remove their checkpoints.
+   */
+  private async removeBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
+    // First get the blocks to be removed so we can clean up contract data
+    const removedBlocks = await this.store.removeBlocksAfter(blockNumber);
+
+    // Clean up contract data and logs for the removed blocks
+    await Promise.all([
+      this.store.deleteLogs(removedBlocks),
+      ...removedBlocks.map(block => this.removeContractDataFromDb(block)),
+    ]);
+
+    return removedBlocks;
+  }
+
+  /**
+   * Removes all checkpoints after the given checkpoint number.
    * Deletes ContractClassPublished, ContractInstancePublished, ContractInstanceUpdated data
-   * that was stored for the unwound checkpoints.
+   * that was stored for the removed checkpoints. Also removes ALL blocks (both checkpointed
+   * and uncheckpointed) after the last block of the given checkpoint.
    *
-   * @param from - The checkpoint number to unwind from (must be the current tip).
-   * @param checkpointsToUnwind - The number of checkpoints to unwind.
+   * @param checkpointNumber - Remove all checkpoints strictly after this one.
    * @returns True if the operation is successful.
    */
-  public async unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number): Promise<boolean> {
-    if (checkpointsToUnwind <= 0) {
-      throw new Error(`Cannot unwind ${checkpointsToUnwind} blocks`);
-    }
-
-    const last = await this.store.getSynchedCheckpointNumber();
-    if (from != last) {
-      throw new Error(`Cannot unwind checkpoints from checkpoint ${from} when the last checkpoint is ${last}`);
-    }
-
-    const blocks = [];
-    const lastCheckpointNumber = from + checkpointsToUnwind - 1;
-    for (let checkpointNumber = from; checkpointNumber <= lastCheckpointNumber; checkpointNumber++) {
-      const blocksForCheckpoint = await this.store.getBlocksForCheckpoint(checkpointNumber);
-      if (!blocksForCheckpoint) {
-        continue;
-      }
-      blocks.push(...blocksForCheckpoint);
-    }
+  public async removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<boolean> {
+    const { blocksRemoved = [] } = await this.store.removeCheckpointsAfter(checkpointNumber);
 
     const opResults = await Promise.all([
       // Prune rolls back to the last proven block, which is by definition valid
       this.store.setPendingChainValidationStatus({ valid: true }),
-      // Remove contract data for all blocks being unwound
-      ...blocks.map(block => this.removeBlockDataFromDB(block)),
-      this.store.deleteLogs(blocks),
-      this.store.unwindCheckpoints(from, checkpointsToUnwind),
+      // Remove contract data for all blocks being removed
+      ...blocksRemoved.map(block => this.removeContractDataFromDb(block)),
+      this.store.deleteLogs(blocksRemoved),
     ]);
 
     return opResults.every(Boolean);
   }
 
   /** Extracts and stores contract data from a single block. */
-  private addBlockDataToDB(block: L2Block): Promise<boolean> {
-    return this.editContractBlockData(block, Operation.Store);
+  private addContractDataToDb(block: L2Block): Promise<boolean> {
+    return this.updateContractDataOnDb(block, Operation.Store);
   }
 
   /** Removes contract data associated with a block. */
-  private removeBlockDataFromDB(block: L2Block): Promise<boolean> {
-    return this.editContractBlockData(block, Operation.Delete);
+  private removeContractDataFromDb(block: L2Block): Promise<boolean> {
+    return this.updateContractDataOnDb(block, Operation.Delete);
   }
 
   /** Adds or remove contract data associated with a block. */
-  private async editContractBlockData(block: L2Block, operation: Operation): Promise<boolean> {
+  private async updateContractDataOnDb(block: L2Block, operation: Operation): Promise<boolean> {
     const contractClassLogs = block.body.txEffects.flatMap(txEffect => txEffect.contractClassLogs);
     const privateLogs = block.body.txEffects.flatMap(txEffect => txEffect.privateLogs);
     const publicLogs = block.body.txEffects.flatMap(txEffect => txEffect.publicLogs);

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -258,7 +258,7 @@ export class ArchiverL1Synchronizer implements Traceable {
         `Pruning blocks after block ${lastCheckpointedBlockNumber} due to slot ${firstUncheckpointedBlockSlot} not being checkpointed`,
         { firstUncheckpointedBlockHeader: firstUncheckpointedBlockHeader.toInspect(), slotAtNextL1Block },
       );
-      const prunedBlocks = await this.updater.removeBlocksAfter(lastCheckpointedBlockNumber);
+      const prunedBlocks = await this.updater.removeUncheckpointedBlocksAfter(lastCheckpointedBlockNumber);
 
       if (prunedBlocks.length > 0) {
         this.events.emit(L2BlockSourceEvents.L2PruneUncheckpointed, {
@@ -331,10 +331,10 @@ export class ArchiverL1Synchronizer implements Traceable {
       this.log.debug(
         `L2 prune from ${provenCheckpointNumber + 1} to ${localPendingCheckpointNumber} will occur on next checkpoint submission.`,
       );
-      await this.updater.unwindCheckpoints(localPendingCheckpointNumber, checkpointsToUnwind);
+      await this.updater.removeCheckpointsAfter(provenCheckpointNumber);
       this.log.warn(
-        `Unwound ${count(checkpointsToUnwind, 'checkpoint')} from checkpoint ${localPendingCheckpointNumber} ` +
-          `to ${provenCheckpointNumber} due to predicted reorg at L1 block ${currentL1BlockNumber}. ` +
+        `Removed ${count(checkpointsToUnwind, 'checkpoint')} after checkpoint ${provenCheckpointNumber} ` +
+          `due to predicted reorg at L1 block ${currentL1BlockNumber}. ` +
           `Updated latest checkpoint is ${await this.store.getSynchedCheckpointNumber()}.`,
       );
       this.instrumentation.processPrune(timer.ms());
@@ -675,11 +675,11 @@ export class ArchiverL1Synchronizer implements Traceable {
           tipAfterUnwind--;
         }
 
-        const checkpointsToUnwind = localPendingCheckpointNumber - tipAfterUnwind;
-        await this.updater.unwindCheckpoints(localPendingCheckpointNumber, checkpointsToUnwind);
+        const checkpointsToRemove = localPendingCheckpointNumber - tipAfterUnwind;
+        await this.updater.removeCheckpointsAfter(CheckpointNumber(tipAfterUnwind));
 
         this.log.warn(
-          `Unwound ${count(checkpointsToUnwind, 'checkpoint')} from checkpoint ${localPendingCheckpointNumber} ` +
+          `Removed ${count(checkpointsToRemove, 'checkpoint')} after checkpoint ${tipAfterUnwind} ` +
             `due to mismatched checkpoint hashes at L1 block ${currentL1BlockNumber}. ` +
             `Updated L2 latest checkpoint is ${await this.store.getSynchedCheckpointNumber()}.`,
         );
@@ -806,8 +806,8 @@ export class ArchiverL1Synchronizer implements Traceable {
         const updatedValidationResult =
           rollupStatus.validationResult === initialValidationResult ? undefined : rollupStatus.validationResult;
         const [processDuration, result] = await elapsed(() =>
-          execInSpan(this.tracer, 'Archiver.setCheckpointData', () =>
-            this.updater.setNewCheckpointData(validCheckpoints, updatedValidationResult),
+          execInSpan(this.tracer, 'Archiver.addCheckpoints', () =>
+            this.updater.addCheckpoints(validCheckpoints, updatedValidationResult),
           ),
         );
         this.instrumentation.processNewBlocks(

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -38,6 +38,7 @@ import {
   BlockIndexNotSequentialError,
   BlockNotFoundError,
   BlockNumberNotSequentialError,
+  CannotOverwriteCheckpointedBlockError,
   CheckpointNotFoundError,
   CheckpointNumberNotConsistentError,
   CheckpointNumberNotSequentialError,
@@ -76,6 +77,8 @@ export type CheckpointData = {
   l1: L1PublishedData;
   attestations: Buffer[];
 };
+
+export type RemoveCheckpointsResult = { blocksRemoved: L2Block[] | undefined };
 
 /**
  * LMDB-based block storage for the archiver.
@@ -142,11 +145,13 @@ export class BlockStore {
   }
 
   /**
-   * Append new blocks to the store's list. All blocks must be for the 'current' checkpoint
-   * @param blocks - The L2 blocks to be added to the store.
+   * Append new proposed blocks to the store's list. All blocks must be for the 'current' checkpoint.
+   * These are uncheckpointed blocks that have been proposed by the sequencer but not yet included in a checkpoint on L1.
+   * For checkpointed blocks (already published to L1), use addCheckpoints() instead.
+   * @param blocks - The proposed L2 blocks to be added to the store.
    * @returns True if the operation is successful.
    */
-  async addBlocks(blocks: L2Block[], opts: { force?: boolean } = {}): Promise<boolean> {
+  async addProposedBlocks(blocks: L2Block[], opts: { force?: boolean } = {}): Promise<boolean> {
     if (blocks.length === 0) {
       return true;
     }
@@ -161,6 +166,12 @@ export class BlockStore {
       // Extract the latest block and checkpoint numbers
       const previousBlockNumber = await this.getLatestBlockNumber();
       const previousCheckpointNumber = await this.getLatestCheckpointNumber();
+
+      // Verify we're not overwriting checkpointed blocks
+      const lastCheckpointedBlockNumber = await this.getCheckpointedL2BlockNumber();
+      if (!opts.force && firstBlockNumber <= lastCheckpointedBlockNumber) {
+        throw new CannotOverwriteCheckpointedBlockError(firstBlockNumber, lastCheckpointedBlockNumber);
+      }
 
       // Check that the first block number is the expected one
       if (!opts.force && previousBlockNumber !== firstBlockNumber - 1) {
@@ -385,51 +396,48 @@ export class BlockStore {
   }
 
   /**
-   * Unwinds checkpoints from the database
-   * @param from -  The tip of the chain, passed for verification purposes,
-   *                ensuring that we don't end up deleting something we did not intend
-   * @param checkpointsToUnwind - The number of checkpoints we are to unwind
-   * @returns True if the operation is successful
+   * Removes all checkpoints with checkpoint number > checkpointNumber.
+   * Also removes ALL blocks (both checkpointed and uncheckpointed) after the last block of the given checkpoint.
+   * @param checkpointNumber - Remove all checkpoints strictly after this one.
    */
-  async unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number) {
+  async removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<RemoveCheckpointsResult> {
     return await this.db.transactionAsync(async () => {
-      const last = await this.getLatestCheckpointNumber();
-      if (from !== last) {
-        throw new Error(`Can only unwind checkpoints from the tip (requested ${from} but current tip is ${last})`);
+      const latestCheckpointNumber = await this.getLatestCheckpointNumber();
+
+      if (checkpointNumber >= latestCheckpointNumber) {
+        this.#log.warn(`No checkpoints to remove after ${checkpointNumber} (latest is ${latestCheckpointNumber})`);
+        return { blocksRemoved: undefined };
       }
 
+      // If the proven checkpoint is beyond the target, update it
       const proven = await this.getProvenCheckpointNumber();
-      if (from - checkpointsToUnwind < proven) {
-        await this.setProvenCheckpointNumber(CheckpointNumber(from - checkpointsToUnwind));
+      if (proven > checkpointNumber) {
+        this.#log.warn(`Updating proven checkpoint ${proven} to last valid checkpoint ${checkpointNumber}`);
+        await this.setProvenCheckpointNumber(checkpointNumber);
       }
 
-      for (let i = 0; i < checkpointsToUnwind; i++) {
-        const checkpointNumber = from - i;
-        const checkpoint = await this.#checkpoints.getAsync(checkpointNumber);
-
-        if (checkpoint === undefined) {
-          this.#log.warn(`Cannot remove checkpoint ${checkpointNumber} from the store since we don't have it`);
-          continue;
+      // Find the last block number to keep (last block of the given checkpoint, or 0 if no checkpoint)
+      let lastBlockToKeep: BlockNumber;
+      if (checkpointNumber <= 0) {
+        lastBlockToKeep = BlockNumber(INITIAL_L2_BLOCK_NUM - 1);
+      } else {
+        const targetCheckpoint = await this.#checkpoints.getAsync(checkpointNumber);
+        if (!targetCheckpoint) {
+          throw new Error(`Target checkpoint ${checkpointNumber} not found in store`);
         }
-        await this.#checkpoints.delete(checkpointNumber);
-        const maxBlock = checkpoint.startBlock + checkpoint.numBlocks - 1;
-
-        for (let blockNumber = checkpoint.startBlock; blockNumber <= maxBlock; blockNumber++) {
-          const block = await this.getBlock(BlockNumber(blockNumber));
-
-          if (block === undefined) {
-            this.#log.warn(`Cannot remove block ${blockNumber} from the store since we don't have it`);
-            continue;
-          }
-
-          await this.deleteBlock(block);
-          this.#log.debug(
-            `Unwound block ${blockNumber} ${(await block.hash()).toString()} for checkpoint ${checkpointNumber}`,
-          );
-        }
+        lastBlockToKeep = BlockNumber(targetCheckpoint.startBlock + targetCheckpoint.numBlocks - 1);
       }
 
-      return true;
+      // Remove all blocks after lastBlockToKeep (both checkpointed and uncheckpointed)
+      const blocksRemoved = await this.removeBlocksAfter(lastBlockToKeep);
+
+      // Remove all checkpoints after the target
+      for (let c = latestCheckpointNumber; c > checkpointNumber; c = CheckpointNumber(c - 1)) {
+        await this.#checkpoints.delete(c);
+        this.#log.debug(`Removed checkpoint ${c}`);
+      }
+
+      return { blocksRemoved };
     });
   }
 
@@ -510,10 +518,11 @@ export class BlockStore {
 
   /**
    * Removes all blocks with block number > blockNumber.
+   * Does not remove any associated checkpoints.
    * @param blockNumber - The block number to remove after.
    * @returns The removed blocks (for event emission).
    */
-  async unwindBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
+  async removeBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
     return await this.db.transactionAsync(async () => {
       const removedBlocks: L2Block[] = [];
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -45,6 +45,7 @@ import {
   BlockArchiveNotConsistentError,
   BlockIndexNotSequentialError,
   BlockNumberNotSequentialError,
+  CannotOverwriteCheckpointedBlockError,
   CheckpointNumberNotConsistentError,
   CheckpointNumberNotSequentialError,
   InitialBlockNumberNotSequentialError,
@@ -288,26 +289,26 @@ describe('KVArchiverDataStore', () => {
     });
   });
 
-  describe('unwindcheckpoints', () => {
-    it('unwinding checkpoints will remove checkpoints from the chain', async () => {
+  describe('removeCheckpointsAfter', () => {
+    it('removing checkpoints will remove checkpoints from the chain', async () => {
       await store.addCheckpoints(publishedCheckpoints);
       const checkpointNumber = await store.getSynchedCheckpointNumber();
       const lastCheckpoint = publishedCheckpoints.at(-1)!;
       const lastBlockNumber = lastCheckpoint.checkpoint.blocks[0].number;
 
-      // Verify block exists before unwinding
+      // Verify block exists before removing
       const retrievedBlock = await store.getCheckpointedBlock(BlockNumber(BlockNumber(lastBlockNumber)));
       expect(retrievedBlock).toBeDefined();
       expect(retrievedBlock!.block.header.equals(lastCheckpoint.checkpoint.blocks[0].header)).toBe(true);
       expect(retrievedBlock!.checkpointNumber).toEqual(checkpointNumber);
 
-      await store.unwindCheckpoints(checkpointNumber, 1);
+      await store.removeCheckpointsAfter(CheckpointNumber(checkpointNumber - 1));
 
       expect(await store.getSynchedCheckpointNumber()).toBe(checkpointNumber - 1);
       await expect(store.getCheckpointedBlock(BlockNumber(BlockNumber(lastBlockNumber)))).resolves.toBeUndefined();
     });
 
-    it('can unwind multiple empty blocks', async () => {
+    it('can remove multiple checkpoints', async () => {
       // Create checkpoints sequentially to chain archive roots
       const emptyCheckpoints: PublishedCheckpoint[] = [];
       for (let i = 0; i < 10; i++) {
@@ -323,28 +324,21 @@ describe('KVArchiverDataStore', () => {
       await store.addCheckpoints(emptyCheckpoints);
       expect(await store.getSynchedCheckpointNumber()).toBe(10);
 
-      await store.unwindCheckpoints(CheckpointNumber(10), 3);
+      await store.removeCheckpointsAfter(CheckpointNumber(7));
       expect(await store.getSynchedCheckpointNumber()).toBe(7);
       expect((await store.getRangeOfCheckpoints(CheckpointNumber(1), 10)).map(b => b.checkpointNumber)).toEqual([
         1, 2, 3, 4, 5, 6, 7,
       ]);
     });
 
-    it('refuses to unwind checkpoints if the tip is not the last checkpoint', async () => {
-      await store.addCheckpoints(publishedCheckpoints);
-      await expect(store.unwindCheckpoints(CheckpointNumber(5), 1)).rejects.toThrow(
-        /can only unwind checkpoints from the tip/i,
-      );
-    });
-
-    it('unwound blocks and headers cannot be retrieved by hash or archive', async () => {
+    it('removed blocks and headers cannot be retrieved by hash or archive', async () => {
       await store.addCheckpoints(publishedCheckpoints);
       const lastCheckpoint = publishedCheckpoints[publishedCheckpoints.length - 1];
       const lastBlock = lastCheckpoint.checkpoint.blocks[0];
       const blockHash = await lastBlock.header.hash();
       const archive = lastBlock.archive.root;
 
-      // Verify block and header exist before unwinding
+      // Verify block and header exist before removing
       const retrievedByHash = await store.getCheckpointedBlockByHash(blockHash);
       expect(retrievedByHash).toBeDefined();
       expect(retrievedByHash!.block.header.equals(lastBlock.header)).toBe(true);
@@ -361,14 +355,96 @@ describe('KVArchiverDataStore', () => {
       expect(headerByArchive).toBeDefined();
       expect(headerByArchive!.equals(lastBlock.header)).toBe(true);
 
-      // Unwind the checkpoint
-      await store.unwindCheckpoints(lastCheckpoint.checkpoint.number, 1);
+      // Remove the checkpoint
+      await store.removeCheckpointsAfter(CheckpointNumber(lastCheckpoint.checkpoint.number - 1));
 
-      // Verify neither block nor header can be retrieved after unwinding
+      // Verify neither block nor header can be retrieved after removal
       expect(await store.getCheckpointedBlockByHash(blockHash)).toBeUndefined();
       expect(await store.getCheckpointedBlockByArchive(archive)).toBeUndefined();
       expect(await store.getBlockHeaderByHash(blockHash)).toBeUndefined();
       expect(await store.getBlockHeaderByArchive(archive)).toBeUndefined();
+    });
+
+    it('orphaned blocks are removed when removing checkpoints', async () => {
+      // This test covers the scenario where:
+      // 1. Checkpoint 1 is added (with block 1)
+      // 2. Block 2 is added locally for upcoming checkpoint 2 (but checkpoint 2 doesn't exist yet)
+      // 3. Checkpoint 1 is removed due to L1 reorg
+      // 4. Block 2 should also be removed, even though it's not associated with any checkpoint entry
+
+      // Add checkpoint 1 with block 1
+      const checkpoint1Cp = await Checkpoint.random(CheckpointNumber(1), { numBlocks: 1, startBlockNumber: 1 });
+      const checkpoint1 = makePublishedCheckpoint(checkpoint1Cp, 10);
+      await store.addCheckpoints([checkpoint1]);
+
+      expect(await store.getSynchedCheckpointNumber()).toBe(1);
+      expect(await store.getLatestBlockNumber()).toBe(1);
+      expect(await store.getCheckpointedL2BlockNumber()).toBe(1);
+
+      // Add block 2 locally for upcoming checkpoint 2 (no checkpoint entry yet)
+      const lastBlockArchive = checkpoint1.checkpoint.blocks[0].archive;
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        lastArchive: lastBlockArchive,
+      });
+      await store.addProposedBlocks([block2]);
+
+      // Verify state: checkpoint 1 exists, block 2 exists but is orphaned (no checkpoint 2)
+      expect(await store.getSynchedCheckpointNumber()).toBe(1);
+      expect(await store.getLatestBlockNumber()).toBe(2);
+      expect(await store.getCheckpointedL2BlockNumber()).toBe(1);
+      expect(await store.getBlock(BlockNumber(2))).toBeDefined();
+
+      // Remove checkpoint 1 (simulating L1 reorg)
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
+
+      // Verify that BOTH block 1 (from checkpoint) AND block 2 (orphaned) are removed
+      expect(await store.getSynchedCheckpointNumber()).toBe(0);
+      expect(await store.getLatestBlockNumber()).toBe(0);
+      expect(await store.getCheckpointedL2BlockNumber()).toBe(0);
+      expect(await store.getBlock(BlockNumber(1))).toBeUndefined();
+      expect(await store.getBlock(BlockNumber(2))).toBeUndefined();
+    });
+
+    it('multiple orphaned blocks are removed when removing checkpoints', async () => {
+      // Similar to above but with multiple orphaned blocks
+      // Add checkpoint 1 with block 1
+      const checkpoint1Cp = await Checkpoint.random(CheckpointNumber(1), { numBlocks: 1, startBlockNumber: 1 });
+      const checkpoint1 = makePublishedCheckpoint(checkpoint1Cp, 10);
+      await store.addCheckpoints([checkpoint1]);
+
+      // Add blocks 2, 3, 4 locally for upcoming checkpoint 2
+      const lastBlockArchive = checkpoint1.checkpoint.blocks[0].archive;
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+        lastArchive: lastBlockArchive,
+      });
+      const block3 = await L2Block.random(BlockNumber(3), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+        lastArchive: block2.archive,
+      });
+      const block4 = await L2Block.random(BlockNumber(4), {
+        checkpointNumber: CheckpointNumber(2),
+        indexWithinCheckpoint: IndexWithinCheckpoint(2),
+        lastArchive: block3.archive,
+      });
+      await store.addProposedBlocks([block2, block3, block4]);
+
+      expect(await store.getSynchedCheckpointNumber()).toBe(1);
+      expect(await store.getLatestBlockNumber()).toBe(4);
+
+      // Remove checkpoint 1
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
+
+      // All blocks should be removed
+      expect(await store.getSynchedCheckpointNumber()).toBe(0);
+      expect(await store.getLatestBlockNumber()).toBe(0);
+      for (let i = 1; i <= 4; i++) {
+        expect(await store.getBlock(BlockNumber(i))).toBeUndefined();
+      }
     });
   });
 
@@ -430,20 +506,20 @@ describe('KVArchiverDataStore', () => {
       expect(await store.getSynchedCheckpointNumber()).toBe(3);
       expect(await store.getLatestBlockNumber()).toBe(7);
 
-      // Unwind the last checkpoint (which has 2 blocks)
-      await store.unwindCheckpoints(CheckpointNumber(3), 1);
+      // Remove the last checkpoint (which has 2 blocks)
+      await store.removeCheckpointsAfter(CheckpointNumber(2));
 
       expect(await store.getSynchedCheckpointNumber()).toBe(2);
       expect(await store.getLatestBlockNumber()).toBe(5);
 
-      // Unwind another checkpoint (which has 3 blocks)
-      await store.unwindCheckpoints(CheckpointNumber(2), 1);
+      // Remove another checkpoint (which has 3 blocks)
+      await store.removeCheckpointsAfter(CheckpointNumber(1));
 
       expect(await store.getSynchedCheckpointNumber()).toBe(1);
       expect(await store.getLatestBlockNumber()).toBe(2);
     });
 
-    it('unwinding multiple checkpoints with multiple blocks in one go', async () => {
+    it('removing multiple checkpoints with multiple blocks in one go', async () => {
       // Create 4 checkpoints with varying block counts, chaining archive roots
       // Checkpoint 1: blocks 1-2 (2 blocks)
       // Checkpoint 2: blocks 3-5 (3 blocks)
@@ -482,8 +558,8 @@ describe('KVArchiverDataStore', () => {
       expect(await store.getSynchedCheckpointNumber()).toBe(4);
       expect(await store.getLatestBlockNumber()).toBe(10);
 
-      // Unwind 2 checkpoints at once (checkpoints 3 and 4, which together have 5 blocks)
-      await store.unwindCheckpoints(CheckpointNumber(4), 2);
+      // Remove checkpoints 3 and 4 (which together have 5 blocks)
+      await store.removeCheckpointsAfter(CheckpointNumber(2));
 
       expect(await store.getSynchedCheckpointNumber()).toBe(2);
       expect(await store.getLatestBlockNumber()).toBe(5);
@@ -498,8 +574,8 @@ describe('KVArchiverDataStore', () => {
         expect(await store.getCheckpointedBlock(BlockNumber(BlockNumber(blockNumber)))).toBeUndefined();
       }
 
-      // Unwind remaining 2 checkpoints at once (checkpoints 1 and 2, which together have 5 blocks)
-      await store.unwindCheckpoints(CheckpointNumber(2), 2);
+      // Remove remaining checkpoints 1 and 2 (which together have 5 blocks)
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
 
       expect(await store.getSynchedCheckpointNumber()).toBe(0);
       expect(await store.getLatestBlockNumber()).toBe(0);
@@ -594,7 +670,7 @@ describe('KVArchiverDataStore', () => {
       }
     });
 
-    it('unwinding a multi-block checkpoint removes all its blocks', async () => {
+    it('removing a multi-block checkpoint removes all its blocks', async () => {
       const checkpoint = makePublishedCheckpoint(
         await Checkpoint.random(CheckpointNumber(1), { numBlocks: 3, startBlockNumber: 1 }),
         10,
@@ -607,8 +683,8 @@ describe('KVArchiverDataStore', () => {
         expect(await store.getCheckpointedBlock(BlockNumber(blockNumber))).toBeDefined();
       }
 
-      // Unwind the checkpoint
-      await store.unwindCheckpoints(CheckpointNumber(1), 1);
+      // Remove the checkpoint
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
 
       // Verify all 3 blocks are removed
       for (let blockNumber = 1; blockNumber <= 3; blockNumber++) {
@@ -651,7 +727,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block5.archive,
       });
 
-      await store.addBlocks([block4, block5, block6]);
+      await store.addProposedBlocks([block4, block5, block6]);
 
       // Checkpoint number should still be 1 (no new checkpoint added)
       expect(await store.getSynchedCheckpointNumber()).toBe(1);
@@ -679,7 +755,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block3.archive,
       });
-      await store.addBlocks([block3, block4]);
+      await store.addProposedBlocks([block3, block4]);
 
       // getBlock should work for both checkpointed and uncheckpointed blocks
       expect((await store.getBlock(BlockNumber(1)))?.number).toBe(1);
@@ -693,7 +769,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(2),
         lastArchive: block4.archive,
       });
-      await store.addBlocks([block5]);
+      await store.addProposedBlocks([block5]);
 
       // Verify the uncheckpointed blocks have correct data
       const retrieved3 = await store.getBlock(BlockNumber(3));
@@ -718,7 +794,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block1.archive,
       });
-      await store.addBlocks([block1, block2]);
+      await store.addProposedBlocks([block1, block2]);
 
       // getBlockByHash should work for uncheckpointed blocks
       const hash1 = await block1.header.hash();
@@ -742,7 +818,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block1.archive,
       });
-      await store.addBlocks([block1, block2]);
+      await store.addProposedBlocks([block1, block2]);
 
       // getBlockByArchive should work for uncheckpointed blocks
       const archive1 = block1.archive.root;
@@ -775,7 +851,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block3.archive,
       });
-      await store.addBlocks([block3, block4]);
+      await store.addProposedBlocks([block3, block4]);
 
       // getCheckpointedBlock should work for checkpointed blocks
       expect((await store.getCheckpointedBlock(BlockNumber(1)))?.block.number).toBe(1);
@@ -796,7 +872,7 @@ describe('KVArchiverDataStore', () => {
         checkpointNumber: CheckpointNumber(1),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
-      await store.addBlocks([block1]);
+      await store.addProposedBlocks([block1]);
 
       const hash = await block1.header.hash();
 
@@ -813,7 +889,7 @@ describe('KVArchiverDataStore', () => {
         checkpointNumber: CheckpointNumber(1),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
-      await store.addBlocks([block1]);
+      await store.addProposedBlocks([block1]);
 
       const archive = block1.archive.root;
 
@@ -840,7 +916,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(2),
         lastArchive: block2.archive,
       });
-      await store.addBlocks([block1, block2, block3]);
+      await store.addProposedBlocks([block1, block2, block3]);
 
       expect(await store.getSynchedCheckpointNumber()).toBe(0);
       expect(await store.getLatestBlockNumber()).toBe(3);
@@ -900,7 +976,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(2),
         lastArchive: block4.archive,
       });
-      await store.addBlocks([block3, block4, block5]);
+      await store.addProposedBlocks([block3, block4, block5]);
 
       expect(await store.getSynchedCheckpointNumber()).toBe(1);
       expect(await store.getLatestBlockNumber()).toBe(5);
@@ -959,7 +1035,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block3.archive,
       });
-      await store.addBlocks([block3, block4]);
+      await store.addProposedBlocks([block3, block4]);
 
       // getBlocks should retrieve all blocks
       const allBlocks = await store.getBlocks(BlockNumber(1), 10);
@@ -968,7 +1044,7 @@ describe('KVArchiverDataStore', () => {
     });
   });
 
-  describe('addBlocks validation', () => {
+  describe('addProposedBlocks validation', () => {
     it('throws if blocks have different checkpoint numbers', async () => {
       // First, establish checkpoint 1 with blocks 1-2
       const checkpoint1 = makePublishedCheckpoint(
@@ -991,7 +1067,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block3.archive,
       });
 
-      await expect(store.addBlocks([block3, block4])).rejects.toThrow(CheckpointNumberNotConsistentError);
+      await expect(store.addProposedBlocks([block3, block4])).rejects.toThrow(CheckpointNumberNotConsistentError);
     });
 
     it('throws if checkpoint number is not the current checkpoint', async () => {
@@ -1012,7 +1088,9 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
       });
 
-      await expect(store.addBlocks([block3, block4])).rejects.toThrow(InitialCheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlocks([block3, block4])).rejects.toThrow(
+        InitialCheckpointNumberNotSequentialError,
+      );
     });
 
     it('allows blocks with the same checkpoint number for the current checkpoint', async () => {
@@ -1036,7 +1114,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block3.archive,
       });
 
-      await expect(store.addBlocks([block3, block4])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3, block4])).resolves.toBe(true);
 
       // Verify blocks were added
       expect((await store.getBlock(BlockNumber(3)))?.equals(block3)).toBe(true);
@@ -1055,7 +1133,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block1.archive,
       });
 
-      await expect(store.addBlocks([block1, block2])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block1, block2])).resolves.toBe(true);
 
       // Verify blocks were added
       expect((await store.getBlock(BlockNumber(1)))?.equals(block1)).toBe(true);
@@ -1074,8 +1152,8 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
 
-      await expect(store.addBlocks([block1])).resolves.toBe(true);
-      await expect(store.addBlocks([block2])).rejects.toThrow(InitialBlockNumberNotSequentialError);
+      await expect(store.addProposedBlocks([block1])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block2])).rejects.toThrow(InitialBlockNumberNotSequentialError);
     });
 
     it('throws if first block has wrong checkpoint number when store is empty', async () => {
@@ -1089,7 +1167,9 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
       });
 
-      await expect(store.addBlocks([block1, block2])).rejects.toThrow(InitialCheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlocks([block1, block2])).rejects.toThrow(
+        InitialCheckpointNumberNotSequentialError,
+      );
     });
 
     it('allows adding more blocks to the same checkpoint in separate calls', async () => {
@@ -1107,7 +1187,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: lastBlockArchive,
       });
-      await expect(store.addBlocks([block3])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3])).resolves.toBe(true);
 
       // Add block 4 for the same checkpoint 2 in a separate call
       const block4 = await L2Block.random(BlockNumber(4), {
@@ -1115,7 +1195,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: block3.archive,
       });
-      await expect(store.addBlocks([block4])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block4])).resolves.toBe(true);
 
       expect(await store.getLatestBlockNumber()).toBe(4);
     });
@@ -1135,7 +1215,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: lastBlockArchive,
       });
-      await expect(store.addBlocks([block3])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3])).resolves.toBe(true);
 
       // Add block 4 for the same checkpoint 2 in a separate call but with a missing index
       const block4 = await L2Block.random(BlockNumber(4), {
@@ -1143,7 +1223,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(2),
         lastArchive: block3.archive,
       });
-      await expect(store.addBlocks([block4])).rejects.toThrow(BlockIndexNotSequentialError);
+      await expect(store.addProposedBlocks([block4])).rejects.toThrow(BlockIndexNotSequentialError);
 
       expect(await store.getLatestBlockNumber()).toBe(3);
     });
@@ -1163,7 +1243,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: lastBlockArchive,
       });
-      await store.addBlocks([block3]);
+      await store.addProposedBlocks([block3]);
 
       // Try to add block 4 for checkpoint 3 (should fail because current checkpoint is still 2)
       const block4 = await L2Block.random(BlockNumber(4), {
@@ -1171,7 +1251,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: block3.archive,
       });
-      await expect(store.addBlocks([block4])).rejects.toThrow(InitialCheckpointNumberNotSequentialError);
+      await expect(store.addProposedBlocks([block4])).rejects.toThrow(InitialCheckpointNumberNotSequentialError);
     });
 
     it('force option bypasses checkpoint number validation', async () => {
@@ -1195,7 +1275,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block3.archive,
       });
 
-      await expect(store.addBlocks([block3, block4], { force: true })).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3, block4], { force: true })).resolves.toBe(true);
     });
 
     it('force option bypasses blockindex number validation', async () => {
@@ -1219,7 +1299,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block3.archive,
       });
 
-      await expect(store.addBlocks([block3, block4], { force: true })).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3, block4], { force: true })).resolves.toBe(true);
     });
 
     it('throws if adding blocks with non-consecutive archives', async () => {
@@ -1235,7 +1315,7 @@ describe('KVArchiverDataStore', () => {
         checkpointNumber: CheckpointNumber(2),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
       });
-      await expect(store.addBlocks([block3])).rejects.toThrow(BlockArchiveNotConsistentError);
+      await expect(store.addProposedBlocks([block3])).rejects.toThrow(BlockArchiveNotConsistentError);
 
       expect(await store.getLatestBlockNumber()).toBe(2);
     });
@@ -1255,7 +1335,7 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: lastBlockArchive,
       });
-      await expect(store.addBlocks([block3])).resolves.toBe(true);
+      await expect(store.addProposedBlocks([block3])).resolves.toBe(true);
 
       // Add block 4 with incorrect archive (should fail)
       const block4 = await L2Block.random(BlockNumber(4), {
@@ -1263,9 +1343,34 @@ describe('KVArchiverDataStore', () => {
         indexWithinCheckpoint: IndexWithinCheckpoint(1),
         lastArchive: AppendOnlyTreeSnapshot.random(),
       });
-      await expect(store.addBlocks([block4])).rejects.toThrow(BlockArchiveNotConsistentError);
+      await expect(store.addProposedBlocks([block4])).rejects.toThrow(BlockArchiveNotConsistentError);
 
       expect(await store.getLatestBlockNumber()).toBe(3);
+    });
+
+    it('throws if adding blocks that would overwrite checkpointed blocks', async () => {
+      // First, establish checkpoint 1 with blocks 1-2
+      const checkpoint1 = makePublishedCheckpoint(
+        await Checkpoint.random(CheckpointNumber(1), { numBlocks: 2, startBlockNumber: 1 }),
+        10,
+      );
+      await store.addCheckpoints([checkpoint1]);
+
+      expect(await store.getCheckpointedL2BlockNumber()).toBe(2);
+
+      // Try to add a block that would overwrite checkpointed block 2
+      const block2 = await L2Block.random(BlockNumber(2), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+      });
+      await expect(store.addProposedBlocks([block2])).rejects.toThrow(CannotOverwriteCheckpointedBlockError);
+
+      // Try to add a block that would overwrite checkpointed block 1
+      const block1 = await L2Block.random(BlockNumber(1), {
+        checkpointNumber: CheckpointNumber(1),
+        indexWithinCheckpoint: IndexWithinCheckpoint(0),
+      });
+      await expect(store.addProposedBlocks([block1])).rejects.toThrow(CannotOverwriteCheckpointedBlockError);
     });
   });
 
@@ -1521,8 +1626,8 @@ describe('KVArchiverDataStore', () => {
 
       await store.addCheckpoints([checkpoint1, checkpoint2, checkpoint3]);
 
-      // Unwind checkpoint 3
-      await store.unwindCheckpoints(CheckpointNumber(3), 1);
+      // Remove checkpoint 3
+      await store.removeCheckpointsAfter(CheckpointNumber(2));
 
       const checkpoints = await store.getRangeOfCheckpoints(CheckpointNumber(1), 10);
       expect(checkpoints.length).toBe(2);
@@ -1696,7 +1801,7 @@ describe('KVArchiverDataStore', () => {
 
   it('deleteLogs', async () => {
     const block = publishedCheckpoints[0].checkpoint.blocks[0];
-    await store.addBlocks([block]);
+    await store.addProposedBlocks([block]);
     await expect(store.addLogs([block])).resolves.toEqual(true);
 
     expect((await store.getPublicLogs({ fromBlock: BlockNumber(1) })).logs.length).toEqual(
@@ -1746,7 +1851,7 @@ describe('KVArchiverDataStore', () => {
       () => getBlock(5).body.txEffects[2],
       () => getBlock(1).body.txEffects[0],
     ])('tries to retrieves a previously stored transaction after deleted', async getTxEffect => {
-      await store.unwindCheckpoints(CheckpointNumber(publishedCheckpoints.length), publishedCheckpoints.length);
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
 
       const txEffect = getTxEffect();
       const actualTx = await store.getTxEffect(txEffect.txHash);
@@ -1757,7 +1862,7 @@ describe('KVArchiverDataStore', () => {
       await expect(store.getTxEffect(TxHash.random())).resolves.toBeUndefined();
     });
 
-    it('does not fail if the block is unwound while requesting a tx', async () => {
+    it('does not fail if the block is removed while requesting a tx', async () => {
       const txEffect = getBlock(1).body.txEffects[0];
       let done = false;
       void (async () => {
@@ -1766,7 +1871,7 @@ describe('KVArchiverDataStore', () => {
           await sleep(1);
         }
       })();
-      await store.unwindCheckpoints(CheckpointNumber(publishedCheckpoints.length), publishedCheckpoints.length);
+      await store.removeCheckpointsAfter(CheckpointNumber(0));
       done = true;
       expect(await store.getTxEffect(txEffect.txHash)).toEqual(undefined);
     });
@@ -2592,7 +2697,7 @@ describe('KVArchiverDataStore', () => {
       const targetTxHash = targetBlock.body.txEffects[targetTxIndex].txHash;
 
       await Promise.all([
-        store.unwindCheckpoints(CheckpointNumber(numBlocksForPublicLogs), numBlocksForPublicLogs),
+        store.removeCheckpointsAfter(CheckpointNumber(0)),
         store.deleteLogs(publishedCheckpoints.slice(0, numBlocksForPublicLogs).flatMap(b => b.checkpoint.blocks)),
       ]);
 
@@ -2930,7 +3035,7 @@ describe('KVArchiverDataStore', () => {
   });
 
   describe('idempotency', () => {
-    it('handles adding blocks via addBlocks then same blocks via addCheckpoints', async () => {
+    it('handles adding blocks via addProposedBlocks then same blocks via addCheckpoints', async () => {
       // First add checkpoint 1 to establish a base
       const checkpoint1 = makePublishedCheckpoint(
         await Checkpoint.random(CheckpointNumber(1), { numBlocks: 1, startBlockNumber: 1 }),
@@ -2938,13 +3043,13 @@ describe('KVArchiverDataStore', () => {
       );
       await store.addCheckpoints([checkpoint1]);
 
-      // Add provisional block 2 via addBlocks
+      // Add provisional block 2 via addProposedBlocks
       const provisionalBlock = await L2Block.random(BlockNumber(2), {
         checkpointNumber: CheckpointNumber(2),
         indexWithinCheckpoint: IndexWithinCheckpoint(0),
         lastArchive: checkpoint1.checkpoint.blocks[0].archive,
       });
-      await store.addBlocks([provisionalBlock]);
+      await store.addProposedBlocks([provisionalBlock]);
 
       // Now add checkpoint 2 containing the same block via addCheckpoints
       const checkpoint2 = new Checkpoint(
@@ -3050,7 +3155,7 @@ describe('KVArchiverDataStore', () => {
         slotNumber: SlotNumber(101), // Different slot number
       });
 
-      await store.addBlocks([block1, block2, block3]);
+      await store.addProposedBlocks([block1, block2, block3]);
 
       const blocksForSlot100 = await store.getBlocksForSlot(SlotNumber(100));
       expect(blocksForSlot100.length).toBe(2);
@@ -3070,7 +3175,7 @@ describe('KVArchiverDataStore', () => {
         slotNumber: SlotNumber(100),
       });
 
-      await store.addBlocks([block1]);
+      await store.addProposedBlocks([block1]);
 
       const blocksForSlot999 = await store.getBlocksForSlot(SlotNumber(999));
       expect(blocksForSlot999).toEqual([]);
@@ -3101,7 +3206,7 @@ describe('KVArchiverDataStore', () => {
         slotNumber: SlotNumber(50),
       });
 
-      await store.addBlocks([block1, block2, block3]);
+      await store.addProposedBlocks([block1, block2, block3]);
 
       const blocksForSlot = await store.getBlocksForSlot(SlotNumber(50));
       expect(blocksForSlot.length).toBe(3);
@@ -3134,7 +3239,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block3.archive,
       });
 
-      await store.addBlocks([block1, block2, block3, block4]);
+      await store.addProposedBlocks([block1, block2, block3, block4]);
       expect(await store.getLatestBlockNumber()).toBe(4);
 
       // Remove blocks after block 2
@@ -3163,7 +3268,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block2.archive,
       });
 
-      await store.addBlocks([block1, block2, block3]);
+      await store.addProposedBlocks([block1, block2, block3]);
 
       // Remove blocks after block 1
       const removedBlocks = await store.removeBlocksAfter(BlockNumber(1));
@@ -3184,7 +3289,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block1.archive,
       });
 
-      await store.addBlocks([block1, block2]);
+      await store.addProposedBlocks([block1, block2]);
 
       // Remove blocks after block 2 (none to remove)
       const removedBlocks = await store.removeBlocksAfter(BlockNumber(2));
@@ -3212,7 +3317,7 @@ describe('KVArchiverDataStore', () => {
         txsPerBlock: 2,
       });
 
-      await store.addBlocks([block1, block2]);
+      await store.addProposedBlocks([block1, block2]);
 
       // Verify block2 is retrievable by hash and archive before removal
       const block2Hash = await block2.header.hash();
@@ -3264,7 +3369,7 @@ describe('KVArchiverDataStore', () => {
         lastArchive: block1.archive,
       });
 
-      await store.addBlocks([block1, block2]);
+      await store.addProposedBlocks([block1, block2]);
 
       const removedBlocks = await store.removeBlocksAfter(BlockNumber(0));
 

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -25,7 +25,7 @@ import type { UInt64 } from '@aztec/stdlib/types';
 import { join } from 'path';
 
 import type { InboxMessage } from '../structs/inbox_message.js';
-import { BlockStore, type CheckpointData } from './block_store.js';
+import { BlockStore, type CheckpointData, type RemoveCheckpointsResult } from './block_store.js';
 import { ContractClassStore } from './contract_class_store.js';
 import { ContractInstanceStore } from './contract_instance_store.js';
 import { LogStore } from './log_store.js';
@@ -235,12 +235,14 @@ export class KVArchiverDataStore implements ContractDataSource {
   }
 
   /**
-   * Append new blocks to the store's list.
-   * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
+   * Append new proposed blocks to the store's list.
+   * These are uncheckpointed blocks that have been proposed by the sequencer but not yet included in a checkpoint on L1.
+   * For checkpointed blocks (already published to L1), use addCheckpoints() instead.
+   * @param blocks - The proposed L2 blocks to be added to the store.
    * @returns True if the operation is successful.
    */
-  addBlocks(blocks: L2Block[], opts: { force?: boolean; checkpointNumber?: number } = {}): Promise<boolean> {
-    return this.#blockStore.addBlocks(blocks, opts);
+  addProposedBlocks(blocks: L2Block[], opts: { force?: boolean; checkpointNumber?: number } = {}): Promise<boolean> {
+    return this.#blockStore.addProposedBlocks(blocks, opts);
   }
 
   /**
@@ -261,14 +263,12 @@ export class KVArchiverDataStore implements ContractDataSource {
   }
 
   /**
-   * Unwinds checkpoints from the database
-   * @param from -  The tip of the chain, passed for verification purposes,
-   *                ensuring that we don't end up deleting something we did not intend
-   * @param checkpointsToUnwind - The number of checkpoints we are to unwind
-   * @returns True if the operation is successful
+   * Removes all checkpoints with checkpoint number > checkpointNumber.
+   * Also removes ALL blocks (both checkpointed and uncheckpointed) after the last block of the given checkpoint.
+   * @param checkpointNumber - Remove all checkpoints strictly after this one.
    */
-  unwindCheckpoints(from: CheckpointNumber, checkpointsToUnwind: number): Promise<boolean> {
-    return this.#blockStore.unwindCheckpoints(from, checkpointsToUnwind);
+  removeCheckpointsAfter(checkpointNumber: CheckpointNumber): Promise<RemoveCheckpointsResult> {
+    return this.#blockStore.removeCheckpointsAfter(checkpointNumber);
   }
 
   /**
@@ -629,10 +629,11 @@ export class KVArchiverDataStore implements ContractDataSource {
 
   /**
    * Removes all blocks with block number > blockNumber.
+   * Does not remove any associated checkpoints.
    * @param blockNumber - The block number to remove after.
    * @returns The removed blocks (for event emission).
    */
   removeBlocksAfter(blockNumber: BlockNumber): Promise<L2Block[]> {
-    return this.#blockStore.unwindBlocksAfter(blockNumber);
+    return this.#blockStore.removeBlocksAfter(blockNumber);
   }
 }

--- a/yarn-project/archiver/src/test/mock_archiver.ts
+++ b/yarn-project/archiver/src/test/mock_archiver.ts
@@ -57,7 +57,7 @@ export class MockPrefilledArchiver extends MockArchiver {
 
     const fromBlock = this.l2Blocks.length;
     // TODO: Add L2 blocks and checkpoints separately once archiver has the apis for that.
-    this.addBlocks(this.prefilled.slice(fromBlock, fromBlock + numBlocks).flatMap(c => c.blocks));
+    this.addProposedBlocks(this.prefilled.slice(fromBlock, fromBlock + numBlocks).flatMap(c => c.blocks));
     return Promise.resolve();
   }
 }

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -43,9 +43,9 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     this.log.verbose(`Created ${numBlocks} blocks in the mock L2 block source`);
   }
 
-  public addBlocks(blocks: L2Block[]) {
+  public addProposedBlocks(blocks: L2Block[]) {
     this.l2Blocks.push(...blocks);
-    this.log.verbose(`Added ${blocks.length} blocks to the mock L2 block source`);
+    this.log.verbose(`Added ${blocks.length} proposed blocks to the mock L2 block source`);
   }
 
   public removeBlocks(numBlocks: number) {

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -347,7 +347,7 @@ describe('P2P Client', () => {
         finalized: { block: { number: BlockNumber(50), hash: expect.any(String) }, checkpoint: anyCheckpoint },
       });
 
-      blockSource.addBlocks([await L2Block.random(BlockNumber(91)), await L2Block.random(BlockNumber(92))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(91)), await L2Block.random(BlockNumber(92))]);
       blockSource.setCheckpointedBlockNumber(92);
 
       await client.sync();
@@ -445,7 +445,7 @@ describe('P2P Client', () => {
 
     it('syncs new blocks', async () => {
       await client.start();
-      blockSource.addBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
       await client.sync();
       expect(await client.getSyncedLatestBlockNum()).toEqual(102);
     });
@@ -471,7 +471,7 @@ describe('P2P Client', () => {
 
     it('stops tx collection for pruned blocks', async () => {
       await client.start();
-      blockSource.addBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
       await client.sync();
 
       blockSource.removeBlocks(1);
@@ -481,7 +481,7 @@ describe('P2P Client', () => {
 
     it('stops tx collection for proven blocks', async () => {
       await client.start();
-      blockSource.addBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(101)), await L2Block.random(BlockNumber(102))]);
       await client.sync();
 
       await advanceToProvenBlock(BlockNumber(101));
@@ -495,7 +495,7 @@ describe('P2P Client', () => {
       await block.hash();
 
       txPool.hasTxs.mockResolvedValue([true, false, true]);
-      blockSource.addBlocks([block]);
+      blockSource.addProposedBlocks([block]);
       await client.sync();
 
       expect(txCollection.startCollecting).toHaveBeenCalledTimes(1);
@@ -507,7 +507,7 @@ describe('P2P Client', () => {
 
     it('clears non-evictable txs when new blocks are synced', async () => {
       await client.start();
-      blockSource.addBlocks([await L2Block.random(BlockNumber(101))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(101))]);
       await client.sync();
 
       expect(txPool.clearNonEvictableTxs).toHaveBeenCalled();
@@ -575,7 +575,7 @@ describe('P2P Client', () => {
       ]);
 
       await realClient.start();
-      blockSource.addBlocks([await L2Block.random(BlockNumber(101))]);
+      blockSource.addProposedBlocks([await L2Block.random(BlockNumber(101))]);
       await realClient.sync();
 
       const tx6 = await mockTx(nextTxSeed++, { maxPriorityFeesPerGas: new GasFees(6, 6) });

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -21,13 +21,9 @@ export class TXEArchiver extends ArchiverDataSourceBase {
     super(store);
   }
 
-  // TXE-specific method for adding checkpoints
-  public async addCheckpoints(checkpoints: PublishedCheckpoint[], result?: ValidateCheckpointResult): Promise<boolean> {
-    await this.updater.setNewCheckpointData(checkpoints, result);
-    return true;
+  public async addCheckpoints(checkpoints: PublishedCheckpoint[], result?: ValidateCheckpointResult): Promise<void> {
+    await this.updater.addCheckpoints(checkpoints, result);
   }
-
-  // Abstract method implementations
 
   public getRollupAddress(): Promise<EthAddress> {
     throw new Error('TXE Archiver does not implement "getRollupAddress"');

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -1,11 +1,14 @@
 import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { TestCircuitVerifier } from '@aztec/bb-prover/test';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { AnchorBlockStore } from '@aztec/pxe/server';
 import { L2Block } from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 
 import { TXEArchiver } from './archiver.js';
@@ -59,14 +62,25 @@ export class TXEStateMachine {
   }
 
   public async handleL2Block(block: L2Block) {
-    // Create a checkpoint from the block - L2Block doesn't have toCheckpoint() method
-    // We need to construct the Checkpoint manually
-    const checkpoint = await Checkpoint.random(block.checkpointNumber, {
-      numBlocks: 1,
-      startBlockNumber: Number(block.number),
-    });
-    // Replace the random block with our actual block
-    checkpoint.blocks = [block];
+    // Create a checkpoint from the block manually
+    const checkpoint = new Checkpoint(
+      block.archive,
+      CheckpointHeader.from({
+        lastArchiveRoot: block.header.lastArchive.root,
+        inHash: Fr.ZERO,
+        blobsHash: Fr.ZERO,
+        blockHeadersHash: Fr.ZERO,
+        epochOutHash: Fr.ZERO,
+        slotNumber: block.header.globalVariables.slotNumber,
+        timestamp: block.header.globalVariables.timestamp,
+        coinbase: block.header.globalVariables.coinbase,
+        feeRecipient: block.header.globalVariables.feeRecipient,
+        gasFees: block.header.globalVariables.gasFees,
+        totalManaUsed: block.header.totalManaUsed,
+      }),
+      [block],
+      CheckpointNumber.fromBlockNumber(block.number),
+    );
 
     const publishedCheckpoint = new PublishedCheckpoint(
       checkpoint,
@@ -78,9 +92,9 @@ export class TXEStateMachine {
       [],
     );
     await Promise.all([
-      this.synchronizer.handleL2Block(block), // L2Block doesn't need toL2Block() conversion
+      this.synchronizer.handleL2Block(block),
       this.archiver.addCheckpoints([publishedCheckpoint], undefined),
-      this.anchorBlockStore.setHeader(block.header), // Use .header property directly
+      this.anchorBlockStore.setHeader(block.header),
     ]);
   }
 }


### PR DESCRIPTION
  When calling `unwindCheckpoints` (now `removeCheckpointsAfter`), any proposed uncheckpointed  
  blocks were NOT being removed, resulting in a "gap" in blocks. For example:                   
                                                                                                
  - We had checkpointed up to block 10, and then 2 more uncheckpointed blocks (11 and 12)       
  - We called `unwindCheckpoints` to remove the last checkpoint, which included blocks 6-10     
  - This removed blocks 6-10, so the last block was 5                                           
  - BUT we forgot to delete blocks 11 and 12, so we ended up with a gap (5 → 11, 12), which is  
  not allowed                                                                                   
                                                                                                
  ### Changes                                                                                   
                                                                                                
  - **Renamed `unwindCheckpoints` to `removeCheckpointsAfter`** with a simpler API: instead of  
  `(from, count)`, it now takes just `(checkpointNumber)` and removes all checkpoints strictly  
  after that number       
  - **Renamed `addBlocks` to `addProposedBlocks`** in the store with a check that verifies that we are not overwriting any checkpointed block with a proposed one (cc @PhilWindle)                                                                      
  - **Fixed the bug**: `removeCheckpointsAfter` now finds the last block of the target          
  checkpoint and removes ALL blocks after it (both checkpointed and uncheckpointed), preventing 
  orphaned blocks                                                                               
  - **Added unit tests** for the fix: `orphaned blocks are removed when removing checkpoints`   
  and `multiple orphaned blocks are removed when removing checkpoints`                          
  - **Renamed `removeBlocksAfter` to private** in `DataStoreUpdater`, and added                 
  `removeUncheckpointedBlocksAfter` as the public method with a safety check that throws if you 
  try to remove checkpointed blocks                                                             
  - **Added defense-in-depth validation**: `addBlocks()` now throws                             
  `CannotOverwriteCheckpointedBlockError` if attempting to add a block that would overwrite     
  already-checkpointed data                                                                     
  - **Renamed internal methods** for clarity: `addBlockDataToDB` → `addContractDataToDb`,       
  `removeBlockDataFromDB` → `removeContractDataFromDb`, `editContractBlockData` →               
  `updateContractDataOnDb`, `setNewCheckpointData` → `addCheckpoints`     