### PR TITLE
fix(test): increase wallet min fee padding for p2p e2e tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -128,6 +128,7 @@ export class P2PNetworkTest {
       metricsPort: metricsPort,
       numberOfInitialFundedAccounts: 2,
       startProverNode,
+      walletMinFeePadding: 2.0,
     };
 
     this.deployL1ContractsArgs = {

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -209,6 +209,8 @@ export type SetupOptions = {
   skipAccountDeployment?: boolean;
   /** L1 contracts deployment arguments. */
   l1ContractsArgs?: Partial<DeployAztecL1ContractsArgs>;
+  /** Wallet minimum fee padding multiplier (defaults to 0.5, which is 50% padding). */
+  walletMinFeePadding?: number;
 } & Partial<AztecNodeConfig>;
 
 /** Context for an end-to-end test as returned by the `setup` function */
@@ -268,7 +270,7 @@ export type EndToEndContext = {
  */
 async function setupWithRemoteEnvironment(
   account: HDAccount | PrivateKeyAccount,
-  config: AztecNodeConfig,
+  config: AztecNodeConfig & SetupOptions,
   logger: Logger,
   numberOfAccounts: number,
 ): Promise<EndToEndContext> {
@@ -289,6 +291,11 @@ async function setupWithRemoteEnvironment(
   };
   const ethCheatCodes = new EthCheatCodes(config.l1RpcUrls, new DateProvider());
   const wallet = await TestWallet.create(aztecNode);
+
+  if (config.walletMinFeePadding !== undefined) {
+    wallet.setMinFeePadding(config.walletMinFeePadding);
+  }
+
   const cheatCodes = await CheatCodes.create(config.l1RpcUrls, aztecNode, new DateProvider());
   const teardown = () => Promise.resolve();
 
@@ -605,6 +612,10 @@ export async function setup(
     // For tests we only want proving enabled if specifically requested
     pxeConfig.proverEnabled = !!pxeOpts.proverEnabled;
     const wallet = await TestWallet.create(aztecNodeService, pxeConfig);
+
+    if (opts.walletMinFeePadding !== undefined) {
+      wallet.setMinFeePadding(opts.walletMinFeePadding);
+    }
 
     const cheatCodes = await CheatCodes.create(config.l1RpcUrls, aztecNodeService, dateProvider);
 


### PR DESCRIPTION
We had txs being rejected by nodes in p2p e2e tests due to "insufficient fee", which happens because of a time warp between tx creation and inclusion.

```
13:51:40 [13:51:40.803] VERBOSE: sequencer:tx_validator:tx_gas Skipping transaction 0x0bf77f35f6b5811684c3abb39eadb17ac323f41d90ee81727343c27fbaf1d0e2 due to insufficient fee per gas {"txMaxFeesPerGas":{"feePerDaGas":0,"feePerL2Gas":219323250000},"currentGasFees":{"feePerDaGas":0,"feePerL2Gas":565045100000}}
```

This increases the min padding from 50% to 200%.
