### PR TITLE
chore: store proper block number in ws revision during fork

### DIFF
--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -173,7 +173,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
       this.initialHeader!,
       new WorldStateRevision(
         /*forkId=*/ resp.forkId,
-        /* blockNumber=*/ BlockNumber.ZERO,
+        /* blockNumber=*/ blockNumber ?? BlockNumber.ZERO,
         /* includeUncommitted=*/ true,
       ),
       opts,


### PR DESCRIPTION
Should not impact behaviour but help with logging afterwards.
