### PR TITLE
feat: nicer contract debug logs + minor related cleanup

### DIFF
--- a/yarn-project/foundation/src/log/log-filters.test.ts
+++ b/yarn-project/foundation/src/log/log-filters.test.ts
@@ -1,18 +1,18 @@
-import { parseEnv } from './log-filters.js';
+import { parseLogLevelEnvVar } from './log-filters.js';
 
 describe('parseEnv', () => {
   const defaultLevel = 'info';
 
   it('returns default level and empty filters when env is empty', () => {
     const env = '';
-    const [level, filters] = parseEnv(env, defaultLevel);
+    const [level, filters] = parseLogLevelEnvVar(env, defaultLevel);
     expect(level).toBe(defaultLevel);
     expect(filters).toEqual([]);
   });
 
   it('parses level and filters from env string', () => {
     const env = 'debug;warn:module1,module2;error:module3';
-    const [level, filters] = parseEnv(env, defaultLevel);
+    const [level, filters] = parseLogLevelEnvVar(env, defaultLevel);
     expect(level).toBe('debug');
     expect(filters).toEqual([
       ['module3', 'error'],
@@ -23,7 +23,7 @@ describe('parseEnv', () => {
 
   it('handles spaces in env string', () => {
     const env = 'debug; warn: module1, module2; error: module3';
-    const [level, filters] = parseEnv(env, defaultLevel);
+    const [level, filters] = parseLogLevelEnvVar(env, defaultLevel);
     expect(level).toBe('debug');
     expect(filters).toEqual([
       ['module3', 'error'],
@@ -34,17 +34,17 @@ describe('parseEnv', () => {
 
   it('throws an error for invalid default log level', () => {
     const env = 'invalid;module1:warn';
-    expect(() => parseEnv(env, defaultLevel)).toThrow('Invalid log level: invalid');
+    expect(() => parseLogLevelEnvVar(env, defaultLevel)).toThrow('Invalid log level: invalid');
   });
 
   it('throws an error for invalid log level in filter', () => {
     const env = 'invalid;warn:module';
-    expect(() => parseEnv(env, defaultLevel)).toThrow('Invalid log level: invalid');
+    expect(() => parseLogLevelEnvVar(env, defaultLevel)).toThrow('Invalid log level: invalid');
   });
 
   it('throws an error for invalid log filter statement', () => {
     const defaultLevel = 'info';
     const env = 'debug;warn:module1;error:';
-    expect(() => parseEnv(env, defaultLevel)).toThrow('Invalid log filter statement: error');
+    expect(() => parseLogLevelEnvVar(env, defaultLevel)).toThrow('Invalid log filter statement: error');
   });
 });

--- a/yarn-project/foundation/src/log/log-filters.ts
+++ b/yarn-project/foundation/src/log/log-filters.ts
@@ -19,22 +19,40 @@ export function getLogLevelFromFilters(filters: LogFilters, module: string): Log
   return undefined;
 }
 
-export function assertLogLevel(level: string): asserts level is LogLevel {
+/**
+ * Parses the LOG_LEVEL env string into a default level and per-module filter overrides.
+ *
+ * Format: `<default_level>;<level>:<module1>,<module2>;<level>:<module3>;...`
+ * - First segment (before the first `;`) is the default log level for all modules.
+ * - Remaining segments are `level:module` pairs: apply the given level to the listed modules (comma-separated).
+ * - Later filters override earlier ones for overlapping module matches.
+ * - The `aztec:` prefix is stripped from module names; spaces are trimmed.
+ *
+ * @example
+ * ```ts
+ * parseLogLevel('debug;warn:module1,module2;error:module3', 'info')
+ * // => ['debug', [['module3', 'error'], ['module2', 'warn'], ['module1', 'warn']]]
+ * ```
+ */
+export function parseLogLevelEnvVar(
+  logLevelEnvVar: string | undefined,
+  defaultLevel: LogLevel,
+): [LogLevel, LogFilters] {
+  if (!logLevelEnvVar) {
+    return [defaultLevel, []];
+  }
+  const [level] = logLevelEnvVar.split(';', 1);
+  assertValidLogLevel(level);
+  return [level, parseFilters(logLevelEnvVar.slice(level.length + 1))];
+}
+
+function assertValidLogLevel(level: string): asserts level is LogLevel {
   if (!LogLevels.includes(level as LogLevel)) {
     throw new Error(`Invalid log level: ${level}`);
   }
 }
 
-export function parseEnv(env: string | undefined, defaultLevel: LogLevel): [LogLevel, LogFilters] {
-  if (!env) {
-    return [defaultLevel, []];
-  }
-  const [level] = env.split(';', 1);
-  assertLogLevel(level);
-  return [level, parseFilters(env.slice(level.length + 1))];
-}
-
-export function parseFilters(definition: string | undefined): LogFilters {
+function parseFilters(definition: string | undefined): LogFilters {
   if (!definition) {
     return [];
   }
@@ -48,7 +66,7 @@ export function parseFilters(definition: string | undefined): LogFilters {
       throw new Error(`Invalid log filter statement: ${statement}`);
     }
     const sanitizedLevel = level.trim().toLowerCase();
-    assertLogLevel(sanitizedLevel);
+    assertValidLogLevel(sanitizedLevel);
     for (const module of modules.split(',')) {
       filters.push([
         module

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -8,7 +8,7 @@ import { compactArray } from '../collection/array.js';
 import type { EnvVar } from '../config/index.js';
 import { parseBooleanEnv } from '../config/parse-env.js';
 import { GoogleCloudLoggerConfig } from './gcloud-logger-config.js';
-import { getLogLevelFromFilters, parseEnv } from './log-filters.js';
+import { getLogLevelFromFilters, parseLogLevelEnvVar } from './log-filters.js';
 import type { LogLevel } from './log-levels.js';
 import type { LogData, LogFn } from './log_fn.js';
 
@@ -126,7 +126,7 @@ function isLevelEnabled(logger: pino.Logger<'verbose', boolean>, level: LogLevel
 
 // Load log levels from environment variables.
 const defaultLogLevel = process.env.NODE_ENV === 'test' ? 'silent' : 'info';
-export const [logLevel, logFilters] = parseEnv(process.env.LOG_LEVEL, defaultLogLevel);
+export const [logLevel, logFilters] = parseLogLevelEnvVar(process.env.LOG_LEVEL, defaultLogLevel);
 
 // Define custom logging levels for pino.
 const customLevels = { verbose: 25 };

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -54,7 +54,7 @@ export interface IMiscOracle {
 
   utilityGetRandomField(): Fr;
   utilityAssertCompatibleOracleVersion(version: number): void;
-  utilityDebugLog(level: number, message: string, fields: Fr[]): void;
+  utilityDebugLog(level: number, message: string, fields: Fr[]): Promise<void>;
 }
 
 /**

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -417,7 +417,7 @@ export class Oracle {
     return Promise.resolve([]);
   }
 
-  utilityDebugLog(
+  async utilityDebugLog(
     level: ACVMField[],
     message: ACVMField[],
     _ignoredFieldsSize: ACVMField[],
@@ -426,8 +426,8 @@ export class Oracle {
     const levelFr = Fr.fromString(level[0]);
     const messageStr = message.map(acvmField => String.fromCharCode(Fr.fromString(acvmField).toNumber())).join('');
     const fieldsFr = fields.map(Fr.fromString);
-    this.handlerAsMisc().utilityDebugLog(levelFr.toNumber(), messageStr, fieldsFr);
-    return Promise.resolve([]);
+    await this.handlerAsMisc().utilityDebugLog(levelFr.toNumber(), messageStr, fieldsFr);
+    return [];
   }
 
   // This function's name is directly hardcoded in `circuit_recorder.ts`. Don't forget to update it there if you

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -3,7 +3,7 @@ import type { BlockNumber } from '@aztec/foundation/branded-types';
 import { Aes128 } from '@aztec/foundation/crypto/aes128';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { Point } from '@aztec/foundation/curves/grumpkin';
-import { LogLevels, applyStringFormatting, createLogger } from '@aztec/foundation/log';
+import { LogLevels, type Logger, applyStringFormatting, createLogger } from '@aztec/foundation/log';
 import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
@@ -47,7 +47,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   isMisc = true as const;
   isUtility = true as const;
 
-  private aztecNrDebugLog = createLogger('aztec-nr:debug_log');
+  private contractLogger: Logger | undefined;
 
   constructor(
     protected readonly contractAddress: AztecAddress,
@@ -354,12 +354,28 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return values;
   }
 
-  public utilityDebugLog(level: number, message: string, fields: Fr[]): void {
+  /**
+   * Returns a per-contract logger whose output is prefixed with `contract_log::<name>(<addrAbbrev>)`.
+   */
+  async #getContractLogger(): Promise<Logger> {
+    if (!this.contractLogger) {
+      const addrAbbrev = this.contractAddress.toString().slice(0, 10);
+      const name = await this.contractStore.getDebugContractName(this.contractAddress);
+      const module = name ? `contract_log::${name}(${addrAbbrev})` : `contract_log::${addrAbbrev}`;
+      // Purpose of instanceId is to distinguish logs from different instances of the same component. It makes sense
+      // to re-use jobId as instanceId here as executions of different PXE jobs are isolated.
+      this.contractLogger = createLogger(module, { instanceId: this.jobId });
+    }
+    return this.contractLogger;
+  }
+
+  public async utilityDebugLog(level: number, message: string, fields: Fr[]): Promise<void> {
     if (!LogLevels[level]) {
       throw new Error(`Invalid debug log level: ${level}`);
     }
     const levelName = LogLevels[level];
-    this.aztecNrDebugLog[levelName](`${applyStringFormatting(message, fields)}`);
+    const logger = await this.#getContractLogger();
+    logger[levelName](`${applyStringFormatting(message, fields)}`);
   }
 
   public async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -131,13 +131,14 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
   }
 
   // We instruct users to debug contracts via this oracle, so it makes sense that they'd expect it to also work in tests
-  utilityDebugLog(level: number, message: string, fields: Fr[]): void {
+  utilityDebugLog(level: number, message: string, fields: Fr[]): Promise<void> {
     if (!LogLevels[level]) {
       throw new Error(`Invalid debug log level: ${level}`);
     }
     const levelName = LogLevels[level];
 
     this.logger[levelName](`${applyStringFormatting(message, fields)}`, { module: `${this.logger.module}:debug_log` });
+    return Promise.resolve();
   }
 
   txeGetDefaultAddress(): AztecAddress {

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -328,7 +328,7 @@ export class RPCTranslator {
 
   // When the argument is a slice, noir automatically adds a length field to oracle call.
   // When the argument is an array, we add the field length manually to the signature.
-  utilityDebugLog(
+  async utilityDebugLog(
     foreignLevel: ForeignCallSingle,
     foreignMessage: ForeignCallArray,
     _foreignLength: ForeignCallSingle,
@@ -340,7 +340,7 @@ export class RPCTranslator {
       .join('');
     const fields = fromArray(foreignFields);
 
-    this.handlerAsMisc().utilityDebugLog(level, message, fields);
+    await this.handlerAsMisc().utilityDebugLog(level, message, fields);
 
     return toForeignCallResult([]);
   }


### PR DESCRIPTION
In this PR I refactor how logs emitted from contracts are handled:
- ~I register a `contract_log` module that is treated differently in that it has the default log level set to "debug". This ensures that by default Noir contract devs will see their logs printed out no matter the "system-wide" default log level (this was a common source of confusion for devs). Note that this results in dev needing to set `export LOG_LEVEL="silent;silent:contract_log"` to truly silence all logs. This feels controversial but I feel like it's currently the best tradeoff as devs were confused of not seeing their contract logs (contract logs are generally also not that spammy).~ **Update**: [As mentioned below](https://github.com/AztecProtocol/aztec-packages/pull/19960#discussion_r2782321185) this is not the way to go and will be handled differnetly.
- I make the emitted logs nicer by having them include name and first few bytes of address:

<img width="1260" height="470" alt="image" src="https://github.com/user-attachments/assets/b3a14cbe-d55e-44bf-9ae5-e26f3e1f35de" />

## Followup work
- Rename the `utilityDebugLog` handler as `utilityLog` and clean up the `noir-projects/noir-protocol-circuits/crates/types/src/debug_log.nr` file that is now in a sad state,
- make the nice contract logs work in public as well (this is currently broken).