### PR TITLE
fix(ci): Do not use --exact-match when setting Noir versions for aztec-up bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -151,7 +151,7 @@ function check_toolchains {
 
 function versions {
   local noir_version anvil_version node_version cmake_version clang_version zig_version rustc_version wasi_sdk_version
-  noir_version=$(git -C noir/noir-repo describe --tags --exact-match HEAD)
+  noir_version=$(git -C noir/noir-repo describe --tags --always HEAD)
   anvil_version=$(anvil --version | head -n1 | sed -E 's/anvil Version: ([0-9.]+).*/\1/')
   node_version=$(node --version | cut -d 'v' -f 2)
   cmake_version=$(cmake --version | head -n1 | cut -d' ' -f3)


### PR DESCRIPTION
If I want to test a patch in the Noir submodule against CI by altering `noir/noir-repo` directly rather than needing a new temporary tag it is currently not possible. 

When aztec-up [fetchs the versions](https://github.com/AztecProtocol/aztec-packages/blob/0bee1eb2dba5ed7d0b88466ae8ab58b9177dceb1/aztec-up/bootstrap.sh#L8) the `noir_version` expects an exact match for the tag. 

This prevents being able to directly modify the submodule as no tag exists. I ran into this issue in https://github.com/AztecProtocol/aztec-packages/pull/19871 where CI would fail with `fatal: no tag exactly matches '515b2702975fd85069fae48ddd0d90a56cd65628'` at `aztec-up/bootstrap.sh`. This does not affect release builds as those are also protected in the [Noir build](https://github.com/AztecProtocol/aztec-packages/blob/f94d8e86e88ad812c50a2661f63fedc30c59a04b/noir/bootstrap.sh#L98). 