### PR TITLE
refactor!: BlockHash type cleanup

### DIFF
--- a/yarn-project/archiver/src/modules/data_source_base.ts
+++ b/yarn-project/archiver/src/modules/data_source_base.ts
@@ -4,7 +4,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import { isDefined } from '@aztec/foundation/types';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { CheckpointedL2Block, CommitteeAttestation, L2Block, type L2Tips } from '@aztec/stdlib/block';
+import { type BlockHash, CheckpointedL2Block, CommitteeAttestation, L2Block, type L2Tips } from '@aztec/stdlib/block';
 import { Checkpoint, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
@@ -121,7 +121,7 @@ export abstract class ArchiverDataSourceBase
     return this.store.getCheckpointedBlocks(from, limit);
   }
 
-  public getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
+  public getBlockHeaderByHash(blockHash: BlockHash): Promise<BlockHeader | undefined> {
     return this.store.getBlockHeaderByHash(blockHash);
   }
 
@@ -347,7 +347,7 @@ export abstract class ArchiverDataSourceBase
     return this.store.getBlocks(from, limit);
   }
 
-  public getCheckpointedBlockByHash(blockHash: Fr): Promise<CheckpointedL2Block | undefined> {
+  public getCheckpointedBlockByHash(blockHash: BlockHash): Promise<CheckpointedL2Block | undefined> {
     return this.store.getCheckpointedBlockByHash(blockHash);
   }
 
@@ -355,7 +355,7 @@ export abstract class ArchiverDataSourceBase
     return this.store.getCheckpointedBlockByArchive(archive);
   }
 
-  public async getL2BlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+  public async getL2BlockByHash(blockHash: BlockHash): Promise<L2Block | undefined> {
     const checkpointedBlock = await this.store.getCheckpointedBlockByHash(blockHash);
     return checkpointedBlock?.block;
   }

--- a/yarn-project/archiver/src/store/block_store.ts
+++ b/yarn-project/archiver/src/store/block_store.ts
@@ -351,7 +351,7 @@ export class BlockStore {
   }
 
   private async addBlockToDatabase(block: L2Block, checkpointNumber: number, indexWithinCheckpoint: number) {
-    const blockHash = BlockHash.fromField(await block.hash());
+    const blockHash = await block.hash();
 
     await this.#blocks.set(block.number, {
       header: block.header.toBuffer(),
@@ -624,7 +624,7 @@ export class BlockStore {
     }
   }
 
-  async getCheckpointedBlockByHash(blockHash: Fr): Promise<CheckpointedL2Block | undefined> {
+  async getCheckpointedBlockByHash(blockHash: BlockHash): Promise<CheckpointedL2Block | undefined> {
     const blockNumber = await this.#blockHashIndex.getAsync(blockHash.toString());
     if (blockNumber === undefined) {
       return undefined;

--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -335,7 +335,7 @@ describe('KVArchiverDataStore', () => {
       await store.addCheckpoints(publishedCheckpoints);
       const lastCheckpoint = publishedCheckpoints[publishedCheckpoints.length - 1];
       const lastBlock = lastCheckpoint.checkpoint.blocks[0];
-      const blockHash = (await lastBlock.header.hash()).toField();
+      const blockHash = await lastBlock.header.hash();
       const archive = lastBlock.archive.root;
 
       // Verify block and header exist before removing
@@ -639,7 +639,7 @@ describe('KVArchiverDataStore', () => {
       // Check each block by its hash
       for (let i = 0; i < checkpoint.checkpoint.blocks.length; i++) {
         const block = checkpoint.checkpoint.blocks[i];
-        const blockHash = (await block.header.hash()).toField();
+        const blockHash = await block.header.hash();
         const retrievedBlock = await store.getCheckpointedBlockByHash(blockHash);
 
         expect(retrievedBlock).toBeDefined();
@@ -797,8 +797,8 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlocks([block1, block2]);
 
       // getBlockByHash should work for uncheckpointed blocks
-      const hash1 = (await block1.header.hash()).toField();
-      const hash2 = (await block2.header.hash()).toField();
+      const hash1 = await block1.header.hash();
+      const hash2 = await block2.header.hash();
 
       const retrieved1 = await store.getBlockByHash(hash1);
       expect(retrieved1!.equals(block1)).toBe(true);
@@ -874,7 +874,7 @@ describe('KVArchiverDataStore', () => {
       });
       await store.addProposedBlocks([block1]);
 
-      const hash = (await block1.header.hash()).toField();
+      const hash = await block1.header.hash();
 
       // getCheckpointedBlockByHash should return undefined
       expect(await store.getCheckpointedBlockByHash(hash)).toBeUndefined();
@@ -1666,7 +1666,7 @@ describe('KVArchiverDataStore', () => {
     it('retrieves a block by its hash', async () => {
       const expectedCheckpoint = publishedCheckpoints[5];
       const expectedBlock = expectedCheckpoint.checkpoint.blocks[0];
-      const blockHash = (await expectedBlock.header.hash()).toField();
+      const blockHash = await expectedBlock.header.hash();
       const retrievedBlock = await store.getCheckpointedBlockByHash(blockHash);
 
       expect(retrievedBlock).toBeDefined();
@@ -1674,7 +1674,7 @@ describe('KVArchiverDataStore', () => {
     });
 
     it('returns undefined for non-existent block hash', async () => {
-      const nonExistentHash = Fr.random();
+      const nonExistentHash = BlockHash.random();
       await expect(store.getCheckpointedBlockByHash(nonExistentHash)).resolves.toBeUndefined();
     });
   });
@@ -1707,7 +1707,7 @@ describe('KVArchiverDataStore', () => {
 
     it('retrieves a block header by its hash', async () => {
       const expectedBlock = publishedCheckpoints[7].checkpoint.blocks[0];
-      const blockHash = (await expectedBlock.header.hash()).toField();
+      const blockHash = await expectedBlock.header.hash();
       const retrievedHeader = await store.getBlockHeaderByHash(blockHash);
 
       expect(retrievedHeader).toBeDefined();
@@ -1715,7 +1715,7 @@ describe('KVArchiverDataStore', () => {
     });
 
     it('returns undefined for non-existent block hash', async () => {
-      const nonExistentHash = Fr.random();
+      const nonExistentHash = BlockHash.random();
       await expect(store.getBlockHeaderByHash(nonExistentHash)).resolves.toBeUndefined();
     });
   });
@@ -3320,7 +3320,7 @@ describe('KVArchiverDataStore', () => {
       await store.addProposedBlocks([block1, block2]);
 
       // Verify block2 is retrievable by hash and archive before removal
-      const block2Hash = (await block2.header.hash()).toField();
+      const block2Hash = await block2.header.hash();
       const block2Archive = block2.archive.root;
 
       expect(await store.getBlockByHash(block2Hash)).toBeDefined();
@@ -3346,7 +3346,7 @@ describe('KVArchiverDataStore', () => {
       }
 
       // Verify block1's data is still intact
-      const block1Hash = (await block1.header.hash()).toField();
+      const block1Hash = await block1.header.hash();
       const block1Archive = block1.archive.root;
 
       expect(await store.getBlockByHash(block1Hash)).toBeDefined();

--- a/yarn-project/archiver/src/store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.ts
@@ -291,7 +291,7 @@ export class KVArchiverDataStore implements ContractDataSource {
    * Returns the block for the given hash, or undefined if not exists.
    * @param blockHash - The block hash to return.
    */
-  getCheckpointedBlockByHash(blockHash: Fr): Promise<CheckpointedL2Block | undefined> {
+  getCheckpointedBlockByHash(blockHash: BlockHash): Promise<CheckpointedL2Block | undefined> {
     return this.#blockStore.getCheckpointedBlockByHash(blockHash);
   }
   /**
@@ -312,8 +312,8 @@ export class KVArchiverDataStore implements ContractDataSource {
    * Returns the block for the given hash, or undefined if not exists.
    * @param blockHash - The block hash to return.
    */
-  getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
-    return this.#blockStore.getBlockByHash(BlockHash.fromField(blockHash));
+  getBlockByHash(blockHash: BlockHash): Promise<L2Block | undefined> {
+    return this.#blockStore.getBlockByHash(blockHash);
   }
   /**
    * Returns the block for the given archive root, or undefined if not exists.
@@ -357,8 +357,8 @@ export class KVArchiverDataStore implements ContractDataSource {
    * Returns the block header for the given hash, or undefined if not exists.
    * @param blockHash - The block hash to return.
    */
-  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
-    return this.#blockStore.getBlockHeaderByHash(BlockHash.fromField(blockHash));
+  getBlockHeaderByHash(blockHash: BlockHash): Promise<BlockHeader | undefined> {
+    return this.#blockStore.getBlockHeaderByHash(blockHash);
   }
 
   /**

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -271,7 +271,7 @@ export class LogStore {
     });
   }
 
-  #packWithBlockHash(blockHash: Fr, data: Buffer<ArrayBufferLike>[]): Buffer<ArrayBufferLike> {
+  #packWithBlockHash(blockHash: BlockHash, data: Buffer<ArrayBufferLike>[]): Buffer<ArrayBufferLike> {
     return Buffer.concat([blockHash.toBuffer(), ...data]);
   }
 
@@ -282,7 +282,7 @@ export class LogStore {
       throw new Error('Failed to read block hash from log entry buffer');
     }
 
-    return BlockHash.fromField(blockHash);
+    return new BlockHash(blockHash);
   }
 
   deleteLogs(blocks: L2Block[]): Promise<boolean> {

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -195,7 +195,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return checkpoint;
   }
 
-  public async getCheckpointedBlockByHash(blockHash: Fr): Promise<CheckpointedL2Block | undefined> {
+  public async getCheckpointedBlockByHash(blockHash: BlockHash): Promise<CheckpointedL2Block | undefined> {
     for (const block of this.l2Blocks) {
       const hash = await block.hash();
       if (hash.equals(blockHash)) {
@@ -225,7 +225,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     );
   }
 
-  public async getL2BlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+  public async getL2BlockByHash(blockHash: BlockHash): Promise<L2Block | undefined> {
     for (const block of this.l2Blocks) {
       const hash = await block.hash();
       if (hash.equals(blockHash)) {
@@ -240,7 +240,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return Promise.resolve(block);
   }
 
-  public async getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined> {
+  public async getBlockHeaderByHash(blockHash: BlockHash): Promise<BlockHeader | undefined> {
     for (const block of this.l2Blocks) {
       const hash = await block.hash();
       if (hash.equals(blockHash)) {
@@ -322,7 +322,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return {
       data: txEffect,
       l2BlockNumber: block.number,
-      l2BlockHash: BlockHash.fromField(await block.hash()),
+      l2BlockHash: await block.hash(),
       txIndexInBlock: block.body.txEffects.indexOf(txEffect),
     };
   }
@@ -343,7 +343,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
             TxExecutionResult.SUCCESS,
             undefined,
             txEffect.transactionFee.toBigInt(),
-            BlockHash.fromField(await block.hash()),
+            await block.hash(),
             block.number,
           );
         }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -570,8 +570,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @returns The requested block.
    */
   public async getBlock(block: BlockParameter): Promise<L2Block | undefined> {
-    if (BlockHash.isL2BlockHash(block)) {
-      return this.getBlockByHash(Fr.fromBuffer(block.toBuffer()));
+    if (BlockHash.isBlockHash(block)) {
+      return this.getBlockByHash(block);
     }
     const blockNumber = block === 'latest' ? await this.getBlockNumber() : (block as BlockNumber);
     if (blockNumber === BlockNumber.ZERO) {
@@ -585,9 +585,9 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * @param blockHash - The block hash being requested.
    * @returns The requested block.
    */
-  public async getBlockByHash(blockHash: Fr): Promise<L2Block | undefined> {
+  public async getBlockByHash(blockHash: BlockHash): Promise<L2Block | undefined> {
     const initialBlockHash = await this.#getInitialHeaderHash();
-    if (blockHash.equals(Fr.fromBuffer(initialBlockHash.toBuffer()))) {
+    if (blockHash.equals(initialBlockHash)) {
       return this.buildInitialBlock();
     }
     return await this.blockSource.getL2BlockByHash(blockHash);
@@ -697,8 +697,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     if (referenceBlock) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (!referenceBlock.equals(initialBlockHash)) {
-        const blockHashFr = Fr.fromBuffer(referenceBlock.toBuffer());
-        const header = await this.blockSource.getBlockHeaderByHash(blockHashFr);
+        const header = await this.blockSource.getBlockHeaderByHash(referenceBlock);
         if (!header) {
           throw new Error(
             `Block ${referenceBlock.toString()} not found in the node. This might indicate a reorg has occurred.`,
@@ -718,8 +717,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     if (referenceBlock) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (!referenceBlock.equals(initialBlockHash)) {
-        const blockHashFr = Fr.fromBuffer(referenceBlock.toBuffer());
-        const header = await this.blockSource.getBlockHeaderByHash(blockHashFr);
+        const header = await this.blockSource.getBlockHeaderByHash(referenceBlock);
         if (!header) {
           throw new Error(
             `Block ${referenceBlock.toString()} not found in the node. This might indicate a reorg has occurred.`,
@@ -915,7 +913,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       }
       return {
         l2BlockNumber: BlockNumber(Number(blockNumber)),
-        l2BlockHash: BlockHash.fromField(blockHash),
+        l2BlockHash: new BlockHash(blockHash),
         data: index,
       };
     });
@@ -1118,14 +1116,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   public async getBlockHeader(block: BlockParameter = 'latest'): Promise<BlockHeader | undefined> {
-    if (BlockHash.isL2BlockHash(block)) {
+    if (BlockHash.isBlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.
         return this.worldStateSynchronizer.getCommitted().getInitialHeader();
       }
-      const blockHashFr = Fr.fromBuffer(block.toBuffer());
-      return this.blockSource.getBlockHeaderByHash(blockHashFr);
+      return this.blockSource.getBlockHeaderByHash(block);
     } else {
       // Block source doesn't handle initial header so we need to handle the case separately.
       const blockNumber = block === 'latest' ? await this.getBlockNumber() : (block as BlockNumber);
@@ -1442,15 +1439,14 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       return this.worldStateSynchronizer.getCommitted();
     }
 
-    if (BlockHash.isL2BlockHash(block)) {
+    if (BlockHash.isBlockHash(block)) {
       const initialBlockHash = await this.#getInitialHeaderHash();
       if (block.equals(initialBlockHash)) {
         // Block source doesn't handle initial header so we need to handle the case separately.
         return this.worldStateSynchronizer.getSnapshot(BlockNumber.ZERO);
       }
 
-      const blockHashFr = Fr.fromBuffer(block.toBuffer());
-      const header = await this.blockSource.getBlockHeaderByHash(blockHashFr);
+      const header = await this.blockSource.getBlockHeaderByHash(block);
       if (!header) {
         throw new Error(
           `Block hash ${block.toString()} not found when querying world state. If the node API has been queried with anchor block hash possibly a reorg has occurred.`,

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -59,12 +59,12 @@ describe('e2e_simple', () => {
       const initialBlockByHash = await aztecNode.getBlock(initialHeaderHash);
       expect(initialBlockByHash).toBeDefined();
       const initialBlockHash = await initialBlockByHash!.hash();
-      expect(initialBlockHash.equals(initialHeaderHash.toField())).toBeTrue();
+      expect(initialBlockHash.equals(initialHeaderHash)).toBeTrue();
       expect(initialBlockByHash?.body.txEffects.length).toBe(0);
       const initialBlockByNumber = await aztecNode.getBlock(BlockNumber.ZERO);
       expect(initialBlockByNumber).toBeDefined();
       const initialBlockByNumberHash = await initialBlockByNumber!.hash();
-      expect(initialBlockByNumberHash.equals(initialHeaderHash.toField())).toBeTrue();
+      expect(initialBlockByNumberHash.equals(initialHeaderHash)).toBeTrue();
       expect(initialBlockByNumber?.body.txEffects.length).toBe(0);
     });
 

--- a/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
@@ -113,7 +113,9 @@ describe('e2e_snapshot_sync', () => {
 
     log.warn(`Checking for L2 block ${L2_TARGET_BLOCK_NUM} with hash ${blockHash} on both nodes`);
     const getBlockHashLeafIndex = (node: AztecNode) =>
-      node.findLeavesIndexes(BlockNumber(L2_TARGET_BLOCK_NUM), MerkleTreeId.ARCHIVE, [blockHash]).then(([i]) => i);
+      node
+        .findLeavesIndexes(BlockNumber(L2_TARGET_BLOCK_NUM), MerkleTreeId.ARCHIVE, [blockHash.toFr()])
+        .then(([i]) => i);
     expect(await getBlockHashLeafIndex(context.aztecNode)).toBeDefined();
     expect(await getBlockHashLeafIndex(node)).toBeDefined();
 
@@ -228,7 +230,9 @@ describe('e2e_snapshot_sync', () => {
 
     log.warn(`Checking for L2 block ${L2_TARGET_BLOCK_NUM} with hash ${blockHash} on both nodes`);
     const getBlockHashLeafIndex = (node: AztecNode) =>
-      node.findLeavesIndexes(BlockNumber(L2_TARGET_BLOCK_NUM), MerkleTreeId.ARCHIVE, [blockHash]).then(([i]) => i);
+      node
+        .findLeavesIndexes(BlockNumber(L2_TARGET_BLOCK_NUM), MerkleTreeId.ARCHIVE, [blockHash.toFr()])
+        .then(([i]) => i);
     expect(await getBlockHashLeafIndex(context.aztecNode)).toBeDefined();
     expect(await getBlockHashLeafIndex(node)).toBeDefined();
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -322,7 +322,7 @@ describe('KV TX pool', () => {
     // modify tx1 to return no archive indices
     tx1.data.constants.anchorBlockHeader.globalVariables.blockNumber = BlockNumber(1);
     const tx1HeaderHash = await tx1.data.constants.anchorBlockHeader.hash();
-    const tx1HeaderHashFr = tx1HeaderHash.toField();
+    const tx1HeaderHashFr = tx1HeaderHash;
     db.findLeafIndices.mockImplementation((tree, leaves) => {
       if (tree === MerkleTreeId.ARCHIVE) {
         return Promise.resolve((leaves as Fr[]).map(l => (l.equals(tx1HeaderHashFr) ? undefined : 1n)));

--- a/yarn-project/p2p/src/msg_validators/tx_validator/archive_cache.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/archive_cache.test.ts
@@ -1,4 +1,4 @@
-import { Fr } from '@aztec/foundation/curves/bn254';
+import { BlockHash } from '@aztec/stdlib/block';
 import type { MerkleTreeReadOperations } from '@aztec/stdlib/interfaces/server';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -9,12 +9,12 @@ import { ArchiveCache } from './archive_cache.js';
 describe('ArchiveCache', () => {
   let archiveCache: ArchiveCache;
   let db: MockProxy<MerkleTreeReadOperations>;
-  let archives: Fr[];
+  let archives: BlockHash[];
 
   beforeEach(() => {
     db = mock<MerkleTreeReadOperations>();
     archiveCache = new ArchiveCache(db);
-    archives = [Fr.random(), Fr.random(), Fr.random()];
+    archives = [BlockHash.random(), BlockHash.random(), BlockHash.random()];
   });
 
   it('checks archive existence against db', async () => {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/archive_cache.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/archive_cache.ts
@@ -1,5 +1,5 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { ArchiveSource } from '@aztec/p2p';
+import type { BlockHash } from '@aztec/stdlib/block';
 import type { MerkleTreeReadOperations } from '@aztec/stdlib/interfaces/server';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -14,8 +14,8 @@ export class ArchiveCache implements ArchiveSource {
     this.archives = new Map<string, bigint>();
   }
 
-  public async getArchiveIndices(archives: Fr[]): Promise<(bigint | undefined)[]> {
-    const toCheckDb = archives.filter(n => !this.archives.has(n.toString()));
+  public async getArchiveIndices(archives: BlockHash[]): Promise<(bigint | undefined)[]> {
+    const toCheckDb = archives.filter(n => !this.archives.has(n.toString())).map(n => n.toFr());
     const dbHits = await this.db.findLeafIndices(MerkleTreeId.ARCHIVE, toCheckDb);
     dbHits.forEach((x, index) => {
       if (x !== undefined) {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.test.ts
@@ -1,5 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { Fr } from '@aztec/foundation/curves/bn254';
+import { BlockHash } from '@aztec/stdlib/block';
 import { mockTxForRollup } from '@aztec/stdlib/testing';
 import { type AnyTx, TX_ERROR_BLOCK_HEADER, type TxValidationResult } from '@aztec/stdlib/tx';
 
@@ -27,8 +27,8 @@ describe('BlockHeaderTxValidator', () => {
     );
 
     const goodTx = await mockTxForRollup();
-    const goodTxHeaderHash = (await goodTx.data.constants.anchorBlockHeader.hash()).toField();
-    archiveSource.getArchiveIndices.mockImplementation((archives: Fr[]) => {
+    const goodTxHeaderHash = await goodTx.data.constants.anchorBlockHeader.hash();
+    archiveSource.getArchiveIndices.mockImplementation((archives: BlockHash[]) => {
       if (archives[0].equals(goodTxHeaderHash)) {
         return Promise.resolve([1n]);
       } else {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/block_header_validator.ts
@@ -1,9 +1,9 @@
-import type { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
+import type { BlockHash } from '@aztec/stdlib/block';
 import { type AnyTx, TX_ERROR_BLOCK_HEADER, type TxValidationResult, type TxValidator } from '@aztec/stdlib/tx';
 
 export interface ArchiveSource {
-  getArchiveIndices: (archives: Fr[]) => Promise<(bigint | undefined)[]>;
+  getArchiveIndices: (archives: BlockHash[]) => Promise<(bigint | undefined)[]>;
 }
 
 export class BlockHeaderTxValidator<T extends AnyTx> implements TxValidator<T> {
@@ -16,9 +16,7 @@ export class BlockHeaderTxValidator<T extends AnyTx> implements TxValidator<T> {
   }
 
   async validateTx(tx: T): Promise<TxValidationResult> {
-    const [index] = await this.#archiveSource.getArchiveIndices([
-      (await tx.data.constants.anchorBlockHeader.hash()).toField(),
-    ]);
+    const [index] = await this.#archiveSource.getArchiveIndices([await tx.data.constants.anchorBlockHeader.hash()]);
     if (index === undefined) {
       this.#log.verbose(`Rejecting tx ${'txHash' in tx ? tx.txHash : tx.hash} for referencing an unknown block header`);
       return { result: 'invalid', reason: [TX_ERROR_BLOCK_HEADER] };

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -97,9 +97,9 @@ export const insertSideEffectsAndBuildBaseRollupHints = runInSpan(
 
     const { nullifierInsertionResult, publicDataInsertionResult } = await insertSideEffects(tx, db);
 
-    const blockHash = (await tx.data.constants.anchorBlockHeader.hash()).toField();
+    const blockHash = await tx.data.constants.anchorBlockHeader.hash();
     const anchorBlockArchiveSiblingPath = (
-      await getMembershipWitnessFor(blockHash, MerkleTreeId.ARCHIVE, ARCHIVE_HEIGHT, db)
+      await getMembershipWitnessFor(blockHash.toFr(), MerkleTreeId.ARCHIVE, ARCHIVE_HEIGHT, db)
     ).siblingPath;
 
     const contractClassLogsFields = makeTuple(

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -368,7 +368,7 @@ export class EpochProvingJob implements Traceable {
     this.epochCheckPromise = new RunningPromise(
       async () => {
         const blockHeaders = await l2BlockSource.getCheckpointedBlockHeadersForEpoch(this.epochNumber);
-        const blockHashes = await Promise.all(blockHeaders.map(async header => (await header.hash()).toField()));
+        const blockHashes = await Promise.all(blockHeaders.map(header => header.hash()));
         const thisBlocks = this.checkpoints.flatMap(checkpoint => checkpoint.blocks);
         const thisBlockHashes = await Promise.all(thisBlocks.map(block => block.hash()));
         if (

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -61,7 +61,7 @@ describe('BlockSynchronizer', () => {
     const block3Hash = Fr.fromString('0x3');
     aztecNode.getBlockHeader.mockImplementation(async block => {
       // For the test, when block hash matches block 3, return block header for block 3
-      if (block instanceof BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
+      if (block instanceof BlockHash && block.equals(block3Hash)) {
         return (await L2Block.random(BlockNumber(3))).header;
       }
       return undefined;
@@ -85,7 +85,7 @@ describe('BlockSynchronizer', () => {
     const block3Hash = Fr.fromString('0x3');
     aztecNode.getBlockHeader.mockImplementation(async block => {
       // For the test, when block hash matches block 3, return block header for block 3
-      if (block instanceof BlockHash && Fr.fromBuffer(block.toBuffer()).equals(block3Hash)) {
+      if (block instanceof BlockHash && block.equals(block3Hash)) {
         return (await L2Block.random(BlockNumber(3))).header;
       }
       return undefined;

--- a/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/stored_private_event.ts
@@ -49,7 +49,7 @@ export class StoredPrivateEvent {
     const msgContentLength = reader.readNumber();
     const msgContent = reader.readArray(msgContentLength, Fr);
     const l2BlockNumber = reader.readNumber();
-    const l2BlockHash = BlockHash.fromBuffer(reader);
+    const l2BlockHash = new BlockHash(Fr.fromBuffer(reader));
     const txHash = TxHash.fromBuffer(reader);
     const txIndexInBlock = reader.readNumber();
     const eventIndexInTx = reader.readNumber();

--- a/yarn-project/stdlib/src/block/block_hash.test.ts
+++ b/yarn-project/stdlib/src/block/block_hash.test.ts
@@ -1,76 +1,31 @@
-import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
 
 import { BlockHash } from './block_hash.js';
 
 describe('BlockHash', () => {
-  describe('isL2BlockHash', () => {
+  describe('isBlockHash', () => {
     it('returns true for BlockHash instances', () => {
       const hash = BlockHash.random();
-      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
+      expect(BlockHash.isBlockHash(hash)).toBe(true);
     });
 
-    it('returns true for BlockHash created from field', () => {
-      const hash = BlockHash.fromField(Fr.random());
-      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
+    it('returns false for plain Fr instances', () => {
+      const fr = Fr.random();
+      expect(BlockHash.isBlockHash(fr)).toBe(false);
+    });
+  });
+
+  describe('inheritance', () => {
+    it('is an instance of Fr', () => {
+      const hash = BlockHash.random();
+      expect(hash).toBeInstanceOf(Fr);
     });
 
-    it('returns true for BlockHash created from buffer', () => {
-      const hash = BlockHash.fromBuffer(Buffer.alloc(32, 1));
-      expect(BlockHash.isL2BlockHash(hash)).toBe(true);
-    });
-
-    it('returns true for duck-typed Buffer32-like objects with 32-byte buffer', () => {
-      // Simulates a case where instanceof fails due to module duplication
-      const fakeHash = {
-        buffer: Buffer.alloc(32, 0xab),
-        toBuffer: () => Buffer.alloc(32, 0xab),
-      };
-      expect(BlockHash.isL2BlockHash(fakeHash)).toBe(true);
-    });
-
-    it('returns false for plain numbers', () => {
-      expect(BlockHash.isL2BlockHash(0)).toBe(false);
-      expect(BlockHash.isL2BlockHash(123)).toBe(false);
-      expect(BlockHash.isL2BlockHash(-1)).toBe(false);
-    });
-
-    it('returns false for strings', () => {
-      expect(BlockHash.isL2BlockHash('latest')).toBe(false);
-      expect(BlockHash.isL2BlockHash('0x1234')).toBe(false);
-    });
-
-    it('returns false for null and undefined', () => {
-      expect(BlockHash.isL2BlockHash(null)).toBe(false);
-      expect(BlockHash.isL2BlockHash(undefined)).toBe(false);
-    });
-
-    it('returns false for objects without buffer property', () => {
-      expect(BlockHash.isL2BlockHash({})).toBe(false);
-      expect(BlockHash.isL2BlockHash({ toBuffer: () => Buffer.alloc(32) })).toBe(false);
-    });
-
-    it('returns false for objects with non-Buffer buffer property', () => {
-      expect(BlockHash.isL2BlockHash({ buffer: 'not a buffer', toBuffer: () => Buffer.alloc(32) })).toBe(false);
-      expect(BlockHash.isL2BlockHash({ buffer: [1, 2, 3], toBuffer: () => Buffer.alloc(32) })).toBe(false);
-    });
-
-    it('returns false for objects with wrong buffer length', () => {
-      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(16), toBuffer: () => Buffer.alloc(16) })).toBe(false);
-      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(64), toBuffer: () => Buffer.alloc(64) })).toBe(false);
-    });
-
-    it('returns false for objects without toBuffer method', () => {
-      expect(BlockHash.isL2BlockHash({ buffer: Buffer.alloc(32) })).toBe(false);
-    });
-
-    it('returns false for plain Buffer32 instances when checking type strictly', () => {
-      // Note: Buffer32 will pass duck typing since it has the same structure
-      // This is acceptable since the goal is to identify hash-like objects
-      const buf32 = Buffer32.random();
-      // Buffer32 has the same structure, so duck typing will return true
-      // This is expected behavior - we want to handle Buffer32-like objects
-      expect(BlockHash.isL2BlockHash(buf32)).toBe(true);
+    it('round-trips through toString/fromString', () => {
+      const original = BlockHash.random();
+      const restored = BlockHash.fromString(original.toString());
+      expect(restored.equals(original)).toBe(true);
+      expect(BlockHash.isBlockHash(restored)).toBe(true);
     });
   });
 });

--- a/yarn-project/stdlib/src/block/block_hash.ts
+++ b/yarn-project/stdlib/src/block/block_hash.ts
@@ -1,70 +1,45 @@
-import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { BufferReader } from '@aztec/foundation/serialize';
+import type { ZodFor } from '@aztec/foundation/schemas';
 
-import { schemas } from '../schemas/schemas.js';
+import { inspect } from 'util';
+
+import { hexSchemaFor } from '../schemas/schemas.js';
+
+const BLOCK_HASH_BRAND = Symbol.for('aztec.BlockHash');
 
 /** Hash of an L2 block. */
-export class BlockHash extends Buffer32 {
-  constructor(
-    /** The buffer containing the hash. */
-    hash: Buffer,
-  ) {
+export class BlockHash extends Fr {
+  readonly [BLOCK_HASH_BRAND] = true as const;
+
+  constructor(hash: Fr) {
     super(hash);
   }
 
+  override [inspect.custom]() {
+    return `BlockHash<${this.toString()}>`;
+  }
+
+  toFr(): Fr {
+    return new Fr(this.toBigInt());
+  }
+
   /**
-   * Type guard that checks if a value is an BlockHash instance.
-   * Uses duck typing to handle cases where instanceof fails due to module duplication.
-   * Checks for Buffer32-like structure with a 32-byte buffer.
+   * Type guard that checks if a value is a BlockHash instance.
+   * Uses Symbol.for to ensure cross-module compatibility.
    */
-  static isL2BlockHash(value: unknown): value is BlockHash {
-    if (value instanceof BlockHash) {
-      return true;
-    }
-    // Duck typing fallback: check if it looks like a Buffer32 with a 32-byte buffer
-    // This helps when instanceof fails due to module duplication
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      'buffer' in value &&
-      Buffer.isBuffer((value as Buffer32).buffer) &&
-      (value as Buffer32).buffer.length === 32 &&
-      'toBuffer' in value &&
-      typeof (value as Buffer32).toBuffer === 'function'
-    );
+  static isBlockHash(value: unknown): value is BlockHash {
+    return typeof value === 'object' && value !== null && BLOCK_HASH_BRAND in value;
   }
 
   static override random() {
-    return new BlockHash(Fr.random().toBuffer());
-  }
-
-  static override fromNumber(num: number): BlockHash {
-    return new BlockHash(super.fromNumber(num).toBuffer());
-  }
-
-  static override fromBuffer(buffer: Buffer | BufferReader) {
-    const reader = BufferReader.asReader(buffer);
-    return new BlockHash(reader.readBytes(BlockHash.SIZE));
+    return new BlockHash(Fr.random());
   }
 
   static override fromString(str: string): BlockHash {
-    return new BlockHash(super.fromString(str).toBuffer());
+    return new BlockHash(Fr.fromString(str));
   }
 
-  static get schema() {
-    return schemas.BufferHex.transform(value => new BlockHash(value));
-  }
-
-  static zero() {
-    return new BlockHash(Buffer32.ZERO.toBuffer());
-  }
-
-  static override fromField(hash: Fr) {
-    return new BlockHash(hash.toBuffer());
-  }
-
-  toField(): Fr {
-    return Fr.fromBuffer(this.toBuffer());
+  static override get schema() {
+    return hexSchemaFor(BlockHash) as ZodFor<BlockHash>;
   }
 }

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -33,7 +33,7 @@ export async function wrapDataInBlock<T>(data: T, block: L2Block): Promise<DataI
   return {
     data,
     l2BlockNumber: block.number,
-    l2BlockHash: BlockHash.fromField(await block.hash()),
+    l2BlockHash: await block.hash(),
   };
 }
 

--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import type { PrivateLog } from '../logs/private_log.js';
 import { AppendOnlyTreeSnapshot } from '../trees/append_only_tree_snapshot.js';
 import { BlockHeader } from '../tx/block_header.js';
+import type { BlockHash } from './block_hash.js';
 import { Body } from './body.js';
 import type { L2BlockInfo } from './l2_block_info.js';
 
@@ -89,9 +90,8 @@ export class L2Block {
    * Returns the block's hash (hash of block header).
    * @returns The block's hash.
    */
-  public async hash(): Promise<Fr> {
-    const blockHash = await this.header.hash();
-    return blockHash.toField();
+  public hash(): Promise<BlockHash> {
+    return this.header.hash();
   }
 
   /**

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -20,6 +20,7 @@ import type { BlockHeader } from '../tx/block_header.js';
 import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import type { TxHash } from '../tx/tx_hash.js';
 import type { TxReceipt } from '../tx/tx_receipt.js';
+import type { BlockHash } from './block_hash.js';
 import type { CheckpointedL2Block } from './checkpointed_l2_block.js';
 import type { L2Block } from './l2_block.js';
 import type { ValidateCheckpointNegativeResult, ValidateCheckpointResult } from './validate_block_result.js';
@@ -102,7 +103,7 @@ export interface L2BlockSource {
    * @param blockHash - The block hash to retrieve.
    * @returns The requested block header (or undefined if not found).
    */
-  getBlockHeaderByHash(blockHash: Fr): Promise<BlockHeader | undefined>;
+  getBlockHeaderByHash(blockHash: BlockHash): Promise<BlockHeader | undefined>;
 
   /**
    * Gets a block header by its archive root.
@@ -123,7 +124,7 @@ export interface L2BlockSource {
    * @param blockHash - The block hash to retrieve.
    * @returns The requested L2 block (or undefined if not found).
    */
-  getL2BlockByHash(blockHash: Fr): Promise<L2Block | undefined>;
+  getL2BlockByHash(blockHash: BlockHash): Promise<L2Block | undefined>;
 
   /**
    * Gets an L2 block by its archive root.
@@ -228,7 +229,7 @@ export interface L2BlockSource {
    * @param blockHash - The block hash to retrieve.
    * @returns The requested block (or undefined if not found).
    */
-  getCheckpointedBlockByHash(blockHash: Fr): Promise<CheckpointedL2Block | undefined>;
+  getCheckpointedBlockByHash(blockHash: BlockHash): Promise<CheckpointedL2Block | undefined>;
 
   /**
    * Gets a checkpointed block by its archive root.

--- a/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_stream/l2_block_stream.test.ts
@@ -37,7 +37,7 @@ describe('L2BlockStream', () => {
       number: BlockNumber(number),
       checkpointNumber: CheckpointNumber(number),
       indexWithinCheckpoint: 0,
-      hash: () => Promise.resolve(new Fr(number)),
+      hash: () => Promise.resolve(new BlockHash(new Fr(number))),
     }) as L2Block;
 
   const makeCheckpointedBlock = (number: number, checkpointNum: number): CheckpointedL2Block =>
@@ -47,7 +47,7 @@ describe('L2BlockStream', () => {
     }) as CheckpointedL2Block;
 
   const makeHeader = (number: number) =>
-    ({ hash: () => Promise.resolve(BlockHash.fromField(new Fr(number))) }) as BlockHeader;
+    ({ hash: () => Promise.resolve(new BlockHash(new Fr(number))) }) as BlockHeader;
 
   const makeBlockId = (number: number): L2BlockId => ({ number: BlockNumber(number), hash: makeHash(number) });
 
@@ -388,7 +388,7 @@ describe('L2BlockStream', () => {
         number: BlockNumber(blockNum),
         checkpointNumber: CheckpointNumber(checkpointNum),
         indexWithinCheckpoint: blockNum - firstBlockInCheckpoint,
-        hash: () => Promise.resolve(new Fr(blockNum)),
+        hash: () => Promise.resolve(new BlockHash(new Fr(blockNum))),
       } as L2Block;
     };
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -111,7 +111,7 @@ describe('ArchiverApiSchema', () => {
   });
 
   it('getBlockHeaderByHash', async () => {
-    const result = await context.client.getBlockHeaderByHash(Fr.random());
+    const result = await context.client.getBlockHeaderByHash(BlockHash.random());
     expect(result).toBeInstanceOf(BlockHeader);
   });
 
@@ -121,7 +121,7 @@ describe('ArchiverApiSchema', () => {
   });
 
   it('getL2BlockByHash', async () => {
-    const result = await context.client.getL2BlockByHash(Fr.random());
+    const result = await context.client.getL2BlockByHash(BlockHash.random());
     expect(result).toBeInstanceOf(L2Block);
   });
 
@@ -152,7 +152,7 @@ describe('ArchiverApiSchema', () => {
   });
 
   it('getCheckpointedBlockByHash', async () => {
-    const result = await context.client.getCheckpointedBlockByHash(Fr.random());
+    const result = await context.client.getCheckpointedBlockByHash(BlockHash.random());
     expect(result).toBeDefined();
     expect(result!.block.constructor.name).toEqual('L2Block');
     expect(result!.attestations[0]).toBeInstanceOf(CommitteeAttestation);
@@ -431,7 +431,7 @@ class MockArchiver implements ArchiverApi {
     return Promise.resolve(Checkpoint.random());
   }
 
-  async getCheckpointedBlockByHash(_blockHash: Fr): Promise<CheckpointedL2Block | undefined> {
+  async getCheckpointedBlockByHash(_blockHash: BlockHash): Promise<CheckpointedL2Block | undefined> {
     return CheckpointedL2Block.fromFields({
       checkpointNumber: CheckpointNumber(1),
       block: await L2Block.random(BlockNumber(1)),
@@ -447,7 +447,7 @@ class MockArchiver implements ArchiverApi {
       l1: new L1PublishedData(1n, 0n, `0x`),
     });
   }
-  getBlockHeaderByHash(_blockHash: Fr): Promise<BlockHeader | undefined> {
+  getBlockHeaderByHash(_blockHash: BlockHash): Promise<BlockHeader | undefined> {
     return Promise.resolve(BlockHeader.empty());
   }
   getBlockHeaderByArchive(_archive: Fr): Promise<BlockHeader | undefined> {
@@ -456,7 +456,7 @@ class MockArchiver implements ArchiverApi {
   getL2Block(number: BlockNumber): Promise<L2Block | undefined> {
     return L2Block.random(number);
   }
-  getL2BlockByHash(_blockHash: Fr): Promise<L2Block | undefined> {
+  getL2BlockByHash(_blockHash: BlockHash): Promise<L2Block | undefined> {
     return L2Block.random(BlockNumber(1));
   }
   getL2BlockByArchive(_archive: Fr): Promise<L2Block | undefined> {
@@ -466,7 +466,7 @@ class MockArchiver implements ArchiverApi {
     expect(_txHash).toBeInstanceOf(TxHash);
     return {
       l2BlockNumber: BlockNumber(1),
-      l2BlockHash: BlockHash.fromNumber(0x12),
+      l2BlockHash: new BlockHash(new Fr(0x12)),
       data: await TxEffect.random(),
       txIndexInBlock: randomInt(10),
     };

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -4,6 +4,7 @@ import type { ApiSchemaFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
+import { BlockHash } from '../block/block_hash.js';
 import { CheckpointedL2Block } from '../block/checkpointed_l2_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
@@ -99,12 +100,12 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(CheckpointNumberSchema, schemas.Integer)
     .returns(z.array(PublishedCheckpoint.schema)),
-  getCheckpointedBlockByHash: z.function().args(schemas.Fr).returns(CheckpointedL2Block.schema.optional()),
+  getCheckpointedBlockByHash: z.function().args(BlockHash.schema).returns(CheckpointedL2Block.schema.optional()),
   getCheckpointedBlockByArchive: z.function().args(schemas.Fr).returns(CheckpointedL2Block.schema.optional()),
-  getBlockHeaderByHash: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
+  getBlockHeaderByHash: z.function().args(BlockHash.schema).returns(BlockHeader.schema.optional()),
   getBlockHeaderByArchive: z.function().args(schemas.Fr).returns(BlockHeader.schema.optional()),
   getL2Block: z.function().args(BlockNumberSchema).returns(L2Block.schema.optional()),
-  getL2BlockByHash: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
+  getL2BlockByHash: z.function().args(BlockHash.schema).returns(L2Block.schema.optional()),
   getL2BlockByArchive: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
   getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -109,10 +109,7 @@ describe('AztecNodeApiSchema', () => {
       Fr.random(),
       Fr.random(),
     ]);
-    expect(response).toEqual([
-      { data: 1n, l2BlockNumber: 1, l2BlockHash: BlockHash.fromNumber(BlockNumber(1)) },
-      undefined,
-    ]);
+    expect(response).toEqual([{ data: 1n, l2BlockNumber: 1, l2BlockHash: new BlockHash(new Fr(1)) }, undefined]);
 
     await expect(
       context.client.findLeavesIndexes(BlockNumber(1), MerkleTreeId.ARCHIVE, times(MAX_RPC_LEN + 1, Fr.random)),
@@ -194,7 +191,7 @@ describe('AztecNodeApiSchema', () => {
   });
 
   it('getBlockByHash', async () => {
-    const response = await context.client.getBlockByHash(Fr.random());
+    const response = await context.client.getBlockByHash(BlockHash.random());
     expect(response).toBeInstanceOf(L2Block);
   });
 
@@ -204,7 +201,7 @@ describe('AztecNodeApiSchema', () => {
   });
 
   it('getBlockHeader', async () => {
-    const response = await context.client.getBlockHeader(BlockHash.fromField(Fr.random()));
+    const response = await context.client.getBlockHeader(new BlockHash(Fr.random()));
     expect(response).toBeInstanceOf(BlockHeader);
   });
 
@@ -571,7 +568,7 @@ class MockAztecNode implements AztecNode {
     expect(leafValues[0]).toBeInstanceOf(Fr);
     expect(leafValues[1]).toBeInstanceOf(Fr);
     return Promise.resolve([
-      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: BlockHash.fromNumber(BlockNumber(1)) },
+      { data: 1n, l2BlockNumber: BlockNumber(1), l2BlockHash: new BlockHash(new Fr(1)) },
       undefined,
     ]);
   }
@@ -666,7 +663,7 @@ class MockAztecNode implements AztecNode {
     const blockNum = number === 'latest' ? BlockNumber(1) : (number as BlockNumber);
     return L2Block.random(blockNum);
   }
-  getBlockByHash(_blockHash: Fr): Promise<L2Block | undefined> {
+  getBlockByHash(_blockHash: BlockHash): Promise<L2Block | undefined> {
     return L2Block.random(BlockNumber(1));
   }
   getBlockByArchive(_archive: Fr): Promise<L2Block | undefined> {
@@ -784,7 +781,7 @@ class MockAztecNode implements AztecNode {
     expect(txHash).toBeInstanceOf(TxHash);
     return {
       l2BlockNumber: BlockNumber(1),
-      l2BlockHash: BlockHash.fromNumber(0x12),
+      l2BlockHash: new BlockHash(new Fr(0x12)),
       data: await TxEffect.random(),
       txIndexInBlock: randomInt(10),
     };

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -234,7 +234,7 @@ export interface AztecNode
    * @param blockHash - The block hash being requested.
    * @returns The requested block.
    */
-  getBlockByHash(blockHash: Fr): Promise<L2Block | undefined>;
+  getBlockByHash(blockHash: BlockHash): Promise<L2Block | undefined>;
 
   /**
    * Get a block specified by its archive root.
@@ -579,7 +579,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getBlock: z.function().args(BlockParameterSchema).returns(L2Block.schema.optional()),
 
-  getBlockByHash: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
+  getBlockByHash: z.function().args(BlockHash.schema).returns(L2Block.schema.optional()),
 
   getBlockByArchive: z.function().args(schemas.Fr).returns(L2Block.schema.optional()),
 

--- a/yarn-project/stdlib/src/logs/log_id.ts
+++ b/yarn-project/stdlib/src/logs/log_id.ts
@@ -1,6 +1,7 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { BlockNumber, BlockNumberSchema } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { BufferReader } from '@aztec/foundation/serialize';
 
 import { z } from 'zod';
@@ -81,7 +82,7 @@ export class LogId {
     const reader = BufferReader.asReader(buffer);
 
     const blockNumber = BlockNumber(reader.readNumber());
-    const blockHash = reader.readObject(BlockHash);
+    const blockHash = new BlockHash(reader.readObject(Fr));
     const txIndex = reader.readNumber();
     const logIndex = reader.readNumber();
 

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -164,8 +164,8 @@ export class BlockHeader {
 
   hash(): Promise<BlockHash> {
     if (!this._cachedHash) {
-      this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HEADER_HASH).then(fr =>
-        BlockHash.fromField(fr),
+      this._cachedHash = poseidon2HashWithSeparator(this.toFields(), GeneratorIndex.BLOCK_HEADER_HASH).then(
+        fr => new BlockHash(fr),
       );
     }
     return this._cachedHash;
@@ -173,7 +173,7 @@ export class BlockHeader {
 
   /** Manually set the hash for this block header if already computed */
   setHash(hashed: Fr) {
-    this._cachedHash = Promise.resolve(BlockHash.fromField(hashed));
+    this._cachedHash = Promise.resolve(new BlockHash(hashed));
   }
 
   static random(overrides: Partial<FieldsOf<BlockHeader>> & Partial<FieldsOf<GlobalVariables>> = {}): BlockHeader {

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -1,4 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
@@ -26,7 +27,7 @@ export function serializeIndexedTxEffect(effect: IndexedTxEffect): Buffer {
 export function deserializeIndexedTxEffect(buffer: Buffer): IndexedTxEffect {
   const reader = BufferReader.asReader(buffer);
 
-  const l2BlockHash = reader.readObject(BlockHash);
+  const l2BlockHash = new BlockHash(reader.readObject(Fr));
   const l2BlockNumber = BlockNumber(reader.readNumber());
   const txIndexInBlock = reader.readNumber();
   const data = reader.readObject(TxEffect);

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -351,7 +351,7 @@ export class RPCTranslator {
     foreignStartStorageSlot: ForeignCallSingle,
     foreignNumberOfElements: ForeignCallSingle,
   ) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const contractAddress = addressFromSingle(foreignContractAddress);
     const startStorageSlot = fromSingle(foreignStartStorageSlot);
     const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
@@ -367,7 +367,7 @@ export class RPCTranslator {
   }
 
   async utilityGetPublicDataWitness(foreignBlockHash: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const leafSlot = fromSingle(foreignLeafSlot);
 
     const witness = await this.handlerAsUtility().utilityGetPublicDataWitness(blockHash, leafSlot);
@@ -574,7 +574,7 @@ export class RPCTranslator {
   }
 
   async utilityGetNullifierMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignNullifier: ForeignCallSingle) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const nullifier = fromSingle(foreignNullifier);
 
     const witness = await this.handlerAsUtility().utilityGetNullifierMembershipWitness(blockHash, nullifier);
@@ -642,7 +642,7 @@ export class RPCTranslator {
   }
 
   async utilityGetNoteHashMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignLeafValue: ForeignCallSingle) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const leafValue = fromSingle(foreignLeafValue);
 
     const witness = await this.handlerAsUtility().utilityGetNoteHashMembershipWitness(blockHash, leafValue);
@@ -654,7 +654,7 @@ export class RPCTranslator {
   }
 
   async utilityGetArchiveMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignLeafValue: ForeignCallSingle) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const leafValue = fromSingle(foreignLeafValue);
 
     const witness = await this.handlerAsUtility().utilityGetArchiveMembershipWitness(blockHash, leafValue);
@@ -669,7 +669,7 @@ export class RPCTranslator {
     foreignBlockHash: ForeignCallSingle,
     foreignNullifier: ForeignCallSingle,
   ) {
-    const blockHash = BlockHash.fromString(foreignBlockHash);
+    const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const nullifier = fromSingle(foreignNullifier);
 
     const witness = await this.handlerAsUtility().utilityGetLowNullifierMembershipWitness(blockHash, nullifier);

--- a/yarn-project/world-state/src/native/message.ts
+++ b/yarn-project/world-state/src/native/message.ts
@@ -1,6 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { Tuple } from '@aztec/foundation/serialize';
+import type { BlockHash } from '@aztec/stdlib/block';
 import { AppendOnlyTreeSnapshot, MerkleTreeId } from '@aztec/stdlib/trees';
 import type { StateReference } from '@aztec/stdlib/tx';
 import type { UInt32 } from '@aztec/stdlib/types';
@@ -412,7 +413,7 @@ interface UpdateArchiveRequest extends WithForkId {
 interface SyncBlockRequest extends WithCanonicalForkId {
   blockNumber: BlockNumber;
   blockStateRef: BlockStateReference;
-  blockHeaderHash: Fr;
+  blockHeaderHash: BlockHash;
   paddedNoteHashes: readonly SerializedLeafValue[];
   paddedL1ToL2Messages: readonly SerializedLeafValue[];
   paddedNullifiers: readonly SerializedLeafValue[];

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -147,9 +147,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
 
     // the initial header _must_ be the first element in the archive tree
     // if this assertion fails, check that the hashing done in Header in yarn-project matches the initial header hash done in world_state.cpp
-    const indices = await committed.findLeafIndices(MerkleTreeId.ARCHIVE, [
-      (await this.initialHeader.hash()).toField(),
-    ]);
+    const indices = await committed.findLeafIndices(MerkleTreeId.ARCHIVE, [(await this.initialHeader.hash()).toFr()]);
     const initialHeaderIndex = indices[0];
     assert.strictEqual(initialHeaderIndex, 0n, 'Invalid initial archive state');
   }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -56,7 +56,7 @@ describe('ServerWorldStateSynchronizer', () => {
 
     merkleTreeRead = mock<MerkleTreeReadOperations>();
     merkleTreeRead.getInitialHeader.mockReturnValue({
-      hash: () => Promise.resolve(BlockHash.fromField(Fr.random())),
+      hash: () => Promise.resolve(new BlockHash(Fr.random())),
     } as BlockHeader);
     merkleTreeRead.getLeafValue.mockResolvedValue(Fr.random());
 

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -6,7 +6,6 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
-import { BlockHash } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -94,9 +93,8 @@ describe('world-state integration', () => {
   };
 
   const expectSynchedBlockHashMatches = async (number: number) => {
-    const syncedBlockHashFr = await db.getCommitted().getLeafValue(MerkleTreeId.ARCHIVE, BigInt(number));
-    const syncedBlockHash = syncedBlockHashFr ? BlockHash.fromField(syncedBlockHashFr) : undefined;
-    const archiverBlockHash = await archiver.getBlockHeader(number).then(h => h?.hash());
+    const syncedBlockHash = await db.getCommitted().getLeafValue(MerkleTreeId.ARCHIVE, BigInt(number));
+    const archiverBlockHash = await (await archiver.getBlockHeader(number))?.hash();
     expect(syncedBlockHash).toEqual(archiverBlockHash);
   };
 


### PR DESCRIPTION
As Santiago proposed [here](https://github.com/AztecProtocol/aztec-packages/pull/19899#pullrequestreview-3705795090) makes sense to have `BlockHash` extend from `Fr` instead from `Buffer32` because the hash is the output of Poseidon2 hash and hence natively a field.

Also introduced branding to avoid collisions with `Fr` and cleaned up the type from unused functions.