### PR TITLE
refactor: stripping protocol contracts of dependency on Aztec.nr macros

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { path = "../../../../aztec-nr/aztec" }
+aztec = { path = "../aztec_sublib" }

--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
@@ -4,20 +4,23 @@
  * @dev This contract allows users to approve/reject public actions that can be performed on their behalf by other
  * addresses
  */
-use dep::aztec::macros::aztec;
-
-#[aztec]
 pub contract AuthRegistry {
-    use dep::aztec::{
+    use aztec::{
         authwit::auth::{
             assert_current_call_valid_authwit, compute_authwit_message_hash, IS_VALID_SELECTOR,
         },
-        macros::{functions::{external, only_self, view}, storage::storage},
-        protocol::address::AztecAddress,
-        state_vars::{Map, PublicMutable},
+        context::{PrivateContext, PublicContext, UtilityContext},
+        hash::{hash_args, hash_calldata_array},
+        oracle::{avm, execution_cache, version::assert_compatible_oracle_version},
+        protocol::{
+            abis::function_selector::FunctionSelector,
+            address::AztecAddress,
+            traits::{Deserialize, FromField, Serialize, ToField},
+            utils::reader::Reader,
+        },
+        state_vars::{Map, PublicMutable, StateVariable},
     };
 
-    #[storage]
     struct Storage<Context> {
         /// Map of addresses that have rejected all actions
         reject_all: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
@@ -32,9 +35,20 @@ pub contract AuthRegistry {
      * @param message_hash The message hash being authorized
      * @param authorize True if the caller is authorized to perform the message hash, false otherwise
      */
-    #[external("public")]
-    fn set_authorized(message_hash: Field, authorize: bool) {
-        self.storage.approved_actions.at(self.msg_sender()).at(message_hash).write(authorize);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    unconstrained fn set_authorized(message_hash: Field, authorize: bool) {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 2] =
+                    avm::calldata_copy(1, <Field as Serialize>::N + <bool as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        // MACRO CODE END
+
+        storage.approved_actions.at(avm::sender()).at(message_hash).write(authorize);
     }
 
     /**
@@ -44,9 +58,19 @@ pub contract AuthRegistry {
      *
      * @param reject True if all actions should be rejected, false otherwise
      */
-    #[external("public")]
-    fn set_reject_all(reject: bool) {
-        self.storage.reject_all.at(self.msg_sender()).write(reject);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    unconstrained fn set_reject_all(reject: bool) {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] = avm::calldata_copy(1, <bool as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        // MACRO CODE END
+
+        storage.reject_all.at(avm::sender()).write(reject);
     }
 
     /**
@@ -59,21 +83,32 @@ pub contract AuthRegistry {
      * @param inner_hash The inner_hash of the authwit
      * @return `IS_VALID_SELECTOR` if the action was consumed, revert otherwise
      */
-    #[external("public")]
-    fn consume(on_behalf_of: AztecAddress, inner_hash: Field) -> Field {
-        assert_eq(false, self.storage.reject_all.at(on_behalf_of).read(), "rejecting all");
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    unconstrained fn consume(on_behalf_of: AztecAddress, inner_hash: Field) -> pub Field {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 2] =
+                    avm::calldata_copy(1, <AztecAddress as Serialize>::N + <Field as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        // MACRO CODE END
+
+        assert_eq(false, storage.reject_all.at(on_behalf_of).read(), "rejecting all");
 
         let message_hash = compute_authwit_message_hash(
-            self.msg_sender(),
-            self.context.chain_id(),
-            self.context.version(),
+            context.maybe_msg_sender().unwrap(),
+            context.chain_id(),
+            context.version(),
             inner_hash,
         );
 
-        let authorized = self.storage.approved_actions.at(on_behalf_of).at(message_hash).read();
+        let authorized = storage.approved_actions.at(on_behalf_of).at(message_hash).read();
 
         assert_eq(true, authorized, "unauthorized");
-        self.storage.approved_actions.at(on_behalf_of).at(message_hash).write(false);
+        storage.approved_actions.at(on_behalf_of).at(message_hash).write(false);
 
         IS_VALID_SELECTOR
     }
@@ -89,10 +124,49 @@ pub contract AuthRegistry {
      * @param message_hash The message hash to authorize
      * @param authorize True if the message hash should be authorized, false otherwise
      */
-    #[external("private")]
-    fn set_authorized_private(approver: AztecAddress, message_hash: Field, authorize: bool) {
-        assert_current_call_valid_authwit::<3>(self.context, approver);
-        self.enqueue_self._set_authorized(approver, message_hash, authorize);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
+    fn set_authorized_private(
+        inputs: aztec::context::inputs::PrivateContextInputs,
+        approver: AztecAddress,
+        message_hash: Field,
+        authorize: bool,
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
+        // body or in the subsequent enqueued public function call, I have removed that check.
+        assert_compatible_oracle_version();
+
+        let serialized_params: [Field; 3] =
+            [approver.to_field(), message_hash, authorize.to_field()];
+        let args_hash: Field = hash_args(serialized_params);
+        let mut context: PrivateContext = PrivateContext::new(inputs, args_hash);
+
+        // MACRO CODE END
+
+        // 3 corresponds to the number of arguments of the function
+        assert_current_call_valid_authwit::<3>(&mut context, approver);
+
+        // Enqueue call to _set_authorized
+        // Note: This was originally just `self.enqueue_self._set_authorized(approver, message_hash, authorize);`
+        // before de-macroification.
+        {
+            let enqueue_params: [Field; 3] =
+                [approver.to_field(), message_hash, authorize.to_field()];
+            let selector: FunctionSelector = FunctionSelector::from_field(_SET_AUTHORIZED_SELECTOR);
+            let calldata: [Field; 4] = [selector.to_field()].concat(enqueue_params);
+            let calldata_hash: Field = hash_calldata_array(calldata);
+            execution_cache::store(calldata, calldata_hash);
+            context.call_public_function_with_calldata_hash(
+                context.this_address(),
+                calldata_hash,
+                false,
+                false,
+            );
+        }
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
     /**
@@ -103,10 +177,30 @@ pub contract AuthRegistry {
      * @param message_hash The message hash being authorized
      * @param authorize True if the caller is authorized to perform the message hash, false otherwise
      */
-    #[external("public")]
-    #[only_self]
-    fn _set_authorized(approver: AztecAddress, message_hash: Field, authorize: bool) {
-        self.storage.approved_actions.at(approver).at(message_hash).write(authorize);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_only_self]
+    unconstrained fn _set_authorized(approver: AztecAddress, message_hash: Field, authorize: bool) {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 3] = avm::calldata_copy(
+                    1,
+                    (<AztecAddress as Serialize>::N + <Field as Serialize>::N)
+                        + <bool as Serialize>::N,
+                );
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+
+        // Originally injected by the #[only_self] macro
+        assert(
+            avm::sender() == context.this_address(),
+            "Function _set_authorized can only be called by the same contract",
+        );
+        // MACRO CODE END
+
+        storage.approved_actions.at(approver).at(message_hash).write(authorize);
     }
 
     /**
@@ -115,10 +209,24 @@ pub contract AuthRegistry {
      * @param on_behalf_of The address to check
      * @return True if all actions are rejected, false otherwise
      */
-    #[external("public")]
-    #[view]
-    fn is_reject_all(on_behalf_of: AztecAddress) -> bool {
-        self.storage.reject_all.at(on_behalf_of).read()
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
+    unconstrained fn is_reject_all(on_behalf_of: AztecAddress) -> pub bool {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] =
+                    avm::calldata_copy(1, <AztecAddress as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+
+        // Originally injected by the #[view] macro
+        assert(context.is_static_call(), "Function is_reject_all can only be called statically");
+        // MACRO CODE END
+
+        storage.reject_all.at(on_behalf_of).read()
     }
 
     /**
@@ -128,20 +236,218 @@ pub contract AuthRegistry {
      * @param message_hash The message hash to check
      * @return True if the caller is authorized to perform the action, false otherwise
      */
-    #[external("public")]
-    #[view]
-    fn is_consumable(on_behalf_of: AztecAddress, message_hash: Field) -> bool {
-        self.storage.approved_actions.at(on_behalf_of).at(message_hash).read()
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
+    unconstrained fn is_consumable(on_behalf_of: AztecAddress, message_hash: Field) -> pub bool {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 2] =
+                    avm::calldata_copy(1, <AztecAddress as Serialize>::N + <Field as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+
+        // Originally injected by the #[view] macro
+        assert(context.is_static_call(), "Function is_consumable can only be called statically");
+        // MACRO CODE END
+
+        storage.approved_actions.at(on_behalf_of).at(message_hash).read()
     }
 
     /**
      * Just like `is_consumable`, but a utility function and not public.
      */
-    #[external("utility")]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_utility]
     unconstrained fn utility_is_consumable(
         on_behalf_of: AztecAddress,
         message_hash: Field,
-    ) -> bool {
-        self.storage.approved_actions.at(on_behalf_of).at(message_hash).read()
+    ) -> pub bool {
+        // MACRO CODE START
+        assert_compatible_oracle_version();
+
+        let context: UtilityContext = UtilityContext::new();
+        let storage: Storage<UtilityContext> = Storage::init(context);
+        // MACRO CODE END
+
+        storage.approved_actions.at(on_behalf_of).at(message_hash).read()
+    }
+
+    // // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+
+    // Function selectors computed at comptime from function signatures
+    global SET_AUTHORIZED_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("set_authorized(Field,bool)").to_field() };
+    global SET_REJECT_ALL_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("set_reject_all(bool)").to_field() };
+    global CONSUME_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("consume((Field),Field)").to_field() };
+    global _SET_AUTHORIZED_SELECTOR: Field = comptime {
+        FunctionSelector::from_signature("_set_authorized((Field),Field,bool)").to_field()
+    };
+    global IS_REJECT_ALL_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("is_reject_all((Field))").to_field() };
+    global IS_CONSUMABLE_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("is_consumable((Field),Field)").to_field() };
+
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    pub unconstrained fn public_dispatch(selector: Field) {
+        if selector == SET_AUTHORIZED_SELECTOR {
+            let input_calldata: [Field; 2] =
+                avm::calldata_copy(1, <Field as Serialize>::N + <bool as Serialize>::N);
+            let mut reader: Reader<2> = Reader::new(input_calldata);
+            let arg0: Field = reader.read_struct(<Field as Deserialize>::deserialize);
+            let arg1: bool = reader.read_struct(<bool as Deserialize>::deserialize);
+            set_authorized(arg0, arg1);
+            avm::avm_return([].as_vector());
+        };
+        if selector == SET_REJECT_ALL_SELECTOR {
+            let input_calldata: [Field; 1] = avm::calldata_copy(1, <bool as Serialize>::N);
+            let mut reader: Reader<1> = Reader::new(input_calldata);
+            let arg0: bool = reader.read_struct(<bool as Deserialize>::deserialize);
+            set_reject_all(arg0);
+            avm::avm_return([].as_vector());
+        };
+        if selector == CONSUME_SELECTOR {
+            let input_calldata: [Field; 2] =
+                avm::calldata_copy(1, <AztecAddress as Serialize>::N + <Field as Serialize>::N);
+            let mut reader: Reader<2> = Reader::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(<AztecAddress as Deserialize>::deserialize);
+            let arg1: Field = reader.read_struct(<Field as Deserialize>::deserialize);
+            let return_value: [Field; 1] = <Field as Serialize>::serialize(consume(arg0, arg1));
+            avm::avm_return(return_value.as_vector());
+        };
+        if selector == _SET_AUTHORIZED_SELECTOR {
+            let input_calldata: [Field; 3] = avm::calldata_copy(
+                1,
+                (<AztecAddress as Serialize>::N + <Field as Serialize>::N) + <bool as Serialize>::N,
+            );
+            let mut reader: Reader<3> = Reader::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(<AztecAddress as Deserialize>::deserialize);
+            let arg1: Field = reader.read_struct(<Field as Deserialize>::deserialize);
+            let arg2: bool = reader.read_struct(<bool as Deserialize>::deserialize);
+            _set_authorized(arg0, arg1, arg2);
+            avm::avm_return([].as_vector());
+        };
+        if selector == IS_REJECT_ALL_SELECTOR {
+            let input_calldata: [Field; 1] = avm::calldata_copy(1, <AztecAddress as Serialize>::N);
+            let mut reader: Reader<1> = Reader::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(<AztecAddress as Deserialize>::deserialize);
+            let return_value: [Field; 1] = <bool as Serialize>::serialize(is_reject_all(arg0));
+            avm::avm_return(return_value.as_vector());
+        };
+        if selector == IS_CONSUMABLE_SELECTOR {
+            let input_calldata: [Field; 2] =
+                avm::calldata_copy(1, <AztecAddress as Serialize>::N + <Field as Serialize>::N);
+            let mut reader: Reader<2> = Reader::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(<AztecAddress as Deserialize>::deserialize);
+            let arg1: Field = reader.read_struct(<Field as Deserialize>::deserialize);
+            let return_value: [Field; 1] =
+                <bool as Serialize>::serialize(is_consumable(arg0, arg1));
+            avm::avm_return(return_value.as_vector());
+        };
+        panic(f"Unknown selector {selector}")
+    }
+
+    impl<Context> Storage<Context> {
+        fn init(context: Context) -> Self {
+            Self {
+                reject_all: <Map<AztecAddress, PublicMutable<bool, Context>, Context> as StateVariable<1, Context>>::new(
+                    context,
+                    1,
+                ),
+                approved_actions: <Map<AztecAddress, Map<Field, PublicMutable<bool, Context>, Context>, Context> as StateVariable<1, Context>>::new(
+                    context,
+                    2,
+                ),
+            }
+        }
+    }
+
+    // Parameter structs for ABI
+    pub struct _set_authorized_parameters {
+        pub _approver: AztecAddress,
+        pub _message_hash: Field,
+        pub _authorize: bool,
+    }
+
+    pub struct consume_parameters {
+        pub _on_behalf_of: AztecAddress,
+        pub _inner_hash: Field,
+    }
+
+    pub struct is_consumable_parameters {
+        pub _on_behalf_of: AztecAddress,
+        pub _message_hash: Field,
+    }
+
+    pub struct is_reject_all_parameters {
+        pub _on_behalf_of: AztecAddress,
+    }
+
+    pub struct set_authorized_parameters {
+        pub _message_hash: Field,
+        pub _authorize: bool,
+    }
+
+    pub struct set_authorized_private_parameters {
+        pub _approver: AztecAddress,
+        pub _message_hash: Field,
+        pub _authorize: bool,
+    }
+
+    pub struct set_reject_all_parameters {
+        pub _reject: bool,
+    }
+
+    pub struct utility_is_consumable_parameters {
+        pub _on_behalf_of: AztecAddress,
+        pub _message_hash: Field,
+    }
+
+    // ABI structs
+    #[abi(functions)]
+    pub struct _set_authorized_abi {
+        parameters: _set_authorized_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct consume_abi {
+        parameters: consume_parameters,
+        return_type: Field,
+    }
+
+    #[abi(functions)]
+    pub struct is_consumable_abi {
+        parameters: is_consumable_parameters,
+        return_type: bool,
+    }
+
+    #[abi(functions)]
+    pub struct is_reject_all_abi {
+        parameters: is_reject_all_parameters,
+        return_type: bool,
+    }
+
+    #[abi(functions)]
+    pub struct set_authorized_abi {
+        parameters: set_authorized_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct set_authorized_private_abi {
+        parameters: set_authorized_private_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct set_reject_all_abi {
+        parameters: set_reject_all_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct utility_is_consumable_abi {
+        parameters: utility_is_consumable_parameters,
+        return_type: bool,
     }
 }

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "aztec_sublib"
+type = "lib"
+
+[dependencies]
+protocol_types = { path = "../../../../noir-protocol-circuits/crates/types" }

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/auth.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/auth.nr
@@ -1,0 +1,151 @@
+use crate::context::{gas::GasOpts, PrivateContext, PublicContext};
+use crate::protocol::{
+    abis::function_selector::FunctionSelector,
+    address::AztecAddress,
+    constants::{
+        CANONICAL_AUTH_REGISTRY_ADDRESS, DOM_SEP__AUTHWIT_INNER, DOM_SEP__AUTHWIT_NULLIFIER,
+        DOM_SEP__AUTHWIT_OUTER,
+    },
+    hash::poseidon2_hash_with_separator,
+    traits::ToField,
+};
+
+/// Success indicator for authwit - 4 last bytes of poseidon2_hash_bytes("IS_VALID()")
+pub global IS_VALID_SELECTOR: Field = 0x47dacd73;
+
+/// Assert that `on_behalf_of` has authorized the current call with a valid authentication witness
+///
+/// @param on_behalf_of The address that has allegedly authorized the current call
+pub fn assert_current_call_valid_authwit<let N: u32>(
+    context: &mut PrivateContext,
+    on_behalf_of: AztecAddress,
+) {
+    let args_hash: Field = context.get_args_hash();
+
+    let inner_hash = compute_inner_authwit_hash([
+        context.maybe_msg_sender().unwrap().to_field(),
+        context.selector().to_field(),
+        args_hash,
+    ]);
+
+    assert_inner_hash_valid_authwit(context, on_behalf_of, inner_hash);
+}
+
+/// Assert that a specific `inner_hash` is valid for the `on_behalf_of` address
+///
+/// @param on_behalf_of The address that has allegedly authorized the current call
+/// @param inner_hash The hash of the message to authorize
+pub fn assert_inner_hash_valid_authwit(
+    context: &mut PrivateContext,
+    on_behalf_of: AztecAddress,
+    inner_hash: Field,
+) {
+    // We perform a static call here and not a standard one to ensure that the account contract cannot re-enter.
+    let result: Field = context
+        .static_call_private_function(
+            on_behalf_of,
+            comptime { FunctionSelector::from_signature("verify_private_authwit(Field)") },
+            [inner_hash],
+        )
+        .get_preimage();
+    assert(result == IS_VALID_SELECTOR, "Message not authorized by account");
+    // Compute the nullifier to prevent replay attacks
+    let nullifier = compute_authwit_nullifier(on_behalf_of, inner_hash);
+    context.push_nullifier(nullifier);
+}
+
+/// Assert that `on_behalf_of` has authorized the current call in the authentication registry
+///
+/// @param on_behalf_of The address that has allegedly authorized the current call
+pub unconstrained fn assert_current_call_valid_authwit_public(
+    context: PublicContext,
+    on_behalf_of: AztecAddress,
+) {
+    let inner_hash = compute_inner_authwit_hash([
+        context.maybe_msg_sender().unwrap().to_field(),
+        context.selector().to_field(),
+        context.get_args_hash(),
+    ]);
+    assert_inner_hash_valid_authwit_public(context, on_behalf_of, inner_hash);
+}
+
+/// Assert that `on_behalf_of` has authorized a specific `inner_hash` in the authentication registry
+///
+/// @param on_behalf_of The address that has allegedly authorized the `inner_hash`
+pub unconstrained fn assert_inner_hash_valid_authwit_public(
+    context: PublicContext,
+    on_behalf_of: AztecAddress,
+    inner_hash: Field,
+) {
+    let results: [Field] = context.call_public_function(
+        CANONICAL_AUTH_REGISTRY_ADDRESS,
+        comptime { FunctionSelector::from_signature("consume((Field),Field)") },
+        [on_behalf_of.to_field(), inner_hash],
+        GasOpts::default(),
+    );
+    assert(results.len() == 1, "Invalid response from registry");
+    assert(results[0] == IS_VALID_SELECTOR, "Message not authorized by account");
+}
+
+/// Computes the `inner_hash` of the authentication witness
+///
+/// @param args The arguments to hash
+pub fn compute_inner_authwit_hash<let N: u32>(args: [Field; N]) -> Field {
+    poseidon2_hash_with_separator(args, DOM_SEP__AUTHWIT_INNER)
+}
+
+/// Computes the `authwit_nullifier` for a specific `on_behalf_of` and `inner_hash`
+///
+/// @param on_behalf_of The address that has authorized the `inner_hash`
+/// @param inner_hash The hash of the message to authorize
+pub fn compute_authwit_nullifier(on_behalf_of: AztecAddress, inner_hash: Field) -> Field {
+    poseidon2_hash_with_separator(
+        [on_behalf_of.to_field(), inner_hash],
+        DOM_SEP__AUTHWIT_NULLIFIER,
+    )
+}
+
+/// Computes the `message_hash` for the authentication witness
+///
+/// @param consumer The address of the contract that is consuming the message
+/// @param chain_id The chain id of the chain that the message is being consumed on
+/// @param version The version of the chain that the message is being consumed on
+/// @param inner_hash The hash of the "inner" message that is being consumed
+pub fn compute_authwit_message_hash(
+    consumer: AztecAddress,
+    chain_id: Field,
+    version: Field,
+    inner_hash: Field,
+) -> Field {
+    poseidon2_hash_with_separator(
+        [consumer.to_field(), chain_id, version, inner_hash],
+        DOM_SEP__AUTHWIT_OUTER,
+    )
+}
+
+/// Helper function to set the authorization status of a message hash
+///
+/// @param message_hash The hash of the message to authorize
+/// @param authorize True if the message should be authorized, false if it should be revoked
+pub unconstrained fn set_authorized(context: PublicContext, message_hash: Field, authorize: bool) {
+    let res = context.call_public_function(
+        CANONICAL_AUTH_REGISTRY_ADDRESS,
+        comptime { FunctionSelector::from_signature("set_authorized(Field,bool)") },
+        [message_hash, authorize as Field],
+        GasOpts::default(),
+    );
+    assert(res.len() == 0);
+}
+
+/// Helper function to reject all authwits
+///
+/// @param reject True if all authwits should be rejected, false otherwise
+pub unconstrained fn set_reject_all(context: PublicContext, reject: bool) {
+    let res = context.call_public_function(
+        CANONICAL_AUTH_REGISTRY_ADDRESS,
+        comptime { FunctionSelector::from_signature("set_reject_all(bool)") },
+        [context.this_address().to_field(), reject as Field],
+        GasOpts::default(),
+    );
+    assert(res.len() == 0);
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/mod.nr
@@ -1,0 +1,9 @@
+//! Authentication witness module for protocol contracts.
+
+pub mod auth;
+
+pub use auth::{
+    assert_current_call_valid_authwit, assert_inner_hash_valid_authwit,
+    compute_authwit_message_hash, compute_authwit_nullifier, compute_inner_authwit_hash,
+    IS_VALID_SELECTOR,
+};

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/gas.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/gas.nr
@@ -1,0 +1,14 @@
+pub struct GasOpts {
+    pub l2_gas: Option<u32>,
+    pub da_gas: Option<u32>,
+}
+
+impl GasOpts {
+    pub fn default() -> Self {
+        GasOpts { l2_gas: Option::none(), da_gas: Option::none() }
+    }
+
+    pub fn new(l2_gas: u32, da_gas: u32) -> Self {
+        GasOpts { l2_gas: Option::some(l2_gas), da_gas: Option::some(da_gas) }
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/inputs.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/inputs.nr
@@ -1,0 +1,25 @@
+use crate::protocol::{
+    abis::{
+        block_header::BlockHeader, call_context::CallContext, transaction::tx_context::TxContext,
+    },
+    traits::Empty,
+};
+
+// PrivateContextInputs are expected to be provided to each private function
+#[derive(Eq)]
+pub struct PrivateContextInputs {
+    pub call_context: CallContext,
+    pub anchor_block_header: BlockHeader,
+    pub tx_context: TxContext,
+    pub start_side_effect_counter: u32,
+}
+impl Empty for PrivateContextInputs {
+    fn empty() -> Self {
+        PrivateContextInputs {
+            call_context: CallContext::empty(),
+            anchor_block_header: BlockHeader::empty(),
+            tx_context: TxContext::empty(),
+            start_side_effect_counter: 0 as u32,
+        }
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/mod.nr
@@ -1,0 +1,17 @@
+//! Execution context types for protocol contracts.
+
+pub mod inputs;
+pub mod returns_hash;
+pub mod private_context;
+pub mod public_context;
+pub mod utility_context;
+pub mod gas;
+pub mod nullifier_existence_request;
+
+pub use gas::GasOpts;
+pub use inputs::PrivateContextInputs;
+pub use nullifier_existence_request::NullifierExistenceRequest;
+pub use private_context::PrivateContext;
+pub use public_context::PublicContext;
+pub use returns_hash::ReturnsHash;
+pub use utility_context::UtilityContext;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/nullifier_existence_request.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/nullifier_existence_request.nr
@@ -1,0 +1,46 @@
+use crate::protocol::address::aztec_address::AztecAddress;
+
+/// A request to assert the existence of a nullifier.
+///
+/// Used by [crate::context::private_context::PrivateContext::assert_nullifier_exists].
+pub struct NullifierExistenceRequest {
+    nullifier: Field,
+    maybe_contract_address: Option<AztecAddress>,
+}
+
+impl NullifierExistenceRequest {
+    /// Creates an existence request for a pending nullifier.
+    ///
+    /// Pending nullifiers have not been siloed with the contract address. These requests are created using the
+    /// unsiloed value and address of the contract that emitted the nullifier.
+    pub fn for_pending(unsiloed_nullifier: Field, contract_address: AztecAddress) -> Self {
+        // The kernel doesn't take options; it takes a nullifier and an address, and infers whether the request is
+        // siloed based on whether the address is zero or non-zero. When passing the value to the kernel, we use
+        // `maybe_addr.unwrap_or(Address::ZERO)`. Therefore, passing a zero address to `for_pending` is not allowed
+        // since it would be interpreted by the kernel as a settled request.
+        assert(
+            !contract_address.is_zero(),
+            "Can't read a pending nullifier with a zero contract address",
+        );
+        Self {
+            nullifier: unsiloed_nullifier,
+            maybe_contract_address: Option::some(contract_address),
+        }
+    }
+
+    /// Creates an existence request for a settled nullifier.
+    ///
+    /// Unlike pending nullifiers, settled nullifiers have been siloed with their contract addresses before adding to
+    /// the nullifier tree, and their existence request is created using the siloed value.
+    pub fn for_settled(siloed_nullifier: Field) -> Self {
+        Self { nullifier: siloed_nullifier, maybe_contract_address: Option::none() }
+    }
+
+    pub fn nullifier(self) -> Field {
+        self.nullifier
+    }
+
+    pub fn maybe_contract_address(self) -> Option<AztecAddress> {
+        self.maybe_contract_address
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/private_context.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/private_context.nr
@@ -1,0 +1,419 @@
+use crate::{
+    context::{inputs::PrivateContextInputs, NullifierExistenceRequest, ReturnsHash},
+    hash::hash_args,
+    messaging::process_l1_to_l2_message,
+    oracle::{
+        call_private_function::call_private_function_internal,
+        enqueue_public_function_call::{
+            is_side_effect_counter_revertible_oracle_wrapper, notify_enqueued_public_function_call,
+            notify_set_min_revertible_side_effect_counter,
+        },
+        execution_cache,
+        logs::notify_created_contract_class_log,
+        nullifiers::notify_created_nullifier,
+    },
+};
+use crate::protocol::{
+    abis::{
+        block_header::BlockHeader,
+        call_context::CallContext,
+        function_selector::FunctionSelector,
+        gas_settings::GasSettings,
+        log_hash::LogHash,
+        nullifier::Nullifier,
+        private_call_request::PrivateCallRequest,
+        private_circuit_public_inputs::PrivateCircuitPublicInputs,
+        private_log::{PrivateLog, PrivateLogData},
+        public_call_request::PublicCallRequest,
+    },
+    address::{AztecAddress, EthAddress},
+    constants::{
+        CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, MAX_CONTRACT_CLASS_LOGS_PER_CALL,
+        MAX_ENQUEUED_CALLS_PER_CALL, MAX_INCLUDE_BY_TIMESTAMP_DURATION, MAX_L2_TO_L1_MSGS_PER_CALL,
+        MAX_NULLIFIER_READ_REQUESTS_PER_CALL, MAX_NULLIFIERS_PER_CALL,
+        MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL, MAX_PRIVATE_LOGS_PER_CALL,
+        NULL_MSG_SENDER_CONTRACT_ADDRESS, PRIVATE_LOG_SIZE_IN_FIELDS,
+    },
+    hash::poseidon2_hash,
+    messaging::l2_to_l1_message::L2ToL1Message,
+    side_effect::{Counted, scoped::Scoped},
+    traits::Empty,
+    utils::arrays::{ClaimedLengthArray, trimmed_array_length_hint},
+};
+
+/// Minimal PrivateContext for protocol contracts going to audit.
+/// Contains only the methods actually used by: fee_juice, auth_registry, contract_class_registry, contract_instance_registry
+#[derive(Eq)]
+pub struct PrivateContext {
+    pub inputs: PrivateContextInputs,
+    pub side_effect_counter: u32,
+
+    pub min_revertible_side_effect_counter: u32,
+    pub is_fee_payer: bool,
+
+    pub args_hash: Field,
+    pub return_hash: Field,
+
+    pub include_by_timestamp: u64,
+
+    pub nullifier_read_requests: BoundedVec<Scoped<Counted<Field>>, MAX_NULLIFIER_READ_REQUESTS_PER_CALL>,
+
+    pub nullifiers: BoundedVec<Counted<Nullifier>, MAX_NULLIFIERS_PER_CALL>,
+
+    pub private_call_requests: BoundedVec<PrivateCallRequest, MAX_PRIVATE_CALL_STACK_LENGTH_PER_CALL>,
+    pub public_call_requests: BoundedVec<Counted<PublicCallRequest>, MAX_ENQUEUED_CALLS_PER_CALL>,
+    pub public_teardown_call_request: PublicCallRequest,
+    pub l2_to_l1_msgs: BoundedVec<Counted<L2ToL1Message>, MAX_L2_TO_L1_MSGS_PER_CALL>,
+
+    // Header of a block whose state is used during private execution (not the block the transaction is included in).
+    pub anchor_block_header: BlockHeader,
+
+    pub private_logs: BoundedVec<Counted<PrivateLogData>, MAX_PRIVATE_LOGS_PER_CALL>,
+    pub contract_class_logs_hashes: BoundedVec<Counted<LogHash>, MAX_CONTRACT_CLASS_LOGS_PER_CALL>,
+
+    pub expected_non_revertible_side_effect_counter: u32,
+    pub expected_revertible_side_effect_counter: u32,
+}
+
+impl PrivateContext {
+    pub fn new(inputs: PrivateContextInputs, args_hash: Field) -> PrivateContext {
+        let max_allowed_include_by_timestamp = inputs.anchor_block_header.global_variables.timestamp
+            + MAX_INCLUDE_BY_TIMESTAMP_DURATION;
+        PrivateContext {
+            inputs,
+            side_effect_counter: inputs.start_side_effect_counter + 1,
+            min_revertible_side_effect_counter: 0,
+            is_fee_payer: false,
+            args_hash,
+            return_hash: 0,
+            include_by_timestamp: max_allowed_include_by_timestamp,
+            nullifier_read_requests: BoundedVec::new(),
+            nullifiers: BoundedVec::new(),
+            anchor_block_header: inputs.anchor_block_header,
+            private_call_requests: BoundedVec::new(),
+            public_call_requests: BoundedVec::new(),
+            public_teardown_call_request: PublicCallRequest::empty(),
+            l2_to_l1_msgs: BoundedVec::new(),
+            private_logs: BoundedVec::new(),
+            contract_class_logs_hashes: BoundedVec::new(),
+            expected_non_revertible_side_effect_counter: 0,
+            expected_revertible_side_effect_counter: 0,
+        }
+    }
+
+    /// Returns the contract address that initiated this function call (similar to msg.sender in Solidity).
+    pub fn maybe_msg_sender(self) -> Option<AztecAddress> {
+        let maybe_msg_sender = self.inputs.call_context.msg_sender;
+        if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
+            Option::none()
+        } else {
+            Option::some(maybe_msg_sender)
+        }
+    }
+
+    /// Returns the contract address of the current function being executed.
+    pub fn this_address(self) -> AztecAddress {
+        self.inputs.call_context.contract_address
+    }
+
+    /// Returns the chain ID of the current network.
+    pub fn chain_id(self) -> Field {
+        self.inputs.tx_context.chain_id
+    }
+
+    /// Returns the protocol version.
+    pub fn version(self) -> Field {
+        self.inputs.tx_context.version
+    }
+
+    /// Returns the gas settings for the current transaction.
+    pub fn gas_settings(self) -> GasSettings {
+        self.inputs.tx_context.gas_settings
+    }
+
+    /// Returns the function selector of the currently executing function.
+    pub fn selector(self) -> FunctionSelector {
+        self.inputs.call_context.function_selector
+    }
+
+    /// Returns the hash of the arguments passed to the current function.
+    pub fn get_args_hash(self) -> Field {
+        self.args_hash
+    }
+
+    /// Returns the anchor block header.
+    pub fn get_anchor_block_header(self) -> BlockHeader {
+        self.anchor_block_header
+    }
+
+    /// Sets the hash of the return values for this private function.
+    pub fn set_return_hash<let N: u32>(&mut self, serialized_return_values: [Field; N]) {
+        let return_hash = hash_args(serialized_return_values);
+        self.return_hash = return_hash;
+        execution_cache::store(serialized_return_values, return_hash);
+    }
+
+    /// Builds the PrivateCircuitPublicInputs for this private function.
+    pub fn finish(self) -> PrivateCircuitPublicInputs {
+        PrivateCircuitPublicInputs {
+            call_context: self.inputs.call_context,
+            args_hash: self.args_hash,
+            returns_hash: self.return_hash,
+            min_revertible_side_effect_counter: self.min_revertible_side_effect_counter,
+            is_fee_payer: self.is_fee_payer,
+            include_by_timestamp: self.include_by_timestamp,
+            note_hash_read_requests: ClaimedLengthArray::empty(), // Not used by protocol contracts
+            nullifier_read_requests: ClaimedLengthArray::from_bounded_vec(
+                self.nullifier_read_requests,
+            ),
+            key_validation_requests_and_generators: ClaimedLengthArray::empty(), // Not used by protocol contracts
+            note_hashes: ClaimedLengthArray::empty(), // Not used by protocol contracts
+            nullifiers: ClaimedLengthArray::from_bounded_vec(self.nullifiers),
+            private_call_requests: ClaimedLengthArray::from_bounded_vec(self.private_call_requests),
+            public_call_requests: ClaimedLengthArray::from_bounded_vec(self.public_call_requests),
+            public_teardown_call_request: self.public_teardown_call_request,
+            l2_to_l1_msgs: ClaimedLengthArray::from_bounded_vec(self.l2_to_l1_msgs),
+            start_side_effect_counter: self.inputs.start_side_effect_counter,
+            end_side_effect_counter: self.side_effect_counter,
+            private_logs: ClaimedLengthArray::from_bounded_vec(self.private_logs),
+            contract_class_logs_hashes: ClaimedLengthArray::from_bounded_vec(
+                self.contract_class_logs_hashes,
+            ),
+            anchor_block_header: self.anchor_block_header,
+            tx_context: self.inputs.tx_context,
+            expected_non_revertible_side_effect_counter: self
+                .expected_non_revertible_side_effect_counter,
+            expected_revertible_side_effect_counter: self.expected_revertible_side_effect_counter,
+        }
+    }
+
+    /// Declares the end of the "setup phase" of this tx. Used by fee_juice.
+    pub fn end_setup(&mut self) {
+        self.side_effect_counter += 1;
+        self.min_revertible_side_effect_counter = self.next_counter();
+        notify_set_min_revertible_side_effect_counter(self.min_revertible_side_effect_counter);
+    }
+
+    pub fn in_revertible_phase(&mut self) -> bool {
+        let current_counter = self.side_effect_counter;
+
+        // Safety: Kernel will validate that the claim is correct by validating the expected counters.
+        let is_revertible =
+            unsafe { is_side_effect_counter_revertible_oracle_wrapper(current_counter) };
+
+        if is_revertible {
+            if (self.expected_revertible_side_effect_counter == 0)
+                | (current_counter < self.expected_revertible_side_effect_counter) {
+                self.expected_revertible_side_effect_counter = current_counter;
+            }
+        } else if current_counter > self.expected_non_revertible_side_effect_counter {
+            self.expected_non_revertible_side_effect_counter = current_counter;
+        }
+
+        is_revertible
+    }
+
+    /// Sets a deadline for when this transaction must be included in a block.
+    pub fn set_include_by_timestamp(&mut self, include_by_timestamp: u64) {
+        self.include_by_timestamp = std::cmp::min(self.include_by_timestamp, include_by_timestamp);
+    }
+
+    /// Pushes a new nullifier. Used by class_registry and instance_registry.
+    pub fn push_nullifier(&mut self, nullifier: Field) {
+        notify_created_nullifier(nullifier);
+        self.nullifiers.push(Nullifier { value: nullifier, note_hash: 0 }.count(self.next_counter()));
+    }
+
+    /// Asserts that a nullifier has been emitted. Used by instance_registry.
+    pub fn assert_nullifier_exists(
+        &mut self,
+        nullifier_existence_request: NullifierExistenceRequest,
+    ) {
+        let nullifier = nullifier_existence_request.nullifier();
+        let contract_address =
+            nullifier_existence_request.maybe_contract_address().unwrap_or(AztecAddress::zero());
+
+        let request = Scoped::new(
+            Counted::new(nullifier, self.next_counter()),
+            contract_address,
+        );
+
+        self.nullifier_read_requests.push(request);
+    }
+
+    /// Consumes a message sent from Ethereum (L1) to Aztec (L2). Used by fee_juice.
+    pub fn consume_l1_to_l2_message(
+        &mut self,
+        content: Field,
+        secret: Field,
+        sender: EthAddress,
+        leaf_index: Field,
+    ) {
+        let nullifier = process_l1_to_l2_message(
+            self.anchor_block_header.state.l1_to_l2_message_tree.root,
+            self.this_address(),
+            sender,
+            self.chain_id(),
+            self.version(),
+            content,
+            secret,
+            leaf_index,
+        );
+
+        // Push nullifier (and the "commitment" corresponding to this can be "empty")
+        self.push_nullifier(nullifier)
+    }
+
+    /// Emits a private log. Used by instance_registry.
+    pub fn emit_private_log(&mut self, log: [Field; PRIVATE_LOG_SIZE_IN_FIELDS], length: u32) {
+        let counter = self.next_counter();
+        let private_log = PrivateLogData { log: PrivateLog::new(log, length), note_hash_counter: 0 }
+            .count(counter);
+        self.private_logs.push(private_log);
+    }
+
+    /// Emits a contract class log. Used by class_registry.
+    pub fn emit_contract_class_log<let N: u32>(&mut self, log: [Field; N]) {
+        let contract_address = self.this_address();
+        let counter = self.next_counter();
+
+        let log_to_emit: [Field; CONTRACT_CLASS_LOG_SIZE_IN_FIELDS] =
+            log.concat([0; CONTRACT_CLASS_LOG_SIZE_IN_FIELDS - N]);
+        // Safety: The below length is constrained in the base rollup, which will make sure that all the fields beyond
+        // length are zero. However, it won't be able to check that we didn't add extra padding (trailing zeroes) or
+        // that we cut trailing zeroes from the end.
+        let length = unsafe { trimmed_array_length_hint(log_to_emit) };
+        // We hash the entire padded log to ensure a user cannot pass a shorter length and so emit incorrect shorter
+        // bytecode.
+        let log_hash = poseidon2_hash(log_to_emit);
+        // Safety: the below only exists to broadcast the raw log, so we can provide it to the base rollup later to be
+        // constrained.
+        unsafe {
+            notify_created_contract_class_log(contract_address, log_to_emit, length, counter);
+        }
+
+        self.contract_class_logs_hashes.push(LogHash { value: log_hash, length: length }.count(
+            counter,
+        ));
+    }
+
+    /// Makes a read-only call to a private function. Used by auth_registry for authwit.
+    pub fn static_call_private_function<let ArgsCount: u32>(
+        &mut self,
+        contract_address: AztecAddress,
+        function_selector: FunctionSelector,
+        args: [Field; ArgsCount],
+    ) -> ReturnsHash {
+        let args_hash = hash_args(args);
+        execution_cache::store(args, args_hash);
+        self.call_private_function_with_args_hash(
+            contract_address,
+            function_selector,
+            args_hash,
+            true,
+        )
+    }
+
+    fn call_private_function_with_args_hash(
+        &mut self,
+        contract_address: AztecAddress,
+        function_selector: FunctionSelector,
+        args_hash: Field,
+        is_static_call: bool,
+    ) -> ReturnsHash {
+        let mut is_static_call = is_static_call | self.inputs.call_context.is_static_call;
+        let start_side_effect_counter = self.side_effect_counter;
+
+        // Safety: The oracle simulates the private call and returns the value of the side effects counter after
+        // execution of the call.
+        let (end_side_effect_counter, returns_hash) = unsafe {
+            call_private_function_internal(
+                contract_address,
+                function_selector,
+                args_hash,
+                start_side_effect_counter,
+                is_static_call,
+            )
+        };
+
+        self.private_call_requests.push(
+            PrivateCallRequest {
+                call_context: CallContext {
+                    msg_sender: self.this_address(),
+                    contract_address,
+                    function_selector,
+                    is_static_call,
+                },
+                args_hash,
+                returns_hash,
+                start_side_effect_counter,
+                end_side_effect_counter,
+            },
+        );
+
+        self.side_effect_counter = end_side_effect_counter + 1;
+        ReturnsHash::new(returns_hash)
+    }
+
+    /// Enqueues a call to a public function with a calldata hash. Used by fee_juice and auth_registry.
+    pub fn call_public_function_with_calldata_hash(
+        &mut self,
+        contract_address: AztecAddress,
+        calldata_hash: Field,
+        is_static_call: bool,
+        hide_msg_sender: bool,
+    ) {
+        let counter = self.next_counter();
+
+        let mut is_static_call = is_static_call | self.inputs.call_context.is_static_call;
+
+        notify_enqueued_public_function_call(
+            contract_address,
+            calldata_hash,
+            counter,
+            is_static_call,
+        );
+
+        let msg_sender = if hide_msg_sender {
+            NULL_MSG_SENDER_CONTRACT_ADDRESS
+        } else {
+            self.this_address()
+        };
+
+        let call_request =
+            PublicCallRequest { msg_sender, contract_address, is_static_call, calldata_hash };
+
+        self.public_call_requests.push(Counted::new(call_request, counter));
+    }
+
+    fn next_counter(&mut self) -> u32 {
+        let counter = self.side_effect_counter;
+        self.side_effect_counter += 1;
+        counter
+    }
+}
+
+impl Empty for PrivateContext {
+    fn empty() -> Self {
+        PrivateContext {
+            inputs: PrivateContextInputs::empty(),
+            side_effect_counter: 0 as u32,
+            min_revertible_side_effect_counter: 0 as u32,
+            is_fee_payer: false,
+            args_hash: 0,
+            return_hash: 0,
+            include_by_timestamp: 0,
+            nullifier_read_requests: BoundedVec::new(),
+            nullifiers: BoundedVec::new(),
+            private_call_requests: BoundedVec::new(),
+            public_call_requests: BoundedVec::new(),
+            public_teardown_call_request: PublicCallRequest::empty(),
+            l2_to_l1_msgs: BoundedVec::new(),
+            anchor_block_header: BlockHeader::empty(),
+            private_logs: BoundedVec::new(),
+            contract_class_logs_hashes: BoundedVec::new(),
+            expected_non_revertible_side_effect_counter: 0,
+            expected_revertible_side_effect_counter: 0,
+        }
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/public_context.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/public_context.nr
@@ -1,0 +1,326 @@
+use crate::{
+    context::gas::GasOpts,
+    hash::{
+        compute_l1_to_l2_message_hash, compute_l1_to_l2_message_nullifier, compute_secret_hash,
+        compute_siloed_nullifier,
+    },
+    oracle::avm,
+};
+use crate::protocol::{
+    abis::function_selector::FunctionSelector,
+    address::{AztecAddress, EthAddress},
+    constants::{MAX_U32_VALUE, NULL_MSG_SENDER_CONTRACT_ADDRESS},
+    traits::{Empty, FromField, Packable, Serialize, ToField},
+};
+
+/// Minimal PublicContext for protocol contracts going to audit.
+pub struct PublicContext {
+    pub args_hash: Option<Field>,
+    pub compute_args_hash: fn() -> Field,
+}
+
+impl Eq for PublicContext {
+    fn eq(self, other: Self) -> bool {
+        (self.args_hash == other.args_hash)
+        // Can't compare the function compute_args_hash
+    }
+}
+
+impl PublicContext {
+    pub fn new(compute_args_hash: fn() -> Field) -> Self {
+        PublicContext { args_hash: Option::none(), compute_args_hash }
+    }
+
+    /// Emits a _public_ log that will be visible onchain to everyone.
+    pub fn emit_public_log<T>(_self: Self, log: T)
+    where
+        T: Serialize,
+    {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::emit_public_log(Serialize::serialize(log).as_vector()) };
+    }
+
+    /// Checks if a given note hash exists in the note hash tree at a particular leaf_index.
+    pub fn note_hash_exists(_self: Self, note_hash: Field, leaf_index: u64) -> bool {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::note_hash_exists(note_hash, leaf_index) } == 1
+    }
+
+    /// Checks if a specific L1-to-L2 message exists in the L1-to-L2 message tree at a particular leaf index.
+    pub fn l1_to_l2_msg_exists(_self: Self, msg_hash: Field, msg_leaf_index: Field) -> bool {
+        // Safety: AVM opcodes are constrained by the AVM itself TODO(alvaro): Make l1l2msg leaf index a u64 upstream
+        unsafe { avm::l1_to_l2_msg_exists(msg_hash, msg_leaf_index as u64) } == 1
+    }
+
+    /// Returns `true` if an `unsiloed_nullifier` has been emitted by `contract_address`.
+    pub fn nullifier_exists_unsafe(
+        _self: Self,
+        unsiloed_nullifier: Field,
+        contract_address: AztecAddress,
+    ) -> bool {
+        let siloed_nullifier = compute_siloed_nullifier(contract_address, unsiloed_nullifier);
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::nullifier_exists(siloed_nullifier) } == 1
+    }
+
+    /// Consumes a message sent from Ethereum (L1) to Aztec (L2).
+    pub fn consume_l1_to_l2_message(
+        self: Self,
+        content: Field,
+        secret: Field,
+        sender: EthAddress,
+        leaf_index: Field,
+    ) {
+        let secret_hash = compute_secret_hash(secret);
+        let message_hash = compute_l1_to_l2_message_hash(
+            sender,
+            self.chain_id(),
+            /*recipient=*/
+            self.this_address(),
+            self.version(),
+            content,
+            secret_hash,
+            leaf_index,
+        );
+        let nullifier = compute_l1_to_l2_message_nullifier(message_hash, secret);
+
+        assert(
+            !self.nullifier_exists_unsafe(nullifier, self.this_address()),
+            "L1-to-L2 message is already nullified",
+        );
+        assert(
+            self.l1_to_l2_msg_exists(message_hash, leaf_index),
+            "Tried to consume nonexistent L1-to-L2 message",
+        );
+
+        self.push_nullifier(nullifier);
+    }
+
+    /// Sends an "L2 -> L1 message".
+    pub fn message_portal(_self: Self, recipient: EthAddress, content: Field) {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::send_l2_to_l1_msg(recipient, content) };
+    }
+
+    /// Calls a public function on another contract.
+    pub unconstrained fn call_public_function<let N: u32>(
+        _self: Self,
+        contract_address: AztecAddress,
+        function_selector: FunctionSelector,
+        args: [Field; N],
+        gas_opts: GasOpts,
+    ) -> [Field] {
+        let calldata = [function_selector.to_field()].concat(args);
+
+        avm::call(
+            gas_opts.l2_gas.unwrap_or(MAX_U32_VALUE),
+            gas_opts.da_gas.unwrap_or(MAX_U32_VALUE),
+            contract_address,
+            calldata,
+        );
+        // Use success_copy to determine whether the call succeeded
+        let success = avm::success_copy();
+
+        let result_data = avm::returndata_copy(0, avm::returndata_size());
+        if !success {
+            // Rethrow the revert data.
+            avm::revert(result_data);
+        }
+        result_data
+    }
+
+    /// Makes a read-only call to a public function on another contract.
+    pub unconstrained fn static_call_public_function<let N: u32>(
+        _self: Self,
+        contract_address: AztecAddress,
+        function_selector: FunctionSelector,
+        args: [Field; N],
+        gas_opts: GasOpts,
+    ) -> [Field] {
+        let calldata = [function_selector.to_field()].concat(args);
+
+        avm::call_static(
+            gas_opts.l2_gas.unwrap_or(MAX_U32_VALUE),
+            gas_opts.da_gas.unwrap_or(MAX_U32_VALUE),
+            contract_address,
+            calldata,
+        );
+        // Use success_copy to determine whether the call succeeded
+        let success = avm::success_copy();
+
+        let result_data = avm::returndata_copy(0, avm::returndata_size());
+        if !success {
+            // Rethrow the revert data.
+            avm::revert(result_data);
+        }
+        result_data
+    }
+
+    /// Adds a new note hash to the Note Hash Tree.
+    pub fn push_note_hash(_self: Self, note_hash: Field) {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::emit_note_hash(note_hash) };
+    }
+
+    /// Adds a new nullifier to the Nullifier Tree.
+    pub fn push_nullifier(_self: Self, nullifier: Field) {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::emit_nullifier(nullifier) };
+    }
+
+    /// Returns the address of the current contract being executed.
+    pub fn this_address(_self: Self) -> AztecAddress {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::address()
+        }
+    }
+
+    /// Returns the contract address that initiated this function call.
+    pub fn maybe_msg_sender(_self: Self) -> Option<AztecAddress> {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        let maybe_msg_sender = unsafe { avm::sender() };
+        if maybe_msg_sender == NULL_MSG_SENDER_CONTRACT_ADDRESS {
+            Option::none()
+        } else {
+            Option::some(maybe_msg_sender)
+        }
+    }
+
+    /// Returns the function selector of the currently-executing function.
+    pub fn selector(_self: Self) -> FunctionSelector {
+        // The selector is the first element of the calldata when calling a public function through dispatch.
+        // Safety: AVM opcodes are constrained by the AVM itself.
+        let raw_selector: [Field; 1] = unsafe { avm::calldata_copy(0, 1) };
+        FunctionSelector::from_field(raw_selector[0])
+    }
+
+    /// Returns the hash of the arguments passed to the current function.
+    pub fn get_args_hash(mut self) -> Field {
+        if !self.args_hash.is_some() {
+            self.args_hash = Option::some((self.compute_args_hash)());
+        }
+
+        self.args_hash.unwrap_unchecked()
+    }
+
+    /// Returns the "transaction fee" for the current transaction.
+    pub fn transaction_fee(_self: Self) -> Field {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::transaction_fee()
+        }
+    }
+
+    /// Returns the chain ID of the current network.
+    pub fn chain_id(_self: Self) -> Field {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::chain_id()
+        }
+    }
+
+    /// Returns the protocol version.
+    pub fn version(_self: Self) -> Field {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::version()
+        }
+    }
+
+    /// Returns the current block number.
+    pub fn block_number(_self: Self) -> u32 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::block_number()
+        }
+    }
+
+    /// Returns the timestamp of the current block.
+    pub fn timestamp(_self: Self) -> u64 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::timestamp()
+        }
+    }
+
+    /// Returns the fee per unit of L2 gas.
+    pub fn min_fee_per_l2_gas(_self: Self) -> u128 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::min_fee_per_l2_gas()
+        }
+    }
+
+    /// Returns the fee per unit of DA gas.
+    pub fn min_fee_per_da_gas(_self: Self) -> u128 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::min_fee_per_da_gas()
+        }
+    }
+
+    /// Returns the remaining L2 gas available.
+    pub fn l2_gas_left(_self: Self) -> u32 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::l2_gas_left()
+        }
+    }
+
+    /// Returns the remaining DA gas available.
+    pub fn da_gas_left(_self: Self) -> u32 {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe {
+            avm::da_gas_left()
+        }
+    }
+
+    /// Checks if the current execution is within a staticcall context.
+    pub fn is_static_call(_self: Self) -> bool {
+        // Safety: AVM opcodes are constrained by the AVM itself
+        unsafe { avm::is_static_call() } == 1
+    }
+
+    /// Reads raw field values from public storage.
+    pub fn raw_storage_read<let N: u32>(self: Self, storage_slot: Field) -> [Field; N] {
+        let mut out = [0; N];
+        for i in 0..N {
+            // Safety: AVM opcodes are constrained by the AVM itself
+            out[i] = unsafe {
+                avm::storage_read(storage_slot + i as Field, self.this_address().to_field())
+            };
+        }
+        out
+    }
+
+    /// Reads a typed value from public storage.
+    pub fn storage_read<T>(self, storage_slot: Field) -> T
+    where
+        T: Packable,
+    {
+        T::unpack(self.raw_storage_read(storage_slot))
+    }
+
+    /// Writes raw field values to public storage.
+    pub fn raw_storage_write<let N: u32>(_self: Self, storage_slot: Field, values: [Field; N]) {
+        for i in 0..N {
+            // Safety: AVM opcodes are constrained by the AVM itself
+            unsafe { avm::storage_write(storage_slot + i as Field, values[i]) };
+        }
+    }
+
+    /// Writes a typed value to public storage.
+    pub fn storage_write<T>(self, storage_slot: Field, value: T)
+    where
+        T: Packable,
+    {
+        self.raw_storage_write(storage_slot, value.pack());
+    }
+}
+
+impl Empty for PublicContext {
+    fn empty() -> Self {
+        PublicContext::new(|| 0)
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/returns_hash.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/returns_hash.nr
@@ -1,0 +1,34 @@
+use crate::{hash::hash_args, oracle::execution_cache};
+use crate::protocol::traits::Deserialize;
+
+/// A hash that represents a private contract function call's return value. Call `get_preimage` to get the underlying
+/// value.
+///
+/// The kernels don't process the actual return values but instead their hashes, so it is up to contracts to populate
+/// oracles with the preimages of these hashes on return to make them available to their callers.
+///
+/// Public calls don't utilize this mechanism since the AVM does process the full return values.
+pub struct ReturnsHash {
+    hash: Field,
+}
+
+impl ReturnsHash {
+    pub fn new(hash: Field) -> Self {
+        ReturnsHash { hash }
+    }
+
+    /// Fetches the underlying return value from an oracle, constraining that it corresponds to the return data hash.
+    pub fn get_preimage<T>(self) -> T
+    where
+        T: Deserialize,
+    {
+        // Safety: We verify that the value returned by `load` is the preimage of `hash`, fully constraining it. If `T`
+        // is `()`, then `preimage` must be an array of length 0 (since that is `()`'s deserialization length).
+        // `hash_args` handles empty arrays following the protocol rules (i.e. an empty args array is signaled with a
+        // zero hash), correctly constraining `self.hash`.
+        let preimage = unsafe { execution_cache::load(self.hash) };
+        assert_eq(self.hash, hash_args(preimage), "Preimage mismatch");
+
+        Deserialize::deserialize(preimage)
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/utility_context.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/context/utility_context.nr
@@ -1,0 +1,60 @@
+use crate::oracle::{execution::get_utility_context, storage::storage_read};
+use crate::protocol::{abis::block_header::BlockHeader, address::AztecAddress, traits::Packable};
+
+// If you'll modify this struct don't forget to update utility_context.ts as well.
+pub struct UtilityContext {
+    block_header: BlockHeader,
+    contract_address: AztecAddress,
+}
+
+impl UtilityContext {
+    pub unconstrained fn new() -> Self {
+        get_utility_context()
+    }
+
+    pub unconstrained fn at(contract_address: AztecAddress) -> Self {
+        // We get a context with default contract address, and then we construct the final context with the provided
+        // contract address.
+        let default_context = get_utility_context();
+
+        Self { block_header: default_context.block_header, contract_address }
+    }
+
+    pub fn block_header(self) -> BlockHeader {
+        self.block_header
+    }
+
+    pub fn block_number(self) -> u32 {
+        self.block_header.global_variables.block_number
+    }
+
+    pub fn timestamp(self) -> u64 {
+        self.block_header.global_variables.timestamp
+    }
+
+    pub fn this_address(self) -> AztecAddress {
+        self.contract_address
+    }
+
+    pub fn version(self) -> Field {
+        self.block_header.global_variables.version
+    }
+
+    pub fn chain_id(self) -> Field {
+        self.block_header.global_variables.chain_id
+    }
+
+    pub unconstrained fn raw_storage_read<let N: u32>(
+        self: Self,
+        storage_slot: Field,
+    ) -> [Field; N] {
+        storage_read(self.block_header, self.this_address(), storage_slot)
+    }
+
+    pub unconstrained fn storage_read<T>(self, storage_slot: Field) -> T
+    where
+        T: Packable,
+    {
+        T::unpack(self.raw_storage_read(storage_slot))
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/hash.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/hash.nr
@@ -1,0 +1,95 @@
+//! Aztec hash functions.
+
+use crate::protocol::{
+    address::{AztecAddress, EthAddress},
+    constants::{
+        DOM_SEP__FUNCTION_ARGS, DOM_SEP__MESSAGE_NULLIFIER, DOM_SEP__PUBLIC_BYTECODE,
+        DOM_SEP__PUBLIC_CALLDATA, DOM_SEP__SECRET_HASH, MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS,
+    },
+    hash::{poseidon2_hash_subarray, poseidon2_hash_with_separator, sha256_to_field},
+    traits::ToField,
+};
+
+pub use crate::protocol::hash::compute_siloed_nullifier;
+
+pub fn compute_secret_hash(secret: Field) -> Field {
+    poseidon2_hash_with_separator([secret], DOM_SEP__SECRET_HASH)
+}
+
+pub fn compute_l1_to_l2_message_hash(
+    sender: EthAddress,
+    chain_id: Field,
+    recipient: AztecAddress,
+    version: Field,
+    content: Field,
+    secret_hash: Field,
+    leaf_index: Field,
+) -> Field {
+    let mut hash_bytes = [0 as u8; 224];
+    let sender_bytes: [u8; 32] = sender.to_field().to_be_bytes();
+    let chain_id_bytes: [u8; 32] = chain_id.to_be_bytes();
+    let recipient_bytes: [u8; 32] = recipient.to_field().to_be_bytes();
+    let version_bytes: [u8; 32] = version.to_be_bytes();
+    let content_bytes: [u8; 32] = content.to_be_bytes();
+    let secret_hash_bytes: [u8; 32] = secret_hash.to_be_bytes();
+    let leaf_index_bytes: [u8; 32] = leaf_index.to_be_bytes();
+
+    for i in 0..32 {
+        hash_bytes[i] = sender_bytes[i];
+        hash_bytes[i + 32] = chain_id_bytes[i];
+        hash_bytes[i + 64] = recipient_bytes[i];
+        hash_bytes[i + 96] = version_bytes[i];
+        hash_bytes[i + 128] = content_bytes[i];
+        hash_bytes[i + 160] = secret_hash_bytes[i];
+        hash_bytes[i + 192] = leaf_index_bytes[i];
+    }
+
+    sha256_to_field(hash_bytes)
+}
+
+// The nullifier of a l1 to l2 message is the hash of the message salted with the secret
+pub fn compute_l1_to_l2_message_nullifier(message_hash: Field, secret: Field) -> Field {
+    poseidon2_hash_with_separator([message_hash, secret], DOM_SEP__MESSAGE_NULLIFIER)
+}
+
+// Computes the hash of input arguments or return values for private functions, or for authwit creation.
+pub fn hash_args<let N: u32>(args: [Field; N]) -> Field {
+    if args.len() == 0 {
+        0
+    } else {
+        poseidon2_hash_with_separator(args, DOM_SEP__FUNCTION_ARGS)
+    }
+}
+
+// Computes the hash of calldata for public functions.
+pub fn hash_calldata_array<let N: u32>(calldata: [Field; N]) -> Field {
+    poseidon2_hash_with_separator(calldata, DOM_SEP__PUBLIC_CALLDATA)
+}
+
+/// Computes the public bytecode commitment for a contract class. The commitment is `hash([separator, ...bytecode])`
+/// where bytecode omits the length prefix present in `packed_bytecode`.
+///
+/// @param packed_bytecode - The packed bytecode of the contract class. 0th word is the length in bytes.
+/// packed_bytecode is mutable so that we can avoid copying the array to construct one starting with separator instead
+/// of length. @returns The public bytecode commitment.
+pub fn compute_public_bytecode_commitment(
+    mut packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS],
+) -> Field {
+    // First field element contains the length of the bytecode
+    let bytecode_length_in_bytes: u32 = packed_public_bytecode[0] as u32;
+    let bytecode_length_in_fields: u32 =
+        (bytecode_length_in_bytes / 31) + (bytecode_length_in_bytes % 31 != 0) as u32;
+    // Don't allow empty public bytecode. AVM doesn't handle execution of contracts that exist with empty bytecode.
+    assert(bytecode_length_in_fields != 0);
+    assert(bytecode_length_in_fields < MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS);
+
+    // Packed_bytecode's 0th entry is the length. Replace it with separator before hashing.
+    let separator = DOM_SEP__PUBLIC_BYTECODE.to_field();
+    packed_public_bytecode[0] = separator;
+
+    // `fields_to_hash` is the number of fields from the start of `packed_public_bytecode` that should be included in
+    // the hash. Fields after this length are ignored. +1 to account for the separator.
+    let num_fields_to_hash = bytecode_length_in_fields + 1;
+
+    poseidon2_hash_subarray(packed_public_bytecode, num_fields_to_hash)
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/mod.nr
@@ -1,0 +1,3 @@
+//! History modules for historical state access.
+
+pub mod storage;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/storage.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/storage.nr
@@ -1,0 +1,55 @@
+//! Historical storage accesses.
+
+use crate::protocol::{
+    abis::block_header::BlockHeader,
+    address::AztecAddress,
+    constants::{DOM_SEP__PUBLIC_LEAF_SLOT, PUBLIC_DATA_TREE_HEIGHT},
+    data::{public_data_storage_read, PublicDataTreeLeafPreimage},
+    hash::poseidon2_hash_with_separator,
+    merkle_tree::MembershipWitness,
+    traits::{Deserialize, Hash, Serialize, ToField},
+};
+
+#[derive(Deserialize, Eq, Serialize)]
+pub struct PublicDataWitness {
+    pub index: Field,
+    pub leaf_preimage: PublicDataTreeLeafPreimage,
+    pub path: [Field; PUBLIC_DATA_TREE_HEIGHT],
+}
+
+#[oracle(utilityGetPublicDataWitness)]
+unconstrained fn get_public_data_witness_oracle(
+    _block_hash: Field,
+    _public_data_tree_index: Field,
+) -> PublicDataWitness {}
+
+pub unconstrained fn get_public_data_witness(
+    block_header: BlockHeader,
+    public_data_tree_index: Field,
+) -> PublicDataWitness {
+    let block_hash = block_header.hash();
+    get_public_data_witness_oracle(block_hash, public_data_tree_index)
+}
+
+pub fn public_storage_historical_read(
+    block_header: BlockHeader,
+    storage_slot: Field,
+    contract_address: AztecAddress,
+) -> Field {
+    // 1) Compute the leaf index by siloing the storage slot with the contract address
+    let public_data_tree_index = poseidon2_hash_with_separator(
+        [contract_address.to_field(), storage_slot],
+        DOM_SEP__PUBLIC_LEAF_SLOT,
+    );
+
+    // 2) Get the membership witness for the tree index.
+    // Safety: The witness is only used as a "magical value" that makes the proof below pass. Hence it's safe.
+    let witness = unsafe { get_public_data_witness(block_header, public_data_tree_index) };
+
+    public_data_storage_read(
+        block_header.state.partial.public_data_tree.root,
+        public_data_tree_index,
+        MembershipWitness { leaf_index: witness.index, sibling_path: witness.path },
+        witness.leaf_preimage,
+    )
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/lib.nr
@@ -1,0 +1,19 @@
+//! Minimal protocol lib for audit contracts.
+//!
+//! This crate extracts only the necessary functionality from `aztec.nr` for the 4 protocol contracts
+//! going to audit (fee_juice, auth_registry, contract_class_registry, contract_instance_registry).
+//! This removes the dependency on the unstable `aztec` crate.
+
+pub mod context;
+pub mod hash;
+pub mod messaging;
+pub mod oracle;
+pub mod state_vars;
+pub mod authwit;
+pub mod nullifier;
+pub mod utils;
+pub mod history;
+pub mod macros;
+
+// Re-export protocol_types as `protocol` for compatibility with existing aztec imports
+pub use protocol_types as protocol;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/internals_functions_generation/abi_attributes.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/internals_functions_generation/abi_attributes.nr
@@ -1,0 +1,27 @@
+//! ABI attributes that are applied by the Aztec.nr macros to the generated functions with the
+//! `__aztec_nr_internals___` prefix in the name. The attributes are prefixed with `abi_` as they are used only for
+//! ABI purposes and artifact generation.
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[external("private")]`.
+pub comptime fn abi_private(_f: FunctionDefinition) {}
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[external("public")]`.
+pub comptime fn abi_public(_f: FunctionDefinition) {}
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[external("utility")]`.
+pub comptime fn abi_utility(_f: FunctionDefinition) {}
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[view]`.
+pub comptime fn abi_view(_f: FunctionDefinition) {}
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[only_self]`.
+pub comptime fn abi_only_self(_f: FunctionDefinition) {}
+
+// Applied to macro-generated functions with the `__aztec_nr_internals___` prefix, which are created from functions
+// annotated with `#[initializer]`.
+pub comptime fn abi_initializer(_f: FunctionDefinition) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/internals_functions_generation/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/internals_functions_generation/mod.nr
@@ -1,0 +1,3 @@
+//! ABI-related attributes for de-macroified protocol contracts.
+
+pub mod abi_attributes;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/macros/mod.nr
@@ -1,0 +1,3 @@
+//! Macros module for de-macroified protocol contracts.
+
+pub mod internals_functions_generation;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/messaging.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/messaging.nr
@@ -1,0 +1,42 @@
+use crate::{
+    hash::{compute_l1_to_l2_message_hash, compute_l1_to_l2_message_nullifier, compute_secret_hash},
+    oracle::get_l1_to_l2_membership_witness::get_l1_to_l2_membership_witness,
+};
+
+use crate::protocol::{
+    address::{AztecAddress, EthAddress},
+    merkle_tree::root::root_from_sibling_path,
+};
+
+pub fn process_l1_to_l2_message(
+    l1_to_l2_root: Field,
+    contract_address: AztecAddress,
+    portal_contract_address: EthAddress,
+    chain_id: Field,
+    version: Field,
+    content: Field,
+    secret: Field,
+    leaf_index: Field,
+) -> Field {
+    let secret_hash = compute_secret_hash(secret);
+    let message_hash = compute_l1_to_l2_message_hash(
+        portal_contract_address,
+        chain_id,
+        contract_address,
+        version,
+        content,
+        secret_hash,
+        leaf_index,
+    );
+
+    // We prove that `message_hash` is in the tree by showing the derivation of the tree root, using a merkle path we
+    // get from an oracle.
+    // Safety: The witness is only used as a "magical value" that makes the merkle proof below pass. Hence it's safe.
+    let (_leaf_index, sibling_path) =
+        unsafe { get_l1_to_l2_membership_witness(contract_address, message_hash, secret) };
+
+    let root = root_from_sibling_path(message_hash, leaf_index, sibling_path);
+    assert_eq(root, l1_to_l2_root, "Message not in state");
+
+    compute_l1_to_l2_message_nullifier(message_hash, secret)
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/nullifier/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/nullifier/mod.nr
@@ -1,0 +1,5 @@
+//! Nullifier utilities for protocol contracts.
+
+pub mod utils;
+
+pub use utils::compute_nullifier_existence_request;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/nullifier/utils.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/nullifier/utils.nr
@@ -1,0 +1,27 @@
+use crate::{context::NullifierExistenceRequest, oracle::nullifiers::is_nullifier_pending};
+
+use crate::protocol::{address::aztec_address::AztecAddress, hash::compute_siloed_nullifier};
+
+/// Returns the [NullifierExistenceRequest] used to prove a nullifier exists.
+pub fn compute_nullifier_existence_request(
+    unsiloed_nullifier: Field,
+    contract_address: AztecAddress,
+) -> NullifierExistenceRequest {
+    let pending_read_request =
+        NullifierExistenceRequest::for_pending(unsiloed_nullifier, contract_address);
+
+    let siloed_nullifier = compute_siloed_nullifier(contract_address, unsiloed_nullifier);
+    let settled_read_request = NullifierExistenceRequest::for_settled(siloed_nullifier);
+
+    // Safety: This is a hint to check whether we are reading a pending or settled nullifier. The chosen read request
+    // will be validated by the kernel. Failure to provide a correct hint will cause the read request validation to
+    // fail.
+    let should_use_pending_read_request =
+        unsafe { is_nullifier_pending(unsiloed_nullifier, contract_address) };
+
+    if should_use_pending_read_request {
+        pending_read_request
+    } else {
+        settled_read_request
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/avm.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/avm.nr
@@ -1,0 +1,225 @@
+//! AVM oracles.
+//!
+//! There are only available during public execution. Calling any of them from a private or utility function will
+//! result in runtime errors.
+
+use crate::protocol::address::{AztecAddress, EthAddress};
+
+pub unconstrained fn address() -> AztecAddress {
+    address_opcode()
+}
+pub unconstrained fn sender() -> AztecAddress {
+    sender_opcode()
+}
+pub unconstrained fn transaction_fee() -> Field {
+    transaction_fee_opcode()
+}
+pub unconstrained fn chain_id() -> Field {
+    chain_id_opcode()
+}
+pub unconstrained fn version() -> Field {
+    version_opcode()
+}
+pub unconstrained fn block_number() -> u32 {
+    block_number_opcode()
+}
+pub unconstrained fn timestamp() -> u64 {
+    timestamp_opcode()
+}
+pub unconstrained fn min_fee_per_l2_gas() -> u128 {
+    min_fee_per_l2_gas_opcode()
+}
+pub unconstrained fn min_fee_per_da_gas() -> u128 {
+    min_fee_per_da_gas_opcode()
+}
+pub unconstrained fn l2_gas_left() -> u32 {
+    l2_gas_left_opcode()
+}
+pub unconstrained fn da_gas_left() -> u32 {
+    da_gas_left_opcode()
+}
+pub unconstrained fn is_static_call() -> u1 {
+    is_static_call_opcode()
+}
+pub unconstrained fn note_hash_exists(note_hash: Field, leaf_index: u64) -> u1 {
+    note_hash_exists_opcode(note_hash, leaf_index)
+}
+pub unconstrained fn emit_note_hash(note_hash: Field) {
+    emit_note_hash_opcode(note_hash)
+}
+pub unconstrained fn nullifier_exists(siloed_nullifier: Field) -> u1 {
+    nullifier_exists_opcode(siloed_nullifier)
+}
+pub unconstrained fn emit_nullifier(nullifier: Field) {
+    emit_nullifier_opcode(nullifier)
+}
+pub unconstrained fn emit_public_log(message: [Field]) {
+    emit_public_log_opcode(message)
+}
+pub unconstrained fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: u64) -> u1 {
+    l1_to_l2_msg_exists_opcode(msg_hash, msg_leaf_index)
+}
+pub unconstrained fn send_l2_to_l1_msg(recipient: EthAddress, content: Field) {
+    send_l2_to_l1_msg_opcode(recipient, content)
+}
+
+pub unconstrained fn call<let N: u32>(
+    l2_gas_allocation: u32,
+    da_gas_allocation: u32,
+    address: AztecAddress,
+    args: [Field; N],
+) {
+    call_opcode(l2_gas_allocation, da_gas_allocation, address, N, args)
+}
+
+pub unconstrained fn call_static<let N: u32>(
+    l2_gas_allocation: u32,
+    da_gas_allocation: u32,
+    address: AztecAddress,
+    args: [Field; N],
+) {
+    call_static_opcode(l2_gas_allocation, da_gas_allocation, address, N, args)
+}
+
+pub unconstrained fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {
+    calldata_copy_opcode(cdoffset, copy_size)
+}
+
+/// `success_copy` is placed immediately after the CALL opcode to get the success value
+pub unconstrained fn success_copy() -> bool {
+    success_copy_opcode()
+}
+
+pub unconstrained fn returndata_size() -> u32 {
+    returndata_size_opcode()
+}
+
+pub unconstrained fn returndata_copy(rdoffset: u32, copy_size: u32) -> [Field] {
+    returndata_copy_opcode(rdoffset, copy_size)
+}
+
+/// The additional prefix is to avoid clashing with the `return` Noir keyword.
+pub unconstrained fn avm_return(returndata: [Field]) {
+    return_opcode(returndata)
+}
+
+/// This opcode reverts using the exact data given. In general it should only be used to do rethrows, where the revert
+/// data is the same as the original revert data. For normal reverts, use Noir's `assert` which, on top of reverting,
+/// will also add an error selector to the revert data.
+pub unconstrained fn revert(revertdata: [Field]) {
+    revert_opcode(revertdata)
+}
+
+pub unconstrained fn storage_read(storage_slot: Field, contract_address: Field) -> Field {
+    storage_read_opcode(storage_slot, contract_address)
+}
+
+pub unconstrained fn storage_write(storage_slot: Field, value: Field) {
+    storage_write_opcode(storage_slot, value);
+}
+
+#[oracle(avmOpcodeAddress)]
+unconstrained fn address_opcode() -> AztecAddress {}
+
+#[oracle(avmOpcodeSender)]
+unconstrained fn sender_opcode() -> AztecAddress {}
+
+#[oracle(avmOpcodeTransactionFee)]
+unconstrained fn transaction_fee_opcode() -> Field {}
+
+#[oracle(avmOpcodeChainId)]
+unconstrained fn chain_id_opcode() -> Field {}
+
+#[oracle(avmOpcodeVersion)]
+unconstrained fn version_opcode() -> Field {}
+
+#[oracle(avmOpcodeBlockNumber)]
+unconstrained fn block_number_opcode() -> u32 {}
+
+#[oracle(avmOpcodeTimestamp)]
+unconstrained fn timestamp_opcode() -> u64 {}
+
+#[oracle(avmOpcodeMinFeePerL2Gas)]
+unconstrained fn min_fee_per_l2_gas_opcode() -> u128 {}
+
+#[oracle(avmOpcodeMinFeePerDaGas)]
+unconstrained fn min_fee_per_da_gas_opcode() -> u128 {}
+
+#[oracle(avmOpcodeL2GasLeft)]
+unconstrained fn l2_gas_left_opcode() -> u32 {}
+
+#[oracle(avmOpcodeDaGasLeft)]
+unconstrained fn da_gas_left_opcode() -> u32 {}
+
+#[oracle(avmOpcodeIsStaticCall)]
+unconstrained fn is_static_call_opcode() -> u1 {}
+
+#[oracle(avmOpcodeNoteHashExists)]
+unconstrained fn note_hash_exists_opcode(note_hash: Field, leaf_index: u64) -> u1 {}
+
+#[oracle(avmOpcodeEmitNoteHash)]
+unconstrained fn emit_note_hash_opcode(note_hash: Field) {}
+
+#[oracle(avmOpcodeNullifierExists)]
+unconstrained fn nullifier_exists_opcode(siloed_nullifier: Field) -> u1 {}
+
+#[oracle(avmOpcodeEmitNullifier)]
+unconstrained fn emit_nullifier_opcode(nullifier: Field) {}
+
+// TODO(#11124): rename unencrypted to public in avm
+#[oracle(avmOpcodeEmitUnencryptedLog)]
+unconstrained fn emit_public_log_opcode(message: [Field]) {}
+
+#[oracle(avmOpcodeL1ToL2MsgExists)]
+unconstrained fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: u64) -> u1 {}
+
+#[oracle(avmOpcodeSendL2ToL1Msg)]
+unconstrained fn send_l2_to_l1_msg_opcode(recipient: EthAddress, content: Field) {}
+
+#[oracle(avmOpcodeCalldataCopy)]
+unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {}
+
+#[oracle(avmOpcodeReturndataSize)]
+unconstrained fn returndata_size_opcode() -> u32 {}
+
+#[oracle(avmOpcodeReturndataCopy)]
+unconstrained fn returndata_copy_opcode(rdoffset: u32, copy_size: u32) -> [Field] {}
+
+#[oracle(avmOpcodeReturn)]
+unconstrained fn return_opcode(returndata: [Field]) {}
+
+#[oracle(avmOpcodeRevert)]
+unconstrained fn revert_opcode(revertdata: [Field]) {}
+
+// While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
+// level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
+// that route.
+#[oracle(avmOpcodeCall)]
+unconstrained fn call_opcode<let N: u32>(
+    l2_gas_allocation: u32,
+    da_gas_allocation: u32,
+    address: AztecAddress,
+    length: u32,
+    args: [Field; N],
+) {}
+
+// While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
+// level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
+// that route.
+#[oracle(avmOpcodeStaticCall)]
+unconstrained fn call_static_opcode<let N: u32>(
+    l2_gas_allocation: u32,
+    da_gas_allocation: u32,
+    address: AztecAddress,
+    length: u32,
+    args: [Field; N],
+) {}
+
+#[oracle(avmOpcodeSuccessCopy)]
+unconstrained fn success_copy_opcode() -> bool {}
+
+#[oracle(avmOpcodeStorageRead)]
+unconstrained fn storage_read_opcode(storage_slot: Field, contract_address: Field) -> Field {}
+
+#[oracle(avmOpcodeStorageWrite)]
+unconstrained fn storage_write_opcode(storage_slot: Field, value: Field) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/call_private_function.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/call_private_function.nr
@@ -1,0 +1,34 @@
+use crate::protocol::{
+    abis::function_selector::FunctionSelector, address::AztecAddress, utils::reader::Reader,
+};
+
+#[oracle(privateCallPrivateFunction)]
+unconstrained fn call_private_function_oracle(
+    _contract_address: AztecAddress,
+    _function_selector: FunctionSelector,
+    _args_hash: Field,
+    _start_side_effect_counter: u32,
+    _is_static_call: bool,
+) -> [Field; 2] {}
+
+pub unconstrained fn call_private_function_internal(
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args_hash: Field,
+    start_side_effect_counter: u32,
+    is_static_call: bool,
+) -> (u32, Field) {
+    let fields = call_private_function_oracle(
+        contract_address,
+        function_selector,
+        args_hash,
+        start_side_effect_counter,
+        is_static_call,
+    );
+
+    let mut reader = Reader::new(fields);
+    let end_side_effect_counter = reader.read_u32();
+    let returns_hash = reader.read();
+
+    (end_side_effect_counter, returns_hash)
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/capsules.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/capsules.nr
@@ -1,0 +1,71 @@
+use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
+
+/// Stores arbitrary information in a per-contract non-volatile database, which can later be retrieved with `load`. If
+/// data was already stored at this slot, it is overwritten.
+pub unconstrained fn store<T>(contract_address: AztecAddress, slot: Field, value: T)
+where
+    T: Serialize,
+{
+    let serialized = value.serialize();
+    store_oracle(contract_address, slot, serialized);
+}
+
+/// Returns data previously stored via `storeCapsule` in the per-contract non-volatile database. Returns Option::none()
+/// if nothing was stored at the given slot.
+pub unconstrained fn load<T>(contract_address: AztecAddress, slot: Field) -> Option<T>
+where
+    T: Deserialize,
+{
+    let serialized_option = load_oracle(contract_address, slot, <T as Deserialize>::N);
+    serialized_option.map(|arr| Deserialize::deserialize(arr))
+}
+
+/// Deletes data in the per-contract non-volatile database. Does nothing if no data was present.
+pub unconstrained fn delete(contract_address: AztecAddress, slot: Field) {
+    delete_oracle(contract_address, slot);
+}
+
+/// Copies a number of contiguous entries in the per-contract non-volatile database. This allows for efficient data
+/// structures by avoiding repeated calls to `loadCapsule` and `storeCapsule`. Supports overlapping source and
+/// destination regions (which will result in the overlapped source values being overwritten). All copied slots must
+/// exist in the database (i.e. have been stored and not deleted)
+pub unconstrained fn copy(
+    contract_address: AztecAddress,
+    src_slot: Field,
+    dst_slot: Field,
+    num_entries: u32,
+) {
+    copy_oracle(contract_address, src_slot, dst_slot, num_entries);
+}
+
+#[oracle(utilityStoreCapsule)]
+unconstrained fn store_oracle<let N: u32>(
+    contract_address: AztecAddress,
+    slot: Field,
+    values: [Field; N],
+) {}
+
+/// We need to pass in `array_len` (the value of N) as a parameter to tell the oracle how many fields the response must
+/// have.
+///
+/// Note that the oracle returns an Option<[Field; N]> because we cannot return an Option<T> directly. That would
+/// require for the oracle resolver to know the shape of T (e.g. if T were a struct of 3 u32 values then the expected
+/// response shape would be 3 single items, whereas it were a struct containing `u32, [Field;10], u32` then the
+/// expected shape would be single, array, single.). Instead, we return the serialization and deserialize in Noir.
+#[oracle(utilityLoadCapsule)]
+unconstrained fn load_oracle<let N: u32>(
+    contract_address: AztecAddress,
+    slot: Field,
+    array_len: u32,
+) -> Option<[Field; N]> {}
+
+#[oracle(utilityDeleteCapsule)]
+unconstrained fn delete_oracle(contract_address: AztecAddress, slot: Field) {}
+
+#[oracle(utilityCopyCapsule)]
+unconstrained fn copy_oracle(
+    contract_address: AztecAddress,
+    src_slot: Field,
+    dst_slot: Field,
+    num_entries: u32,
+) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/enqueue_public_function_call.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/enqueue_public_function_call.nr
@@ -1,0 +1,101 @@
+use crate::protocol::address::AztecAddress;
+
+#[oracle(privateNotifyEnqueuedPublicFunctionCall)]
+unconstrained fn notify_enqueued_public_function_call_oracle(
+    _contract_address: AztecAddress,
+    _calldata_hash: Field,
+    _side_effect_counter: u32,
+    _is_static_call: bool,
+) {}
+
+unconstrained fn notify_enqueued_public_function_call_wrapper(
+    contract_address: AztecAddress,
+    calldata_hash: Field,
+    side_effect_counter: u32,
+    is_static_call: bool,
+) {
+    notify_enqueued_public_function_call_oracle(
+        contract_address,
+        calldata_hash,
+        side_effect_counter,
+        is_static_call,
+    )
+}
+
+pub fn notify_enqueued_public_function_call(
+    contract_address: AztecAddress,
+    calldata_hash: Field,
+    side_effect_counter: u32,
+    is_static_call: bool,
+) {
+    // Safety: Notifies the simulator that a public call has been enqueued, allowing it to prepare hints for the AVM to
+    // process this call.
+    unsafe {
+        notify_enqueued_public_function_call_wrapper(
+            contract_address,
+            calldata_hash,
+            side_effect_counter,
+            is_static_call,
+        )
+    }
+}
+
+#[oracle(privateNotifySetPublicTeardownFunctionCall)]
+unconstrained fn notify_set_public_teardown_function_call_oracle(
+    _contract_address: AztecAddress,
+    _calldata_hash: Field,
+    _side_effect_counter: u32,
+    _is_static_call: bool,
+) {}
+
+unconstrained fn notify_set_public_teardown_function_call_wrapper(
+    contract_address: AztecAddress,
+    calldata_hash: Field,
+    side_effect_counter: u32,
+    is_static_call: bool,
+) {
+    notify_set_public_teardown_function_call_oracle(
+        contract_address,
+        calldata_hash,
+        side_effect_counter,
+        is_static_call,
+    )
+}
+
+pub fn notify_set_public_teardown_function_call(
+    contract_address: AztecAddress,
+    calldata_hash: Field,
+    side_effect_counter: u32,
+    is_static_call: bool,
+) {
+    // Safety: Notifies the simulator that a teardown call has been set, allowing it to prepare hints for the AVM to
+    // process this call.
+    unsafe {
+        notify_set_public_teardown_function_call_wrapper(
+            contract_address,
+            calldata_hash,
+            side_effect_counter,
+            is_static_call,
+        )
+    }
+}
+
+pub fn notify_set_min_revertible_side_effect_counter(counter: u32) {
+    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to
+    // call.
+    unsafe { notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter) };
+}
+
+pub unconstrained fn notify_set_min_revertible_side_effect_counter_oracle_wrapper(counter: u32) {
+    notify_set_min_revertible_side_effect_counter_oracle(counter);
+}
+
+#[oracle(privateNotifySetMinRevertibleSideEffectCounter)]
+unconstrained fn notify_set_min_revertible_side_effect_counter_oracle(_counter: u32) {}
+
+pub unconstrained fn is_side_effect_counter_revertible_oracle_wrapper(counter: u32) -> bool {
+    is_side_effect_counter_revertible_oracle(counter)
+}
+
+#[oracle(privateIsSideEffectCounterRevertible)]
+unconstrained fn is_side_effect_counter_revertible_oracle(counter: u32) -> bool {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution.nr
@@ -1,0 +1,10 @@
+use crate::context::UtilityContext;
+
+#[oracle(utilityGetUtilityContext)]
+unconstrained fn get_utility_context_oracle() -> UtilityContext {}
+
+/// Returns a utility context built from the global variables of anchor block and the contract address of the function
+/// being executed.
+pub unconstrained fn get_utility_context() -> UtilityContext {
+    get_utility_context_oracle()
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution_cache.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution_cache.nr
@@ -1,0 +1,23 @@
+/// Stores values represented as slice in execution cache to be later obtained by its hash.
+pub fn store<let N: u32>(values: [Field; N], hash: Field) {
+    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to
+    // call. When loading the values, however, the caller must check that the values are indeed the preimage.
+    unsafe { store_in_execution_cache_oracle_wrapper(values, hash) };
+}
+
+unconstrained fn store_in_execution_cache_oracle_wrapper<let N: u32>(
+    values: [Field; N],
+    hash: Field,
+) {
+    store_in_execution_cache_oracle(values, hash);
+}
+
+pub unconstrained fn load<let N: u32>(hash: Field) -> [Field; N] {
+    load_from_execution_cache_oracle(hash)
+}
+
+#[oracle(privateStoreInExecutionCache)]
+unconstrained fn store_in_execution_cache_oracle<let N: u32>(_values: [Field; N], _hash: Field) {}
+
+#[oracle(privateLoadFromExecutionCache)]
+unconstrained fn load_from_execution_cache_oracle<let N: u32>(_hash: Field) -> [Field; N] {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/get_l1_to_l2_membership_witness.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/get_l1_to_l2_membership_witness.nr
@@ -1,0 +1,19 @@
+use crate::protocol::{address::AztecAddress, constants::L1_TO_L2_MSG_TREE_HEIGHT};
+
+/// Returns the leaf index and sibling path of an entry in the L1 to L2 messaging tree, which can then be used to prove
+/// its existence.
+pub unconstrained fn get_l1_to_l2_membership_witness(
+    contract_address: AztecAddress,
+    message_hash: Field,
+    secret: Field,
+) -> (Field, [Field; L1_TO_L2_MSG_TREE_HEIGHT]) {
+    get_l1_to_l2_membership_witness_oracle(contract_address, message_hash, secret)
+}
+
+// Obtains membership witness (index and sibling path) for a message in the L1 to L2 message tree.
+#[oracle(utilityGetL1ToL2MembershipWitness)]
+unconstrained fn get_l1_to_l2_membership_witness_oracle(
+    _contract_address: AztecAddress,
+    _message_hash: Field,
+    _secret: Field,
+) -> (Field, [Field; L1_TO_L2_MSG_TREE_HEIGHT]) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/logs.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/logs.nr
@@ -1,0 +1,19 @@
+use crate::protocol::address::AztecAddress;
+
+/// The below only exists to broadcast the raw log, so we can provide it to the base rollup later to be constrained.
+pub unconstrained fn notify_created_contract_class_log<let N: u32>(
+    contract_address: AztecAddress,
+    message: [Field; N],
+    length: u32,
+    counter: u32,
+) {
+    notify_created_contract_class_log_private_oracle(contract_address, message, length, counter)
+}
+
+#[oracle(privateNotifyCreatedContractClassLog)]
+unconstrained fn notify_created_contract_class_log_private_oracle<let N: u32>(
+    contract_address: AztecAddress,
+    message: [Field; N],
+    length: u32,
+    counter: u32,
+) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/mod.nr
@@ -1,0 +1,17 @@
+//! Oracle modules for protocol contracts.
+
+pub mod avm;
+pub mod version;
+pub mod execution_cache;
+pub mod capsules;
+pub mod storage;
+pub mod execution;
+pub mod get_l1_to_l2_membership_witness;
+pub mod nullifiers;
+pub mod enqueue_public_function_call;
+pub mod call_private_function;
+pub mod logs;
+
+// debug_log oracle is used by both noir-protocol-circuits and this crate and for this reason we just re-export it
+// here from protocol_types.
+pub use protocol_types::debug_log;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/nullifiers.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/nullifiers.nr
@@ -1,0 +1,46 @@
+//! Nullifier creation, existence checks, etc.
+
+use crate::protocol::address::aztec_address::AztecAddress;
+
+/// Notifies the simulator that a nullifier has been created, so that its correct status (pending or settled) can be
+/// determined when reading nullifiers in subsequent private function calls. The first non-revertible nullifier emitted
+/// is also used to compute note nonces.
+pub fn notify_created_nullifier(inner_nullifier: Field) {
+    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe to
+    // call.
+    unsafe { notify_created_nullifier_oracle(inner_nullifier) };
+}
+
+#[oracle(privateNotifyCreatedNullifier)]
+unconstrained fn notify_created_nullifier_oracle(_inner_nullifier: Field) {}
+
+/// Returns true if the nullifier has been emitted in the same transaction, i.e. if [notify_created_nullifier] has been
+/// called for this inner nullifier from the contract with the specified address.
+///
+/// Note that despite sharing pending transaction information with the app, this is not a privacy leak: anyone in the
+/// network can always determine in which transaction a inner nullifier was emitted by a given contract by simply
+/// inspecting transaction effects. What _would_ constitute a leak would be to share the list of inner pending
+/// nullifiers, as that would reveal their preimages.
+pub unconstrained fn is_nullifier_pending(
+    inner_nullifier: Field,
+    contract_address: AztecAddress,
+) -> bool {
+    is_nullifier_pending_oracle(inner_nullifier, contract_address)
+}
+
+#[oracle(privateIsNullifierPending)]
+unconstrained fn is_nullifier_pending_oracle(
+    _inner_nullifier: Field,
+    _contract_address: AztecAddress,
+) -> bool {}
+
+/// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
+/// nullifier, but a `false` value should not be relied upon since other transactions may emit this nullifier before
+/// the current transaction is included in a block. While this might seem of little use at first, certain design
+/// patterns benefit from this abstraction (see e.g. `PrivateMutable`).
+pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
+    check_nullifier_exists_oracle(inner_nullifier)
+}
+
+#[oracle(utilityCheckNullifierExists)]
+unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/storage.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/storage.nr
@@ -1,0 +1,35 @@
+use crate::protocol::{
+    abis::block_header::BlockHeader,
+    address::AztecAddress,
+    traits::{Hash, Packable, ToField},
+};
+
+#[oracle(utilityStorageRead)]
+unconstrained fn storage_read_oracle<let N: u32>(
+    block_hash: Field,
+    address: Field,
+    storage_slot: Field,
+    length: u32,
+) -> [Field; N] {}
+
+pub unconstrained fn raw_storage_read<let N: u32>(
+    block_hash_to_read_from: Field,
+    address: AztecAddress,
+    storage_slot: Field,
+) -> [Field; N] {
+    storage_read_oracle(block_hash_to_read_from, address.to_field(), storage_slot, N)
+}
+
+pub unconstrained fn storage_read<T>(
+    header_to_read_from: BlockHeader,
+    address: AztecAddress,
+    storage_slot: Field,
+) -> T
+where
+    T: Packable,
+{
+    let block_hash_to_read_from = header_to_read_from.hash();
+    T::unpack(
+        raw_storage_read(block_hash_to_read_from, address, storage_slot),
+    )
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/version.nr
@@ -1,0 +1,23 @@
+/// The ORACLE_VERSION constant is used to check that the oracle interface is in sync between PXE and Aztec.nr. We need
+/// to version the oracle interface to ensure that developers get a reasonable error message if they use incompatible
+/// versions of Aztec.nr and PXE. The TypeScript counterpart is in `oracle_version.ts`.
+///
+/// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
+/// and if the oracle version is incompatible an error is thrown.
+pub global ORACLE_VERSION: Field = 9;
+
+/// Asserts that the version of the oracle is compatible with the version expected by the contract.
+pub fn assert_compatible_oracle_version() {
+    // Safety: This oracle call returns nothing: we only call it to check Aztec.nr and Oracle interface versions are
+    // compatible. It is therefore always safe to call.
+    unsafe {
+        assert_compatible_oracle_version_wrapper();
+    }
+}
+
+unconstrained fn assert_compatible_oracle_version_wrapper() {
+    assert_compatible_oracle_version_oracle(ORACLE_VERSION);
+}
+
+#[oracle(utilityAssertCompatibleOracleVersion)]
+unconstrained fn assert_compatible_oracle_version_oracle(version: Field) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/delayed_public_mutable.nr
@@ -1,0 +1,204 @@
+use crate::protocol::{
+    delayed_public_mutable::{
+        delayed_public_mutable_values::{unpack_delay_change, unpack_value_change},
+        DelayedPublicMutableValues,
+        ScheduledDelayChange,
+        ScheduledValueChange,
+    },
+    traits::Packable,
+};
+
+use crate::{
+    context::{PrivateContext, PublicContext, UtilityContext},
+    state_vars::StateVariable,
+    utils::WithHash,
+};
+
+/// Public mutable values with private read access.
+pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
+    context: Context,
+    storage_slot: Field,
+}
+
+// DelayedPublicMutable<T> stores a value of type T that is:
+//  - publicly known (i.e. unencrypted)
+//  - mutable in public
+//  - readable in private with no contention
+impl<T, let InitialDelay: u64, Context, let M: u32> StateVariable<M + 1, Context> for DelayedPublicMutable<T, InitialDelay, Context>
+where
+    DelayedPublicMutableValues<T, InitialDelay>: Packable<N = M>,
+{
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        Self { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
+    }
+}
+
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, PublicContext>
+where
+    T: Eq,
+{
+
+    pub fn schedule_value_change(self, new_value: T)
+    where
+        T: Packable,
+    {
+        let _value_change = self.schedule_and_return_value_change(new_value);
+    }
+
+    pub fn schedule_and_return_value_change(self, new_value: T) -> ScheduledValueChange<T>
+    where
+        T: Packable,
+    {
+        let mut value_change = self.read_value_change();
+        let delay_change = self.read_delay_change();
+
+        let current_timestamp = self.context.timestamp();
+        let current_delay = delay_change.get_current(current_timestamp);
+
+        // TODO: make this configurable https://github.com/AztecProtocol/aztec-packages/issues/5501
+        let timestamp_of_change = current_timestamp + current_delay;
+        value_change.schedule_change(
+            new_value,
+            current_timestamp,
+            current_delay,
+            timestamp_of_change,
+        );
+
+        self.write(value_change, delay_change);
+
+        value_change
+    }
+
+    pub fn schedule_delay_change(self, new_delay: u64)
+    where
+        T: Packable,
+    {
+        let mut delay_change = self.read_delay_change();
+
+        let current_timestamp = self.context.timestamp();
+
+        delay_change.schedule_change(new_delay, current_timestamp);
+
+        self.write(self.read_value_change(), delay_change);
+    }
+
+    pub fn get_current_value(self) -> T
+    where
+        T: Packable,
+    {
+        let current_timestamp = self.context.timestamp();
+        let value_change = self.read_value_change();
+
+        value_change.get_current_at(current_timestamp)
+    }
+
+    pub fn get_current_delay(self) -> u64
+    where
+        T: Packable,
+    {
+        let current_timestamp = self.context.timestamp();
+        self.read_delay_change().get_current(current_timestamp)
+    }
+
+    pub fn get_scheduled_value(self) -> (T, u64)
+    where
+        T: Packable,
+    {
+        self.read_value_change().get_scheduled()
+    }
+
+    pub fn get_scheduled_delay(self) -> (u64, u64)
+    where
+        T: Packable,
+    {
+        self.read_delay_change().get_scheduled()
+    }
+
+    fn read_value_change(self) -> ScheduledValueChange<T>
+    where
+        T: Packable,
+    {
+        let packed = self.context.storage_read(self.storage_slot);
+        unpack_value_change::<T, <T as Packable>::N>(packed)
+    }
+
+    fn read_delay_change(self) -> ScheduledDelayChange<InitialDelay>
+    where
+        T: Packable,
+    {
+        let packed = self.context.storage_read(self.storage_slot);
+        unpack_delay_change::<InitialDelay>(packed)
+    }
+
+    fn write(
+        self,
+        value_change: ScheduledValueChange<T>,
+        delay_change: ScheduledDelayChange<InitialDelay>,
+    )
+    where
+        T: Packable,
+    {
+        let values = WithHash::new(DelayedPublicMutableValues::new(value_change, delay_change));
+
+        self.context.storage_write(self.storage_slot, values);
+    }
+}
+
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, &mut PrivateContext>
+where
+    T: Eq,
+{
+    pub fn get_current_value(self) -> T
+    where
+        T: Packable,
+    {
+        // When reading the current value in private we construct a historical state proof for the public value.
+        let (value_change, delay_change, anchor_timestamp) = self.anchor_read_from_public_storage();
+
+        let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(anchor_timestamp);
+        let time_horizon = value_change.get_time_horizon(anchor_timestamp, effective_minimum_delay);
+
+        // We prevent this transaction from being included in any timestamp after the time horizon.
+        self.context.set_include_by_timestamp(time_horizon);
+
+        value_change.get_current_at(anchor_timestamp)
+    }
+
+    fn anchor_read_from_public_storage(
+        self,
+    ) -> (ScheduledValueChange<T>, ScheduledDelayChange<InitialDelay>, u64)
+    where
+        T: Packable,
+    {
+        let header = self.context.get_anchor_block_header();
+        let address = self.context.this_address();
+
+        let anchor_timestamp = header.global_variables.timestamp;
+
+        let values: DelayedPublicMutableValues<T, InitialDelay> =
+            WithHash::historical_public_storage_read(header, address, self.storage_slot);
+
+        (values.svc, values.sdc, anchor_timestamp)
+    }
+}
+
+impl<T, let InitialDelay: u64> DelayedPublicMutable<T, InitialDelay, UtilityContext>
+where
+    T: Eq,
+{
+    pub unconstrained fn get_current_value(self) -> T
+    where
+        T: Packable,
+    {
+        let dpmv: DelayedPublicMutableValues<T, InitialDelay> =
+            WithHash::utility_public_storage_read(self.context, self.storage_slot);
+
+        let current_timestamp = self.context.timestamp();
+        dpmv.svc.get_current_at(current_timestamp)
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/map.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/map.nr
@@ -1,0 +1,39 @@
+use crate::protocol::{storage::map::derive_storage_slot_in_map, traits::ToField};
+use crate::state_vars::StateVariable;
+
+/// A key-value container for state variables.
+///
+/// A key-value storage container that maps keys to state variables, similar to Solidity mappings.
+pub struct Map<K, V, Context> {
+    pub context: Context,
+    storage_slot: Field,
+}
+
+// Map reserves a single storage slot regardless of what it stores because nothing is stored at said slot: it is only
+// used to derive the storage slots of nested state variables.
+impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        Map { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
+    }
+}
+
+impl<K, V, Context> Map<K, V, Context> {
+    /// Returns the state variable associated with the given key.
+    ///
+    /// This is equivalent to accessing `mapping[key]` in Solidity.
+    pub fn at<let N: u32>(self, key: K) -> V
+    where
+        K: ToField,
+        V: StateVariable<N, Context>,
+    {
+        V::new(
+            self.context,
+            derive_storage_slot_in_map(self.storage_slot, key),
+        )
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/mod.nr
@@ -1,0 +1,13 @@
+//! State variables for protocol contracts.
+
+pub mod state_variable;
+pub mod storable;
+pub mod map;
+pub mod public_mutable;
+pub mod delayed_public_mutable;
+
+pub use delayed_public_mutable::DelayedPublicMutable;
+pub use map::Map;
+pub use public_mutable::PublicMutable;
+pub use state_variable::StateVariable;
+pub use storable::Storable;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/public_mutable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/public_mutable.nr
@@ -1,0 +1,54 @@
+use crate::context::{PublicContext, UtilityContext};
+use crate::protocol::traits::Packable;
+use crate::state_vars::StateVariable;
+
+/// Mutable public values.
+///
+/// This is one of the most basic public state variables. It is equivalent to a non-`immutable` non-`constant` Solidity
+/// state variable.
+pub struct PublicMutable<T, Context> {
+    context: Context,
+    storage_slot: Field,
+}
+
+impl<T, Context, let M: u32> StateVariable<M, Context> for PublicMutable<T, Context>
+where
+    T: Packable<N = M>,
+{
+    fn new(context: Context, storage_slot: Field) -> Self {
+        assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
+        PublicMutable { context, storage_slot }
+    }
+
+    fn get_storage_slot(self) -> Field {
+        self.storage_slot
+    }
+}
+
+impl<T> PublicMutable<T, PublicContext> {
+    /// Returns the current value.
+    pub fn read(self) -> T
+    where
+        T: Packable,
+    {
+        self.context.storage_read(self.storage_slot)
+    }
+
+    /// Stores a new value.
+    pub fn write(self, value: T)
+    where
+        T: Packable,
+    {
+        self.context.storage_write(self.storage_slot, value);
+    }
+}
+
+impl<T> PublicMutable<T, UtilityContext> {
+    /// Returns the value at the anchor block.
+    pub unconstrained fn read(self) -> T
+    where
+        T: Packable,
+    {
+        self.context.storage_read(self.storage_slot)
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/state_variable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/state_variable.nr
@@ -1,0 +1,17 @@
+/// A trait that defines the common interface for all Aztec state variables. State variables are variables that can be
+/// stored in the contract's storage. Examples of state variables are `PublicMutable`, `Map` or `DelayedPublicMutable`.
+///
+/// # Type Parameters
+///
+/// * `N` - A compile-time constant that determines how many storage slots need to be reserved for this state variable.
+/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+/// determines which methods of the state variable are available and controls whether the variable can be accessed in
+/// public, private or utility functions.
+///
+pub trait StateVariable<let N: u32, Context> {
+    /// Initializes a new state variable at a given storage slot.
+    fn new(context: Context, storage_slot: Field) -> Self;
+
+    /// Returns the storage slot at which the state variable is placed.
+    fn get_storage_slot(self) -> Field;
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/storable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/storable.nr
@@ -1,0 +1,7 @@
+/// Exported storage layout definition.
+///
+/// Struct representing an exportable storage variable in the contract. Every entry in the storage struct will be
+/// exported in the compilation artifact as a Storable entity, containing the storage slot.
+pub struct Storable {
+    pub slot: Field,
+}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/utils/mod.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/utils/mod.nr
@@ -1,0 +1,5 @@
+//! Utility modules for protocol contracts.
+
+pub mod with_hash;
+
+pub use with_hash::WithHash;

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/utils/with_hash.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/utils/with_hash.nr
@@ -1,0 +1,113 @@
+use crate::{
+    context::{PublicContext, UtilityContext},
+    history::storage::public_storage_historical_read,
+    oracle,
+};
+use crate::protocol::{
+    abis::block_header::BlockHeader, address::AztecAddress, hash::poseidon2_hash, traits::Packable,
+};
+
+/// A struct that allows for efficient reading of value `T` from public storage in private.
+///
+/// The efficient reads are achieved by verifying large values through a single hash check and then proving inclusion
+/// only of the hash in public storage. This reduces the number of required tree inclusion proofs from `M` to 1.
+///
+/// # Type Parameters
+/// - `T`: The underlying type being wrapped, must implement `Packable<N>`
+/// - `M`: The number of field elements required to pack values of type `T`
+pub struct WithHash<T, let M: u32> {
+    value: T,
+    packed: [Field; M],
+    hash: Field,
+}
+
+impl<T, let M: u32> WithHash<T, M>
+where
+    T: Packable<N = M> + Eq,
+{
+    pub fn new(value: T) -> Self {
+        let packed = value.pack();
+        Self { value, packed, hash: poseidon2_hash(packed) }
+    }
+
+    pub fn get_value(self) -> T {
+        self.value
+    }
+
+    pub fn get_hash(self) -> Field {
+        self.hash
+    }
+
+    /// Reads the value stored in this [WithHash] from public storage.
+    pub fn public_storage_read(context: PublicContext, storage_slot: Field) -> T {
+        context.storage_read(storage_slot)
+    }
+
+    pub unconstrained fn utility_public_storage_read(
+        context: UtilityContext,
+        storage_slot: Field,
+    ) -> T {
+        context.storage_read(storage_slot)
+    }
+
+    pub fn historical_public_storage_read(
+        header_to_read_from: BlockHeader,
+        address: AztecAddress,
+        storage_slot: Field,
+    ) -> T {
+        // We could simply produce historical inclusion proofs for each field in `packed`, but that would require one
+        // full sibling path per storage slot. Instead, we get an oracle to provide us the values, and instead we prove
+        // inclusion of their hash, which is both a much smaller proof (a single slot), and also independent of the
+        // size of T.
+        let hint = WithHash::new(
+            // Safety: We verify that a hash of the hint/packed data matches the stored hash.
+            unsafe { oracle::storage::storage_read(header_to_read_from, address, storage_slot) },
+        );
+
+        // The actual `value` (of type T, of packed length M fields) is stored in contiguous fields from the
+        // `storage_slot`. The _hash_ of the `value` is stored at the end, at slot: `storage_slot + M`.
+        let hash =
+            public_storage_historical_read(header_to_read_from, storage_slot + M as Field, address);
+
+        if hash != 0 {
+            assert_eq(hash, hint.get_hash(), "Hint values do not match hash");
+        } else {
+            // The hash slot can only hold a zero if it is uninitialized. Therefore, the hints must then be zero (i.e.
+            // the default value for public storage) as well.
+            assert_eq(
+                hint.get_value(),
+                T::unpack(std::mem::zeroed()),
+                "Non-zero hint for zero hash",
+            );
+        };
+
+        hint.get_value()
+    }
+}
+
+impl<T, let M: u32> Packable for WithHash<T, M>
+where
+    T: Packable<N = M>,
+{
+    let N: u32 = M + 1;
+
+    fn pack(self) -> [Field; Self::N] {
+        let mut result: [Field; Self::N] = std::mem::zeroed();
+        for i in 0..M {
+            result[i] = self.packed[i];
+        }
+        result[M] = self.hash;
+
+        result
+    }
+
+    fn unpack(packed: [Field; Self::N]) -> Self {
+        let mut value_packed = [0; M];
+        for i in 0..M {
+            value_packed[i] = packed[i];
+        }
+        let hash = packed[M];
+
+        Self { value: T::unpack(value_packed), packed: value_packed, hash }
+    }
+}

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { path = "../../../../aztec-nr/aztec" }
+aztec = { path = "../aztec_sublib" }

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/class_published.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/class_published.nr
@@ -1,8 +1,8 @@
-use dep::aztec::protocol::{
+use aztec::protocol::{
     constants::{CONTRACT_CLASS_PUBLISHED_MAGIC_VALUE, MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS},
     contract_class_id::ContractClassId,
 };
-use dep::aztec::protocol::traits::ToField;
+use aztec::protocol::traits::ToField;
 
 pub struct ContractClassPublished {
     pub contract_class_id: ContractClassId,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/private_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/private_function_broadcasted.nr
@@ -1,4 +1,4 @@
-use dep::aztec::protocol::{
+use aztec::protocol::{
     abis::function_selector::FunctionSelector,
     constants::{
         ARTIFACT_FUNCTION_TREE_MAX_HEIGHT,
@@ -9,7 +9,7 @@ use dep::aztec::protocol::{
     contract_class_id::ContractClassId,
     traits::Serialize,
 };
-use dep::aztec::protocol::traits::ToField;
+use aztec::protocol::traits::ToField;
 use std::meta::derive;
 
 #[derive(Serialize)]

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/utility_function_broadcasted.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/events/utility_function_broadcasted.nr
@@ -1,4 +1,4 @@
-use dep::aztec::protocol::{
+use aztec::protocol::{
     abis::function_selector::FunctionSelector,
     constants::{
         ARTIFACT_FUNCTION_TREE_MAX_HEIGHT,
@@ -9,7 +9,7 @@ use dep::aztec::protocol::{
     contract_class_id::ContractClassId,
     traits::Serialize,
 };
-use dep::aztec::protocol::traits::ToField;
+use aztec::protocol::traits::ToField;
 use std::meta::derive;
 
 #[derive(Serialize)]

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/main.nr
@@ -1,24 +1,6 @@
 mod events;
 
-use dep::aztec::macros::aztec;
-
-#[aztec]
 pub contract ContractClassRegistry {
-    use dep::aztec::{
-        hash::compute_public_bytecode_commitment,
-        macros::functions::external,
-        protocol::{
-            constants::{
-                ARTIFACT_FUNCTION_TREE_MAX_HEIGHT, CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
-                FUNCTION_TREE_HEIGHT, MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS,
-                MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS,
-                MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS,
-            },
-            contract_class_id::ContractClassId,
-            traits::ToField,
-        },
-    };
-
     use crate::events::{
         class_published::ContractClassPublished,
         private_function_broadcasted::{
@@ -28,19 +10,48 @@ pub contract ContractClassRegistry {
             ClassUtilityFunctionBroadcasted, InnerUtilityFunction, UtilityFunction,
         },
     };
+    use aztec::{
+        hash::compute_public_bytecode_commitment,
+        oracle::capsules,
+        protocol::{
+            constants::{
+                CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
+                MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS,
+                MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS,
+            },
+            contract_class_id::ContractClassId,
+            traits::{Serialize, ToField},
+        },
+    };
 
-    use dep::aztec::oracle::capsules;
-
-    #[external("private")]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn publish(
+        inputs: aztec::context::inputs::PrivateContextInputs,
         artifact_hash: Field,
         private_functions_root: Field,
         public_bytecode_commitment: Field,
-    ) {
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
+        // body, I have removed that check.
+        aztec::oracle::version::assert_compatible_oracle_version();
+
+        let serialized_params: [Field; 3] =
+            [artifact_hash, private_functions_root, public_bytecode_commitment];
+
+        let args_hash: Field = aztec::hash::hash_args(serialized_params);
+        let mut context: aztec::context::PrivateContext =
+            aztec::context::PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
         // Safety: We load the bytecode via a capsule, which is unconstrained. In order to ensure the loaded bytecode
         // matches the expected one, we recompute the commitment and assert it matches the one provided by the caller.
-        let mut packed_public_bytecode: [Field; MAX_PACKED_PUBLIC_BYTECODE_SIZE_IN_FIELDS] = unsafe {
-            capsules::load(self.address, CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT).unwrap()
+        let mut packed_public_bytecode: [Field; 3000] = unsafe {
+            capsules::load(
+                context.this_address(),
+                CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
+            )
+                .unwrap()
         };
         // Compute and check the public bytecode commitment
         let computed_public_bytecode_commitment =
@@ -57,10 +68,10 @@ pub contract ContractClassRegistry {
         // Emit the contract class id as a nullifier:
         // - to demonstrate that this contract class hasn't been published before
         // - to enable apps to read that this contract class has been published.
-        self.context.push_nullifier(contract_class_id.to_field());
+        context.push_nullifier(contract_class_id.to_field());
 
         // Broadcast class info including public bytecode
-        dep::aztec::oracle::debug_log::debug_log_format(
+        aztec::oracle::debug_log::debug_log_format(
             "ContractClassPublished: {}",
             [
                 contract_class_id.to_field(),
@@ -77,28 +88,57 @@ pub contract ContractClassRegistry {
             private_functions_root,
             packed_public_bytecode,
         };
-        self.context.emit_contract_class_log(event.serialize_non_standard());
+        context.emit_contract_class_log(event.serialize_non_standard());
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
-    #[external("private")]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn broadcast_private_function(
+        inputs: aztec::context::inputs::PrivateContextInputs,
         contract_class_id: ContractClassId,
         artifact_metadata_hash: Field,
         utility_functions_artifact_tree_root: Field,
-        private_function_tree_sibling_path: [Field; FUNCTION_TREE_HEIGHT],
+        private_function_tree_sibling_path: [Field; 7],
         private_function_tree_leaf_index: Field,
-        artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
+        artifact_function_tree_sibling_path: [Field; 7],
         artifact_function_tree_leaf_index: Field,
         function_data: InnerPrivateFunction,
-    ) {
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
+        // body, I have removed that check.
+        aztec::oracle::version::assert_compatible_oracle_version();
+
+        let serialized_params: [Field; 22] = [
+            contract_class_id.to_field(),
+            artifact_metadata_hash,
+            utility_functions_artifact_tree_root,
+        ]
+            .concat(private_function_tree_sibling_path)
+            .concat([private_function_tree_leaf_index])
+            .concat(artifact_function_tree_sibling_path)
+            .concat([artifact_function_tree_leaf_index])
+            .concat(function_data.serialize());
+
+        let args_hash: Field = aztec::hash::hash_args(serialized_params);
+        let mut context: aztec::context::PrivateContext =
+            aztec::context::PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
         // Safety: The bytecode loaded here is unconstrained, which is acceptable since:
         // 1. Unlike public functions, we don't need execution guarantees for private functions.
         // 2. This broadcast simply provides convenient bytecode sharing vs offchain distribution.
         // 3. Computing the VK for private bytecode in-circuit is not possible, so we can't do better.
         let private_bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_PRIVATE_FUNCTION_IN_FIELDS] = unsafe {
-            capsules::load(self.address, CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT).unwrap()
+            capsules::load(
+                context.this_address(),
+                CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
+            )
+                .unwrap()
         };
-
         let event = ClassPrivateFunctionBroadcasted {
             contract_class_id,
             artifact_metadata_hash,
@@ -114,7 +154,7 @@ pub contract ContractClassRegistry {
                 bytecode: private_bytecode,
             },
         };
-        dep::aztec::oracle::debug_log::debug_log_format(
+        aztec::oracle::debug_log::debug_log_format(
             "ClassPrivateFunctionBroadcasted: {}",
             [
                 contract_class_id.to_field(),
@@ -125,23 +165,51 @@ pub contract ContractClassRegistry {
                 function_data.metadata_hash,
             ],
         );
-        self.context.emit_contract_class_log(event.serialize_non_standard());
+        context.emit_contract_class_log(event.serialize_non_standard());
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
-    #[external("private")]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn broadcast_utility_function(
+        inputs: aztec::context::inputs::PrivateContextInputs,
         contract_class_id: ContractClassId,
         artifact_metadata_hash: Field,
         private_functions_artifact_tree_root: Field,
-        artifact_function_tree_sibling_path: [Field; ARTIFACT_FUNCTION_TREE_MAX_HEIGHT],
+        artifact_function_tree_sibling_path: [Field; 7],
         artifact_function_tree_leaf_index: Field,
         function_data: InnerUtilityFunction,
-    ) {
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
+        // body, I have removed that check.
+        aztec::oracle::version::assert_compatible_oracle_version();
+
+        let serialized_params: [Field; 13] = [
+            contract_class_id.to_field(),
+            artifact_metadata_hash,
+            private_functions_artifact_tree_root,
+        ]
+            .concat(artifact_function_tree_sibling_path)
+            .concat([artifact_function_tree_leaf_index])
+            .concat(function_data.serialize());
+
+        let args_hash: Field = aztec::hash::hash_args(serialized_params);
+        let mut context: aztec::context::PrivateContext =
+            aztec::context::PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
         // Safety: The bytecode loaded here is unconstrained, which is acceptable since:
         // 1. Unlike public functions, we don't need execution guarantees for utility functions.
         // 2. This broadcast simply provides convenient bytecode sharing vs offchain distribution.
         let utility_bytecode: [Field; MAX_PACKED_BYTECODE_SIZE_PER_UTILITY_FUNCTION_IN_FIELDS] = unsafe {
-            capsules::load(self.address, CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT).unwrap()
+            capsules::load(
+                context.this_address(),
+                CONTRACT_CLASS_REGISTRY_BYTECODE_CAPSULE_SLOT,
+            )
+                .unwrap()
         };
         let event = ClassUtilityFunctionBroadcasted {
             contract_class_id,
@@ -155,7 +223,7 @@ pub contract ContractClassRegistry {
                 bytecode: utility_bytecode,
             },
         };
-        dep::aztec::oracle::debug_log::debug_log_format(
+        aztec::oracle::debug_log::debug_log_format(
             "ClassUtilityFunctionBroadcasted: {}",
             [
                 contract_class_id.to_field(),
@@ -165,7 +233,53 @@ pub contract ContractClassRegistry {
                 function_data.metadata_hash,
             ],
         );
-        self.context.emit_contract_class_log(event.serialize_non_standard());
+        context.emit_contract_class_log(event.serialize_non_standard());
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
+    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+
+    pub struct broadcast_private_function_parameters {
+        pub _contract_class_id: ContractClassId,
+        pub _artifact_metadata_hash: Field,
+        pub _utility_functions_artifact_tree_root: Field,
+        pub _private_function_tree_sibling_path: [Field; 7],
+        pub _private_function_tree_leaf_index: Field,
+        pub _artifact_function_tree_sibling_path: [Field; 7],
+        pub _artifact_function_tree_leaf_index: Field,
+        pub _function_data: InnerPrivateFunction,
+    }
+
+    pub struct broadcast_utility_function_parameters {
+        pub _contract_class_id: ContractClassId,
+        pub _artifact_metadata_hash: Field,
+        pub _private_functions_artifact_tree_root: Field,
+        pub _artifact_function_tree_sibling_path: [Field; 7],
+        pub _artifact_function_tree_leaf_index: Field,
+        pub _function_data: InnerUtilityFunction,
+    }
+
+    pub struct publish_parameters {
+        pub _artifact_hash: Field,
+        pub _private_functions_root: Field,
+        pub _public_bytecode_commitment: Field,
+    }
+
+    #[abi(functions)]
+    pub struct broadcast_private_function_abi {
+        parameters: broadcast_private_function_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct broadcast_utility_function_abi {
+        parameters: broadcast_utility_function_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct publish_abi {
+        parameters: publish_parameters,
+    }
 }

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { path = "../../../../aztec-nr/aztec" }
+aztec = { path = "../aztec_sublib" }

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
@@ -1,11 +1,16 @@
-use aztec::macros::aztec;
-
-#[aztec]
+/**
+ * @title ContractInstanceRegistry Contract
+ * @notice Manages the registration and updating of contract instances
+ * @dev This contract allows deploying new contract instances and updating their class IDs
+ */
 pub contract ContractInstanceRegistry {
     use aztec::{
-        macros::{events::event, functions::{external, view}, storage::storage},
+        context::{PrivateContext, PublicContext},
+        hash::hash_args,
         nullifier::utils::compute_nullifier_existence_request,
+        oracle::{avm, debug_log::debug_log_format, version::assert_compatible_oracle_version},
         protocol::{
+            abis::function_selector::FunctionSelector,
             address::{AztecAddress, PartialAddress},
             constants::{
                 CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS, CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE,
@@ -14,12 +19,13 @@ pub contract ContractInstanceRegistry {
             contract_class_id::ContractClassId,
             point::validate_on_curve,
             public_keys::PublicKeys,
-            traits::{Serialize, ToField},
+            traits::{Deserialize, Serialize, ToField},
+            utils::reader::Reader,
         },
-        state_vars::{DelayedPublicMutable, Map},
+        state_vars::{DelayedPublicMutable, Map, StateVariable},
     };
 
-    #[event]
+    #[abi(events)]
     struct ContractInstancePublished {
         CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE: Field,
         address: AztecAddress,
@@ -82,7 +88,8 @@ pub contract ContractInstanceRegistry {
         }
     }
 
-    #[event]
+    #[abi(events)]
+    #[derive(Serialize)]
     struct ContractInstanceUpdated {
         CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE: Field,
         address: AztecAddress,
@@ -91,30 +98,48 @@ pub contract ContractInstanceRegistry {
         timestamp_of_change: u64,
     }
 
-    #[storage]
     struct Storage<Context> {
         updated_class_ids: Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context>,
     }
 
-    #[external("private")]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn publish_for_public_execution(
+        inputs: aztec::context::inputs::PrivateContextInputs,
         salt: Field,
         contract_class_id: ContractClassId,
         initialization_hash: Field,
         public_keys: PublicKeys,
         universal_deploy: bool,
-    ) {
-        // contract class must be published in order to publish an instance
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
+        // body, I have removed that check.
+        assert_compatible_oracle_version();
+
+        let serialized_params: [Field; 16] = [
+            salt,
+            contract_class_id.to_field(),
+            initialization_hash,
+        ]
+            .concat(public_keys.serialize())
+            .concat([universal_deploy.to_field()]);
+
+        let args_hash: Field = hash_args(serialized_params);
+        let mut context: PrivateContext = PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
+        // Verify that the contract class is registered
         let nullifier_existence_request = compute_nullifier_existence_request(
             contract_class_id.to_field(),
             CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
         );
-        self.context.assert_nullifier_exists(nullifier_existence_request);
+        context.assert_nullifier_exists(nullifier_existence_request);
 
+        // Determine the deployer based on universal_deploy flag
         let deployer = if universal_deploy {
             AztecAddress::zero()
         } else {
-            self.msg_sender()
+            context.maybe_msg_sender().unwrap()
         };
 
         let partial_address =
@@ -133,9 +158,9 @@ pub contract ContractInstanceRegistry {
         // Emit the address as a nullifier:
         // - to demonstrate that this contract instance hasn't been published before
         // - to enable apps to read that this contract instance has been published.
-        self.context.push_nullifier(address.to_field());
+        context.push_nullifier(address.to_field());
 
-        // Broadcast the event
+        // Emit the deployment event
         let event = ContractInstancePublished {
             CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE,
             contract_class_id,
@@ -146,40 +171,50 @@ pub contract ContractInstanceRegistry {
             deployer,
             version: 1,
         };
-
         let payload = event.serialize_non_standard();
-        aztec::oracle::debug_log::debug_log_format("ContractInstancePublished: {}", payload);
-
+        debug_log_format("ContractInstancePublished: {}", payload);
         let padded_log = payload.concat([0; 3]);
-        // Only the payload needs to be emitted. Since the siloed tag of this event log is publicly known, it's
-        // acceptable to pad the log with 0s and reveal the actual payload length.
         let length = payload.len();
-        self.context.emit_private_log(padded_log, length);
+        context.emit_private_log(padded_log, length);
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
-    #[external("public")]
-    fn update(new_contract_class_id: ContractClassId) {
-        let address = self.msg_sender();
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    unconstrained fn update(new_contract_class_id: ContractClassId) {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] =
+                    avm::calldata_copy(1, <ContractClassId as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        // MACRO CODE END
+
+        let address = context.maybe_msg_sender().unwrap();
 
         // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
         // information through publishing, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists_unsafe(address.to_field(), self.address),
+            context.nullifier_exists_unsafe(address.to_field(), context.this_address()),
             "msg.sender is not deployed",
         );
 
         // Safety: we're using the nullifier's existence as a guarantee of the availability of the new contract class'
         // information through registration, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists_unsafe(
+            context.nullifier_exists_unsafe(
                 new_contract_class_id.to_field(),
                 CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
             ),
             "New contract class is not registered",
         );
 
-        let scheduled_value_update = self
-            .storage
+        let scheduled_value_update = storage
             .updated_class_ids
             .at(address)
             .schedule_and_return_value_change(new_contract_class_id);
@@ -192,29 +227,143 @@ pub contract ContractInstanceRegistry {
             new_contract_class_id,
             timestamp_of_change,
         };
-
-        self.context.emit_public_log(event);
+        context.emit_public_log(event);
     }
 
-    #[external("public")]
-    fn set_update_delay(new_update_delay: u64) {
-        let msg_sender = self.msg_sender();
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    unconstrained fn set_update_delay(new_update_delay: u64) {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] = avm::calldata_copy(1, <u64 as Serialize>::N);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        // MACRO CODE END
+
+        let msg_sender = context.maybe_msg_sender().unwrap();
 
         // Safety: we're using the nullifier's existence as a guarantee of the availability of the contract's
         // information through publishing, which is safe - we just need this information to be _eventually_ available.
         assert(
-            self.context.nullifier_exists_unsafe(msg_sender.to_field(), self.address),
+            context.nullifier_exists_unsafe(msg_sender.to_field(), context.this_address()),
             "msg.sender is not deployed",
         );
 
         assert(new_update_delay >= MINIMUM_UPDATE_DELAY, "New update delay is too low");
 
-        self.storage.updated_class_ids.at(msg_sender).schedule_delay_change(new_update_delay);
+        storage.updated_class_ids.at(msg_sender).schedule_delay_change(new_update_delay);
     }
 
-    #[external("public")]
-    #[view]
-    fn get_update_delay() -> u64 {
-        self.storage.updated_class_ids.at(self.msg_sender()).get_current_delay()
+    /**
+     * Gets the current update delay for the caller's contract instance.
+     *
+     * @return The current update delay value
+     */
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
+    unconstrained fn get_update_delay() -> pub u64 {
+        // MACRO CODE START
+        let context: PublicContext = PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 0] = avm::calldata_copy(1, 0);
+                hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<PublicContext> = Storage::init(context);
+        assert(context.is_static_call(), "Function get_update_delay can only be called statically");
+        // MACRO CODE END
+
+        storage.updated_class_ids.at(avm::sender()).get_current_delay()
+    }
+
+    // // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+
+    // Function selectors computed at comptime from function signatures
+    global UPDATE_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("update((Field))").to_field() };
+    global SET_UPDATE_DELAY_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("set_update_delay(u64)").to_field() };
+    global GET_UPDATE_DELAY_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("get_update_delay()").to_field() };
+
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    pub unconstrained fn public_dispatch(selector: Field) {
+        if selector == UPDATE_SELECTOR {
+            let input_calldata: [Field; 1] =
+                avm::calldata_copy(1, <ContractClassId as Serialize>::N);
+            let mut reader: Reader<1> = Reader::new(input_calldata);
+            let arg0: ContractClassId =
+                reader.read_struct(<ContractClassId as Deserialize>::deserialize);
+            update(arg0);
+            avm::avm_return([].as_vector());
+        };
+        if selector == SET_UPDATE_DELAY_SELECTOR {
+            let input_calldata: [Field; 1] = avm::calldata_copy(1, <u64 as Serialize>::N);
+            let mut reader: Reader<1> = Reader::new(input_calldata);
+            let arg0: u64 = reader.read_struct(<u64 as Deserialize>::deserialize);
+            set_update_delay(arg0);
+            avm::avm_return([].as_vector());
+        };
+        if selector == GET_UPDATE_DELAY_SELECTOR {
+            let return_value: [Field; 1] = <u64 as Serialize>::serialize(get_update_delay());
+            avm::avm_return(return_value.as_vector());
+        };
+        panic(f"Unknown selector {selector}")
+    }
+
+    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+
+    impl<Context> Storage<Context> {
+        fn init(context: Context) -> Self {
+            Self {
+                updated_class_ids: <Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context> as StateVariable<1, Context>>::new(
+                    context,
+                    1,
+                ),
+            }
+        }
+    }
+
+    // Parameter structs for ABI
+    pub struct publish_for_public_execution_parameters {
+        pub _salt: Field,
+        pub _contract_class_id: ContractClassId,
+        pub _initialization_hash: Field,
+        pub _public_keys: PublicKeys,
+        pub _universal_deploy: bool,
+    }
+
+    pub struct update_parameters {
+        pub _new_contract_class_id: ContractClassId,
+    }
+
+    pub struct set_update_delay_parameters {
+        pub _new_update_delay: u64,
+    }
+
+    pub struct get_update_delay_parameters {}
+
+    // ABI structs
+    #[abi(functions)]
+    pub struct publish_for_public_execution_abi {
+        parameters: publish_for_public_execution_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct update_abi {
+        parameters: update_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct set_update_delay_abi {
+        parameters: set_update_delay_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct get_update_delay_abi {
+        parameters: get_update_delay_parameters,
+        return_type: u64,
     }
 }

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/Nargo.toml
@@ -5,5 +5,5 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { path = "../../../../aztec-nr/aztec" }
+aztec = { path = "../aztec_sublib" }
 keccak256 = { tag = "v0.1.3", git = "https://github.com/noir-lang/keccak256" }

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/lib.nr
@@ -1,7 +1,7 @@
-use dep::aztec::context::PublicContext;
-use dep::aztec::protocol::address::AztecAddress;
-use dep::aztec::protocol::hash::sha256_to_field;
-use dep::aztec::protocol::traits::ToField;
+use aztec::context::PublicContext;
+use aztec::protocol::address::AztecAddress;
+use aztec::protocol::hash::sha256_to_field;
+use aztec::protocol::traits::ToField;
 
 pub fn calculate_fee<TPublicContext>(context: PublicContext) -> Field {
     context.transaction_fee()

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
@@ -1,89 +1,321 @@
 mod lib;
 
-use dep::aztec::macros::aztec;
-
-#[aztec]
 pub contract FeeJuice {
-    use dep::aztec::{
-        macros::{functions::{external, internal, nophasecheck, only_self, view}, storage::storage},
+    use crate::lib::get_bridge_gas_msg_hash;
+    use aztec::{
         protocol::{
+            abis::function_selector::FunctionSelector,
             address::{AztecAddress, EthAddress},
             constants::FEE_JUICE_ADDRESS,
             traits::ToField,
         },
         state_vars::{Map, PublicMutable},
     };
-
-    use crate::lib::get_bridge_gas_msg_hash;
     use std::ops::Add;
 
-    #[storage]
     struct Storage<Context> {
         // This map is accessed directly by protocol circuits to check balances for fee payment.
         // Do not change this storage layout unless you also update the base rollup circuits.
         balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
     }
 
+    global INCREASE_PUBLIC_BALANCE_SELECTOR: Field = comptime {
+        FunctionSelector::from_signature("_increase_public_balance((Field),u128)").to_field()
+    };
+    global CHECK_BALANCE_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("check_balance(u128)").to_field() };
+    global BALANCE_OF_PUBLIC_SELECTOR: Field =
+        comptime { FunctionSelector::from_signature("balance_of_public((Field))").to_field() };
+
     /// Verifies that a message from L1 exists with the correct claim information, consumes it (emitting a nullifier)
-    /// and enqueues the increase in public balance of the recipient
-    #[internal("private")]
-    fn claim_helper(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {
-        let content_hash = get_bridge_gas_msg_hash(to, amount);
-        let portal_address = EthAddress::from_field(FEE_JUICE_ADDRESS.to_field());
+    /// and enqueues the increase in public balance of the recipient.
+    #[contract_library_method]
+    fn claim_helper(
+        context: &mut aztec::context::PrivateContext,
+        to: AztecAddress,
+        amount: u128,
+        secret: Field,
+        message_leaf_index: Field,
+    ) {
+        let content_hash: Field = get_bridge_gas_msg_hash(to, amount);
+        let portal_address: EthAddress = EthAddress::from_field(FEE_JUICE_ADDRESS.to_field());
         assert(!portal_address.is_zero());
 
         // Consume message and emit nullifier
-        self.context.consume_l1_to_l2_message(
-            content_hash,
-            secret,
-            portal_address,
-            message_leaf_index,
-        );
+        context.consume_l1_to_l2_message(content_hash, secret, portal_address, message_leaf_index);
 
-        // TODO(palla/gas) Emit an unencrypted log to announce which L1 to L2 message has been claimed
-        // Otherwise, we cannot trace L1 deposits to their corresponding claims on L2
-        self.enqueue_self._increase_public_balance(to, amount);
+        // Enqueue call to _increase_public_balance
+        // Note: The rest of the function body used to be `self.enqueue_self._increase_public_balance(to, amount);`
+        // before de-macroification.
+        let serialized_params: [Field; 2] = [to.to_field(), amount.to_field()];
+        let calldata: [Field; 1 + 2] = [INCREASE_PUBLIC_BALANCE_SELECTOR].concat(serialized_params);
+        let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
+        aztec::oracle::execution_cache::store(calldata, calldata_hash);
+        context.call_public_function_with_calldata_hash(
+            context.this_address(),
+            calldata_hash,
+            false,
+            false,
+        );
     }
 
     /// Claims FeeJuice by consuming an L1 to L2 message with the provided information.
-    #[external("private")]
-    fn claim(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {
-        self.internal.claim_helper(to, amount, secret, message_leaf_index);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
+    fn claim(
+        inputs: aztec::context::inputs::PrivateContextInputs,
+        to: AztecAddress,
+        amount: u128,
+        secret: Field,
+        message_leaf_index: Field,
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function.
+        // nor in the claim helper function or the enqueued public function call, I have removed that check.
+        aztec::oracle::version::assert_compatible_oracle_version();
+        let serialized_params: [Field; 4] =
+            [to.to_field(), amount.to_field(), secret, message_leaf_index];
+        let args_hash: Field = aztec::hash::hash_args(serialized_params);
+        let mut context: aztec::context::PrivateContext =
+            aztec::context::PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
+        claim_helper(&mut context, to, amount, secret, message_leaf_index);
+
+        // MACRO CODE START
+        context.finish()
+        // MACRO CODE END
     }
 
     /// Claims FeeJuice by consuming an L1 to L2 message with the provided information. After enqueuing the
     /// the balance increase it ends the setup phase, making sure the claim happens in the non-revertible phase
     /// of the transaction. This variant should only be used when the intent is to pay the transaction fee via
     /// the claimed fee juice in a single interaction.
-    #[external("private")]
-    #[nophasecheck]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn claim_and_end_setup(
+        inputs: aztec::context::inputs::PrivateContextInputs,
         to: AztecAddress,
         amount: u128,
         secret: Field,
         message_leaf_index: Field,
-    ) {
-        self.internal.claim_helper(to, amount, secret, message_leaf_index);
-        self.context.end_setup();
+    ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
+        // MACRO CODE START
+        aztec::oracle::version::assert_compatible_oracle_version();
+        let serialized_params: [Field; 4] =
+            [to.to_field(), amount.to_field(), secret, message_leaf_index];
+        let args_hash: Field = aztec::hash::hash_args(serialized_params);
+        let mut context: aztec::context::PrivateContext =
+            aztec::context::PrivateContext::new(inputs, args_hash);
+        // MACRO CODE END
+
+        claim_helper(&mut context, to, amount, secret, message_leaf_index);
+
+        // MACRO CODE START
+        context.end_setup();
+        context.finish()
+        // MACRO CODE END
     }
 
-    #[external("public")]
-    #[only_self]
-    fn _increase_public_balance(to: AztecAddress, amount: u128) {
-        let new_balance = self.storage.balances.at(to).read().add(amount);
-        self.storage.balances.at(to).write(new_balance);
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_only_self]
+    unconstrained fn _increase_public_balance(to: AztecAddress, amount: u128) {
+        // MACRO CODE START
+        let context: aztec::context::PublicContext = aztec::context::PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 2] = aztec::oracle::avm::calldata_copy(
+                    1,
+                    <AztecAddress as aztec::protocol::traits::Serialize>::N
+                        + <u128 as aztec::protocol::traits::Serialize>::N,
+                );
+                aztec::hash::hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<aztec::context::PublicContext> =
+            Storage::<aztec::context::PublicContext>::init(context);
+
+        assert(
+            context.maybe_msg_sender().unwrap() == context.this_address(),
+            "Function _increase_public_balance can only be called by the same contract",
+        );
+        // MACRO CODE END
+
+        let new_balance = storage.balances.at(to).read().add(amount);
+        storage.balances.at(to).write(new_balance);
     }
 
-    #[external("public")]
-    #[view]
-    fn check_balance(fee_limit: u128) {
-        assert(self.storage.balances.at(self.msg_sender()).read() >= fee_limit, "Balance too low");
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
+    unconstrained fn check_balance(fee_limit: u128) {
+        // MACRO CODE START
+        let context: aztec::context::PublicContext = aztec::context::PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] = aztec::oracle::avm::calldata_copy(
+                    1,
+                    <u128 as aztec::protocol::traits::Serialize>::N,
+                );
+                aztec::hash::hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<aztec::context::PublicContext> =
+            Storage::<aztec::context::PublicContext>::init(context);
+
+        assert(context.is_static_call(), "Function check_balance can only be called statically");
+        // MACRO CODE END
+
+        assert(
+            storage.balances.at(context.maybe_msg_sender().unwrap()).read() >= fee_limit,
+            "Balance too low",
+        );
     }
 
-    // utility function for testing
-    #[external("public")]
-    #[view]
-    fn balance_of_public(owner: AztecAddress) -> pub u128 {
-        self.storage.balances.at(owner).read()
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
+    unconstrained fn balance_of_public(owner: AztecAddress) -> pub u128 {
+        // MACRO CODE START
+        let context: aztec::context::PublicContext = aztec::context::PublicContext::new(
+            || -> Field {
+                let serialized_args: [Field; 1] = aztec::oracle::avm::calldata_copy(
+                    1,
+                    <AztecAddress as aztec::protocol::traits::Serialize>::N,
+                );
+                aztec::hash::hash_args(serialized_args)
+            },
+        );
+        let storage: Storage<aztec::context::PublicContext> =
+            Storage::<aztec::context::PublicContext>::init(context);
+
+        assert(
+            context.is_static_call(),
+            "Function balance_of_public can only be called statically",
+        );
+        // MACRO CODE END
+
+        storage.balances.at(owner).read()
+    }
+
+    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+
+    #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
+    pub unconstrained fn public_dispatch(selector: Field) {
+        if selector == INCREASE_PUBLIC_BALANCE_SELECTOR {
+            let input_calldata: [Field; 2] = aztec::oracle::avm::calldata_copy(
+                1,
+                <AztecAddress as aztec::protocol::traits::Serialize>::N
+                    + <u128 as aztec::protocol::traits::Serialize>::N,
+            );
+            let mut reader: aztec::protocol::utils::reader::Reader<2> =
+                aztec::protocol::utils::reader::Reader::<2>::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(
+                <AztecAddress as aztec::protocol::traits::Deserialize>::deserialize,
+            );
+            let arg1: u128 =
+                reader.read_struct(<u128 as aztec::protocol::traits::Deserialize>::deserialize);
+            _increase_public_balance(arg0, arg1);
+            aztec::oracle::avm::avm_return([].as_vector());
+        };
+        if selector == CHECK_BALANCE_SELECTOR {
+            let input_calldata: [Field; 1] = aztec::oracle::avm::calldata_copy(
+                1,
+                <u128 as aztec::protocol::traits::Serialize>::N,
+            );
+            let mut reader: aztec::protocol::utils::reader::Reader<1> =
+                aztec::protocol::utils::reader::Reader::<1>::new(input_calldata);
+            let arg0: u128 =
+                reader.read_struct(<u128 as aztec::protocol::traits::Deserialize>::deserialize);
+            check_balance(arg0);
+            aztec::oracle::avm::avm_return([].as_vector());
+        };
+        if selector == BALANCE_OF_PUBLIC_SELECTOR {
+            let input_calldata: [Field; 1] = aztec::oracle::avm::calldata_copy(
+                1,
+                <AztecAddress as aztec::protocol::traits::Serialize>::N,
+            );
+            let mut reader: aztec::protocol::utils::reader::Reader<1> =
+                aztec::protocol::utils::reader::Reader::<1>::new(input_calldata);
+            let arg0: AztecAddress = reader.read_struct(
+                <AztecAddress as aztec::protocol::traits::Deserialize>::deserialize,
+            );
+            let return_value: [Field; 1] =
+                <u128 as aztec::protocol::traits::Serialize>::serialize(balance_of_public(arg0));
+            aztec::oracle::avm::avm_return(return_value.as_vector());
+        };
+        panic(f"Unknown selector {selector}")
+    }
+
+    pub struct StorageLayoutFields {
+        pub balances: aztec::state_vars::Storable,
+    }
+
+    pub struct StorageLayout<let N: u32> {
+        pub contract_name: str<N>,
+        pub fields: StorageLayoutFields,
+    }
+
+    #[abi(storage)]
+    pub global STORAGE_LAYOUT_FeeJuice: StorageLayout<8> = StorageLayout::<8> {
+        contract_name: "FeeJuice",
+        fields: StorageLayoutFields { balances: aztec::state_vars::Storable { slot: 1 } },
+    };
+
+    impl<Context> Storage<Context> {
+        fn init(context: Context) -> Self {
+            Self {
+                balances: <Map<AztecAddress, PublicMutable<u128, Context>, Context> as aztec::state_vars::StateVariable<1, Context>>::new(
+                    context,
+                    1,
+                ),
+            }
+        }
+    }
+    pub struct _increase_public_balance_parameters {
+        pub _to: AztecAddress,
+        pub _amount: u128,
+    }
+
+    pub struct balance_of_public_parameters {
+        pub _owner: AztecAddress,
+    }
+
+    pub struct check_balance_parameters {
+        pub _fee_limit: u128,
+    }
+
+    pub struct claim_and_end_setup_parameters {
+        pub _to: AztecAddress,
+        pub _amount: u128,
+        pub _secret: Field,
+        pub _message_leaf_index: Field,
+    }
+
+    pub struct claim_parameters {
+        pub _to: AztecAddress,
+        pub _amount: u128,
+        pub _secret: Field,
+        pub _message_leaf_index: Field,
+    }
+
+    #[abi(functions)]
+    pub struct _increase_public_balance_abi {
+        parameters: _increase_public_balance_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct balance_of_public_abi {
+        parameters: balance_of_public_parameters,
+        return_type: u128,
+    }
+
+    #[abi(functions)]
+    pub struct check_balance_abi {
+        parameters: check_balance_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct claim_abi {
+        parameters: claim_parameters,
+    }
+
+    #[abi(functions)]
+    pub struct claim_and_end_setup_abi {
+        parameters: claim_and_end_setup_parameters,
     }
 }


### PR DESCRIPTION
As mentioned in a PR down the stack protocol circuits are about to undergo an audit and with that also the protocol contracts.

Since the Aztec.nr macros are in flux and very complicated it has been decided that we want to strip them from the protocol contracts. In this PR I do this change.

In the code I put comments regarding what is originally a macro generated code in order to explain its strangeness.

Based on feedback from Kesha I also copied out the necessary functionality from `Aztec.nr` into a smaller "sublib". The sublib keeps the same structure so the imports of protocol contracts were unchanged. It's a lot of code though. Sad.

## Note for reviewer

I don't think the the sublib code needs to be checked - it's just a copy-paste. What I would like some feedback on is whether the de-macroification is found to be reasonable. I beautified the macro code with AI (e.g. streamlining the serialization into args hash etc.). I thoroughly went through the diff but re-checking whether I have fat-fingered something would be great 👍 
