### PR TITLE
fix: removed extra property

### DIFF
--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -352,14 +352,7 @@ export abstract class BaseWallet implements Wallet {
     const instance = await this.pxe.getContractInstance(address);
     const initNullifier = await siloNullifier(address, address.toField());
     const publiclyRegisteredContract = await this.aztecNode.getContract(address);
-    const [initNullifierMembershipWitness, publiclyRegisteredContractClass] = await Promise.all([
-      this.aztecNode.getNullifierMembershipWitness('latest', initNullifier),
-      publiclyRegisteredContract
-        ? this.aztecNode.getContractClass(
-            publiclyRegisteredContract.currentContractClassId || instance?.currentContractClassId,
-          )
-        : undefined,
-    ]);
+    const initNullifierMembershipWitness = await this.aztecNode.getNullifierMembershipWitness('latest', initNullifier);
     const isContractUpdated =
       publiclyRegisteredContract &&
       !publiclyRegisteredContract.currentContractClassId.equals(publiclyRegisteredContract.originalContractClassId);
@@ -367,7 +360,6 @@ export abstract class BaseWallet implements Wallet {
       instance: instance ?? undefined,
       isContractInitialized: !!initNullifierMembershipWitness,
       isContractPublished: !!publiclyRegisteredContract,
-      isContractClassPubliclyRegistered: !!publiclyRegisteredContractClass,
       isContractUpdated: !!isContractUpdated,
       updatedContractClassId: isContractUpdated ? publiclyRegisteredContract.currentContractClassId : undefined,
     };


### PR DESCRIPTION
`BaseWallet` included `isContractClassPubliclyRegistered` which was computed by asking the node for the contract instance the address argument points to. This is incorrect, since it would return undefined for a contract that has not been publicly deployed, even if in fact its class had been registered.