### PR TITLE
feat: add hook to redirect CI log fetches to analyze-logs agent

### DIFF
--- a/.claude/scripts/check-ci-url.py
+++ b/.claude/scripts/check-ci-url.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+
+data = json.load(sys.stdin)
+url = data.get('tool_input', {}).get('url', '')
+
+if 'ci.aztec-labs.com' in url:
+    # Allow if basic auth is present (user:pass@)
+    if re.search(r'://[^/:]+:[^/@]+@ci\.aztec-labs\.com', url):
+        sys.exit(0)
+    print(f'BLOCKED: Cannot WebFetch ci.aztec-labs.com (requires auth). Use /ci-logs skill instead: /ci-logs {url}', file=sys.stderr)
+    sys.exit(2)
+
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/scripts/check-ci-url.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ci-logs/ci-logs.md
+++ b/.claude/skills/ci-logs/ci-logs.md
@@ -1,0 +1,52 @@
+---
+name: ci-logs
+description: Analyze CI logs from ci.aztec-labs.com. Use this instead of WebFetch for CI URLs.
+user-invocable: true
+arguments: <url-or-hash>
+---
+
+# CI Log Analysis
+
+When you need to analyze logs from ci.aztec-labs.com, use the Task tool to spawn the analyze-logs agent.
+
+## Usage
+
+1. **Extract the hash** from the URL (e.g., `http://ci.aztec-labs.com/e93bcfdc738dc2e0` → `e93bcfdc738dc2e0`)
+
+2. **Spawn the analyze-logs agent** using the Task tool:
+
+```
+Task(
+  subagent_type: "analyze-logs",
+  prompt: "Analyze CI log hash: <hash>. Focus: errors",
+  description: "Analyze CI logs"
+)
+```
+
+## Examples
+
+**User asks:** "What failed in http://ci.aztec-labs.com/343c52b17688d2cd"
+
+**You do:**
+```
+Task(
+  subagent_type: "analyze-logs",
+  prompt: "Analyze CI log hash: 343c52b17688d2cd. Focus: errors. Download with: yarn ci dlog 343c52b17688d2cd > /tmp/343c52b17688d2cd.log",
+  description: "Analyze CI failure"
+)
+```
+
+**For specific test analysis:**
+```
+Task(
+  subagent_type: "analyze-logs",
+  prompt: "Analyze CI log hash: 343c52b17688d2cd. Focus: test 'my test name'",
+  description: "Analyze test failure"
+)
+```
+
+## Do NOT
+
+- Do NOT use WebFetch to access ci.aztec-labs.com (requires auth)
+- Do NOT try to curl the URL directly
+- Always use the analyze-logs agent which knows how to use `yarn ci dlog`


### PR DESCRIPTION
## Summary
- Adds PreToolUse hook that blocks WebFetch to ci.aztec-labs.com
- Redirects Claude to use /ci-logs skill which spawns analyze-logs agent
- Agent uses `yarn ci dlog` for authenticated log access

🤖 Generated with [Claude Code](https://claude.com/claude-code)