### PR TITLE
refactor(log): replace withLogNameSuffix with actor-based AsyncLocalStorage

### DIFF
--- a/boxes/boxes/vanilla/app/embedded-wallet.ts
+++ b/boxes/boxes/vanilla/app/embedded-wallet.ts
@@ -125,9 +125,7 @@ export class EmbeddedWallet extends BaseWallet {
     const config = getPXEConfig();
     config.l1Contracts = await aztecNode.getL1ContractAddresses();
     config.proverEnabled = PROVER_ENABLED;
-    const pxe = await createPXE(aztecNode, config, {
-      useLogSuffix: true,
-    });
+    const pxe = await createPXE(aztecNode, config, {});
 
     // Register Sponsored FPC Contract with PXE
     await pxe.registerContract(await EmbeddedWallet.#getSponsoredPFCContract());

--- a/boxes/boxes/vanilla/scripts/deploy.ts
+++ b/boxes/boxes/vanilla/scripts/deploy.ts
@@ -9,10 +9,7 @@ import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { Fr } from '@aztec/aztec.js/fields';
 import { PublicKeys } from '@aztec/aztec.js/keys';
 import { createAztecNodeClient } from '@aztec/aztec.js/node';
-import type {
-  DeployAccountOptions,
-  Wallet,
-} from '@aztec/aztec.js/wallet';
+import type { DeployAccountOptions, Wallet } from '@aztec/aztec.js/wallet';
 import { type AztecNode } from '@aztec/aztec.js/node';
 import { SPONSORED_FPC_SALT } from '@aztec/constants';
 import { createStore } from '@aztec/kv-store/lmdb';
@@ -43,10 +40,7 @@ async function setupWallet(aztecNode: AztecNode) {
   config.dataDirectory = 'pxe';
   config.proverEnabled = PROVER_ENABLED;
 
-  return await TestWallet.create(aztecNode, config, {
-    store,
-    useLogSuffix: true,
-  });
+  return await TestWallet.create(aztecNode, config, { store });
 }
 
 async function getSponsoredPFCContract() {

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -158,7 +158,11 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
 
     await this.blobClient.testSources();
     await this.synchronizer.testEthereumNodeSynced();
-    await validateAndLogTraceAvailability(this.debugClient, this.config.ethereumAllowNoDebugHosts ?? false);
+    await validateAndLogTraceAvailability(
+      this.debugClient,
+      this.config.ethereumAllowNoDebugHosts ?? false,
+      this.log.getBindings(),
+    );
 
     // Log initial state for the archiver
     const { l1StartBlock } = this.l1Constants;

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -6,7 +6,6 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { merge } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
@@ -38,7 +37,7 @@ export async function createArchiverStore(
     ...userConfig,
     dataStoreMapSizeKb: userConfig.archiverStoreMapSizeKb ?? userConfig.dataStoreMapSizeKb,
   };
-  const store = await createStore(ARCHIVER_STORE_NAME, ARCHIVER_DB_VERSION, config, createLogger('archiver:lmdb'));
+  const store = await createStore(ARCHIVER_STORE_NAME, ARCHIVER_DB_VERSION, config);
   return new KVArchiverDataStore(store, config.maxLogs, l1Constants);
 }
 

--- a/yarn-project/archiver/src/l1/validate_trace.ts
+++ b/yarn-project/archiver/src/l1/validate_trace.ts
@@ -1,13 +1,11 @@
 import type { ViemPublicDebugClient } from '@aztec/ethereum/types';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 
 import type { Hex } from 'viem';
 import type { ZodSchema } from 'zod';
 
 import { callTraceSchema } from './debug_tx.js';
 import { traceTransactionResponseSchema } from './trace_tx.js';
-
-const logger = createLogger('aztec:archiver:validate_trace');
 
 /**
  * Helper function to test a trace method with validation
@@ -17,6 +15,7 @@ const logger = createLogger('aztec:archiver:validate_trace');
  * @param schema - Zod schema to validate the response
  * @param method - Name of the RPC method ('debug_traceTransaction' or 'trace_transaction')
  * @param blockType - Type of block being tested ('recent' or 'old')
+ * @param logger - Logger instance
  * @returns true if the method works and validation passes, false otherwise
  */
 async function testTraceMethod(
@@ -25,6 +24,7 @@ async function testTraceMethod(
   schema: ZodSchema,
   method: 'debug_traceTransaction' | 'trace_transaction',
   blockType: string,
+  logger: Logger,
 ): Promise<boolean> {
   try {
     // Make request with appropriate params based on method name
@@ -59,9 +59,14 @@ export interface TraceAvailability {
  * Validates the availability of debug/trace methods on the Ethereum client.
  *
  * @param client - The Viem public debug client
+ * @param bindings - Optional logger bindings for context
  * @returns Object indicating which trace methods are available for recent and old blocks
  */
-export async function validateTraceAvailability(client: ViemPublicDebugClient): Promise<TraceAvailability> {
+export async function validateTraceAvailability(
+  client: ViemPublicDebugClient,
+  bindings?: LoggerBindings,
+): Promise<TraceAvailability> {
+  const logger = createLogger('archiver:validate_trace', bindings);
   const result: TraceAvailability = {
     debugTraceRecent: false,
     traceTransactionRecent: false,
@@ -95,6 +100,7 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
       callTraceSchema,
       'debug_traceTransaction',
       'recent',
+      logger,
     );
 
     // Test trace_transaction with recent block
@@ -104,6 +110,7 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
       traceTransactionResponseSchema,
       'trace_transaction',
       'recent',
+      logger,
     );
 
     // Get a block from 512 blocks ago
@@ -132,7 +139,14 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
     const oldTxHash = oldBlock.transactions[0] as Hex;
 
     // Test debug_traceTransaction with old block
-    result.debugTraceOld = await testTraceMethod(client, oldTxHash, callTraceSchema, 'debug_traceTransaction', 'old');
+    result.debugTraceOld = await testTraceMethod(
+      client,
+      oldTxHash,
+      callTraceSchema,
+      'debug_traceTransaction',
+      'old',
+      logger,
+    );
 
     // Test trace_transaction with old block
     result.traceTransactionOld = await testTraceMethod(
@@ -141,6 +155,7 @@ export async function validateTraceAvailability(client: ViemPublicDebugClient): 
       traceTransactionResponseSchema,
       'trace_transaction',
       'old',
+      logger,
     );
   } catch (error) {
     logger.warn(`Error validating debug_traceTransaction and trace_transaction availability: ${error}`);
@@ -159,15 +174,18 @@ function hasTxs(block: { transactions?: Hex[] }): boolean {
  *
  * @param client - The Viem public debug client
  * @param ethereumAllowNoDebugHosts - If false, throws an error when no trace methods are available
+ * @param bindings - Optional logger bindings for context
  * @throws Error if ethereumAllowNoDebugHosts is false and no trace methods are available
  */
 export async function validateAndLogTraceAvailability(
   client: ViemPublicDebugClient,
   ethereumAllowNoDebugHosts: boolean,
+  bindings?: LoggerBindings,
 ): Promise<void> {
+  const logger = createLogger('archiver:validate_trace', bindings);
   logger.debug('Validating trace/debug method availability...');
 
-  const availability = await validateTraceAvailability(client);
+  const availability = await validateTraceAvailability(client, bindings);
 
   // Check if we have support for old blocks (either debug or trace)
   const hasOldBlockSupport = availability.debugTraceOld || availability.traceTransactionOld;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1183,6 +1183,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       this.contractDataSource,
       new DateProvider(),
       this.telemetry,
+      this.log.getBindings(),
     );
 
     this.log.verbose(`Simulating public calls for tx ${txHash}`, {
@@ -1236,16 +1237,22 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // We accept transactions if they are not expired by the next slot (checked based on the IncludeByTimestamp field)
     const { ts: nextSlotTimestamp } = this.epochCache.getEpochAndSlotInNextL1Slot();
     const blockNumber = BlockNumber((await this.blockSource.getBlockNumber()) + 1);
-    const validator = createValidatorForAcceptingTxs(db, this.contractDataSource, verifier, {
-      timestamp: nextSlotTimestamp,
-      blockNumber,
-      l1ChainId: this.l1ChainId,
-      rollupVersion: this.version,
-      setupAllowList: this.config.txPublicSetupAllowList ?? (await getDefaultAllowedSetupFunctions()),
-      gasFees: await this.getCurrentMinFees(),
-      skipFeeEnforcement,
-      txsPermitted: !this.config.disableTransactions,
-    });
+    const validator = createValidatorForAcceptingTxs(
+      db,
+      this.contractDataSource,
+      verifier,
+      {
+        timestamp: nextSlotTimestamp,
+        blockNumber,
+        l1ChainId: this.l1ChainId,
+        rollupVersion: this.version,
+        setupAllowList: this.config.txPublicSetupAllowList ?? (await getDefaultAllowedSetupFunctions()),
+        gasFees: await this.getCurrentMinFees(),
+        skipFeeEnforcement,
+        txsPermitted: !this.config.disableTransactions,
+      },
+      this.log.getBindings(),
+    );
 
     return await validator.validateTx(tx);
   }

--- a/yarn-project/aztec-node/src/sentinel/factory.ts
+++ b/yarn-project/aztec-node/src/sentinel/factory.ts
@@ -20,12 +20,7 @@ export async function createSentinel(
   if (!config.sentinelEnabled) {
     return undefined;
   }
-  const kvStore = await createStore(
-    'sentinel',
-    SentinelStore.SCHEMA_VERSION,
-    config,
-    createLogger('node:sentinel:lmdb'),
-  );
+  const kvStore = await createStore('sentinel', SentinelStore.SCHEMA_VERSION, config, logger.getBindings());
   const storeHistoryLength = config.sentinelHistoryLengthInEpochs * epochCache.getL1Constants().epochDuration;
   const storeHistoricProvenPerformanceLength = config.sentinelHistoricProvenPerformanceLengthInEpochs;
   const sentinelStore = new SentinelStore(kvStore, {

--- a/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
@@ -1,6 +1,6 @@
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import type { NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
-import { type LogFn, createLogger } from '@aztec/foundation/log';
+import type { LogFn } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { type BootnodeConfig, BootstrapNode, bootnodeConfigMappings } from '@aztec/p2p';
 import { emptyChainConfig } from '@aztec/stdlib/config';
@@ -27,7 +27,7 @@ export async function startP2PBootstrap(
   const telemetryConfig = extractRelevantOptions<TelemetryClientConfig>(options, telemetryClientConfigMappings, 'tel');
   const telemetryClient = await initTelemetryClient(telemetryConfig);
 
-  const store = await createStore('p2p-bootstrap', 1, config, createLogger('p2p:bootstrap:store'));
+  const store = await createStore('p2p-bootstrap', 1, config);
   const node = new BootstrapNode(store, telemetryClient);
   await node.start(config);
   signalHandlers.push(() => node.stop());

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -44,6 +44,10 @@ class InterceptingLogger implements Logger {
     throw new Error('Not implemented');
   }
 
+  getBindings() {
+    return this.logger.getBindings();
+  }
+
   private intercept(level: LogLevel, msg: string, ...args: any[]) {
     this.logs.push(...msg.split('\n'));
     // Forward to the wrapped logger

--- a/yarn-project/bb-prover/src/prover/server/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/server/bb_prover.ts
@@ -463,6 +463,7 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       this.config.acvmWorkingDirectory,
       this.config.acvmBinaryPath,
       outputWitnessFile,
+      logger,
     );
 
     const artifact = getServerCircuitArtifact(circuitType);

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -40,7 +40,7 @@ describe('e2e_2_pxes', () => {
     // Account A is already deployed in setup
 
     // Deploy accountB via walletB.
-    ({ wallet: walletB, teardown: teardownB } = await setupPXEAndGetWallet(aztecNode, {}, undefined, true));
+    ({ wallet: walletB, teardown: teardownB } = await setupPXEAndGetWallet(aztecNode, {}, undefined, 'pxe-1'));
     const accountBManager = await walletB.createSchnorrAccount(
       initialFundedAccounts[1].secret,
       initialFundedAccounts[1].salt,

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -14,7 +14,7 @@ import type { ExtendedViemWalletClient } from '@aztec/ethereum/types';
 import { BlockNumber, CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import { randomBytes } from '@aztec/foundation/crypto/random';
-import { withLogNameSuffix } from '@aztec/foundation/log';
+import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
@@ -211,14 +211,14 @@ export class EpochsTestContext {
   public async createProverNode(opts: { dontStart?: boolean } & Partial<ProverNodeConfig> = {}) {
     this.logger.warn('Creating and syncing a simulated prover node...');
     const proverNodePrivateKey = this.getNextPrivateKey();
-    const suffix = (this.proverNodes.length + 1).toString();
-    const proverNode = await withLogNameSuffix(suffix, () =>
+    const proverIndex = this.proverNodes.length + 1;
+    const proverNode = await withLoggerBindings({ actor: `prover-${proverIndex}` }, () =>
       createAndSyncProverNode(
         proverNodePrivateKey,
         { ...this.context.config },
         {
           dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
-          proverId: EthAddress.fromNumber(parseInt(suffix, 10)),
+          proverId: EthAddress.fromNumber(proverIndex),
           dontStart: opts.dontStart,
           ...opts,
         },
@@ -247,12 +247,13 @@ export class EpochsTestContext {
   private async createNode(
     opts: Partial<AztecNodeConfig> & { txDelayerMaxInclusionTimeIntoSlot?: number; dontStartSequencer?: boolean } = {},
   ) {
-    const suffix = (this.nodes.length + 1).toString();
+    const nodeIndex = this.nodes.length + 1;
+    const actorPrefix = opts.disableValidator ? 'node' : 'validator';
     const { mockGossipSubNetwork } = this.context;
     const resolvedConfig = { ...this.context.config, ...opts };
     const p2pEnabled = resolvedConfig.p2pEnabled || mockGossipSubNetwork !== undefined;
     const p2pIp = resolvedConfig.p2pIp ?? (p2pEnabled ? '127.0.0.1' : undefined);
-    const node = await withLogNameSuffix(suffix, () =>
+    const node = await withLoggerBindings({ actor: `${actorPrefix}-${nodeIndex}` }, () =>
       AztecNodeService.createAndSync(
         {
           ...resolvedConfig,

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -274,7 +274,11 @@ describe('e2e_p2p_add_rollup', () => {
     ) => {
       // Bridge assets into the rollup, and consume the message.
       // We are doing some of the things that are in the crosschain harness, but we don't actually want the full thing
-      const wallet = await TestWallet.create(node, { ...getPXEConfig(), proverEnabled: false }, { useLogSuffix: true });
+      const wallet = await TestWallet.create(
+        node,
+        { ...getPXEConfig(), proverEnabled: false },
+        { loggerActorLabel: 'pxe-bridge' },
+      );
       const aliceAccountManager = await wallet.createSchnorrAccount(aliceAccount.secret, aliceAccount.salt);
       const aliceDeploymethod = await aliceAccountManager.getDeployMethod();
       await aliceDeploymethod.send({

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -56,7 +56,11 @@ export const submitTransactions = async (
 ): Promise<TxHash[]> => {
   const rpcConfig = getRpcConfig();
   rpcConfig.proverEnabled = false;
-  const wallet = await TestWallet.create(node, { ...getPXEConfig(), proverEnabled: false }, { useLogSuffix: true });
+  const wallet = await TestWallet.create(
+    node,
+    { ...getPXEConfig(), proverEnabled: false },
+    { loggerActorLabel: 'pxe-tx' },
+  );
   const fundedAccountManager = await wallet.createSchnorrAccount(fundedAccount.secret, fundedAccount.salt);
   return submitTxsTo(wallet, fundedAccountManager.address, numTxs, logger);
 };
@@ -70,7 +74,11 @@ export async function prepareTransactions(
   const rpcConfig = getRpcConfig();
   rpcConfig.proverEnabled = false;
 
-  const wallet = await TestWallet.create(node, { ...getPXEConfig(), proverEnabled: false }, { useLogSuffix: true });
+  const wallet = await TestWallet.create(
+    node,
+    { ...getPXEConfig(), proverEnabled: false },
+    { loggerActorLabel: 'pxe-tx' },
+  );
   const fundedAccountManager = await wallet.createSchnorrAccount(fundedAccount.secret, fundedAccount.salt);
 
   const testContractInstance = await getContractInstanceFromInstantiationParams(TestContractArtifact, {

--- a/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
@@ -7,7 +7,8 @@ import { ChainMonitor } from '@aztec/ethereum/test';
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { tryRmDir } from '@aztec/foundation/fs';
-import { logger, withLogNameSuffix } from '@aztec/foundation/log';
+import { logger } from '@aztec/foundation/log';
+import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { retryUntil } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
 import { ProverNode, type ProverNodeConfig } from '@aztec/prover-node';
@@ -55,9 +56,9 @@ describe('e2e_snapshot_sync', () => {
   });
 
   // Adapted from epochs-test
-  const createNonValidatorNode = async (suffix: string, config: Partial<AztecNodeConfig> = {}) => {
+  const createNonValidatorNode = async (name: string, config: Partial<AztecNodeConfig> = {}) => {
     log.warn('Creating and syncing a node without a validator...');
-    return await withLogNameSuffix(suffix, () =>
+    return await withLoggerBindings({ actor: `node-${name}` }, () =>
       AztecNodeService.createAndSync({
         ...context.config,
         disableValidator: true,

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -198,7 +198,7 @@ export class FullProverTest {
       this.aztecNode,
       { proverEnabled: this.realProofs },
       undefined,
-      true,
+      'pxe-proven',
     );
     this.logger.debug(`Contract address ${this.fakeProofsAsset.address}`);
     await provenWallet.registerContract(this.fakeProofsAssetInstance, TokenContract.artifact);

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -41,7 +41,7 @@ import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { SecretValue } from '@aztec/foundation/config';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { tryRmDir } from '@aztec/foundation/fs';
-import { withLogNameSuffix } from '@aztec/foundation/log';
+import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
@@ -125,14 +125,14 @@ export async function setupSharedBlobStorage(config: { dataDirectory?: string } 
  * @param aztecNode - An instance of Aztec Node.
  * @param opts - Partial configuration for the PXE.
  * @param logger - The logger to be used.
- * @param useLogSuffix - Whether to add a randomly generated suffix to the PXE debug logs.
+ * @param actor - Actor label to include in log output (e.g., 'pxe-test').
  * @returns A test wallet, logger and teardown function.
  */
 export async function setupPXEAndGetWallet(
   aztecNode: AztecNode,
   opts: Partial<PXEConfig> = {},
   logger = getLogger(),
-  useLogSuffix = false,
+  actor?: string,
 ): Promise<{
   wallet: TestWallet;
   logger: Logger;
@@ -150,9 +150,7 @@ export async function setupPXEAndGetWallet(
 
   const teardown = configuredDataDirectory ? () => Promise.resolve() : () => tryRmDir(PXEConfig.dataDirectory!);
 
-  const wallet = await TestWallet.create(aztecNode, PXEConfig, {
-    useLogSuffix,
-  });
+  const wallet = await TestWallet.create(aztecNode, PXEConfig, { loggerActorLabel: actor });
 
   return {
     wallet,
@@ -574,10 +572,12 @@ export async function setup(
       }
     }
 
-    const aztecNodeService = await AztecNodeService.createAndSync(
-      config,
-      { dateProvider, telemetry: telemetryClient, p2pClientDeps, logger: createLogger('node:MAIN-aztec-node') },
-      { prefilledPublicData },
+    const aztecNodeService = await withLoggerBindings({ actor: 'node-0' }, () =>
+      AztecNodeService.createAndSync(
+        config,
+        { dateProvider, telemetry: telemetryClient, p2pClientDeps },
+        { prefilledPublicData },
+      ),
     );
     const sequencerClient = aztecNodeService.getSequencer();
 
@@ -611,7 +611,7 @@ export async function setup(
     pxeConfig.dataDirectory = path.join(directoryToCleanup, randomBytes(8).toString('hex'));
     // For tests we only want proving enabled if specifically requested
     pxeConfig.proverEnabled = !!pxeOpts.proverEnabled;
-    const wallet = await TestWallet.create(aztecNodeService, pxeConfig);
+    const wallet = await TestWallet.create(aztecNodeService, pxeConfig, { loggerActorLabel: 'pxe-0' });
 
     if (opts.walletMinFeePadding !== undefined) {
       wallet.setMinFeePadding(opts.walletMinFeePadding);
@@ -797,7 +797,7 @@ export function createAndSyncProverNode(
   prefilledPublicData: PublicDataTreeLeaf[] = [],
   proverNodeDeps: ProverNodeDeps = {},
 ) {
-  return withLogNameSuffix('prover-node', async () => {
+  return withLoggerBindings({ actor: 'prover-0' }, async () => {
     const aztecNodeTxProvider = aztecNode && {
       getTxByHash: aztecNode.getTxByHash.bind(aztecNode),
       getTxsByHash: aztecNode.getTxsByHash.bind(aztecNode),

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -4,14 +4,13 @@
 import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { range } from '@aztec/foundation/array';
 import { SecretValue } from '@aztec/foundation/config';
-import { addLogNameHandler, removeLogNameHandler } from '@aztec/foundation/log';
+import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { bufferToHex } from '@aztec/foundation/string';
 import type { DateProvider } from '@aztec/foundation/timer';
 import type { ProverNodeConfig, ProverNodeDeps } from '@aztec/prover-node';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 
 import getPort from 'get-port';
-import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { createAndSyncProverNode, getPrivateKeyFromIndex } from './utils.js';
@@ -21,6 +20,11 @@ import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 // index 1, and prover node with index 2, so all of our loops here need to start from 3
 // to avoid running validators with the same key
 export const ATTESTER_PRIVATE_KEYS_START_INDEX = 3;
+
+// Global counters for actor naming (start at 1)
+let validatorCounter = 1;
+let nodeCounter = 1;
+let proverCounter = 1;
 
 export function generatePrivateKeys(startIndex: number, numberOfKeys: number): `0x${string}`[] {
   const privateKeys: `0x${string}`[] = [];
@@ -44,10 +48,6 @@ export async function createNodes(
   validatorsPerNode = 1,
 ): Promise<AztecNodeService[]> {
   const nodePromises: Promise<AztecNodeService>[] = [];
-  const loggerIdStorage = new AsyncLocalStorage<string>();
-  const logNameHandler = (module: string) =>
-    loggerIdStorage.getStore() ? `${module}:${loggerIdStorage.getStore()}` : module;
-  addLogNameHandler(logNameHandler);
 
   for (let i = 0; i < numNodes; i++) {
     const index = indexOffset + i;
@@ -69,7 +69,6 @@ export async function createNodes(
       prefilledPublicData,
       dataDir,
       metricsPort,
-      loggerIdStorage,
     );
     nodePromises.push(nodePromise);
   }
@@ -81,7 +80,6 @@ export async function createNodes(
     throw new Error('Sequencer not found');
   }
 
-  removeLogNameHandler(logNameHandler);
   return nodes;
 }
 
@@ -95,9 +93,9 @@ export async function createNode(
   prefilledPublicData?: PublicDataTreeLeaf[],
   dataDirectory?: string,
   metricsPort?: number,
-  loggerIdStorage?: AsyncLocalStorage<string>,
 ) {
-  const createNode = async () => {
+  const actorIndex = validatorCounter++;
+  return await withLoggerBindings({ actor: `validator-${actorIndex}` }, async () => {
     const validatorConfig = await createValidatorConfig(config, bootstrapNode, tcpPort, addressIndex, dataDirectory);
     const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
     return await AztecNodeService.createAndSync(
@@ -105,8 +103,7 @@ export async function createNode(
       { telemetry, dateProvider },
       { prefilledPublicData, dontStartSequencer: config.dontStartSequencer },
     );
-  };
-  return loggerIdStorage ? await loggerIdStorage.run(tcpPort.toString(), createNode) : createNode();
+  });
 }
 
 /** Creates a P2P enabled instance of Aztec Node Service without a validator */
@@ -118,9 +115,9 @@ export async function createNonValidatorNode(
   prefilledPublicData?: PublicDataTreeLeaf[],
   dataDirectory?: string,
   metricsPort?: number,
-  loggerIdStorage?: AsyncLocalStorage<string>,
 ) {
-  const createNode = async () => {
+  const actorIndex = nodeCounter++;
+  return await withLoggerBindings({ actor: `node-${actorIndex}` }, async () => {
     const p2pConfig = await createP2PConfig(baseConfig, bootstrapNode, tcpPort, dataDirectory);
     const config: AztecNodeConfig = {
       ...p2pConfig,
@@ -130,8 +127,7 @@ export async function createNonValidatorNode(
     };
     const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
     return await AztecNodeService.createAndSync(config, { telemetry, dateProvider }, { prefilledPublicData });
-  };
-  return loggerIdStorage ? await loggerIdStorage.run(tcpPort.toString(), createNode) : createNode();
+  });
 }
 
 export async function createProverNode(
@@ -143,9 +139,9 @@ export async function createProverNode(
   prefilledPublicData?: PublicDataTreeLeaf[],
   dataDirectory?: string,
   metricsPort?: number,
-  loggerIdStorage?: AsyncLocalStorage<string>,
 ) {
-  const createProverNode = async () => {
+  const actorIndex = proverCounter++;
+  return await withLoggerBindings({ actor: `prover-${actorIndex}` }, async () => {
     const proverNodePrivateKey = getPrivateKeyFromIndex(ATTESTER_PRIVATE_KEYS_START_INDEX + addressIndex)!;
     const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
 
@@ -165,8 +161,7 @@ export async function createProverNode(
       prefilledPublicData,
       { ...proverNodeDeps, telemetry },
     );
-  };
-  return loggerIdStorage ? await loggerIdStorage.run(tcpPort.toString(), createProverNode) : createProverNode();
+  });
 }
 
 export async function createP2PConfig(

--- a/yarn-project/ethereum/src/publisher_manager.ts
+++ b/yarn-project/ethereum/src/publisher_manager.ts
@@ -1,5 +1,5 @@
 import { pick } from '@aztec/foundation/collection';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 
 import { L1TxUtils, TxUtilsState } from './l1_tx_utils/index.js';
 
@@ -28,13 +28,15 @@ const busyStates: TxUtilsState[] = [
 export type PublisherFilter<UtilsType extends L1TxUtils> = (utils: UtilsType) => boolean;
 
 export class PublisherManager<UtilsType extends L1TxUtils = L1TxUtils> {
-  private log = createLogger('publisher:manager');
+  private log: Logger;
   private config: { publisherAllowInvalidStates?: boolean };
 
   constructor(
     private publishers: UtilsType[],
     config: { publisherAllowInvalidStates?: boolean },
+    bindings?: LoggerBindings,
   ) {
+    this.log = createLogger('publisher:manager', bindings);
     this.log.info(`PublisherManager initialized with ${publishers.length} publishers.`);
     this.publishers = publishers;
     this.config = pick(config, 'publisherAllowInvalidStates');

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -33,7 +33,7 @@ export async function startAnvil(
       const anvil = createAnvil({
         anvilBinary,
         host: '127.0.0.1',
-        port: opts.port ?? 8545,
+        port: opts.port ?? (process.env.ANVIL_PORT ? parseInt(process.env.ANVIL_PORT) : 8545),
         blockTime: opts.l1BlockTime,
         stopTimeout: 1000,
         accounts: opts.accounts ?? 20,

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -51,6 +51,7 @@
     "./iterable": "./dest/iterable/index.js",
     "./iterator": "./dest/iterator/index.js",
     "./log": "./dest/log/index.js",
+    "./log/server": "./dest/log/pino-logger-server.js",
     "./mutex": "./dest/mutex/index.js",
     "./retry": "./dest/retry/index.js",
     "./running-promise": "./dest/running-promise/index.js",

--- a/yarn-project/foundation/src/config/env_var.ts
+++ b/yarn-project/foundation/src/config/env_var.ts
@@ -77,6 +77,7 @@ export type EnvVar =
   | 'L1_CONSENSUS_HOST_API_KEY_HEADERS'
   | 'LOG_JSON'
   | 'LOG_MULTILINE'
+  | 'LOG_NO_COLOR_PER_ACTOR'
   | 'LOG_LEVEL'
   | 'MNEMONIC'
   | 'NETWORK'

--- a/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
+++ b/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../../log/pino-logger.js';
+import { type Logger, type LoggerBindings, createLogger } from '../../log/pino-logger.js';
 
 /**
  * A number generator which is used as a source of randomness in the system. If the SEED env variable is set, the
@@ -12,9 +12,13 @@ export class RandomnessSingleton {
   private static instance: RandomnessSingleton;
 
   private counter = 0;
-  private readonly log = createLogger('foundation:randomness_singleton');
+  private log: Logger;
 
-  private constructor(private readonly seed?: number) {
+  private constructor(
+    private readonly seed?: number,
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('foundation:randomness_singleton', bindings);
     if (seed !== undefined) {
       this.log.debug(`Using pseudo-randomness with seed: ${seed}`);
       this.counter = seed;
@@ -23,10 +27,10 @@ export class RandomnessSingleton {
     }
   }
 
-  public static getInstance(): RandomnessSingleton {
+  public static getInstance(bindings?: LoggerBindings): RandomnessSingleton {
     if (!RandomnessSingleton.instance) {
       const seed = process.env.SEED ? Number(process.env.SEED) : undefined;
-      RandomnessSingleton.instance = new RandomnessSingleton(seed);
+      RandomnessSingleton.instance = new RandomnessSingleton(seed, bindings);
     }
 
     return RandomnessSingleton.instance;

--- a/yarn-project/foundation/src/jest/setup.mjs
+++ b/yarn-project/foundation/src/jest/setup.mjs
@@ -1,3 +1,4 @@
+import { parseBooleanEnv } from '@aztec/foundation/config';
 import { overwriteLoggingStream, pinoPrettyOpts } from '@aztec/foundation/log';
 
 import pretty from 'pino-pretty';
@@ -6,4 +7,6 @@ import pretty from 'pino-pretty';
 // file so we don't mess up with dependencies in non-testing environments,
 // since pino-pretty messes up with browser bundles.
 // See also https://www.npmjs.com/package/pino-pretty?activeTab=readme#user-content-usage-with-jest
-overwriteLoggingStream(pretty(pinoPrettyOpts));
+if (!parseBooleanEnv(process.env.LOG_JSON)) {
+  overwriteLoggingStream(pretty(pinoPrettyOpts));
+}

--- a/yarn-project/foundation/src/log/libp2p_logger.ts
+++ b/yarn-project/foundation/src/log/libp2p_logger.ts
@@ -2,15 +2,17 @@ import type { ComponentLogger, Logger } from '@libp2p/interface';
 
 import { getLogLevelFromFilters } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';
-import { logFilters, logger } from './pino-logger.js';
+import { type LoggerBindings, logFilters, logger } from './pino-logger.js';
 
 /**
  * Creates a libp2p compatible logger that wraps our pino logger.
  * This adapter implements the ComponentLogger interface required by libp2p.
+ * @param namespace - Base namespace for the logger
+ * @param bindings - Optional bindings to pass to the logger (actor, instanceId)
  */
-export function createLibp2pComponentLogger(namespace: string): ComponentLogger {
+export function createLibp2pComponentLogger(namespace: string, bindings?: LoggerBindings): ComponentLogger {
   return {
-    forComponent: (component: string) => createLibp2pLogger(`${namespace}:${component}`),
+    forComponent: (component: string) => createLibp2pLogger(`${namespace}:${component}`, bindings),
   };
 }
 
@@ -24,9 +26,14 @@ function replaceFormatting(message: string) {
   return message.replace(/(%p|%a)/g, '%s');
 }
 
-function createLibp2pLogger(component: string): Logger {
+function createLibp2pLogger(component: string, bindings?: LoggerBindings): Logger {
   // Create a direct pino logger instance for libp2p that supports string interpolation
-  const log = logger.child({ module: component }, { level: getLogLevelFromFilters(logFilters, component) });
+  const actor = bindings?.actor;
+  const instanceId = bindings?.instanceId;
+  const log = logger.child(
+    { module: component, ...(actor && { actor }), ...(instanceId && { instanceId }) },
+    { level: getLogLevelFromFilters(logFilters, component) },
+  );
 
   const logIfEnabled = (level: LogLevel, message: string, ...args: unknown[]) => {
     if (!log.isLevelEnabled(level)) {

--- a/yarn-project/foundation/src/log/pino-logger-server.ts
+++ b/yarn-project/foundation/src/log/pino-logger-server.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { type LoggerBindings, addLogBindingsHandler, removeLogBindingsHandler } from './pino-logger.js';
+
+/** AsyncLocalStorage for logger bindings context propagation (Node.js only). */
+const bindingsStorage = new AsyncLocalStorage<LoggerBindings>();
+
+/** Returns the current bindings from AsyncLocalStorage, if any. */
+export function getBindings(): LoggerBindings | undefined {
+  return bindingsStorage.getStore();
+}
+
+/**
+ * Runs a callback within a bindings context. All loggers created within the callback
+ * will automatically inherit the bindings (actor, instanceId) via the log bindings handler.
+ */
+export async function withLoggerBindings<T>(bindings: LoggerBindings, callback: () => Promise<T>): Promise<T> {
+  const handler = () => bindingsStorage.getStore();
+  addLogBindingsHandler(handler);
+  try {
+    return await bindingsStorage.run(bindings, callback);
+  } finally {
+    removeLogBindingsHandler(handler);
+  }
+}

--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -1,0 +1,233 @@
+import { build as buildPrettyStream } from 'pino-pretty';
+import { Writable } from 'stream';
+
+import {
+  createLogger,
+  getActorColor,
+  logger,
+  overwriteLoggingStream,
+  pinoPrettyOpts,
+  registerLoggingStream,
+  resetActorColors,
+} from './pino-logger.js';
+
+/** Set LOG_TEST_LOGS=1 to print captured log output to console when running tests. */
+const LOG_TEST_LOGS = process.env.LOG_TEST_LOGS === '1';
+
+/**
+ * A writable stream that captures output to an array of strings.
+ * Used for testing logger output without intercepting stderr.
+ */
+class CapturingStream extends Writable {
+  public lines: string[] = [];
+
+  override _write(chunk: Buffer, _encoding: string, callback: (error?: Error | null) => void): void {
+    this.lines.push(chunk.toString());
+    callback();
+  }
+
+  /** Clears the captured lines. */
+  clear(): void {
+    this.lines = [];
+  }
+
+  /** Returns all captured lines as parsed JSON objects. */
+  getJsonLines(): unknown[] {
+    return this.lines.map(line => JSON.parse(line));
+  }
+}
+
+describe('pino-logger', () => {
+  let capturingStream: CapturingStream;
+  let originalLevel: string;
+
+  beforeAll(() => {
+    // Store original level and set to trace to capture all logs
+    originalLevel = logger.level;
+    logger.level = 'trace';
+  });
+
+  afterAll(() => {
+    // Restore original level
+    logger.level = originalLevel;
+  });
+
+  beforeEach(() => {
+    capturingStream = new CapturingStream();
+    registerLoggingStream(capturingStream);
+  });
+
+  it('logs messages with the correct module and level', () => {
+    const testLogger = createLogger('test-module');
+
+    // Force the logger to log at info level
+    testLogger.info('Hello world', { foo: 'bar' });
+
+    // Check that we captured the log
+    expect(capturingStream.lines.length).toBeGreaterThan(0);
+
+    const logEntry = JSON.parse(capturingStream.lines[capturingStream.lines.length - 1]);
+    expect(logEntry.module).toBe('test-module');
+    expect(logEntry.msg).toBe('Hello world');
+    expect(logEntry.foo).toBe('bar');
+    expect(logEntry.level).toBe(30); // info level
+  });
+
+  it('logs at different levels', () => {
+    const testLogger = createLogger('level-test');
+    capturingStream.clear();
+
+    testLogger.warn('A warning message');
+    testLogger.error('An error message');
+
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(2);
+
+    expect(entries[0]).toMatchObject({
+      module: 'level-test',
+      msg: 'A warning message',
+      level: 40, // warn
+    });
+
+    expect(entries[1]).toMatchObject({
+      module: 'level-test',
+      msg: 'An error message',
+      level: 50, // error
+    });
+  });
+
+  it('can use overwriteLoggingStream for isolated capture', () => {
+    // overwriteLoggingStream replaces the stream entirely (no accumulation)
+    const isolatedStream = new CapturingStream();
+    overwriteLoggingStream(isolatedStream);
+
+    const testLogger = createLogger('isolated-test');
+    testLogger.info('Isolated message');
+
+    expect(isolatedStream.lines).toHaveLength(1);
+    expect(JSON.parse(isolatedStream.lines[0])).toMatchObject({
+      module: 'isolated-test',
+      msg: 'Isolated message',
+    });
+  });
+
+  it('generates pretty output when using pino-pretty', () => {
+    const capturedOutput = new CapturingStream();
+
+    // Create a pino-pretty stream that writes to our capturing stream
+    // Use colors only when debugging so we can see them in console
+    const prettyStream = buildPrettyStream({
+      ...pinoPrettyOpts,
+      destination: capturedOutput,
+      colorize: LOG_TEST_LOGS,
+    });
+
+    overwriteLoggingStream(prettyStream);
+
+    const testLogger = createLogger('pretty-test', { actor: 'tester' });
+    testLogger.info('A pretty message', { extraData: 123 });
+    testLogger.warn('A warning');
+    testLogger.error('An error', new Error('Something went wrong'));
+    testLogger.debug('Debug info', { nested: { data: 'value' } });
+
+    // Pretty output should contain the module name and message in human-readable format
+    const output = capturedOutput.lines.join('');
+
+    if (LOG_TEST_LOGS) {
+      // eslint-disable-next-line no-console
+      console.log(output);
+    }
+
+    expect(output).toContain('pretty-test');
+    expect(output).toContain('A pretty message');
+    expect(output).toContain('extraData');
+    expect(output).toContain('123');
+    // Should NOT be valid JSON (it's pretty-printed)
+    expect(() => JSON.parse(output.trim())).toThrow();
+  });
+
+  it('logs instanceId in the output', () => {
+    const capturedOutput = new CapturingStream();
+
+    const prettyStream = buildPrettyStream({
+      ...pinoPrettyOpts,
+      destination: capturedOutput,
+      colorize: LOG_TEST_LOGS,
+    });
+
+    overwriteLoggingStream(prettyStream);
+
+    const testLogger = createLogger('instance-test', { instanceId: 'slot-42' });
+    testLogger.info('Testing instanceId binding');
+
+    const output = capturedOutput.lines.join('');
+
+    if (LOG_TEST_LOGS) {
+      // eslint-disable-next-line no-console
+      console.log(output);
+    }
+
+    expect(output).toContain('instance-test');
+    expect(output).toContain('slot-42');
+    expect(output).toContain('Testing instanceId binding');
+  });
+
+  it('creates child logger preserving bindings', () => {
+    const parentLogger = createLogger('parent-module', { instanceId: 'epoch-5' });
+    const childLogger = parentLogger.createChild('child');
+
+    capturingStream.clear();
+    childLogger.info('Child message');
+
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      module: 'parent-module:child',
+      instanceId: 'epoch-5',
+      msg: 'Child message',
+    });
+  });
+
+  it('returns bindings via getBindings', () => {
+    const testLogger = createLogger('bindings-test', { actor: 'main', instanceId: 'id-123' });
+    const bindings = testLogger.getBindings();
+
+    expect(bindings).toEqual({
+      actor: 'main',
+      instanceId: 'id-123',
+    });
+  });
+
+  describe('actor colors', () => {
+    beforeEach(() => {
+      resetActorColors();
+    });
+
+    it('returns the same color for the same actor', () => {
+      const color1 = getActorColor('my-actor');
+      const color2 = getActorColor('my-actor');
+
+      expect(color1).toBe(color2);
+    });
+
+    it('resets actor colors with resetActorColors', () => {
+      const colorBefore = getActorColor('actor-a');
+      resetActorColors();
+      const colorAfter = getActorColor('actor-b');
+
+      // After reset, next actor gets the first color (same as actor-a had before)
+      expect(colorBefore).toBe(colorAfter);
+    });
+
+    it('cycles through colors when more actors than colors', () => {
+      const COLOR_COUNT = 8;
+      // Get COLOR_COUNT+1 different actors to force cycling
+      const colors: ReturnType<typeof getActorColor>[] = [];
+      for (let i = 0; i < COLOR_COUNT + 1; i++) {
+        colors.push(getActorColor(`actor-${i}`));
+      }
+
+      expect(colors[COLOR_COUNT]).toBe(colors[0]);
+    });
+  });
+});

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -1,4 +1,4 @@
-import { createColors, isColorSupported } from 'colorette';
+import { type Color, createColors, isColorSupported } from 'colorette';
 import isNode from 'detect-node';
 import { pino, symbols } from 'pino';
 import type { Writable } from 'stream';
@@ -12,9 +12,51 @@ import { getLogLevelFromFilters, parseEnv } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';
 import type { LogData, LogFn } from './log_fn.js';
 
-export function createLogger(module: string): Logger {
-  module = logNameHandlers.reduce((moduleName, handler) => handler(moduleName), module.replace(/^aztec:/, ''));
-  const pinoLogger = logger.child({ module }, { level: getLogLevelFromFilters(logFilters, module) });
+/** Optional bindings to pass to createLogger for additional context. */
+export type LoggerBindings = {
+  /** Actor label shown in logs (e.g., 'MAIN', 'prover-node'). */
+  actor?: string;
+  /** Instance identifier for distinguishing multiple instances of the same component. */
+  instanceId?: string;
+};
+
+// Allow global hooks for providing default bindings.
+// Used by withLoggerBindings in pino-logger-server to propagate bindings via AsyncLocalStorage.
+type LogBindingsHandler = () => LoggerBindings | undefined;
+const logBindingsHandlers: LogBindingsHandler[] = [];
+
+export function addLogBindingsHandler(handler: LogBindingsHandler): void {
+  logBindingsHandlers.push(handler);
+}
+
+export function removeLogBindingsHandler(handler: LogBindingsHandler) {
+  const index = logBindingsHandlers.indexOf(handler);
+  if (index !== -1) {
+    logBindingsHandlers.splice(index, 1);
+  }
+}
+
+function getBindingsFromHandlers(): LoggerBindings | undefined {
+  for (const handler of logBindingsHandlers) {
+    const bindings = handler();
+    if (bindings) {
+      return bindings;
+    }
+  }
+  return undefined;
+}
+
+export function createLogger(module: string, bindings?: LoggerBindings): Logger {
+  module = module.replace(/^aztec:/, '');
+
+  const resolvedBindings = { ...getBindingsFromHandlers(), ...bindings };
+  const actor = resolvedBindings?.actor;
+  const instanceId = resolvedBindings?.instanceId;
+
+  const pinoLogger = logger.child(
+    { module, ...(actor && { actor }), ...(instanceId && { instanceId }) },
+    { level: getLogLevelFromFilters(logFilters, module) },
+  );
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
@@ -44,9 +86,22 @@ export function createLogger(module: string): Logger {
     isLevelEnabled: (level: LogLevel) => isLevelEnabled(pinoLogger, level),
     /** Module name for the logger. */
     module,
-    /** Creates another logger by extending this logger module name. */
-    createChild: (childModule: string) => createLogger(`${module}:${childModule}`),
+    /** Creates another logger by extending this logger module name and preserving bindings. */
+    createChild: (childModule: string) => createLogger(`${module}:${childModule}`, { actor, instanceId }),
+    /** Returns the bindings (actor, instanceId) for this logger. */
+    getBindings: () => ({ actor, instanceId }),
   };
+}
+
+/**
+ * Returns a logger for the given module. If loggerOrBindings is already a Logger, returns it directly.
+ * Otherwise, creates a new logger with the given module name and bindings.
+ */
+export function resolveLogger(module: string, loggerOrBindings?: Logger | LoggerBindings): Logger {
+  if (loggerOrBindings && 'info' in loggerOrBindings) {
+    return loggerOrBindings as Logger;
+  }
+  return createLogger(module, loggerOrBindings);
 }
 
 // Allow global hooks for processing log data.
@@ -60,31 +115,6 @@ export function addLogDataHandler(handler: LogDataHandler): void {
 
 function processLogData(data: LogData): LogData {
   return logDataHandlers.reduce((accum, handler) => handler(accum), data);
-}
-
-// Allow global hooks for tweaking module names.
-// Used in tests to add a uid to modules, so we can differentiate multiple nodes in the same process.
-type LogNameHandler = (module: string) => string;
-const logNameHandlers: LogNameHandler[] = [];
-
-export function addLogNameHandler(handler: LogNameHandler): void {
-  logNameHandlers.push(handler);
-}
-
-export function removeLogNameHandler(handler: LogNameHandler) {
-  const index = logNameHandlers.indexOf(handler);
-  if (index !== -1) {
-    logNameHandlers.splice(index, 1);
-  }
-}
-
-/** Creates all loggers within the given callback with the suffix appended to the module name. */
-export async function withLogNameSuffix<T>(suffix: string, callback: () => Promise<T>): Promise<T> {
-  const logNameHandler = (module: string) => `${module}:${suffix}`;
-  addLogNameHandler(logNameHandler);
-  const result = await callback();
-  removeLogNameHandler(logNameHandler);
-  return result;
 }
 
 // Patch isLevelEnabled missing from pino/browser.
@@ -146,22 +176,90 @@ export const levels = {
 // Transport options for pretty logging to stderr via pino-pretty.
 const colorEnv = process.env['FORCE_COLOR' satisfies EnvVar];
 const useColor = colorEnv === undefined ? isColorSupported : parseBooleanEnv(colorEnv);
-const { bold, reset } = createColors({ useColor });
-export const pinoPrettyOpts = {
+const { bold, reset, cyan, magenta, yellow, blue, green, magentaBright, yellowBright, blueBright, greenBright } =
+  createColors({ useColor });
+
+// Per-actor coloring: each unique actor gets a different color for easier visual distinction.
+// Disabled when LOG_NO_COLOR_PER_ACTOR is set to a truthy value.
+const useColorPerActor = useColor && !parseBooleanEnv(process.env['LOG_NO_COLOR_PER_ACTOR' satisfies EnvVar]);
+const actorColors: Color[] = [yellow, magenta, blue, green, magentaBright, yellowBright, blueBright, greenBright];
+const actorColorMap = new Map<string, Color>();
+let nextColorIndex = 0;
+
+/** Returns the color function assigned to a given actor, assigning a new one if needed. */
+export function getActorColor(actor: string): Color {
+  let color = actorColorMap.get(actor);
+  if (!color) {
+    color = actorColors[nextColorIndex % actorColors.length];
+    actorColorMap.set(actor, color);
+    nextColorIndex++;
+  }
+  return color;
+}
+
+/** Resets the actor-to-color mapping. Useful for testing. */
+export function resetActorColors(): void {
+  actorColorMap.clear();
+  nextColorIndex = 0;
+}
+
+// String template for messageFormat (used in worker threads and when per-actor coloring is disabled).
+const messageFormatString = `${bold('{module}')}{if actor} ${cyan('{actor}')}{end}{if instanceId} ${reset(cyan('{instanceId}'))}{end} ${reset('{msg}')}`;
+
+// Function for messageFormat when per-actor coloring is enabled (can only be used in-process, not worker threads).
+type LogObject = { actor?: string; module?: string; instanceId?: string; msg?: string };
+
+/** Formats a log message with per-actor coloring. Actor, module, and instanceId share the same color. */
+export function formatLogMessage(log: LogObject, messageKey: string): string {
+  const actor = log.actor;
+  const module = log.module ?? '';
+  const instanceId = log.instanceId;
+  const msg = log[messageKey as keyof LogObject] ?? '';
+
+  // Use actor color for actor, module, and instanceId when actor is present
+  const color = actor ? getActorColor(actor) : cyan;
+
+  let result = bold(color(module));
+  if (actor) {
+    result += ' ' + color(actor);
+  }
+  if (instanceId) {
+    result += ' ' + reset(color(instanceId));
+  }
+  result += ' ' + reset(String(msg));
+  return result;
+}
+
+// Base options for pino-pretty (shared between transport and direct use).
+const pinoPrettyBaseOpts = {
   destination: 2,
   sync: true,
   colorize: useColor,
-  ignore: 'module,pid,hostname,trace_id,span_id,trace_flags,severity',
-  messageFormat: `${bold('{module}')} ${reset('{msg}')}`,
+  ignore: 'module,actor,instanceId,pid,hostname,trace_id,span_id,trace_flags,severity',
   customLevels: 'fatal:60,error:50,warn:40,info:30,verbose:25,debug:20,trace:10',
   customColors: 'fatal:bgRed,error:red,warn:yellow,info:green,verbose:magenta,debug:blue,trace:gray',
   minimumLevel: 'trace' as const,
   singleLine: !parseBooleanEnv(process.env['LOG_MULTILINE' satisfies EnvVar]),
 };
 
+/**
+ * Pino-pretty options for direct use (e.g., jest/setup.mjs).
+ * Includes function-based messageFormat for per-actor coloring when enabled.
+ */
+export const pinoPrettyOpts = {
+  ...pinoPrettyBaseOpts,
+  messageFormat: useColorPerActor ? formatLogMessage : messageFormatString,
+};
+
+// Transport options use string template only (functions can't be serialized to worker threads).
+const prettyTransportOpts = {
+  ...pinoPrettyBaseOpts,
+  messageFormat: messageFormatString,
+};
+
 const prettyTransport: pino.TransportTargetOptions = {
   target: 'pino-pretty',
-  options: pinoPrettyOpts,
+  options: prettyTransportOpts,
   level: 'trace',
 };
 
@@ -262,6 +360,8 @@ export type Logger = { [K in LogLevel]: LogFn } & { /** Error log function */ er
   isLevelEnabled: (level: LogLevel) => boolean;
   module: string;
   createChild: (childModule: string) => Logger;
+  /** Returns the bindings (actor, instanceId) for this logger. */
+  getBindings: () => LoggerBindings;
 };
 
 /**

--- a/yarn-project/kv-store/src/interfaces/utils.ts
+++ b/yarn-project/kv-store/src/interfaces/utils.ts
@@ -14,6 +14,7 @@ export const mockLogger = {
   isLevelEnabled: (_level: string) => true,
   module: 'kv-store:mock-logger',
   createChild: () => mockLogger,
+  getBindings: () => ({}),
 };
 /* eslint-enable no-console */
 

--- a/yarn-project/kv-store/src/lmdb-v2/factory.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/factory.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { DatabaseVersionManager } from '@aztec/stdlib/database-version';
 
 import { mkdir, mkdtemp, rm } from 'fs/promises';
@@ -15,8 +15,9 @@ export async function createStore(
   name: string,
   schemaVersion: number,
   config: DataStoreConfig,
-  log: Logger = createLogger('kv-store:lmdb-v2:' + name),
+  bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
+  const log = createLogger('kv-store:lmdb-v2:' + name, bindings);
   const { dataDirectory, l1Contracts } = config;
 
   let store: AztecLMDBStoreV2;
@@ -33,7 +34,7 @@ export async function createStore(
       rollupAddress,
       dataDirectory: subDir,
       onOpen: dbDirectory =>
-        AztecLMDBStoreV2.new(dbDirectory, config.dataStoreMapSizeKb, MAX_READERS, () => Promise.resolve(), log),
+        AztecLMDBStoreV2.new(dbDirectory, config.dataStoreMapSizeKb, MAX_READERS, () => Promise.resolve(), bindings),
     });
 
     log.info(
@@ -41,7 +42,7 @@ export async function createStore(
     );
     [store] = await versionManager.open();
   } else {
-    store = await openTmpStore(name, true, config.dataStoreMapSizeKb, MAX_READERS, log);
+    store = await openTmpStore(name, true, config.dataStoreMapSizeKb, MAX_READERS, bindings);
   }
 
   return store;
@@ -52,8 +53,9 @@ export async function openTmpStore(
   ephemeral: boolean = true,
   dbMapSizeKb = 10 * 1_024 * 1_024, // 10GB
   maxReaders = MAX_READERS,
-  log: Logger = createLogger('kv-store:lmdb-v2:' + name),
+  bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
+  const log = createLogger('kv-store:lmdb-v2:' + name, bindings);
   const dataDir = await mkdtemp(join(tmpdir(), name + '-'));
   log.debug(`Created temporary data store at: ${dataDir} with size: ${dbMapSizeKb} KB (LMDB v2)`);
 
@@ -73,17 +75,18 @@ export async function openTmpStore(
 
   // For temporary stores, we don't need to worry about versioning
   // as they are ephemeral and get cleaned up after use
-  return AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, cleanup, log);
+  return AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, cleanup, bindings);
 }
 
 export async function openStoreAt(
   dataDir: string,
   dbMapSizeKb = 10 * 1_024 * 1_024, // 10GB
   maxReaders = MAX_READERS,
-  log: Logger = createLogger('kv-store:lmdb-v2'),
+  bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
+  const log = createLogger('kv-store:lmdb-v2', bindings);
   log.debug(`Opening data store at: ${dataDir} with size: ${dbMapSizeKb} KB (LMDB v2)`);
-  return await AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, undefined, log);
+  return await AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, undefined, bindings);
 }
 
 export async function openVersionedStoreAt(
@@ -92,14 +95,15 @@ export async function openVersionedStoreAt(
   rollupAddress: EthAddress,
   dbMapSizeKb = 10 * 1_024 * 1_024, // 10GB
   maxReaders = MAX_READERS,
-  log: Logger = createLogger('kv-store:lmdb-v2'),
+  bindings?: LoggerBindings,
 ): Promise<AztecLMDBStoreV2> {
+  const log = createLogger('kv-store:lmdb-v2', bindings);
   log.debug(`Opening data store at: ${dataDirectory} with size: ${dbMapSizeKb} KB (LMDB v2)`);
   const [store] = await new DatabaseVersionManager({
     schemaVersion,
     rollupAddress,
     dataDirectory,
-    onOpen: dataDir => AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, undefined, log),
+    onOpen: dataDir => AztecLMDBStoreV2.new(dataDir, dbMapSizeKb, maxReaders, undefined, bindings),
   }).open();
   return store;
 }

--- a/yarn-project/kv-store/src/lmdb-v2/store.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { Semaphore, SerialQueue } from '@aztec/foundation/queue';
 import { MsgpackChannel, NativeLMDBStore } from '@aztec/native';
 
@@ -75,8 +75,9 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
     dbMapSizeKb: number = 10 * 1024 * 1024,
     maxReaders: number = 16,
     cleanup?: () => Promise<void>,
-    log = createLogger('kv-store:lmdb-v2'),
+    bindings?: LoggerBindings,
   ) {
+    const log = createLogger('kv-store:lmdb-v2', bindings);
     const db = new AztecLMDBStoreV2(dataDir, dbMapSizeKb, maxReaders, log, cleanup);
     await db.start();
     return db;

--- a/yarn-project/node-lib/src/factories/l1_tx_utils.ts
+++ b/yarn-project/node-lib/src/factories/l1_tx_utils.ts
@@ -40,7 +40,7 @@ async function createSharedDeps(
   // Note that we do NOT bind them to the rollup address, since we still need to
   // monitor and cancel txs for previous rollups to free up our nonces.
   const noRollupConfig = omit(config, 'l1Contracts');
-  const kvStore = await createStore(L1_TX_STORE_NAME, L1TxStore.SCHEMA_VERSION, noRollupConfig, logger);
+  const kvStore = await createStore(L1_TX_STORE_NAME, L1TxStore.SCHEMA_VERSION, noRollupConfig, logger.getBindings());
   const store = new L1TxStore(kvStore, logger);
 
   const meter = deps.telemetry.getMeter('L1TxUtils');

--- a/yarn-project/p2p-bootstrap/src/index.ts
+++ b/yarn-project/p2p-bootstrap/src/index.ts
@@ -1,12 +1,10 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { type BootnodeConfig, BootstrapNode } from '@aztec/p2p';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import Koa from 'koa';
 import Router from 'koa-router';
-
-const debugLogger = createLogger('p2p-bootstrap:bootstrap_node');
 
 const { HTTP_PORT } = process.env;
 
@@ -16,11 +14,12 @@ const { HTTP_PORT } = process.env;
 async function main(
   config: BootnodeConfig,
   telemetryClient: TelemetryClient = getTelemetryClient(),
-  logger = debugLogger,
+  bindings?: LoggerBindings,
 ) {
-  const store = await createStore('p2p-bootstrap', 1, config, logger);
+  const logger = createLogger('p2p-bootstrap:bootstrap_node', bindings);
+  const store = await createStore('p2p-bootstrap', 1, config, bindings);
 
-  const bootstrapNode = new BootstrapNode(store, telemetryClient, logger);
+  const bootstrapNode = new BootstrapNode(store, telemetryClient, bindings);
   await bootstrapNode.start(config);
   logger.info('DiscV5 Bootnode started');
 

--- a/yarn-project/p2p/src/bootstrap/bootstrap.ts
+++ b/yarn-project/p2p/src/bootstrap/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { P2PBootstrapApi } from '@aztec/stdlib/interfaces/server';
 import { OtelMetricsAdapter, type TelemetryClient } from '@aztec/telemetry-client';
@@ -18,12 +18,15 @@ import { convertToMultiaddr, getPeerIdPrivateKey, getPublicIp } from '../util.js
 export class BootstrapNode implements P2PBootstrapApi {
   private node?: Discv5EventEmitter = undefined;
   private peerId?: PeerId;
+  private logger: Logger;
 
   constructor(
     private store: AztecAsyncKVStore,
     private telemetry: TelemetryClient,
-    private logger = createLogger('p2p:bootstrap'),
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.logger = createLogger('p2p:bootstrap', bindings);
+  }
 
   /**
    * Starts the bootstrap node.
@@ -65,7 +68,7 @@ export class BootstrapNode implements P2PBootstrapApi {
 
     this.logger.debug(`Starting bootstrap node ${peerId} listening on ${listenAddrUdp.toString()}`);
 
-    const metricsRegistry = new OtelMetricsAdapter(this.telemetry);
+    const metricsRegistry = new OtelMetricsAdapter(this.telemetry, this.logger.getBindings());
     this.node = Discv5.create({
       enr: ourEnr,
       peerId,

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -62,15 +62,11 @@ export async function createP2PClient<T extends P2PClientType>(
     );
   }
 
-  const store = deps.store ?? (await createStore(P2P_STORE_NAME, 2, config, createLogger('p2p:lmdb-v2')));
-  const archive = await createStore(P2P_ARCHIVE_STORE_NAME, 1, config, createLogger('p2p-archive:lmdb-v2'));
-  const peerStore = await createStore(P2P_PEER_STORE_NAME, 1, config, createLogger('p2p-peer:lmdb-v2'));
-  const attestationStore = await createStore(
-    P2P_ATTESTATION_STORE_NAME,
-    1,
-    config,
-    createLogger('p2p-attestation:lmdb-v2'),
-  );
+  const bindings = logger.getBindings();
+  const store = deps.store ?? (await createStore(P2P_STORE_NAME, 2, config, bindings));
+  const archive = await createStore(P2P_ARCHIVE_STORE_NAME, 1, config, bindings);
+  const peerStore = await createStore(P2P_PEER_STORE_NAME, 1, config, bindings);
+  const attestationStore = await createStore(P2P_ATTESTATION_STORE_NAME, 1, config, bindings);
   const l1Constants = await archiver.getL1Constants();
 
   const mempools: MemPools = {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
@@ -1,5 +1,5 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { type AnyTx, TX_ERROR_BLOCK_HEADER, type TxValidationResult, type TxValidator } from '@aztec/stdlib/tx';
 
 export interface ArchiveSource {
@@ -7,11 +7,12 @@ export interface ArchiveSource {
 }
 
 export class BlockHeaderTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('p2p:tx_validator:tx_block_header');
+  #log: Logger;
   #archiveSource: ArchiveSource;
 
-  constructor(archiveSource: ArchiveSource) {
+  constructor(archiveSource: ArchiveSource, bindings?: LoggerBindings) {
     this.#archiveSource = archiveSource;
+    this.#log = createLogger('p2p:tx_validator:tx_block_header', bindings);
   }
 
   async validateTx(tx: T): Promise<TxValidationResult> {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/data_validator.ts
@@ -1,5 +1,5 @@
 import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS } from '@aztec/constants';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { computeCalldataHash } from '@aztec/stdlib/hash';
 import {
   TX_ERROR_CALLDATA_COUNT_MISMATCH,
@@ -16,7 +16,11 @@ import {
 } from '@aztec/stdlib/tx';
 
 export class DataTxValidator implements TxValidator<Tx> {
-  #log = createLogger('p2p:tx_validator:tx_data');
+  #log: Logger;
+
+  constructor(bindings?: LoggerBindings) {
+    this.#log = createLogger('p2p:tx_validator:tx_data', bindings);
+  }
 
   async validateTx(tx: Tx): Promise<TxValidationResult> {
     const reason =

--- a/yarn-project/p2p/src/msg_validators/tx_validator/double_spend_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/double_spend_validator.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import {
   type AnyTx,
   TX_ERROR_DUPLICATE_NULLIFIER_IN_TX,
@@ -13,11 +13,12 @@ export interface NullifierSource {
 }
 
 export class DoubleSpendTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('p2p:tx_validator:tx_double_spend');
+  #log: Logger;
   #nullifierSource: NullifierSource;
 
-  constructor(nullifierSource: NullifierSource) {
+  constructor(nullifierSource: NullifierSource, bindings?: LoggerBindings) {
     this.#nullifierSource = nullifierSource;
+    this.#log = createLogger('p2p:tx_validator:tx_double_spend', bindings);
   }
 
   async validateTx(tx: T): Promise<TxValidationResult> {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/factory.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/factory.ts
@@ -1,5 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { LoggerBindings } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractAddress, protocolContractsHash } from '@aztec/protocol-contracts';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
@@ -46,43 +47,53 @@ export function createTxMessageValidators(
   proofVerifier: ClientProtocolCircuitVerifier,
   txsPermitted: boolean,
   allowedInSetup: AllowedElement[] = [],
+  bindings?: LoggerBindings,
 ): Record<string, MessageValidator>[] {
   const merkleTree = worldStateSynchronizer.getCommitted();
 
   return [
     {
       txsPermittedValidator: {
-        validator: new TxPermittedValidator(txsPermitted),
+        validator: new TxPermittedValidator(txsPermitted, bindings),
         severity: PeerErrorSeverity.MidToleranceError,
       },
       dataValidator: {
-        validator: new DataTxValidator(),
+        validator: new DataTxValidator(bindings),
         severity: PeerErrorSeverity.HighToleranceError,
       },
       metadataValidator: {
-        validator: new MetadataTxValidator({
-          l1ChainId: new Fr(l1ChainId),
-          rollupVersion: new Fr(rollupVersion),
-          protocolContractsHash,
-          vkTreeRoot: getVKTreeRoot(),
-        }),
+        validator: new MetadataTxValidator(
+          {
+            l1ChainId: new Fr(l1ChainId),
+            rollupVersion: new Fr(rollupVersion),
+            protocolContractsHash,
+            vkTreeRoot: getVKTreeRoot(),
+          },
+          bindings,
+        ),
         severity: PeerErrorSeverity.HighToleranceError,
       },
       timestampValidator: {
-        validator: new TimestampTxValidator<Tx>({
-          timestamp,
-          blockNumber,
-        }),
+        validator: new TimestampTxValidator<Tx>(
+          {
+            timestamp,
+            blockNumber,
+          },
+          bindings,
+        ),
         severity: PeerErrorSeverity.MidToleranceError,
       },
       doubleSpendValidator: {
-        validator: new DoubleSpendTxValidator({
-          nullifiersExist: async (nullifiers: Buffer[]) => {
-            const merkleTree = worldStateSynchronizer.getCommitted();
-            const indices = await merkleTree.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, nullifiers);
-            return indices.map(index => index !== undefined);
+        validator: new DoubleSpendTxValidator(
+          {
+            nullifiersExist: async (nullifiers: Buffer[]) => {
+              const merkleTree = worldStateSynchronizer.getCommitted();
+              const indices = await merkleTree.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, nullifiers);
+              return indices.map(index => index !== undefined);
+            },
           },
-        }),
+          bindings,
+        ),
         severity: PeerErrorSeverity.HighToleranceError,
       },
       gasValidator: {
@@ -90,21 +101,22 @@ export function createTxMessageValidators(
           new DatabasePublicStateSource(merkleTree),
           ProtocolContractAddress.FeeJuice,
           gasFees,
+          bindings,
         ),
         severity: PeerErrorSeverity.HighToleranceError,
       },
       phasesValidator: {
-        validator: new PhasesTxValidator(contractDataSource, allowedInSetup, timestamp),
+        validator: new PhasesTxValidator(contractDataSource, allowedInSetup, timestamp, bindings),
         severity: PeerErrorSeverity.MidToleranceError,
       },
       blockHeaderValidator: {
-        validator: new BlockHeaderTxValidator(new ArchiveCache(merkleTree)),
+        validator: new BlockHeaderTxValidator(new ArchiveCache(merkleTree), bindings),
         severity: PeerErrorSeverity.HighToleranceError,
       },
     },
     {
       proofValidator: {
-        validator: new TxProofValidator(proofVerifier),
+        validator: new TxProofValidator(proofVerifier, bindings),
         severity: PeerErrorSeverity.MidToleranceError,
       },
     },
@@ -120,16 +132,20 @@ export function createTxReqRespValidator(
     l1ChainId: number;
     rollupVersion: number;
   },
+  bindings?: LoggerBindings,
 ): TxValidator {
   return new AggregateTxValidator(
-    new MetadataTxValidator({
-      l1ChainId: new Fr(l1ChainId),
-      rollupVersion: new Fr(rollupVersion),
-      protocolContractsHash,
-      vkTreeRoot: getVKTreeRoot(),
-    }),
-    new SizeTxValidator(),
-    new DataTxValidator(),
-    new TxProofValidator(verifier),
+    new MetadataTxValidator(
+      {
+        l1ChainId: new Fr(l1ChainId),
+        rollupVersion: new Fr(rollupVersion),
+        protocolContractsHash,
+        vkTreeRoot: getVKTreeRoot(),
+      },
+      bindings,
+    ),
+    new SizeTxValidator(bindings),
+    new DataTxValidator(bindings),
+    new TxProofValidator(verifier, bindings),
   );
 }

--- a/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
@@ -1,5 +1,5 @@
 import { AVM_MAX_PROCESSABLE_L2_GAS, FIXED_DA_GAS, FIXED_L2_GAS } from '@aztec/constants';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
@@ -17,12 +17,18 @@ import {
 import { getFeePayerClaimAmount, getTxFeeLimit } from './fee_payer_balance.js';
 
 export class GasTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_gas');
+  #log: Logger;
   #publicDataSource: PublicStateSource;
   #feeJuiceAddress: AztecAddress;
   #gasFees: GasFees;
 
-  constructor(publicDataSource: PublicStateSource, feeJuiceAddress: AztecAddress, gasFees: GasFees) {
+  constructor(
+    publicDataSource: PublicStateSource,
+    feeJuiceAddress: AztecAddress,
+    gasFees: GasFees,
+    bindings?: LoggerBindings,
+  ) {
+    this.#log = createLogger('sequencer:tx_validator:tx_gas', bindings);
     this.#publicDataSource = publicDataSource;
     this.#feeJuiceAddress = feeJuiceAddress;
     this.#gasFees = gasFees;

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
@@ -1,5 +1,5 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import {
   type AnyTx,
   TX_ERROR_INCORRECT_L1_CHAIN_ID,
@@ -11,7 +11,7 @@ import {
 } from '@aztec/stdlib/tx';
 
 export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('p2p:tx_validator:tx_metadata');
+  #log: Logger;
 
   constructor(
     private values: {
@@ -20,7 +20,10 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
       vkTreeRoot: Fr;
       protocolContractsHash: Fr;
     },
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.#log = createLogger('p2p:tx_validator:tx_metadata', bindings);
+  }
 
   validateTx(tx: T): Promise<TxValidationResult> {
     const errors = [];

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { PublicContractsDB, getCallRequestsWithCalldataByPhase } from '@aztec/simulator/server';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { AllowedElement } from '@aztec/stdlib/interfaces/server';
@@ -14,15 +14,17 @@ import {
 import type { UInt64 } from '@aztec/stdlib/types';
 
 export class PhasesTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_phases');
+  #log: Logger;
   private contractsDB: PublicContractsDB;
 
   constructor(
     contracts: ContractDataSource,
     private setupAllowList: AllowedElement[],
     private timestamp: UInt64,
+    bindings?: LoggerBindings,
   ) {
-    this.contractsDB = new PublicContractsDB(contracts);
+    this.#log = createLogger('sequencer:tx_validator:tx_phases', bindings);
+    this.contractsDB = new PublicContractsDB(contracts, bindings);
   }
 
   async validateTx(tx: Tx): Promise<TxValidationResult> {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/size_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/size_validator.ts
@@ -1,9 +1,13 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { MAX_TX_SIZE_KB } from '@aztec/stdlib/p2p';
 import { Tx, type TxValidationResult, type TxValidator } from '@aztec/stdlib/tx';
 
 export class SizeTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_size');
+  #log: Logger;
+
+  constructor(bindings?: LoggerBindings) {
+    this.#log = createLogger('p2p:tx_validator:tx_size', bindings);
+  }
 
   validateTx(tx: Tx): Promise<TxValidationResult> {
     const txSize = tx.getSize();

--- a/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.ts
@@ -1,5 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import {
   type AnyTx,
   TX_ERROR_INVALID_INCLUDE_BY_TIMESTAMP,
@@ -10,7 +10,7 @@ import {
 import type { UInt64 } from '@aztec/stdlib/types';
 
 export class TimestampTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('p2p:tx_validator:timestamp');
+  #log: Logger;
 
   constructor(
     private values: {
@@ -20,7 +20,10 @@ export class TimestampTxValidator<T extends AnyTx> implements TxValidator<T> {
       // Block number in which the tx is considered to be included.
       blockNumber: BlockNumber;
     },
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.#log = createLogger('p2p:tx_validator:timestamp', bindings);
+  }
 
   validateTx(tx: T): Promise<TxValidationResult> {
     const includeByTimestamp = tx.data.includeByTimestamp;

--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_permitted_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_permitted_validator.ts
@@ -1,10 +1,15 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { Tx, TxValidationResult, TxValidator } from '@aztec/stdlib/tx';
 
 export class TxPermittedValidator implements TxValidator<Tx> {
-  #log = createLogger('p2p:tx_validator:tx_permitted');
+  #log: Logger;
 
-  constructor(private permitted: boolean) {}
+  constructor(
+    private permitted: boolean,
+    bindings?: LoggerBindings,
+  ) {
+    this.#log = createLogger('p2p:tx_validator:tx_permitted', bindings);
+  }
 
   validateTx(tx: Tx): Promise<TxValidationResult> {
     if (!this.permitted) {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_proof_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_proof_validator.ts
@@ -1,11 +1,16 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
 import { TX_ERROR_INVALID_PROOF, Tx, type TxValidationResult, type TxValidator } from '@aztec/stdlib/tx';
 
 export class TxProofValidator implements TxValidator<Tx> {
-  #log = createLogger('p2p:tx_validator:private_proof');
+  #log: Logger;
 
-  constructor(private verifier: ClientProtocolCircuitVerifier) {}
+  constructor(
+    private verifier: ClientProtocolCircuitVerifier,
+    bindings?: LoggerBindings,
+  ) {
+    this.#log = createLogger('p2p:tx_validator:proof', bindings);
+  }
 
   async validateTx(tx: Tx): Promise<TxValidationResult> {
     const result = await this.verifier.verifyProof(tx);

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -87,7 +87,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       this.packageVersion,
     ));
 
-    const metricsRegistry = new OtelMetricsAdapter(telemetry);
+    const metricsRegistry = new OtelMetricsAdapter(telemetry, this.logger.getBindings());
     this.discv5 = Discv5.create({
       enr: this.enr,
       peerId,

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -1,4 +1,3 @@
-import { addLogNameHandler } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
@@ -49,10 +48,6 @@ describe('Discv5Service', () => {
     queryForIp: false,
     ...emptyChainConfig,
   };
-
-  beforeAll(() => {
-    addLogNameHandler(name => (name === 'p2p:discv5_service' ? `${name}:${basePort}` : name));
-  });
 
   beforeEach(async () => {
     const telemetryClient = getTelemetryClient();

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -284,14 +284,14 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
 
     const datastore = new AztecDatastore(peerStore);
 
-    const otelMetricsAdapter = new OtelMetricsAdapter(telemetry);
+    const otelMetricsAdapter = new OtelMetricsAdapter(telemetry, logger.getBindings());
 
     const peerDiscoveryService = new DiscV5Service(
       peerId,
       config,
       packageVersion,
       telemetry,
-      createLogger(`${logger.module}:discv5_service`),
+      createLogger(`${logger.module}:discv5_service`, logger.getBindings()),
     );
 
     // Seed libp2p's bootstrap discovery with private and trusted peers
@@ -452,7 +452,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
           connectionManager: components.connectionManager,
         }),
       },
-      logger: createLibp2pComponentLogger(logger.module),
+      logger: createLibp2pComponentLogger(logger.module, logger.getBindings()),
     });
 
     const peerScoring = new PeerScoring(config, telemetry);
@@ -1508,6 +1508,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       this.proofVerifier,
       !this.config.disableTransactions,
       allowedInSetup,
+      this.logger.getBindings(),
     );
   }
 
@@ -1561,15 +1562,18 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       return PeerErrorSeverity.HighToleranceError;
     }
 
-    const snapshotValidator = new DoubleSpendTxValidator({
-      nullifiersExist: async (nullifiers: Buffer[]) => {
-        const merkleTree = this.worldStateSynchronizer.getSnapshot(
-          BlockNumber(blockNumber - this.config.doubleSpendSeverePeerPenaltyWindow),
-        );
-        const indices = await merkleTree.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, nullifiers);
-        return indices.map(index => index !== undefined);
+    const snapshotValidator = new DoubleSpendTxValidator(
+      {
+        nullifiersExist: async (nullifiers: Buffer[]) => {
+          const merkleTree = this.worldStateSynchronizer.getSnapshot(
+            BlockNumber(blockNumber - this.config.doubleSpendSeverePeerPenaltyWindow),
+          );
+          const indices = await merkleTree.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, nullifiers);
+          return indices.map(index => index !== undefined);
+        },
       },
-    });
+      this.logger.getBindings(),
+    );
 
     const validSnapshot = await snapshotValidator.validateTx(tx);
     if (validSnapshot.result !== 'valid') {

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -3,7 +3,7 @@ import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { type CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { L2Block } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
@@ -34,7 +34,7 @@ import {
  * Finally completes the checkpoint by computing its header.
  */
 export class LightweightCheckpointBuilder {
-  private readonly logger = createLogger('lightweight-checkpoint-builder');
+  private readonly logger: Logger;
 
   private lastArchives: AppendOnlyTreeSnapshot[] = [];
   private spongeBlob: SpongeBlob;
@@ -47,7 +47,12 @@ export class LightweightCheckpointBuilder {
     public readonly l1ToL2Messages: Fr[],
     private readonly previousCheckpointOutHashes: Fr[],
     public readonly db: MerkleTreeWriteOperations,
+    bindings?: LoggerBindings,
   ) {
+    this.logger = createLogger('checkpoint-builder', {
+      ...bindings,
+      instanceId: `checkpoint-${checkpointNumber}`,
+    });
     this.spongeBlob = SpongeBlob.init();
     this.logger.debug('Starting new checkpoint', { constants, l1ToL2Messages });
   }
@@ -58,6 +63,7 @@ export class LightweightCheckpointBuilder {
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     db: MerkleTreeWriteOperations,
+    bindings?: LoggerBindings,
   ): Promise<LightweightCheckpointBuilder> {
     // Insert l1-to-l2 messages into the tree.
     await db.appendLeaves(
@@ -71,6 +77,7 @@ export class LightweightCheckpointBuilder {
       l1ToL2Messages,
       previousCheckpointOutHashes,
       db,
+      bindings,
     );
   }
 
@@ -87,6 +94,7 @@ export class LightweightCheckpointBuilder {
     previousCheckpointOutHashes: Fr[],
     db: MerkleTreeWriteOperations,
     existingBlocks: L2Block[],
+    bindings?: LoggerBindings,
   ): Promise<LightweightCheckpointBuilder> {
     const builder = new LightweightCheckpointBuilder(
       checkpointNumber,
@@ -94,6 +102,7 @@ export class LightweightCheckpointBuilder {
       l1ToL2Messages,
       previousCheckpointOutHashes,
       db,
+      bindings,
     );
 
     builder.logger.debug('Resuming checkpoint from existing blocks', {
@@ -264,6 +273,7 @@ export class LightweightCheckpointBuilder {
       [...this.l1ToL2Messages],
       [...this.previousCheckpointOutHashes],
       this.db,
+      this.logger.getBindings(),
     );
     clone.lastArchives = [...this.lastArchives];
     clone.spongeBlob = this.spongeBlob.clone();

--- a/yarn-project/prover-client/src/mocks/fixtures.ts
+++ b/yarn-project/prover-client/src/mocks/fixtures.ts
@@ -75,7 +75,8 @@ export async function getSimulator(
       logger?.info(
         `Using native ACVM at ${config.acvmBinaryPath} and working directory ${config.acvmWorkingDirectory}`,
       );
-      return new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath);
+      const acvmLogger = logger?.createChild('acvm-native');
+      return new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath, undefined, acvmLogger);
     } catch {
       logger?.warn(`Failed to access ACVM at ${config.acvmBinaryPath}, falling back to WASM`);
     }

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -10,7 +10,7 @@ import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AbortError } from '@aztec/foundation/error';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { assertLength } from '@aztec/foundation/serialize';
 import { pushTestData } from '@aztec/foundation/testing';
@@ -71,8 +71,6 @@ import { EpochProvingState, type ProvingResult, type TreeSnapshots } from './epo
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
 import { TxProvingState } from './tx-proving-state.js';
 
-const logger = createLogger('prover-client:orchestrator');
-
 type WorldStateFork = {
   fork: MerkleTreeWriteOperations;
   cleanupPromise: Promise<void> | undefined;
@@ -100,6 +98,7 @@ export class ProvingOrchestrator implements EpochProver {
   private metrics: ProvingOrchestratorMetrics;
   // eslint-disable-next-line aztec-custom/no-non-primitive-in-collections
   private dbs: Map<BlockNumber, WorldStateFork> = new Map();
+  private logger: Logger;
 
   constructor(
     private dbProvider: ReadonlyWorldStateAccess & ForkMerkleTreeOperations,
@@ -107,7 +106,9 @@ export class ProvingOrchestrator implements EpochProver {
     private readonly proverId: EthAddress,
     private readonly cancelJobsOnStop: boolean = false,
     telemetryClient: TelemetryClient = getTelemetryClient(),
+    bindings?: LoggerBindings,
   ) {
+    this.logger = createLogger('prover-client:orchestrator', bindings);
     this.metrics = new ProvingOrchestratorMetrics(telemetryClient, 'ProvingOrchestrator');
   }
 
@@ -141,7 +142,7 @@ export class ProvingOrchestrator implements EpochProver {
 
     const { promise: _promise, resolve, reject } = promiseWithResolvers<ProvingResult>();
     const promise = _promise.catch((reason): ProvingResult => ({ status: 'failure', reason }));
-    logger.info(`Starting epoch ${epochNumber} with ${totalNumCheckpoints} checkpoints.`);
+    this.logger.info(`Starting epoch ${epochNumber} with ${totalNumCheckpoints} checkpoints.`);
     this.provingState = new EpochProvingState(
       epochNumber,
       totalNumCheckpoints,
@@ -233,7 +234,7 @@ export class ProvingOrchestrator implements EpochProver {
     }
 
     const constants = checkpointProvingState.constants;
-    logger.info(`Starting block ${blockNumber} for slot ${constants.slotNumber}.`);
+    this.logger.info(`Starting block ${blockNumber} for slot ${constants.slotNumber}.`);
 
     // Fork the db only when it's not already set. The db for the first block is set in `startNewCheckpoint`.
     if (!this.dbs.has(blockNumber)) {
@@ -294,7 +295,7 @@ export class ProvingOrchestrator implements EpochProver {
     if (!txs.length) {
       // To avoid an ugly throw below. If we require an empty block, we can just call setBlockCompleted
       // on a block with no txs. We cannot do that here because we cannot find the blockNumber without any txs.
-      logger.warn(`Provided no txs to orchestrator addTxs.`);
+      this.logger.warn(`Provided no txs to orchestrator addTxs.`);
       return;
     }
 
@@ -314,7 +315,7 @@ export class ProvingOrchestrator implements EpochProver {
       throw new Error(`Block ${blockNumber} has been initialized with transactions.`);
     }
 
-    logger.info(`Adding ${txs.length} transactions to block ${blockNumber}`);
+    this.logger.info(`Adding ${txs.length} transactions to block ${blockNumber}`);
 
     const db = this.dbs.get(blockNumber)!.fork;
     const lastArchive = provingState.lastArchiveTreeSnapshot;
@@ -329,7 +330,7 @@ export class ProvingOrchestrator implements EpochProver {
 
         validateTx(tx);
 
-        logger.debug(`Received transaction: ${tx.hash}`);
+        this.logger.debug(`Received transaction: ${tx.hash}`);
 
         const startSpongeBlob = spongeBlobState.clone();
         const [hints, treeSnapshots] = await this.prepareBaseRollupInputs(
@@ -350,10 +351,10 @@ export class ProvingOrchestrator implements EpochProver {
         const txIndex = provingState.addNewTx(txProvingState);
         if (txProvingState.requireAvmProof) {
           this.getOrEnqueueChonkVerifier(provingState, txIndex);
-          logger.debug(`Enqueueing public VM for tx ${txIndex}`);
+          this.logger.debug(`Enqueueing public VM for tx ${txIndex}`);
           this.enqueueVM(provingState, txIndex);
         } else {
-          logger.debug(`Enqueueing base rollup for private-only tx ${txIndex}`);
+          this.logger.debug(`Enqueueing base rollup for private-only tx ${txIndex}`);
           this.enqueueBaseRollup(provingState, txIndex);
         }
       } catch (err: any) {
@@ -396,7 +397,7 @@ export class ProvingOrchestrator implements EpochProver {
             typeof NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH
           >
         >();
-      logger.debug(`Starting chonk verifier circuit for tx ${txHash}`);
+      this.logger.debug(`Starting chonk verifier circuit for tx ${txHash}`);
       this.doEnqueueChonkVerifier(txHash, privateInputs, proof => {
         tubeProof.resolve(proof);
       });
@@ -436,11 +437,11 @@ export class ProvingOrchestrator implements EpochProver {
     }
 
     // Given we've applied every change from this block, now assemble the block header:
-    logger.verbose(`Block ${blockNumber} completed. Assembling header.`);
+    this.logger.verbose(`Block ${blockNumber} completed. Assembling header.`);
     const header = await provingState.buildBlockHeader();
 
     if (expectedHeader && !header.equals(expectedHeader)) {
-      logger.error(`Block header mismatch: header=${header} expectedHeader=${expectedHeader}`);
+      this.logger.error(`Block header mismatch: header=${header} expectedHeader=${expectedHeader}`);
       throw new Error('Block header mismatch');
     }
 
@@ -448,7 +449,7 @@ export class ProvingOrchestrator implements EpochProver {
     const db = this.dbs.get(provingState.blockNumber)!.fork;
 
     // Update the archive tree, so we're ready to start processing the next block:
-    logger.verbose(
+    this.logger.verbose(
       `Updating archive tree with block ${provingState.blockNumber} header ${(await header.hash()).toString()}`,
     );
     await db.updateArchive(header);
@@ -462,19 +463,19 @@ export class ProvingOrchestrator implements EpochProver {
   protected async verifyBuiltBlockAgainstSyncedState(provingState: BlockProvingState) {
     const builtBlockHeader = provingState.getBuiltBlockHeader();
     if (!builtBlockHeader) {
-      logger.debug('Block header not built yet, skipping header check.');
+      this.logger.debug('Block header not built yet, skipping header check.');
       return;
     }
 
     const output = provingState.getBlockRootRollupOutput();
     if (!output) {
-      logger.debug('Block root rollup proof not built yet, skipping header check.');
+      this.logger.debug('Block root rollup proof not built yet, skipping header check.');
       return;
     }
     const header = await buildHeaderFromCircuitOutputs(output);
 
     if (!(await header.hash()).equals(await builtBlockHeader.hash())) {
-      logger.error(`Block header mismatch.\nCircuit: ${inspect(header)}\nComputed: ${inspect(builtBlockHeader)}`);
+      this.logger.error(`Block header mismatch.\nCircuit: ${inspect(header)}\nComputed: ${inspect(builtBlockHeader)}`);
       provingState.reject(`Block header hash mismatch.`);
       return;
     }
@@ -486,7 +487,7 @@ export class ProvingOrchestrator implements EpochProver {
     const newArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, db);
     const syncedArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, this.dbProvider.getSnapshot(blockNumber));
     if (!syncedArchive.equals(newArchive)) {
-      logger.error(
+      this.logger.error(
         `Archive tree mismatch for block ${blockNumber}: world state synced to ${inspect(
           syncedArchive,
         )} but built ${inspect(newArchive)}`,
@@ -497,7 +498,7 @@ export class ProvingOrchestrator implements EpochProver {
 
     const circuitArchive = output.newArchive;
     if (!newArchive.equals(circuitArchive)) {
-      logger.error(`New archive mismatch.\nCircuit: ${output.newArchive}\nComputed: ${newArchive}`);
+      this.logger.error(`New archive mismatch.\nCircuit: ${output.newArchive}\nComputed: ${newArchive}`);
       provingState.reject(`New archive mismatch.`);
       return;
     }
@@ -554,7 +555,7 @@ export class ProvingOrchestrator implements EpochProver {
   }
 
   private async cleanupDBFork(blockNumber: BlockNumber): Promise<void> {
-    logger.debug(`Cleaning up world state fork for ${blockNumber}`);
+    this.logger.debug(`Cleaning up world state fork for ${blockNumber}`);
     const fork = this.dbs.get(blockNumber);
     if (!fork) {
       return;
@@ -567,7 +568,7 @@ export class ProvingOrchestrator implements EpochProver {
       await fork.cleanupPromise;
       this.dbs.delete(blockNumber);
     } catch (err) {
-      logger.error(`Error closing db for block ${blockNumber}`, err);
+      this.logger.error(`Error closing db for block ${blockNumber}`, err);
     }
   }
 
@@ -583,7 +584,7 @@ export class ProvingOrchestrator implements EpochProver {
     callback: (result: T) => void | Promise<void>,
   ) {
     if (!provingState.verifyState()) {
-      logger.debug(`Not enqueuing job, state no longer valid`);
+      this.logger.debug(`Not enqueuing job, state no longer valid`);
       return;
     }
 
@@ -601,7 +602,7 @@ export class ProvingOrchestrator implements EpochProver {
 
         const result = await request(controller.signal);
         if (!provingState.verifyState()) {
-          logger.debug(`State no longer valid, discarding result`);
+          this.logger.debug(`State no longer valid, discarding result`);
           return;
         }
 
@@ -619,7 +620,7 @@ export class ProvingOrchestrator implements EpochProver {
           return;
         }
 
-        logger.error(`Error thrown when proving job`, err);
+        this.logger.error(`Error thrown when proving job`, err);
         provingState!.reject(`${err}`);
       } finally {
         const index = this.pendingProvingJobs.indexOf(controller);
@@ -704,12 +705,12 @@ export class ProvingOrchestrator implements EpochProver {
   // Executes the next level of merge if all inputs are available
   private enqueueBaseRollup(provingState: BlockProvingState, txIndex: number) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running base rollup, state invalid');
+      this.logger.debug('Not running base rollup, state invalid');
       return;
     }
 
     if (!provingState.tryStartProvingBase(txIndex)) {
-      logger.debug(`Base rollup for tx ${txIndex} already started.`);
+      this.logger.debug(`Base rollup for tx ${txIndex} already started.`);
       return;
     }
 
@@ -717,7 +718,7 @@ export class ProvingOrchestrator implements EpochProver {
     const { processedTx } = txProvingState;
     const { rollupType, inputs } = txProvingState.getBaseRollupTypeAndInputs();
 
-    logger.debug(`Enqueuing deferred proving base rollup for ${processedTx.hash.toString()}`);
+    this.logger.debug(`Enqueuing deferred proving base rollup for ${processedTx.hash.toString()}`);
 
     this.deferredProving(
       provingState,
@@ -741,7 +742,7 @@ export class ProvingOrchestrator implements EpochProver {
         },
       ),
       result => {
-        logger.debug(`Completed proof for ${rollupType} for tx ${processedTx.hash.toString()}`);
+        this.logger.debug(`Completed proof for ${rollupType} for tx ${processedTx.hash.toString()}`);
         validatePartialState(result.inputs.endTreeSnapshots, txProvingState.treeSnapshots);
         const leafLocation = provingState.setBaseRollupProof(txIndex, result);
         if (provingState.totalNumTxs === 1) {
@@ -757,7 +758,7 @@ export class ProvingOrchestrator implements EpochProver {
   // Once completed, will enqueue the the public tx base rollup.
   private getOrEnqueueChonkVerifier(provingState: BlockProvingState, txIndex: number) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running chonk verifier circuit, state invalid');
+      this.logger.debug('Not running chonk verifier circuit, state invalid');
       return;
     }
 
@@ -770,19 +771,19 @@ export class ProvingOrchestrator implements EpochProver {
         typeof NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH
       >,
     ) => {
-      logger.debug(`Got chonk verifier proof for tx index: ${txIndex}`, { txHash });
+      this.logger.debug(`Got chonk verifier proof for tx index: ${txIndex}`, { txHash });
       txProvingState.setPublicChonkVerifierProof(result);
       this.provingState?.cachedChonkVerifierProofs.delete(txHash);
       this.checkAndEnqueueBaseRollup(provingState, txIndex);
     };
 
     if (this.provingState?.cachedChonkVerifierProofs.has(txHash)) {
-      logger.debug(`Chonk verifier proof already enqueued for tx index: ${txIndex}`, { txHash });
+      this.logger.debug(`Chonk verifier proof already enqueued for tx index: ${txIndex}`, { txHash });
       void this.provingState!.cachedChonkVerifierProofs.get(txHash)!.then(handleResult);
       return;
     }
 
-    logger.debug(`Enqueuing chonk verifier circuit for tx index: ${txIndex}`);
+    this.logger.debug(`Enqueuing chonk verifier circuit for tx index: ${txIndex}`);
     this.doEnqueueChonkVerifier(txHash, txProvingState.getPublicChonkVerifierPrivateInputs(), handleResult);
   }
 
@@ -798,7 +799,7 @@ export class ProvingOrchestrator implements EpochProver {
     provingState: EpochProvingState | BlockProvingState = this.provingState!,
   ) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running chonk verifier circuit, state invalid');
+      this.logger.debug('Not running chonk verifier circuit, state invalid');
       return;
     }
 
@@ -821,12 +822,12 @@ export class ProvingOrchestrator implements EpochProver {
   // Enqueues the next level of merge if all inputs are available
   private enqueueMergeRollup(provingState: BlockProvingState, location: TreeNodeLocation) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running merge rollup. State no longer valid.');
+      this.logger.debug('Not running merge rollup. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingMerge(location)) {
-      logger.debug('Merge rollup already started.');
+      this.logger.debug('Merge rollup already started.');
       return;
     }
 
@@ -852,18 +853,18 @@ export class ProvingOrchestrator implements EpochProver {
   // Executes the block root rollup circuit
   private enqueueBlockRootRollup(provingState: BlockProvingState) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running block root rollup, state no longer valid');
+      this.logger.debug('Not running block root rollup, state no longer valid');
       return;
     }
 
     if (!provingState.tryStartProvingBlockRoot()) {
-      logger.debug('Block root rollup already started.');
+      this.logger.debug('Block root rollup already started.');
       return;
     }
 
     const { rollupType, inputs } = provingState.getBlockRootRollupTypeAndInputs();
 
-    logger.debug(`Enqueuing ${rollupType} for block ${provingState.blockNumber}.`);
+    this.logger.debug(`Enqueuing ${rollupType} for block ${provingState.blockNumber}.`);
 
     this.deferredProving(
       provingState,
@@ -888,7 +889,7 @@ export class ProvingOrchestrator implements EpochProver {
         },
       ),
       async result => {
-        logger.debug(`Completed ${rollupType} proof for block ${provingState.blockNumber}`);
+        this.logger.debug(`Completed ${rollupType} proof for block ${provingState.blockNumber}`);
 
         const leafLocation = provingState.setBlockRootRollupProof(result);
         const checkpointProvingState = provingState.parentCheckpoint;
@@ -916,12 +917,12 @@ export class ProvingOrchestrator implements EpochProver {
     baseParityIndex: number,
   ) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running base parity. State no longer valid.');
+      this.logger.debug('Not running base parity. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingBaseParity(baseParityIndex)) {
-      logger.warn(`Base parity ${baseParityIndex} already started.`);
+      this.logger.warn(`Base parity ${baseParityIndex} already started.`);
       return;
     }
 
@@ -956,12 +957,12 @@ export class ProvingOrchestrator implements EpochProver {
   // Enqueues the root rollup proof if all inputs are available
   private enqueueRootParityCircuit(provingState: BlockProvingState) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running root parity. State no longer valid.');
+      this.logger.debug('Not running root parity. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingRootParity()) {
-      logger.debug('Root parity already started.');
+      this.logger.debug('Root parity already started.');
       return;
     }
 
@@ -988,12 +989,12 @@ export class ProvingOrchestrator implements EpochProver {
   // Enqueues the next level of merge if all inputs are available
   private enqueueBlockMergeRollup(provingState: CheckpointProvingState, location: TreeNodeLocation) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running block merge rollup. State no longer valid.');
+      this.logger.debug('Not running block merge rollup. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingBlockMerge(location)) {
-      logger.debug('Block merge rollup already started.');
+      this.logger.debug('Block merge rollup already started.');
       return;
     }
 
@@ -1017,18 +1018,18 @@ export class ProvingOrchestrator implements EpochProver {
 
   private enqueueCheckpointRootRollup(provingState: CheckpointProvingState) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running checkpoint root rollup. State no longer valid.');
+      this.logger.debug('Not running checkpoint root rollup. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingCheckpointRoot()) {
-      logger.debug('Checkpoint root rollup already started.');
+      this.logger.debug('Checkpoint root rollup already started.');
       return;
     }
 
     const rollupType = provingState.getCheckpointRootRollupType();
 
-    logger.debug(`Enqueuing ${rollupType} for checkpoint ${provingState.index}.`);
+    this.logger.debug(`Enqueuing ${rollupType} for checkpoint ${provingState.index}.`);
 
     const inputs = provingState.getCheckpointRootRollupInputs();
 
@@ -1052,7 +1053,7 @@ export class ProvingOrchestrator implements EpochProver {
         const computedEndBlobAccumulatorState = provingState.getEndBlobAccumulator()!.toBlobAccumulator();
         const circuitEndBlobAccumulatorState = result.inputs.endBlobAccumulator;
         if (!circuitEndBlobAccumulatorState.equals(computedEndBlobAccumulatorState)) {
-          logger.error(
+          this.logger.error(
             `Blob accumulator state mismatch.\nCircuit: ${inspect(circuitEndBlobAccumulatorState)}\nComputed: ${inspect(
               computedEndBlobAccumulatorState,
             )}`,
@@ -1061,7 +1062,7 @@ export class ProvingOrchestrator implements EpochProver {
           return;
         }
 
-        logger.debug(`Completed ${rollupType} proof for checkpoint ${provingState.index}.`);
+        this.logger.debug(`Completed ${rollupType} proof for checkpoint ${provingState.index}.`);
 
         const leafLocation = provingState.setCheckpointRootRollupProof(result);
         const epochProvingState = provingState.parentEpoch;
@@ -1077,12 +1078,12 @@ export class ProvingOrchestrator implements EpochProver {
 
   private enqueueCheckpointMergeRollup(provingState: EpochProvingState, location: TreeNodeLocation) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running checkpoint merge rollup. State no longer valid.');
+      this.logger.debug('Not running checkpoint merge rollup. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingCheckpointMerge(location)) {
-      logger.debug('Checkpoint merge rollup already started.');
+      this.logger.debug('Checkpoint merge rollup already started.');
       return;
     }
 
@@ -1099,7 +1100,7 @@ export class ProvingOrchestrator implements EpochProver {
         signal => this.prover.getCheckpointMergeRollupProof(inputs, signal, provingState.epochNumber),
       ),
       result => {
-        logger.debug('Completed proof for checkpoint merge rollup.');
+        this.logger.debug('Completed proof for checkpoint merge rollup.');
         provingState.setCheckpointMergeRollupProof(location, result);
         this.checkAndEnqueueNextCheckpointMergeRollup(provingState, location);
       },
@@ -1108,16 +1109,16 @@ export class ProvingOrchestrator implements EpochProver {
 
   private enqueueEpochPadding(provingState: EpochProvingState) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running epoch padding. State no longer valid.');
+      this.logger.debug('Not running epoch padding. State no longer valid.');
       return;
     }
 
     if (!provingState.tryStartProvingPaddingCheckpoint()) {
-      logger.debug('Padding checkpoint already started.');
+      this.logger.debug('Padding checkpoint already started.');
       return;
     }
 
-    logger.debug('Padding epoch proof with a padding block root proof.');
+    this.logger.debug('Padding epoch proof with a padding block root proof.');
 
     const inputs = provingState.getPaddingCheckpointInputs();
 
@@ -1132,7 +1133,7 @@ export class ProvingOrchestrator implements EpochProver {
         signal => this.prover.getCheckpointPaddingRollupProof(inputs, signal, provingState.epochNumber),
       ),
       result => {
-        logger.debug('Completed proof for padding checkpoint.');
+        this.logger.debug('Completed proof for padding checkpoint.');
         provingState.setCheckpointPaddingProof(result);
         this.checkAndEnqueueRootRollup(provingState);
       },
@@ -1142,11 +1143,11 @@ export class ProvingOrchestrator implements EpochProver {
   // Executes the root rollup circuit
   private enqueueRootRollup(provingState: EpochProvingState) {
     if (!provingState.verifyState()) {
-      logger.debug('Not running root rollup, state no longer valid');
+      this.logger.debug('Not running root rollup, state no longer valid');
       return;
     }
 
-    logger.debug(`Preparing root rollup`);
+    this.logger.debug(`Preparing root rollup`);
 
     const inputs = provingState.getRootRollupInputs();
 
@@ -1161,7 +1162,7 @@ export class ProvingOrchestrator implements EpochProver {
         signal => this.prover.getRootRollupProof(inputs, signal, provingState.epochNumber),
       ),
       result => {
-        logger.verbose(`Orchestrator completed root rollup for epoch ${provingState.epochNumber}`);
+        this.logger.verbose(`Orchestrator completed root rollup for epoch ${provingState.epochNumber}`);
         provingState.setRootRollupProof(result);
         provingState.resolve({ status: 'success' });
       },
@@ -1183,7 +1184,7 @@ export class ProvingOrchestrator implements EpochProver {
 
   private checkAndEnqueueBlockRootRollup(provingState: BlockProvingState) {
     if (!provingState.isReadyForBlockRootRollup()) {
-      logger.debug('Not ready for block root rollup');
+      this.logger.debug('Not ready for block root rollup');
       return;
     }
 
@@ -1226,7 +1227,7 @@ export class ProvingOrchestrator implements EpochProver {
 
   private checkAndEnqueueRootRollup(provingState: EpochProvingState) {
     if (!provingState.isReadyForRootRollup()) {
-      logger.debug('Not ready for root rollup');
+      this.logger.debug('Not ready for root rollup');
       return;
     }
 
@@ -1241,7 +1242,7 @@ export class ProvingOrchestrator implements EpochProver {
    */
   private enqueueVM(provingState: BlockProvingState, txIndex: number) {
     if (!provingState.verifyState()) {
-      logger.debug(`Not running VM circuit as state is no longer valid`);
+      this.logger.debug(`Not running VM circuit as state is no longer valid`);
       return;
     }
 
@@ -1260,7 +1261,7 @@ export class ProvingOrchestrator implements EpochProver {
     );
 
     this.deferredProving(provingState, doAvmProving, proof => {
-      logger.debug(`Proven VM for tx index: ${txIndex}`);
+      this.logger.debug(`Proven VM for tx index: ${txIndex}`);
       txProvingState.setAvmProof(proof);
       this.checkAndEnqueueBaseRollup(provingState, txIndex);
     });
@@ -1273,7 +1274,7 @@ export class ProvingOrchestrator implements EpochProver {
     }
 
     // We must have completed all proving (chonk verifier proof and (if required) vm proof are generated), we now move to the base rollup.
-    logger.debug(`Public functions completed for tx ${txIndex} enqueueing base rollup`);
+    this.logger.debug(`Public functions completed for tx ${txIndex} enqueueing base rollup`);
 
     this.enqueueBaseRollup(provingState, txIndex);
   }

--- a/yarn-project/prover-client/src/prover-client/prover-client.ts
+++ b/yarn-project/prover-client/src/prover-client/prover-client.ts
@@ -1,7 +1,7 @@
 import { type ACVMConfig, type BBConfig, BBNativeRollupProver, TestCircuitProver } from '@aztec/bb-prover';
 import { times } from '@aztec/foundation/collection';
 import type { EthAddress } from '@aztec/foundation/eth-address';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { NativeACVMSimulator } from '@aztec/simulator/server';
 import {
   type ActualProverConfig,
@@ -38,20 +38,28 @@ export class ProverClient implements EpochProverManager {
     private orchestratorClient: ProvingJobProducer,
     private agentClient?: ProvingJobConsumer,
     private telemetry: TelemetryClient = getTelemetryClient(),
-    private log = createLogger('prover-client:tx-prover'),
+    private log: Logger = createLogger('prover-client:tx-prover'),
   ) {
     this.proofStore = new InlineProofStore();
     this.failedProofStore = this.config.failedProofStore ? createProofStore(this.config.failedProofStore) : undefined;
   }
 
   public createEpochProver(): EpochProver {
-    const facade = new BrokerCircuitProverFacade(this.orchestratorClient, this.proofStore, this.failedProofStore);
+    const bindings = this.log.getBindings();
+    const facade = new BrokerCircuitProverFacade(
+      this.orchestratorClient,
+      this.proofStore,
+      this.failedProofStore,
+      undefined,
+      bindings,
+    );
     const orchestrator = new ProvingOrchestrator(
       this.worldState,
       facade,
       this.config.proverId,
       this.config.cancelJobsOnStop,
       this.telemetry,
+      bindings,
     );
     return new ServerEpochProver(facade, orchestrator);
   }
@@ -134,9 +142,11 @@ export class ProverClient implements EpochProverManager {
 
     const proofStore = new InlineProofStore();
     const prover = await buildServerCircuitProver(this.config, this.telemetry);
+    const bindings = this.log.getBindings();
     this.agents = times(
       this.config.proverAgentCount,
-      () => new ProvingAgent(this.agentClient!, proofStore, prover, [], this.config.proverAgentPollIntervalMs),
+      () =>
+        new ProvingAgent(this.agentClient!, proofStore, prover, [], this.config.proverAgentPollIntervalMs, bindings),
     );
 
     await Promise.all(this.agents.map(agent => agent.start()));
@@ -155,8 +165,9 @@ export function buildServerCircuitProver(
     return BBNativeRollupProver.new(config, telemetry);
   }
 
+  const logger = createLogger('prover-client:acvm-native');
   const simulator = config.acvmBinaryPath
-    ? new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath)
+    ? new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath, undefined, logger)
     : undefined;
 
   return Promise.resolve(new TestCircuitProver(simulator, config, telemetry));

--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
@@ -6,7 +6,7 @@ import type {
 } from '@aztec/constants';
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { sha256 } from '@aztec/foundation/crypto/sha256';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { truncate } from '@aztec/foundation/string';
 import type { AvmCircuitInputs } from '@aztec/stdlib/avm';
@@ -68,14 +68,17 @@ export class BrokerCircuitProverFacade implements ServerCircuitProver {
   private runningPromise?: RunningPromise;
   private timeOfLastSnapshotSync = Date.now();
   private jobsToRetrieve: Set<ProvingJobId> = new Set();
+  private log: Logger;
 
   constructor(
     private broker: ProvingJobProducer,
     private proofStore: ProofStore = new InlineProofStore(),
     private failedProofStore?: ProofStore,
     private pollIntervalMs = 1000,
-    private log = createLogger('prover-client:broker-circuit-prover-facade'),
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('prover-client:broker-circuit-prover-facade', bindings);
+  }
 
   /**
    * This is a critical section. This function can not be async since it writes

--- a/yarn-project/prover-client/src/proving_broker/proving_agent.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_agent.ts
@@ -1,5 +1,5 @@
 import { AbortError } from '@aztec/foundation/error';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { truncate } from '@aztec/foundation/string';
 import { ProvingError } from '@aztec/stdlib/errors';
@@ -23,6 +23,7 @@ import { ProvingJobController, ProvingJobControllerStatus } from './proving_job_
 export class ProvingAgent {
   private currentJobController?: ProvingJobController;
   private runningPromise: RunningPromise;
+  private log: Logger;
 
   constructor(
     /** The source of proving jobs */
@@ -35,8 +36,9 @@ export class ProvingAgent {
     private proofAllowList: Array<ProvingRequestType> = [],
     /** How long to wait between jobs */
     private pollIntervalMs = 1000,
-    private log = createLogger('prover-client:proving-agent'),
+    bindings?: LoggerBindings,
   ) {
+    this.log = createLogger('prover-client:proving-agent', bindings);
     this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.pollIntervalMs);
   }
 
@@ -159,6 +161,7 @@ export class ProvingAgent {
         // no need to await this here. The controller will stay alive (in DONE state) until the result is send to the broker
         void this.runningPromise.trigger();
       },
+      this.log.getBindings(),
     );
 
     if (abortedProofJobId) {

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_agent_integration.test.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_agent_integration.test.ts
@@ -2,7 +2,6 @@ import { EpochNumber } from '@aztec/foundation/branded-types';
 import { times } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto/random';
 import { sha256 } from '@aztec/foundation/crypto/sha256';
-import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { ProvingJob, makeProvingJobId } from '@aztec/stdlib/interfaces/server';
@@ -45,10 +44,7 @@ describe('ProvingBroker <-> ProvingAgent integration', () => {
 
     prover = new MockProver();
     store = new InlineProofStore();
-    agents = times(
-      AGENTS,
-      i => new ProvingAgent(broker, store, prover, [], WORK_LOOP, createLogger('prover-agent-' + i)),
-    );
+    agents = times(AGENTS, i => new ProvingAgent(broker, store, prover, [], WORK_LOOP, { instanceId: `agent-${i}` }));
 
     await broker.start();
     agents.forEach(agent => agent.start());

--- a/yarn-project/prover-client/src/proving_broker/proving_job_controller.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_job_controller.ts
@@ -1,7 +1,7 @@
 import { EpochNumber } from '@aztec/foundation/branded-types';
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { AbortError } from '@aztec/foundation/error';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type {
   ProvingJobId,
   ProvingJobInputs,
@@ -21,6 +21,7 @@ export class ProvingJobController {
   private promise?: Promise<void>;
   private abortController = new AbortController();
   private result?: ProvingJobResultsMap[ProvingRequestType] | Error;
+  private log: Logger;
 
   constructor(
     private jobId: ProvingJobId,
@@ -29,8 +30,13 @@ export class ProvingJobController {
     private startedAt: number,
     private circuitProver: ServerCircuitProver,
     private onComplete: () => void,
-    private log = createLogger('prover-client:proving-agent:job-controller-' + randomBytes(4).toString('hex')),
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('prover-client:proving-agent:job-controller', {
+      instanceId: randomBytes(4).toString('hex'),
+      ...bindings,
+    });
+  }
 
   public start(): void {
     if (this.status !== ProvingJobControllerStatus.IDLE) {

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -31,7 +31,7 @@ export async function rerunEpochProvingJob(
   const metrics = new ProverNodeJobMetrics(telemetry.getMeter('prover-job'), telemetry.getTracer('prover-job'));
   const worldState = await createWorldState(config);
   const archiver = await createArchiverStore(config, { epochDuration: config.aztecEpochDuration });
-  const publicProcessorFactory = new PublicProcessorFactory(archiver);
+  const publicProcessorFactory = new PublicProcessorFactory(archiver, undefined, undefined, log.getBindings());
 
   const publisher = { submitEpochProof: () => Promise.resolve(true) };
   const l2BlockSourceForReorgDetection = undefined;
@@ -53,6 +53,7 @@ export async function rerunEpochProvingJob(
     metrics,
     deadline,
     { skipEpochCheck: true },
+    log.getBindings(),
   );
 
   log.info(`Rerunning epoch proving job for epoch ${jobData.epochNumber}`);

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -153,7 +153,7 @@ export async function createProverNode(
     deps.publisherFactory ??
     new ProverPublisherFactory(config, {
       rollupContract,
-      publisherManager: new PublisherManager(l1TxUtils, config),
+      publisherManager: new PublisherManager(l1TxUtils, config, log.getBindings()),
       telemetry,
     });
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -3,7 +3,7 @@ import { asyncPool } from '@aztec/foundation/async-pool';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -43,7 +43,7 @@ export type EpochProvingJobOptions = {
  */
 export class EpochProvingJob implements Traceable {
   private state: EpochProvingJobState = 'initialized';
-  private log = createLogger('prover-node:epoch-proving-job');
+  private log: Logger;
   private uuid: string;
 
   private runPromise: Promise<void> | undefined;
@@ -62,9 +62,14 @@ export class EpochProvingJob implements Traceable {
     private metrics: ProverNodeJobMetrics,
     private deadline: Date | undefined,
     private config: EpochProvingJobOptions,
+    bindings?: LoggerBindings,
   ) {
     validateEpochProvingJobData(data);
     this.uuid = crypto.randomUUID();
+    this.log = createLogger('prover-node:epoch-proving-job', {
+      ...bindings,
+      instanceId: `epoch-${data.epochNumber}`,
+    });
     this.tracer = metrics.tracer;
   }
 

--- a/yarn-project/prover-node/src/prover-node-publisher.ts
+++ b/yarn-project/prover-node/src/prover-node-publisher.ts
@@ -7,7 +7,7 @@ import { CheckpointNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { areArraysEqual } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { Tuple } from '@aztec/foundation/serialize';
 import { Timer } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
@@ -39,7 +39,7 @@ export class ProverNodePublisher {
   private interrupted = false;
   private metrics: ProverNodePublisherMetrics;
 
-  protected log = createLogger('prover-node:l1-tx-publisher');
+  protected log: Logger;
 
   protected rollupContract: RollupContract;
 
@@ -52,10 +52,12 @@ export class ProverNodePublisher {
       l1TxUtils: L1TxUtils;
       telemetry?: TelemetryClient;
     },
+    bindings?: LoggerBindings,
   ) {
     const telemetry = deps.telemetry ?? getTelemetryClient();
 
     this.metrics = new ProverNodePublisherMetrics(telemetry, 'ProverNode');
+    this.log = createLogger('prover-node:l1-tx-publisher', bindings);
 
     this.rollupContract = deps.rollupContract;
     this.l1TxUtils = deps.l1TxUtils;

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -288,6 +288,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.contractDataSource,
       this.dateProvider,
       this.telemetryClient,
+      this.log.getBindings(),
     );
 
     // Set deadline for this job to run. It will abort if it takes too long.
@@ -384,6 +385,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.jobMetrics,
       deadline,
       { parallelBlockLimit, skipSubmitProof: proverNodeDisableProofPublish, ...opts },
+      this.log.getBindings(),
     );
   }
 

--- a/yarn-project/prover-node/src/prover-publisher-factory.ts
+++ b/yarn-project/prover-node/src/prover-publisher-factory.ts
@@ -1,6 +1,7 @@
 import type { RollupContract } from '@aztec/ethereum/contracts';
 import type { L1TxUtils } from '@aztec/ethereum/l1-tx-utils';
 import type { PublisherManager } from '@aztec/ethereum/publisher-manager';
+import type { LoggerBindings } from '@aztec/foundation/log';
 import type { PublisherConfig, TxSenderConfig } from '@aztec/sequencer-client';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
@@ -14,6 +15,7 @@ export class ProverPublisherFactory {
       publisherManager: PublisherManager<L1TxUtils>;
       telemetry?: TelemetryClient;
     },
+    private bindings?: LoggerBindings,
   ) {}
 
   public async start() {
@@ -30,10 +32,14 @@ export class ProverPublisherFactory {
    */
   public async create(): Promise<ProverNodePublisher> {
     const l1Publisher = await this.deps.publisherManager.getAvailablePublisher();
-    return new ProverNodePublisher(this.config, {
-      rollupContract: this.deps.rollupContract,
-      l1TxUtils: l1Publisher,
-      telemetry: this.deps.telemetry,
-    });
+    return new ProverNodePublisher(
+      this.config,
+      {
+        rollupContract: this.deps.rollupContract,
+        l1TxUtils: l1Publisher,
+        telemetry: this.deps.telemetry,
+      },
+      this.bindings,
+    );
   }
 }

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -1,5 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2TipsKVStore } from '@aztec/kv-store/stores';
 import { BlockHash, L2BlockStream, type L2BlockStreamEvent, type L2BlockStreamEventHandler } from '@aztec/stdlib/block';
@@ -29,22 +29,25 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     private privateEventStore: PrivateEventStore,
     private l2TipsStore: L2TipsKVStore,
     private config: Partial<BlockSynchronizerConfig> = {},
-    loggerOrSuffix?: string | Logger,
+    bindings?: LoggerBindings,
   ) {
-    this.log =
-      !loggerOrSuffix || typeof loggerOrSuffix === 'string'
-        ? createLogger(loggerOrSuffix ? `pxe:block_synchronizer:${loggerOrSuffix}` : `pxe:block_synchronizer`)
-        : loggerOrSuffix;
+    this.log = createLogger('pxe:block_synchronizer', bindings);
     this.blockStream = this.createBlockStream(config);
   }
 
   protected createBlockStream(config: Partial<BlockSynchronizerConfig>): L2BlockStream {
-    return new L2BlockStream(this.node, this.l2TipsStore, this, createLogger('pxe:block_stream'), {
-      batchSize: config.l2BlockBatchSize,
-      // Skipping finalized blocks makes us sync much faster - we only need to download blocks other than the latest one
-      // in order to detect reorgs, and there can be no reorgs on finalized block, making this safe.
-      skipFinalized: true,
-    });
+    return new L2BlockStream(
+      this.node,
+      this.l2TipsStore,
+      this,
+      createLogger('pxe:block_stream', this.log.getBindings()),
+      {
+        batchSize: config.l2BlockBatchSize,
+        // Skipping finalized blocks makes us sync much faster - we only need to download blocks other than the latest one
+        // in order to detect reorgs, and there can be no reorgs on finalized block, making this safe.
+        skipFinalized: true,
+      },
+    );
   }
 
   /** Handle events emitted by the block stream. */

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -356,6 +356,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.senderAddressBookStore,
       this.addressStore,
       this.jobId,
+      this.log.getBindings(),
     );
 
     const noteService = new NoteService(this.noteStore, this.aztecNode, this.anchorBlockStore, this.jobId);
@@ -461,6 +462,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.senderAddressBookStore,
       this.addressStore,
       this.jobId,
+      this.log.getBindings(),
     );
 
     const maybeLogRetrievalResponses = await logService.bulkRetrieveLogs(logRetrievalRequests);

--- a/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
@@ -1,6 +1,5 @@
 import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBBundlePrivateKernelProver } from '@aztec/bb-prover/client/bundle';
-import { randomBytes } from '@aztec/foundation/crypto/random';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/indexeddb';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
@@ -26,13 +25,7 @@ export async function createPXE(
   config: PXEConfig,
   options: PXECreationOptions = { loggers: {} },
 ) {
-  const logSuffix =
-    typeof options.useLogSuffix === 'boolean'
-      ? options.useLogSuffix
-        ? randomBytes(3).toString('hex')
-        : undefined
-      : options.useLogSuffix;
-
+  const actor = options.loggerActorLabel;
   const loggers = options.loggers ?? {};
 
   const l1Contracts = await aztecNode.getL1ContractAddresses();
@@ -41,14 +34,12 @@ export async function createPXE(
     l1Contracts,
   } as PXEConfig;
 
-  const storeLogger = loggers.store ? loggers.store : createLogger('pxe:data:idb' + (logSuffix ? `:${logSuffix}` : ''));
+  const storeLogger = loggers.store ?? createLogger('pxe:data:idb', { actor });
 
   const store = options.store ?? (await createStore('pxe_data', configWithContracts, storeLogger));
 
   const simulator = options.simulator ?? new WASMSimulator();
-  const proverLogger = loggers.prover
-    ? loggers.prover
-    : createLogger('pxe:bb:wasm:bundle' + (logSuffix ? `:${logSuffix}` : ''));
+  const proverLogger = loggers.prover ?? createLogger('pxe:bb:wasm:bundle', { actor });
 
   let prover;
   if (options.proverOrOptions instanceof BBPrivateKernelProver) {
@@ -58,7 +49,7 @@ export async function createPXE(
   }
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
-  const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));
+  const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
   const pxe = await PXE.create(aztecNode, store, prover, simulator, protocolContractsProvider, config, pxeLogger);
   return pxe;
 }

--- a/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
@@ -1,6 +1,5 @@
 import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBLazyPrivateKernelProver } from '@aztec/bb-prover/client/lazy';
-import { randomBytes } from '@aztec/foundation/crypto/random';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/indexeddb';
 import { LazyProtocolContractsProvider } from '@aztec/protocol-contracts/providers/lazy';
@@ -17,7 +16,7 @@ import type { PXECreationOptions } from '../../pxe_creation_options.js';
  *
  * @param aztecNode - The AztecNode instance to be used by the server.
  * @param config - The PXE Config to use
- * @param
+ * @param options - (Optional) Optional information for creating an PXE.
  * @returns A Promise that resolves to the started PXE instance.
  */
 export async function createPXE(
@@ -25,12 +24,7 @@ export async function createPXE(
   config: PXEConfig,
   options: PXECreationOptions = { loggers: {} },
 ) {
-  const logSuffix =
-    typeof options.useLogSuffix === 'boolean'
-      ? options.useLogSuffix
-        ? randomBytes(3).toString('hex')
-        : undefined
-      : options.useLogSuffix;
+  const actor = options.loggerActorLabel;
 
   const l1Contracts = await aztecNode.getL1ContractAddresses();
   const configWithContracts = {
@@ -40,14 +34,12 @@ export async function createPXE(
 
   const loggers = options.loggers ?? {};
 
-  const storeLogger = loggers.store ? loggers.store : createLogger('pxe:data:idb' + (logSuffix ? `:${logSuffix}` : ''));
+  const storeLogger = loggers.store ?? createLogger('pxe:data:idb', { actor });
 
   const store = options.store ?? (await createStore('pxe_data', configWithContracts, storeLogger));
 
   const simulator = options.simulator ?? new WASMSimulator();
-  const proverLogger = loggers.prover
-    ? loggers.prover
-    : createLogger('pxe:bb:wasm:bundle' + (logSuffix ? `:${logSuffix}` : ''));
+  const proverLogger = loggers.prover ?? createLogger('pxe:bb:wasm:bundle', { actor });
 
   let prover;
   if (options.proverOrOptions instanceof BBPrivateKernelProver) {
@@ -57,7 +49,7 @@ export async function createPXE(
   }
   const protocolContractsProvider = new LazyProtocolContractsProvider();
 
-  const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));
+  const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
   const pxe = await PXE.create(aztecNode, store, prover, simulator, protocolContractsProvider, config, pxeLogger);
   return pxe;
 }

--- a/yarn-project/pxe/src/entrypoints/pxe_creation_options.ts
+++ b/yarn-project/pxe/src/entrypoints/pxe_creation_options.ts
@@ -6,7 +6,8 @@ import type { PrivateKernelProver } from '@aztec/stdlib/interfaces/client';
 
 export type PXECreationOptions = {
   loggers?: { store?: Logger; pxe?: Logger; prover?: Logger };
-  useLogSuffix?: boolean | string;
+  /** Actor label to include in log output (e.g., 'pxe-0', 'pxe-test'). */
+  loggerActorLabel?: string;
   proverOrOptions?: PrivateKernelProver | BBPrivateKernelProverOptions;
   store?: AztecAsyncKVStore;
   simulator?: CircuitSimulator;

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -1,6 +1,5 @@
 import { BBPrivateKernelProver } from '@aztec/bb-prover/client';
 import { BBBundlePrivateKernelProver } from '@aztec/bb-prover/client/bundle';
-import { randomBytes } from '@aztec/foundation/crypto/random';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
@@ -20,17 +19,13 @@ export async function createPXE(
   config: PXEConfigWithoutDefaults,
   options: PXECreationOptions = { loggers: {} },
 ) {
+  const actor = options.loggerActorLabel;
+  const recorderLogger = createLogger('simulator:acvm:recording', { actor });
   const recorder = process.env.CIRCUIT_RECORD_DIR
-    ? new FileCircuitRecorder(process.env.CIRCUIT_RECORD_DIR)
-    : new MemoryCircuitRecorder();
-  const simulator = new SimulatorRecorderWrapper(new WASMSimulator(), recorder);
-
-  const logSuffix =
-    typeof options.useLogSuffix === 'boolean'
-      ? options.useLogSuffix
-        ? randomBytes(3).toString('hex')
-        : undefined
-      : options.useLogSuffix;
+    ? new FileCircuitRecorder(process.env.CIRCUIT_RECORD_DIR, recorderLogger)
+    : new MemoryCircuitRecorder(recorderLogger);
+  const simulatorLogger = createLogger('wasm-simulator', { actor });
+  const simulator = new SimulatorRecorderWrapper(new WASMSimulator(simulatorLogger), recorder);
   const loggers = options.loggers ?? {};
 
   const { l1ChainId, l1ContractAddresses: l1Contracts, rollupVersion } = await aztecNode.getNodeInfo();
@@ -43,14 +38,15 @@ export async function createPXE(
   };
 
   if (!options.store) {
-    const storeLogger = loggers.store
-      ? loggers.store
-      : createLogger('pxe:data:lmdb' + (logSuffix ? `:${logSuffix}` : ''));
-    options.store = await createStore('pxe_data', PXE_DATA_SCHEMA_VERSION, configWithContracts, storeLogger);
+    const storeLogger = loggers.store ?? createLogger('pxe:data:lmdb', { actor });
+    options.store = await createStore(
+      'pxe_data',
+      PXE_DATA_SCHEMA_VERSION,
+      configWithContracts,
+      storeLogger.getBindings(),
+    );
   }
-  const proverLogger = loggers.prover
-    ? loggers.prover
-    : createLogger('pxe:bb:native' + (logSuffix ? `:${logSuffix}` : ''));
+  const proverLogger = loggers.prover ?? createLogger('pxe:bb:native', { actor });
 
   let prover;
   if (options.proverOrOptions instanceof BBPrivateKernelProver) {
@@ -61,7 +57,7 @@ export async function createPXE(
 
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
-  const pxeLogger = loggers.pxe ? loggers.pxe : createLogger('pxe:service' + (logSuffix ? `:${logSuffix}` : ''));
+  const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
   const pxe = await PXE.create(
     aztecNode,
     options.store,

--- a/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
+++ b/yarn-project/pxe/src/job_coordinator/job_coordinator.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from '@aztec/foundation/crypto/random';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 
 /**
@@ -40,7 +40,7 @@ export interface StagedStore {
  * using a job queue with concurrency=1.
  */
 export class JobCoordinator {
-  private readonly log = createLogger('pxe:job_coordinator');
+  private readonly log: Logger;
 
   /** The underlying KV store */
   kvStore: AztecAsyncKVStore;
@@ -48,8 +48,9 @@ export class JobCoordinator {
   #currentJobId: string | undefined;
   #stores: Map<string, StagedStore> = new Map();
 
-  constructor(kvStore: AztecAsyncKVStore) {
+  constructor(kvStore: AztecAsyncKVStore, bindings?: LoggerBindings) {
     this.kvStore = kvStore;
+    this.log = createLogger('pxe:job_coordinator', bindings);
   }
 
   /**

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -1,5 +1,5 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { KeyStore } from '@aztec/key-store';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CompleteAddress } from '@aztec/stdlib/contract';
@@ -20,7 +20,7 @@ import {
 } from '../tagging/index.js';
 
 export class LogService {
-  private log = createLogger('log_service');
+  private log: Logger;
 
   constructor(
     private readonly aztecNode: AztecNode,
@@ -31,7 +31,10 @@ export class LogService {
     private readonly senderAddressBookStore: SenderAddressBookStore,
     private readonly addressStore: AddressStore,
     private readonly jobId: string,
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('pxe:log_service', bindings);
+  }
 
   public async bulkRetrieveLogs(logRetrievalRequests: LogRetrievalRequest[]): Promise<(LogRetrievalResponse | null)[]> {
     return await Promise.all(

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.ts
@@ -1,6 +1,6 @@
 import { vkAsFieldsMegaHonk } from '@aztec/foundation/crypto/keys';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { pushTestData } from '@aztec/foundation/testing';
 import { Timer } from '@aztec/foundation/timer';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
@@ -56,13 +56,16 @@ export interface PrivateKernelExecutionProverConfig {
  * inform state tree updates.
  */
 export class PrivateKernelExecutionProver {
-  private log = createLogger('pxe:private-kernel-execution-prover');
+  private log: Logger;
 
   constructor(
     private oracle: PrivateKernelOracle,
     private proofCreator: PrivateKernelProver,
     private fakeProofs = false,
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('pxe:private-kernel-execution-prover', bindings);
+  }
 
   /**
    * Generate a proof for a given transaction request and execution result.

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -1,7 +1,7 @@
 import type { PrivateEventFilter } from '@aztec/aztec.js/wallet';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { Timer } from '@aztec/foundation/timer';
 import { KeyStore } from '@aztec/key-store';
@@ -128,6 +128,10 @@ export class PXE {
     config: PXEConfig,
     loggerOrSuffix?: string | Logger,
   ) {
+    // Extract bindings from the logger, or use empty bindings if a string suffix is provided.
+    const bindings: LoggerBindings | undefined =
+      loggerOrSuffix && typeof loggerOrSuffix !== 'string' ? loggerOrSuffix.getBindings() : undefined;
+
     const log =
       !loggerOrSuffix || typeof loggerOrSuffix === 'string'
         ? createLogger(loggerOrSuffix ? `pxe:service:${loggerOrSuffix}` : `pxe:service`)
@@ -153,10 +157,10 @@ export class PXE {
       privateEventStore,
       tipsStore,
       config,
-      loggerOrSuffix,
+      bindings,
     );
 
-    const jobCoordinator = new JobCoordinator(store);
+    const jobCoordinator = new JobCoordinator(store, bindings);
     jobCoordinator.registerStores([
       capsuleStore,
       senderTaggingStore,
@@ -400,7 +404,12 @@ export class PXE {
     const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
     const anchorBlockHash = await anchorBlockHeader.hash();
     const kernelOracle = new PrivateKernelOracle(this.contractStore, this.keyStore, this.node, anchorBlockHash);
-    const kernelTraceProver = new PrivateKernelExecutionProver(kernelOracle, proofCreator, !this.proverEnabled);
+    const kernelTraceProver = new PrivateKernelExecutionProver(
+      kernelOracle,
+      proofCreator,
+      !this.proverEnabled,
+      this.log.getBindings(),
+    );
     this.log.debug(`Executing kernel trace prover (${JSON.stringify(config)})...`);
     return await kernelTraceProver.proveWithKernels(txExecutionRequest.toTxRequest(), privateExecutionResult, config);
   }

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -85,7 +85,7 @@ export class SequencerClient {
       publicClient,
       l1TxUtils.map(x => x.getSenderAddress()),
     );
-    const publisherManager = new PublisherManager(l1TxUtils, config);
+    const publisherManager = new PublisherManager(l1TxUtils, config, log.getBindings());
     const rollupContract = new RollupContract(publicClient, config.l1Contracts.rollupAddress.toString());
     const [l1GenesisTime, slotDuration, rollupVersion, rollupManaLimit] = await Promise.all([
       rollupContract.getL1GenesisTime(),

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -18,7 +18,6 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { TimeoutError } from '@aztec/foundation/error';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
-import { createLogger } from '@aztec/foundation/log';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
@@ -538,8 +537,8 @@ describe('CheckpointProposalJob', () => {
       metrics,
       eventEmitter,
       setStateFn,
-      createLogger('sequencer:checkpoint-proposal-job'),
       getTelemetryClient().getTracer('test'),
+      { actor: 'test' }, // bindings
     );
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -7,7 +7,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { filter } from '@aztec/foundation/iterator';
-import type { Logger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { sleep, sleepUntil } from '@aztec/foundation/sleep';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
 import { type TypedEventEmitter, unfreeze } from '@aztec/foundation/types';
@@ -59,6 +59,8 @@ const TXS_POLLING_MS = 500;
  * the Sequencer once the check for being the proposer for the slot has succeeded.
  */
 export class CheckpointProposalJob implements Traceable {
+  protected readonly log: Logger;
+
   constructor(
     private readonly epoch: EpochNumber,
     private readonly slot: SlotNumber,
@@ -86,9 +88,11 @@ export class CheckpointProposalJob implements Traceable {
     private readonly metrics: SequencerMetrics,
     private readonly eventEmitter: TypedEventEmitter<SequencerEvents>,
     private readonly setStateFn: (state: SequencerState, slot?: SlotNumber) => void,
-    protected readonly log: Logger,
     public readonly tracer: Tracer,
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('sequencer:checkpoint-proposal', { ...bindings, instanceId: `slot-${slot}` });
+  }
 
   /**
    * Executes the checkpoint proposal job.
@@ -190,6 +194,7 @@ export class CheckpointProposalJob implements Traceable {
         l1ToL2Messages,
         previousCheckpointOutHashes,
         fork,
+        this.log.getBindings(),
       );
 
       // Options for the validator client when creating block and checkpoint proposals

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -424,8 +424,8 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.metrics,
       this,
       this.setState.bind(this),
-      this.log,
       this.tracer,
+      this.log.getBindings(),
     );
   }
 

--- a/yarn-project/simulator/src/private/acvm/acvm.ts
+++ b/yarn-project/simulator/src/private/acvm/acvm.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, resolveLogger } from '@aztec/foundation/log';
 import {
   type ExecutionError,
   type ForeignCallInput,
@@ -37,6 +37,7 @@ export interface ACIRExecutionResult {
  * @param acir - The ACIR circuit bytecode to execute.
  * @param initialWitness - The initial witness map defining all of the inputs to `circuit`.
  * @param callback - A callback to process any foreign calls from the circuit.
+ * @param logger - Optional logger for ACVM execution logs.
  * @returns The solved witness calculated by executing the circuit on the provided inputs, as well as the return
  * witness indices as specified by the circuit.
  */
@@ -44,9 +45,9 @@ export async function acvm(
   acir: Buffer,
   initialWitness: ACVMWitness,
   callback: ACIRCallback,
+  loggerOrBindings?: Logger | LoggerBindings,
 ): Promise<ACIRExecutionResult> {
-  const logger = createLogger('simulator:acvm');
-
+  const logger = resolveLogger('simulator:acvm', loggerOrBindings);
   const solvedAndReturnWitness = await executeCircuitWithReturnWitness(
     acir,
     initialWitness,

--- a/yarn-project/simulator/src/private/acvm_native.ts
+++ b/yarn-project/simulator/src/private/acvm_native.ts
@@ -1,5 +1,5 @@
 import { runInDirectory } from '@aztec/foundation/fs';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, resolveLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import type { ForeignCallHandler, WitnessMap } from '@aztec/noir-acvm_js';
 import type { FunctionArtifactWithContractName } from '@aztec/stdlib/abi';
@@ -11,8 +11,6 @@ import { promises as fs } from 'fs';
 import type { ACIRCallback, ACIRExecutionResult } from './acvm/acvm.js';
 import type { ACVMWitness } from './acvm/acvm_types.js';
 import type { CircuitSimulator } from './circuit_simulator.js';
-
-const logger = createLogger('simulator:acvm-native');
 
 export enum ACVM_RESULT {
   SUCCESS,
@@ -64,7 +62,9 @@ export async function executeNativeCircuit(
   workingDirectory: string,
   pathToAcvm: string,
   outputFilename?: string,
+  loggerOrBindings?: Logger | LoggerBindings,
 ): Promise<ACVMResult> {
+  const logger = resolveLogger('simulator:acvm-native', loggerOrBindings);
   const bytecodeFilename = 'bytecode';
   const witnessFilename = 'input_witness.toml';
 
@@ -145,11 +145,16 @@ export async function executeNativeCircuit(
 }
 
 export class NativeACVMSimulator implements CircuitSimulator {
+  private logger: Logger;
+
   constructor(
     private workingDirectory: string,
     private pathToAcvm: string,
     private witnessFilename?: string,
-  ) {}
+    loggerOrBindings?: Logger | LoggerBindings,
+  ) {
+    this.logger = resolveLogger('simulator:acvm-native', loggerOrBindings);
+  }
 
   async executeProtocolCircuit(
     input: ACVMWitness,
@@ -172,6 +177,7 @@ export class NativeACVMSimulator implements CircuitSimulator {
         directory,
         this.pathToAcvm,
         this.witnessFilename,
+        this.logger,
       );
 
       if (result.status == ACVM_RESULT.FAILURE) {
@@ -181,7 +187,7 @@ export class NativeACVMSimulator implements CircuitSimulator {
       return result;
     };
 
-    return await runInDirectory(this.workingDirectory, operation, false, logger);
+    return await runInDirectory(this.workingDirectory, operation, false, this.logger);
   }
 
   executeUserCircuit(

--- a/yarn-project/simulator/src/private/acvm_wasm.ts
+++ b/yarn-project/simulator/src/private/acvm_wasm.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, resolveLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import initACVM, { type ExecutionError, type ForeignCallHandler, executeCircuit } from '@aztec/noir-acvm_js';
 import initAbi from '@aztec/noir-noirc_abi';
@@ -11,7 +11,11 @@ import type { ACVMSuccess } from './acvm_native.js';
 import { type CircuitSimulator, enrichNoirError } from './circuit_simulator.js';
 
 export class WASMSimulator implements CircuitSimulator {
-  constructor(protected log = createLogger('wasm-simulator')) {}
+  protected log: Logger;
+
+  constructor(loggerOrBindings?: Logger | LoggerBindings) {
+    this.log = resolveLogger('wasm-simulator', loggerOrBindings);
+  }
 
   async init(): Promise<void> {
     // If these are available, then we are in the
@@ -67,6 +71,6 @@ export class WASMSimulator implements CircuitSimulator {
     callback: ACIRCallback,
   ): Promise<ACIRExecutionResult> {
     await this.init();
-    return acvm(artifact.bytecode, input, callback);
+    return acvm(artifact.bytecode, input, callback, this.log.createChild('acvm'));
   }
 }

--- a/yarn-project/simulator/src/private/circuit_recording/circuit_recorder.ts
+++ b/yarn-project/simulator/src/private/circuit_recording/circuit_recorder.ts
@@ -1,5 +1,5 @@
 import { sha512 } from '@aztec/foundation/crypto/sha512';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, resolveLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import type { ForeignCallHandler, ForeignCallInput, ForeignCallOutput } from '@aztec/noir-acvm_js';
 
@@ -89,14 +89,16 @@ export class CircuitRecording {
  * ```
  */
 export class CircuitRecorder {
-  protected readonly logger = createLogger('simulator:acvm:recording');
+  protected readonly logger: Logger;
 
   protected recording?: CircuitRecording;
 
   private stackDepth: number = 0;
   private newCircuit: boolean = true;
 
-  protected constructor() {}
+  protected constructor(loggerOrBindings?: Logger | LoggerBindings) {
+    this.logger = resolveLogger('simulator:acvm:recording', loggerOrBindings);
+  }
 
   /**
    * Initializes a new circuit recording session.

--- a/yarn-project/simulator/src/private/circuit_recording/file_circuit_recorder.ts
+++ b/yarn-project/simulator/src/private/circuit_recording/file_circuit_recorder.ts
@@ -1,3 +1,5 @@
+import type { Logger } from '@aztec/foundation/log';
+
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -7,8 +9,11 @@ import { CircuitRecorder, type CircuitRecording } from './circuit_recorder.js';
 export class FileCircuitRecorder extends CircuitRecorder {
   declare recording?: CircuitRecording & { filePath: string; isFirstCall: boolean };
 
-  constructor(private readonly recordDir: string) {
-    super();
+  constructor(
+    private readonly recordDir: string,
+    logger?: Logger,
+  ) {
+    super(logger);
   }
 
   override async start(

--- a/yarn-project/simulator/src/private/circuit_recording/memory_circuit_recorder.ts
+++ b/yarn-project/simulator/src/private/circuit_recording/memory_circuit_recorder.ts
@@ -1,11 +1,13 @@
+import type { Logger } from '@aztec/foundation/log';
+
 import { CircuitRecorder } from './circuit_recorder.js';
 
-/*
+/**
  * In memory circuit recorder uses the default implementation. This is kept
- * while we decide the fate of the FileCircuitRecorder
+ * while we decide the fate of the FileCircuitRecorder.
  */
 export class MemoryCircuitRecorder extends CircuitRecorder {
-  constructor() {
-    super();
+  constructor(logger?: Logger) {
+    super(logger);
   }
 }

--- a/yarn-project/simulator/src/private/factory.ts
+++ b/yarn-project/simulator/src/private/factory.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, resolveLogger } from '@aztec/foundation/log';
 
 import { promises as fs } from 'fs';
 
@@ -21,18 +21,21 @@ export function getSimulatorConfigFromEnv() {
 
 export async function createSimulator(
   config: SimulatorConfig,
-  logger: Logger = createLogger('simulator'),
+  loggerOrBindings?: Logger | LoggerBindings,
 ): Promise<CircuitSimulator> {
+  const logger = resolveLogger('simulator', loggerOrBindings);
   if (config.acvmBinaryPath && config.acvmWorkingDirectory) {
     try {
       await fs.access(config.acvmBinaryPath, fs.constants.R_OK);
       await fs.mkdir(config.acvmWorkingDirectory, { recursive: true });
       logger.info(`Using native ACVM at ${config.acvmBinaryPath} and working directory ${config.acvmWorkingDirectory}`);
-      return new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath);
+      const acvmLogger = logger.createChild('acvm-native');
+      return new NativeACVMSimulator(config.acvmWorkingDirectory, config.acvmBinaryPath, undefined, acvmLogger);
     } catch {
       logger.warn(`Failed to access ACVM at ${config.acvmBinaryPath}, falling back to WASM`);
     }
   }
   logger.info('Using WASM ACVM simulation');
-  return new WASMSimulator();
+  const wasmLogger = logger.createChild('wasm');
+  return new WASMSimulator(wasmLogger);
 }

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -5,7 +5,7 @@ import {
   PUBLIC_DATA_SUBTREE_HEIGHT,
 } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { ContractClassPublishedEvent } from '@aztec/protocol-contracts/class-registry';
 import { ContractInstancePublishedEvent } from '@aztec/protocol-contracts/instance-registry';
@@ -46,9 +46,14 @@ import { L1ToL2MessageIndexOutOfRangeError, NoteHashIndexOutOfRangeError } from 
 export class PublicContractsDB implements PublicContractsDBInterface {
   private contractStateStack: ContractsDbCheckpoint[] = [new ContractsDbCheckpoint()];
 
-  private log = createLogger('simulator:contracts-data-source');
+  private log: Logger;
 
-  constructor(private dataSource: ContractDataSource) {}
+  constructor(
+    private dataSource: ContractDataSource,
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('simulator:contracts-data-source', bindings);
+  }
 
   public async addContracts(contractDeploymentData: ContractDeploymentData): Promise<void> {
     const currentState = this.getCurrentState();
@@ -208,9 +213,14 @@ export class PublicContractsDB implements PublicContractsDBInterface {
  * to decide whether to use hints or not (same with tracing, etc).
  */
 export class PublicTreesDB implements PublicStateDBInterface {
-  private logger = createLogger('simulator:public-trees-db');
+  private logger: Logger;
 
-  constructor(private readonly db: MerkleTreeWriteOperations) {}
+  constructor(
+    private readonly db: MerkleTreeWriteOperations,
+    bindings?: LoggerBindings,
+  ) {
+    this.logger = createLogger('simulator:public-trees-db', bindings);
+  }
 
   public async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {
     const timer = new Timer();

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -1,4 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
 import { AvmTestContractArtifact } from '@aztec/noir-test-contracts.js/AvmTest';
@@ -60,6 +61,7 @@ describe.each([
       simulator,
       new TestDateProvider(),
       getTelemetryClient(),
+      createLogger('simulator:public-processor'),
     );
 
     tester = new PublicTxSimulationTester(merkleTrees, contractDataSource);

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/timeout_race.test.ts
@@ -282,6 +282,7 @@ describe('PublicProcessor C++ Timeout Race Condition', () => {
         simulator,
         dateProvider,
         getTelemetryClient(),
+        createLogger('simulator:public-processor'),
       );
 
       // Get initial state for trees we need to check

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
@@ -63,6 +63,7 @@ describe.each([
       simulator,
       new TestDateProvider(),
       getTelemetryClient(),
+      createLogger('simulator:public-processor'),
     );
 
     tester = new PublicTxSimulationTester(merkleTrees, contractDataSource, globals);

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -1,6 +1,7 @@
 import { CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE, CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS } from '@aztec/constants';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
@@ -102,6 +103,7 @@ describe('public_processor', () => {
       publicTxSimulator,
       new TestDateProvider(),
       getTelemetryClient(),
+      createLogger('simulator:public-processor'),
     );
   });
 

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -1,7 +1,7 @@
 import { MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX, NULLIFIER_SUBTREE_HEIGHT } from '@aztec/constants';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider, Timer, elapsed, executeTimeout } from '@aztec/foundation/timer';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
@@ -62,11 +62,15 @@ import { PublicProcessorMetrics } from './public_processor_metrics.js';
  * Creates new instances of PublicProcessor given the provided merkle tree db and contract data source.
  */
 export class PublicProcessorFactory {
+  private log: Logger;
   constructor(
     private contractDataSource: ContractDataSource,
     private dateProvider: DateProvider = new DateProvider(),
     protected telemetryClient: TelemetryClient = getTelemetryClient(),
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('simulator:public-processor-factory', bindings);
+  }
 
   /**
    * Creates a new instance of a PublicProcessor.
@@ -79,7 +83,8 @@ export class PublicProcessorFactory {
     globalVariables: GlobalVariables,
     config: PublicSimulatorConfig,
   ): PublicProcessor {
-    const contractsDB = new PublicContractsDB(this.contractDataSource);
+    const bindings = this.log.getBindings();
+    const contractsDB = new PublicContractsDB(this.contractDataSource, bindings);
 
     const guardedFork = new GuardedMerkleTreeOperations(merkleTree);
     const publicTxSimulator = this.createPublicTxSimulator(guardedFork, contractsDB, globalVariables, config);
@@ -91,6 +96,7 @@ export class PublicProcessorFactory {
       publicTxSimulator,
       this.dateProvider,
       this.telemetryClient,
+      createLogger('simulator:public-processor', bindings),
     );
   }
 
@@ -100,7 +106,14 @@ export class PublicProcessorFactory {
     globalVariables: GlobalVariables,
     config?: Partial<PublicTxSimulatorConfig>,
   ): PublicTxSimulatorInterface {
-    return new TelemetryCppPublicTxSimulator(merkleTree, contractsDB, globalVariables, this.telemetryClient, config);
+    return new TelemetryCppPublicTxSimulator(
+      merkleTree,
+      contractsDB,
+      globalVariables,
+      this.telemetryClient,
+      config,
+      this.log.getBindings(),
+    );
   }
 }
 
@@ -125,7 +138,7 @@ export class PublicProcessor implements Traceable {
     protected publicTxSimulator: PublicTxSimulatorInterface,
     private dateProvider: DateProvider,
     telemetryClient: TelemetryClient = getTelemetryClient(),
-    private log = createLogger('simulator:public-processor'),
+    private log: Logger,
     private opts: Pick<SequencerConfig, 'fakeProcessingDelayPerTxMs' | 'fakeThrowAfterProcessingTxCount'> = {},
   ) {
     this.metrics = new PublicProcessorMetrics(telemetryClient, 'PublicProcessor');

--- a/yarn-project/simulator/src/public/public_tx_simulator/contract_provider_for_cpp.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/contract_provider_for_cpp.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { ContractProvider } from '@aztec/native';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import { deserializeFromMessagePack, serializeWithMessagePack } from '@aztec/stdlib/avm';
@@ -10,12 +10,15 @@ import type { GlobalVariables } from '@aztec/stdlib/tx';
 import type { PublicContractsDB } from '../public_db_sources.js';
 
 export class ContractProviderForCpp implements ContractProvider {
-  private log: Logger = createLogger('simulator:contract_provider_for_cpp');
+  private log: Logger;
 
   constructor(
     private contractsDB: PublicContractsDB,
     private globalVariables: GlobalVariables,
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('simulator:contract_provider_for_cpp', bindings);
+  }
 
   public getContractInstance = async (address: string): Promise<Buffer | undefined> => {
     this.log.trace(`Contract provider callback: getContractInstance(${address})`);

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger, logLevel } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger, logLevel } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { type CancellationToken, avmSimulate, cancelSimulation, createCancellationToken } from '@aztec/native';
 import { ProtocolContractsList } from '@aztec/protocol-contracts';
@@ -44,9 +44,10 @@ export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxS
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
-    this.log = createLogger(`simulator:cpp_public_tx_simulator`);
+    super(merkleTree, contractsDB, globalVariables, config, undefined, bindings);
+    this.log = createLogger(`simulator:cpp_public_tx_simulator`, bindings);
   }
 
   /**
@@ -84,7 +85,7 @@ export class CppPublicTxSimulator extends PublicTxSimulator implements PublicTxS
     );
 
     // Create contract provider for callbacks to TypeScript PublicContractsDB from C++
-    const contractProvider = new ContractProviderForCpp(this.contractsDB, this.globalVariables);
+    const contractProvider = new ContractProviderForCpp(this.contractsDB, this.globalVariables, this.bindings);
 
     // Serialize to msgpack and call the C++ simulator
     this.log.trace(`Serializing fast simulation inputs to msgpack...`);
@@ -171,8 +172,9 @@ export class MeasuredCppPublicTxSimulator extends CppPublicTxSimulator implement
     globalVariables: GlobalVariables,
     protected readonly metrics: ExecutorMetricsInterface,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
+    super(merkleTree, contractsDB, globalVariables, config, bindings);
   }
 
   public override async simulate(tx: Tx, txLabel: string = 'unlabeledTx'): Promise<PublicTxResult> {
@@ -200,9 +202,10 @@ export class TelemetryCppPublicTxSimulator extends MeasuredCppPublicTxSimulator 
     globalVariables: GlobalVariables,
     telemetryClient: TelemetryClient = getTelemetryClient(),
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
     const metrics = new ExecutorMetrics(telemetryClient, 'CppPublicTxSimulator');
-    super(merkleTree, contractsDB, globalVariables, metrics, config);
+    super(merkleTree, contractsDB, globalVariables, metrics, config, bindings);
     this.tracer = metrics.tracer;
   }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator_with_hinted_dbs.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_public_tx_simulator_with_hinted_dbs.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger, logLevel } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger, logLevel } from '@aztec/foundation/log';
 import { avmSimulateWithHintedDbs } from '@aztec/native';
 import {
   AvmCircuitInputs,
@@ -34,9 +34,10 @@ export class CppPublicTxSimulatorHintedDbs extends PublicTxSimulator implements 
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
-    this.log = createLogger(`simulator:cpp_public_tx_simulator_hinted_dbs`);
+    super(merkleTree, contractsDB, globalVariables, config, undefined, bindings);
+    this.log = createLogger(`simulator:cpp_public_tx_simulator_hinted_dbs`, bindings);
   }
 
   /**
@@ -115,8 +116,9 @@ export class MeasuredCppPublicTxSimulatorHintedDbs
     globalVariables: GlobalVariables,
     protected readonly metrics: ExecutorMetricsInterface,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
+    super(merkleTree, contractsDB, globalVariables, config, bindings);
   }
 
   public override async simulate(tx: Tx, txLabel: string = 'unlabeledTx'): Promise<PublicTxResult> {

--- a/yarn-project/simulator/src/public/public_tx_simulator/cpp_vs_ts_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/cpp_vs_ts_public_tx_simulator.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger, logLevel } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger, logLevel } from '@aztec/foundation/log';
 import { avmSimulate } from '@aztec/native';
 import { ProtocolContractsList } from '@aztec/protocol-contracts';
 import {
@@ -37,9 +37,10 @@ export class CppVsTsPublicTxSimulator extends PublicTxSimulator implements Publi
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
-    this.log = createLogger(`simulator:cpp_vs_public_tx_simulator`);
+    super(merkleTree, contractsDB, globalVariables, config, undefined, bindings);
+    this.log = createLogger(`simulator:cpp_vs_public_tx_simulator`, bindings);
   }
 
   /**
@@ -103,7 +104,7 @@ export class CppVsTsPublicTxSimulator extends PublicTxSimulator implements Publi
     );
 
     // Create contract provider for callbacks to TypeScript PublicContractsDB from C++
-    const contractProvider = new ContractProviderForCpp(this.contractsDB, this.globalVariables);
+    const contractProvider = new ContractProviderForCpp(this.contractsDB, this.globalVariables, this.bindings);
 
     // Serialize to msgpack and call the C++ simulator
     this.log.debug(`Serializing fast simulation inputs to msgpack...`);
@@ -220,8 +221,9 @@ export class MeasuredCppVsTsPublicTxSimulator
     globalVariables: GlobalVariables,
     protected readonly metrics: ExecutorMetricsInterface,
     config?: Partial<PublicSimulatorConfig>,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
+    super(merkleTree, contractsDB, globalVariables, config, bindings);
   }
 
   public override async simulate(tx: Tx, txLabel: string = 'unlabeledTx'): Promise<PublicTxResult> {

--- a/yarn-project/simulator/src/public/public_tx_simulator/dumping_cpp_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/dumping_cpp_public_tx_simulator.ts
@@ -1,3 +1,4 @@
+import type { LoggerBindings } from '@aztec/foundation/log';
 import {
   AvmCircuitInputs,
   AvmCircuitPublicInputs,
@@ -29,8 +30,9 @@ export class DumpingCppPublicTxSimulator extends CppPublicTxSimulator {
     globalVariables: GlobalVariables,
     config: Partial<PublicSimulatorConfig>,
     outputDir: string,
+    bindings?: LoggerBindings,
   ) {
-    super(merkleTree, contractsDB, globalVariables, config);
+    super(merkleTree, contractsDB, globalVariables, config, bindings);
     assert(config.collectHints === true, 'collectHints must be enabled to dump AVM circuit inputs');
     assert(config.collectPublicInputs === true, 'collectPublicInputs must be enabled to dump AVM circuit inputs');
     this.outputDir = outputDir;

--- a/yarn-project/simulator/src/public/public_tx_simulator/factories.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/factories.ts
@@ -1,3 +1,4 @@
+import type { LoggerBindings } from '@aztec/foundation/log';
 import { PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import type { GlobalVariables } from '@aztec/stdlib/tx';
@@ -17,6 +18,7 @@ export function createPublicTxSimulatorForBlockBuilding(
   contractsDB: PublicContractsDB,
   globalVariables: GlobalVariables,
   telemetryClient: TelemetryClient,
+  bindings?: LoggerBindings,
 ) {
   const config = PublicSimulatorConfig.from({
     skipFeeEnforcement: false,
@@ -35,7 +37,7 @@ export function createPublicTxSimulatorForBlockBuilding(
       collectHints: true,
       collectPublicInputs: true,
     };
-    return new DumpingCppPublicTxSimulator(merkleTree, contractsDB, globalVariables, dumpingConfig, dumpDir);
+    return new DumpingCppPublicTxSimulator(merkleTree, contractsDB, globalVariables, dumpingConfig, dumpDir, bindings);
   }
-  return new TelemetryCppPublicTxSimulator(merkleTree, contractsDB, globalVariables, telemetryClient, config);
+  return new TelemetryCppPublicTxSimulator(merkleTree, contractsDB, globalVariables, telemetryClient, config, bindings);
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
@@ -7,7 +7,7 @@ import {
 } from '@aztec/constants';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import {
   AvmAccumulatedData,
   AvmAccumulatedDataArrayLengths,
@@ -87,8 +87,9 @@ export class PublicTxContext {
     public readonly revertibleAccumulatedDataFromPrivate: PrivateToPublicAccumulatedData,
     public readonly feePayer: AztecAddress,
     private readonly trace: SideEffectTrace,
+    bindings?: LoggerBindings,
   ) {
-    this.log = createLogger(`simulator:public_tx_context`);
+    this.log = createLogger(`simulator:public_tx_context`, bindings);
   }
 
   public static async create(
@@ -98,13 +99,14 @@ export class PublicTxContext {
     globalVariables: GlobalVariables,
     protocolContracts: ProtocolContracts,
     proverId: Fr,
+    bindings?: LoggerBindings,
   ) {
     const contractDeploymentData = AllContractDeploymentData.fromTx(tx);
     const nonRevertibleContractDeploymentData = contractDeploymentData.getNonRevertibleContractDeploymentData();
     const revertibleContractDeploymentData = contractDeploymentData.getRevertibleContractDeploymentData();
     const nonRevertibleAccumulatedDataFromPrivate = tx.data.forPublic!.nonRevertibleAccumulatedData;
 
-    const trace = new SideEffectTrace();
+    const trace = new SideEffectTrace(0, bindings);
 
     const firstNullifier = nonRevertibleAccumulatedDataFromPrivate.nullifiers[0];
 
@@ -115,6 +117,7 @@ export class PublicTxContext {
       trace,
       firstNullifier,
       globalVariables.timestamp,
+      bindings,
     );
 
     const gasSettings = tx.data.constants.txContext.gasSettings;
@@ -124,7 +127,7 @@ export class PublicTxContext {
 
     return new PublicTxContext(
       tx.getTxHash(),
-      new PhaseStateManager(txStateManager),
+      new PhaseStateManager(txStateManager, bindings),
       await txStateManager.getTreeSnapshots(),
       globalVariables,
       protocolContracts,
@@ -142,6 +145,7 @@ export class PublicTxContext {
       tx.data.forPublic!.revertibleAccumulatedData,
       tx.data.feePayer,
       trace,
+      bindings,
     );
   }
 
@@ -441,8 +445,11 @@ class PhaseStateManager {
 
   private currentlyActiveStateManager: PublicPersistableStateManager | undefined;
 
-  constructor(private readonly txStateManager: PublicPersistableStateManager) {
-    this.log = createLogger(`simulator:public_phase_state_manager`);
+  constructor(
+    private readonly txStateManager: PublicPersistableStateManager,
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger(`simulator:public_phase_state_manager`, bindings);
   }
 
   async fork() {

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -1,6 +1,6 @@
 import { AVM_MAX_PROCESSABLE_L2_GAS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress, ProtocolContractsList } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
 import { AvmExecutionHints, AvmTxHint, PublicSimulatorConfig, PublicTxEffect, PublicTxResult } from '@aztec/stdlib/avm';
@@ -81,6 +81,7 @@ type ProcessedPhase = {
 export class PublicTxSimulator implements PublicTxSimulatorInterface {
   protected log: Logger;
   protected readonly config: PublicSimulatorConfig;
+  protected readonly bindings?: LoggerBindings;
 
   constructor(
     protected merkleTree: MerkleTreeWriteOperations,
@@ -88,9 +89,11 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
     protected globalVariables: GlobalVariables,
     config?: Partial<PublicSimulatorConfig>,
     protected protocolContracts: ProtocolContracts = ProtocolContractsList,
+    bindings?: LoggerBindings,
   ) {
     this.config = PublicSimulatorConfig.from(config ?? {});
-    this.log = createLogger(`simulator:public_tx_simulator`);
+    this.bindings = bindings;
+    this.log = createLogger(`simulator:public_tx_simulator`, bindings);
   }
 
   /**
@@ -119,6 +122,7 @@ export class PublicTxSimulator implements PublicTxSimulatorInterface {
       this.globalVariables,
       this.protocolContracts,
       this.config.proverId,
+      this.bindings,
     );
 
     // This will throw if there is a nullifier collision.

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -198,6 +198,7 @@ describe('Public Side Effect Trace', () => {
     it('PreviousValidationRequestArrayLengths and PreviousAccumulatedDataArrayLengths contribute to limits', async () => {
       trace = new SideEffectTrace(
         0,
+        undefined,
         new SideEffectArrayLengths(
           MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
           PROTOCOL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -9,7 +9,7 @@ import {
 } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { type LogLevel, createLogger } from '@aztec/foundation/log';
+import { type LogLevel, type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { PublicDataUpdateRequest } from '@aztec/stdlib/avm';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
@@ -61,7 +61,7 @@ export class SideEffectArrayLengths {
  * Trace side effects for an enqueued public call's execution.
  */
 export class SideEffectTrace implements PublicSideEffectTraceInterface {
-  public log = createLogger('simulator:side_effect_trace');
+  public log: Logger;
 
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number;
@@ -79,6 +79,7 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
   constructor(
     /** The counter of this trace's first side effect. */
     public readonly startSideEffectCounter: number = 0,
+    bindings?: LoggerBindings,
     /** Track parent's (or previous kernel's) lengths so the AVM can properly enforce TX-wide limits,
      *  otherwise the public kernel can fail to prove because TX limits are breached.
      */
@@ -90,11 +91,13 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
     private debugLogMemoryReads: number = 0,
   ) {
     this.sideEffectCounter = startSideEffectCounter;
+    this.log = createLogger('simulator:side_effect_trace', bindings);
   }
 
   public fork() {
     return new SideEffectTrace(
       this.sideEffectCounter,
+      this.log.getBindings(),
       new SideEffectArrayLengths(
         this.previousSideEffectArrayLengths.publicDataWrites + this.userPublicDataWritesLength,
         this.previousSideEffectArrayLengths.protocolPublicDataWrites + this.protocolPublicDataWritesLength,

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -2,7 +2,7 @@ import { CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, MAX_PROTOCOL_CONTRACTS } f
 import { poseidon2Hash } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { type LogLevel, createLogger } from '@aztec/foundation/log';
+import { type LogLevel, type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -42,7 +42,7 @@ import { PublicStorage } from './public_storage.js';
  * Manages merging of successful/reverted child state into current state.
  */
 export class PublicPersistableStateManager {
-  private readonly log = createLogger('simulator:state_manager');
+  private readonly log: Logger;
 
   /** Make sure a forked state is never merged twice. */
   private alreadyMergedIntoParent = false;
@@ -56,7 +56,10 @@ export class PublicPersistableStateManager {
     private readonly doMerkleOperations: boolean = true,
     private readonly publicStorage: PublicStorage = new PublicStorage(treesDB),
     private readonly nullifiers: NullifierManager = new NullifierManager(treesDB),
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('simulator:state_manager', bindings);
+  }
 
   /**
    * Create a new state manager
@@ -67,8 +70,19 @@ export class PublicPersistableStateManager {
     trace: PublicSideEffectTraceInterface,
     firstNullifier: Fr,
     timestamp: UInt64,
+    bindings?: LoggerBindings,
   ): PublicPersistableStateManager {
-    return new PublicPersistableStateManager(treesDB, contractsDB, trace, firstNullifier, timestamp);
+    return new PublicPersistableStateManager(
+      treesDB,
+      contractsDB,
+      trace,
+      firstNullifier,
+      timestamp,
+      undefined,
+      undefined,
+      undefined,
+      bindings,
+    );
   }
 
   /**
@@ -85,6 +99,7 @@ export class PublicPersistableStateManager {
       this.doMerkleOperations,
       this.publicStorage.fork(),
       this.nullifiers.fork(),
+      this.log.getBindings(),
     );
   }
 

--- a/yarn-project/simulator/src/public/test_executor_metrics.ts
+++ b/yarn-project/simulator/src/public/test_executor_metrics.ts
@@ -1,5 +1,5 @@
 import { sum } from '@aztec/foundation/collection';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import type { RevertCode } from '@aztec/stdlib/avm';
 import type { GasUsed } from '@aztec/stdlib/gas';
@@ -88,8 +88,8 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
   private currentTxLabel: string | undefined;
   private txTimer: Timer | undefined;
 
-  constructor() {
-    this.logger = createLogger(`simulator:test_executor_metrics`);
+  constructor(bindings?: LoggerBindings) {
+    this.logger = createLogger(`simulator:test_executor_metrics`, bindings);
   }
 
   startRecordingTxSimulation(txLabel: string) {

--- a/yarn-project/slasher/src/factory/create_facade.ts
+++ b/yarn-project/slasher/src/factory/create_facade.ts
@@ -31,7 +31,7 @@ export async function createSlasherFacade(
     throw new Error('Cannot initialize SlasherClient without a Rollup address');
   }
 
-  const kvStore = await createStore('slasher', SCHEMA_VERSION, config, createLogger('slasher:lmdb'));
+  const kvStore = await createStore('slasher', SCHEMA_VERSION, config, logger.getBindings());
   const rollup = new RollupContract(l1Client, l1Contracts.rollupAddress);
 
   const slashValidatorsNever = config.slashSelfAllowed

--- a/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/watchers/epoch_prune_watcher.ts
@@ -176,6 +176,7 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
       l1ToL2Messages,
       previousCheckpointOutHashes,
       fork,
+      this.log.getBindings(),
     );
 
     const { block, failedTxs, numTxs } = await checkpointBuilder.buildBlock(txs, gv.blockNumber, gv.timestamp, {});

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -1,5 +1,6 @@
 import type { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
+import type { LoggerBindings } from '@aztec/foundation/log';
 
 import type { L2Block } from '../block/l2_block.js';
 import type { ChainConfig, SequencerConfig } from '../config/chain-config.js';
@@ -92,5 +93,6 @@ export interface ICheckpointsBuilder {
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     fork: MerkleTreeWriteOperations,
+    bindings?: LoggerBindings,
   ): Promise<ICheckpointBlockBuilder>;
 }

--- a/yarn-project/telemetry-client/src/prom_otel_adapter.ts
+++ b/yarn-project/telemetry-client/src/prom_otel_adapter.ts
@@ -1,4 +1,4 @@
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 
 import { Registry } from 'prom-client';
@@ -410,12 +410,11 @@ function parseLabelsSafely<Labels extends LabelsGeneric>(labelStr: string, logge
  */
 export class OtelMetricsAdapter extends Registry implements MetricsRegister {
   private readonly meter: Meter;
+  private logger: Logger;
 
-  constructor(
-    telemetryClient: TelemetryClient,
-    private logger: Logger = createLogger('telemetry:otel-metrics-adapter'),
-  ) {
+  constructor(telemetryClient: TelemetryClient, bindings?: LoggerBindings) {
     super();
+    this.logger = createLogger('telemetry:otel-metrics-adapter', bindings);
     this.meter = telemetryClient.getMeter('metrics-adapter');
   }
 

--- a/yarn-project/telemetry-client/src/start.ts
+++ b/yarn-project/telemetry-client/src/start.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type LoggerBindings, createLogger } from '@aztec/foundation/log';
 
 import type { TelemetryClientConfig } from './config.js';
 import { NoopTelemetryClient } from './noop.js';
@@ -9,8 +9,11 @@ export * from './config.js';
 let initialized = false;
 let telemetry: TelemetryClient = new NoopTelemetryClient();
 
-export async function initTelemetryClient(config: TelemetryClientConfig): Promise<TelemetryClient> {
-  const log = createLogger('telemetry:client');
+export async function initTelemetryClient(
+  config: TelemetryClientConfig,
+  bindings?: LoggerBindings,
+): Promise<TelemetryClient> {
+  const log = createLogger('telemetry:client', bindings);
   if (initialized) {
     log.warn('Telemetry client has already been initialized once');
     return telemetry;

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -415,7 +415,11 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const forkedWorldTrees = await this.stateMachine.synchronizer.nativeWorldStateService.fork();
 
-    const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(blockNumber, this.contractStore));
+    const bindings = this.logger.getBindings();
+    const contractsDB = new PublicContractsDB(
+      new TXEPublicContractDataSource(blockNumber, this.contractStore),
+      bindings,
+    );
     const guardedMerkleTrees = new GuardedMerkleTreeOperations(forkedWorldTrees);
     const config = PublicSimulatorConfig.from({
       skipFeeEnforcement: true,
@@ -428,8 +432,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       globals,
       guardedMerkleTrees,
       contractsDB,
-      new CppPublicTxSimulator(guardedMerkleTrees, contractsDB, globals, config),
+      new CppPublicTxSimulator(guardedMerkleTrees, contractsDB, globals, config, bindings),
       new TestDateProvider(),
+      undefined,
+      createLogger('simulator:public-processor', bindings),
     );
 
     const tx = await Tx.create({
@@ -526,7 +532,11 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const forkedWorldTrees = await this.stateMachine.synchronizer.nativeWorldStateService.fork();
 
-    const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(blockNumber, this.contractStore));
+    const bindings2 = this.logger.getBindings();
+    const contractsDB = new PublicContractsDB(
+      new TXEPublicContractDataSource(blockNumber, this.contractStore),
+      bindings2,
+    );
     const guardedMerkleTrees = new GuardedMerkleTreeOperations(forkedWorldTrees);
     const config = PublicSimulatorConfig.from({
       skipFeeEnforcement: true,
@@ -535,8 +545,16 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       collectStatistics: false,
       collectCallMetadata: true,
     });
-    const simulator = new CppPublicTxSimulator(guardedMerkleTrees, contractsDB, globals, config);
-    const processor = new PublicProcessor(globals, guardedMerkleTrees, contractsDB, simulator, new TestDateProvider());
+    const simulator = new CppPublicTxSimulator(guardedMerkleTrees, contractsDB, globals, config, bindings2);
+    const processor = new PublicProcessor(
+      globals,
+      guardedMerkleTrees,
+      contractsDB,
+      simulator,
+      new TestDateProvider(),
+      undefined,
+      createLogger('simulator:public-processor', bindings2),
+    );
 
     // We're simulating a scenario in which private execution immediately enqueues a public call and halts. The private
     // kernel init would in this case inject a nullifier with the transaction request hash as a non-revertible

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -495,6 +495,7 @@ export class BlockProposalHandler {
       previousCheckpointOutHashes,
       fork,
       priorBlocks,
+      this.log.getBindings(),
     );
 
     // Build the new block

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -1,7 +1,7 @@
 import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { merge, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { bufferToHex } from '@aztec/foundation/string';
 import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
 import { getDefaultAllowedSetupFunctions } from '@aztec/p2p/msg_validators';
@@ -36,8 +36,6 @@ import { createValidatorForBlockBuilding } from './tx_validator/tx_validator_fac
 // Re-export for backward compatibility
 export type { BuildBlockInCheckpointResult } from '@aztec/stdlib/interfaces/server';
 
-const log = createLogger('checkpoint-builder');
-
 /** Result of building a block within a checkpoint. Extends the base interface with timer. */
 export interface BuildBlockInCheckpointResultWithTimer extends BuildBlockInCheckpointResult {
   blockBuildingTimer: Timer;
@@ -48,6 +46,8 @@ export interface BuildBlockInCheckpointResultWithTimer extends BuildBlockInCheck
  * and completing it.
  */
 export class CheckpointBuilder implements ICheckpointBlockBuilder {
+  private log: Logger;
+
   constructor(
     private checkpointBuilder: LightweightCheckpointBuilder,
     private fork: MerkleTreeWriteOperations,
@@ -55,7 +55,13 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     private contractDataSource: ContractDataSource,
     private dateProvider: DateProvider,
     private telemetryClient: TelemetryClient,
-  ) {}
+    bindings?: LoggerBindings,
+  ) {
+    this.log = createLogger('checkpoint-builder', {
+      ...bindings,
+      instanceId: `checkpoint-${checkpointBuilder.checkpointNumber}`,
+    });
+  }
 
   getConstantData(): CheckpointGlobalVariables {
     return this.checkpointBuilder.constants;
@@ -73,7 +79,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     const blockBuildingTimer = new Timer();
     const slot = this.checkpointBuilder.constants.slotNumber;
 
-    log.verbose(`Building block ${blockNumber} for slot ${slot} within checkpoint`, {
+    this.log.verbose(`Building block ${blockNumber} for slot ${slot} within checkpoint`, {
       slot,
       blockNumber,
       ...opts,
@@ -115,7 +121,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       usedTxs,
       usedTxBlobFields,
     };
-    log.debug('Built block within checkpoint', res.block.header);
+    this.log.debug('Built block within checkpoint', res.block.header);
     return res;
   }
 
@@ -123,7 +129,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
   async completeCheckpoint(): Promise<Checkpoint> {
     const checkpoint = await this.checkpointBuilder.completeCheckpoint();
 
-    log.verbose(`Completed checkpoint ${checkpoint.number}`, {
+    this.log.verbose(`Completed checkpoint ${checkpoint.number}`, {
       checkpointNumber: checkpoint.number,
       numBlocks: checkpoint.blocks.length,
       archiveRoot: checkpoint.archive.root.toString(),
@@ -139,14 +145,16 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
 
   protected async makeBlockBuilderDeps(globalVariables: GlobalVariables, fork: MerkleTreeWriteOperations) {
     const txPublicSetupAllowList = this.config.txPublicSetupAllowList ?? (await getDefaultAllowedSetupFunctions());
-    const contractsDB = new PublicContractsDB(this.contractDataSource);
+    const contractsDB = new PublicContractsDB(this.contractDataSource, this.log.getBindings());
     const guardedFork = new GuardedMerkleTreeOperations(fork);
 
+    const bindings = this.log.getBindings();
     const publicTxSimulator = createPublicTxSimulatorForBlockBuilding(
       guardedFork,
       contractsDB,
       globalVariables,
       this.telemetryClient,
+      bindings,
     );
 
     const processor = new PublicProcessor(
@@ -156,7 +164,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       publicTxSimulator,
       this.dateProvider,
       this.telemetryClient,
-      undefined,
+      createLogger('simulator:public-processor', bindings),
       this.config,
     );
 
@@ -165,6 +173,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       this.contractDataSource,
       globalVariables,
       txPublicSetupAllowList,
+      this.log.getBindings(),
     );
 
     return {
@@ -176,13 +185,17 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
 
 /** Factory for creating checkpoint builders. */
 export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
+  private log: Logger;
+
   constructor(
     private config: FullNodeBlockBuilderConfig & Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration'>,
     private worldState: WorldStateSynchronizer,
     private contractDataSource: ContractDataSource,
     private dateProvider: DateProvider,
     private telemetryClient: TelemetryClient = getTelemetryClient(),
-  ) {}
+  ) {
+    this.log = createLogger('checkpoint-builder');
+  }
 
   public getConfig(): FullNodeBlockBuilderConfig {
     return this.config;
@@ -201,11 +214,12 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
     l1ToL2Messages: Fr[],
     previousCheckpointOutHashes: Fr[],
     fork: MerkleTreeWriteOperations,
+    bindings?: LoggerBindings,
   ): Promise<CheckpointBuilder> {
     const stateReference = await fork.getStateReference();
     const archiveTree = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
 
-    log.verbose(`Building new checkpoint ${checkpointNumber}`, {
+    this.log.verbose(`Building new checkpoint ${checkpointNumber}`, {
       checkpointNumber,
       msgCount: l1ToL2Messages.length,
       initialStateReference: stateReference.toInspect(),
@@ -219,6 +233,7 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
       l1ToL2Messages,
       previousCheckpointOutHashes,
       fork,
+      bindings,
     );
 
     return new CheckpointBuilder(
@@ -228,6 +243,7 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
       this.contractDataSource,
       this.dateProvider,
       this.telemetryClient,
+      bindings,
     );
   }
 
@@ -241,15 +257,23 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
     previousCheckpointOutHashes: Fr[],
     fork: MerkleTreeWriteOperations,
     existingBlocks: L2Block[] = [],
+    bindings?: LoggerBindings,
   ): Promise<CheckpointBuilder> {
     const stateReference = await fork.getStateReference();
     const archiveTree = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
 
     if (existingBlocks.length === 0) {
-      return this.startCheckpoint(checkpointNumber, constants, l1ToL2Messages, previousCheckpointOutHashes, fork);
+      return this.startCheckpoint(
+        checkpointNumber,
+        constants,
+        l1ToL2Messages,
+        previousCheckpointOutHashes,
+        fork,
+        bindings,
+      );
     }
 
-    log.verbose(`Resuming checkpoint ${checkpointNumber} with ${existingBlocks.length} existing blocks`, {
+    this.log.verbose(`Resuming checkpoint ${checkpointNumber} with ${existingBlocks.length} existing blocks`, {
       checkpointNumber,
       msgCount: l1ToL2Messages.length,
       existingBlockCount: existingBlocks.length,
@@ -265,6 +289,7 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
       previousCheckpointOutHashes,
       fork,
       existingBlocks,
+      bindings,
     );
 
     return new CheckpointBuilder(
@@ -274,6 +299,7 @@ export class FullNodeCheckpointsBuilder implements ICheckpointsBuilder {
       this.contractDataSource,
       this.dateProvider,
       this.telemetryClient,
+      bindings,
     );
   }
 

--- a/yarn-project/validator-client/src/tx_validator/tx_validator_factory.ts
+++ b/yarn-project/validator-client/src/tx_validator/tx_validator_factory.ts
@@ -1,5 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
+import type { LoggerBindings } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import {
   AggregateTxValidator,
@@ -53,32 +54,41 @@ export function createValidatorForAcceptingTxs(
     blockNumber: BlockNumber;
     txsPermitted: boolean;
   },
+  bindings?: LoggerBindings,
 ): TxValidator<Tx> {
   const validators: TxValidator<Tx>[] = [
-    new TxPermittedValidator(txsPermitted),
-    new SizeTxValidator(),
-    new DataTxValidator(),
-    new MetadataTxValidator({
-      l1ChainId: new Fr(l1ChainId),
-      rollupVersion: new Fr(rollupVersion),
-      protocolContractsHash,
-      vkTreeRoot: getVKTreeRoot(),
-    }),
-    new TimestampTxValidator({
-      timestamp,
-      blockNumber,
-    }),
-    new DoubleSpendTxValidator(new NullifierCache(db)),
-    new PhasesTxValidator(contractDataSource, setupAllowList, timestamp),
-    new BlockHeaderTxValidator(new ArchiveCache(db)),
+    new TxPermittedValidator(txsPermitted, bindings),
+    new SizeTxValidator(bindings),
+    new DataTxValidator(bindings),
+    new MetadataTxValidator(
+      {
+        l1ChainId: new Fr(l1ChainId),
+        rollupVersion: new Fr(rollupVersion),
+        protocolContractsHash,
+        vkTreeRoot: getVKTreeRoot(),
+      },
+      bindings,
+    ),
+    new TimestampTxValidator(
+      {
+        timestamp,
+        blockNumber,
+      },
+      bindings,
+    ),
+    new DoubleSpendTxValidator(new NullifierCache(db), bindings),
+    new PhasesTxValidator(contractDataSource, setupAllowList, timestamp, bindings),
+    new BlockHeaderTxValidator(new ArchiveCache(db), bindings),
   ];
 
   if (!skipFeeEnforcement) {
-    validators.push(new GasTxValidator(new DatabasePublicStateSource(db), ProtocolContractAddress.FeeJuice, gasFees));
+    validators.push(
+      new GasTxValidator(new DatabasePublicStateSource(db), ProtocolContractAddress.FeeJuice, gasFees, bindings),
+    );
   }
 
   if (verifier) {
-    validators.push(new TxProofValidator(verifier));
+    validators.push(new TxProofValidator(verifier, bindings));
   }
 
   return new AggregateTxValidator(...validators);
@@ -89,6 +99,7 @@ export function createValidatorForBlockBuilding(
   contractDataSource: ContractDataSource,
   globalVariables: GlobalVariables,
   setupAllowList: AllowedElement[],
+  bindings?: LoggerBindings,
 ): PublicProcessorValidator {
   const nullifierCache = new NullifierCache(db);
   const archiveCache = new ArchiveCache(db);
@@ -102,6 +113,7 @@ export function createValidatorForBlockBuilding(
       contractDataSource,
       globalVariables,
       setupAllowList,
+      bindings,
     ),
     nullifierCache,
   };
@@ -114,22 +126,29 @@ function preprocessValidator(
   contractDataSource: ContractDataSource,
   globalVariables: GlobalVariables,
   setupAllowList: AllowedElement[],
+  bindings?: LoggerBindings,
 ): TxValidator<Tx> {
   // We don't include the TxProofValidator nor the DataTxValidator here because they are already checked by the time we get to block building.
   return new AggregateTxValidator(
-    new MetadataTxValidator({
-      l1ChainId: globalVariables.chainId,
-      rollupVersion: globalVariables.version,
-      protocolContractsHash,
-      vkTreeRoot: getVKTreeRoot(),
-    }),
-    new TimestampTxValidator({
-      timestamp: globalVariables.timestamp,
-      blockNumber: globalVariables.blockNumber,
-    }),
-    new DoubleSpendTxValidator(nullifierCache),
-    new PhasesTxValidator(contractDataSource, setupAllowList, globalVariables.timestamp),
-    new GasTxValidator(publicStateSource, ProtocolContractAddress.FeeJuice, globalVariables.gasFees),
-    new BlockHeaderTxValidator(archiveCache),
+    new MetadataTxValidator(
+      {
+        l1ChainId: globalVariables.chainId,
+        rollupVersion: globalVariables.version,
+        protocolContractsHash,
+        vkTreeRoot: getVKTreeRoot(),
+      },
+      bindings,
+    ),
+    new TimestampTxValidator(
+      {
+        timestamp: globalVariables.timestamp,
+        blockNumber: globalVariables.blockNumber,
+      },
+      bindings,
+    ),
+    new DoubleSpendTxValidator(nullifierCache, bindings),
+    new PhasesTxValidator(contractDataSource, setupAllowList, globalVariables.timestamp, bindings),
+    new GasTxValidator(publicStateSource, ProtocolContractAddress.FeeJuice, globalVariables.gasFees, bindings),
+    new BlockHeaderTxValidator(archiveCache, bindings),
   );
 }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -601,6 +601,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
         previousCheckpointOutHashes,
         fork,
         blocks,
+        this.log.getBindings(),
       );
 
       // Complete the checkpoint to get computed values

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -4,7 +4,7 @@ import { fromEntries, padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { tryRmDir } from '@aztec/foundation/fs';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import type { L2Block } from '@aztec/stdlib/block';
 import { DatabaseVersionManager } from '@aztec/stdlib/database-version';
 import type {
@@ -52,7 +52,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
   protected constructor(
     protected instance: NativeWorldState,
     protected readonly worldStateInstrumentation: WorldStateInstrumentation,
-    protected readonly log: Logger = createLogger('world-state:database'),
+    protected readonly log: Logger,
     private readonly cleanup = () => Promise.resolve(),
   ) {}
 
@@ -62,9 +62,10 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
     wsTreeMapSizes: WorldStateTreeMapSizes,
     prefilledPublicData: PublicDataTreeLeaf[] = [],
     instrumentation = new WorldStateInstrumentation(getTelemetryClient()),
-    log = createLogger('world-state:database'),
+    bindings?: LoggerBindings,
     cleanup = () => Promise.resolve(),
   ): Promise<NativeWorldStateService> {
+    const log = createLogger('world-state:database', bindings);
     const worldStateDirectory = join(dataDir, WORLD_STATE_DIR);
     // Create a version manager to handle versioning
     const versionManager = new DatabaseVersionManager({
@@ -72,7 +73,9 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
       rollupAddress,
       dataDirectory: worldStateDirectory,
       onOpen: (dir: string) => {
-        return Promise.resolve(new NativeWorldState(dir, wsTreeMapSizes, prefilledPublicData, instrumentation));
+        return Promise.resolve(
+          new NativeWorldState(dir, wsTreeMapSizes, prefilledPublicData, instrumentation, bindings),
+        );
       },
     });
 
@@ -93,8 +96,9 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
     cleanupTmpDir = true,
     prefilledPublicData: PublicDataTreeLeaf[] = [],
     instrumentation = new WorldStateInstrumentation(getTelemetryClient()),
+    bindings?: LoggerBindings,
   ): Promise<NativeWorldStateService> {
-    const log = createLogger('world-state:database');
+    const log = createLogger('world-state:database', bindings);
     const dataDir = await mkdtemp(join(tmpdir(), 'aztec-world-state-'));
     const dbMapSizeKb = 10 * 1024 * 1024;
     const worldStateTreeMapSizes: WorldStateTreeMapSizes = {
@@ -116,7 +120,15 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
       }
     };
 
-    return this.new(rollupAddress, dataDir, worldStateTreeMapSizes, prefilledPublicData, instrumentation, log, cleanup);
+    return this.new(
+      rollupAddress,
+      dataDir,
+      worldStateTreeMapSizes,
+      prefilledPublicData,
+      instrumentation,
+      bindings,
+      cleanup,
+    );
   }
 
   protected async init() {

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -8,7 +8,7 @@ import {
   NULLIFIER_TREE_HEIGHT,
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { NativeWorldState as BaseNativeWorldState, MsgpackChannel } from '@aztec/native';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
@@ -57,7 +57,8 @@ export class NativeWorldState implements NativeWorldStateInstance {
     private readonly wsTreeMapSizes: WorldStateTreeMapSizes,
     private readonly prefilledPublicData: PublicDataTreeLeaf[] = [],
     private readonly instrumentation: WorldStateInstrumentation,
-    private readonly log: Logger = createLogger('world-state:database'),
+    bindings?: LoggerBindings,
+    private readonly log: Logger = createLogger('world-state:database', bindings),
   ) {
     const threads = Math.min(cpus().length, MAX_WORLD_STATE_THREADS);
     log.info(
@@ -105,6 +106,7 @@ export class NativeWorldState implements NativeWorldStateInstance {
       this.wsTreeMapSizes,
       this.prefilledPublicData,
       this.instrumentation,
+      this.log.getBindings(),
       this.log,
     );
   }

--- a/yarn-project/world-state/src/synchronizer/factory.ts
+++ b/yarn-project/world-state/src/synchronizer/factory.ts
@@ -1,3 +1,4 @@
+import type { LoggerBindings } from '@aztec/foundation/log';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -22,9 +23,10 @@ export async function createWorldStateSynchronizer(
   l2BlockSource: L2BlockSource & L1ToL2MessageSource,
   prefilledPublicData: PublicDataTreeLeaf[] = [],
   client: TelemetryClient = getTelemetryClient(),
+  bindings?: LoggerBindings,
 ) {
   const instrumentation = new WorldStateInstrumentation(client);
-  const merkleTrees = await createWorldState(config, prefilledPublicData, instrumentation);
+  const merkleTrees = await createWorldState(config, prefilledPublicData, instrumentation, bindings);
   return new ServerWorldStateSynchronizer(merkleTrees, l2BlockSource, config, instrumentation);
 }
 
@@ -42,6 +44,7 @@ export async function createWorldState(
     Pick<DataStoreConfig, 'dataDirectory' | 'dataStoreMapSizeKb' | 'l1Contracts'>,
   prefilledPublicData: PublicDataTreeLeaf[] = [],
   instrumentation: WorldStateInstrumentation = new WorldStateInstrumentation(getTelemetryClient()),
+  bindings?: LoggerBindings,
 ) {
   const dataDirectory = config.worldStateDataDirectory ?? config.dataDirectory;
   const dataStoreMapSizeKb = config.worldStateDbMapSizeKb ?? config.dataStoreMapSizeKb;
@@ -65,11 +68,14 @@ export async function createWorldState(
         wsTreeMapSizes,
         prefilledPublicData,
         instrumentation,
+        bindings,
       )
     : await NativeWorldStateService.tmp(
         config.l1Contracts.rollupAddress,
         !['true', '1'].includes(process.env.DEBUG_WORLD_STATE!),
         prefilledPublicData,
+        instrumentation,
+        bindings,
       );
 
   return merkleTrees;


### PR DESCRIPTION
## Summary

- Introduces logger bindings using `AsyncLocalStorage` for cleaner log output
- Components created within a `withLoggerBindings()` callback automatically inherit the labels
- Bindings include `actor` (eg `node-0`, `prover-1`), only set in tests, and `instanceId` (eg `epoch-1`)
- Both are displayed as a separate field in logs rather than appended to module name
- Browser-safe: AsyncLocalStorage code is isolated in a separate file not exported to browser bundles
- Module, actor, and instance are colored in pretty-printed logs so logs from the same actor have the same color

<img width="882" height="496" alt="image" src="https://github.com/user-attachments/assets/7deda404-b204-422d-8203-b06d0a95e078" />

**Expected log format:** `validator-1 checkpoint-builder checkpoint-5 Building block 1...`  
**Old format:** `checkpoint-builder:validator-1 Building block 1...`

## API

```typescript
// Server-side only (not in browser bundles)
import { withLoggerBindings } from '@aztec/foundation/log/server';

await withLoggerBindings({ actor: 'validator-1' }, async () => {
  // Components created here inherit the bindings
  const node = await AztecNodeService.createAndSync(...);
});

// Loggers expose getBindings() to pass context to child components
const childLogger = createLogger('child-module', parentLogger.getBindings());
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)