### PR TITLE
refactor: remove unnecessary transactionAsync calls from NoteStore and PrivateEventStore

### DIFF
--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -18,8 +18,6 @@ import { StoredNote } from './stored_note.js';
 export class NoteStore implements StagedStore {
   readonly storeName: string = 'note';
 
-  #store: AztecAsyncKVStore;
-
   // Note that we use the siloedNullifier as the note id in the store as it's guaranteed to be unique.
 
   // Main storage for notes. Avoid performing full scans on it as it contains all notes PXE knows, use
@@ -48,7 +46,6 @@ export class NoteStore implements StagedStore {
   #jobLocks: Map<string, Semaphore>;
 
   constructor(store: AztecAsyncKVStore) {
-    this.#store = store;
     this.#notes = store.openMap('notes');
     this.#nullifiersByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
     this.#nullifiersByNullificationBlockNumber = store.openMultiMap('note_block_number_to_nullifier');
@@ -182,43 +179,41 @@ export class NoteStore implements StagedStore {
    * @throws Error if any nullifier is not found in this notes store
    */
   applyNullifiers(nullifiers: DataInBlock<Fr>[], jobId: string): Promise<NoteDao[]> {
-    return this.#withJobLock(jobId, () =>
-      this.#store.transactionAsync(async () => {
-        if (nullifiers.length === 0) {
-          return [];
-        }
+    return this.#withJobLock(jobId, async () => {
+      if (nullifiers.length === 0) {
+        return [];
+      }
 
-        const notesToNullify = await Promise.all(
-          nullifiers.map(async nullifierInBlock => {
-            const nullifier = nullifierInBlock.data.toString();
+      const notesToNullify = await Promise.all(
+        nullifiers.map(async nullifierInBlock => {
+          const nullifier = nullifierInBlock.data.toString();
 
-            const storedNote = await this.#readNote(nullifier, jobId);
-            if (!storedNote) {
-              throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB`);
-            }
-
-            return { storedNote: await this.#readNote(nullifier, jobId), blockNumber: nullifierInBlock.l2BlockNumber };
-          }),
-        );
-
-        const notesNullifiedInThisCall: Map<string, NoteDao> = new Map();
-        for (const noteToNullify of notesToNullify) {
-          // Safe to coerce (!) because we throw if we find any undefined above
-          const note = noteToNullify.storedNote!;
-
-          // Skip already nullified notes
-          if (note.isNullified()) {
-            continue;
+          const storedNote = await this.#readNote(nullifier, jobId);
+          if (!storedNote) {
+            throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB`);
           }
 
-          note.markAsNullified(noteToNullify.blockNumber);
-          this.#writeNote(note, jobId);
-          notesNullifiedInThisCall.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
+          return { storedNote: await this.#readNote(nullifier, jobId), blockNumber: nullifierInBlock.l2BlockNumber };
+        }),
+      );
+
+      const notesNullifiedInThisCall: Map<string, NoteDao> = new Map();
+      for (const noteToNullify of notesToNullify) {
+        // Safe to coerce (!) because we throw if we find any undefined above
+        const note = noteToNullify.storedNote!;
+
+        // Skip already nullified notes
+        if (note.isNullified()) {
+          continue;
         }
 
-        return [...notesNullifiedInThisCall.values()];
-      }),
-    );
+        note.markAsNullified(noteToNullify.blockNumber);
+        this.#writeNote(note, jobId);
+        notesNullifiedInThisCall.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
+      }
+
+      return [...notesNullifiedInThisCall.values()];
+    });
   }
 
   /**

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -131,78 +131,76 @@ export class PrivateEventStore implements StagedStore {
    * @returns - The event log contents, augmented with metadata about the transaction and block in which the event was
    * included.
    */
-  public getPrivateEvents(
+  public async getPrivateEvents(
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
   ): Promise<PackedPrivateEvent[]> {
-    return this.#store.transactionAsync(async () => {
-      const events: Array<{
-        l2BlockNumber: number;
-        txIndexInBlock: number;
-        eventIndexInTx: number;
-        event: PackedPrivateEvent;
-      }> = [];
+    const events: Array<{
+      l2BlockNumber: number;
+      txIndexInBlock: number;
+      eventIndexInTx: number;
+      event: PackedPrivateEvent;
+    }> = [];
 
-      const key = this.#keyFor(filter.contractAddress, eventSelector);
-      const targetScopes = new Set(filter.scopes.map(s => s.toString()));
+    const key = this.#keyFor(filter.contractAddress, eventSelector);
+    const targetScopes = new Set(filter.scopes.map(s => s.toString()));
 
-      const eventIds: string[] = await toArray(this.#eventsByContractAndEventSelector.getValuesAsync(key));
+    const eventIds: string[] = await toArray(this.#eventsByContractAndEventSelector.getValuesAsync(key));
 
-      for (const eventId of eventIds) {
-        const eventBuffer = await this.#events.getAsync(eventId);
+    for (const eventId of eventIds) {
+      const eventBuffer = await this.#events.getAsync(eventId);
 
-        // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
-        if (!eventBuffer) {
-          this.logger.verbose(
-            `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
-          );
-          continue;
-        }
-
-        const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
-
-        // Filter by block range
-        if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
-          continue;
-        }
-
-        // Filter by scopes
-        if (storedPrivateEvent.scopes.intersection(targetScopes).size === 0) {
-          continue;
-        }
-
-        // Filter by txHash
-        if (filter.txHash && !storedPrivateEvent.txHash.equals(filter.txHash)) {
-          continue;
-        }
-
-        events.push({
-          l2BlockNumber: storedPrivateEvent.l2BlockNumber,
-          txIndexInBlock: storedPrivateEvent.txIndexInBlock,
-          eventIndexInTx: storedPrivateEvent.eventIndexInTx,
-          event: {
-            packedEvent: storedPrivateEvent.msgContent,
-            l2BlockNumber: BlockNumber(storedPrivateEvent.l2BlockNumber),
-            txHash: storedPrivateEvent.txHash,
-            l2BlockHash: storedPrivateEvent.l2BlockHash,
-            eventSelector,
-          },
-        });
+      // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
+      if (!eventBuffer) {
+        this.logger.verbose(
+          `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
+        );
+        continue;
       }
 
-      // Sort by block number, then by tx index within block, then by event index within tx
-      events.sort((a, b) => {
-        if (a.l2BlockNumber !== b.l2BlockNumber) {
-          return a.l2BlockNumber - b.l2BlockNumber;
-        }
-        if (a.txIndexInBlock !== b.txIndexInBlock) {
-          return a.txIndexInBlock - b.txIndexInBlock;
-        }
-        return a.eventIndexInTx - b.eventIndexInTx;
-      });
+      const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
 
-      return events.map(ev => ev.event);
+      // Filter by block range
+      if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
+        continue;
+      }
+
+      // Filter by scopes
+      if (storedPrivateEvent.scopes.intersection(targetScopes).size === 0) {
+        continue;
+      }
+
+      // Filter by txHash
+      if (filter.txHash && !storedPrivateEvent.txHash.equals(filter.txHash)) {
+        continue;
+      }
+
+      events.push({
+        l2BlockNumber: storedPrivateEvent.l2BlockNumber,
+        txIndexInBlock: storedPrivateEvent.txIndexInBlock,
+        eventIndexInTx: storedPrivateEvent.eventIndexInTx,
+        event: {
+          packedEvent: storedPrivateEvent.msgContent,
+          l2BlockNumber: BlockNumber(storedPrivateEvent.l2BlockNumber),
+          txHash: storedPrivateEvent.txHash,
+          l2BlockHash: storedPrivateEvent.l2BlockHash,
+          eventSelector,
+        },
+      });
+    }
+
+    // Sort by block number, then by tx index within block, then by event index within tx
+    events.sort((a, b) => {
+      if (a.l2BlockNumber !== b.l2BlockNumber) {
+        return a.l2BlockNumber - b.l2BlockNumber;
+      }
+      if (a.txIndexInBlock !== b.txIndexInBlock) {
+        return a.txIndexInBlock - b.txIndexInBlock;
+      }
+      return a.eventIndexInTx - b.eventIndexInTx;
     });
+
+    return events.map(ev => ev.event);
   }
 
   /**


### PR DESCRIPTION
First of a series of PRs that will aim at reducing the usage of `transactionAsync` in PXE to the minimum, if not completely.

This one removes a `transactionAsync` call from `NoteStore#applyNullifiers` and `PrivateEventStore#getPrivateEvents`. 

It is safe to do so since `applyNullifiers` doesn't write to the DB, it just writes to the in-memory staged slice that the store keeps for the duration of job.

It is also safe to do so in `getPrivateEvents` because it also doesn't write to the DB, it just reads committed events.

Writes from both stores are issued on `commit`, which is still done in a `transactionAsync` wrapper (note that particular case will probably remain as one of the few legitimate usages of `transactionAsync`). 

# Why we need to hunt down `transactionAsync`

The issue with `transactionAsync` is that it works as intended with LMDB stores, but it breaks assumptions in IndexedDB.

Browsers are free to auto-commit IndexedDB transactions whenever a micro-task resolves without adding a read or write request to it. 

That browser behavior in practice makes it extremely hard to guarantee that what's run inside a `transactionAsync` wrapper will not be auto-committed. 

`transactionAsync` is designed to make all operations across all store collections be routed through the same transactional context. We have to assume that whenever any code inside a `transactionAsync` resolves a promise without generating more work to the DB, the browser can and will commit the transaction, resulting in a `TransactionInactiveError` like the one in the screenshot.
 
This is especially tricky to deal with because while aztec-packages has a very thorough CI test harness, 99% of it runs on LMDB on Node. The issues discussed in this description affect only browser environments. I took some time to evaluate libs that simulate IndexedDB, but none seem to be reliable enough. That means we can only enhance coverage and regression testing of this by adding playwright headless browser tests, which are slow and heavy.

<img width="1172" height="258" alt="Screenshot 2026-01-27 at 13 15 21 (1)" src="https://github.com/user-attachments/assets/af093110-9a09-4f79-bbde-5c255d09d7d8" />
