### PR TITLE
feat(ci): release canary branch automation

### DIFF
--- a/.github/workflows/release-canary-pr-update.yml
+++ b/.github/workflows/release-canary-pr-update.yml
@@ -1,0 +1,112 @@
+name: Alpha Team Canary
+
+on:
+  push:
+    branches:
+      - next
+    paths:
+      # Match any file named bootstrap.sh
+      - '**/bootstrap.sh'
+      # Anything in ci3 folder
+      - 'ci3/**'
+
+env:
+  CANARY_BRANCH: ad/chore/ci-release-pr-canary
+  PR_TITLE: "no-merge: alpha canary PR"
+  PR_LABEL: ci-release-pr
+
+jobs:
+  update-canary-pr:
+    name: Update alpha team canary PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name AztecBot
+          git config --global user.email tech@aztecprotocol.com
+
+      - name: Ensure canary branch and PR exist
+        id: ensure-pr
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: |
+          # Check if branch exists
+          if ! git ls-remote --exit-code --heads origin "$CANARY_BRANCH" >/dev/null 2>&1; then
+            echo "Creating canary branch from next"
+            git checkout -b "$CANARY_BRANCH" origin/next
+            git push -u origin "$CANARY_BRANCH"
+          fi
+
+          # Check if PR exists
+          pr_number=$(gh pr list --state open --head "$CANARY_BRANCH" --json number --jq '.[0].number')
+
+          if [[ -z "$pr_number" ]]; then
+            echo "Creating canary PR"
+            pr_url=$(gh pr create \
+              --head "$CANARY_BRANCH" \
+              --base next \
+              --title "$PR_TITLE" \
+              --label "$PR_LABEL" \
+              --body "This PR tests certain CI labels periodically. Any failures in this branch log to alpha-team channel with slack.
+
+          This PR is automatically updated when \`**/bootstrap.sh\` or \`ci3/**\` files are pushed to \`next\`.
+
+          **Important:** This PR should never be merged. It exists solely to test the \`ci-release-pr\` label.")
+
+            pr_number=$(gh pr list --state open --head "$CANARY_BRANCH" --json number --jq '.[0].number')
+            echo "Created canary PR #$pr_number"
+          fi
+
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+
+      - name: Check if CI is already running
+        id: check-ci
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: |
+          pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
+
+          # Check if CI is currently running on this PR
+          running_ci=$(gh run list --branch "$CANARY_BRANCH" --workflow ci3.yml --status in_progress --json databaseId --jq 'length')
+
+          if [[ "$running_ci" -gt 0 ]]; then
+            echo "CI is already running on canary PR #$pr_number, skipping update"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "No CI running, proceeding with update"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Merge next into canary branch
+        if: steps.check-ci.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: |
+          pr_number="${{ steps.ensure-pr.outputs.pr_number }}"
+
+          # Fetch both branches
+          git fetch origin "$CANARY_BRANCH" next
+
+          # Checkout the canary branch
+          git checkout "$CANARY_BRANCH"
+
+          # Merge next into canary branch
+          if git merge origin/next --no-edit -m "Merge branch 'next' into $CANARY_BRANCH"; then
+            echo "Successfully merged next into $CANARY_BRANCH"
+            git push origin "$CANARY_BRANCH"
+            echo "Pushed update to $CANARY_BRANCH"
+
+            # Re-add the ci-release-pr label (it gets removed after each CI run)
+            gh pr edit "$pr_number" --add-label "$PR_LABEL"
+            echo "Re-added $PR_LABEL label to PR #$pr_number"
+          else
+            echo "Merge conflict detected, aborting"
+            git merge --abort
+            exit 1
+          fi

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -188,7 +188,7 @@ container_script=$(
   case \$code in
     155) ;;
     0) log_ci_run PASSED \$ci_log_id ;;
-    *) log_ci_run FAILED \$ci_log_id && merge_train_failure_slack_notify \$ci_log_id ;;
+    *) log_ci_run FAILED \$ci_log_id && merge_train_failure_slack_notify \$ci_log_id && release_canary_slack_notify \$ci_log_id ;;
   esac
   exit \$code
 EOF

--- a/ci3/release_canary_slack_notify
+++ b/ci3/release_canary_slack_notify
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eu
+
+# Sends Slack notification for alpha team canary CI failures.
+# Called from ci3/bootstrap_ec2 on CI failure.
+#
+# Usage: alpha_team_canary_slack_notify <ci_log_id>
+#
+# Environment variables:
+#   SLACK_BOT_TOKEN - Required for sending Slack messages
+#   PR_HEAD_REF - Branch name (set for PR runs)
+#   REF_NAME - Git ref name (set for tag runs)
+
+ALPHA_CANARY_BRANCH="ad/chore/ci-release-pr-canary"
+
+# Determine if this is an alpha canary run:
+# 1. PR run on the canary branch
+# 2. Release tag (v0.0.1-commit.*) where the commit is on the canary branch
+is_alpha_canary=false
+
+if [[ "${PR_HEAD_REF:-}" == "$ALPHA_CANARY_BRANCH" ]]; then
+  # Case 1: Direct PR run on the canary branch
+  is_alpha_canary=true
+elif [[ "${REF_NAME:-}" =~ ^v0\.0\.1-commit\. ]]; then
+  # Case 2: Release tag from ci-release-pr label - check if commit is on canary branch
+  if git fetch --depth=50 origin "$ALPHA_CANARY_BRANCH" 2>/dev/null && \
+     git merge-base --is-ancestor HEAD FETCH_HEAD 2>/dev/null; then
+    is_alpha_canary=true
+  fi
+fi
+
+if [[ "$is_alpha_canary" != "true" ]]; then
+  exit 0
+fi
+
+ci_log_id=${1:-}
+
+send_slack_message() {
+  local message=$1
+  if [[ -z "${SLACK_BOT_TOKEN:-}" ]]; then
+    echo "SLACK_BOT_TOKEN not set, skipping notification"
+    return 0
+  fi
+
+  local data=$(cat <<EOF
+{
+  "channel": "#alpha-team",
+  "text": "$message"
+}
+EOF
+)
+  curl -s -X POST https://slack.com/api/chat.postMessage \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H "Content-type: application/json" \
+    --data "$data"
+}
+
+set -x
+
+send_slack_message "CI failed on alpha team canary (ci-release-pr): http://ci.aztec-labs.com/$ci_log_id"


### PR DESCRIPTION
## Summary
- Adds the "Alpha Team Canary" workflow that triggers on push to `next` when `**/bootstrap.sh` or `ci3/**` files change
- The workflow:
  - Ensures the canary branch and PR exist (creates them if needed)
  - Checks if CI is already running before updating to avoid duplicate runs
  - Merges `next` into the canary PR branch (`ad/chore/ci-release-pr-canary`)
  - Notifies `#alpha-team` Slack channel on workflow failure
- Adds `ci3/alpha_team_canary_slack_notify` script for Slack notifications (matches merge train pattern)
- Adds CI failure notification call to `ci3/bootstrap_ec2` alongside merge train notifications

This works together with the canary PR #19936 which is a long-running PR with the `ci-release-pr` label for testing CI release processes.