### PR TITLE
fix: log slash amounts as strings

### DIFF
--- a/yarn-project/slasher/src/slash_offenses_collector.ts
+++ b/yarn-project/slasher/src/slash_offenses_collector.ts
@@ -85,7 +85,11 @@ export class SlashOffensesCollector {
         }
       }
 
-      this.log.info(`Adding pending offense for validator ${arg.validator}`, pendingOffense);
+      this.log.info(`Adding pending offense for validator ${arg.validator}`, {
+        ...pendingOffense,
+        epochOrSlot: pendingOffense.epochOrSlot.toString(),
+        amount: pendingOffense.amount.toString(),
+      });
       await this.offensesStore.addPendingOffense(pendingOffense);
     }
   }

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -281,8 +281,12 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
         return undefined;
       }
 
+      const slashActionsWithAmounts = slashActions.map(action => ({
+        validator: action.validator.toString(),
+        slashAmount: action.slashAmount.toString(),
+      }));
       this.log.info(`Round ${executableRound} is ready to execute with ${slashActions.length} slashes`, {
-        slashActions,
+        slashActions: slashActionsWithAmounts,
         payloadAddress: payload.address.toString(),
         ...logData,
       });
@@ -348,11 +352,15 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
       return undefined;
     }
 
+    const offensesToSlashLog = offensesToSlash.map(offense => ({
+      ...offense,
+      amount: offense.amount.toString(),
+    }));
     this.log.info(`Voting to slash ${offensesToSlash.length} offenses`, {
       slotNumber,
       currentRound,
       slashedRound,
-      offensesToSlash,
+      offensesToSlash: offensesToSlashLog,
     });
 
     const committees = await this.collectCommitteesActiveDuringRound(slashedRound);


### PR DESCRIPTION
Fixes [A-478](https://linear.app/aztec-labs/issue/A-478/investigate-wrong-slashing-amounts)
GKE was clamping the numbers when logging to 64-bit, hence the number `9223372036854776000` being logged (which is approximately `2^63`).
Converting those number to strings but maybe should look into a utility in `pino-logger.ts`

Added follow-up: https://linear.app/aztec-labs/issue/A-495/handle-bigints-in-pino-logger