### PR TITLE
fix: include rollup address to HA DB primary key

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.test.ts
@@ -52,6 +52,7 @@ describe('createKeyStoreForValidator', () => {
       web3SignerUrl,
       validatorAddresses: validatorAddresses.map(addr => addr),
       publisherAddresses: publisherAddresses.map(addr => addr),
+      l1Contracts: { rollupAddress: EthAddress.random() },
     } as TxSenderConfig & ValidatorClientConfig & SequencerClientConfig & SharedNodeConfig;
   };
 
@@ -71,6 +72,7 @@ describe('createKeyStoreForValidator', () => {
       publisherPrivateKeys: undefined,
       coinbase: undefined,
       feeRecipient: undefined,
+      l1Contracts: { rollupAddress: EthAddress.random() },
     } as unknown as TxSenderConfig & ValidatorClientConfig & SequencerClientConfig & SharedNodeConfig;
     const result = createKeyStoreForValidator(config);
     expect(result).toBeUndefined();

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_voter.ha.integration.test.ts
@@ -250,6 +250,7 @@ describe('CheckpointVoter HA Integration', () => {
       disabledValidators: [],
       validatorReexecute: false,
       haSigningEnabled: true,
+      l1Contracts: { rollupAddress: EthAddress.fromString(rollupContract.address.toString()) },
       nodeId: config.nodeId || 'ha-node-1',
       pollingIntervalMs: 100,
       signingTimeoutMs: 3000,

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -170,6 +170,9 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
       pollingIntervalMs: 50,
       signingTimeoutMs: 3000,
       maxStuckDutiesAgeMs: 72000,
+      l1Contracts: {
+        rollupAddress: EthAddress.random(),
+      },
     });
   }
   startSnapshotUpload(_location: string): Promise<void> {

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -52,7 +52,8 @@ export interface AztecNodeAdmin {
   getSlashOffenses(round: bigint | 'all' | 'current'): Promise<Offense[]>;
 }
 
-export type AztecNodeAdminConfig = ValidatorClientFullConfig &
+// L1 contracts are not mutable via admin updates.
+export type AztecNodeAdminConfig = Omit<ValidatorClientFullConfig, 'l1Contracts'> &
   SequencerConfig &
   ProverConfig &
   SlasherConfig &
@@ -65,7 +66,7 @@ export type AztecNodeAdminConfig = ValidatorClientFullConfig &
 
 export const AztecNodeAdminConfigSchema = SequencerConfigSchema.merge(ProverConfigSchema)
   .merge(SlasherConfigSchema)
-  .merge(ValidatorClientFullConfigSchema)
+  .merge(ValidatorClientFullConfigSchema.omit({ l1Contracts: true }))
   .merge(
     ArchiverSpecificConfigSchema.pick({
       archiverPollingIntervalMS: true,

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -57,6 +57,7 @@ describe('ValidatorClient HA Integration', () => {
   let txProvider: MockProxy<TxProvider>;
   let blobClient: MockProxy<BlobClientInterface>;
   let dateProvider: TestDateProvider;
+  let rollupAddress: EthAddress;
 
   // Track resources for cleanup
   let pools: Pool[];
@@ -115,6 +116,8 @@ describe('ValidatorClient HA Integration', () => {
     };
     keyStoreManager = new KeystoreManager(keyStore);
 
+    rollupAddress = EthAddress.random();
+
     // Create 5 HA validator instances for use across all tests
     const baseConfig: ValidatorClientConfig & Pick<SlasherConfig, 'slashBroadcastedInvalidBlockPenalty'> = {
       validatorPrivateKeys: new SecretValue(validatorPrivateKeys),
@@ -123,6 +126,7 @@ describe('ValidatorClient HA Integration', () => {
       disabledValidators: [],
       validatorReexecute: false,
       slashBroadcastedInvalidBlockPenalty: 1n,
+      l1Contracts: { rollupAddress },
       haSigningEnabled: true,
       nodeId: 'ha-node-1', // temporary
       pollingIntervalMs: 100,

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -161,6 +161,7 @@ describe('ValidatorClient Integration', () => {
     // Create and start validator
     const validator = await ValidatorClient.new(
       {
+        l1Contracts: { rollupAddress },
         validatorPrivateKeys: new SecretValue([privateKey]),
         attestationPollingIntervalMs: 100,
         disableValidator: false,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -117,6 +117,7 @@ describe('ValidatorClient', () => {
       slashBroadcastedInvalidBlockPenalty: 1n,
       disableTransactions: false,
       haSigningEnabled: false,
+      l1Contracts: { rollupAddress: EthAddress.random() },
       nodeId: 'test-node-id',
       pollingIntervalMs: 1000,
       signingTimeoutMs: 1000,

--- a/yarn-project/validator-ha-signer/package.json
+++ b/yarn-project/validator-ha-signer/package.json
@@ -74,6 +74,7 @@
     ]
   },
   "dependencies": {
+    "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.11.3",

--- a/yarn-project/validator-ha-signer/src/config.ts
+++ b/yarn-project/validator-ha-signer/src/config.ts
@@ -1,3 +1,4 @@
+import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import {
   type ConfigMappingsType,
   booleanConfigHelper,
@@ -6,6 +7,7 @@ import {
   numberConfigHelper,
   optionalNumberConfigHelper,
 } from '@aztec/foundation/config';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import type { ZodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
@@ -19,6 +21,8 @@ import { z } from 'zod';
 export interface ValidatorHASignerConfig {
   /** Whether HA signing / slashing protection is enabled */
   haSigningEnabled: boolean;
+  /** L1 contract addresses (rollup address required) */
+  l1Contracts: Pick<L1ContractAddresses, 'rollupAddress'>;
   /** Unique identifier for this node */
   nodeId: string;
   /** How long to wait between polls when a duty is being signed (ms) */
@@ -50,6 +54,15 @@ export const validatorHASignerConfigMappings: ConfigMappingsType<ValidatorHASign
     env: 'VALIDATOR_HA_SIGNING_ENABLED',
     description: 'Whether HA signing / slashing protection is enabled',
     ...booleanConfigHelper(false),
+  },
+  l1Contracts: {
+    description: 'L1 contract addresses (rollup address required)',
+    nested: {
+      rollupAddress: {
+        description: 'The Ethereum address of the rollup contract (must be set programmatically)',
+        parseEnv: (val: string) => EthAddress.fromString(val),
+      },
+    },
   },
   nodeId: {
     env: 'VALIDATOR_HA_NODE_ID',
@@ -113,6 +126,9 @@ export function getConfigEnvVars(): ValidatorHASignerConfig {
 
 export const ValidatorHASignerConfigSchema = z.object({
   haSigningEnabled: z.boolean(),
+  l1Contracts: z.object({
+    rollupAddress: z.instanceof(EthAddress),
+  }),
   nodeId: z.string(),
   pollingIntervalMs: z.number().min(0),
   signingTimeoutMs: z.number().min(0),

--- a/yarn-project/validator-ha-signer/src/db/postgres.test.ts
+++ b/yarn-project/validator-ha-signer/src/db/postgres.test.ts
@@ -28,6 +28,7 @@ import { type DutyRow, DutyStatus, DutyType, type InsertOrGetRow } from './types
 describe('PostgreSQL Queries', () => {
   let db: PGlite;
 
+  const ROLLUP_ADDRESS = EthAddress.random().toString();
   const VALIDATOR_ADDRESS = EthAddress.random().toString();
   const SLOT = 100n;
   const BLOCK_NUMBER = 50n;
@@ -54,7 +55,8 @@ describe('PostgreSQL Queries', () => {
   describe('INSERT_OR_GET_DUTY', () => {
     it('should insert new record and return is_new=true', async () => {
       const result = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -68,7 +70,8 @@ describe('PostgreSQL Queries', () => {
       const row = result.rows[0];
       expect(row.is_new).toBe(true);
       expect(row.status).toBe(DutyStatus.SIGNING);
-      expect(row.validator_address).toBe(VALIDATOR_ADDRESS.toString());
+      expect(row.rollup_address).toBe(ROLLUP_ADDRESS);
+      expect(row.validator_address).toBe(VALIDATOR_ADDRESS);
       expect(BigInt(row.slot)).toBe(SLOT);
       expect(row.node_id).toBe(NODE_ID);
       expect(row.lock_token).toBe(LOCK_TOKEN);
@@ -77,7 +80,8 @@ describe('PostgreSQL Queries', () => {
     it('should return existing record with is_new=false on duplicate', async () => {
       // First insert
       await db.query(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -89,7 +93,8 @@ describe('PostgreSQL Queries', () => {
 
       // Second insert attempt with different node
       const result = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -108,7 +113,8 @@ describe('PostgreSQL Queries', () => {
     it('should not expose lock_token for existing records', async () => {
       // node acquires the lock
       const insertResult = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -122,7 +128,8 @@ describe('PostgreSQL Queries', () => {
 
       // Second insert attempt - should not get the original lock_token
       const conflictResult = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -138,7 +145,8 @@ describe('PostgreSQL Queries', () => {
     it('should allow different duty types for same slot', async () => {
       // Insert BLOCK_PROPOSAL
       const result1 = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -150,7 +158,8 @@ describe('PostgreSQL Queries', () => {
 
       // Insert ATTESTATION for same slot
       const result2 = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         -1,
@@ -166,7 +175,8 @@ describe('PostgreSQL Queries', () => {
 
     it('should allow same duty type for different slots', async () => {
       const result1 = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         '100',
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -177,7 +187,8 @@ describe('PostgreSQL Queries', () => {
       ]);
 
       const result2 = await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         '101',
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -196,7 +207,8 @@ describe('PostgreSQL Queries', () => {
     it('should update status to signed and set signature with correct token', async () => {
       // Insert a duty first
       await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -209,7 +221,8 @@ describe('PostgreSQL Queries', () => {
       // Update to signed with correct token
       const updateResult = await db.query(UPDATE_DUTY_SIGNED, [
         SIGNATURE,
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -222,7 +235,7 @@ describe('PostgreSQL Queries', () => {
       const selectResult = await db.query<DutyRow>(
         `SELECT status, signature, completed_at FROM validator_duties
          WHERE validator_address = $1 AND slot = $2 AND duty_type = $3 AND block_index_within_checkpoint = $4`,
-        [VALIDATOR_ADDRESS.toString(), SLOT.toString(), DUTY_TYPE, BLOCK_INDEX_WITHIN_CHECKPOINT],
+        [VALIDATOR_ADDRESS, SLOT.toString(), DUTY_TYPE, BLOCK_INDEX_WITHIN_CHECKPOINT],
       );
 
       const row = selectResult.rows[0];
@@ -233,7 +246,8 @@ describe('PostgreSQL Queries', () => {
 
     it('should not update with wrong token', async () => {
       await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -246,7 +260,8 @@ describe('PostgreSQL Queries', () => {
       // Try to update with wrong token
       const updateResult = await db.query<DutyRow>(UPDATE_DUTY_SIGNED, [
         SIGNATURE,
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -258,7 +273,7 @@ describe('PostgreSQL Queries', () => {
       // Verify still in signing state
       const selectResult = await db.query<DutyRow>(
         `SELECT status FROM validator_duties WHERE validator_address = $1 AND slot = $2`,
-        [VALIDATOR_ADDRESS.toString(), SLOT.toString()],
+        [VALIDATOR_ADDRESS, SLOT.toString()],
       );
       expect(selectResult.rows[0].status).toBe(DutyStatus.SIGNING);
     });
@@ -266,7 +281,8 @@ describe('PostgreSQL Queries', () => {
     it('should not update if status is not signing', async () => {
       // Insert and mark as signed
       await db.query<InsertOrGetRow>(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -277,7 +293,8 @@ describe('PostgreSQL Queries', () => {
       ]);
       await db.query<DutyRow>(UPDATE_DUTY_SIGNED, [
         SIGNATURE,
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -286,8 +303,9 @@ describe('PostgreSQL Queries', () => {
 
       // Try to update again with correct token
       const result = await db.query<DutyRow>(UPDATE_DUTY_SIGNED, [
+        ROLLUP_ADDRESS,
         'new-signature',
-        VALIDATOR_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -299,7 +317,7 @@ describe('PostgreSQL Queries', () => {
       // Verify signature unchanged
       const selectResult = await db.query<DutyRow>(
         `SELECT signature FROM validator_duties WHERE validator_address = $1 AND slot = $2`,
-        [VALIDATOR_ADDRESS.toString(), SLOT.toString()],
+        [VALIDATOR_ADDRESS, SLOT.toString()],
       );
       expect(selectResult.rows[0].signature).toBe(SIGNATURE);
     });
@@ -308,7 +326,8 @@ describe('PostgreSQL Queries', () => {
   describe('DELETE_DUTY', () => {
     it('should delete a signing duty with correct token', async () => {
       await db.query(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -319,7 +338,8 @@ describe('PostgreSQL Queries', () => {
       ]);
 
       const deleteResult = await db.query(DELETE_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -330,7 +350,7 @@ describe('PostgreSQL Queries', () => {
 
       // Verify deleted
       const selectResult = await db.query(`SELECT * FROM validator_duties WHERE validator_address = $1 AND slot = $2`, [
-        VALIDATOR_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
       ]);
       expect(selectResult.rows.length).toBe(0);
@@ -338,7 +358,8 @@ describe('PostgreSQL Queries', () => {
 
     it('should not delete with wrong token', async () => {
       await db.query(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -349,7 +370,8 @@ describe('PostgreSQL Queries', () => {
       ]);
 
       const deleteResult = await db.query(DELETE_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -360,7 +382,7 @@ describe('PostgreSQL Queries', () => {
 
       // Verify still exists
       const selectResult = await db.query(`SELECT * FROM validator_duties WHERE validator_address = $1 AND slot = $2`, [
-        VALIDATOR_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
       ]);
       expect(selectResult.rows.length).toBe(1);
@@ -368,7 +390,8 @@ describe('PostgreSQL Queries', () => {
 
     it('should not delete a signed duty', async () => {
       await db.query(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -379,7 +402,8 @@ describe('PostgreSQL Queries', () => {
       ]);
       await db.query(UPDATE_DUTY_SIGNED, [
         SIGNATURE,
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -388,7 +412,8 @@ describe('PostgreSQL Queries', () => {
 
       // Even with correct token, can't delete a signed duty
       const deleteResult = await db.query(DELETE_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         DUTY_TYPE,
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -399,7 +424,7 @@ describe('PostgreSQL Queries', () => {
 
       // Verify still exists
       const selectResult = await db.query(`SELECT * FROM validator_duties WHERE validator_address = $1 AND slot = $2`, [
-        VALIDATOR_ADDRESS.toString(),
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
       ]);
       expect(selectResult.rows.length).toBe(1);
@@ -409,7 +434,8 @@ describe('PostgreSQL Queries', () => {
   describe('constraints', () => {
     it('should enforce primary key constraint (validator_address, slot, duty_type, block_index_within_checkpoint)', async () => {
       await db.query(INSERT_OR_GET_DUTY, [
-        VALIDATOR_ADDRESS.toString(),
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
         SLOT.toString(),
         BLOCK_NUMBER.toString(),
         BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -425,7 +451,7 @@ describe('PostgreSQL Queries', () => {
           `INSERT INTO validator_duties (validator_address, slot, block_number, block_index_within_checkpoint, duty_type, status, message_hash, node_id, lock_token)
            VALUES ($1, $2, $3, $4, $5, 'signing', $6, $7, $8)`,
           [
-            VALIDATOR_ADDRESS.toString(),
+            VALIDATOR_ADDRESS,
             SLOT.toString(),
             BLOCK_NUMBER.toString(),
             BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -444,7 +470,7 @@ describe('PostgreSQL Queries', () => {
           `INSERT INTO validator_duties (validator_address, slot, block_number, block_index_within_checkpoint, duty_type, status, message_hash, node_id, lock_token)
            VALUES ($1, $2, $3, $4, 'INVALID_TYPE', 'signing', $5, $6, $7)`,
           [
-            VALIDATOR_ADDRESS.toString(),
+            VALIDATOR_ADDRESS,
             SLOT.toString(),
             BLOCK_NUMBER.toString(),
             BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -462,7 +488,7 @@ describe('PostgreSQL Queries', () => {
           `INSERT INTO validator_duties (validator_address, slot, block_number, block_index_within_checkpoint, duty_type, status, message_hash, node_id, lock_token)
            VALUES ($1, $2, $3, $4, $5, 'invalid_status', $6, $7, $8)`,
           [
-            VALIDATOR_ADDRESS.toString(),
+            VALIDATOR_ADDRESS,
             SLOT.toString(),
             BLOCK_NUMBER.toString(),
             BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -565,6 +591,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
   });
 
   describe('tryInsertOrGetExisting retry logic', () => {
+    const ROLLUP_ADDRESS = EthAddress.random();
     const VALIDATOR_ADDRESS = EthAddress.random();
     const SLOT = SlotNumber(100);
     const BLOCK_NUMBER = BlockNumber(50);
@@ -595,6 +622,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
       });
 
       const result = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -625,6 +653,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       await expect(
         spDb.tryInsertOrGetExisting({
+          rollupAddress: ROLLUP_ADDRESS,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: SLOT,
           blockNumber: BLOCK_NUMBER,
@@ -646,6 +675,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
       // These use snake_case to match database column names
       /* eslint-disable camelcase */
       const mockRow1 = {
+        rollup_address: ROLLUP_ADDRESS.toString(),
         validator_address: VALIDATOR_ADDRESS.toString(),
         slot: SLOT.toString(),
         block_number: BLOCK_NUMBER.toString(),
@@ -662,6 +692,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
         is_new: true,
       } as InsertOrGetRow;
       const mockRow2 = {
+        rollup_address: ROLLUP_ADDRESS.toString(),
         validator_address: VALIDATOR_ADDRESS.toString(),
         slot: SLOT.toString(),
         block_number: BLOCK_NUMBER.toString(),
@@ -689,6 +720,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       await expect(
         spDb.tryInsertOrGetExisting({
+          rollupAddress: ROLLUP_ADDRESS,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: SLOT,
           blockNumber: BLOCK_NUMBER,
@@ -705,6 +737,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
   });
 
   describe('large numbers handling', () => {
+    const ROLLUP_ADDRESS = EthAddress.random();
     const VALIDATOR_ADDRESS = EthAddress.random();
     const SLOT = SlotNumber(100);
     const BLOCK_NUMBER = BlockNumber(50);
@@ -723,6 +756,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       const spDb = new PostgresSlashingProtectionDatabase(pool);
       const result = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: largeSlot,
         blockNumber: BLOCK_NUMBER,
@@ -741,6 +775,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       const spDb = new PostgresSlashingProtectionDatabase(pool);
       const result = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: largeBlockNumber,
@@ -756,6 +791,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
   });
 
   describe('updateDutySigned', () => {
+    const ROLLUP_ADDRESS = EthAddress.random();
     const VALIDATOR_ADDRESS = EthAddress.random();
     const SLOT = SlotNumber(100);
     const BLOCK_NUMBER = BlockNumber(50);
@@ -775,6 +811,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert a duty first
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -789,6 +826,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Update to signed
       const success = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
         VALIDATOR_ADDRESS,
         SLOT,
         DutyType.BLOCK_PROPOSAL,
@@ -817,6 +855,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert a duty first
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -830,6 +869,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Try to update with wrong token
       const success = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
         VALIDATOR_ADDRESS,
         SLOT,
         DutyType.BLOCK_PROPOSAL,
@@ -852,6 +892,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
       const spDb = new PostgresSlashingProtectionDatabase(pool);
 
       const success = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
         VALIDATOR_ADDRESS,
         SLOT,
         DutyType.BLOCK_PROPOSAL,
@@ -868,6 +909,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert and mark as signed
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -878,10 +920,19 @@ describe('PostgresSlashingProtectionDatabase', () => {
       });
 
       const lockToken = insertResult.record.lockToken;
-      await spDb.updateDutySigned(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, SIGNATURE, lockToken, 0);
+      await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        SIGNATURE,
+        lockToken,
+        0,
+      );
 
       // Try to update again with correct token
       const success = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
         VALIDATOR_ADDRESS,
         SLOT,
         DutyType.BLOCK_PROPOSAL,
@@ -905,6 +956,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert an ATTESTATION duty (non-block-proposal, so no blockIndexWithinCheckpoint)
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -918,6 +970,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Update to signed with -1 for block index (non-block-proposal duty)
       const success = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
         VALIDATOR_ADDRESS,
         SLOT,
         DutyType.ATTESTATION,
@@ -944,6 +997,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
   });
 
   describe('deleteDuty', () => {
+    const ROLLUP_ADDRESS = EthAddress.random();
     const VALIDATOR_ADDRESS = EthAddress.random();
     const SLOT = SlotNumber(100);
     const BLOCK_NUMBER = BlockNumber(50);
@@ -962,6 +1016,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert a duty first
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -975,7 +1030,14 @@ describe('PostgresSlashingProtectionDatabase', () => {
       const lockToken = insertResult.record.lockToken;
 
       // Delete the duty
-      const success = await spDb.deleteDuty(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, lockToken, 0);
+      const success = await spDb.deleteDuty(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        lockToken,
+        0,
+      );
 
       expect(success).toBe(true);
 
@@ -992,6 +1054,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert a duty first
       await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -1002,7 +1065,14 @@ describe('PostgresSlashingProtectionDatabase', () => {
       });
 
       // Try to delete with wrong token
-      const success = await spDb.deleteDuty(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, 'wrong-token', 0);
+      const success = await spDb.deleteDuty(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        'wrong-token',
+        0,
+      );
 
       expect(success).toBe(false);
 
@@ -1017,7 +1087,14 @@ describe('PostgresSlashingProtectionDatabase', () => {
     it('should return false if duty not found', async () => {
       const spDb = new PostgresSlashingProtectionDatabase(pool);
 
-      const success = await spDb.deleteDuty(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, 'some-token', 0);
+      const success = await spDb.deleteDuty(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        'some-token',
+        0,
+      );
 
       expect(success).toBe(false);
     });
@@ -1027,6 +1104,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert and mark as signed
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -1037,10 +1115,25 @@ describe('PostgresSlashingProtectionDatabase', () => {
       });
 
       const lockToken = insertResult.record.lockToken;
-      await spDb.updateDutySigned(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, '0xsignature', lockToken, 0);
+      await spDb.updateDutySigned(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        '0xsignature',
+        lockToken,
+        0,
+      );
 
       // Try to delete with correct token (should fail because duty is signed)
-      const success = await spDb.deleteDuty(VALIDATOR_ADDRESS, SLOT, DutyType.BLOCK_PROPOSAL, lockToken, 0);
+      const success = await spDb.deleteDuty(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        lockToken,
+        0,
+      );
 
       expect(success).toBe(false);
 
@@ -1057,6 +1150,7 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
       // Insert an ATTESTATION duty (non-block-proposal, so no blockIndexWithinCheckpoint)
       const insertResult = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -1069,7 +1163,14 @@ describe('PostgresSlashingProtectionDatabase', () => {
       const lockToken = insertResult.record.lockToken;
 
       // Delete with -1 for block index (non-block-proposal duty)
-      const success = await spDb.deleteDuty(VALIDATOR_ADDRESS, SLOT, DutyType.ATTESTATION, lockToken, -1);
+      const success = await spDb.deleteDuty(
+        ROLLUP_ADDRESS,
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.ATTESTATION,
+        lockToken,
+        -1,
+      );
 
       expect(success).toBe(true);
 
@@ -1079,6 +1180,186 @@ describe('PostgresSlashingProtectionDatabase', () => {
         [VALIDATOR_ADDRESS.toString(), SLOT.toString(), DutyType.ATTESTATION],
       );
       expect(selectResult.rows.length).toBe(0);
+    });
+  });
+
+  describe('Rollup Address Isolation', () => {
+    const ROLLUP_ADDRESS_1 = EthAddress.random();
+    const ROLLUP_ADDRESS_2 = EthAddress.random();
+    const VALIDATOR_ADDRESS = EthAddress.random();
+    const SLOT = SlotNumber(100);
+    const BLOCK_NUMBER = BlockNumber(50);
+    const MESSAGE_HASH = Buffer32.random().toString();
+    const NODE_ID = 'node-1';
+
+    beforeEach(async () => {
+      for (const statement of SCHEMA_SETUP) {
+        await pglite.query(statement);
+      }
+      await pglite.query(INSERT_SCHEMA_VERSION, [SCHEMA_VERSION]);
+    });
+
+    it('should allow same validator/slot/duty for different rollup addresses', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(pool);
+
+      // Insert duty for rollup1
+      const result1 = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS_1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+        dutyType: DutyType.BLOCK_PROPOSAL,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      });
+
+      // Insert same duty but for rollup2 - should succeed (no conflict)
+      const result2 = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS_2,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT, // Same slot!
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+        dutyType: DutyType.BLOCK_PROPOSAL,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      });
+
+      expect(result1.isNew).toBe(true);
+      expect(result2.isNew).toBe(true); // Both should succeed
+      expect(result1.record.rollupAddress).toEqual(ROLLUP_ADDRESS_1);
+      expect(result2.record.rollupAddress).toEqual(ROLLUP_ADDRESS_2);
+      expect(result1.record.slot).toBe(SLOT);
+      expect(result2.record.slot).toBe(SLOT);
+    });
+
+    it('should only update duties for the specified rollup address', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(pool);
+
+      // Create duty for rollup1
+      const result1 = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS_1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+        dutyType: DutyType.BLOCK_PROPOSAL,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      });
+
+      expect(result1.isNew).toBe(true);
+      const lockToken = result1.record.lockToken;
+
+      // Try to update using rollup2 address - should fail (no match)
+      const updated = await spDb.updateDutySigned(
+        ROLLUP_ADDRESS_2, // Wrong rollup!
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        '0xsignature',
+        lockToken,
+        0,
+      );
+
+      expect(updated).toBe(false); // Should not update duty from different rollup
+    });
+
+    it('should only delete duties for the specified rollup address', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(pool);
+
+      // Create duty for rollup1
+      const result1 = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS_1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+        dutyType: DutyType.BLOCK_PROPOSAL,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      });
+
+      expect(result1.isNew).toBe(true);
+      const lockToken = result1.record.lockToken;
+
+      // Try to delete using rollup2 address - should fail (no match)
+      const deleted = await spDb.deleteDuty(
+        ROLLUP_ADDRESS_2, // Wrong rollup!
+        VALIDATOR_ADDRESS,
+        SLOT,
+        DutyType.BLOCK_PROPOSAL,
+        lockToken,
+        0,
+      );
+
+      expect(deleted).toBe(false); // Should not delete duty from different rollup
+
+      // Verify the duty still exists for rollup1
+      const result2 = await spDb.tryInsertOrGetExisting({
+        rollupAddress: ROLLUP_ADDRESS_1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+        dutyType: DutyType.BLOCK_PROPOSAL,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      });
+
+      expect(result2.isNew).toBe(false); // Still exists
+    });
+  });
+
+  describe('Rollup Upgrade Scenario', () => {
+    const VALIDATOR_ADDRESS = EthAddress.random();
+    const NODE_ID = 'node-1';
+
+    beforeEach(async () => {
+      for (const statement of SCHEMA_SETUP) {
+        await pglite.query(statement);
+      }
+      await pglite.query(INSERT_SCHEMA_VERSION, [SCHEMA_VERSION]);
+    });
+
+    it('should allow overlapping block proposals across rollup addresses', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(pool);
+      const oldRollupAddress = EthAddress.random();
+      const newRollupAddress = EthAddress.random();
+      const slot = SlotNumber(100);
+      const blockNumber = BlockNumber(50);
+
+      // Old rollup: validator proposes 3 blocks in same slot
+      for (let blockIdx = 0; blockIdx < 3; blockIdx++) {
+        const result = await spDb.tryInsertOrGetExisting({
+          rollupAddress: oldRollupAddress,
+          validatorAddress: VALIDATOR_ADDRESS,
+          slot,
+          blockNumber,
+          blockIndexWithinCheckpoint: IndexWithinCheckpoint(blockIdx),
+          dutyType: DutyType.BLOCK_PROPOSAL,
+          messageHash: Buffer32.random().toString(),
+          nodeId: NODE_ID,
+        });
+        expect(result.isNew).toBe(true);
+      }
+
+      // New rollup: validator should be able to propose 3 blocks in same slot again
+      for (let blockIdx = 0; blockIdx < 3; blockIdx++) {
+        const result = await spDb.tryInsertOrGetExisting({
+          rollupAddress: newRollupAddress,
+          validatorAddress: VALIDATOR_ADDRESS,
+          slot, // Same slot!
+          blockNumber,
+          blockIndexWithinCheckpoint: IndexWithinCheckpoint(blockIdx), // Same index!
+          dutyType: DutyType.BLOCK_PROPOSAL,
+          messageHash: Buffer32.random().toString(),
+          nodeId: NODE_ID,
+        });
+        expect(result.isNew).toBe(true);
+        expect(result.record.rollupAddress).toEqual(newRollupAddress);
+      }
     });
   });
 });

--- a/yarn-project/validator-ha-signer/src/db/postgres.ts
+++ b/yarn-project/validator-ha-signer/src/db/postgres.ts
@@ -101,6 +101,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
     const result = await retry<QueryResult<InsertOrGetRow>>(
       async () => {
         const queryResult: QueryResult<InsertOrGetRow> = await this.pool.query(INSERT_OR_GET_DUTY, [
+          params.rollupAddress.toString(),
           params.validatorAddress.toString(),
           params.slot.toString(),
           params.blockNumber.toString(),
@@ -148,6 +149,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
    * @returns true if the update succeeded, false if token didn't match or duty not found
    */
   async updateDutySigned(
+    rollupAddress: EthAddress,
     validatorAddress: EthAddress,
     slot: SlotNumber,
     dutyType: DutyType,
@@ -157,6 +159,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
   ): Promise<boolean> {
     const result = await this.pool.query(UPDATE_DUTY_SIGNED, [
       signature,
+      rollupAddress.toString(),
       validatorAddress.toString(),
       slot.toString(),
       dutyType,
@@ -166,6 +169,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
 
     if (result.rowCount === 0) {
       this.log.warn('Failed to update duty to signed status: invalid token or duty not found', {
+        rollupAddress: rollupAddress.toString(),
         validatorAddress: validatorAddress.toString(),
         slot: slot.toString(),
         dutyType,
@@ -184,6 +188,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
    * @returns true if the delete succeeded, false if token didn't match or duty not found
    */
   async deleteDuty(
+    rollupAddress: EthAddress,
     validatorAddress: EthAddress,
     slot: SlotNumber,
     dutyType: DutyType,
@@ -191,6 +196,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
     blockIndexWithinCheckpoint: number,
   ): Promise<boolean> {
     const result = await this.pool.query(DELETE_DUTY, [
+      rollupAddress.toString(),
       validatorAddress.toString(),
       slot.toString(),
       dutyType,
@@ -200,6 +206,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
 
     if (result.rowCount === 0) {
       this.log.warn('Failed to delete duty: invalid token or duty not found', {
+        rollupAddress: rollupAddress.toString(),
         validatorAddress: validatorAddress.toString(),
         slot: slot.toString(),
         dutyType,
@@ -215,6 +222,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
    */
   private rowToRecord(row: DutyRow): ValidatorDutyRecord {
     return {
+      rollupAddress: EthAddress.fromString(row.rollup_address),
       validatorAddress: EthAddress.fromString(row.validator_address),
       slot: SlotNumber.fromString(row.slot),
       blockNumber: BlockNumber.fromString(row.block_number),

--- a/yarn-project/validator-ha-signer/src/db/schema.ts
+++ b/yarn-project/validator-ha-signer/src/db/schema.ts
@@ -16,6 +16,7 @@ export const SCHEMA_VERSION = 1;
  */
 export const CREATE_VALIDATOR_DUTIES_TABLE = `
 CREATE TABLE IF NOT EXISTS validator_duties (
+  rollup_address VARCHAR(42) NOT NULL,
   validator_address VARCHAR(42) NOT NULL,
   slot BIGINT NOT NULL,
   block_number BIGINT NOT NULL,
@@ -30,7 +31,7 @@ CREATE TABLE IF NOT EXISTS validator_duties (
   completed_at TIMESTAMP,
   error_message TEXT,
 
-  PRIMARY KEY (validator_address, slot, duty_type, block_index_within_checkpoint),
+  PRIMARY KEY (rollup_address, validator_address, slot, duty_type, block_index_within_checkpoint),
   CHECK (completed_at IS NULL OR completed_at >= started_at)
 );
 `;
@@ -101,6 +102,7 @@ SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;
 export const INSERT_OR_GET_DUTY = `
 WITH inserted AS (
   INSERT INTO validator_duties (
+    rollup_address,
     validator_address,
     slot,
     block_number,
@@ -111,9 +113,10 @@ WITH inserted AS (
     node_id,
     lock_token,
     started_at
-  ) VALUES ($1, $2, $3, $4, $5, 'signing', $6, $7, $8, CURRENT_TIMESTAMP)
-  ON CONFLICT (validator_address, slot, duty_type, block_index_within_checkpoint) DO NOTHING
+  ) VALUES ($1, $2, $3, $4, $5, $6, 'signing', $7, $8, $9, CURRENT_TIMESTAMP)
+  ON CONFLICT (rollup_address, validator_address, slot, duty_type, block_index_within_checkpoint) DO NOTHING
   RETURNING
+    rollup_address,
     validator_address,
     slot,
     block_number,
@@ -132,6 +135,7 @@ WITH inserted AS (
 SELECT * FROM inserted
 UNION ALL
 SELECT
+  rollup_address,
   validator_address,
   slot,
   block_number,
@@ -147,10 +151,11 @@ SELECT
   error_message,
   FALSE as is_new
 FROM validator_duties
-WHERE validator_address = $1
-  AND slot = $2
-  AND duty_type = $5
-  AND block_index_within_checkpoint = $4
+WHERE rollup_address = $1
+  AND validator_address = $2
+  AND slot = $3
+  AND duty_type = $6
+  AND block_index_within_checkpoint = $5
   AND NOT EXISTS (SELECT 1 FROM inserted);
 `;
 
@@ -162,12 +167,13 @@ UPDATE validator_duties
 SET status = 'signed',
     signature = $1,
     completed_at = CURRENT_TIMESTAMP
-WHERE validator_address = $2
-  AND slot = $3
-  AND duty_type = $4
-  AND block_index_within_checkpoint = $5
+WHERE rollup_address = $2
+  AND validator_address = $3
+  AND slot = $4
+  AND duty_type = $5
+  AND block_index_within_checkpoint = $6
   AND status = 'signing'
-  AND lock_token = $6;
+  AND lock_token = $7;
 `;
 
 /**
@@ -176,12 +182,13 @@ WHERE validator_address = $2
  */
 export const DELETE_DUTY = `
 DELETE FROM validator_duties
-WHERE validator_address = $1
-  AND slot = $2
-  AND duty_type = $3
-  AND block_index_within_checkpoint = $4
+WHERE rollup_address = $1
+  AND validator_address = $2
+  AND slot = $3
+  AND duty_type = $4
+  AND block_index_within_checkpoint = $5
   AND status = 'signing'
-  AND lock_token = $5;
+  AND lock_token = $6;
 `;
 
 /**
@@ -231,6 +238,7 @@ export const DROP_SCHEMA_VERSION_TABLE = `DROP TABLE IF EXISTS schema_version;`;
  */
 export const GET_STUCK_DUTIES = `
 SELECT
+  rollup_address,
   validator_address,
   slot,
   block_number,

--- a/yarn-project/validator-ha-signer/src/db/types.test.ts
+++ b/yarn-project/validator-ha-signer/src/db/types.test.ts
@@ -61,10 +61,12 @@ describe('normalizeBlockIndex', () => {
 describe('getBlockIndexFromDutyIdentifier', () => {
   const validatorAddress = EthAddress.random();
   const slot = SlotNumber(100);
+  const rollupAddress = EthAddress.random();
 
   describe('BLOCK_PROPOSAL duties', () => {
     it('should return the blockIndexWithinCheckpoint', () => {
       const duty: BlockProposalDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
@@ -73,6 +75,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
       expect(getBlockIndexFromDutyIdentifier(duty)).toBe(0);
 
       const duty2: BlockProposalDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         blockIndexWithinCheckpoint: IndexWithinCheckpoint(5),
@@ -85,6 +88,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
   describe('non-BLOCK_PROPOSAL duties', () => {
     it('should return -1 for CHECKPOINT_PROPOSAL', () => {
       const duty: OtherDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         dutyType: DutyType.CHECKPOINT_PROPOSAL,
@@ -94,6 +98,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
 
     it('should return -1 for ATTESTATION', () => {
       const duty: OtherDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         dutyType: DutyType.ATTESTATION,
@@ -103,6 +108,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
 
     it('should return -1 for ATTESTATIONS_AND_SIGNERS', () => {
       const duty: OtherDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         dutyType: DutyType.ATTESTATIONS_AND_SIGNERS,
@@ -112,6 +118,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
 
     it('should return -1 for GOVERNANCE_VOTE', () => {
       const duty: OtherDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         dutyType: DutyType.GOVERNANCE_VOTE,
@@ -121,6 +128,7 @@ describe('getBlockIndexFromDutyIdentifier', () => {
 
     it('should return -1 for SLASHING_VOTE', () => {
       const duty: OtherDutyIdentifier = {
+        rollupAddress,
         validatorAddress,
         slot,
         dutyType: DutyType.SLASHING_VOTE,

--- a/yarn-project/validator-ha-signer/src/db/types.ts
+++ b/yarn-project/validator-ha-signer/src/db/types.ts
@@ -6,6 +6,7 @@ import type { Signature } from '@aztec/foundation/eth-signature';
  * Row type from PostgreSQL query
  */
 export interface DutyRow {
+  rollup_address: string;
   validator_address: string;
   slot: string;
   block_number: string;
@@ -54,6 +55,8 @@ export enum DutyStatus {
  * Record of a validator duty in the database
  */
 export interface ValidatorDutyRecord {
+  /** Ethereum address of the rollup contract */
+  rollupAddress: EthAddress;
   /** Ethereum address of the validator */
   validatorAddress: EthAddress;
   /** Slot number for this duty */
@@ -87,6 +90,7 @@ export interface ValidatorDutyRecord {
  * blockIndexWithinCheckpoint is REQUIRED and must be >= 0.
  */
 export interface BlockProposalDutyIdentifier {
+  rollupAddress: EthAddress;
   validatorAddress: EthAddress;
   slot: SlotNumber;
   /** Block index within checkpoint (0, 1, 2...). Required for block proposals. */
@@ -99,6 +103,7 @@ export interface BlockProposalDutyIdentifier {
  * blockIndexWithinCheckpoint is not applicable (internally stored as -1).
  */
 export interface OtherDutyIdentifier {
+  rollupAddress: EthAddress;
   validatorAddress: EthAddress;
   slot: SlotNumber;
   dutyType:

--- a/yarn-project/validator-ha-signer/src/slashing_protection_service.test.ts
+++ b/yarn-project/validator-ha-signer/src/slashing_protection_service.test.ts
@@ -13,6 +13,7 @@ import { Pool } from './test/pglite_pool.js';
 import { type CheckAndRecordParams, DutyStatus, DutyType, type ValidatorHASignerConfig } from './types.js';
 
 // Test data constants
+const ROLLUP_ADDRESS = EthAddress.random();
 const VALIDATOR_ADDRESS = EthAddress.random();
 const SLOT = SlotNumber(100);
 const BLOCK_NUMBER = BlockNumber(50);
@@ -41,6 +42,7 @@ describe('SlashingProtectionService', () => {
 
     config = {
       haSigningEnabled: true,
+      l1Contracts: { rollupAddress: ROLLUP_ADDRESS },
       nodeId: NODE_ID,
       pollingIntervalMs: 50,
       signingTimeoutMs: 1000,
@@ -57,6 +59,7 @@ describe('SlashingProtectionService', () => {
   describe('checkAndRecord', () => {
     it('should acquire lock on first attempt', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -78,6 +81,7 @@ describe('SlashingProtectionService', () => {
 
     it('should throw DutyAlreadySignedError when duty already signed with same data', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -90,6 +94,7 @@ describe('SlashingProtectionService', () => {
       // First node signs
       const lockToken = await service.checkAndRecord(params);
       await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -106,6 +111,7 @@ describe('SlashingProtectionService', () => {
 
     it('should throw SlashingProtectionError when duty already signed with different data', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -118,6 +124,7 @@ describe('SlashingProtectionService', () => {
       // First node signs
       const lockToken = await service.checkAndRecord(params);
       await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -134,6 +141,7 @@ describe('SlashingProtectionService', () => {
 
     it('should allow retry after deleted duty', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -146,6 +154,7 @@ describe('SlashingProtectionService', () => {
       // First node acquires lock then deletes (simulating failure)
       const lockToken = await service.checkAndRecord(params);
       await service.deleteDuty({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -165,6 +174,7 @@ describe('SlashingProtectionService', () => {
 
     it('should wait and throw when another node is signing same data', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -184,6 +194,7 @@ describe('SlashingProtectionService', () => {
       // Complete first node's signing after a short delay
       await sleep(100);
       await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -199,6 +210,7 @@ describe('SlashingProtectionService', () => {
 
     it('should wait and throw when another node is signing different data', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -218,6 +230,7 @@ describe('SlashingProtectionService', () => {
       // Complete first node's signing after a short delay
       await sleep(100);
       await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -233,6 +246,7 @@ describe('SlashingProtectionService', () => {
 
     it('should acquire lock after other node deletes duty on failure', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -247,6 +261,7 @@ describe('SlashingProtectionService', () => {
 
       // First node deletes on failure
       await service.deleteDuty({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -271,6 +286,7 @@ describe('SlashingProtectionService', () => {
 
       try {
         const params: CheckAndRecordParams = {
+          rollupAddress: ROLLUP_ADDRESS,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: SLOT,
           blockNumber: BLOCK_NUMBER,
@@ -295,6 +311,7 @@ describe('SlashingProtectionService', () => {
   describe('recordSuccess', () => {
     it('should update duty to signed status', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -306,6 +323,7 @@ describe('SlashingProtectionService', () => {
 
       const lockToken = await service.checkAndRecord(params);
       const success = await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -325,6 +343,7 @@ describe('SlashingProtectionService', () => {
 
     it('should fail to update with wrong lockToken', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -336,6 +355,7 @@ describe('SlashingProtectionService', () => {
 
       await service.checkAndRecord(params);
       const success = await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -355,6 +375,7 @@ describe('SlashingProtectionService', () => {
   describe('deleteDuty', () => {
     it('should delete duty with correct lockToken', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -366,6 +387,7 @@ describe('SlashingProtectionService', () => {
 
       const lockToken = await service.checkAndRecord(params);
       const success = await service.deleteDuty({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -381,6 +403,7 @@ describe('SlashingProtectionService', () => {
 
     it('should fail to delete with wrong lockToken', async () => {
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -392,6 +415,7 @@ describe('SlashingProtectionService', () => {
 
       await service.checkAndRecord(params);
       const success = await service.deleteDuty({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -409,6 +433,7 @@ describe('SlashingProtectionService', () => {
   describe('concurrent operations', () => {
     it('should handle multiple nodes competing for the same duty', async () => {
       const params1: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -428,6 +453,7 @@ describe('SlashingProtectionService', () => {
       // Whichever resolves first is the actual winner
       const winner = await Promise.race(promises);
       await service.recordSuccess({
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
@@ -460,6 +486,7 @@ describe('SlashingProtectionService', () => {
 
       for (let i = 0; i < 5; i++) {
         const params: CheckAndRecordParams = {
+          rollupAddress: ROLLUP_ADDRESS,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: SlotNumber(100),
           blockNumber: BlockNumber(50),
@@ -476,6 +503,7 @@ describe('SlashingProtectionService', () => {
       // Verify all duties were created
       for (let i = 0; i < 5; i++) {
         const result = await db.tryInsertOrGetExisting({
+          rollupAddress: ROLLUP_ADDRESS,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: SlotNumber(100),
           blockNumber: BlockNumber(50),
@@ -506,6 +534,7 @@ describe('SlashingProtectionService', () => {
     it('should cleanup stuck duties on start', async () => {
       // Create a stuck duty by directly inserting (simulating a crash)
       const params: CheckAndRecordParams = {
+        rollupAddress: ROLLUP_ADDRESS,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SLOT,
         blockNumber: BLOCK_NUMBER,
@@ -541,6 +570,237 @@ describe('SlashingProtectionService', () => {
       // Now the duty should be deleted, so we can insert again
       result = await db.tryInsertOrGetExisting(params);
       expect(result.isNew).toBe(true);
+    });
+  });
+
+  describe('Rollup Upgrade Scenarios', () => {
+    it('should allow same slot/duty for different rollup addresses', async () => {
+      const rollupAddress1 = EthAddress.random();
+      const rollupAddress2 = EthAddress.random();
+
+      const service1 = new SlashingProtectionService(db, {
+        ...config,
+        l1Contracts: { rollupAddress: rollupAddress1 },
+      });
+      const service2 = new SlashingProtectionService(db, {
+        ...config,
+        l1Contracts: { rollupAddress: rollupAddress2 },
+      });
+
+      // Sign same slots for both rollups (e.g. rollup upgrade: slots reset, same slot numbers reused)
+      for (let slotNum = 1; slotNum <= 5; slotNum++) {
+        const params1: CheckAndRecordParams = {
+          rollupAddress: rollupAddress1,
+          validatorAddress: VALIDATOR_ADDRESS,
+          slot: SlotNumber(slotNum),
+          blockNumber: BlockNumber(slotNum),
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          messageHash: MESSAGE_HASH,
+          nodeId: NODE_ID,
+        };
+
+        const lockToken1 = await service1.checkAndRecord(params1);
+        await service1.recordSuccess({
+          rollupAddress: rollupAddress1,
+          validatorAddress: VALIDATOR_ADDRESS,
+          slot: SlotNumber(slotNum),
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          signature: { toString: () => SIGNATURE } as any,
+          nodeId: NODE_ID,
+          lockToken: lockToken1,
+        });
+
+        const params2 = { ...params1, rollupAddress: rollupAddress2 };
+        const lockToken2 = await service2.checkAndRecord(params2);
+        await service2.recordSuccess({
+          rollupAddress: rollupAddress2,
+          validatorAddress: VALIDATOR_ADDRESS,
+          slot: SlotNumber(slotNum),
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          signature: { toString: () => SIGNATURE } as any,
+          nodeId: NODE_ID,
+          lockToken: lockToken2,
+        });
+      }
+
+      // Both rollups should have records for each slot
+      const paramsForSlot1Rollup1: CheckAndRecordParams = {
+        rollupAddress: rollupAddress1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SlotNumber(1),
+        blockNumber: BlockNumber(1),
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      };
+      const paramsForSlot1Rollup2: CheckAndRecordParams = {
+        ...paramsForSlot1Rollup1,
+        rollupAddress: rollupAddress2,
+      };
+      const result1 = await db.tryInsertOrGetExisting(paramsForSlot1Rollup1);
+      const result2 = await db.tryInsertOrGetExisting(paramsForSlot1Rollup2);
+      expect(result1.isNew).toBe(false);
+      expect(result2.isNew).toBe(false);
+      expect(result1.record.rollupAddress).toEqual(rollupAddress1);
+      expect(result2.record.rollupAddress).toEqual(rollupAddress2);
+    });
+
+    it('should handle multiple validators across rollup upgrade', async () => {
+      const oldRollupAddress = EthAddress.random();
+      const newRollupAddress = EthAddress.random();
+      const validator1 = EthAddress.random();
+      const validator2 = EthAddress.random();
+      const validator3 = EthAddress.random();
+      const validators = [validator1, validator2, validator3];
+
+      const oldService = new SlashingProtectionService(db, {
+        ...config,
+        l1Contracts: { rollupAddress: oldRollupAddress },
+      });
+      const newService = new SlashingProtectionService(db, {
+        ...config,
+        l1Contracts: { rollupAddress: newRollupAddress },
+      });
+
+      // Old rollup: all validators sign slot 100
+      for (const validator of validators) {
+        const params: CheckAndRecordParams = {
+          rollupAddress: oldRollupAddress,
+          validatorAddress: validator,
+          slot: SLOT,
+          blockNumber: BLOCK_NUMBER,
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          messageHash: MESSAGE_HASH,
+          nodeId: NODE_ID,
+        };
+
+        const lockToken = await oldService.checkAndRecord(params);
+        await oldService.recordSuccess({
+          rollupAddress: oldRollupAddress,
+          validatorAddress: validator,
+          slot: SLOT,
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          signature: { toString: () => SIGNATURE } as any,
+          nodeId: NODE_ID,
+          lockToken,
+        });
+      }
+
+      // New rollup: all validators should be able to sign slot 100 again
+      for (const validator of validators) {
+        const params: CheckAndRecordParams = {
+          rollupAddress: newRollupAddress,
+          validatorAddress: validator,
+          slot: SLOT, // Same slot!
+          blockNumber: BLOCK_NUMBER,
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          messageHash: MESSAGE_HASH,
+          nodeId: NODE_ID,
+        };
+
+        const lockToken = await newService.checkAndRecord(params);
+        await newService.recordSuccess({
+          rollupAddress: newRollupAddress,
+          validatorAddress: validator,
+          slot: SLOT,
+          blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+          dutyType: DUTY_TYPE,
+          signature: { toString: () => SIGNATURE } as any,
+          nodeId: NODE_ID,
+          lockToken,
+        });
+
+        const result = await db.tryInsertOrGetExisting(params);
+        expect(result.isNew).toBe(false);
+        expect(result.record.rollupAddress).toEqual(newRollupAddress);
+      }
+    });
+
+    it('should prevent cross-rollup duty deletion/update', async () => {
+      const rollupAddress1 = EthAddress.random();
+      const rollupAddress2 = EthAddress.random();
+
+      const service1 = new SlashingProtectionService(db, {
+        ...config,
+        l1Contracts: { rollupAddress: rollupAddress1 },
+      });
+
+      const params: CheckAndRecordParams = {
+        rollupAddress: rollupAddress1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      };
+      const params2: CheckAndRecordParams = {
+        rollupAddress: rollupAddress2,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockNumber: BLOCK_NUMBER,
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        messageHash: MESSAGE_HASH,
+        nodeId: NODE_ID,
+      };
+
+      // Create duty for rollup1
+      const lockToken1 = await service1.checkAndRecord(params);
+      // Create duty for rollup2 (same slot/validator is allowed across rollups)
+      const lockToken2 = await service1.checkAndRecord(params2);
+
+      // Try to delete rollup1 duty using rollup2 address - should fail
+      const deleted = await service1.deleteDuty({
+        rollupAddress: rollupAddress2, // Wrong rollup!
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        lockToken: lockToken1,
+      });
+
+      expect(deleted).toBe(false);
+
+      // Duty should still exist for rollup1
+      const result = await db.tryInsertOrGetExisting(params);
+      expect(result.isNew).toBe(false);
+      expect(result.record.status).toBe(DutyStatus.SIGNING);
+
+      // Duty for rollup2 should still exist
+      const result2 = await db.tryInsertOrGetExisting(params2);
+      expect(result2.isNew).toBe(false);
+      expect(result2.record.status).toBe(DutyStatus.SIGNING);
+
+      // Delete rollup1 duty with correct rollup address should succeed
+      const deletedCorrect = await service1.deleteDuty({
+        rollupAddress: rollupAddress1,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        lockToken: lockToken1,
+      });
+      expect(deletedCorrect).toBe(true);
+
+      // Delete rollup2 duty with correct rollup address should succeed
+      const deletedCorrect2 = await service1.deleteDuty({
+        rollupAddress: rollupAddress2,
+        validatorAddress: VALIDATOR_ADDRESS,
+        slot: SLOT,
+        blockIndexWithinCheckpoint: BLOCK_INDEX_WITHIN_CHECKPOINT,
+        dutyType: DUTY_TYPE,
+        lockToken: lockToken2,
+      });
+      expect(deletedCorrect2).toBe(true);
     });
   });
 });

--- a/yarn-project/validator-ha-signer/src/slashing_protection_service.ts
+++ b/yarn-project/validator-ha-signer/src/slashing_protection_service.ts
@@ -149,10 +149,11 @@ export class SlashingProtectionService {
    * @returns true if the update succeeded, false if token didn't match
    */
   async recordSuccess(params: RecordSuccessParams): Promise<boolean> {
-    const { validatorAddress, slot, dutyType, signature, nodeId, lockToken } = params;
+    const { rollupAddress, validatorAddress, slot, dutyType, signature, nodeId, lockToken } = params;
     const blockIndexWithinCheckpoint = getBlockIndexFromDutyIdentifier(params);
 
     const success = await this.db.updateDutySigned(
+      rollupAddress,
       validatorAddress,
       slot,
       dutyType,
@@ -184,10 +185,17 @@ export class SlashingProtectionService {
    * @returns true if the delete succeeded, false if token didn't match
    */
   async deleteDuty(params: DeleteDutyParams): Promise<boolean> {
-    const { validatorAddress, slot, dutyType, lockToken } = params;
+    const { rollupAddress, validatorAddress, slot, dutyType, lockToken } = params;
     const blockIndexWithinCheckpoint = getBlockIndexFromDutyIdentifier(params);
 
-    const success = await this.db.deleteDuty(validatorAddress, slot, dutyType, lockToken, blockIndexWithinCheckpoint);
+    const success = await this.db.deleteDuty(
+      rollupAddress,
+      validatorAddress,
+      slot,
+      dutyType,
+      lockToken,
+      blockIndexWithinCheckpoint,
+    );
 
     if (success) {
       this.log.info(`Deleted duty ${dutyType} at slot ${slot} to allow retry`, {

--- a/yarn-project/validator-ha-signer/src/types.ts
+++ b/yarn-project/validator-ha-signer/src/types.ts
@@ -170,6 +170,7 @@ export interface SlashingProtectionDatabase {
    * @returns true if the update succeeded, false if token didn't match or duty not found
    */
   updateDutySigned(
+    rollupAddress: EthAddress,
     validatorAddress: EthAddress,
     slot: SlotNumber,
     dutyType: DutyType,
@@ -186,6 +187,7 @@ export interface SlashingProtectionDatabase {
    * @returns true if the delete succeeded, false if token didn't match or duty not found
    */
   deleteDuty(
+    rollupAddress: EthAddress,
     validatorAddress: EthAddress,
     slot: SlotNumber,
     dutyType: DutyType,

--- a/yarn-project/validator-ha-signer/src/validator_ha_signer.test.ts
+++ b/yarn-project/validator-ha-signer/src/validator_ha_signer.test.ts
@@ -43,6 +43,7 @@ describe('ValidatorHASigner', () => {
 
     config = {
       haSigningEnabled: true,
+      l1Contracts: { rollupAddress: EthAddress.random() },
       nodeId: NODE_ID,
       pollingIntervalMs: 50,
       signingTimeoutMs: 1000,
@@ -57,7 +58,10 @@ describe('ValidatorHASigner', () => {
 
   describe('initialization', () => {
     it('should not initialize when nodeId is not explicitly set', () => {
-      const defaultConfig = { ...defaultValidatorHASignerConfig };
+      const defaultConfig = {
+        ...defaultValidatorHASignerConfig,
+        l1Contracts: { rollupAddress: EthAddress.random() },
+      };
       expect(
         () =>
           new ValidatorHASigner(db, {
@@ -116,6 +120,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify duty was recorded
       const dutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -149,6 +154,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify duty was deleted
       const dutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -257,6 +263,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify both duties exist
       const blockDutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -266,6 +273,7 @@ describe('ValidatorHASigner', () => {
         nodeId: NODE_ID,
       });
       const attestationDutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -337,6 +345,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify both duties exist
       const blockDutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -346,6 +355,7 @@ describe('ValidatorHASigner', () => {
         nodeId: NODE_ID,
       });
       const blockDutyResult2 = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -403,6 +413,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify all three duties exist in database
       const block0Result = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot,
         blockNumber,
@@ -412,6 +423,7 @@ describe('ValidatorHASigner', () => {
         nodeId: NODE_ID,
       });
       const block1Result = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot,
         blockNumber,
@@ -421,6 +433,7 @@ describe('ValidatorHASigner', () => {
         nodeId: NODE_ID,
       });
       const checkpointResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot,
         blockNumber,
@@ -580,6 +593,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify both duties were recorded with blockNumber = 0
       const governanceResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(0), // getBlockNumberFromSigningContext returns 0 for vote duties
@@ -588,6 +602,7 @@ describe('ValidatorHASigner', () => {
         nodeId: NODE_ID,
       });
       const slashingResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(0),
@@ -810,6 +825,7 @@ describe('ValidatorHASigner', () => {
 
         // Verify the duty is recorded in the database with the winning nodeId
         const dutyResult = await db.tryInsertOrGetExisting({
+          rollupAddress: config.l1Contracts.rollupAddress,
           validatorAddress: VALIDATOR_ADDRESS,
           slot: sameSlot,
           blockNumber: sameBlockNumber,
@@ -930,6 +946,7 @@ describe('ValidatorHASigner', () => {
 
       // Verify the duty is marked as signed by the second signer
       const dutyResult = await db.tryInsertOrGetExisting({
+        rollupAddress: config.l1Contracts.rollupAddress,
         validatorAddress: VALIDATOR_ADDRESS,
         slot: SlotNumber(100),
         blockNumber: BlockNumber(50),
@@ -940,6 +957,101 @@ describe('ValidatorHASigner', () => {
       });
       expect(dutyResult.isNew).toBe(false);
       expect(dutyResult.record.status).toBe(DutyStatus.SIGNED);
+    });
+  });
+
+  describe('Rollup Upgrade Scenarios', () => {
+    it('should allow same slot signing across different rollup addresses', async () => {
+      const oldRollupAddress = EthAddress.random();
+      const newRollupAddress = EthAddress.random();
+
+      // Create signer with old rollup address
+      const oldSigner = new ValidatorHASigner(db, {
+        ...config,
+        l1Contracts: { rollupAddress: oldRollupAddress },
+      });
+      oldSigner.start();
+
+      try {
+        const signFn = jest.fn<(messageHash: Buffer32) => Promise<Signature>>();
+        signFn.mockResolvedValue(mockSignature);
+
+        // Sign with old rollup
+        await oldSigner.signWithProtection(
+          VALIDATOR_ADDRESS,
+          MESSAGE_HASH,
+          {
+            slot: SlotNumber(100),
+            blockNumber: BlockNumber(50),
+            dutyType: DutyType.BLOCK_PROPOSAL,
+            blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+          },
+          signFn,
+        );
+
+        expect(signFn).toHaveBeenCalledTimes(1);
+
+        // "Upgrade" - create new signer with new rollup address
+        const newSigner = new ValidatorHASigner(db, {
+          ...config,
+          l1Contracts: { rollupAddress: newRollupAddress },
+        });
+        newSigner.start();
+
+        try {
+          const signFn2 = jest.fn<(messageHash: Buffer32) => Promise<Signature>>();
+          signFn2.mockResolvedValue(mockSignature);
+
+          // Sign same slot with new rollup - should succeed (no conflict)
+          await newSigner.signWithProtection(
+            VALIDATOR_ADDRESS,
+            MESSAGE_HASH,
+            {
+              slot: SlotNumber(100), // Same slot!
+              blockNumber: BlockNumber(50),
+              dutyType: DutyType.BLOCK_PROPOSAL,
+              blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+            },
+            signFn2,
+          );
+
+          expect(signFn2).toHaveBeenCalledTimes(1);
+
+          // Verify both duties exist with different rollup addresses
+          const oldDuty = await db.tryInsertOrGetExisting({
+            rollupAddress: oldRollupAddress,
+            validatorAddress: VALIDATOR_ADDRESS,
+            slot: SlotNumber(100),
+            blockNumber: BlockNumber(50),
+            dutyType: DutyType.BLOCK_PROPOSAL,
+            blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+            messageHash: MESSAGE_HASH.toString(),
+            nodeId: NODE_ID,
+          });
+
+          const newDuty = await db.tryInsertOrGetExisting({
+            rollupAddress: newRollupAddress,
+            validatorAddress: VALIDATOR_ADDRESS,
+            slot: SlotNumber(100),
+            blockNumber: BlockNumber(50),
+            dutyType: DutyType.BLOCK_PROPOSAL,
+            blockIndexWithinCheckpoint: IndexWithinCheckpoint(0),
+            messageHash: MESSAGE_HASH.toString(),
+            nodeId: NODE_ID,
+          });
+
+          expect(oldDuty.isNew).toBe(false);
+          expect(newDuty.isNew).toBe(false);
+          expect(oldDuty.record.rollupAddress).toEqual(oldRollupAddress);
+          expect(newDuty.record.rollupAddress).toEqual(newRollupAddress);
+          expect(oldDuty.record.status).toBe(DutyStatus.SIGNED);
+          expect(newDuty.record.status).toBe(DutyStatus.SIGNED);
+        } finally {
+          await newSigner.stop();
+        }
+      } finally {
+        await oldSigner.stop();
+      }
     });
   });
 });

--- a/yarn-project/validator-ha-signer/src/validator_ha_signer.ts
+++ b/yarn-project/validator-ha-signer/src/validator_ha_signer.ts
@@ -6,7 +6,7 @@
  * node will sign for a given duty (slot + duty type).
  */
 import type { Buffer32 } from '@aztec/foundation/buffer';
-import type { EthAddress } from '@aztec/foundation/eth-address';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Signature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 
@@ -41,6 +41,7 @@ import {
 export class ValidatorHASigner {
   private readonly log: Logger;
   private readonly slashingProtection: SlashingProtectionService;
+  private readonly rollupAddress: EthAddress;
 
   constructor(
     db: SlashingProtectionDatabase,
@@ -56,9 +57,11 @@ export class ValidatorHASigner {
     if (!config.nodeId || config.nodeId === '') {
       throw new Error('NODE_ID is required for high-availability setups');
     }
+    this.rollupAddress = config.l1Contracts.rollupAddress;
     this.slashingProtection = new SlashingProtectionService(db, config);
     this.log.info('Validator HA Signer initialized with slashing protection', {
       nodeId: config.nodeId,
+      rollupAddress: this.rollupAddress.toString(),
     });
   }
 
@@ -88,6 +91,7 @@ export class ValidatorHASigner {
     let dutyIdentifier: DutyIdentifier;
     if (context.dutyType === DutyType.BLOCK_PROPOSAL) {
       dutyIdentifier = {
+        rollupAddress: this.rollupAddress,
         validatorAddress,
         slot: context.slot,
         blockIndexWithinCheckpoint: context.blockIndexWithinCheckpoint,
@@ -95,6 +99,7 @@ export class ValidatorHASigner {
       };
     } else {
       dutyIdentifier = {
+        rollupAddress: this.rollupAddress,
         validatorAddress,
         slot: context.slot,
         dutyType: context.dutyType,

--- a/yarn-project/validator-ha-signer/tsconfig.json
+++ b/yarn-project/validator-ha-signer/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../ethereum"
+    },
+    {
       "path": "../foundation"
     }
   ],

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -2302,6 +2302,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/validator-ha-signer@workspace:validator-ha-signer"
   dependencies:
+    "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@electric-sql/pglite": "npm:^0.3.14"
     "@jest/globals": "npm:^30.0.0"


### PR DESCRIPTION
Fixes [A-486](https://linear.app/aztec-labs/issue/A-486/use-rollup-address-for-high-availability-db-primary-key)

## Include rollup address in HA DB primary key

- **validator-ha-signer**: Add `rollup_address` to `validator_duties` primary key so slashing protection and duties are scoped per rollup.
- **validator-ha-signer**: Require `l1Contracts.rollupAddress` in config.
- **aztec-node-admin**: Omit `l1Contracts` from `AztecNodeAdminConfig` (L1 contracts are not mutable via admin).