### PR TITLE
DO NOTE MERGE reset audit comments

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/keys/constants.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/constants.nr
@@ -2,13 +2,16 @@ use dep::protocol_types::constants::{
     DOM_SEP__IVSK_M, DOM_SEP__NSK_M, DOM_SEP__OVSK_M, DOM_SEP__TSK_M,
 };
 
+// TODO: this should live in noir-protocol-circuits/
 pub global NULLIFIER_INDEX: Field = 0;
 pub global INCOMING_INDEX: Field = 1;
 pub global OUTGOING_INDEX: Field = 2;
 pub global TAGGING_INDEX: Field = 3;
 
+// TODO: this should live in noir-protocol-circuits/
 pub global NUM_KEY_TYPES: u32 = 4;
 
+// TODO: this should live in noir-protocol-circuits/
 pub global sk_generators: [Field; 4] = [
     DOM_SEP__NSK_M as Field,
     DOM_SEP__IVSK_M as Field,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array.nr
@@ -84,6 +84,7 @@ unconstrained fn get_num_padded_items<Value, let N: u32>(
 where
     Value: Ordered,
 {
+    // Q: where do we assert that the padding is contiguous and immediately after the proper data?
     let mut num_padded_items = 0;
     for i in original_array_length..CappedSize {
         if padded_items[i].counter() == MAX_U32_VALUE {
@@ -184,7 +185,7 @@ where
                 // - Items within the range [original_array.length, CappedSize) in the `sorted_padded_transformed_array`
                 //   are padded items, which must have a counter of `MAX_U32_VALUE` or 0.
                 // - Items within the range [0, original_array.length) in the `original_array` must not have a counter
-                //   of 0 (requirement of the parameter) or `MAX_U32_VALUE` (checked above).
+                //   of 0 (requirement of the parameter) or `MAX_U32_VALUE` (checked above [Q: Checked where, above? Checked in an earlier circuit, maybe? Or earlier in this circuit?]).
                 (original, sorted_index)
             };
 
@@ -195,7 +196,9 @@ where
             // Validate that the counter of the transformed item matches the counter of the original/padded item.
             assert_eq(from.counter(), to.counter(), "mapped item has mismatch counter");
 
-            if !should_be_padded {
+            // Q:
+            // This fn combines checks against output_array.array[to_index] (which is conditionally derived) and output_array.array[i], which makes
+            // it quite difficult to comprehend, and difficult to figure out if we're actually covering all inputs and outputs.
                 // Validate that counters within the range [0, original_array.length) are strictly increasing.
                 // Since all items within the range [0, original_array.length) in the `original_array` must have a
                 // unique counter (a requirement of the parameter), this check guarantees that all items in the

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array/check_padded_items.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array/check_padded_items.nr
@@ -8,7 +8,7 @@ use types::traits::Empty;
 pub unconstrained fn check_padded_items<T, let N: u32>(
     padded_items: [T; N],
     num_original_items: u32,
-    capped_size: u32,
+    capped_size: u32, // Should this be passed as a generic parameter, or does it not matter?
 )
 where
     T: Empty,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array/get_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array/get_order_hints.nr
@@ -37,7 +37,7 @@ where
         let elem = sorted_tuples[i].elem;
         sorted_counters[i] = elem.counter();
         let original_index = if elem.counter() == 0 {
-            i
+            i // Q: why do we do this?
         } else {
             sorted_tuples[i].original_index
         };

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_side_effect_counters.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_side_effect_counters.nr
@@ -51,6 +51,8 @@ impl SideEffectCounter {
         self.global_index == MAX_U32_VALUE
     }
 
+    // Q: why don't we use counter=0 as "nullish"?
+    // Mike: (It does make me a bit nervous that we don't also assert the counter to be `0`, though. Mike: come back to this.)
     pub fn assert_null<let N: u32>(self, msg: str<N>) {
         assert_eq(self.global_index, MAX_U32_VALUE, msg);
     }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
@@ -366,6 +366,7 @@ impl PrivateKernelCircuitOutputComposer {
         &mut self,
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
+        // TODO: check if this abomination is still true:
         // BUG: If we delete this print, the resoluting note_hashes bounded vec is missing the original items.
         no_op(self.public_inputs.end.note_hashes);
         let note_hashes = private_call_public_inputs.note_hashes;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
@@ -42,6 +42,7 @@ fn assert_correctly_siloed_note_hash(
         (siloed, unique)
     };
 
+    // Q (from 6 months ago):
     // We've already spent constraints checking `prev.counter() < min_revertible_side_effect_counter` in
     // transient_data.nr (there, it was: `note_hash.counter() >= split_counter`).
     // I wonder how many extra constraints this is costing?
@@ -115,6 +116,7 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
         }
     }
 
+    // YES MICHAEL. KEEP GOING. YOU'RE ON THE HOME STRAIGHT NOW. ALMOST DONE. DON'T GIVE UP. FOCUS.
     pub fn validate<let NoteHashPendingReadAmount: u32, let NoteHashSettledReadAmount: u32, let NullifierPendingReadAmount: u32, let NullifierSettledReadAmount: u32, let KeyValidationAmount: u32, let TransientDataSquashingAmount: u32, let NoteHashSiloingAmount: u32, let NullifierSiloingAmount: u32, let PrivateLogSiloingAmount: u32>(
         self,
     ) {
@@ -234,7 +236,9 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
     }
 
     fn validate_transient_data<let TransientDataSquashingAmount: u32>(self) {
-        // For private only txs, we squash all transient data.
+        // For private-only txs, we squash all transient data.
+        // TODO: consider doing this within `validate_squashable_note_hash_nullifier_pair` where it's used.
+        // Q: why is this called "split counter"?
         let split_counter = if self.previous_kernel.is_private_only {
             0
         } else {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator/validate_note_logs_linked_to_note_hashes.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator/validate_note_logs_linked_to_note_hashes.nr
@@ -42,6 +42,10 @@ fn validate_note_log_linked_to_note_hash_with_hint<let NUM_NOTE_HASHES: u32>(
 /// - Uses the matching index as a hint to validate the link using `validate_note_log_linked_to_note_hash_with_hint`.
 ///
 /// Note: It also checks logs beyond the claimed length of the logs array.
+/// Q: Is this function actually necessary to call? Do we care if claimed "note logs" are actually related to 
+/// any real note_hashes? Surely we'll find out in a Reset circuit which attempts to squash them. 
+/// And if there is no linked note_hash, and if we don't attempt to squash the logs, then that's the app's fault
+/// and we don't care about preventing that?
 pub fn validate_note_logs_linked_to_note_hashes<let NUM_LOGS: u32, let NUM_NOTE_HASHES: u32>(
     logs: ClaimedLengthArray<Scoped<Counted<PrivateLogData>>, NUM_LOGS>,
     note_hashes: ClaimedLengthArray<Scoped<Counted<NoteHash>>, NUM_NOTE_HASHES>,
@@ -57,7 +61,7 @@ pub fn validate_note_logs_linked_to_note_hashes<let NUM_LOGS: u32, let NUM_NOTE_
                 );
                 if index == note_hashes.array.len() {
                     // If the note hash is not found, return 0 as the index hint so the error message can be more
-                    // explicit.
+                    // explicit. [Q: I don't understand why we do this: we're replacing "not found" with "found at index 0"??]
                     0
                 } else {
                     index

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/get_propagated_key_validation_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/get_propagated_key_validation_requests.nr
@@ -6,7 +6,7 @@ use dep::types::{
 /// Creates the set of un-validated key validation requests to be propagated to the next circuit.
 pub unconstrained fn get_propagated_key_validation_requests<let N: u32>(
     key_validation_requests: ClaimedLengthArray<Scoped<KeyValidationRequestAndGenerator>, N>,
-    key_validation_amount: u32,
+    key_validation_amount: u32, // TODO: Should this be a generic param, or is it ok here? Consider at least changing the case to PascalCase to make the reader's brain realise it's special.
 ) -> ClaimedLengthArray<Scoped<KeyValidationRequestAndGenerator>, N> {
     let mut propagated = ClaimedLengthArray::empty();
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/key_validation_requests_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/key_validation_requests_validator.nr
@@ -18,13 +18,23 @@ impl<let RequestsLen: u32, let HintsLen: u32> KeyValidationRequestsValidator<Req
     // When a reset circuit does not require key validations, the `hints` array will still contain at least one item,
     // while `KeyValidationAmount` will be set to zero.
     pub fn validate<let KeyValidationAmount: u32>(self) {
+        // TODO: consider putting the != 0 case first, so that it matches the layout of read_request_validator, so that it's easier to compare the files side-by-side.
         if KeyValidationAmount == 0 {
             assert_eq(
                 self.propagated_requests,
+            // I've put this static_assert here, but maybe I'm misunderstanding things.
+            std::static_assert(
+                KeyValidationHintsLen == 1,
+                "NAUGHTY",
+            );
+
                 self.key_validation_requests,
                 "All unverified key validation requests must be propagated",
             );
         } else {
+            // std::static_assert(
+            //     KeyValidationAmount ==
+            //     KeyValidationHintsLen,
             assert_eq(
                 KeyValidationAmount,
                 HintsLen,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/validate_key_validation_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/key_validation_request/validate_key_validation_request.nr
@@ -11,6 +11,7 @@ pub fn validate_key_validation_request(
     let contract_address = scoped_request.contract_address;
     let request_and_generator = scoped_request.inner;
     let request = request_and_generator.request;
+    // TODO: rename:
     let sk_app_generator = request_and_generator.sk_app_generator;
 
     // First we check that derived public key matches master public key from request.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
@@ -51,8 +51,9 @@ where
             // a read request by pointing to a valid `read_request_index`.
             for hint in self.hints.pending_read_hints {
                 assert_eq(
+                    // Q: should we also assert that hint.pending_value_index is also nullish, for peace of mind?
                     hint.read_request_index,
-                    ReadRequestLen,
+                    ReadRequestLen, // Why use this as the sentinel for "unused"? Would it be simpler to use MAX_U32?
                     "Unused pending read hint must not point to a read request",
                 );
             }
@@ -76,6 +77,12 @@ where
                 self.tree_root,
             );
         } else {
+            // I've put this static_assert here, but maybe I'm misunderstanding things.
+            std::static_assert(
+                self.hints.settled_read_hints.len() == 1,
+                "NAUGHTY",
+            );
+
             // Validate unused hints: Ensure that all index hints are set to `ReadRequestLen`.
             // This guarantees that the hints cannot be used in `validate_propagated_read_requests` to skip propagating
             // a read request by pointing to a valid `read_request_index`.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
@@ -10,7 +10,8 @@ pub struct PendingReadHint {
 
 impl PendingReadHint {
     pub fn skip(read_request_len: u32) -> Self {
-        PendingReadHint { read_request_index: read_request_len, pending_value_index: 0 }
+        PendingReadHint { read_request_index: read_request_len, pending_value_index: 0 } // TODO: seems dangerous to default to this meaningful index of `0`, instead of the length of the pending_value_index or MAX_U32.
+        // TODO: could we also use MAX_U32 for a skipped read_request_index too, instead of passing-in and using read_request_len (it would avoid having to thread the value through functions)?
     }
 }
 
@@ -20,7 +21,7 @@ impl PendingReadHint {
 /// - Pending values are those produced within the current transaction. This array contains values that may be emitted
 ///   before or after the read requests were made.
 /// - Each `PendingReadHint` provides indices to link a read request with its corresponding pending value.
-/// - Unused hints must be marked with `read_request_index == ReadRequestLen`.
+/// - Unused hints must be marked with `read_request_index == ReadRequestLen`. // TODO: consider using MAX_U32_VALUE
 ///
 /// Invariants checked:
 /// 1. If a hint is active (its `read_request_index` is NOT `ReadRequestLen`):
@@ -45,7 +46,29 @@ where
     for hint in hints {
         let read_request_index = hint.read_request_index;
         let pending_value_index = hint.pending_value_index;
+        // Consider using MAX_U32 for null items.
+        // So the `pending_read_hints` array isn't constrained to be dense on the lhs, empty on the rhs.
+        // You could have [hint, null, hint, null, hint, null] and that is acceptable? Is that safe?
+        //
+        // WAIT - possible bug to think about:
+        // If a PENDING item of `read_request_actions` points to an entry of `pending_read_hints`, but that 
+        // entry's `read_request_index` is maliciously set to null (currently ReadRequestLen, but my brain would
+        // prefer MAX_U32), then this `if` block will be skipped. This would allow me to make fake read_requests that
+        // don't match up to any of the pending note_hashes/nullifiers. So I could read anything I like
+        // within my app circuit (like a note that contains infinite value).
+        // NOPE - there's a check in validate_propagated_read_requests which ensures the `read_request_index` matches
+        // the index of a read_request_action that points to it. DAMMIT, no bug for me today.
+        // TODO: describe this attack in more detail, and explain how constraints elsewhere prevent it.
         if read_request_index != ReadRequestLen {
+            // Oh no! Range checks! Sad face!
+            // So by not asserting that the rhs of our arrays are empty (in the assert_array_appended logic of
+            // the init/inner kernel circuits), we now have to protect against them being nonempty?
+            // Has that init/inner optimisation caused more constraints overall, or not?
+            // I guess because the pending_read_hints array is generally smaller than the larger arrays 
+            // (by design), we probably are saving constraints with the current approach?
+            // I wonder if `<` has more constraints than a subtraction (that would underflow and fail)?
+            // E.g. we could do assert(pending_values.length - pending_value_index != 0); maybe?
+            // Often `<` is just a subtraction in disguise in arithmetic algorithms.
             assert(
                 pending_value_index < pending_values.length,
                 "Cannot read a pending value beyond claimed length",
@@ -69,6 +92,10 @@ where
                 pending_value.counter() < read_request.counter(),
                 "Pending value must be emitted before the read request",
             );
+        } // Belt and braces:
+        else {
+            // Adds 8 gates.
+            assert_eq(pending_value_index, MAX_U32_VALUE);
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_propagated_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_propagated_read_requests.nr
@@ -8,6 +8,9 @@ pub fn validate_propagated_read_requests<let ReadRequestLen: u32, let PendingRea
 ) {
     let mut num_propagated = 0;
     for i in 0..ReadRequestLen {
+        // Q: this doesn't prevent PENDING and SETTLED read_request_actions beyond 
+        // read_requests.length. Is that safe? Is the worst that can happen that another read_request
+        // (beyond the length) is matched-up to a note/nullifier, which has no bearing on the validity of the tx at all?
         let read_request = read_requests.array[i];
         let status = hints.read_request_actions[i];
         if status.action == ReadRequestActions.READ_AS_PENDING {
@@ -40,11 +43,12 @@ pub fn validate_propagated_read_requests<let ReadRequestLen: u32, let PendingRea
                 "Mismatch propagated read request",
             );
 
-            if i < read_requests.length {
+            // Ah, it costs 160 gates to do this assertion:
+            // I'm suggesting it just to protect against accidental bugs; there are many hinted arrays in this
+            // read_requests validation subprotocol, and it's hard to track attacks.
+            assert_eq(status.hint_index, MAX_U32_VALUE, "Invalid value");
                 // Only count the propagated read request if it's within the claimed length.
-                // Without this check, we'd be counting all un-validated read requests, even empty ones, and incorrectly
-                // include them in the final claimed length.
-                //
+                // Edit on the below note: I moved it in and it's cheaper. Please double-check this is safe?
                 // Note: it's cheaper not to include the above `assert_eq` inside this if statement.
                 // But if any two read requests beyond the claimed length differ, the assertion will fail,
                 // because num_propagated will no longer be incremented and both will refer to the same index

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
@@ -47,6 +47,7 @@ where
 {
     for hint in hints {
         let read_request_index = hint.read_request_index;
+        // TODO: same concern over a bug here as `validate_pending_read_requests`. Need to check `validate_propagated_read_requests`.
         if read_request_index != ReadRequestLen {
             let read_request = read_requests.array[read_request_index];
             // To read a settled value, the app should have siloed the value with the contract address so that it
@@ -54,6 +55,9 @@ where
             // While the contract address could technically be ignored here, we assert that it is zero to prevent
             // misconfigured hints from causing a pending read request to be incorrectly validated as a settled read
             // request.
+            // TODO: check if other kernel circuit code _relies_ on settled read_requests having a 
+            // zero contract_address.
+            // (I know that the contract_address of _new_ notes and nullifiers is imbued with meaning in other circuits.)
             assert(
                 read_request.contract_address.is_zero(),
                 "Settled read request must have zero contract address",

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints.nr
@@ -30,6 +30,7 @@ pub struct DerivedHints<let SquashingHintsLen: u32, let NoteHashesLen: u32, let 
     pub note_log_linked_source_indices: [NoteLogLinkedSourceIndices; LogsLen],
 }
 
+/// Q: should we have just derived all this at the beginning, within `squash_transient_data`?
 /// Constructs all derived hints needed to apply transient data squashing logic.
 ///
 /// Given the same input parameters, this function will deterministically return the same derived hints.
@@ -42,15 +43,19 @@ pub unconstrained fn build_derived_hints<let NoteHashesLen: u32, let NullifiersL
     expected_kept_note_hashes: ClaimedLengthArray<Scoped<Counted<NoteHash>>, NoteHashesLen>,
     transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
 ) -> DerivedHints<SquashingHintsLen, NoteHashesLen, NullifiersLen, LogsLen> {
+    // Already computed in an earlier unconstrained fn?
     let num_active_squashing_hints =
         get_num_active_squashing_hints(transient_data_squashing_hints, nullifiers);
 
     let nullifier_index_sorted_tuples =
         build_nullifier_index_sorted_tuples(transient_data_squashing_hints);
 
+    // TODO: consider calling the illustrative `build_squash_flags` fn instead.
+    // Already computed in an earlier unconstrained fn?
     let note_hash_squash_flags =
         build_note_hash_squash_flags(transient_data_squashing_hints, num_active_squashing_hints);
 
+    // Already computed in an earlier unconstrained fn?
     let nullifier_squash_flags =
         build_nullifier_squash_flags(transient_data_squashing_hints, num_active_squashing_hints);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/note_log_linked_source_indices.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/note_log_linked_source_indices.nr
@@ -31,7 +31,9 @@ pub unconstrained fn build_note_log_linked_source_indices<let LogsLen: u32, let 
     kept_note_hashes: ClaimedLengthArray<Scoped<Counted<NoteHash>>, NoteHashesLen>,
     transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
 ) -> [NoteLogLinkedSourceIndices; LogsLen] {
-    let mut linked_source_indices = [
+    // TODO: it'd be nicer to not instantiate the default/null items to 0, because 0 is a valid index.
+    // To avoid confusion, could we use MAX_U32_VALUE instead. Oh, we'll hit out of bounds errors if we do that? Risky?
+    let mut linked_source_indices: [NoteLogLinkedSourceIndices; LogsLen] = [
         NoteLogLinkedSourceIndices {
             transient_data_squashing_hint_index: 0,
             kept_note_hash_index: 0,
@@ -72,6 +74,17 @@ pub unconstrained fn build_note_log_linked_source_indices<let LogsLen: u32, let 
             }
         }
     }
+
+    // Possible bug: with the above approach, if we end up with an item:
+    //  NoteLogLinkedSourceIndices {
+    //     transient_data_squashing_hint_index: 0,
+    //     kept_note_hash_index: 0,
+    // }
+    // ... then it is ambiguous whether: it's empty, or it has been squashed (against the note_hash pointed to by index 0 of the transient_data_squashing_hints), or it has been kept and propagated to index 0 of the kept_note_hashes.
+    // What are the consequences of this bug?
+    // In fact, I need to read on to understand why we even track a kept_note_hash_index only 
+    // for logs with associated note_hashes.
+    // Are there tests that cope with a (0,0) case? There's an example in my diagram.
 
     linked_source_indices
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/num_active_squashing_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/num_active_squashing_hints.nr
@@ -8,12 +8,16 @@ use dep::types::{
 /// Returns the number of active hints in the `transient_data_squashing_hints` array.
 /// Only the first `num_active_squashing_hints` entries in the array are used to squash (note hash, nullifier) pairs.
 /// Remaining entries are considered inactive and will be ignored.
+// Q: what happens if there's a discrepancy where a hint.note_hash_index isn't nullish but the hint.nullifier_index is (or vice versa)?
+// Should we throw an error that the transient_data_squashing_hints input is malformed?
+// Q: what happens if the notes length is different from the nullifiers length? We're only checking against NullifiersLen and not NoteHashesLen; seems dangerous for future aztec devs.
+// Q: what happens if there are more hints beyond the first nullish entry? Should we throw an error that the transient_data_squashing_hints input is malformed?
 pub unconstrained fn get_num_active_squashing_hints<let SquashingHintsLen: u32, let NullifiersLen: u32>(
     transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
-    _nullifiers: ClaimedLengthArray<Scoped<Counted<Nullifier>>, NullifiersLen>,
+    _nullifiers: ClaimedLengthArray<Scoped<Counted<Nullifier>>, NullifiersLen>, // Can we call this fn with turbofish syntax instead, so we don't have this unused `nullifiers` param and all its dependencies?
 ) -> u32 {
     find_first_index(
         transient_data_squashing_hints,
-        |hint| hint.nullifier_index == NullifiersLen,
+        |hint| hint.nullifier_index == NullifiersLen, // TODO: would it be cleaner to use MAX_U32_VALUE instead of NullifiersLen? 
     )
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/squash_flags.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints/squash_flags.nr
@@ -1,5 +1,26 @@
 use crate::reset::transient_data::transient_data_squashing_hint::TransientDataSquashingHint;
 
+// TODO: consider replacing the two fns in this file with one which implements the `for` loop from
+// squash_transient_data.nr, to avoid duplicated code (and then call this):
+// I.e.:
+pub unconstrained fn build_squash_flags<let SquashingHintsLen: u32, let NoteHashesLen: u32, let NullifiersLen: u32>(
+    transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    num_active_squashing_hints: u32,
+) -> ([bool; NoteHashesLen], [bool; NullifiersLen]) {
+    let mut note_hash_squash_flags = [false; NoteHashesLen];
+    let mut nullifier_squash_flags = [false; NullifiersLen];
+
+    for i in 0..num_active_squashing_hints {
+        let hint = transient_data_squashing_hints[i];
+        note_hash_squash_flags[hint.note_hash_index] = true;
+        nullifier_squash_flags[hint.nullifier_index] = true;
+    }
+
+    (note_hash_squash_flags, nullifier_squash_flags)
+}
+
+// TODO: consider removing.
+
 /// Constructs a boolean flag array indicating which note hashes are to be squashed.
 /// For each active squashing hint, sets the flag at the corresponding `note_hash_index` to `true`.
 pub unconstrained fn build_note_hash_squash_flags<let SquashingHintsLen: u32, let NoteHashesLen: u32>(

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
@@ -32,7 +32,7 @@ pub unconstrained fn squash_transient_data<let NoteHashesLen: u32, let Nullifier
     let num_active_squashing_hints =
         get_num_active_squashing_hints(transient_data_squashing_hints, nullifiers);
     for i in 0..num_active_squashing_hints {
-        let hint = transient_data_squashing_hints[i];
+    // TODO: consider replacing this with the illustrative fn in squash_flags.nr.
         note_hash_squash_flags[hint.note_hash_index] = true;
         nullifier_squash_flags[hint.nullifier_index] = true;
     }
@@ -54,9 +54,8 @@ pub unconstrained fn squash_transient_data<let NoteHashesLen: u32, let Nullifier
     }
 
     let mut kept_logs = ClaimedLengthArray::empty();
-    for i in 0..logs.length {
-        let log = logs.array[i];
-        if log.innermost().note_hash_counter == 0 {
+            // Q: why do we use the note_hash counter for log<-->note linkages,
+            // but we use the note_hash itself for nullifier<-->note linkages? Inconsistent.
             // The log is not associated with any note hash.
             kept_logs.push(log);
         } else {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
@@ -48,6 +48,15 @@ pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let 
 
         // === Read the hinted data ===
         // If the log is squashed, it should be linked to the note hash at this index.
+        // Concern: There is ambiguity in how the `note_log_linked_source_indices` are created. Specifically,
+        // a "null" value for `note_log_linked_source_indices.transient_data_squashing_hint_index` and
+        // for `note_log_linked_source_indices.kept_note_hash_index` is `0`, but `0` is also a valid index.
+        // So you can have things like {0, 0} and not know if it's a hint which says the log is
+        // linked to no notes, or the log is linked to the 0th kept index, or the log is linked to the 
+        // 0th note_hash to squash.
+        // I'm finding it a bit difficult to reason about.
+        // Can we not use a different nullish value, like MAX_U32_VALUE?
+        // Hmmm Maybe this is why `is_log_linked_to_note_hash` gracefully returns a bool (rather than doing assertions).
         let squashed_note_hash_index = transient_data_squashing_hints[linked_source_indices
             .transient_data_squashing_hint_index]
             .note_hash_index;
@@ -58,6 +67,8 @@ pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let 
         let expected_kept_log = expected_kept_logs.array[kept_logs_counter];
 
         // === Determine if the log should be kept ===
+        // Q: should we make the indices unambigious?
+        // Q: should we constrain unused hints to be nullish?
         // A log will be kept if:
         // - it is not a note log, OR
         // - it is linked to a kept note hash.
@@ -99,7 +110,8 @@ pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let 
             // know it must point to a valid entry in `note_hashes`.
 
             // === Log and squashed note hash must both be revertible or non-revertible ===
-            // If the squashed note hash is revertible (i.e., counter >= split_counter), the log
+            //
+            // If the squashed note hash is revertible (i.e., counter > split_counter) [Shouldn't this be strict `>`?], the log
             // must also be revertible.
             // If the squashed note hash is non-revertible, the log must be non-revertible.
             //
@@ -111,7 +123,7 @@ pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let 
             //
             // While it is unlikely that an app would want to retain a log linked to a discarded note hash, or discard
             // a log while its note hash is kept, it is still a valid scenario that must be handled.
-            let is_note_hash_revertible = hinted_squashed_note_hash.counter() >= split_counter;
+            let is_note_hash_revertible = hinted_squashed_note_hash.counter() >= split_counter; // Shouldn't this be strict `>`?
             let is_log_revertible = log.counter() >= split_counter;
             assert_eq(
                 is_note_hash_revertible,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing.nr
@@ -52,6 +52,7 @@ pub fn validate_note_hash_nullifier_squashing<let NoteHashesLen: u32, let Nullif
 
             // Validate the squash flags are correctly set.
             // They are used later to check that the kept note hashes and nullifiers are correctly propagated.
+            // TODO: do we need to assert that the other flags are all `false`?
             assert(note_hash_squash_flags[hint.note_hash_index], "Wrong squashed note hash hint");
             assert(nullifier_squash_flags[hint.nullifier_index], "Wrong squashed nullifier hint");
         }
@@ -81,6 +82,7 @@ pub fn validate_note_hash_nullifier_squashing<let NoteHashesLen: u32, let Nullif
     }
     // If a flag is set to `true` for a note hash that is not squashed, the `kept_note_hashes_counter` will be smaller
     // than it should be, and the below check will fail.
+    // Belt&Braces: consider putting in actual checks to assert the rest of the flags are `false`.
     assert_eq(
         kept_note_hashes_counter + num_squashed_pairs,
         NoteHashesLen,
@@ -112,6 +114,7 @@ pub fn validate_note_hash_nullifier_squashing<let NoteHashesLen: u32, let Nullif
     }
     // If a flag is set to `true` for a nullifier that is not squashed, the `kept_nullifiers_counter` will be smaller
     // than it should be, and the below check will fail.
+    // Belt&Braces: consider putting in actual checks to assert the rest of the flags are `false`.
     assert_eq(
         kept_nullifiers_counter + num_squashed_pairs,
         NullifiersLen,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing/validate_squashable_note_hash_nullifier_pair.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing/validate_squashable_note_hash_nullifier_pair.nr
@@ -44,7 +44,7 @@ pub fn validate_squashable_note_hash_nullifier_pair(
     // nullified when the transaction reverts.
     //
     // Note: No need to check the other way around. Since the nullifier counter must be larger than the note hash
-    // counter, it's not possible to have a non-revertible nullifier nullifying a revertible note hash.
+    // TODO: these can be strict `>`, right?
     if nullifier.counter() >= split_counter {
         assert(
             note_hash.counter() >= split_counter,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_transient_data_squashing_hints.nr
@@ -23,6 +23,9 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
     note_hashes: ClaimedLengthArray<Scoped<Counted<NoteHash>>, NoteHashesLen>,
     nullifiers: ClaimedLengthArray<Scoped<Counted<Nullifier>>, NullifiersLen>,
     transient_data_squashing_hints: [TransientDataSquashingHint; SquashingHintsLen],
+    // Q: is the prover free to choose any value for `num_active_squashing_hints` (up to the SquashingHintsLen)?
+    // I.e. is it true that the prover can choose to squash as many as they like in this iteration, as long as the
+    // squashing hints are unique and result in actual (note,nullifier) pairs matching? 
     num_active_squashing_hints: u32,
     // Sorted values of nullifier indices (with original indices) used to validate uniqueness.
     nullifier_index_sorted_tuples: [SortedTuple<u32>; SquashingHintsLen],
@@ -34,7 +37,7 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
 
         // === Determine if the hint is active ===
         // Only the first `num_active_squashing_hints` hints are active and allowed to be used for squashing.
-        is_active_hint &= i != num_active_squashing_hints;
+        is_active_hint &= i != num_active_squashing_hints; // Q: how do we constrain num_active_squashing_hints to be correct?
 
         if is_active_hint {
             // === Ensure each `note_hash_index` is unique ===
@@ -57,6 +60,9 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
             //
             // This check does not guarantee that the nullifier indices are unique, because two tuples may have the same
             // `original_index` that points to the same hint in `transient_data_squashing_hints`.
+            //
+            // Possible bug: It looks like you could have sorted_tuple.original_index _within_ the active hint range with a corresponding elem that points to 
+            // an index _outside_ of the active hint range.
             assert_eq(
                 nullifier_index_sorted_tuple.elem,
                 transient_data_squashing_hints[nullifier_index_sorted_tuple.original_index]
@@ -66,6 +72,8 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
             // === Nullifier index uniqueness check: Step 2 ===
             // Ensure all the "active" values in the sorted tuples are unique by checking that they are in increasing
             // order.
+            // TODO: write a test that there CANNOT be duplicate nullifier_index_sorted_tuple.original_index items, 
+            // because of this check:
             if i != 0 {
                 assert(
                     nullifier_index_sorted_tuple.elem > nullifier_index_sorted_tuples[i - 1].elem,
@@ -91,6 +99,10 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
                 NullifiersLen,
                 "Unused nullifier index hint must be set to NullifiersLen",
             );
+
+            // Bug: we need to assert:
+            // nullifier_index_sorted_tuple.elem == NullifiersLen
+            // nullifier_index_sorted_tuple.original_index == NullifiersLen,
         }
     }
 
@@ -102,6 +114,7 @@ pub fn validate_transient_data_squashing_hints<let NoteHashesLen: u32, let Nulli
     // Because step 3 guarantees that the nullifier index in all inactive hints is set to the sentinel value, we can be
     // sure that these earlier sorted values must come from active entries in `transient_data_squashing_hints`.
     if num_active_squashing_hints != 0 {
+        // [Incorrect: step 3 only guarantees that all rhs items of `transient_data_squashing_hints.nullifier_index are the sentinel; not the _sorted_ array!], 
         assert(
             nullifier_index_sorted_tuples[num_active_squashing_hints - 1].elem < nullifiers.length,
             "Nullifier index hint exceeds claimed length",

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
@@ -6,7 +6,7 @@ pub struct Nullifier {
     pub value: Field,
     // A nullifier may track the note hash that it nullifies, to enable squashing. This will be discarded in the
     // private tail and only the value is sent to public-land.
-    pub note_hash: Field,
+    pub note_hash: Field, // Consider renaming to: `linked_note_hash`.
 }
 
 impl Empty for Nullifier {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_log.nr
@@ -12,7 +12,7 @@ pub type PrivateLog = Log<PRIVATE_LOG_SIZE_IN_FIELDS>;
 pub struct PrivateLogData {
     pub log: Log<PRIVATE_LOG_SIZE_IN_FIELDS>,
     // The counter of the note hash this log is for. 0 if it does not link to a note hash.
-    pub note_hash_counter: u32,
+    pub note_hash_counter: u32, // TODO: consider renaming to `linked_note_hash_counter`, because I keep forgetting what this is for.
 }
 
 impl Empty for PrivateLogData {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request_and_generator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request_and_generator.nr
@@ -6,10 +6,12 @@ use crate::{
 };
 use std::meta::derive;
 
+// TODO: rename to KeyValidationRequestAndSeparator or KeyValidationRequestAndType or KeyValidationRequestAndKeyId ("Generator" is an artifact of using pedersen hashing). Ultimately, the "Separator"/"Type"/"Id" is conveying the type of keypair: Nullifier/Ivpk/Ovpk, etc. 
+// Can we simply call it a `KeyValidationRequest` and get rid of the other kind of `KeyValidationRequest`? Is there ever a time where we use the current KeyValidationRequest without its wrapper of KeyValidationRequestAndGenerator?
 #[derive(Deserialize, Eq, Serialize)]
 pub struct KeyValidationRequestAndGenerator {
     pub request: KeyValidationRequest,
-    pub sk_app_generator: Field,
+    pub sk_app_generator: Field, // TODO: Rename to `key_id`, as that's essentially what it is.
 }
 
 impl Empty for KeyValidationRequestAndGenerator {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/address/eth_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/address/eth_address.nr
@@ -6,7 +6,8 @@ use std::meta::derive;
 
 #[derive(Deserialize, Eq, Packable, Serialize)]
 pub struct EthAddress {
-    inner: Field,
+    // TODO: consider creating a safe version which is range-checked at construction and an unsafe version.
+    inner: Field, // We defer the <= 20-byte range check to the tail circuit.
 }
 
 impl Empty for EthAddress {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
@@ -238,11 +238,13 @@ pub global MULTI_CALL_ENTRYPOINT_ADDRESS: AztecAddress = AztecAddress::from_fiel
 pub global FEE_JUICE_ADDRESS: AztecAddress = AztecAddress::from_field(5);
 pub global PUBLIC_CHECKS_ADDRESS: AztecAddress = AztecAddress::from_field(6);
 
+// TODO: inevitably, the protocol will one day want to increase the available magic protocol contract addresses,
+// so I suggest we make this address be something like "poseidon2("padding".to_field())".
 // `SIDE_EFFECT_MASKING_ADDRESS` is used by the protocol circuits to silo the padding side effects. It's not a protocol
 // contract (hence its address is greater than `MAX_PROTOCOL_CONTRACTS`).
 // It's not possible to create an actual contract whose address equals this value. If it were possible, it would mean
 // that anyone can freely change the state of the contract by adding padding side effects to their transactions.
-pub global SIDE_EFFECT_MASKING_ADDRESS: AztecAddress = AztecAddress::from_field(12); // MAX_PROTOCOL_CONTRACTS + 1, but can't automatically derive or constants generator fails
+pub global SIDE_EFFECT_MASKING_ADDRESS: AztecAddress = AztecAddress::from_field(12); // MAX_PROTOCOL_CONTRACTS + 1, but can't automatically derive or constants generator fails. TODO: can we fix the constants generator to allow arithmetic?
 
 // NULL MSG_SENDER CONTRACT ADDRESS (not part of the protocol contracts tree).
 pub global NULL_MSG_SENDER_CONTRACT_ADDRESS: AztecAddress = AztecAddress::from_field(

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -112,9 +112,10 @@ pub fn silo_nullifier(nullifier: Scoped<Counted<Nullifier>>) -> Field {
     let value = nullifier.innermost().value;
     // Q: shouldn't we be checking whether the _whole_ scoped, counted, nullifier struct is empty?
     // A: We don't have to. The init and inner circuits add a contract address only to non-empty nullifiers.
+    // MIKE: double-check the changes we made to assert_array_appended to ensure this is still true!!!
     // So we know we should silo it if the contract address is not empty.
     if nullifier.contract_address.is_zero() {
-        value // Return `value` instead of 0 because an already-siloed nullifier's contract address is zero.
+        // Q: perhaps this fn should mutate the nullifier's contract_address to 0, if needed?
     } else {
         compute_siloed_nullifier(nullifier.contract_address, value)
     }
@@ -150,7 +151,7 @@ pub fn compute_contract_class_log_hash(log: [Field; CONTRACT_CLASS_LOG_SIZE_IN_F
 pub fn compute_app_secret_key(
     master_secret_key: EmbeddedCurveScalar,
     app_address: AztecAddress,
-    app_secret_key_domain_separator: Field,
+    app_secret_key_domain_separator: Field, // Q: I'm not even sure if this is needed. Maybe it's protecting against a user who accidentally created the same nsk_m and ivpk_m, but I'm not sure why we'd want to protect against that. I can't find where it was decided we need it.
 ) -> Field {
     poseidon2_hash_with_separator(
         [master_secret_key.hi, master_secret_key.lo, app_address.to_field()],

--- a/noir-projects/noir-protocol-circuits/private_kernel_reset_config.json
+++ b/noir-projects/noir-protocol-circuits/private_kernel_reset_config.json
@@ -1,49 +1,54 @@
 {
   "dimensions": {
     "NOTE_HASH_PENDING_READ": {
-      "variants": [32],
+      "variants": [0, 32],
       "standalone": [64],
-      "cost": 100
+      "cost": 85,
+      "comment": "it would be nice if this was a js file, so that we could write comments to justify these choices of dimension"
     },
     "NOTE_HASH_SETTLED_READ": {
-      "variants": [4, 16],
+      "variants": [4, 8, 16],
       "standalone": [64],
-      "cost": 3000
+      "cost": 3600
     },
     "NULLIFIER_PENDING_READ": {
-      "variants": [32],
+      "variants": [0, 32],
       "standalone": [64],
-      "cost": 100
+      "cost": 90
     },
     "NULLIFIER_SETTLED_READ": {
-      "variants": [4, 16],
+      "variants": [4, 8, 16],
       "standalone": [64],
-      "cost": 3000
+      "cost": 3760,
+      "comment": "should we have combined the nullifier settled reads and note settled reads to be interchangeable (to save on wasted constraints)?"
     },
     "KEY_VALIDATION": {
-      "variants": [4],
+      "variants": [1, 4],
       "standalone": [64],
-      "cost": 2500
+      "cost": 765,
+      "comment": "It's a 765 per iteration for 32, but ~1000 cost per iteration for 4. 1 will be common for just one nullifier key for a whole tx. Wait... do we de-duplicate? I think Leila said it wasn't worth it, which is surprising so my intuition is off."
     },
     "TRANSIENT_DATA_SQUASHING": {
-      "variants": [4],
+      "variants": [0, 4],
       "standalone": [64],
-      "cost": 100
+      "cost": 680,
+      "comment": "wait, the cost is ~21k for 32 or 20k for ~4. We should have a 0 variant, and we should even consider enabling apps to opt out of squashing (exchanging $ for speed)"
     },
     "NOTE_HASH_SILOING": {
       "variants": [4, 64],
       "standalone": [],
-      "cost": 250
+      "cost": 290
     },
     "NULLIFIER_SILOING": {
       "variants": [4, 64],
       "standalone": [],
-      "cost": 150
+      "cost": 140
     },
     "PRIVATE_LOG_SILOING": {
       "variants": [4, 64],
       "standalone": [],
-      "cost": 150
+      "cost": 300,
+      "comment": "we _could_ have variants of 0, for when people use offchain logs."
     }
   },
   "specialCases": [


### PR DESCRIPTION
Bear in mind: I started looking at this circuit... 10 or 12 days ago.
So some of these comments were early on before I understood what came later, and might have since been reconciled in my own head. Sorry for not filtering that stuff from this PR (who knows, maybe it'll trigger you to realise bugs).

**I think I found one bug. Maybe two.**

Also pasting what I mentioned on slack -- just a feeling of nervousness:

The things I'm nervous about, and which I spent a while thinking about:
- Sentinel values that collide with meaningful values.
- Sentinel values that can vary depending on the compilation contants (e.g. using ReadRequestsLen as a sentinel instead of MAX_U32_VALUE)
- Sometimes we intentionally avoid assertions (to save constraints) that hint arrays are empty beyond their length (e.g. nullifier_index_sorted_tuples or note_log_linked_source_indices), and it makes me nervous.
- Sometimes we avoid asserting that unused elements of hint arrays are nullish, and instead rely on other checks to imply that they're nullish (which takes a long time to think about).


