### PR TITLE
fix(sequencer): use checkpointed chain tip for sync check

### DIFF
--- a/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_publisher/e2e_l1_publisher.test.ts
@@ -40,6 +40,8 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { hexToBuffer } from '@aztec/foundation/string';
 import { TestDateProvider } from '@aztec/foundation/timer';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractsList, protocolContractsHash } from '@aztec/protocol-contracts';
@@ -137,6 +139,7 @@ describe('L1Publisher integration', () => {
   let ethCheatCodes: EthCheatCodesWithState;
   let rollupCheatCodes: RollupCheatCodes;
   let worldStateSynchronizer: ServerWorldStateSynchronizer;
+  let worldStateStore: AztecAsyncKVStore;
   let epochCache: EpochCache;
 
   let rpcUrl: string;
@@ -248,7 +251,13 @@ describe('L1Publisher integration', () => {
       worldStateDbMapSizeKb: 10 * 1024 * 1024,
       worldStateBlockHistory: 0,
     };
-    worldStateSynchronizer = new ServerWorldStateSynchronizer(builderDb, blockSource, worldStateConfig);
+    worldStateStore = await openTmpStore('world-state-test');
+    worldStateSynchronizer = new ServerWorldStateSynchronizer(
+      builderDb,
+      blockSource,
+      worldStateStore,
+      worldStateConfig,
+    );
     await worldStateSynchronizer.start();
 
     const sequencerL1Client = createExtendedL1Client(config.l1RpcUrls, sequencerPK, foundry);
@@ -312,6 +321,7 @@ describe('L1Publisher integration', () => {
   afterEach(async () => {
     await tryStop(anvil);
     await tryStop(worldStateSynchronizer);
+    await worldStateStore?.close();
   });
 
   const makeProcessedTx = (seed = 0x1): Promise<ProcessedTx> =>

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -1,4 +1,4 @@
-import type { EthAddress, L2BlockId } from '@aztec/stdlib/block';
+import type { EthAddress, L2BlockId, L2Tips } from '@aztec/stdlib/block';
 import type { P2PApiFull } from '@aztec/stdlib/interfaces/server';
 import type { BlockProposal, CheckpointAttestation, CheckpointProposal, P2PClientType } from '@aztec/stdlib/p2p';
 import type { Tx, TxHash } from '@aztec/stdlib/tx';
@@ -183,6 +183,9 @@ export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApiFull<T> & 
    * Returns the current status of the p2p client.
    */
   getStatus(): Promise<P2PSyncState>;
+
+  /** Returns the synced chain tips by the p2p client. */
+  getL2Tips(): Promise<L2Tips>;
 
   /**
    * Returns the ENR of this node, if any.

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts
@@ -170,7 +170,7 @@ describe('TxPool: Benchmarks', () => {
         });
       },
     });
-    wsSync = new ServerWorldStateSynchronizer(ws, l2, getDefaultConfig(worldStateConfigMappings));
+    wsSync = new ServerWorldStateSynchronizer(ws, l2, store, getDefaultConfig(worldStateConfigMappings));
     await wsSync.start();
     pool = new AztecKVTxPool(store, store, wsSync);
   });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -475,7 +475,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
    * We don't check against the previous block submitted since it may have been reorg'd out.
    */
   protected async checkSync(args: { ts: bigint; slot: SlotNumber }): Promise<SequencerSyncCheckResult | undefined> {
-    // Check that the archiver and dependencies have synced to the previous L1 slot at least
+    // Check that the archiver and dependencies have synced to the previous L1 slot
     // TODO(#14766): Archiver reports L1 timestamp based on L1 blocks seen, which means that a missed L1 block will
     // cause the archiver L1 timestamp to fall behind, and cause this sequencer to start processing one L1 slot later.
     const l1Timestamp = await this.l2BlockSource.getL1Timestamp();
@@ -490,13 +490,10 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     const syncedBlocks = await Promise.all([
-      this.worldState.status().then(({ syncSummary }) => ({
-        number: syncSummary.latestBlockNumber,
-        hash: syncSummary.latestBlockHash,
-      })),
-      this.l2BlockSource.getL2Tips().then(t => t.proposed),
-      this.p2pClient.getStatus().then(p2p => p2p.syncedToL2Block),
-      this.l1ToL2MessageSource.getL2Tips().then(t => t.proposed),
+      this.worldState.getL2Tips().then(t => t.checkpointed),
+      this.l2BlockSource.getL2Tips().then(t => t.checkpointed),
+      this.p2pClient.getL2Tips().then(p2p => p2p.checkpointed),
+      this.l1ToL2MessageSource.getL2Tips().then(t => t.checkpointed),
       this.l2BlockSource.getPendingChainValidationStatus(),
     ] as const);
 
@@ -506,10 +503,13 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     // as the world state can compute the new genesis block hash, but other components use the hardcoded constant.
     // TODO(palla/mbps): Fix the above. All components should be able to handle dynamic genesis block hashes.
     const result =
-      (l2BlockSource.number === 0 && worldState.number === 0 && p2p.number === 0 && l1ToL2MessageSource.number === 0) ||
-      (worldState.hash === l2BlockSource.hash &&
-        p2p.hash === l2BlockSource.hash &&
-        l1ToL2MessageSource.hash === l2BlockSource.hash);
+      (l2BlockSource.block.number === 0 &&
+        worldState.block.number === 0 &&
+        p2p.block.number === 0 &&
+        l1ToL2MessageSource.block.number === 0) ||
+      (worldState.block.hash === l2BlockSource.block.hash &&
+        p2p.block.hash === l2BlockSource.block.hash &&
+        l1ToL2MessageSource.block.hash === l2BlockSource.block.hash);
 
     if (!result) {
       this.log.debug(`Sequencer sync check failed`, { worldState, l2BlockSource, p2p, l1ToL2MessageSource });
@@ -517,7 +517,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
 
     // Special case for genesis state
-    const blockNumber = worldState.number;
+    const blockNumber = l2BlockSource.block.number;
     if (blockNumber < INITIAL_L2_BLOCK_NUM) {
       const archive = new Fr((await this.worldState.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
       return {

--- a/yarn-project/stdlib/src/interfaces/world_state.ts
+++ b/yarn-project/stdlib/src/interfaces/world_state.ts
@@ -3,6 +3,7 @@ import type { PromiseWithResolvers } from '@aztec/foundation/promise';
 
 import { z } from 'zod';
 
+import type { L2Tips } from '../block/l2_block_source.js';
 import type { SnapshotDataKeys } from '../snapshots/types.js';
 import type { MerkleTreeReadOperations, MerkleTreeWriteOperations } from './merkle_tree_operations.js';
 
@@ -89,6 +90,9 @@ export interface WorldStateSynchronizer extends ReadonlyWorldStateAccess, ForkMe
 
   /** Deletes the db */
   clear(): Promise<void>;
+
+  /** Returns the chain tips that have been synced by the world state synchronizer. */
+  getL2Tips(): Promise<L2Tips>;
 }
 
 export const WorldStateSyncStatusSchema: z.ZodType<WorldStateSyncStatus, z.ZodTypeDef, any> = z.object({

--- a/yarn-project/txe/src/state_machine/synchronizer.ts
+++ b/yarn-project/txe/src/state_machine/synchronizer.ts
@@ -85,4 +85,8 @@ export class TXESynchronizer implements WorldStateSynchronizer {
   public clear(): Promise<void> {
     throw new Error('TXE Synchronizer does not implement "clear"');
   }
+
+  public getL2Tips(): Promise<never> {
+    throw new Error('TXE Synchronizer does not implement "getL2Tips"');
+  }
 }

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -87,6 +87,7 @@
   },
   "devDependencies": {
     "@aztec/archiver": "workspace:^",
+    "@aztec/kv-store": "workspace:^",
     "@aztec/world-state": "workspace:^",
     "@electric-sql/pglite": "^0.3.14",
     "@jest/globals": "^30.0.0",

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -13,6 +13,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { Hex } from '@aztec/foundation/string';
 import { TestDateProvider } from '@aztec/foundation/timer';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import type { P2P, PeerId } from '@aztec/p2p';
@@ -115,7 +116,8 @@ describe('ValidatorClient Integration', () => {
       worldStateBlockHistory: 0,
     };
     const worldStateDb = await NativeWorldStateService.tmp(rollupAddress, true, prefilledPublicData);
-    const synchronizer = new ServerWorldStateSynchronizer(worldStateDb, archiver, wsConfig);
+    const worldStateStore = await openTmpStore('validator-ws-test');
+    const synchronizer = new ServerWorldStateSynchronizer(worldStateDb, archiver, worldStateStore, wsConfig);
     await synchronizer.start();
 
     // Create real checkpoints builder

--- a/yarn-project/validator-client/tsconfig.json
+++ b/yarn-project/validator-client/tsconfig.json
@@ -58,6 +58,9 @@
       "path": "../archiver"
     },
     {
+      "path": "../kv-store"
+    },
+    {
       "path": "../world-state"
     }
   ],

--- a/yarn-project/world-state/src/synchronizer/factory.ts
+++ b/yarn-project/world-state/src/synchronizer/factory.ts
@@ -1,4 +1,6 @@
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
@@ -17,15 +19,20 @@ export interface WorldStateTreeMapSizes {
   publicDataTreeMapSizeKb: number;
 }
 
+export const WORLD_STATE_STORE_NAME = 'world_state';
+export const WORLD_STATE_STORE_VERSION = 1;
+
 export async function createWorldStateSynchronizer(
   config: WorldStateConfig & DataStoreConfig,
   l2BlockSource: L2BlockSource & L1ToL2MessageSource,
   prefilledPublicData: PublicDataTreeLeaf[] = [],
   client: TelemetryClient = getTelemetryClient(),
+  store?: AztecAsyncKVStore,
 ) {
   const instrumentation = new WorldStateInstrumentation(client);
   const merkleTrees = await createWorldState(config, prefilledPublicData, instrumentation);
-  return new ServerWorldStateSynchronizer(merkleTrees, l2BlockSource, config, instrumentation);
+  const kvStore = store ?? (await createStore(WORLD_STATE_STORE_NAME, WORLD_STATE_STORE_VERSION, config));
+  return new ServerWorldStateSynchronizer(merkleTrees, l2BlockSource, kvStore, config, instrumentation);
 }
 
 export async function createWorldState(

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -3,6 +3,8 @@ import { BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { BlockHash, L2Block, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
@@ -28,6 +30,7 @@ describe('ServerWorldStateSynchronizer', () => {
   let merkleTreeDb: MockProxy<MerkleTreeAdminDatabase>;
   let merkleTreeRead: MockProxy<MerkleTreeReadOperations>;
   let l2BlockStream: MockProxy<L2BlockStream>;
+  let store: AztecAsyncKVStore;
 
   let server: TestWorldStateSynchronizer;
   let latestHandledBlockNumber: number;
@@ -47,7 +50,7 @@ describe('ServerWorldStateSynchronizer', () => {
     );
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     blockAndMessagesSource = mock<L2BlockSource & L1ToL2MessageSource>();
     blockAndMessagesSource.getBlockNumber.mockResolvedValue(BlockNumber(LATEST_BLOCK_NUMBER));
     blockAndMessagesSource.getL1ToL2Messages.mockImplementation(checkNumber => {
@@ -83,11 +86,13 @@ describe('ServerWorldStateSynchronizer', () => {
       worldStateBlockHistory: 0,
     };
 
-    server = new TestWorldStateSynchronizer(merkleTreeDb, blockAndMessagesSource, config, l2BlockStream);
+    store = await openTmpStore('test');
+    server = new TestWorldStateSynchronizer(merkleTreeDb, blockAndMessagesSource, store, config, l2BlockStream);
   });
 
   afterEach(async () => {
     await server.stop();
+    await store?.close();
   });
 
   const pushBlocks = async (from: number, to: number) => {
@@ -249,10 +254,11 @@ class TestWorldStateSynchronizer extends ServerWorldStateSynchronizer {
   constructor(
     merkleTrees: MerkleTreeAdminDatabase,
     blockAndMessagesSource: L2BlockSource & L1ToL2MessageSource,
+    store: AztecAsyncKVStore,
     worldStateConfig: WorldStateConfig,
     private mockBlockStream: L2BlockStream,
   ) {
-    super(merkleTrees, blockAndMessagesSource, worldStateConfig);
+    super(merkleTrees, blockAndMessagesSource, store, worldStateConfig);
   }
 
   protected override createBlockStream(): L2BlockStream {

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -1,13 +1,12 @@
-import { GENESIS_BLOCK_HEADER_HASH, INITIAL_L2_BLOCK_NUM, INITIAL_L2_CHECKPOINT_NUM } from '@aztec/constants';
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { elapsed } from '@aztec/foundation/timer';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import { L2TipsKVStore } from '@aztec/kv-store/stores';
 import {
-  GENESIS_CHECKPOINT_HEADER_HASH,
   type L2Block,
-  type L2BlockId,
   type L2BlockSource,
   L2BlockStream,
   type L2BlockStreamEvent,
@@ -51,6 +50,7 @@ export class ServerWorldStateSynchronizer
 
   private syncPromise = promiseWithResolvers<void>();
   protected blockStream: L2BlockStream | undefined;
+  private l2Tips: L2TipsKVStore;
 
   // WorldState doesn't track the proven block number, it only tracks the latest tips of the pending chain and the finalized chain
   // store the proven block number here, in the synchronizer, so that we don't end up spamming the logs with 'chain-proved' events
@@ -59,12 +59,14 @@ export class ServerWorldStateSynchronizer
   constructor(
     private readonly merkleTreeDb: MerkleTreeAdminDatabase,
     private readonly l2BlockSource: L2BlockSource & L1ToL2MessageSource,
+    private store: AztecAsyncKVStore,
     private readonly config: WorldStateConfig,
     private instrumentation = new WorldStateInstrumentation(getTelemetryClient()),
     private readonly log: Logger = createLogger('world_state'),
   ) {
     this.merkleTreeCommitted = this.merkleTreeDb.getCommitted();
     this.historyToKeep = config.worldStateBlockHistory < 1 ? undefined : config.worldStateBlockHistory;
+    this.l2Tips = new L2TipsKVStore(store, 'world_state');
     this.log.info(
       `Created world state synchroniser with block history of ${
         this.historyToKeep === undefined ? 'infinity' : this.historyToKeep
@@ -239,41 +241,8 @@ export class ServerWorldStateSynchronizer
   }
 
   /** Returns the latest L2 block number for each tip of the chain (latest, proven, finalized). */
-  public async getL2Tips(): Promise<L2Tips> {
-    const status = await this.merkleTreeDb.getStatusSummary();
-    const unfinalizedBlockHashPromise = this.getL2BlockHash(status.unfinalizedBlockNumber);
-    const finalizedBlockHashPromise = this.getL2BlockHash(status.finalizedBlockNumber);
-
-    const provenBlockNumber = this.provenBlockNumber ?? status.finalizedBlockNumber;
-    const provenBlockHashPromise =
-      this.provenBlockNumber === undefined ? finalizedBlockHashPromise : this.getL2BlockHash(this.provenBlockNumber);
-
-    const [unfinalizedBlockHash, finalizedBlockHash, provenBlockHash] = await Promise.all([
-      unfinalizedBlockHashPromise,
-      finalizedBlockHashPromise,
-      provenBlockHashPromise,
-    ]);
-    const latestBlockId: L2BlockId = { number: status.unfinalizedBlockNumber, hash: unfinalizedBlockHash! };
-
-    // World state doesn't track checkpointed blocks or checkpoints themselves.
-    // but we use a block stream so we need to provide 'local' L2Tips.
-    // We configure the block stream to ignore checkpoints and set checkpoint values to genesis here.
-    const genesisCheckpointHeaderHash = GENESIS_CHECKPOINT_HEADER_HASH.toString();
-    return {
-      proposed: latestBlockId,
-      checkpointed: {
-        block: { number: INITIAL_L2_BLOCK_NUM, hash: GENESIS_BLOCK_HEADER_HASH.toString() },
-        checkpoint: { number: INITIAL_L2_CHECKPOINT_NUM, hash: genesisCheckpointHeaderHash },
-      },
-      finalized: {
-        block: { number: status.finalizedBlockNumber, hash: finalizedBlockHash ?? '' },
-        checkpoint: { number: INITIAL_L2_CHECKPOINT_NUM, hash: genesisCheckpointHeaderHash },
-      },
-      proven: {
-        block: { number: provenBlockNumber, hash: provenBlockHash ?? '' },
-        checkpoint: { number: INITIAL_L2_CHECKPOINT_NUM, hash: genesisCheckpointHeaderHash },
-      },
-    };
+  public getL2Tips(): Promise<L2Tips> {
+    return this.l2Tips.getL2Tips();
   }
 
   /** Handles an event emitted by the block stream. */
@@ -291,6 +260,19 @@ export class ServerWorldStateSynchronizer
       case 'chain-finalized':
         await this.handleChainFinalized(event.block.number);
         break;
+    }
+
+    await this.l2Tips.handleBlockStreamEvent(event);
+
+    // Check if initial sync is complete AFTER tips are updated
+    if (
+      event.type === 'blocks-added' &&
+      this.currentState === WorldStateRunningState.SYNCHING &&
+      event.blocks.length > 0 &&
+      event.blocks.at(-1)!.number >= this.latestBlockNumberAtStart
+    ) {
+      this.setCurrentState(WorldStateRunningState.RUNNING);
+      this.syncPromise.resolve();
     }
   }
 
@@ -346,14 +328,7 @@ export class ServerWorldStateSynchronizer
       blockHash: await l2Block.hash().then(h => h.toString()),
       l1ToL2Messages: l1ToL2Messages.map(msg => msg.toString()),
     });
-    const result = await this.merkleTreeDb.handleL2BlockAndMessages(l2Block, l1ToL2Messages);
-
-    if (this.currentState === WorldStateRunningState.SYNCHING && l2Block.number >= this.latestBlockNumberAtStart) {
-      this.setCurrentState(WorldStateRunningState.RUNNING);
-      this.syncPromise.resolve();
-    }
-
-    return result;
+    return this.merkleTreeDb.handleL2BlockAndMessages(l2Block, l1ToL2Messages);
   }
 
   private async handleChainFinalized(blockNumber: BlockNumber) {

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -5,7 +5,9 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
@@ -27,6 +29,7 @@ describe('world-state integration', () => {
   let synchronizer: TestWorldStateSynchronizer;
   let config: WorldStateConfig & DataStoreConfig;
   let log: Logger;
+  let store: AztecAsyncKVStore;
 
   let checkpoints: { checkpoint: Checkpoint; messages: Fr[] }[];
 
@@ -59,13 +62,15 @@ describe('world-state integration', () => {
     archiver = new MockPrefilledArchiver(checkpoints);
 
     db = (await createWorldState(config)) as NativeWorldStateService;
-    synchronizer = new TestWorldStateSynchronizer(db, archiver, config);
+    store = await openTmpStore('world-state-integration-test');
+    synchronizer = new TestWorldStateSynchronizer(db, archiver, store, config);
     log.info(`Created synchronizer`);
   }, 30_000);
 
   afterEach(async () => {
     await synchronizer.stop();
     await db.close();
+    await store?.close();
   });
 
   const awaitSync = async (blockToSyncTo: number, finalized?: number, maxTimeoutMS = 30000) => {
@@ -153,7 +158,7 @@ describe('world-state integration', () => {
       await expectSynchedToBlock(5);
       await synchronizer.stopBlockStream();
 
-      synchronizer = new TestWorldStateSynchronizer(db, archiver, config);
+      synchronizer = new TestWorldStateSynchronizer(db, archiver, store, config);
 
       await archiver.createBlocks(3);
       await synchronizer.start();
@@ -194,7 +199,10 @@ describe('world-state integration', () => {
   describe('immediate sync', () => {
     beforeEach(() => {
       // Set up a synchronizer with a longer block check interval to avoid interference with immediate sync
-      synchronizer = new TestWorldStateSynchronizer(db, archiver, { ...config, worldStateBlockCheckIntervalMS: 1000 });
+      synchronizer = new TestWorldStateSynchronizer(db, archiver, store, {
+        ...config,
+        worldStateBlockCheckIntervalMS: 1000,
+      });
     });
 
     it('syncs immediately to the latest block', async () => {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -2269,6 +2269,7 @@ __metadata:
     "@aztec/epoch-cache": "workspace:^"
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
+    "@aztec/kv-store": "workspace:^"
     "@aztec/node-keystore": "workspace:^"
     "@aztec/noir-protocol-circuits-types": "workspace:^"
     "@aztec/p2p": "workspace:^"


### PR DESCRIPTION
Do not use proposed blocks for the sync check on the sequencer to decide if we can move forward with proposing a block. Instead, we should look at the checkpointed chain.

This PR also adds an L2 tips store to world state so it can respond to getL2Tips requests, and exposes the tips store from p2p client as well.

