### PR TITLE
chore(e2e): try deflake epochs first slot

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -59,6 +59,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
       disableAnvilTestWatcher: true,
       aztecProofSubmissionEpochs: 1024,
       aztecEpochDuration: 32,
+      aztecSlotDurationInL1Slots: 3,
       startProverNode: false,
       aztecTargetCommitteeSize: COMMITTEE_SIZE,
       enforceTimeTable: true,
@@ -77,7 +78,11 @@ describe('e2e_epochs/epochs_first_slot', () => {
     // Start the validator nodes
     logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
     nodes = await asyncMap(validators, ({ privateKey }) =>
-      test.createValidatorNode([privateKey], { dontStartSequencer: true, txDelayerMaxInclusionTimeIntoSlot: 1 }),
+      test.createValidatorNode([privateKey], {
+        dontStartSequencer: true,
+        txDelayerMaxInclusionTimeIntoSlot: 2,
+        l1PublishingTime: test.L1_BLOCK_TIME_IN_S - 1,
+      }),
     );
     logger.warn(`Started ${NODE_COUNT} validator nodes.`, { validators: validators.map(v => v.attester.toString()) });
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -51,7 +51,11 @@ export const WORLD_STATE_BLOCK_CHECK_INTERVAL = 50;
 export const ARCHIVER_POLL_INTERVAL = 50;
 export const DEFAULT_L1_BLOCK_TIME = process.env.CI ? 12 : 8;
 
-export type EpochsTestOpts = Partial<SetupOptions> & { numberOfAccounts?: number; pxeOpts?: Partial<PXEConfig> };
+export type EpochsTestOpts = Partial<SetupOptions> & {
+  numberOfAccounts?: number;
+  pxeOpts?: Partial<PXEConfig>;
+  aztecSlotDurationInL1Slots?: number;
+};
 
 export type TrackedSequencerEvent = {
   [K in keyof SequencerEvents]: Parameters<SequencerEvents[K]>[0] & {
@@ -96,7 +100,7 @@ export class EpochsTestContext {
       ? parseInt(process.env.L1_BLOCK_TIME)
       : DEFAULT_L1_BLOCK_TIME;
     const ethereumSlotDuration = opts.ethereumSlotDuration ?? envEthereumSlotDuration;
-    const aztecSlotDuration = opts.aztecSlotDuration ?? ethereumSlotDuration * 2;
+    const aztecSlotDuration = opts.aztecSlotDuration ?? (opts.aztecSlotDurationInL1Slots ?? 2) * ethereumSlotDuration;
     const aztecEpochDuration = opts.aztecEpochDuration ?? 6;
     const aztecProofSubmissionEpochs = opts.aztecProofSubmissionEpochs ?? 1;
     const l1PublishingTime = opts.l1PublishingTime ?? 1;


### PR DESCRIPTION
The txDelayerMaxInclusionTimeIntoSlot was incompatible with the l1 publishing time. We were telling the sequencer that it only needed 1s to get their tx included in a block, but we required 11s.
