### PR TITLE
feat: support JSON input files for bb verify command (v2)

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -47,10 +47,10 @@ function run_proof_generation {
   dump_fail "$prove_cmd"
 
   # Extract fields from JSON output (already hex-encoded with 0x prefix)
-  local vk_fields=$(jq -c '.fields' "$outdir/vk.json")
-  local vk_hash_field=$(jq -c '.vk_hash' "$outdir/vk.json")
-  local public_inputs_fields=$(jq -c '.fields' "$outdir/public_inputs.json")
-  local proof_fields=$(jq -c '.fields' "$outdir/proof.json")
+  local vk_fields=$(jq -c '.vk' "$outdir/vk.json")
+  local vk_hash_field=$(jq -c '.hash' "$outdir/vk.json")
+  local public_inputs_fields=$(jq -c '.public_inputs' "$outdir/public_inputs.json")
+  local proof_fields=$(jq -c '.proof' "$outdir/proof.json")
 
   generate_toml "$program" "$vk_fields" "$vk_hash_field" "$proof_fields" "$public_inputs_fields"
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -39,7 +39,8 @@ void write_chonk_vk(std::vector<uint8_t> bytecode, const std::filesystem::path& 
     if (is_stdout) {
         write_bytes_to_stdout(response.bytes);
     } else if (flags.output_format == "json") {
-        std::string json_content = build_json_output(response.fields, "vk", flags);
+        // Note: Chonk VK doesn't have a hash, so we pass an empty string
+        std::string json_content = VkJson::build(response.fields, "", flags.scheme);
         write_file(output_path / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
         info("VK (JSON) saved to ", output_path / "vk.json");
     } else {
@@ -80,7 +81,8 @@ void ChonkAPI::prove(const Flags& flags,
             write_bytes_to_stdout(to_buffer(proof_fields));
         } else if (flags.output_format == "json") {
             vinfo("writing Chonk proof (JSON) in directory ", output_dir);
-            std::string json_content = build_json_output(proof_fields, "proof", flags);
+            // Note: Chonk proof doesn't have a vk_hash, so we pass an empty string
+            std::string json_content = ProofJson::build(proof_fields, "", flags.scheme);
             write_file(output_dir / "proof.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
             info("Proof (JSON) saved to ", output_dir / "proof.json");
         } else {

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -27,7 +27,7 @@ void write_vk_outputs(const bbapi::CircuitComputeVk::Response& vk_response,
 {
     if (flags.output_format == "json") {
         std::string json_content =
-            build_json_output(vk_response.fields, "vk", flags, bytes_to_hex_string(vk_response.hash));
+            VkJson::build(vk_response.fields, bytes_to_hex_string(vk_response.hash), flags.scheme);
         write_file(output_dir / "vk.json", std::vector<uint8_t>(json_content.begin(), json_content.end()));
         info("VK (JSON) saved to ", output_dir / "vk.json");
     } else {
@@ -44,11 +44,11 @@ void write_proof_outputs(const bbapi::CircuitProve::Response& prove_response,
 {
     if (flags.output_format == "json") {
         std::string vk_hash = bytes_to_hex_string(prove_response.vk.hash);
-        std::string proof_json = build_json_output(prove_response.proof, "proof", flags, vk_hash);
+        std::string proof_json = ProofJson::build(prove_response.proof, vk_hash, flags.scheme);
         write_file(output_dir / "proof.json", std::vector<uint8_t>(proof_json.begin(), proof_json.end()));
         info("Proof (JSON) saved to ", output_dir / "proof.json");
 
-        std::string pi_json = build_json_output(prove_response.public_inputs, "public_inputs", flags);
+        std::string pi_json = PublicInputsJson::build(prove_response.public_inputs, flags.scheme);
         write_file(output_dir / "public_inputs.json", std::vector<uint8_t>(pi_json.begin(), pi_json.end()));
         info("Public inputs (JSON) saved to ", output_dir / "public_inputs.json");
     } else {
@@ -119,10 +119,32 @@ bool UltraHonkAPI::verify(const Flags& flags,
                           const std::filesystem::path& vk_path)
 {
     BB_BENCH_NAME("UltraHonkAPI::verify");
-    // Read input files
-    auto public_inputs = many_from_buffer<uint256_t>(read_file(public_inputs_path));
-    auto proof = many_from_buffer<uint256_t>(read_file(proof_path));
-    auto vk_bytes = read_vk_file(vk_path);
+
+    // Read and parse input files (auto-detect JSON vs binary format)
+    std::vector<uint256_t> public_inputs;
+    std::vector<uint256_t> proof;
+    std::vector<uint8_t> vk_bytes;
+
+    auto public_inputs_content = read_file(public_inputs_path);
+    if (auto json = try_parse_json(public_inputs_content)) {
+        public_inputs = PublicInputsJson::parse(*json);
+    } else {
+        public_inputs = many_from_buffer<uint256_t>(public_inputs_content);
+    }
+
+    auto proof_content = read_file(proof_path);
+    if (auto json = try_parse_json(proof_content)) {
+        proof = ProofJson::parse(*json);
+    } else {
+        proof = many_from_buffer<uint256_t>(proof_content);
+    }
+
+    auto vk_content = read_file(vk_path);
+    if (auto json = try_parse_json(vk_content)) {
+        vk_bytes = VkJson::parse_to_bytes(*json);
+    } else {
+        vk_bytes = std::move(vk_content);
+    }
 
     // Convert flags to ProofSystemSettings
     bbapi::ProofSystemSettings settings{ .ipa_accumulation = flags.ipa_accumulation,

--- a/barretenberg/cpp/src/barretenberg/api/json_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/json_output.hpp
@@ -1,13 +1,26 @@
 #pragma once
 
 #include "barretenberg/api/api.hpp"
+#include "barretenberg/common/throw_or_abort.hpp"
 #include "barretenberg/common/version.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/serialize/msgpack.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
+
+// nlohmann/json has sign-conversion warnings that fail with -Werror in WASM builds
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#endif
+#include <nlohmann/json.hpp>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 namespace bb {
 
@@ -25,59 +38,195 @@ inline std::string bytes_to_hex_string(const std::vector<uint8_t>& bytes)
 }
 
 /**
- * @brief Serializable structure for JSON output (msgpack-compatible)
+ * @brief Try to parse file content as JSON
+ *
+ * @details Attempts to parse the content as JSON.
+ * Returns nullopt if parsing fails, allowing fallback to binary format.
  */
-struct JsonOutput {
-    std::vector<std::string> fields;
-    std::string vk_hash;   // Only for VK and proof (hash of VK the proof targets)
-    std::string file_kind; // "vk", "proof", or "public_inputs"
+inline std::optional<nlohmann::json> try_parse_json(const std::vector<uint8_t>& content)
+{
+    // Quick check: JSON objects must start with '{' (after whitespace)
+    for (const auto& byte : content) {
+        if (std::isspace(static_cast<unsigned char>(byte)) != 0) {
+            continue;
+        }
+        if (byte != '{') {
+            return std::nullopt;
+        }
+        break;
+    }
+
+    // Try to parse as JSON
+    try {
+        std::string str(content.begin(), content.end());
+        return nlohmann::json::parse(str);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+/**
+ * @brief Parse a hex string (with or without 0x prefix) to uint256_t
+ */
+inline uint256_t hex_string_to_uint256(const std::string& hex_str)
+{
+    std::string str = hex_str;
+    // Remove 0x prefix if present
+    if (str.size() >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')) {
+        str = str.substr(2);
+    }
+    // Pad to 64 characters (32 bytes) if needed
+    if (str.size() < 64) {
+        str.insert(0, 64 - str.size(), '0');
+    }
+    return uint256_t(str);
+}
+
+/**
+ * @brief Serializable structure for VK JSON output (msgpack-compatible)
+ */
+struct VkJson {
+    std::vector<std::string> vk;
+    std::string hash;
     std::string bb_version;
     std::string scheme;
-    std::string verifier_target; // Optional
 
-    MSGPACK_FIELDS(fields, vk_hash, file_kind, bb_version, scheme, verifier_target);
+    MSGPACK_FIELDS(vk, hash, bb_version, scheme);
+
+    template <typename T>
+    static std::string build(const std::vector<T>& fields, const std::string& hash, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        VkJson output{ .vk = std::move(hex_fields), .hash = hash, .bb_version = BB_VERSION, .scheme = scheme };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+        std::stringstream ss;
+        ss << oh.get();
+        return ss.str();
+    }
+
+    static std::vector<uint8_t> parse_to_bytes(const nlohmann::json& json)
+    {
+        if (!json.contains("vk") || !json["vk"].is_array()) {
+            throw_or_abort("JSON missing 'vk' array");
+        }
+        std::vector<uint8_t> result;
+        result.reserve(json["vk"].size() * 32);
+        for (const auto& field : json["vk"]) {
+            auto value = hex_string_to_uint256(field.get<std::string>());
+            for (int i = 3; i >= 0; --i) {
+                uint64_t limb = value.data[i];
+                for (int j = 7; j >= 0; --j) {
+                    result.push_back(static_cast<uint8_t>((limb >> (j * 8)) & 0xFF));
+                }
+            }
+        }
+        return result;
+    }
 };
 
 /**
- * @brief Build JSON output string using msgpack serialization
- *
- * @tparam T Field element type (must have operator<< that outputs 0x-prefixed hex)
- * @param fields Vector of field elements to serialize
- * @param file_kind Type identifier: "vk", "proof", or "public_inputs"
- * @param flags API flags containing scheme and verifier_target
- * @param vk_hash Optional hash string for VK or proof files
- * @return JSON string
+ * @brief Serializable structure for proof JSON output (msgpack-compatible)
  */
-template <typename T>
-std::string build_json_output(const std::vector<T>& fields,
-                              const std::string& file_kind,
-                              const API::Flags& flags,
-                              const std::string& vk_hash = "")
-{
-    std::vector<std::string> hex_fields;
-    hex_fields.reserve(fields.size());
-    for (const auto& field : fields) {
+struct ProofJson {
+    std::vector<std::string> proof;
+    std::string vk_hash;
+    std::string bb_version;
+    std::string scheme;
+
+    MSGPACK_FIELDS(proof, vk_hash, bb_version, scheme);
+
+    template <typename T>
+    static std::string build(const std::vector<T>& fields, const std::string& vk_hash, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        ProofJson output{
+            .proof = std::move(hex_fields), .vk_hash = vk_hash, .bb_version = BB_VERSION, .scheme = scheme
+        };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
         std::stringstream ss;
-        ss << field; // T's operator<< outputs "0x" prefix
-        hex_fields.push_back(ss.str());
+        ss << oh.get();
+        return ss.str();
     }
 
-    JsonOutput output{
-        .fields = std::move(hex_fields),
-        .vk_hash = vk_hash,
-        .file_kind = file_kind,
-        .bb_version = BB_VERSION,
-        .scheme = flags.scheme,
-        .verifier_target = flags.verifier_target,
-    };
+    static std::vector<uint256_t> parse(const nlohmann::json& json)
+    {
+        if (!json.contains("proof") || !json["proof"].is_array()) {
+            throw_or_abort("JSON missing 'proof' array");
+        }
+        std::vector<uint256_t> result;
+        result.reserve(json["proof"].size());
+        for (const auto& field : json["proof"]) {
+            result.push_back(hex_string_to_uint256(field.get<std::string>()));
+        }
+        return result;
+    }
+};
 
-    msgpack::sbuffer buffer;
-    msgpack::pack(buffer, output);
-    msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+/**
+ * @brief Serializable structure for public inputs JSON output (msgpack-compatible)
+ */
+struct PublicInputsJson {
+    std::vector<std::string> public_inputs;
+    std::string bb_version;
+    std::string scheme;
 
-    std::stringstream ss;
-    ss << oh.get();
-    return ss.str();
-}
+    MSGPACK_FIELDS(public_inputs, bb_version, scheme);
+
+    template <typename T> static std::string build(const std::vector<T>& fields, const std::string& scheme)
+    {
+        std::vector<std::string> hex_fields;
+        hex_fields.reserve(fields.size());
+        for (const auto& field : fields) {
+            std::stringstream ss;
+            ss << field;
+            hex_fields.push_back(ss.str());
+        }
+
+        PublicInputsJson output{ .public_inputs = std::move(hex_fields), .bb_version = BB_VERSION, .scheme = scheme };
+
+        msgpack::sbuffer buffer;
+        msgpack::pack(buffer, output);
+        msgpack::object_handle oh = msgpack::unpack(buffer.data(), buffer.size());
+
+        std::stringstream ss;
+        ss << oh.get();
+        return ss.str();
+    }
+
+    static std::vector<uint256_t> parse(const nlohmann::json& json)
+    {
+        if (!json.contains("public_inputs") || !json["public_inputs"].is_array()) {
+            throw_or_abort("JSON missing 'public_inputs' array");
+        }
+        std::vector<uint256_t> result;
+        result.reserve(json["public_inputs"].size());
+        for (const auto& field : json["public_inputs"]) {
+            result.push_back(hex_string_to_uint256(field.get<std::string>()));
+        }
+        return result;
+    }
+};
 
 } // namespace bb


### PR DESCRIPTION
## Summary
- Re-land of #19800 with fixes for WASM build and bootstrap.sh field names
- Add type-specific JSON structs (VkJson, ProofJson, PublicInputsJson) with named fields per review feedback
- Auto-detect JSON vs binary format in verify command
- Update bootstrap.sh to use new field names (.vk, .proof, .public_inputs, .hash)
- Suppress nlohmann/json sign-conversion warnings for WASM builds using pragma

## Size Impact

| Build | Without nlohmann/json | With nlohmann/json | Difference |
|-------|----------------------|-------------------|------------|
| Native `bb` | 63.18 MB | 63.20 MB | **+19 KB (0.03%)** |
| WASM `bb` | 13.49 MB | 13.52 MB | **+30 KB (0.22%)** |

## Test plan
- [x] Native build passes
- [x] WASM build passes (with `--target bb`)
- [x] `regenerate_recursive_inputs` passes
- [x] JSON prove and verify works end-to-end