### PR TITLE
fix(docs): avoid aztec-up {version} and directly install correct version

### DIFF
--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/tutorials/contract_tutorials/recursive_verification.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/tutorials/contract_tutorials/recursive_verification.md
@@ -30,8 +30,7 @@ Install the required tools:
 
 ```bash
 # Install Aztec CLI
-bash -i <(curl -s https://install.aztec.network)
-aztec-up 3.0.0-devnet.6-patch.1
+bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.6-patch.1/aztec-install)
 
 # Install Nargo via noirup
 curl -L https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/install | bash

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_devnet.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_devnet.md
@@ -36,16 +36,10 @@ If you're new to Aztec and want to understand local development first, check out
 Before working with devnet, ensure you have:
 
 1. [Docker](https://docs.docker.com/get-started/get-docker/) installed
-2. Aztec CLI installed:
+2. Aztec CLI with devnet version installed:
 
 ```sh
-bash -i <(curl -s https://install.aztec.network)
-```
-
-3. The devnet version installed:
-
-```bash
-aztec-up 3.0.0-devnet.6-patch.1
+bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.6-patch.1/aztec-install)
 ```
 
 :::warning

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_local_network.md
@@ -49,7 +49,7 @@ bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.6-patch.1/aztec-ins
 This will install the following tools:
 
 - **aztec** - compiles and tests aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, pxe, etc) and provides utility commands to interact with the network
-- **aztec-up** - a tool to upgrade the aztec toolchain to the latest, or specific versions.
+- **aztec-up** - a tool to switch the aztec toolchain to a different version. If you already have the toolchain installed, run `aztec-up {version}` to switch versions.
 - **aztec-wallet** - a tool for interacting with the aztec network
 
 ### Start the local network

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/getting_started_on_local_network.md
@@ -43,13 +43,7 @@ Docker needs to be running in order to install the local network. Find instructi
 Run:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-```
-
-Once the installation is complete, install the specific version:
-
-```bash
-aztec-up 3.0.0-devnet.6-patch.1
+bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.6-patch.1/aztec-install)
 ```
 
 This will install the following tools:

--- a/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/docs/tutorials/contract_tutorials/counter_contract.md
@@ -9,7 +9,7 @@ import Image from "@theme/IdealImage";
 
 In this guide, we will create our first Aztec.nr smart contract. We will build a simple private counter, where you can keep your own private counter - so no one knows what ID you are at or when you increment! This contract will get you started with the basic setup and syntax of Aztec.nr, but doesn't showcase all of the awesome stuff Aztec is capable of.
 
-This tutorial is compatible with the Aztec version `v4.0.0-nightly.20260126`. Install the correct version with `bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/)`. Or if you'd like to use a different version, you can find the relevant tutorial by clicking the version dropdown at the top of the page.
+This tutorial is compatible with the Aztec version `v4.0.0-nightly.20260126`. Install the correct version with `bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/aztec-install)`. Or if you'd like to use a different version, you can find the relevant tutorial by clicking the version dropdown at the top of the page.
 
 ## Prerequisites
 

--- a/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/docs/tutorials/contract_tutorials/token_contract.md
@@ -23,7 +23,7 @@ This is an intermediate tutorial that assumes you have:
 - Completed the [Counter Contract tutorial](./counter_contract.md)
 - A Running Aztec local network (see the Counter tutorial for setup)
 - Basic understanding of Aztec.nr syntax and structure
-- Aztec toolchain installed (`bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/)`)
+- Aztec toolchain installed (`bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/aztec-install)`)
 
 If you haven't completed the Counter Contract tutorial, please do so first as we'll skip the basic setup steps covered there.
 

--- a/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_devnet.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_devnet.md
@@ -39,7 +39,7 @@ Before working with devnet, ensure you have:
 2. Aztec CLI with Devnet version installed:
 
 ```sh
-bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.5/)
+bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.5/aztec-install)
 ```
 
 :::warning

--- a/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_local_network.md
@@ -49,7 +49,7 @@ bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/aztec-ins
 This will install the following tools:
 
 - **aztec** - compiles and tests aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, pxe, etc) and provides utility commands to interact with the network
-- **aztec-up** - a tool to upgrade the aztec toolchain to the latest, or specific versions.
+- **aztec-up** - a tool to switch the aztec toolchain to a different version. If you already have the toolchain installed, run `aztec-up {version}` to switch versions.
 - **aztec-wallet** - a tool for interacting with the aztec network
 
 ### Start the local network

--- a/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_local_network.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-nightly.20260126/getting_started_on_local_network.md
@@ -43,7 +43,7 @@ Docker needs to be running in order to install the local network. Find instructi
 Run:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/)
+bash -i <(curl -s https://install.aztec.network/4.0.0-nightly.20260126/aztec-install)
 ```
 
 This will install the following tools:

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/counter_contract.md
@@ -9,7 +9,7 @@ import Image from "@theme/IdealImage";
 
 In this guide, we will create our first Aztec.nr smart contract. We will build a simple private counter, where you can keep your own private counter - so no one knows what ID you are at or when you increment! This contract will get you started with the basic setup and syntax of Aztec.nr, but doesn't showcase all of the awesome stuff Aztec is capable of.
 
-This tutorial is compatible with the Aztec version `#include_aztec_version`. Install the correct version with `bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/)`. Or if you'd like to use a different version, you can find the relevant tutorial by clicking the version dropdown at the top of the page.
+This tutorial is compatible with the Aztec version `#include_aztec_version`. Install the correct version with `bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/aztec-install)`. Or if you'd like to use a different version, you can find the relevant tutorial by clicking the version dropdown at the top of the page.
 
 ## Prerequisites
 

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/recursive_verification.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/recursive_verification.md
@@ -30,8 +30,7 @@ Install the required tools:
 
 ```bash
 # Install Aztec CLI
-bash -i <(curl -s https://install.aztec.network)
-aztec-up 3.0.0-devnet.6-patch.1
+bash -i <(curl -s https://install.aztec.network/3.0.0-devnet.6-patch.1/aztec-install)
 
 # Install Nargo via noirup
 curl -L https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/install | bash

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/token_contract.md
@@ -23,7 +23,7 @@ This is an intermediate tutorial that assumes you have:
 - Completed the [Counter Contract tutorial](./counter_contract.md)
 - A Running Aztec local network (see the Counter tutorial for setup)
 - Basic understanding of Aztec.nr syntax and structure
-- Aztec toolchain installed (`bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/)`)
+- Aztec toolchain installed (`bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/aztec-install)`)
 
 If you haven't completed the Counter Contract tutorial, please do so first as we'll skip the basic setup steps covered there.
 

--- a/docs/docs-developers/getting_started_on_devnet.md
+++ b/docs/docs-developers/getting_started_on_devnet.md
@@ -39,7 +39,7 @@ Before working with devnet, ensure you have:
 2. Aztec CLI with Devnet version installed:
 
 ```sh
-bash -i <(curl -s https://install.aztec.network/#include_devnet_version/)
+bash -i <(curl -s https://install.aztec.network/#include_devnet_version/aztec-install)
 ```
 
 :::warning

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -49,7 +49,7 @@ bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/
 This will install the following tools:
 
 - **aztec** - compiles and tests aztec contracts and launches various infrastructure subsystems (full local network, sequencer, prover, pxe, etc) and provides utility commands to interact with the network
-- **aztec-up** - a tool to upgrade the aztec toolchain to the latest, or specific versions.
+- **aztec-up** - a tool to switch the aztec toolchain to a different version. If you already have the toolchain installed, run `aztec-up {version}` to switch versions.
 - **aztec-wallet** - a tool for interacting with the aztec network
 
 ### Start the local network

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -43,7 +43,7 @@ Docker needs to be running in order to install the local network. Find instructi
 Run:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/)
+bash -i <(curl -s https://install.aztec.network/#include_version_without_prefix/aztec-install)
 ```
 
 This will install the following tools:

--- a/docs/docs-network/operators/keystore/creating-keystores.md
+++ b/docs/docs-network/operators/keystore/creating-keystores.md
@@ -28,7 +28,7 @@ Before creating keystores, ensure you have:
 First, install the Aztec CLI using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network/#release_version/)
+bash -i <(curl -s https://install.aztec.network/#release_version/aztec-install)
 ```
 
 Verify your CLI installation:

--- a/docs/docs-network/operators/prerequisites.md
+++ b/docs/docs-network/operators/prerequisites.md
@@ -56,13 +56,7 @@ The Aztec toolchain provides CLI utilities for key generation, validator registr
 Install the Aztec toolchain using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-```
-
-Install the correct version for the current network:
-
-```bash
-aztec-up #release_version
+bash -i <(curl -s https://install.aztec.network/#release_version/aztec-install)
 ```
 
 ### L1 Ethereum Node Access

--- a/docs/docs-network/operators/setup/staking-provider.md
+++ b/docs/docs-network/operators/setup/staking-provider.md
@@ -22,8 +22,7 @@ Before proceeding, ensure you have:
 - Aztec CLI v#release_version or later installed:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-aztec-up #release_version
+bash -i <(curl -s https://install.aztec.network/#release_version/aztec-install)
 ```
 
 ### Contract Addresses

--- a/docs/network_versioned_docs/version-v2.1.9-ignition/operation/keystore/creating_keystores.md
+++ b/docs/network_versioned_docs/version-v2.1.9-ignition/operation/keystore/creating_keystores.md
@@ -28,7 +28,7 @@ Before creating keystores, ensure you have:
 Install the Aztec CLI using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network/2.1.7/aztec-install)
+bash -i <(curl -s https://install.aztec.network/2.1.9/aztec-install)
 ```
 
 Verify your CLI installation:

--- a/docs/network_versioned_docs/version-v2.1.9-ignition/operation/keystore/creating_keystores.md
+++ b/docs/network_versioned_docs/version-v2.1.9-ignition/operation/keystore/creating_keystores.md
@@ -25,16 +25,10 @@ Before creating keystores, ensure you have:
 
 ## Installing the Aztec CLI
 
-First, install the Aztec CLI using the official installer:
+Install the Aztec CLI using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-```
-
-Then install the correct version for the current network:
-
-```bash
-aztec-up 2.1.7
+bash -i <(curl -s https://install.aztec.network/2.1.7/aztec-install)
 ```
 
 Verify your CLI installation:

--- a/docs/network_versioned_docs/version-v2.1.9-ignition/operation/sequencer_management/running_delegated_stake.md
+++ b/docs/network_versioned_docs/version-v2.1.9-ignition/operation/sequencer_management/running_delegated_stake.md
@@ -22,8 +22,7 @@ Before proceeding, ensure you have:
 - Aztec CLI v2.1.9 or later installed:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-aztec-up --version 2.1.9
+bash -i <(curl -s https://install.aztec.network/2.1.9/aztec-install)
 ```
 
 ### Contract Addresses (Sepolia)

--- a/docs/network_versioned_docs/version-v2.1.9-ignition/prerequisites.md
+++ b/docs/network_versioned_docs/version-v2.1.9-ignition/prerequisites.md
@@ -57,13 +57,7 @@ The Aztec toolchain provides CLI utilities for key generation, validator registr
 Install the Aztec toolchain using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-```
-
-Install the correct version for the current network:
-
-```bash
-aztec-up 2.1.9
+bash -i <(curl -s https://install.aztec.network/2.1.9/aztec-install)
 ```
 
 ### L1 Ethereum Node Access

--- a/docs/network_versioned_docs/version-v3.0.1/operators/keystore/creating-keystores.md
+++ b/docs/network_versioned_docs/version-v3.0.1/operators/keystore/creating-keystores.md
@@ -28,7 +28,7 @@ Before creating keystores, ensure you have:
 First, install the Aztec CLI using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network/3.0.1/)
+bash -i <(curl -s https://install.aztec.network/3.0.1/aztec-install)
 ```
 
 Verify your CLI installation:

--- a/docs/network_versioned_docs/version-v3.0.1/operators/prerequisites.md
+++ b/docs/network_versioned_docs/version-v3.0.1/operators/prerequisites.md
@@ -56,13 +56,7 @@ The Aztec toolchain provides CLI utilities for key generation, validator registr
 Install the Aztec toolchain using the official installer:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-```
-
-Install the correct version for the current network:
-
-```bash
-aztec-up 3.0.1
+bash -i <(curl -s https://install.aztec.network/3.0.1/aztec-install)
 ```
 
 ### L1 Ethereum Node Access

--- a/docs/network_versioned_docs/version-v3.0.1/operators/setup/staking-provider.md
+++ b/docs/network_versioned_docs/version-v3.0.1/operators/setup/staking-provider.md
@@ -22,8 +22,7 @@ Before proceeding, ensure you have:
 - Aztec CLI v3.0.1 or later installed:
 
 ```bash
-bash -i <(curl -s https://install.aztec.network)
-aztec-up 3.0.1
+bash -i <(curl -s https://install.aztec.network/3.0.1/aztec-install)
 ```
 
 ### Contract Addresses


### PR DESCRIPTION
- Stops prompting to switch version via aztec-up, since it double-installs constantly. Let's save a step.
- Expands on aztec-up so the tool is not lost at least. 
- Backports the changes