### PR TITLE
fix: private kernel inner output composer

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
@@ -32,7 +32,6 @@ use types::{
         validation_requests::PrivateValidationRequests,
     },
     address::AztecAddress,
-    debug::no_op,
     hash::{create_protocol_nullifier, silo_nullifier},
     side_effect::Ordered,
     traits::Empty,
@@ -325,11 +324,10 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let read_requests = private_call_public_inputs.note_hash_read_requests;
-        for i in 0..read_requests.array.len() {
-            let request = read_requests.array[i];
-            if !request.is_empty() {
-                self.public_inputs.validation_requests.note_hash_read_requests.push(request);
-            }
+        for i in 0..read_requests.length {
+            self.public_inputs.validation_requests.note_hash_read_requests.push(
+                read_requests.array[i],
+            );
         }
     }
 
@@ -338,11 +336,10 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let nullifier_read_requests = private_call_public_inputs.nullifier_read_requests;
-        for i in 0..nullifier_read_requests.array.len() {
-            let request = nullifier_read_requests.array[i];
-            if !request.is_empty() {
-                self.public_inputs.validation_requests.nullifier_read_requests.push(request);
-            }
+        for i in 0..nullifier_read_requests.length {
+            self.public_inputs.validation_requests.nullifier_read_requests.push(
+                nullifier_read_requests.array[i],
+            );
         }
     }
 
@@ -352,15 +349,15 @@ impl PrivateKernelCircuitOutputComposer {
     ) {
         let key_validation_requests_and_generators =
             private_call_public_inputs.key_validation_requests_and_generators;
-        for i in 0..key_validation_requests_and_generators.array.len() {
-            let request = key_validation_requests_and_generators.array[i];
-            if !request.is_empty() {
-                self
-                    .public_inputs
-                    .validation_requests
-                    .scoped_key_validation_requests_and_generators
-                    .push(request.scope(private_call_public_inputs.call_context.contract_address));
-            }
+        for i in 0..key_validation_requests_and_generators.length {
+            let scoped_request = key_validation_requests_and_generators.array[i].scope(
+                private_call_public_inputs.call_context.contract_address,
+            );
+            self
+                .public_inputs
+                .validation_requests
+                .scoped_key_validation_requests_and_generators
+                .push(scoped_request);
         }
     }
 
@@ -368,16 +365,12 @@ impl PrivateKernelCircuitOutputComposer {
         &mut self,
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
-        // BUG: If we delete this print, the resoluting note_hashes bounded vec is missing the original items.
-        no_op(self.public_inputs.end.note_hashes);
         let note_hashes = private_call_public_inputs.note_hashes;
-        for i in 0..note_hashes.array.len() {
-            let note_hash = note_hashes.array[i];
-            if note_hash.inner != 0 {
-                self.public_inputs.end.note_hashes.push(note_hash.scope(
-                    private_call_public_inputs.call_context.contract_address,
-                ));
-            }
+        for i in 0..note_hashes.length {
+            let scoped_note_hash = note_hashes.array[i].scope(
+                private_call_public_inputs.call_context.contract_address,
+            );
+            self.public_inputs.end.note_hashes.push(scoped_note_hash);
         }
     }
 
@@ -386,13 +379,10 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let nullifiers = private_call_public_inputs.nullifiers;
-        for i in 0..nullifiers.array.len() {
-            let nullifier = nullifiers.array[i];
-            if nullifier.inner.value != 0 {
-                self.public_inputs.end.nullifiers.push(nullifier.scope(
-                    private_call_public_inputs.call_context.contract_address,
-                ));
-            }
+        for i in 0..nullifiers.length {
+            let scoped_nullifier =
+                nullifiers.array[i].scope(private_call_public_inputs.call_context.contract_address);
+            self.public_inputs.end.nullifiers.push(scoped_nullifier);
         }
     }
 
@@ -401,13 +391,11 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let l2_to_l1_msgs = private_call_public_inputs.l2_to_l1_msgs;
-        for i in 0..l2_to_l1_msgs.array.len() {
-            let msg = l2_to_l1_msgs.array[i];
-            if !msg.is_empty() {
-                self.public_inputs.end.l2_to_l1_msgs.push(msg.scope(
-                    private_call_public_inputs.call_context.contract_address,
-                ));
-            }
+        for i in 0..l2_to_l1_msgs.length {
+            let scoped_msg = l2_to_l1_msgs.array[i].scope(
+                private_call_public_inputs.call_context.contract_address,
+            );
+            self.public_inputs.end.l2_to_l1_msgs.push(scoped_msg);
         }
     }
 
@@ -416,23 +404,19 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let private_logs = private_call_public_inputs.private_logs;
-        for i in 0..private_logs.array.len() {
-            let log = private_logs.array[i];
-            if !log.is_empty() {
-                self.public_inputs.end.private_logs.push(log.scope(
-                    private_call_public_inputs.call_context.contract_address,
-                ));
-            }
+        for i in 0..private_logs.length {
+            let scoped_log = private_logs.array[i].scope(
+                private_call_public_inputs.call_context.contract_address,
+            );
+            self.public_inputs.end.private_logs.push(scoped_log);
         }
 
         let contract_class_logs = private_call_public_inputs.contract_class_logs_hashes;
-        for i in 0..contract_class_logs.array.len() {
-            let log = contract_class_logs.array[i];
-            if !log.is_empty() {
-                self.public_inputs.end.contract_class_logs_hashes.push(log.scope(
-                    private_call_public_inputs.call_context.contract_address,
-                ));
-            }
+        for i in 0..contract_class_logs.length {
+            let scoped_log = contract_class_logs.array[i].scope(
+                private_call_public_inputs.call_context.contract_address,
+            );
+            self.public_inputs.end.contract_class_logs_hashes.push(scoped_log);
         }
     }
 
@@ -447,11 +431,9 @@ impl PrivateKernelCircuitOutputComposer {
     ) {
         let call_requests = private_call_public_inputs.private_call_requests;
         let num_requests = call_requests.length;
-        for i in 0..call_requests.array.len() {
-            if i < num_requests {
-                let call_request = call_requests.array[num_requests - i - 1];
-                self.public_inputs.end.private_call_stack.push(call_request);
-            }
+        for i in 0..num_requests {
+            let call_request = call_requests.array[num_requests - i - 1];
+            self.public_inputs.end.private_call_stack.push(call_request);
         }
     }
 
@@ -460,11 +442,8 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         let call_requests = private_call_public_inputs.public_call_requests;
-        for i in 0..call_requests.array.len() {
-            let call_request = call_requests.array[i];
-            if !call_request.is_empty() {
-                self.public_inputs.end.public_call_requests.push(call_request);
-            }
+        for i in 0..call_requests.length {
+            self.public_inputs.end.public_call_requests.push(call_requests.array[i]);
         }
     }
 
@@ -474,8 +453,11 @@ impl PrivateKernelCircuitOutputComposer {
     ) {
         let call_request = private_call_public_inputs.public_teardown_call_request;
         if !call_request.is_empty() {
-            // Q: why would it already be set by this point?
-            // Q: why assert within this unconstrained function?
+            // The public teardown call request may be set at most once.
+            // If the private call sets it, the value from the previous kernel must be empty.
+            // We assert it in this unconstrained function so users can catch the error during simulation, even when
+            // `should_validate_output` is set to false.
+            // The output validator must constrain this properly.
             assert(
                 self.public_inputs.public_teardown_call_request.is_empty(),
                 "Public teardown call request already set",
@@ -489,8 +471,11 @@ impl PrivateKernelCircuitOutputComposer {
         private_call_public_inputs: PrivateCircuitPublicInputs,
     ) {
         if (private_call_public_inputs.is_fee_payer) {
-            // Q: why would it already be set by this point?
-            // Q: why assert within this unconstrained function?
+            // The fee payer must be set once and only once.
+            // If the private call sets it, the value from the previous kernel must be empty.
+            // We assert it in this unconstrained function so users can catch the error during simulation, even when
+            // `should_validate_output` is set to false.
+            // The output validator must constrain this properly.
             assert(self.public_inputs.fee_payer.is_zero(), "Cannot overwrite non-empty fee_payer");
             self.public_inputs.fee_payer = private_call_public_inputs.call_context.contract_address;
         }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/utils/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/utils/mod.nr
@@ -1,1 +1,0 @@
-pub(crate) mod squash_transient_data;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_inner/output_composition_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_inner/output_composition_tests.nr
@@ -1,9 +1,32 @@
 use super::TestBuilder;
 use types::{
-    address::AztecAddress,
+    address::{AztecAddress, EthAddress},
+    constants::{
+        MAX_CONTRACT_CLASS_LOGS_PER_CALL, MAX_CONTRACT_CLASS_LOGS_PER_TX,
+        MAX_ENQUEUED_CALLS_PER_CALL, MAX_ENQUEUED_CALLS_PER_TX,
+        MAX_KEY_VALIDATION_REQUESTS_PER_CALL, MAX_KEY_VALIDATION_REQUESTS_PER_TX,
+        MAX_L2_TO_L1_MSGS_PER_CALL, MAX_L2_TO_L1_MSGS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+        MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NOTE_HASHES_PER_CALL, MAX_NOTE_HASHES_PER_TX,
+        MAX_NULLIFIER_READ_REQUESTS_PER_CALL, MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+        MAX_NULLIFIERS_PER_CALL, MAX_NULLIFIERS_PER_TX, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL,
+        MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX, MAX_PRIVATE_LOGS_PER_CALL, MAX_PRIVATE_LOGS_PER_TX,
+        PRIVATE_LOG_SIZE_IN_FIELDS,
+    },
+    point::Point,
     tests::utils::assert_claimed_length_array_eq,
     traits::{Empty, FromField},
+    utils::arrays::subarray,
 };
+
+fn reverse_array<T, let N: u32>(array: [T; N]) -> [T; N] {
+    let mut result = array;
+    for i in 0..N / 2 {
+        let tmp = array[i];
+        result[i] = array[N - 1 - i];
+        result[N - 1 - i] = tmp;
+    }
+    result
+}
 
 #[test]
 fn with_everything_empty() {
@@ -402,5 +425,320 @@ fn with_everything_non_empty() {
             new_key_validation_requests_and_generators[0],
             new_key_validation_requests_and_generators[1],
         ],
+    );
+}
+
+#[test]
+fn with_full_arrays_from_private_call() {
+    let mut builder = TestBuilder::new();
+
+    // note_hashes
+    builder.previous_kernel.append_note_hashes(MAX_NOTE_HASHES_PER_TX - MAX_NOTE_HASHES_PER_CALL);
+    let previous_note_hashes = subarray::<_, _, MAX_NOTE_HASHES_PER_TX - MAX_NOTE_HASHES_PER_CALL>(
+        builder.previous_kernel.note_hashes.storage(),
+        0,
+    );
+    builder.private_call.append_note_hashes(MAX_NOTE_HASHES_PER_CALL);
+    let new_note_hashes =
+        subarray::<_, _, MAX_NOTE_HASHES_PER_CALL>(builder.private_call.note_hashes.storage(), 0);
+
+    // nullifiers
+    builder.previous_kernel.append_nullifiers(MAX_NULLIFIERS_PER_TX - MAX_NULLIFIERS_PER_CALL);
+    let previous_nullifiers = subarray::<_, _, MAX_NULLIFIERS_PER_TX - MAX_NULLIFIERS_PER_CALL>(
+        builder.previous_kernel.nullifiers.storage(),
+        0,
+    );
+    builder.private_call.append_nullifiers(MAX_NULLIFIERS_PER_CALL);
+    let new_nullifiers =
+        subarray::<_, _, MAX_NULLIFIERS_PER_CALL>(builder.private_call.nullifiers.storage(), 0);
+
+    // l2_to_l1_msgs
+    builder.previous_kernel.append_l2_to_l1_msgs(
+        MAX_L2_TO_L1_MSGS_PER_TX - MAX_L2_TO_L1_MSGS_PER_CALL,
+    );
+    let previous_l2_to_l1_msgs = subarray::<_, _, MAX_L2_TO_L1_MSGS_PER_TX - MAX_L2_TO_L1_MSGS_PER_CALL>(
+        builder.previous_kernel.l2_to_l1_msgs.storage(),
+        0,
+    );
+    builder.private_call.append_l2_to_l1_msgs(MAX_L2_TO_L1_MSGS_PER_CALL);
+    let new_l2_to_l1_msgs = subarray::<_, _, MAX_L2_TO_L1_MSGS_PER_CALL>(
+        builder.private_call.l2_to_l1_msgs.storage(),
+        0,
+    );
+
+    // private_logs
+    builder.previous_kernel.append_private_logs(MAX_PRIVATE_LOGS_PER_TX - MAX_PRIVATE_LOGS_PER_CALL);
+    let previous_private_logs = subarray::<_, _, MAX_PRIVATE_LOGS_PER_TX - MAX_PRIVATE_LOGS_PER_CALL>(
+        builder.previous_kernel.private_logs.storage(),
+        0,
+    );
+    builder.private_call.append_private_logs(MAX_PRIVATE_LOGS_PER_CALL);
+    let new_private_logs =
+        subarray::<_, _, MAX_PRIVATE_LOGS_PER_CALL>(builder.private_call.private_logs.storage(), 0);
+
+    // contract_class_logs_hashes
+    builder.private_call.append_contract_class_logs(MAX_CONTRACT_CLASS_LOGS_PER_CALL);
+    let new_contract_class_logs_hashes = builder.private_call.contract_class_logs_hashes.storage();
+
+    // public_call_requests
+    builder.previous_kernel.append_public_call_requests(
+        MAX_ENQUEUED_CALLS_PER_TX - MAX_ENQUEUED_CALLS_PER_CALL,
+    );
+    let previous_public_call_requests = subarray::<_, _, MAX_ENQUEUED_CALLS_PER_TX - MAX_ENQUEUED_CALLS_PER_CALL>(
+        builder.previous_kernel.public_call_requests.storage(),
+        0,
+    );
+    builder.private_call.append_public_call_requests(MAX_ENQUEUED_CALLS_PER_CALL);
+    let new_public_call_requests = subarray::<_, _, MAX_ENQUEUED_CALLS_PER_CALL>(
+        builder.private_call.public_call_requests.storage(),
+        0,
+    );
+
+    // public_teardown_call_request
+    builder.private_call.set_public_teardown_call_request();
+    let public_teardown_call_request = builder.private_call.public_teardown_call_request;
+
+    // private_call_stack
+    builder.previous_kernel.append_private_call_requests(
+        MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX - MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL,
+    );
+    let previous_private_call_requests = subarray::<_, _, MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX - MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>(
+        builder.previous_kernel.private_call_requests.storage(),
+        0,
+    );
+    builder.private_call.append_private_call_requests(MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL);
+    let new_private_call_requests = subarray::<_, _, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>(
+        builder.private_call.private_call_requests.storage(),
+        0,
+    );
+
+    // note_hash_read_requests
+    builder.previous_kernel.append_note_hash_read_requests(
+        MAX_NOTE_HASH_READ_REQUESTS_PER_TX - MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+    );
+    let previous_note_hash_read_requests = subarray::<_, _, MAX_NOTE_HASH_READ_REQUESTS_PER_TX - MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>(
+        builder.previous_kernel.note_hash_read_requests.storage(),
+        0,
+    );
+    builder.private_call.append_note_hash_read_requests(MAX_NOTE_HASH_READ_REQUESTS_PER_CALL);
+    let new_note_hash_read_requests = subarray::<_, _, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>(
+        builder.private_call.note_hash_read_requests.storage(),
+        0,
+    );
+
+    // nullifier_read_requests
+    builder.previous_kernel.append_nullifier_read_requests(
+        MAX_NULLIFIER_READ_REQUESTS_PER_TX - MAX_NULLIFIER_READ_REQUESTS_PER_CALL,
+    );
+    let previous_nullifier_read_requests = subarray::<_, _, MAX_NULLIFIER_READ_REQUESTS_PER_TX - MAX_NULLIFIER_READ_REQUESTS_PER_CALL>(
+        builder.previous_kernel.nullifier_read_requests.storage(),
+        0,
+    );
+    builder.private_call.append_nullifier_read_requests(MAX_NULLIFIER_READ_REQUESTS_PER_CALL);
+    let new_nullifier_read_requests = subarray::<_, _, MAX_NULLIFIER_READ_REQUESTS_PER_CALL>(
+        builder.private_call.nullifier_read_requests.storage(),
+        0,
+    );
+
+    // key_validation_requests_and_generators
+    builder.previous_kernel.append_key_validation_requests(
+        MAX_KEY_VALIDATION_REQUESTS_PER_TX - MAX_KEY_VALIDATION_REQUESTS_PER_CALL,
+    );
+    let previous_key_validation_requests_and_generators = subarray::<_, _, MAX_KEY_VALIDATION_REQUESTS_PER_TX - MAX_KEY_VALIDATION_REQUESTS_PER_CALL>(
+        builder.previous_kernel.scoped_key_validation_requests_and_generators.storage(),
+        0,
+    );
+    builder.private_call.append_key_validation_requests(MAX_KEY_VALIDATION_REQUESTS_PER_CALL);
+    let new_key_validation_requests_and_generators = subarray::<_, _, MAX_KEY_VALIDATION_REQUESTS_PER_CALL>(
+        builder.private_call.scoped_key_validation_requests_and_generators.storage(),
+        0,
+    );
+
+    let pi = builder.execute();
+
+    assert_claimed_length_array_eq(
+        pi.end.note_hashes,
+        previous_note_hashes.concat(new_note_hashes),
+    );
+    assert_claimed_length_array_eq(
+        pi.end.nullifiers,
+        previous_nullifiers.concat(new_nullifiers),
+    );
+    assert_claimed_length_array_eq(
+        pi.end.l2_to_l1_msgs,
+        previous_l2_to_l1_msgs.concat(new_l2_to_l1_msgs),
+    );
+    assert_claimed_length_array_eq(
+        pi.end.private_logs,
+        previous_private_logs.concat(new_private_logs),
+    );
+    assert_claimed_length_array_eq(
+        pi.end.contract_class_logs_hashes,
+        [new_contract_class_logs_hashes[0]],
+    );
+    assert_claimed_length_array_eq(
+        pi.end.public_call_requests,
+        previous_public_call_requests.concat(new_public_call_requests),
+    );
+    assert_eq(pi.public_teardown_call_request, public_teardown_call_request);
+    assert_claimed_length_array_eq(
+        pi.end.private_call_stack,
+        previous_private_call_requests.concat(reverse_array(new_private_call_requests)),
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.note_hash_read_requests,
+        previous_note_hash_read_requests.concat(new_note_hash_read_requests),
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.nullifier_read_requests,
+        previous_nullifier_read_requests.concat(new_nullifier_read_requests),
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.scoped_key_validation_requests_and_generators,
+        previous_key_validation_requests_and_generators.concat(
+            new_key_validation_requests_and_generators,
+        ),
+    );
+}
+
+#[test]
+fn with_full_arrays_from_previous_kernel() {
+    let mut builder = TestBuilder::new();
+
+    // note_hashes
+    builder.previous_kernel.append_note_hashes(MAX_NOTE_HASHES_PER_TX);
+    let previous_note_hashes = builder.previous_kernel.note_hashes.storage();
+
+    // nullifiers
+    builder.previous_kernel.append_nullifiers(MAX_NULLIFIERS_PER_TX);
+    let previous_nullifiers = builder.previous_kernel.nullifiers.storage();
+
+    // l2_to_l1_msgs
+    builder.previous_kernel.append_l2_to_l1_msgs(MAX_L2_TO_L1_MSGS_PER_TX);
+    let previous_l2_to_l1_msgs = builder.previous_kernel.l2_to_l1_msgs.storage();
+
+    // private_logs
+    builder.previous_kernel.append_private_logs(MAX_PRIVATE_LOGS_PER_TX);
+    let previous_private_logs = builder.previous_kernel.private_logs.storage();
+
+    // contract_class_logs_hashes
+    builder.previous_kernel.append_contract_class_logs(MAX_CONTRACT_CLASS_LOGS_PER_TX);
+    let previous_contract_class_logs_hashes =
+        builder.previous_kernel.contract_class_logs_hashes.storage();
+
+    // public_call_requests
+    builder.previous_kernel.append_public_call_requests(MAX_ENQUEUED_CALLS_PER_TX);
+    let previous_public_call_requests = builder.previous_kernel.public_call_requests.storage();
+
+    // public_teardown_call_request
+    builder.previous_kernel.set_public_teardown_call_request();
+    let public_teardown_call_request = builder.previous_kernel.public_teardown_call_request;
+
+    // private_call_stack
+    builder.previous_kernel.append_private_call_requests(MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX - 1); // -1 for the current call added in the builder
+    let previous_private_call_requests = subarray::<_, _, MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX - 1>(
+        builder.previous_kernel.private_call_requests.storage(),
+        0,
+    );
+
+    // note_hash_read_requests
+    builder.previous_kernel.append_note_hash_read_requests(MAX_NOTE_HASH_READ_REQUESTS_PER_TX);
+    let previous_note_hash_read_requests =
+        builder.previous_kernel.note_hash_read_requests.storage();
+
+    // nullifier_read_requests
+    builder.previous_kernel.append_nullifier_read_requests(MAX_NULLIFIER_READ_REQUESTS_PER_TX);
+    let previous_nullifier_read_requests =
+        builder.previous_kernel.nullifier_read_requests.storage();
+
+    // key_validation_requests_and_generators
+    builder.previous_kernel.append_key_validation_requests(MAX_KEY_VALIDATION_REQUESTS_PER_TX);
+    let previous_key_validation_requests_and_generators =
+        builder.previous_kernel.scoped_key_validation_requests_and_generators.storage();
+
+    let pi = builder.execute();
+
+    assert_claimed_length_array_eq(pi.end.note_hashes, previous_note_hashes);
+    assert_claimed_length_array_eq(pi.end.nullifiers, previous_nullifiers);
+    assert_claimed_length_array_eq(pi.end.l2_to_l1_msgs, previous_l2_to_l1_msgs);
+    assert_claimed_length_array_eq(pi.end.private_logs, previous_private_logs);
+    assert_claimed_length_array_eq(
+        pi.end.contract_class_logs_hashes,
+        [previous_contract_class_logs_hashes[0]],
+    );
+    assert_claimed_length_array_eq(pi.end.public_call_requests, previous_public_call_requests);
+    assert_eq(pi.public_teardown_call_request, public_teardown_call_request);
+    assert_claimed_length_array_eq(pi.end.private_call_stack, previous_private_call_requests);
+    assert_claimed_length_array_eq(
+        pi.validation_requests.note_hash_read_requests,
+        previous_note_hash_read_requests,
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.nullifier_read_requests,
+        previous_nullifier_read_requests,
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.scoped_key_validation_requests_and_generators,
+        previous_key_validation_requests_and_generators,
+    );
+}
+
+#[test]
+fn with_allowed_empty_values_from_private_call() {
+    let mut builder = TestBuilder::new();
+
+    // We add zero/empty values via the fixture builder, instead of changing the claimed lengths to be 1, because the
+    // counters of the side effects should be non-zero.
+
+    builder.private_call.add_new_note_hash(0);
+    let zero_note_hash = builder.private_call.note_hashes.storage()[0];
+
+    builder.private_call.add_nullifier(0);
+    let zero_nullifier = builder.private_call.nullifiers.storage()[0];
+
+    builder.private_call.add_l2_to_l1_message(0, EthAddress::zero());
+    let empty_l2_to_l1_msg = builder.private_call.l2_to_l1_msgs.storage()[0];
+
+    builder.private_call.add_private_log([0; PRIVATE_LOG_SIZE_IN_FIELDS], 0, 0);
+    let empty_private_log = builder.private_call.private_logs.storage()[0];
+
+    builder.private_call.add_contract_class_log_hash(0, 0);
+    let empty_contract_class_logs_hash =
+        builder.private_call.contract_class_logs_hashes.storage()[0];
+
+    builder.private_call.add_note_hash_read_request(0, AztecAddress::zero());
+    let empty_note_hash_read_request = builder.private_call.note_hash_read_requests.storage()[0];
+
+    let _ = builder.private_call.add_nullifier_read_request(0);
+    let empty_nullifier_read_request = builder.private_call.nullifier_read_requests.storage()[0];
+
+    builder.private_call.add_request_for_key_validation(Point::empty(), 0, 0);
+    let empty_key_validation_request =
+        builder.private_call.scoped_key_validation_requests_and_generators.storage()[0];
+
+    // Note: this test only checks that the empty values are propagated. Whether the values are valid is checked
+    // by the Reset or the Tail(-to-Public) circuits.
+
+    let pi = builder.execute();
+
+    assert_claimed_length_array_eq(pi.end.note_hashes, [zero_note_hash]);
+    assert_claimed_length_array_eq(pi.end.nullifiers, [zero_nullifier]);
+    assert_claimed_length_array_eq(pi.end.l2_to_l1_msgs, [empty_l2_to_l1_msg]);
+    assert_claimed_length_array_eq(pi.end.private_logs, [empty_private_log]);
+    assert_claimed_length_array_eq(
+        pi.end.contract_class_logs_hashes,
+        [empty_contract_class_logs_hash],
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.note_hash_read_requests,
+        [empty_note_hash_read_request],
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.nullifier_read_requests,
+        [empty_nullifier_read_request],
+    );
+    assert_claimed_length_array_eq(
+        pi.validation_requests.scoped_key_validation_requests_and_generators,
+        [empty_key_validation_request],
     );
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -910,18 +910,21 @@ impl FixtureBuilder {
         }
     }
 
+    pub fn add_note_hash_read_request(&mut self, value: Field, contract_address: AztecAddress) {
+        let read_request = Counted::new(value, self.next_counter()).scope(contract_address);
+        self.note_hash_read_requests.push(read_request);
+    }
+
     pub fn add_settled_note_hash_read_request(&mut self, value: Field) -> u32 {
         let read_request_index = self.note_hash_read_requests.len();
-        let read_request = Counted::new(value, self.next_counter()).scope(AztecAddress::zero());
-        self.note_hash_read_requests.push(read_request);
+        self.add_note_hash_read_request(value, AztecAddress::zero());
         read_request_index
     }
 
     pub fn add_read_request_for_pending_note_hash(&mut self, note_hash_index: u32) -> u32 {
         let value = self.mock_note_hash_value(note_hash_index);
         let read_request_index = self.note_hash_read_requests.len();
-        let read_request = Counted::new(value, self.next_counter()).scope(self.contract_address);
-        self.note_hash_read_requests.push(read_request);
+        self.add_note_hash_read_request(value, self.contract_address);
         read_request_index
     }
 


### PR DESCRIPTION
It should propagate all items within claimed length, whether they are valid or not. A value might not be valid, but it's the job of Reset or Tail(-to-Public) to catch it. 