### PR TITLE
chore(docs): expand paying fees page with mana and fee analysis

### DIFF
--- a/docs/docs-developers/docs/aztec-js/how_to_pay_fees.md
+++ b/docs/docs-developers/docs/aztec-js/how_to_pay_fees.md
@@ -1,8 +1,8 @@
 ---
 title: Paying Fees
-tags: [fees, transactions, accounts]
+tags: [fees, transactions, accounts, mana, gas]
 sidebar_position: 7
-description: Pay transaction fees on Aztec using different payment methods and fee paying contracts.
+description: Pay transaction fees on Aztec, understand mana costs, estimate gas, and retrieve fees from receipts.
 ---
 
 import { Fees } from '@site/src/components/Snippets/general_snippets';
@@ -28,6 +28,70 @@ This guide walks you through paying transaction fees on Aztec using various paym
 | Private FPC         | Pay with tokens privately     | Private | Token balance, FPC address |
 | Public FPC          | Pay with tokens publicly      | Public  | Token balance, FPC address |
 | Bridge + Claim      | Bootstrap from L1             | Public  | L1 ETH for gas             |
+
+## Mana and Fee Juice
+
+Mana is Aztec's unit of computational effort (like gas on Ethereum), and Fee Juice is the native fee token used to pay for transactions. For a detailed explanation of these concepts, see [Fee Concepts](../foundational-topics/fees.md).
+
+## Estimate mana costs
+
+Before sending a transaction, you can estimate the mana it will consume by simulating with `estimateGas: true`:
+
+```typescript
+const { estimatedGas } = await contract.methods
+  .myFunction(arg1, arg2)
+  .simulate({
+    from: sender.address,
+    fee: { estimateGas: true, estimatedGasPadding: 0.1 },
+  });
+```
+
+The `estimatedGas` object contains:
+
+- `gasLimits.daGas` - Estimated DA mana for main execution
+- `gasLimits.l2Gas` - Estimated L2 mana for main execution
+- `teardownGasLimits.daGas` - Estimated DA mana for teardown phase
+- `teardownGasLimits.l2Gas` - Estimated L2 mana for teardown phase
+
+### Calculate expected fee from estimate
+
+To calculate the expected fee from estimated gas, use the `computeFee` method with current network fees:
+
+```typescript
+// import { createAztecNodeClient } from '@aztec/aztec.js/node';
+// const aztecNode = createAztecNodeClient('http://localhost:8080');
+const currentFees = await aztecNode.getCurrentMinFees();
+const estimatedFee = estimatedGas.gasLimits.computeFee(currentFees).toBigInt();
+console.log("Estimated fee:", estimatedFee);
+```
+
+:::tip
+The `estimatedGasPadding` parameter adds a safety margin to the estimate. A value of `0.1` adds 10% padding. Use higher padding for transactions with variable gas costs.
+:::
+
+## Get transaction fee from receipt
+
+After a transaction is mined, you can retrieve the fee paid from the receipt:
+
+```typescript
+const receipt = await contract.methods
+  .myFunction(arg1, arg2)
+  .send({ from: sender.address })
+  .wait();
+
+console.log("Transaction fee:", receipt.transactionFee);
+```
+
+The `transactionFee` field is a `bigint` representing the total fee paid in the fee token (Fee Juice). You can also check execution status:
+
+```typescript
+if (receipt.hasExecutionSucceeded()) {
+  console.log("Transaction succeeded in block:", receipt.blockNumber);
+  console.log("Fee paid:", receipt.transactionFee);
+} else {
+  console.log("Transaction failed:", receipt.error);
+}
+```
 
 ## Pay with Fee Juice
 
@@ -169,6 +233,17 @@ const receipt = await contract.methods
 ```
 
 ## Configure gas settings
+
+### Understanding gas dimensions
+
+Gas settings specify limits and fees for both DA and L2 dimensions:
+
+- **gasLimits**: Maximum mana for main execution phase
+- **teardownGasLimits**: Maximum mana for teardown phase (used by FPCs for refunds)
+- **maxFeesPerGas**: Maximum price you're willing to pay per mana unit
+- **maxPriorityFeesPerGas**: Priority fee for faster inclusion
+
+The fee limit is calculated as `gasLimits × maxFeesPerGas` for each dimension.
 
 ### Set custom gas limits
 

--- a/docs/docs-developers/docs/foundational-topics/fees.md
+++ b/docs/docs-developers/docs/foundational-topics/fees.md
@@ -1,8 +1,8 @@
 ---
 title: Fees
 sidebar_position: 4
-tags: [fees]
-description: Understand Aztec's fee system including mana-based transaction pricing, Aztec token payments, and how L1 and L2 costs are transparently calculated for users.
+tags: [fees, mana, gas]
+description: Understand Aztec's fee system including mana-based transaction pricing, Aztec token and Fee Juice payments, and how L1 and L2 costs are transparently calculated for users.
 references: ["yarn-project/stdlib/src/gas/gas_settings.ts"]
 ---
 
@@ -17,21 +17,42 @@ In a nutshell, the pricing of transactions transparently accounts for:
 
 This is achieved through multiple variables and calculations.
 
-## Terminology and factors
+## Terminology
 
 Familiar terms from Ethereum mainnet as referred to on the Aztec network:
 
-| Ethereum Mainnet | Aztec                | Description                                                 |
-| ---------------- | -------------------- | ----------------------------------------------------------- |
-| gas              | mana                 | unit measuring computational effort for transaction operations |
-| fee per gas      | Aztec token per mana | price per unit of mana                                      |
-| fee (wei)        | Aztec token          | total fee paid for a transaction                            |
+| Ethereum Mainnet | Aztec              | Description                                                    |
+| ---------------- | ------------------ | -------------------------------------------------------------- |
+| gas              | mana               | Unit measuring computational effort for transaction operations |
+| fee per gas      | Fee Juice per mana | Price per unit of mana                                         |
+| fee (wei)        | Fee Juice          | Total fee paid for a transaction                               |
 
-Fees on Aztec are paid in the Aztec token, which is bridged from L1. An oracle informs the price of Aztec token per wei, which can be used to calculate a transaction's fee in wei.
+## What is mana?
 
-Aztec also borrows ideas from EIP-1559, including congestion multipliers and the ability to specify base and priority fees per mana.
+Mana is Aztec's unit of computational effort, equivalent to gas on Ethereum. Every transaction consumes mana based on the operations it performs.
 
-### Aztec-specific fields
+Mana has two dimensions:
+
+- **Data Availability (DA) mana**: Cost of publishing transaction data to the data availability layer
+- **L2 mana**: Cost of executing the transaction on Aztec
+
+The total transaction fee is calculated as:
+
+```
+fee = (daMana × feePerDaMana) + (l2Mana × feePerL2Mana)
+```
+
+:::note
+The SDK and protocol code use "gas" in variable names (e.g., `daGas`, `l2Gas`, `feePerDaGas`, `feePerL2Gas`) rather than "mana". When reading code, `Gas` and mana refer to the same concept.
+:::
+
+## What is Fee Juice?
+
+Fee Juice is the native fee token on Aztec, used to pay for transaction fees. It is bridged Aztec tokens from Ethereum and is **non-transferable** on Aztec - it can only be used to pay fees, not sent between accounts.
+
+Aztec borrows ideas from EIP-1559, including congestion multipliers and the ability to specify base and priority fees per mana.
+
+## Factors affecting fees
 
 Other fields used in mana and fee calculations are determined in various ways:
 
@@ -54,15 +75,15 @@ import { Gas_Settings_Components, Gas_Settings, Tx_Teardown_Phase } from '@site/
 
 ## Fee payment
 
-A fee payer will have bridged the Aztec token from L1. On Aztec this fee asset is non-transferable, and only deducted by the protocol to pay for fees. A user can claim bridged Aztec token and use it to pay for transaction fees in the same transaction.
+A fee payer obtains Fee Juice by bridging Aztec tokens from Ethereum. The fee payer can be the account itself or a fee-paying contract (FPC), which functions similarly to a paymaster on Ethereum. On Aztec, Fee Juice is non-transferable and only deducted by the protocol to pay for fees. A user can claim bridged Fee Juice and use it to pay for transaction fees in the same transaction.
 
-The mechanism for bridging is the same as any other token. For more on this concept see the [Token Bridge Tutorial](../tutorials/js_tutorials/token_bridge.md) which describes portal contracts and [cross-chain messaging](../aztec-nr/framework-description/how_to_communicate_cross_chain.md).
+Fee Juice uses an enshrined `FeeJuicePortal` contract on Ethereum for bridging, unlike user-deployed token portals. The underlying cross-chain messaging mechanism is similar to other tokens - for more on this concept see the [Token Bridge Tutorial](../tutorials/js_tutorials/token_bridge.md) which describes portal contracts and [cross-chain messaging](../aztec-nr/framework-description/how_to_communicate_cross_chain.md).
 
 ### Payment methods
 
-An account with the Aztec token can pay for its transactions directly, including deployment of a new account, if the Aztec token has been bridged to the address where the account will be deployed.
+An account with Fee Juice can pay for its transactions directly. A new account can even pay for its own deployment transaction, provided Fee Juice was bridged to its address before deployment.
 
-Alternatively, accounts can use fee-paying contracts (FPCs) to pay for transactions. FPCs accept tokens and pay fees in the Aztec token on behalf of users. Common patterns include:
+Alternatively, accounts can use [fee-paying contracts (FPCs)](../aztec-js/how_to_pay_fees.md#fee-payment-contracts-fpc) to pay for transactions. FPCs accept tokens and pay fees in Fee Juice on behalf of users. Common patterns include:
 
 - **Sponsored FPCs**: Pay fees unconditionally, enabling free transactions for users
 - **Token-accepting FPCs**: Accept a specific token in exchange for paying fees


### PR DESCRIPTION
## Summary

- Add "What is mana?" section explaining Aztec's computational unit and DA/L2 dimensions
- Add "Estimate mana costs" section showing how to estimate gas before sending transactions
- Add "Get transaction fee from receipt" section for retrieving fees after execution
- Add "Understanding gas dimensions" subsection explaining gas settings parameters
- Update front-matter with improved description and additional tags

## Test plan

- [x] Spellcheck passes for modified file
- [x] Dev server compiles without errors
- [ ] Visual review of rendered documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)