### PR TITLE
refactor: aligning class name with file name

### DIFF
--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -9,11 +9,11 @@ import { isDefined } from '@aztec/foundation/types';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton, Range } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
+  BlockHash,
   Body,
   CheckpointedL2Block,
   CommitteeAttestation,
   L2Block,
-  L2BlockHash,
   type ValidateCheckpointResult,
   deserializeValidateCheckpointResult,
   serializeValidateCheckpointResult,
@@ -351,7 +351,7 @@ export class BlockStore {
   }
 
   private async addBlockToDatabase(block: L2Block, checkpointNumber: number, indexWithinCheckpoint: number) {
-    const blockHash = L2BlockHash.fromField(await block.hash());
+    const blockHash = BlockHash.fromField(await block.hash());
 
     await this.#blocks.set(block.number, {
       header: block.header.toBuffer(),
@@ -673,7 +673,7 @@ export class BlockStore {
    * @param blockHash - The hash of the block to return.
    * @returns The requested L2 block.
    */
-  async getBlockByHash(blockHash: L2BlockHash): Promise<L2Block | undefined> {
+  async getBlockByHash(blockHash: BlockHash): Promise<L2Block | undefined> {
     const blockNumber = await this.#blockHashIndex.getAsync(blockHash.toString());
     if (blockNumber === undefined) {
       return undefined;
@@ -699,7 +699,7 @@ export class BlockStore {
    * @param blockHash - The hash of the block to return.
    * @returns The requested block header.
    */
-  async getBlockHeaderByHash(blockHash: L2BlockHash): Promise<BlockHeader | undefined> {
+  async getBlockHeaderByHash(blockHash: BlockHash): Promise<BlockHeader | undefined> {
     const blockNumber = await this.#blockHashIndex.getAsync(blockHash.toString());
     if (blockNumber === undefined) {
       return undefined;

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -15,11 +15,11 @@ import { sleep } from '@aztec/foundation/sleep';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
+  BlockHash,
   CheckpointedL2Block,
   CommitteeAttestation,
   EthAddress,
   L2Block,
-  L2BlockHash,
   type ValidateCheckpointResult,
 } from '@aztec/stdlib/block';
 import { Checkpoint, PublishedCheckpoint, randomCheckpointInfo } from '@aztec/stdlib/checkpoint';
@@ -2819,7 +2819,7 @@ describe('KVArchiverDataStore', () => {
     it('"txHash" filter param is ignored when "afterLog" is set', async () => {
       // Get random txHash
       const txHash = TxHash.random();
-      const afterLog = new LogId(BlockNumber(1), L2BlockHash.random(), 0, 0);
+      const afterLog = new LogId(BlockNumber(1), BlockHash.random(), 0, 0);
 
       const response = await store.getPublicLogs({ txHash, afterLog });
       expect(response.logs.length).toBeGreaterThan(1);
@@ -2851,7 +2851,7 @@ describe('KVArchiverDataStore', () => {
         await store.getPublicLogs({
           fromBlock: BlockNumber(2),
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(4), L2BlockHash.random(), 0, 0),
+          afterLog: new LogId(BlockNumber(4), BlockHash.random(), 0, 0),
         })
       ).logs;
       blockNumbers = new Set(logs.map(log => log.id.blockNumber));
@@ -2860,7 +2860,7 @@ describe('KVArchiverDataStore', () => {
       logs = (
         await store.getPublicLogs({
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(5), L2BlockHash.random(), 1, 0),
+          afterLog: new LogId(BlockNumber(5), BlockHash.random(), 1, 0),
         })
       ).logs;
       expect(logs.length).toBe(0);
@@ -2869,7 +2869,7 @@ describe('KVArchiverDataStore', () => {
         await store.getPublicLogs({
           fromBlock: BlockNumber(2),
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(100), L2BlockHash.random(), 0, 0),
+          afterLog: new LogId(BlockNumber(100), BlockHash.random(), 0, 0),
         })
       ).logs;
       expect(logs.length).toBe(0);

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -6,7 +6,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, CustomRange, StoreSize } from '@aztec/kv-store';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { CheckpointedL2Block, L2Block, L2BlockHash, type ValidateCheckpointResult } from '@aztec/stdlib/block';
+import { BlockHash, CheckpointedL2Block, L2Block, type ValidateCheckpointResult } from '@aztec/stdlib/block';
 import type { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type {
   ContractClassPublic,
@@ -313,7 +313,7 @@ export class KVArchiverDataStore implements ContractDataSource {
    * @param blockHash - The block hash to return.
    */
   getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
-    return this.#blockStore.getBlockByHash(L2BlockHash.fromField(blockHash));
+    return this.#blockStore.getBlockByHash(BlockHash.fromField(blockHash));
   }
   /**
    * Returns the block for the given archive root, or undefined if not exists.
@@ -358,7 +358,7 @@ export class KVArchiverDataStore implements ContractDataSource {
    * @param blockHash - The block hash to return.
    */
   getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
-    return this.#blockStore.getBlockHeaderByHash(L2BlockHash.fromField(blockHash));
+    return this.#blockStore.getBlockHeaderByHash(BlockHash.fromField(blockHash));
   }
 
   /**

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -6,7 +6,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { BufferReader, numToUInt32BE } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2Block, L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash, L2Block } from '@aztec/stdlib/block';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import {
@@ -275,14 +275,14 @@ export class LogStore {
     return Buffer.concat([blockHash.toBuffer(), ...data]);
   }
 
-  #unpackBlockHash(reader: BufferReader): L2BlockHash {
+  #unpackBlockHash(reader: BufferReader): BlockHash {
     const blockHash = reader.remainingBytes() > 0 ? reader.readObject(Fr) : undefined;
 
     if (!blockHash) {
       throw new Error('Failed to read block hash from log entry buffer');
     }
 
-    return L2BlockHash.fromField(blockHash);
+    return BlockHash.fromField(blockHash);
   }
 
   deleteLogs(blocks: L2Block[]): Promise<boolean> {
@@ -543,7 +543,7 @@ export class LogStore {
   #accumulateLogs(
     results: (ExtendedContractClassLog | ExtendedPublicLog)[],
     blockNumber: number,
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     txIndex: number,
     txLogs: (ContractClassLog | PublicLog)[],
     filter: LogFilter = {},

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -8,9 +8,9 @@ import { createLogger } from '@aztec/foundation/log';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
+  BlockHash,
   CheckpointedL2Block,
   L2Block,
-  L2BlockHash,
   type L2BlockSource,
   type L2Tips,
   type ValidateCheckpointResult,
@@ -322,7 +322,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return {
       data: txEffect,
       l2BlockNumber: block.number,
-      l2BlockHash: L2BlockHash.fromField(await block.hash()),
+      l2BlockHash: BlockHash.fromField(await block.hash()),
       txIndexInBlock: block.body.txEffects.indexOf(txEffect),
     };
   }
@@ -343,7 +343,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
             TxExecutionResult.SUCCESS,
             undefined,
             txEffect.transactionFee.toBigInt(),
-            L2BlockHash.fromField(await block.hash()),
+            BlockHash.fromField(await block.hash()),
             block.number,
           );
         }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -41,7 +41,7 @@ import {
 } from '@aztec/slasher';
 import { CollectionLimitsConfig, PublicSimulatorConfig } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { type BlockParameter, type DataInBlock, L2Block, L2BlockHash, type L2BlockSource } from '@aztec/stdlib/block';
+import { BlockHash, type BlockParameter, type DataInBlock, L2Block, type L2BlockSource } from '@aztec/stdlib/block';
 import type { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type {
   ContractClassPublic,
@@ -119,7 +119,7 @@ import { NodeMetrics } from './node_metrics.js';
  */
 export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   private metrics: NodeMetrics;
-  private initialHeaderHashPromise: Promise<L2BlockHash> | undefined = undefined;
+  private initialHeaderHashPromise: Promise<BlockHash> | undefined = undefined;
 
   // Prevent two snapshot operations to happen simultaneously
   private isUploadingSnapshot = false;
@@ -570,7 +570,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block.
    */
   public async getBlock(block: BlockParameter): Promise<L2Block | undefined> {
-    if (L2BlockHash.isL2BlockHash(block)) {
+    if (BlockHash.isL2BlockHash(block)) {
       return this.getBlockByHash(Fr.fromBuffer(block.toBuffer()));
     }
     const blockNumber = block === 'latest' ? await this.getBlockNumber() : (block as BlockNumber);
@@ -692,7 +692,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   public async getPrivateLogsByTags(
     tags: SiloedTag[],
     page?: number,
-    referenceBlock?: L2BlockHash,
+    referenceBlock?: BlockHash,
   ): Promise<TxScopedL2Log[][]> {
     if (referenceBlock) {
       const initialBlockHash = await this.#getInitialHeaderHash();
@@ -713,7 +713,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     contractAddress: AztecAddress,
     tags: Tag[],
     page?: number,
-    referenceBlock?: L2BlockHash,
+    referenceBlock?: BlockHash,
   ): Promise<TxScopedL2Log[][]> {
     if (referenceBlock) {
       const initialBlockHash = await this.#getInitialHeaderHash();
@@ -915,7 +915,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       }
       return {
         l2BlockNumber: BlockNumber(Number(blockNumber)),
-        l2BlockHash: L2BlockHash.fromField(blockHash),
+        l2BlockHash: BlockHash.fromField(blockHash),
         data: index,
       };
     });
@@ -1118,7 +1118,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   public async getBlockHeader(block: BlockParameter = 'latest'): Promise<BlockHeader | undefined> {
-    if (L2BlockHash.isL2BlockHash(block)) {
+    if (BlockHash.isL2BlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.
@@ -1409,7 +1409,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     }
   }
 
-  #getInitialHeaderHash(): Promise<L2BlockHash> {
+  #getInitialHeaderHash(): Promise<BlockHash> {
     if (!this.initialHeaderHashPromise) {
       this.initialHeaderHashPromise = this.worldStateSynchronizer.getCommitted().getInitialHeader().hash();
     }
@@ -1435,7 +1435,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       return this.worldStateSynchronizer.getCommitted();
     }
 
-    if (L2BlockHash.isL2BlockHash(block)) {
+    if (BlockHash.isL2BlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -6,7 +6,7 @@ import type { ContractArtifact, EventMetadataDefinition } from '@aztec/stdlib/ab
 import { EventSelector, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { PublicKeys } from '@aztec/stdlib/keys';
 import {
@@ -346,7 +346,7 @@ class MockWallet implements Wallet {
         },
         metadata: {
           l2BlockNumber: BlockNumber(1),
-          l2BlockHash: L2BlockHash.random(),
+          l2BlockHash: BlockHash.random(),
           txHash: TxHash.random(),
         },
       },

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -4,7 +4,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2TipsKVStore } from '@aztec/kv-store/stores';
-import { GENESIS_CHECKPOINT_HEADER_HASH, L2Block, L2BlockHash, type L2BlockStream } from '@aztec/stdlib/block';
+import { BlockHash, GENESIS_CHECKPOINT_HEADER_HASH, L2Block, type L2BlockStream } from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
@@ -61,7 +61,7 @@ describe('BlockSynchronizer', () => {
     const block3Hash = Fr.fromString('0x3');
     aztecNode.getBlockHeader.mockImplementation(async block => {
       // For the test, when block hash matches block 3, return block header for block 3
-      if (block instanceof L2BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
+      if (block instanceof BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
         return (await L2Block.random(BlockNumber(3))).header;
       }
       return undefined;
@@ -85,7 +85,7 @@ describe('BlockSynchronizer', () => {
     const block3Hash = Fr.fromString('0x3');
     aztecNode.getBlockHeader.mockImplementation(async block => {
       // For the test, when block hash matches block 3, return block header for block 3
-      if (block instanceof L2BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
+      if (block instanceof BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
         return (await L2Block.random(BlockNumber(3))).header;
       }
       return undefined;

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -2,12 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2TipsKVStore } from '@aztec/kv-store/stores';
-import {
-  L2BlockHash,
-  L2BlockStream,
-  type L2BlockStreamEvent,
-  type L2BlockStreamEventHandler,
-} from '@aztec/stdlib/block';
+import { BlockHash, L2BlockStream, type L2BlockStreamEvent, type L2BlockStreamEventHandler } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
@@ -106,7 +101,7 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
         // Note that the following is not necessarily the anchor block that will be used in the transaction - if
         // the chain has already moved past the reorg, we'll also see blocks-added events that will push the anchor
         // forward.
-        const newAnchorBlockHeader = await this.node.getBlockHeader(L2BlockHash.fromString(event.block.hash));
+        const newAnchorBlockHeader = await this.node.getBlockHeader(BlockHash.fromString(event.block.hash));
 
         if (!newAnchorBlockHeader) {
           throw new Error(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -5,7 +5,7 @@ import { Point } from '@aztec/foundation/curves/grumpkin';
 import { MembershipWitness } from '@aztec/foundation/trees';
 import type { FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
 import type { ContractClassLog, Tag } from '@aztec/stdlib/logs';
@@ -68,20 +68,20 @@ export interface IUtilityExecutionOracle {
   utilityGetKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest>;
   utilityGetContractInstance(address: AztecAddress): Promise<ContractInstance>;
   utilityGetNoteHashMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     leafValue: Fr,
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
   utilityGetArchiveMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     leafValue: Fr,
   ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined>;
   utilityGetNullifierMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
-  utilityGetPublicDataWitness(blockHash: L2BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined>;
+  utilityGetPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined>;
   utilityGetLowNullifierMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
   utilityGetBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined>;
@@ -111,7 +111,7 @@ export interface IUtilityExecutionOracle {
     secret: Fr,
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
   utilityStorageRead(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
     numberOfElements: number,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -12,7 +12,7 @@ import {
 } from '@aztec/simulator/client';
 import { FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { ContractClassLog, ContractClassLogFields } from '@aztec/stdlib/logs';
 
 import type { IMiscOracle, IPrivateExecutionOracle, IUtilityExecutionOracle } from './interfaces.js';
@@ -141,7 +141,7 @@ export class Oracle {
     [blockHash]: ACVMField[],
     [leafValue]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedBlockHash = L2BlockHash.fromString(blockHash);
+    const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedLeafValue = Fr.fromString(leafValue);
 
     const witness = await this.handlerAsUtility().utilityGetNoteHashMembershipWitness(parsedBlockHash, parsedLeafValue);
@@ -155,7 +155,7 @@ export class Oracle {
     [blockHash]: ACVMField[],
     [leafValue]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedBlockHash = L2BlockHash.fromString(blockHash);
+    const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedLeafValue = Fr.fromString(leafValue);
 
     const witness = await this.handlerAsUtility().utilityGetArchiveMembershipWitness(parsedBlockHash, parsedLeafValue);
@@ -169,7 +169,7 @@ export class Oracle {
     [blockHash]: ACVMField[],
     [nullifier]: ACVMField[], // nullifier, we try to find the witness for (to prove inclusion)
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedBlockHash = L2BlockHash.fromString(blockHash);
+    const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedNullifier = Fr.fromString(nullifier);
 
     const witness = await this.handlerAsUtility().utilityGetNullifierMembershipWitness(
@@ -188,7 +188,7 @@ export class Oracle {
     [blockHash]: ACVMField[],
     [nullifier]: ACVMField[], // nullifier, we try to find the low nullifier witness for (to prove non-inclusion)
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedBlockHash = L2BlockHash.fromString(blockHash);
+    const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedNullifier = Fr.fromString(nullifier);
 
     const witness = await this.handlerAsUtility().utilityGetLowNullifierMembershipWitness(
@@ -207,7 +207,7 @@ export class Oracle {
     [blockHash]: ACVMField[],
     [leafSlot]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const parsedBlockHash = L2BlockHash.fromString(blockHash);
+    const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedLeafSlot = Fr.fromString(leafSlot);
 
     const witness = await this.handlerAsUtility().utilityGetPublicDataWitness(parsedBlockHash, parsedLeafSlot);
@@ -379,7 +379,7 @@ export class Oracle {
     [numberOfElements]: ACVMField[],
   ): Promise<ACVMField[][]> {
     const values = await this.handlerAsUtility().utilityStorageRead(
-      L2BlockHash.fromString(blockHash),
+      BlockHash.fromString(blockHash),
       new AztecAddress(Fr.fromString(contractAddress)),
       Fr.fromString(startStorageSlot),
       +numberOfElements,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -33,7 +33,7 @@ import {
   getFunctionArtifactByName,
 } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { type BlockParameter, L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash, type BlockParameter } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractInstanceWithAddress,
@@ -525,7 +525,7 @@ describe('Private Execution test suite', () => {
         new Fr(0),
         TxHash.random(),
         BlockNumber(Math.abs(randomInt(1000))),
-        L2BlockHash.random().toString(),
+        BlockHash.random().toString(),
         0,
         0,
       );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -6,7 +6,7 @@ import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/Stat
 import { WASMSimulator } from '@aztec/simulator/client';
 import { FunctionCall, FunctionSelector, FunctionType, encodeArguments } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { CompleteAddress, type ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { deriveKeys } from '@aztec/stdlib/keys';
@@ -170,7 +170,7 @@ describe('Utility Execution test suite', () => {
             Fr.random(),
             TxHash.random(),
             BlockNumber(42),
-            L2BlockHash.random().toString(),
+            BlockHash.random().toString(),
             0,
             0,
           ),

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -8,7 +8,7 @@ import type { MembershipWitness } from '@aztec/foundation/trees';
 import type { KeyStore } from '@aztec/key-store';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
@@ -102,7 +102,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @returns The membership witness containing the leaf index and sibling path
    */
   public utilityGetNoteHashMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     leafValue: Fr,
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
     return this.aztecNode.getNoteHashMembershipWitness(blockHash, leafValue);
@@ -115,7 +115,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @returns The membership witness containing the leaf index and sibling path
    */
   public utilityGetArchiveMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     leafValue: Fr,
   ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined> {
     return this.aztecNode.getArchiveMembershipWitness(blockHash, leafValue);
@@ -128,7 +128,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @returns The nullifier membership witness (if found).
    */
   public utilityGetNullifierMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
     return this.aztecNode.getNullifierMembershipWitness(blockHash, nullifier);
@@ -144,7 +144,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * we are trying to prove non-inclusion for.
    */
   public utilityGetLowNullifierMembershipWitness(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
     return this.aztecNode.getLowNullifierMembershipWitness(blockHash, nullifier);
@@ -156,7 +156,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param leafSlot - The slot of the public data tree to get the witness for.
    * @returns - The witness
    */
-  public utilityGetPublicDataWitness(blockHash: L2BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
+  public utilityGetPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
     return this.aztecNode.getPublicDataWitness(blockHash, leafSlot);
   }
 
@@ -318,7 +318,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param numberOfElements - Number of elements to read from the starting storage slot.
    */
   public async utilityStorageRead(
-    blockHash: L2BlockHash,
+    blockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
     numberOfElements: number,

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { BlockHeader, GlobalVariables, type IndexedTxEffect, TxEffect } from '@aztec/stdlib/tx';
@@ -67,7 +67,7 @@ describe('validateAndStoreEvent', () => {
 
     indexedTxEffect = {
       l2BlockNumber: blockNumber,
-      l2BlockHash: L2BlockHash.random(),
+      l2BlockHash: BlockHash.random(),
       data: txEffect,
       txIndexInBlock: 0,
     };

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -3,7 +3,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash, randomDataInBlock } from '@aztec/stdlib/block';
+import { BlockHash, randomDataInBlock } from '@aztec/stdlib/block';
 import type { CompleteAddress } from '@aztec/stdlib/contract';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -247,7 +247,7 @@ describe('NoteService', () => {
 
       indexedTxEffect = {
         l2BlockNumber: blockNumber,
-        l2BlockHash: L2BlockHash.random(),
+        l2BlockHash: BlockHash.random(),
         data: txEffect,
         txIndexInBlock: 0,
       };

--- a/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_oracle.ts
@@ -7,7 +7,7 @@ import { getVKIndex, getVKSiblingPath } from '@aztec/noir-protocol-circuits-type
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import {
   type ContractInstanceWithAddress,
   computeContractClassIdPreimage,
@@ -30,7 +30,7 @@ export class PrivateKernelOracle {
     private contractStore: ContractStore,
     private keyStore: KeyStore,
     private node: AztecNode,
-    private blockHash: L2BlockHash,
+    private blockHash: BlockHash,
   ) {}
 
   /** Retrieves the preimage of a contract address from the registered contract instances db. */

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -10,7 +10,7 @@ import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/prov
 import { WASMSimulator } from '@aztec/simulator/client';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { GENESIS_CHECKPOINT_HEADER_HASH, L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash, GENESIS_CHECKPOINT_HEADER_HASH } from '@aztec/stdlib/block';
 import { getContractClassFromArtifact } from '@aztec/stdlib/contract';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { SiloedTag } from '@aztec/stdlib/logs';
@@ -157,7 +157,7 @@ describe('PXE', () => {
     let contractAddress: AztecAddress;
     let eventSelector: EventSelector;
     let lastKnownBlockNumber: BlockNumber;
-    let l2BlockHash: L2BlockHash;
+    let l2BlockHash: BlockHash;
     let scope: AztecAddress;
     let privateEventStore: PrivateEventStore;
 
@@ -206,7 +206,7 @@ describe('PXE', () => {
 
       contractAddress = contractInstance.address;
       eventSelector = EventSelector.random();
-      l2BlockHash = L2BlockHash.random();
+      l2BlockHash = BlockHash.random();
 
       scope = await AztecAddress.random();
 

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -2,7 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecLMDBStoreV2, openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { NoteDao, NoteStatus } from '@aztec/stdlib/note';
 
 import { NoteStore } from './note_store.js';
@@ -68,7 +68,7 @@ describe('NoteStore', () => {
     return {
       data: note.siloedNullifier,
       l2BlockNumber: blockNumber ?? note.l2BlockNumber,
-      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+      l2BlockHash: BlockHash.fromString(note.l2BlockHash),
     };
   }
 
@@ -404,7 +404,7 @@ describe('NoteStore', () => {
       const fakeNullifier = {
         data: Fr.random(),
         l2BlockNumber: BlockNumber(999),
-        l2BlockHash: L2BlockHash.random(),
+        l2BlockHash: BlockHash.random(),
       };
 
       await expect(noteStore.applyNullifiers([fakeNullifier], 'test')).rejects.toThrow(
@@ -447,7 +447,7 @@ describe('NoteStore', () => {
         {
           data: Fr.random(), // Invalid
           l2BlockNumber: BlockNumber(999),
-          l2BlockHash: L2BlockHash.random(),
+          l2BlockHash: BlockHash.random(),
         },
       ];
 
@@ -706,7 +706,7 @@ describe('NoteStore', () => {
           {
             data: note.siloedNullifier,
             l2BlockNumber: BlockNumber(5),
-            l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+            l2BlockHash: BlockHash.fromString(note.l2BlockHash),
           },
         ];
         await noteStore.applyNullifiers(nullifiers, 'test');
@@ -738,7 +738,7 @@ describe('NoteStore', () => {
           {
             data: note.siloedNullifier,
             l2BlockNumber: BlockNumber(4),
-            l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
+            l2BlockHash: BlockHash.fromString(note.l2BlockHash),
           },
         ];
         await noteStore.applyNullifiers(nullifiers, 'test');
@@ -771,7 +771,7 @@ describe('NoteStore', () => {
           {
             data: note1.siloedNullifier,
             l2BlockNumber: BlockNumber(7),
-            l2BlockHash: L2BlockHash.fromString(note1.l2BlockHash),
+            l2BlockHash: BlockHash.fromString(note1.l2BlockHash),
           },
         ];
         await noteStore.applyNullifiers(nullifiers, 'test');

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.test.ts
@@ -4,7 +4,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import type { PackedPrivateEvent } from '../../pxe.js';
@@ -20,7 +20,7 @@ describe('PrivateEventStore', () => {
   let scope: AztecAddress;
   let msgContent: Fr[];
   let l2BlockNumber: BlockNumber;
-  let l2BlockHash: L2BlockHash;
+  let l2BlockHash: BlockHash;
   let eventSelector: EventSelector;
   let randomness: Fr;
   let txHash: TxHash;
@@ -34,7 +34,7 @@ describe('PrivateEventStore', () => {
     scope = await AztecAddress.random();
     msgContent = getRandomMsgContent();
     l2BlockNumber = BlockNumber(123);
-    l2BlockHash = L2BlockHash.random();
+    l2BlockHash = BlockHash.random();
     eventSelector = EventSelector.random();
     randomness = Fr.random();
     txHash = TxHash.random();

--- a/yarn-project/pxe/src/storage/private_event_store/stored_private_event.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/stored_private_event.test.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import { StoredPrivateEvent } from './stored_private_event.js';
@@ -12,7 +12,7 @@ describe('StoredPrivateEvent', () => {
       randomness?: Fr;
       msgContent?: Fr[];
       l2BlockNumber?: number;
-      l2BlockHash?: L2BlockHash;
+      l2BlockHash?: BlockHash;
       txHash?: TxHash;
       txIndexInBlock?: number;
       eventIndexInTx?: number;
@@ -25,7 +25,7 @@ describe('StoredPrivateEvent', () => {
       overrides.randomness ?? Fr.random(),
       overrides.msgContent ?? [Fr.random(), Fr.random(), Fr.random()],
       overrides.l2BlockNumber ?? 42,
-      overrides.l2BlockHash ?? L2BlockHash.random(),
+      overrides.l2BlockHash ?? BlockHash.random(),
       overrides.txHash ?? TxHash.random(),
       overrides.txIndexInBlock ?? 3,
       overrides.eventIndexInTx ?? 1,

--- a/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
@@ -2,7 +2,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { EventSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
 /** Serializable private event entry with scope tracking. */
@@ -11,7 +11,7 @@ export class StoredPrivateEvent {
     readonly randomness: Fr,
     readonly msgContent: Fr[],
     readonly l2BlockNumber: number,
-    readonly l2BlockHash: L2BlockHash,
+    readonly l2BlockHash: BlockHash,
     readonly txHash: TxHash,
     readonly txIndexInBlock: number,
     readonly eventIndexInTx: number,
@@ -49,7 +49,7 @@ export class StoredPrivateEvent {
     const msgContentLength = reader.readNumber();
     const msgContent = reader.readArray(msgContentLength, Fr);
     const l2BlockNumber = reader.readNumber();
-    const l2BlockHash = L2BlockHash.fromBuffer(reader);
+    const l2BlockHash = BlockHash.fromBuffer(reader);
     const txHash = TxHash.fromBuffer(reader);
     const txIndexInBlock = reader.readNumber();
     const eventIndexInTx = reader.readNumber();

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -1,6 +1,6 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -13,7 +13,7 @@ import { getAllPrivateLogsByTags } from './get_all_logs_by_tags.js';
 // We don't bother testing getAllPublicLogsByTagsFromContract because both of the functions are a simple wrapper around
 // getAllPages function so just testing the private logs function is enough.
 
-const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
+const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
 
 describe('getAllPrivateLogsByTags', () => {
   let aztecNode: MockProxy<AztecNode>;

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.ts
@@ -1,5 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
+import type { BlockHash } from '@aztec/stdlib/block';
 import { MAX_LOGS_PER_TAG } from '@aztec/stdlib/interfaces/api-limit';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
@@ -42,7 +42,7 @@ async function getAllPages<T>(numTags: number, fetchPage: (page: number) => Prom
 export function getAllPrivateLogsByTags(
   aztecNode: AztecNode,
   tags: SiloedTag[],
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
 ): Promise<TxScopedL2Log[][]> {
   return getAllPages(tags.length, page => aztecNode.getPrivateLogsByTags(tags, page, anchorBlockHash));
 }
@@ -60,7 +60,7 @@ export function getAllPublicLogsByTagsFromContract(
   aztecNode: AztecNode,
   contractAddress: AztecAddress,
   tags: Tag[],
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
 ): Promise<TxScopedL2Log[][]> {
   return getAllPages(tags.length, page =>
     aztecNode.getPublicLogsByTagsFromContract(contractAddress, tags, page, anchorBlockHash),

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
@@ -3,7 +3,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { makeBlockHeader, makeL2Tips, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -17,7 +17,7 @@ import { loadPrivateLogsForSenderRecipientPair } from './load_private_logs_for_s
 // In this test suite we don't care about the anchor block behavior as that is sufficiently tested by
 // the loadLogsForRange test suite, so we use a high block number to ensure it occurs after all logs.
 const FAR_FUTURE_BLOCK_NUMBER = BlockNumber(100);
-const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
+const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
 
 describe('loadPrivateLogsForSenderRecipientPair', () => {
   let secret: DirectionalAppTaggingSecret;

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.ts
@@ -1,6 +1,6 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, TxScopedL2Log } from '@aztec/stdlib/logs';
 
@@ -22,7 +22,7 @@ export async function loadPrivateLogsForSenderRecipientPair(
   aztecNode: AztecNode,
   taggingStore: RecipientTaggingStore,
   anchorBlockNumber: BlockNumber,
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
   jobId: string,
 ): Promise<TxScopedL2Log[]> {
   // # Explanation of how the algorithm works

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
@@ -1,7 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -14,7 +14,7 @@ import { loadLogsForRange } from './load_logs_for_range.js';
 // In tests where the anchor block behavior is not under examination, we use a high block number to ensure it occurs
 // after all logs.
 const FAR_FUTURE_BLOCK_NUMBER = BlockNumber(100);
-const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
+const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
 
 describe('loadLogsForRange', () => {
   // App contract address and secret to be used on the input of the loadLogsForRange function.

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
@@ -1,6 +1,6 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { DirectionalAppTaggingSecret, PreTag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -19,7 +19,7 @@ export async function loadLogsForRange(
   start: number,
   end: number,
   anchorBlockNumber: BlockNumber,
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
 ): Promise<Array<{ log: TxScopedL2Log; taggingIndex: number }>> {
   // Derive tags for the window
   const preTags: PreTag[] = Array(end - start)

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -2,7 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 import { TxExecutionResult, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx';
@@ -13,7 +13,7 @@ import { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_s
 import { DirectionalAppTaggingSecret, SiloedTag, Tag, UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN } from '../index.js';
 import { syncSenderTaggingIndexes } from './sync_sender_tagging_indexes.js';
 
-const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
+const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
 
 describe('syncSenderTaggingIndexes', () => {
   // Contract address and secret to be used on the input of the syncSenderTaggingIndexes function.

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.ts
@@ -1,5 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { DirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
 
@@ -27,7 +27,7 @@ export async function syncSenderTaggingIndexes(
   app: AztecAddress,
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
   jobId: string,
 ): Promise<void> {
   // # Explanation of how syncing works

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
 import { randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
@@ -12,7 +12,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { SenderTaggingStore } from '../../../storage/tagging_store/sender_tagging_store.js';
 import { loadAndStoreNewTaggingIndexes } from './load_and_store_new_tagging_indexes.js';
 
-const MOCK_ANCHOR_BLOCK_HASH = L2BlockHash.random();
+const MOCK_ANCHOR_BLOCK_HASH = BlockHash.random();
 
 describe('loadAndStoreNewTaggingIndexes', () => {
   // App contract address and secret to be used on the input of the loadAndStoreNewTaggingIndexes function.

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -1,5 +1,5 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { L2BlockHash } from '@aztec/stdlib/block';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import type { DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 import { SiloedTag, Tag } from '@aztec/stdlib/logs';
@@ -29,7 +29,7 @@ export async function loadAndStoreNewTaggingIndexes(
   end: number,
   aztecNode: AztecNode,
   taggingStore: SenderTaggingStore,
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
   jobId: string,
 ) {
   // We compute the tags for the current window of indexes
@@ -55,7 +55,7 @@ export async function loadAndStoreNewTaggingIndexes(
 async function getTxsContainingTags(
   tags: SiloedTag[],
   aztecNode: AztecNode,
-  anchorBlockHash: L2BlockHash,
+  anchorBlockHash: BlockHash,
 ): Promise<TxHash[][]> {
   // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
   // pagination here.

--- a/yarn-project/stdlib/src/block/block_hash.test.ts
+++ b/yarn-project/stdlib/src/block/block_hash.test.ts
@@ -1,23 +1,23 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 
-import { L2BlockHash } from './block_hash.js';
+import { BlockHash } from './block_hash.js';
 
-describe('L2BlockHash', () => {
+describe('BlockHash', () => {
   describe('isL2BlockHash', () => {
-    it('returns true for L2BlockHash instances', () => {
-      const hash = L2BlockHash.random();
-      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    it('returns true for BlockHash instances', () => {
+      const hash = BlockHash.random();
+      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
     });
 
-    it('returns true for L2BlockHash created from field', () => {
-      const hash = L2BlockHash.fromField(Fr.random());
-      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    it('returns true for BlockHash created from field', () => {
+      const hash = BlockHash.fromField(Fr.random());
+      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
     });
 
-    it('returns true for L2BlockHash created from buffer', () => {
-      const hash = L2BlockHash.fromBuffer(Buffer.alloc(32, 1));
-      expect(L2BlockHash.isL2BlockHash(hash)).toBe(true);
+    it('returns true for BlockHash created from buffer', () => {
+      const hash = BlockHash.fromBuffer(Buffer.alloc(32, 1));
+      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
     });
 
     it('returns true for duck-typed Buffer32-like objects with 32-byte buffer', () => {
@@ -26,42 +26,42 @@ describe('L2BlockHash', () => {
         buffer: Buffer.alloc(32, 0xab),
         toBuffer: () => Buffer.alloc(32, 0xab),
       };
-      expect(L2BlockHash.isL2BlockHash(fakeHash)).toBe(true);
+      expect(BlockHash.isL2BlockHash(fakeHash)).toBe(true);
     });
 
     it('returns false for plain numbers', () => {
-      expect(L2BlockHash.isL2BlockHash(0)).toBe(false);
-      expect(L2BlockHash.isL2BlockHash(123)).toBe(false);
-      expect(L2BlockHash.isL2BlockHash(-1)).toBe(false);
+      expect(BlockHash.isL2BlockHash(0)).toBe(false);
+      expect(BlockHash.isL2BlockHash(123)).toBe(false);
+      expect(BlockHash.isL2BlockHash(-1)).toBe(false);
     });
 
     it('returns false for strings', () => {
-      expect(L2BlockHash.isL2BlockHash('latest')).toBe(false);
-      expect(L2BlockHash.isL2BlockHash('0x1234')).toBe(false);
+      expect(BlockHash.isL2BlockHash('latest')).toBe(false);
+      expect(BlockHash.isL2BlockHash('0x1234')).toBe(false);
     });
 
     it('returns false for null and undefined', () => {
-      expect(L2BlockHash.isL2BlockHash(null)).toBe(false);
-      expect(L2BlockHash.isL2BlockHash(undefined)).toBe(false);
+      expect(BlockHash.isL2BlockHash(null)).toBe(false);
+      expect(BlockHash.isL2BlockHash(undefined)).toBe(false);
     });
 
     it('returns false for objects without buffer property', () => {
-      expect(L2BlockHash.isL2BlockHash({})).toBe(false);
-      expect(L2BlockHash.isL2BlockHash({ toBuffer: () => Buffer.alloc(32) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({})).toBe(false);
+      expect(BlockHash.isL2BlockHash({ toBuffer: () => Buffer.alloc(32) })).toBe(false);
     });
 
     it('returns false for objects with non-Buffer buffer property', () => {
-      expect(L2BlockHash.isL2BlockHash({ buffer: 'not a buffer', toBuffer: () => Buffer.alloc(32) })).toBe(false);
-      expect(L2BlockHash.isL2BlockHash({ buffer: [1, 2, 3], toBuffer: () => Buffer.alloc(32) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({ buffer: 'not a buffer', toBuffer: () => Buffer.alloc(32) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({ buffer: [1, 2, 3], toBuffer: () => Buffer.alloc(32) })).toBe(false);
     });
 
     it('returns false for objects with wrong buffer length', () => {
-      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(16), toBuffer: () => Buffer.alloc(16) })).toBe(false);
-      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(64), toBuffer: () => Buffer.alloc(64) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(16), toBuffer: () => Buffer.alloc(16) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(64), toBuffer: () => Buffer.alloc(64) })).toBe(false);
     });
 
     it('returns false for objects without toBuffer method', () => {
-      expect(L2BlockHash.isL2BlockHash({ buffer: Buffer.alloc(32) })).toBe(false);
+      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(32) })).toBe(false);
     });
 
     it('returns false for plain Buffer32 instances when checking type strictly', () => {
@@ -70,7 +70,7 @@ describe('L2BlockHash', () => {
       const buf32 = Buffer32.random();
       // Buffer32 has the same structure, so duck typing will return true
       // This is expected behavior - we want to handle Buffer32-like objects
-      expect(L2BlockHash.isL2BlockHash(buf32)).toBe(true);
+      expect(BlockHash.isL2BlockHash(buf32)).toBe(true);
     });
   });
 });

--- a/yarn-project/stdlib/src/block/block_hash.ts
+++ b/yarn-project/stdlib/src/block/block_hash.ts
@@ -5,7 +5,7 @@ import { BufferReader } from '@aztec/foundation/serialize';
 import { schemas } from '../schemas/schemas.js';
 
 /** Hash of an L2 block. */
-export class L2BlockHash extends Buffer32 {
+export class BlockHash extends Buffer32 {
   constructor(
     /** The buffer containing the hash. */
     hash: Buffer,
@@ -14,12 +14,12 @@ export class L2BlockHash extends Buffer32 {
   }
 
   /**
-   * Type guard that checks if a value is an L2BlockHash instance.
+   * Type guard that checks if a value is an BlockHash instance.
    * Uses duck typing to handle cases where instanceof fails due to module duplication.
    * Checks for Buffer32-like structure with a 32-byte buffer.
    */
-  static isL2BlockHash(value: unknown): value is L2BlockHash {
-    if (value instanceof L2BlockHash) {
+  static isL2BlockHash(value: unknown): value is BlockHash {
+    if (value instanceof BlockHash) {
       return true;
     }
     // Duck typing fallback: check if it looks like a Buffer32 with a 32-byte buffer
@@ -36,32 +36,32 @@ export class L2BlockHash extends Buffer32 {
   }
 
   static override random() {
-    return new L2BlockHash(Fr.random().toBuffer());
+    return new BlockHash(Fr.random().toBuffer());
   }
 
-  static override fromNumber(num: number): L2BlockHash {
-    return new L2BlockHash(super.fromNumber(num).toBuffer());
+  static override fromNumber(num: number): BlockHash {
+    return new BlockHash(super.fromNumber(num).toBuffer());
   }
 
   static override fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
-    return new L2BlockHash(reader.readBytes(L2BlockHash.SIZE));
+    return new BlockHash(reader.readBytes(BlockHash.SIZE));
   }
 
-  static override fromString(str: string): L2BlockHash {
-    return new L2BlockHash(super.fromString(str).toBuffer());
+  static override fromString(str: string): BlockHash {
+    return new BlockHash(super.fromString(str).toBuffer());
   }
 
   static get schema() {
-    return schemas.BufferHex.transform(value => new L2BlockHash(value));
+    return schemas.BufferHex.transform(value => new BlockHash(value));
   }
 
   static zero() {
-    return new L2BlockHash(Buffer32.ZERO.toBuffer());
+    return new BlockHash(Buffer32.ZERO.toBuffer());
   }
 
   static override fromField(hash: Fr) {
-    return new L2BlockHash(hash.toBuffer());
+    return new BlockHash(hash.toBuffer());
   }
 
   toField(): Fr {

--- a/yarn-project/stdlib/src/block/block_parameter.ts
+++ b/yarn-project/stdlib/src/block/block_parameter.ts
@@ -2,9 +2,9 @@ import { BlockNumberSchema } from '@aztec/foundation/branded-types';
 
 import { z } from 'zod';
 
-import { L2BlockHash } from './block_hash.js';
+import { BlockHash } from './block_hash.js';
 
-export const BlockParameterSchema = z.union([L2BlockHash.schema, BlockNumberSchema, z.literal('latest')]);
+export const BlockParameterSchema = z.union([BlockHash.schema, BlockNumberSchema, z.literal('latest')]);
 
-/** Block parameter - either a specific BlockNumber, block hash (L2BlockHash), or 'latest' */
+/** Block parameter - either a specific BlockNumber, block hash (BlockHash), or 'latest' */
 export type BlockParameter = z.infer<typeof BlockParameterSchema>;

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -2,12 +2,12 @@ import { BlockNumber, BlockNumberSchema } from '@aztec/foundation/branded-types'
 
 import { type ZodTypeAny, z } from 'zod';
 
-import { L2BlockHash } from './block_hash.js';
+import { BlockHash } from './block_hash.js';
 import type { L2Block } from './l2_block.js';
 
 export type InBlock = {
   l2BlockNumber: BlockNumber;
-  l2BlockHash: L2BlockHash;
+  l2BlockHash: BlockHash;
 };
 
 // Note: If you expand this type with indexInBlock, then delete `IndexedTxEffect` and use this type instead.
@@ -18,7 +18,7 @@ export type DataInBlock<T> = {
 export function randomInBlock(): InBlock {
   return {
     l2BlockNumber: BlockNumber(Math.floor(Math.random() * 1000)),
-    l2BlockHash: L2BlockHash.random(),
+    l2BlockHash: BlockHash.random(),
   };
 }
 
@@ -33,14 +33,14 @@ export async function wrapDataInBlock<T>(data: T, block: L2Block): Promise<DataI
   return {
     data,
     l2BlockNumber: block.number,
-    l2BlockHash: L2BlockHash.fromField(await block.hash()),
+    l2BlockHash: BlockHash.fromField(await block.hash()),
   };
 }
 
 export function inBlockSchema() {
   return z.object({
     l2BlockNumber: BlockNumberSchema,
-    l2BlockHash: L2BlockHash.schema,
+    l2BlockHash: BlockHash.schema,
   });
 }
 

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -8,7 +8,7 @@ import times from 'lodash.times';
 
 import type { PublishedCheckpoint } from '../../checkpoint/published_checkpoint.js';
 import type { BlockHeader } from '../../tx/block_header.js';
-import { L2BlockHash } from '../block_hash.js';
+import { BlockHash } from '../block_hash.js';
 import type { CheckpointedL2Block } from '../checkpointed_l2_block.js';
 import type { L2Block } from '../l2_block.js';
 import { GENESIS_CHECKPOINT_HEADER_HASH, type L2BlockId, type L2BlockSource, type L2Tips } from '../l2_block_source.js';
@@ -47,7 +47,7 @@ describe('L2BlockStream', () => {
     }) as CheckpointedL2Block;
 
   const makeHeader = (number: number) =>
-    ({ hash: () => Promise.resolve(L2BlockHash.fromField(new Fr(number))) }) as BlockHeader;
+    ({ hash: () => Promise.resolve(BlockHash.fromField(new Fr(number))) }) as BlockHeader;
 
   const makeBlockId = (number: number): L2BlockId => ({ number: BlockNumber(number), hash: makeHash(number) });
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -10,7 +10,7 @@ import type { ContractArtifact } from '../abi/abi.js';
 import { FunctionSelector } from '../abi/function_selector.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import { CheckpointedL2Block } from '../block/checkpointed_l2_block.js';
-import { CommitteeAttestation, L2Block, L2BlockHash } from '../block/index.js';
+import { BlockHash, CommitteeAttestation, L2Block } from '../block/index.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import type { ValidateCheckpointResult } from '../block/validate_block_result.js';
 import { Checkpoint } from '../checkpoint/checkpoint.js';
@@ -466,7 +466,7 @@ class MockArchiver implements ArchiverApi {
     expect(_txHash).toBeInstanceOf(TxHash);
     return {
       l2BlockNumber: BlockNumber(1),
-      l2BlockHash: L2BlockHash.fromNumber(0x12),
+      l2BlockHash: BlockHash.fromNumber(0x12),
       data: await TxEffect.random(),
       txIndexInBlock: randomInt(10),
     };

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -22,7 +22,7 @@ import times from 'lodash.times';
 import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import type { DataInBlock } from '../block/in_block.js';
-import { type BlockParameter, CommitteeAttestation, L2Block, L2BlockHash } from '../block/index.js';
+import { BlockHash, type BlockParameter, CommitteeAttestation, L2Block } from '../block/index.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import { Checkpoint } from '../checkpoint/checkpoint.js';
 import { L1PublishedData, PublishedCheckpoint } from '../checkpoint/published_checkpoint.js';
@@ -110,7 +110,7 @@ describe('AztecNodeApiSchema', () => {
       Fr.random(),
     ]);
     expect(response).toEqual([
-      { data: 1n, l2BlockNumber: 1, l2BlockHash: L2BlockHash.fromNumber(BlockNumber(1)) },
+      { data: 1n, l2BlockNumber: 1, l2BlockHash: BlockHash.fromNumber(BlockNumber(1)) },
       undefined,
     ]);
 
@@ -204,7 +204,7 @@ describe('AztecNodeApiSchema', () => {
   });
 
   it('getBlockHeader', async () => {
-    const response = await context.client.getBlockHeader(L2BlockHash.fromField(Fr.random()));
+    const response = await context.client.getBlockHeader(BlockHash.fromField(Fr.random()));
     expect(response).toBeInstanceOf(BlockHeader);
   });
 
@@ -571,7 +571,7 @@ class MockAztecNode implements AztecNode {
     expect(leafValues[0]).toBeInstanceOf(Fr);
     expect(leafValues[1]).toBeInstanceOf(Fr);
     return Promise.resolve([
-      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: L2BlockHash.fromNumber(BlockNumber(1)) },
+      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.fromNumber(BlockNumber(1)) },
       undefined,
     ]);
   }
@@ -784,7 +784,7 @@ class MockAztecNode implements AztecNode {
     expect(txHash).toBeInstanceOf(TxHash);
     return {
       l2BlockNumber: BlockNumber(1),
-      l2BlockHash: L2BlockHash.fromNumber(0x12),
+      l2BlockHash: BlockHash.fromNumber(0x12),
       data: await TxEffect.random(),
       txIndexInBlock: randomInt(10),
     };

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -23,7 +23,7 @@ import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 import { z } from 'zod';
 
 import type { AztecAddress } from '../aztec-address/index.js';
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { type BlockParameter, BlockParameterSchema } from '../block/block_parameter.js';
 import { CheckpointedL2Block } from '../block/checkpointed_l2_block.js';
 import { type DataInBlock, dataInBlockSchemaFor } from '../block/in_block.js';
@@ -355,7 +355,7 @@ export interface AztecNode
    * @returns An array of log arrays, one per tag. Returns at most 10 logs per tag per page. If 10 logs are returned
    * for a tag, the caller should fetch the next page to check for more logs.
    */
-  getPrivateLogsByTags(tags: SiloedTag[], page?: number, referenceBlock?: L2BlockHash): Promise<TxScopedL2Log[][]>;
+  getPrivateLogsByTags(tags: SiloedTag[], page?: number, referenceBlock?: BlockHash): Promise<TxScopedL2Log[][]>;
 
   /**
    * Gets public logs that match any of the `tags` from the specified contract. For each tag, an array of matching
@@ -374,7 +374,7 @@ export interface AztecNode
     contractAddress: AztecAddress,
     tags: Tag[],
     page?: number,
-    referenceBlock?: L2BlockHash,
+    referenceBlock?: BlockHash,
   ): Promise<TxScopedL2Log[][]>;
 
   /**
@@ -633,7 +633,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getPrivateLogsByTags: z
     .function()
-    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)), optional(L2BlockHash.schema))
+    .args(z.array(SiloedTag.schema).max(MAX_RPC_LEN), optional(z.number().gte(0)), optional(BlockHash.schema))
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 
   getPublicLogsByTagsFromContract: z
@@ -642,7 +642,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
       schemas.AztecAddress,
       z.array(Tag.schema).max(MAX_RPC_LEN),
       optional(z.number().gte(0)),
-      optional(L2BlockHash.schema),
+      optional(BlockHash.schema),
     )
     .returns(z.array(z.array(TxScopedL2Log.schema))),
 

--- a/yarn-project/stdlib/src/logs/log_id.ts
+++ b/yarn-project/stdlib/src/logs/log_id.ts
@@ -5,7 +5,7 @@ import { BufferReader } from '@aztec/foundation/serialize';
 
 import { z } from 'zod';
 
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { schemas } from '../schemas/index.js';
 
 /** A globally unique log id. */
@@ -20,7 +20,7 @@ export class LogId {
     /** The block number the log was emitted in. */
     public readonly blockNumber: BlockNumber,
     /** The hash of the block the log was emitted in. */
-    public readonly blockHash: L2BlockHash,
+    public readonly blockHash: BlockHash,
     /** The index of a tx in a block the log was emitted in. */
     public readonly txIndex: number,
     /** The index of a log the tx was emitted in. */
@@ -40,7 +40,7 @@ export class LogId {
   static random() {
     return new LogId(
       BlockNumber(Math.floor(Math.random() * 1000) + 1),
-      L2BlockHash.random(),
+      BlockHash.random(),
       Math.floor(Math.random() * 1000),
       Math.floor(Math.random() * 100),
     );
@@ -50,7 +50,7 @@ export class LogId {
     return z
       .object({
         blockNumber: BlockNumberSchema,
-        blockHash: L2BlockHash.schema,
+        blockHash: BlockHash.schema,
         txIndex: schemas.Integer,
         logIndex: schemas.Integer,
       })
@@ -81,7 +81,7 @@ export class LogId {
     const reader = BufferReader.asReader(buffer);
 
     const blockNumber = BlockNumber(reader.readNumber());
-    const blockHash = reader.readObject(L2BlockHash);
+    const blockHash = reader.readObject(BlockHash);
     const txIndex = reader.readNumber();
     const logIndex = reader.readNumber();
 
@@ -104,7 +104,7 @@ export class LogId {
   static fromString(data: string): LogId {
     const [rawBlockNumber, rawTxIndex, rawLogIndex, rawBlockHash] = data.split('-');
     const blockNumber = BlockNumber(Number(rawBlockNumber));
-    const blockHash = L2BlockHash.fromString(rawBlockHash);
+    const blockHash = BlockHash.fromString(rawBlockHash);
     const txIndex = Number(rawTxIndex);
     const logIndex = Number(rawLogIndex);
 

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -11,14 +11,14 @@ import type { FieldsOf } from '@aztec/foundation/types';
 import { inspect } from 'util';
 import { z } from 'zod';
 
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { GlobalVariables } from './global_variables.js';
 import { StateReference } from './state_reference.js';
 
 /** A header of an L2 block. */
 export class BlockHeader {
-  private _cachedHash?: Promise<L2BlockHash>;
+  private _cachedHash?: Promise<BlockHash>;
 
   constructor(
     /** Snapshot of archive before the block is applied. */
@@ -162,10 +162,10 @@ export class BlockHeader {
     return BlockHeader.fromBuffer(hexToBuffer(str));
   }
 
-  hash(): Promise<L2BlockHash> {
+  hash(): Promise<BlockHash> {
     if (!this._cachedHash) {
       this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HASH).then(fr =>
-        L2BlockHash.fromField(fr),
+        BlockHash.fromField(fr),
       );
     }
     return this._cachedHash;
@@ -173,7 +173,7 @@ export class BlockHeader {
 
   /** Manually set the hash for this block header if already computed */
   setHash(hashed: Fr) {
-    this._cachedHash = Promise.resolve(L2BlockHash.fromField(hashed));
+    this._cachedHash = Promise.resolve(BlockHash.fromField(hashed));
   }
 
   static random(overrides: Partial<FieldsOf<BlockHeader>> & Partial<FieldsOf<GlobalVariables>> = {}): BlockHeader {

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -2,7 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { type DataInBlock, dataInBlockSchemaFor, randomDataInBlock } from '../block/in_block.js';
 import { TxEffect } from './tx_effect.js';
 
@@ -26,7 +26,7 @@ export function serializeIndexedTxEffect(effect: IndexedTxEffect): Buffer {
 export function deserializeIndexedTxEffect(buffer: Buffer): IndexedTxEffect {
   const reader = BufferReader.asReader(buffer);
 
-  const l2BlockHash = reader.readObject(L2BlockHash);
+  const l2BlockHash = reader.readObject(BlockHash);
   const l2BlockNumber = BlockNumber(reader.readNumber());
   const txIndexInBlock = reader.readNumber();
   const data = reader.readObject(TxEffect);

--- a/yarn-project/stdlib/src/tx/tx_receipt.test.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.test.ts
@@ -1,7 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { TxHash } from './tx_hash.js';
 import { TxExecutionResult, TxReceipt, TxStatus } from './tx_receipt.js';
 
@@ -13,7 +13,7 @@ describe('TxReceipt', () => {
       TxExecutionResult.SUCCESS,
       'error',
       1n,
-      L2BlockHash.random(),
+      BlockHash.random(),
       BlockNumber(1),
     );
 

--- a/yarn-project/stdlib/src/tx/tx_receipt.ts
+++ b/yarn-project/stdlib/src/tx/tx_receipt.ts
@@ -3,7 +3,7 @@ import { BlockNumber, BlockNumberSchema } from '@aztec/foundation/branded-types'
 import { z } from 'zod';
 
 import { RevertCode } from '../avm/revert_code.js';
-import { L2BlockHash } from '../block/block_hash.js';
+import { BlockHash } from '../block/block_hash.js';
 import { type ZodFor, schemas } from '../schemas/schemas.js';
 import { TxHash } from './tx_hash.js';
 
@@ -54,7 +54,7 @@ export class TxReceipt {
     /** The transaction fee paid for the transaction. */
     public transactionFee?: bigint,
     /** The hash of the block containing the transaction. */
-    public blockHash?: L2BlockHash,
+    public blockHash?: BlockHash,
     /** The block number in which the transaction was included. */
     public blockNumber?: BlockNumber,
   ) {}
@@ -100,7 +100,7 @@ export class TxReceipt {
         status: z.nativeEnum(TxStatus),
         executionResult: z.nativeEnum(TxExecutionResult).optional(),
         error: z.string().optional(),
-        blockHash: L2BlockHash.schema.optional(),
+        blockHash: BlockHash.schema.optional(),
         blockNumber: BlockNumberSchema.optional(),
         transactionFee: schemas.BigInt.optional(),
       })
@@ -113,7 +113,7 @@ export class TxReceipt {
     executionResult?: TxExecutionResult;
     error?: string;
     transactionFee?: bigint;
-    blockHash?: L2BlockHash;
+    blockHash?: BlockHash;
     blockNumber?: BlockNumber;
   }) {
     return new TxReceipt(

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -10,7 +10,7 @@ import {
 } from '@aztec/pxe/simulator';
 import { type ContractArtifact, EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 
 import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfaces.js';
 import type { TXESessionStateHandler } from './txe_session.js';
@@ -351,7 +351,7 @@ export class RPCTranslator {
     foreignStartStorageSlot: ForeignCallSingle,
     foreignNumberOfElements: ForeignCallSingle,
   ) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const contractAddress = addressFromSingle(foreignContractAddress);
     const startStorageSlot = fromSingle(foreignStartStorageSlot);
     const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
@@ -367,7 +367,7 @@ export class RPCTranslator {
   }
 
   async utilityGetPublicDataWitness(foreignBlockHash: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const leafSlot = fromSingle(foreignLeafSlot);
 
     const witness = await this.handlerAsUtility().utilityGetPublicDataWitness(blockHash, leafSlot);
@@ -574,7 +574,7 @@ export class RPCTranslator {
   }
 
   async utilityGetNullifierMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignNullifier: ForeignCallSingle) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const nullifier = fromSingle(foreignNullifier);
 
     const witness = await this.handlerAsUtility().utilityGetNullifierMembershipWitness(blockHash, nullifier);
@@ -642,7 +642,7 @@ export class RPCTranslator {
   }
 
   async utilityGetNoteHashMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignLeafValue: ForeignCallSingle) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const leafValue = fromSingle(foreignLeafValue);
 
     const witness = await this.handlerAsUtility().utilityGetNoteHashMembershipWitness(blockHash, leafValue);
@@ -654,7 +654,7 @@ export class RPCTranslator {
   }
 
   async utilityGetArchiveMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignLeafValue: ForeignCallSingle) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const leafValue = fromSingle(foreignLeafValue);
 
     const witness = await this.handlerAsUtility().utilityGetArchiveMembershipWitness(blockHash, leafValue);
@@ -669,7 +669,7 @@ export class RPCTranslator {
     foreignBlockHash: ForeignCallSingle,
     foreignNullifier: ForeignCallSingle,
   ) {
-    const blockHash = L2BlockHash.fromString(foreignBlockHash);
+    const blockHash = BlockHash.fromString(foreignBlockHash);
     const nullifier = fromSingle(foreignNullifier);
 
     const witness = await this.handlerAsUtility().utilityGetLowNullifierMembershipWitness(blockHash, nullifier);

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.test.ts
@@ -6,7 +6,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 import { PXE, type PackedPrivateEvent } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -55,7 +55,7 @@ describe('BaseWallet', () => {
   function privateEventFor(serial: Fr[]): PackedPrivateEvent {
     return {
       packedEvent: serial,
-      l2BlockHash: L2BlockHash.random(),
+      l2BlockHash: BlockHash.random(),
       l2BlockNumber: BlockNumber(42),
       txHash: TxHash.random(),
       eventSelector: TokenContract.events.Transfer.eventSelector,

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -3,7 +3,7 @@ import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { L2Block, L2BlockHash, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
+import { BlockHash, L2Block, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
@@ -56,7 +56,7 @@ describe('ServerWorldStateSynchronizer', () => {
 
     merkleTreeRead = mock<MerkleTreeReadOperations>();
     merkleTreeRead.getInitialHeader.mockReturnValue({
-      hash: () => Promise.resolve(L2BlockHash.fromField(Fr.random())),
+      hash: () => Promise.resolve(BlockHash.fromField(Fr.random())),
     } as BlockHeader);
     merkleTreeRead.getLeafValue.mockResolvedValue(Fr.random());
 

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -6,7 +6,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
-import { L2BlockHash } from '@aztec/stdlib/block';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -95,7 +95,7 @@ describe('world-state integration', () => {
 
   const expectSynchedBlockHashMatches = async (number: number) => {
     const syncedBlockHashFr = await db.getCommitted().getLeafValue(MerkleTreeId.ARCHIVE, BigInt(number));
-    const syncedBlockHash = syncedBlockHashFr ? L2BlockHash.fromField(syncedBlockHashFr) : undefined;
+    const syncedBlockHash = syncedBlockHashFr ? BlockHash.fromField(syncedBlockHashFr) : undefined;
     const archiverBlockHash = await archiver.getBlockHeader(number).then(h => h?.hash());
     expect(syncedBlockHash).toEqual(archiverBlockHash);
   };


### PR DESCRIPTION
We had an `L2BlockHash` defined in `block_hash.ts` and it was returned from the `hash` function of `BlockHeader`. I didn't like the inconsistency so I decided to just drop "L2" from the class name.

Yesterday I merged a [PR](https://github.com/AztecProtocol/aztec-packages/pull/19899) that touched a lot of this so this might be quite a convenient time to do this (conflicts-wise).

I just globally replaced the "L2BlockHash" string with "BlockHash" so checking this in-depth is not really needed.