### PR TITLE
chore: disable flakey tsc.test.sh

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -221,9 +221,6 @@ function test_cmds {
   # Uses mocha for browser tests, so we have to treat it differently.
   echo "$hash cd yarn-project/kv-store && yarn test"
 
-  # Test the tsc.sh build script
-  echo "$hash yarn-project/scripts/tsc.test.sh"
-
   if [[ "${TARGET_BRANCH:-}" =~ ^v[0-9]+$ ]]; then
     echo "$hash yarn-project/scripts/run_test.sh aztec/src/testnet_compatibility.test.ts"
     echo "$hash yarn-project/scripts/run_test.sh aztec/src/mainnet_compatibility.test.ts"


### PR DESCRIPTION
Had flakes during teardown. This was a low value test. it can be around for manual use.