### PR TITLE
fix(archiver): reject proposed blocks for slots that have already passed

### DIFF
--- a/yarn-project/archiver/src/archiver-sync.test.ts
+++ b/yarn-project/archiver/src/archiver-sync.test.ts
@@ -1080,6 +1080,42 @@ describe('Archiver Sync', () => {
       await expect(archiver.addBlock(blockAlreadySyncedFromCheckpoint)).rejects.toThrow();
     }, 10_000);
 
+    it('rejects adding blocks for past slots', async () => {
+      // L1 constants from setup: slotDuration=24, ethereumSlotDuration=12
+      // L1 blocks per L2 slot = 24/12 = 2
+      // L2 slot for L1 block N = floor((N * 12) / 24) = floor(N / 2)
+
+      // Sync checkpoint 1 from L1 to establish a baseline
+      const { checkpoint: cp1 } = await fake.addCheckpoint(CheckpointNumber(1), {
+        l1BlockNumber: 4n, // This is in L2 slot 2
+        messagesL1BlockNumber: 2n,
+        numL1ToL2Messages: 3,
+        slotNumber: SlotNumber(2),
+      });
+      const cp1Archive = cp1.blocks[cp1.blocks.length - 1].archive;
+
+      fake.setL1BlockNumber(4n);
+      await archiver.syncImmediate();
+
+      expect(await archiver.getSynchedCheckpointNumber()).toEqual(CheckpointNumber(1));
+
+      // Now advance L1 significantly to slot 10 (L1 block 20)
+      // Current slot = floor(20 / 2) = 10
+      // Slot at next L1 block = floor(21 / 2) = 10
+      fake.setL1BlockNumber(20n);
+      await archiver.syncImmediate();
+
+      // Create a block for slot 5 (which has already passed)
+      const pastSlotBlocks = await fake.makeBlocks(CheckpointNumber(2), {
+        l1BlockNumber: 10n, // Would be slot 5
+        previousArchive: cp1Archive,
+        slotNumber: SlotNumber(5), // Explicitly set past slot
+      });
+
+      // Try to add the block for the past slot - should be rejected
+      await expect(archiver.addBlock(pastSlotBlocks[0])).rejects.toThrow(/past slot/);
+    }, 10_000);
+
     it('adds missing blocks when checkpoint has more blocks than local', async () => {
       // Sync checkpoint 1 from L1
       await fake.addCheckpoint(CheckpointNumber(1), {

--- a/yarn-project/archiver/src/archiver.ts
+++ b/yarn-project/archiver/src/archiver.ts
@@ -26,6 +26,7 @@ import { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import {
   type L1RollupConstants,
   getEpochNumberAtTimestamp,
+  getSlotAtNextL1Block,
   getSlotAtTimestamp,
   getSlotRangeForEpoch,
   getTimestampRangeForEpoch,
@@ -212,8 +213,23 @@ export class Archiver extends ArchiverDataSourceBase implements L2BlockSink, Tra
     const queuedItems = this.blockQueue.splice(0, this.blockQueue.length);
     this.log.debug(`Processing ${queuedItems.length} queued block(s)`);
 
+    // Calculate slot threshold for validation
+    const l1Timestamp = this.synchronizer.getL1Timestamp();
+    const slotAtNextL1Block =
+      l1Timestamp === undefined ? undefined : getSlotAtNextL1Block(l1Timestamp, this.l1Constants);
+
     // Process each block individually to properly resolve/reject each promise
     for (const { block, resolve, reject } of queuedItems) {
+      const blockSlot = block.header.globalVariables.slotNumber;
+      if (slotAtNextL1Block !== undefined && blockSlot < slotAtNextL1Block) {
+        this.log.warn(
+          `Rejecting proposed block ${block.number} for past slot ${blockSlot} (current is ${slotAtNextL1Block})`,
+          { block: block.toBlockInfo(), l1Timestamp, slotAtNextL1Block },
+        );
+        reject(new Error(`Block ${block.number} is for past slot ${blockSlot} (current is ${slotAtNextL1Block})`));
+        continue;
+      }
+
       try {
         await this.updater.addProposedBlocks([block]);
         this.log.debug(`Added block ${block.number} to store`);

--- a/yarn-project/archiver/src/modules/l1_synchronizer.ts
+++ b/yarn-project/archiver/src/modules/l1_synchronizer.ts
@@ -16,7 +16,7 @@ import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
 import { isDefined } from '@aztec/foundation/types';
 import { type ArchiverEmitter, L2BlockSourceEvents, type ValidateCheckpointResult } from '@aztec/stdlib/block';
 import { PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
-import { type L1RollupConstants, getEpochAtSlot, getSlotAtTimestamp } from '@aztec/stdlib/epoch-helpers';
+import { type L1RollupConstants, getEpochAtSlot, getSlotAtNextL1Block } from '@aztec/stdlib/epoch-helpers';
 import { computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import { type Traceable, type Tracer, execInSpan, trackSpan } from '@aztec/telemetry-client';
 
@@ -249,8 +249,7 @@ export class ArchiverL1Synchronizer implements Traceable {
     const firstUncheckpointedBlockSlot = firstUncheckpointedBlockHeader?.getSlot();
 
     // What's the slot at the next L1 block? All blocks for slots strictly before this one should've been checkpointed by now.
-    const nextL1BlockTimestamp = currentL1Timestamp + BigInt(this.l1Constants.ethereumSlotDuration);
-    const slotAtNextL1Block = getSlotAtTimestamp(nextL1BlockTimestamp, this.l1Constants);
+    const slotAtNextL1Block = getSlotAtNextL1Block(currentL1Timestamp, this.l1Constants);
 
     // Prune provisional blocks from slots that have ended without being checkpointed
     if (firstUncheckpointedBlockSlot !== undefined && firstUncheckpointedBlockSlot < slotAtNextL1Block) {

--- a/yarn-project/stdlib/src/epoch-helpers/index.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.ts
@@ -51,6 +51,15 @@ export function getSlotAtTimestamp(
     : SlotNumber.fromBigInt((ts - constants.l1GenesisTime) / BigInt(constants.slotDuration));
 }
 
+/** Returns the L2 slot number at the next L1 block based on the current timestamp. */
+export function getSlotAtNextL1Block(
+  currentL1Timestamp: bigint,
+  constants: Pick<L1RollupConstants, 'l1GenesisTime' | 'slotDuration' | 'ethereumSlotDuration'>,
+): SlotNumber {
+  const nextL1BlockTimestamp = currentL1Timestamp + BigInt(constants.ethereumSlotDuration);
+  return getSlotAtTimestamp(nextL1BlockTimestamp, constants);
+}
+
 /** Returns the epoch number for a given timestamp. */
 export function getEpochNumberAtTimestamp(
   ts: bigint,


### PR DESCRIPTION
Do not add proposed blocks to the archiver that would immediately be cleaned up by the L1 synchronizer since they belong to a past slot.