### PR TITLE
chore(e2e): multiple blocks per slot e2e tests

### DIFF
--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -15,6 +15,7 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type ContractInstanceWithAddress, ContractInstanceWithAddressSchema } from '@aztec/stdlib/contract';
 import { Gas } from '@aztec/stdlib/gas';
 import { AbiDecodedSchema, type ApiSchemaFor, optional, schemas, zodFor } from '@aztec/stdlib/schemas';
+import type { ExecutionPayload, InTx } from '@aztec/stdlib/tx';
 import {
   Capsule,
   HashedValues,
@@ -25,7 +26,6 @@ import {
   UtilitySimulationResult,
   inTxSchema,
 } from '@aztec/stdlib/tx';
-import type { ExecutionPayload, InTx } from '@aztec/stdlib/tx';
 
 import { z } from 'zod';
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
@@ -1,0 +1,225 @@
+import type { Archiver } from '@aztec/archiver';
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
+import { NO_WAIT } from '@aztec/aztec.js/contracts';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { Logger } from '@aztec/aztec.js/log';
+import { waitForTx } from '@aztec/aztec.js/node';
+import { RollupContract } from '@aztec/ethereum/contracts';
+import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
+import { asyncMap } from '@aztec/foundation/async-map';
+import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { SecretValue } from '@aztec/foundation/config';
+import { bufferToHex } from '@aztec/foundation/string';
+import { executeTimeout } from '@aztec/foundation/timer';
+import { TestContract } from '@aztec/noir-test-contracts.js/Test';
+import { TxStatus } from '@aztec/stdlib/tx';
+import { TestWallet, proveInteraction } from '@aztec/test-wallet/server';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 15);
+
+const NODE_COUNT = 4;
+const EXPECTED_BLOCKS_PER_CHECKPOINT = 3;
+
+// Send enough transactions to trigger multiple blocks within a checkpoint assuming 2 txs per block.
+// If we start including txs at the 2nd block of a checkpoint, we can ensure a 3-block checkpoint
+// if we produce 10 txs:
+// - Checkpoint 1: Block 1 (0 txs), Block 2 (2 txs), Block 3 (2 txs)
+// - Checkpoint 2: Block 1 (2 txs), Block 2 (2 txs), Block 3 (2 txs)
+const TX_COUNT = 10;
+
+/**
+ * E2E tests for Multiple Blocks Per Slot (MBPS) functionality.
+ * Tests that the system correctly builds multiple blocks within a single slot/checkpoint.
+ */
+describe('e2e_epochs/epochs_mbps', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+  let rollup: RollupContract;
+  let archiver: Archiver;
+
+  let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
+  let contract: TestContract;
+  let wallet: TestWallet;
+  let from: AztecAddress;
+
+  /**
+   * Creates validators and sets up the test context with MBPS configuration.
+   */
+  async function setupTest(opts: {
+    syncChainTip: 'proposed' | 'checkpointed';
+    minTxsPerBlock?: number;
+    maxTxsPerBlock?: number;
+    buildCheckpointIfEmpty?: boolean;
+  }) {
+    const { syncChainTip = 'checkpointed', ...setupOpts } = opts;
+
+    validators = times(NODE_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey, bn254SecretKey: new SecretValue(Fr.random().toBigInt()) };
+    });
+
+    // Setup context with the given set of validators and MBPS configuration.
+    // Timing calculation for 3 blocks per checkpoint with 8s sub-slots:
+    // - initializationOffset ≈ 0.5s (test mode with ethereumSlotDuration < 8)
+    // - 3 blocks × 8s = 24s
+    // - checkpointFinalization = 0.5s (assemble) + 0 (p2p in test) + 2s (L1 publish) = 2.5s
+    // - finalBlockDuration = 8s
+    // - Total: 0.5 + 24 + 8 + 2.5 = 35s → use 36s for margin
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 1,
+      initialValidators: validators,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      aztecProofSubmissionEpochs: 1024,
+      startProverNode: false,
+      enforceTimeTable: true,
+      // L1 slot duration - using < 8 to enable test mode optimizations
+      ethereumSlotDuration: 4,
+      // L2 slot duration - should fit 3 blocks (8s each) + overhead
+      aztecSlotDuration: 36,
+      // Block duration of 8s as specified
+      blockDurationMs: 8000,
+      // L1 publishing time
+      l1PublishingTime: 2,
+      // Reduce attestation propagation time for tests
+      attestationPropagationTime: 0.5,
+      // Committee size of 3
+      aztecTargetCommitteeSize: 3,
+      // Additional options (minTxsPerBlock, maxTxsPerBlock, etc.)
+      ...setupOpts,
+      // PXE options for chain tip syncing
+      pxeOpts: { syncChainTip },
+    });
+
+    ({ context, logger, rollup } = test);
+    wallet = context.wallet;
+    archiver = (context.aztecNode as AztecNodeService).getBlockSource() as Archiver;
+    from = context.accounts[0];
+
+    // Halt block building in initial aztec node, which was not set up as a validator.
+    logger.warn(`Stopping sequencer in initial aztec node.`);
+    await context.sequencer!.stop();
+
+    // Start the validator nodes (but don't start sequencers yet)
+    logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
+    nodes = await asyncMap(validators, ({ privateKey }) =>
+      test.createValidatorNode([privateKey], { dontStartSequencer: true }),
+    );
+    logger.warn(`Started ${NODE_COUNT} validator nodes.`, { validators: validators.map(v => v.attester.toString()) });
+
+    // Register contract for sending txs.
+    contract = await test.registerTestContract(wallet);
+    logger.warn(`Test setup completed.`, { validators: validators.map(v => v.attester.toString()) });
+  }
+
+  /** Retrieves all checkpoints from the archiver and checks that one of them at least has the target block count */
+  async function assertMultipleBlocksPerSlot(targetBlockCount: number, logger: Logger) {
+    const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+    logger.warn(`Retrieved ${checkpoints.length} checkpoints from archiver`, {
+      checkpoints: checkpoints.map(pc => pc.checkpoint.getStats()),
+    });
+
+    let expectedBlockNumber = checkpoints[0].checkpoint.blocks[0].number;
+    let targetFound = false;
+
+    for (const checkpoint of checkpoints) {
+      const blockCount = checkpoint.checkpoint.blocks.length;
+      targetFound = targetFound || blockCount >= targetBlockCount;
+      logger.warn(`Checkpoint ${checkpoint.checkpoint.number} has ${blockCount} blocks`, {
+        checkpoint: checkpoint.checkpoint.getStats(),
+      });
+
+      for (let i = 0; i < blockCount; i++) {
+        const block = checkpoint.checkpoint.blocks[i];
+        expect(block.indexWithinCheckpoint).toBe(i);
+        expect(block.checkpointNumber).toBe(checkpoint.checkpoint.number);
+        expect(block.number).toBe(expectedBlockNumber);
+        expectedBlockNumber++;
+      }
+    }
+
+    expect(targetFound).toBe(true);
+  }
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test?.teardown();
+  });
+
+  it('builds multiple blocks per slot with transactions anchored to checkpointed block', async () => {
+    await setupTest({ syncChainTip: 'checkpointed', minTxsPerBlock: 1, maxTxsPerBlock: 2 });
+
+    // Record the current checkpoint number before starting sequencers
+    const initialCheckpointNumber = await rollup.getCheckpointNumber();
+    logger.warn(`Initial checkpoint number: ${initialCheckpointNumber}`);
+
+    // Pre-prove and send transactions
+    const txs = await timesAsync(TX_COUNT, i =>
+      proveInteraction(context.wallet, contract.methods.emit_nullifier(new Fr(i + 1)), { from }),
+    );
+    const txHashes = await Promise.all(txs.map(tx => tx.send({ wait: NO_WAIT })));
+    logger.warn(`Sent ${txHashes.length} transactions`, { txs: txHashes });
+
+    // Start the sequencers
+    await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+    logger.warn(`Started all sequencers`);
+
+    // Wait until all txs are mined
+    const timeout = test.L2_SLOT_DURATION_IN_S * 5;
+    await executeTimeout(
+      () => Promise.all(txHashes.map(txHash => waitForTx(context.aztecNode, txHash, { timeout }))),
+      timeout * 1000,
+    );
+    logger.warn(`All txs have been mined`);
+
+    await assertMultipleBlocksPerSlot(EXPECTED_BLOCKS_PER_CHECKPOINT, logger);
+  });
+
+  it('builds multiple blocks per slot with transactions anchored to proposed blocks', async () => {
+    await setupTest({ syncChainTip: 'proposed', minTxsPerBlock: 1, maxTxsPerBlock: 1 });
+
+    // Record the current checkpoint number before starting sequencers
+    const initialCheckpointNumber = await rollup.getCheckpointNumber();
+    logger.warn(`Initial checkpoint number: ${initialCheckpointNumber}`);
+
+    // Start the sequencers
+    await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+    logger.warn(`Started all sequencers`);
+
+    // Now send the txs and wait for them to be mined one at a time
+    // If the pxe syncs correctly, every tx should be anchored to the block in which the previous one was mined
+    const txReceipts = [];
+    let expectedAnchorBlockNumber = undefined;
+
+    while (txReceipts.length < TX_COUNT / 2) {
+      logger.warn(`Sending transaction ${txReceipts.length}`);
+      const nullifier = new Fr(txReceipts.length + 1);
+      const tx = await proveInteraction(context.wallet, contract.methods.emit_nullifier(nullifier), { from });
+      const txAnchorBlockNumber = tx.data.constants.anchorBlockHeader.globalVariables.blockNumber;
+      expect(txAnchorBlockNumber).toBeGreaterThanOrEqual(expectedAnchorBlockNumber ?? txAnchorBlockNumber);
+
+      const txReceipt = await tx.send({ wait: { waitForStatus: TxStatus.PROPOSED } });
+      txReceipts.push(txReceipt);
+      expectedAnchorBlockNumber = txReceipt.blockNumber;
+      logger.warn(`Transaction ${txReceipts.length} mined on block ${txReceipt.blockNumber}`, { txReceipt });
+
+      await wallet.sync();
+      expect((await wallet.getSyncedBlockHeader()).getBlockNumber()).toBeGreaterThanOrEqual(txReceipt.blockNumber!);
+    }
+    logger.warn(`All txs have been mined`);
+
+    // We are fine with at least 2 blocks per checkpoint, since we may lose one sub-slot if assembling a tx is slow
+    await assertMultipleBlocksPerSlot(2, logger);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -18,9 +18,11 @@ import { withLogNameSuffix } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
+import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import { getMockPubSubP2PServiceFactory } from '@aztec/p2p/test-helpers';
 import { ProverNode, type ProverNodeConfig, ProverNodePublisher } from '@aztec/prover-node';
 import type { TestProverNode } from '@aztec/prover-node/test';
+import type { PXEConfig } from '@aztec/pxe/config';
 import {
   type SequencerClient,
   type SequencerEvents,
@@ -49,7 +51,7 @@ export const WORLD_STATE_BLOCK_CHECK_INTERVAL = 50;
 export const ARCHIVER_POLL_INTERVAL = 50;
 export const DEFAULT_L1_BLOCK_TIME = process.env.CI ? 12 : 8;
 
-export type EpochsTestOpts = Partial<SetupOptions> & { numberOfAccounts?: number };
+export type EpochsTestOpts = Partial<SetupOptions> & { numberOfAccounts?: number; pxeOpts?: Partial<PXEConfig> };
 
 export type TrackedSequencerEvent = {
   [K in keyof SequencerEvents]: Parameters<SequencerEvents[K]>[0] & {
@@ -147,8 +149,9 @@ export class EpochsTestContext {
         l1PublishingTime,
         ...opts,
       },
-      // Use checkpointed chain tip for PXE to avoid issues with blocks being dropped due to pruned anchor blocks.
-      { syncChainTip: 'checkpointed' },
+      // Use checkpointed chain tip for PXE by default to avoid issues with blocks being dropped due to pruned anchor blocks.
+      // Can be overridden via opts.pxeOpts.
+      { syncChainTip: 'checkpointed', ...opts.pxeOpts },
     );
 
     this.context = context;
@@ -373,6 +376,19 @@ export class EpochsTestContext {
     });
     await wallet.registerContract(instance, SpamContract.artifact);
     return SpamContract.at(instance.address, wallet);
+  }
+
+  /** Registers the TestContract on the given wallet. */
+  public async registerTestContract(wallet: Wallet, salt = Fr.ZERO) {
+    const instance = await getContractInstanceFromInstantiationParams(TestContract.artifact, {
+      constructorArgs: [],
+      constructorArtifact: undefined,
+      salt,
+      publicKeys: undefined,
+      deployer: undefined,
+    });
+    await wallet.registerContract(instance, TestContract.artifact);
+    return TestContract.at(instance.address, wallet);
   }
 
   /** Creates an L1 client using a fresh account with funds from anvil, with a tx delayer already set up. */

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -385,7 +385,7 @@ export async function setup(
       const res = await startAnvil({
         l1BlockTime: opts.ethereumSlotDuration,
         accounts: opts.anvilAccounts,
-        port: opts.anvilPort,
+        port: opts.anvilPort ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : undefined),
       });
       anvil = res.anvil;
       config.l1RpcUrls = [res.rpcUrl];

--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import type { NoteDao, NotesFilter } from '@aztec/stdlib/note';
+import type { BlockHeader } from '@aztec/stdlib/tx';
 
+import type { BlockSynchronizer } from '../block_synchronizer/block_synchronizer.js';
 import type { PXE } from '../pxe.js';
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
+import type { AnchorBlockStore } from '../storage/index.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
 /**
@@ -10,18 +13,20 @@ import type { NoteStore } from '../storage/note_store/note_store.js';
  * No backwards compatibility or API stability should be expected. Use at your own risk.
  */
 export class PXEDebugUtils {
-  #pxe: PXE | undefined = undefined;
+  #pxe!: PXE;
+  #putJobInQueue!: <T>(job: (jobId: string) => Promise<T>) => Promise<T>;
 
   constructor(
     private contractStore: ContractStore,
     private noteStore: NoteStore,
+    private blockStateSynchronizer: BlockSynchronizer,
+    private anchorBlockStore: AnchorBlockStore,
   ) {}
 
-  /**
-   * Not injected through constructor since they're are co-dependant.
-   */
-  public setPXE(pxe: PXE) {
+  /** Not injected through constructor since they're are co-dependant */
+  public setPXE(pxe: PXE, putJobInQueue: <T>(job: (jobId: string) => Promise<T>) => Promise<T>) {
     this.#pxe = pxe;
+    this.#putJobInQueue = putJobInQueue;
   }
 
   /**
@@ -36,14 +41,23 @@ export class PXEDebugUtils {
    * @returns The requested notes.
    */
   public async getNotes(filter: NotesFilter): Promise<NoteDao[]> {
-    if (!this.#pxe) {
-      throw new Error('Cannot getNotes because no PXE is set');
-    }
-
     // We need to manually trigger private state sync to have a guarantee that all the notes are available.
     const call = await this.contractStore.getFunctionCall('sync_state', [], filter.contractAddress);
     await this.#pxe.simulateUtility(call);
 
     return this.noteStore.getNotes(filter, randomBytes(8).toString('hex'));
+  }
+
+  /** Returns the block header up to which the PXE has synced. */
+  public getSyncedBlockHeader(): Promise<BlockHeader> {
+    return this.anchorBlockStore.getBlockHeader();
+  }
+
+  /**
+   * Triggers a sync of the PXE with the node.
+   * Blocks until the sync is complete.
+   */
+  public sync(): Promise<void> {
+    return this.#putJobInQueue(() => this.blockStateSynchronizer.sync());
   }
 }

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -166,7 +166,7 @@ export class PXE {
       noteStore,
     ]);
 
-    const debugUtils = new PXEDebugUtils(contractStore, noteStore);
+    const debugUtils = new PXEDebugUtils(contractStore, noteStore, synchronizer, anchorBlockStore);
 
     const jobQueue = new SerialQueue();
 
@@ -193,7 +193,7 @@ export class PXE {
       debugUtils,
     );
 
-    debugUtils.setPXE(pxe);
+    debugUtils.setPXE(pxe, pxe.#putInJobQueue.bind(pxe));
 
     pxe.jobQueue.start();
 

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -51,8 +51,7 @@ export type ValidatorClientConfig = ValidatorHASignerConfig & {
   /** Whether to run in fisherman mode: validates all proposals and attestations but does not broadcast attestations or participate in consensus */
   fishermanMode?: boolean;
 
-  // TODO(palla/mbps): Change default to false once checkpoint validation is stable
-  /** Skip checkpoint proposal validation and always attest (default: true) */
+  /** Skip checkpoint proposal validation and always attest (default: false) */
   skipCheckpointProposalValidation?: boolean;
 
   /** Skip pushing re-executed blocks to archiver (default: false) */

--- a/yarn-project/test-wallet/src/wallet/test_wallet.ts
+++ b/yarn-project/test-wallet/src/wallet/test_wallet.ts
@@ -18,7 +18,7 @@ import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { NoteDao, NotesFilter } from '@aztec/stdlib/note';
-import type { TxHash, TxReceipt, TxSimulationResult } from '@aztec/stdlib/tx';
+import type { BlockHeader, TxHash, TxReceipt, TxSimulationResult } from '@aztec/stdlib/tx';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 import { BaseWallet } from '@aztec/wallet-sdk/base-wallet';
 
@@ -280,6 +280,19 @@ export abstract class BaseTestWallet extends BaseWallet {
    */
   getNotes(filter: NotesFilter): Promise<NoteDao[]> {
     return this.pxe.debug.getNotes(filter);
+  }
+
+  /** Returns the block header up to which the wallet has synced. */
+  getSyncedBlockHeader(): Promise<BlockHeader> {
+    return this.pxe.debug.getSyncedBlockHeader();
+  }
+
+  /**
+   * Triggers a sync of the wallet with the node to update the latest block header.
+   * Blocks until the sync is complete.
+   */
+  sync(): Promise<void> {
+    return this.pxe.debug.sync();
   }
 
   /**

--- a/yarn-project/validator-client/src/config.ts
+++ b/yarn-project/validator-client/src/config.ts
@@ -65,10 +65,9 @@ export const validatorClientConfigMappings: ConfigMappingsType<ValidatorClientCo
       'Whether to run in fisherman mode: validates all proposals and attestations but does not broadcast attestations or participate in consensus.',
     ...booleanConfigHelper(false),
   },
-  // TODO(palla/mbps): Change default to false once checkpoint validation is stable
   skipCheckpointProposalValidation: {
-    description: 'Skip checkpoint proposal validation and always attest (default: true)',
-    defaultValue: true,
+    description: 'Skip checkpoint proposal validation and always attest (default: false)',
+    defaultValue: false,
   },
   skipPushProposedBlocksToArchiver: {
     description: 'Skip pushing re-executed blocks to archiver (default: false)',

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -418,6 +418,7 @@ describe('ValidatorClient', () => {
         },
       });
 
+      validatorClient.updateConfig({ skipCheckpointProposalValidation: true });
       const attestations = await validatorClient.attestToCheckpointProposal(checkpointProposal, sender);
 
       expect(attestations).toBeDefined();

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -88,11 +88,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
   private proposersOfInvalidBlocks: Set<string> = new Set();
 
-  // TODO(palla/mbps): Remove this once checkpoint validation is stable and we can validate all blocks properly.
-  // Tracks slots for which we have successfully validated a block proposal, so we can attest to checkpoint proposals for those slots.
-  // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
-  private validatedBlockSlots: Set<SlotNumber> = new Set();
-
   protected constructor(
     private keyStore: ExtendedValidatorKeyStore,
     private epochCache: EpochCache,
@@ -414,10 +409,6 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return false;
     }
 
-    // TODO(palla/mbps): Remove this once checkpoint validation is stable.
-    // Track that we successfully validated a block for this slot, so we can attest to checkpoint proposals for it.
-    this.validatedBlockSlots.add(slotNumber);
-
     return true;
   }
 
@@ -462,17 +453,9 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       fishermanMode: this.config.fishermanMode || false,
     });
 
-    // TODO(palla/mbps): Remove this once checkpoint validation is stable.
-    // Check that we have successfully validated a block for this slot before attesting to the checkpoint.
-    if (!this.validatedBlockSlots.has(slotNumber)) {
-      this.log.warn(`No validated block found for slot ${slotNumber}, refusing to attest to checkpoint`, proposalInfo);
-      return undefined;
-    }
-
     // Validate the checkpoint proposal before attesting (unless skipCheckpointProposalValidation is set)
-    // TODO(palla/mbps): Change default to false once checkpoint validation is stable.
-    if (this.config.skipCheckpointProposalValidation !== false) {
-      this.log.verbose(`Skipping checkpoint proposal validation for slot ${slotNumber}`, proposalInfo);
+    if (this.config.skipCheckpointProposalValidation) {
+      this.log.warn(`Skipping checkpoint proposal validation for slot ${slotNumber}`, proposalInfo);
     } else {
       const validationResult = await this.validateCheckpointProposal(proposal, proposalInfo);
       if (!validationResult.isValid) {
@@ -548,7 +531,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     proposalInfo: LogData,
   ): Promise<{ isValid: true } | { isValid: false; reason: string }> {
     const slot = proposal.slotNumber;
-    const timeoutSeconds = 10;
+    const timeoutSeconds = 10; // TODO(palla/mbps): This should map to the timetable settings
 
     // Wait for last block to sync by archive
     let lastBlockHeader: BlockHeader | undefined;


### PR DESCRIPTION
Adds two working (on my machine at least!) e2e tests for mbps with 4 nodes on a mocked p2p gossipsub network:
- With multiple txs broadcasted at the beginning of the test
- With txs anchored to proposed blocks

Also adds methods to force sync and check sync status on the pxe.

Builds on #19915