### PR TITLE
refactor: remove unnecessary pow2 thread count requirement in gemini and gate_separator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -124,8 +124,6 @@ template <typename Curve>
 std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::compute_fold_polynomials(
     const size_t log_n, std::span<const Fr> multilinear_challenge, const Polynomial& A_0, const bool& has_zk)
 {
-    const size_t num_threads = get_num_cpus_pow2();
-
     const size_t virtual_log_n = multilinear_challenge.size();
 
     constexpr size_t efficient_operations_per_thread = 64; // A guess of the number of operation for which there
@@ -150,18 +148,13 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         // size of the previous polynomial/2
         const size_t n_l = 1 << (log_n - l - 1);
 
-        // Use as many threads as it is useful so that 1 thread doesn't process 1 element, but make sure that there is
-        // at least 1
-        size_t num_used_threads = std::min(n_l / efficient_operations_per_thread, num_threads);
-        num_used_threads = num_used_threads ? num_used_threads : 1;
-
         // Opening point is the same for all
         const Fr u_l = multilinear_challenge[l];
 
         // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
         auto A_l_fold = fold_polynomials[l].data();
 
-        parallel_for(num_used_threads, [&](ThreadChunk chunk) {
+        parallel_for(n_l, efficient_operations_per_thread, [&](ThreadChunk chunk) {
             for (size_t j : chunk.range(n_l)) {
                 // fold(Aₗ)[j] = (1-uₗ)⋅even(Aₗ)[j] + uₗ⋅odd(Aₗ)[j]
                 //            = (1-uₗ)⋅Aₗ[2j]      + uₗ⋅Aₗ[2j+1]

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -128,8 +128,9 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
     BB_BENCH_NAME("Gemini::compute_fold_polynomials");
     const size_t virtual_log_n = multilinear_challenge.size();
 
-    constexpr size_t efficient_operations_per_thread = 64; // A guess of the number of operation for which there
-                                                           // would be a point in sending them to a separate thread
+    // Cost per iteration: 1 subtraction + 1 multiplication + 1 addition
+    constexpr size_t fold_iteration_cost =
+        (2 * thread_heuristics::FF_ADDITION_COST) + thread_heuristics::FF_MULTIPLICATION_COST;
 
     // Reserve and allocate space for m-1 Fold polynomials, the foldings of the full batched polynomial A₀
     std::vector<Polynomial> fold_polynomials;
@@ -156,14 +157,15 @@ std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::com
         // A_l_fold = Aₗ₊₁(X) = (1-uₗ)⋅even(Aₗ)(X) + uₗ⋅odd(Aₗ)(X)
         auto A_l_fold = fold_polynomials[l].data();
 
-        parallel_for(n_l, efficient_operations_per_thread, [&](ThreadChunk chunk) {
-            for (size_t j : chunk.range(n_l)) {
+        parallel_for_heuristic(
+            n_l,
+            [&](size_t j) {
                 // fold(Aₗ)[j] = (1-uₗ)⋅even(Aₗ)[j] + uₗ⋅odd(Aₗ)[j]
                 //            = (1-uₗ)⋅Aₗ[2j]      + uₗ⋅Aₗ[2j+1]
                 //            = Aₗ₊₁[j]
                 A_l_fold[j] = A_l[j << 1] + u_l * (A_l[(j << 1) + 1] - A_l[j << 1]);
-            }
-        });
+            },
+            fold_iteration_cost);
         // set Aₗ₊₁ = Aₗ for the next iteration
         A_l = A_l_fold;
     }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -5,6 +5,7 @@
 // =====================
 
 #pragma once
+#include "barretenberg/common/bb_bench.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "gemini.hpp"
 
@@ -124,6 +125,7 @@ template <typename Curve>
 std::vector<typename GeminiProver_<Curve>::Polynomial> GeminiProver_<Curve>::compute_fold_polynomials(
     const size_t log_n, std::span<const Fr> multilinear_challenge, const Polynomial& A_0, const bool& has_zk)
 {
+    BB_BENCH_NAME("Gemini::compute_fold_polynomials");
     const size_t virtual_log_n = multilinear_challenge.size();
 
     constexpr size_t efficient_operations_per_thread = 64; // A guess of the number of operation for which there

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -200,15 +200,4 @@ void parallel_for(size_t num_threads, const Func& func)
     });
 }
 
-// Overload that computes optimal thread count based on work size and minimum iterations per thread
-template <typename Func>
-    requires std::invocable<Func, ThreadChunk>
-void parallel_for(size_t work_size, size_t min_iterations_per_thread, const Func& func)
-{
-    size_t num_threads = calculate_num_threads(work_size, min_iterations_per_thread);
-    parallel_for(num_threads, [&](size_t thread_index) {
-        func(ThreadChunk{ .thread_index = thread_index, .total_threads = num_threads });
-    });
-}
-
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/common/thread.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/thread.hpp
@@ -200,4 +200,15 @@ void parallel_for(size_t num_threads, const Func& func)
     });
 }
 
+// Overload that computes optimal thread count based on work size and minimum iterations per thread
+template <typename Func>
+    requires std::invocable<Func, ThreadChunk>
+void parallel_for(size_t work_size, size_t min_iterations_per_thread, const Func& func)
+{
+    size_t num_threads = calculate_num_threads(work_size, min_iterations_per_thread);
+    parallel_for(num_threads, [&](size_t thread_index) {
+        func(ThreadChunk{ .thread_index = thread_index, .total_threads = num_threads });
+    });
+}
+
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/numeric/bitop/get_msb.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/bitop/get_msb.hpp
@@ -49,6 +49,27 @@ template <typename T> constexpr inline T get_msb(const T in)
     return (sizeof(T) <= 4) ? get_msb32(in) : get_msb64(in);
 }
 
+constexpr inline uint32_t get_lsb32(const uint32_t in)
+{
+    if (in == 0) {
+        return 0;
+    }
+    return static_cast<uint32_t>(__builtin_ctz(in));
+}
+
+constexpr inline uint64_t get_lsb64(const uint64_t in)
+{
+    if (in == 0) {
+        return 0;
+    }
+    return static_cast<uint64_t>(__builtin_ctzll(in));
+}
+
+template <typename T> constexpr inline T get_lsb(const T in)
+{
+    return (sizeof(T) <= 4) ? get_lsb32(in) : get_lsb64(in);
+}
+
 template <typename T> constexpr inline T round_up_power_2(const T in)
 {
     auto lower_bound = T(1) << get_msb(in);

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -176,44 +176,53 @@ template <typename FF> struct GateSeparatorPolynomial {
         // only if the jth bit of i is 1 (j starting with 0 for the least significant bit). For instance, i = 13 = 1101
         // in binary, so the product is betas[0] * betas[2] * betas[3].
         //
-        // Key insight: beta_products[i] = beta_products[i with LSB cleared] * betas[position of LSB]
-        // So if the predecessor (i with LSB cleared) is in our thread's range, we just multiply by one beta.
-        // Otherwise, we compute directly by iterating over only the set bits using ctz (O(popcount) multiplications).
+        // Key insight: beta_products[i] = beta_products[predecessor] * betas[lsb_position], where predecessor is i
+        // with the least significant bit cleared. For example:
+        //   - i = 6 (binary 110): LSB is at position 1, predecessor = 4 (binary 100)
+        //     beta_products[6] = beta_products[4] * betas[1]
+        //   - i = 12 (binary 1100): LSB is at position 2, predecessor = 8 (binary 1000)
+        //     beta_products[12] = beta_products[8] * betas[2]
+        //
+        // For each index i, if the predecessor falls within our thread's range [start, start + chunk_size), we use
+        // this O(1) recurrence. Otherwise, we compute directly by iterating over all set bits in i, which requires
+        // O(popcount(i)) multiplications. This direct computation handles boundary cases between thread chunks.
+        //
+        // This algorithm works with any number of threads (not just powers of 2), unlike the previous prefix/suffix
+        // approach which required power-of-2 thread counts to ensure even work distribution.
 
-        constexpr size_t MIN_ITERATIONS_PER_THREAD = 1 << 6;
-        parallel_for(pow_size, MIN_ITERATIONS_PER_THREAD, [&](ThreadChunk chunk) {
-            auto range = chunk.range(pow_size);
-            if (range.empty()) {
-                return;
-            }
-            size_t start = *range.begin();
-
-            for (size_t i : range) {
-                if (i == 0) {
-                    beta_products.at(0) = scaling_factor;
-                    continue;
-                }
-
-                // Find the lowest set bit position and the predecessor index
-                size_t lsb_pos = numeric::get_lsb(i);
-                size_t predecessor = i ^ (static_cast<size_t>(1) << lsb_pos); // clear the lowest set bit
-
-                if (predecessor >= start) {
-                    // Predecessor is in our range, O(1) computation
-                    beta_products.at(i) = beta_products.at(predecessor) * betas[lsb_pos];
-                } else {
-                    // Predecessor is not in our range, compute directly from set bits only
-                    FF result = scaling_factor;
-                    size_t remaining = i;
-                    while (remaining != 0) {
-                        size_t bit = numeric::get_lsb(remaining);
-                        result *= betas[bit];
-                        remaining ^= static_cast<size_t>(1) << bit; // clear this bit
+        // Cost per iteration: typically 1 multiplication (when predecessor is in range),
+        // occasionally O(popcount) multiplications at chunk boundaries
+        constexpr size_t iteration_cost = thread_heuristics::FF_MULTIPLICATION_COST;
+        parallel_for_heuristic(
+            pow_size,
+            [&](size_t start, size_t end, BB_UNUSED size_t chunk_index) {
+                for (size_t i = start; i < end; i++) {
+                    if (i == 0) {
+                        beta_products.at(0) = scaling_factor;
+                        continue;
                     }
-                    beta_products.at(i) = result;
+
+                    // Find the lowest set bit position and the predecessor index
+                    size_t lsb_pos = numeric::get_lsb(i);
+                    size_t predecessor = i ^ (static_cast<size_t>(1) << lsb_pos); // clear the lowest set bit
+
+                    if (predecessor >= start) {
+                        // Predecessor is in our range, O(1) computation
+                        beta_products.at(i) = beta_products.at(predecessor) * betas[lsb_pos];
+                    } else {
+                        // Predecessor is not in our range, compute directly from set bits only
+                        FF result = scaling_factor;
+                        size_t remaining = i;
+                        while (remaining != 0) {
+                            size_t bit = numeric::get_lsb(remaining);
+                            result *= betas[bit];
+                            remaining ^= static_cast<size_t>(1) << bit; // clear this bit
+                        }
+                        beta_products.at(i) = result;
+                    }
                 }
-            }
-        });
+            },
+            iteration_cost);
 
         return beta_products;
     }

--- a/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/gate_separator.hpp
@@ -171,71 +171,46 @@ template <typename FF> struct GateSeparatorPolynomial {
         size_t pow_size = 1 << log_num_monomials;
         Polynomial<FF> beta_products(pow_size, Polynomial<FF>::DontZeroMemory::FLAG);
 
-        // Determine number of threads for multithreading.
-        // Note: Multithreading is "on" for every round but we reduce the number of threads from the max available based
-        // on a specified minimum number of iterations per thread. This eventually leads to the use of a single thread.
-        // For now we use a power of 2 number of threads simply to ensure the round size is evenly divided.
-        size_t max_num_threads = get_num_cpus_pow2(); // number of available threads (power of 2)
-        size_t min_iterations_per_thread = 1 << 6; // min number of iterations for which we'll spin up a unique thread
-        size_t desired_num_threads = pow_size / min_iterations_per_thread;
-        size_t num_threads = std::min(desired_num_threads, max_num_threads); // fewer than max if justified
-        num_threads = num_threads > 0 ? num_threads : 1;                     // ensure num threads is >= 1
-        size_t iterations_per_thread = pow_size / num_threads;               // actual iterations per thread
-        const size_t num_betas_per_thread = numeric::get_msb(iterations_per_thread);
-
         // Explanations of the algorithm:
         // The product of the betas at index i (beta_products[i]) contains the multiplicative factor betas[j] if and
         // only if the jth bit of i is 1 (j starting with 0 for the least significant bit). For instance, i = 13 = 1101
-        // in binary, so the product is betas[0] * betas[2] * betas[3]. Observe that if we toggle the kth bit of i (0 to
-        // 1), i.e., we add 2^k to i, then the product is multiplied by betas[k]: beta_products[i + 2^k] =
-        // beta_products[i] * betas[k]. If we know the products for the interval of indices [0, 2^k), we can compute all
-        // the products for the interval of indices [2^k, 2^(k+1)) by multiplying each element by betas[k]. Iteratively,
-        // starting with beta_products[0] = 1, we can double the number of computed products at each iteration by
-        // multiplying the previous products by betas[k]. We first multiply beta_products[0] = 1 by betas[0], then we
-        // multiply beta_products[0] and beta_products[1] by betas[1], etc...
+        // in binary, so the product is betas[0] * betas[2] * betas[3].
         //
-        // We distribute the computation of the beta_products evenly across threads, i.e., thread number
-        // thread_idx will handle the interval of indices [thread_idx * iterations_per_thread, (thread_idx + 1) *
-        // iterations_per_thread). Note that for a given thread, all the processed indices have the same
-        // prefix in binary. Therefore, each beta_product of the thread is a multiple of this "prefix product". The
-        // successive products are then populated by the above algorithm whereby we double the interval at each
-        // iteration and multiply by the new beta to process the suffix bits. The difference is that we initialize the
-        // first product with this "prefix product" instead of 1.
+        // Key insight: beta_products[i] = beta_products[i with LSB cleared] * betas[position of LSB]
+        // So if the predecessor (i with LSB cleared) is in our thread's range, we just multiply by one beta.
+        // Otherwise, we compute directly by iterating over only the set bits using ctz (O(popcount) multiplications).
 
-        // Compute the prefix products for each thread
-        std::vector<FF> thread_prefix_beta_products(num_threads);
-        thread_prefix_beta_products.at(0) = scaling_factor;
-
-        // Same algorithm applies for the prefix products. The difference is that we start at a beta which is not the
-        // first one (index 0), but the one at index num_betas_per_thread. We process the high bits only.
-        // Example: If num_betas_per_thread = 3, we compute after the first iteration:
-        //          (1, beta_3)
-        // 2nd iteration: (1, beta_3, beta_4, beta_3 * beta_4)
-        // 3nd iteration: (1, beta_3, beta_4, beta_3 * beta_4, beta_5, beta_3 * beta_5, beta_4 * beta_5, beta_3 * beta_4
-        // * beta_5)
-        // etc ....
-        for (size_t beta_idx = num_betas_per_thread, window_size = 1; beta_idx < log_num_monomials;
-             beta_idx++, window_size <<= 1) {
-            const auto& beta = betas.at(beta_idx);
-            for (size_t j = 0; j < window_size; j++) {
-                thread_prefix_beta_products.at(window_size + j) = beta * thread_prefix_beta_products.at(j);
+        constexpr size_t MIN_ITERATIONS_PER_THREAD = 1 << 6;
+        parallel_for(pow_size, MIN_ITERATIONS_PER_THREAD, [&](ThreadChunk chunk) {
+            auto range = chunk.range(pow_size);
+            if (range.empty()) {
+                return;
             }
-        }
+            size_t start = *range.begin();
 
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            size_t start = thread_idx * iterations_per_thread;
-            beta_products.at(start) = thread_prefix_beta_products.at(thread_idx);
+            for (size_t i : range) {
+                if (i == 0) {
+                    beta_products.at(0) = scaling_factor;
+                    continue;
+                }
 
-            // Compute the suffix products for each thread
-            // Example: Assume we start with the prefix product = beta_3 * beta_5
-            // After the first iteration, we get: (beta_3 * beta_5, beta_0 * beta_3 * beta_5)
-            // 2nd iteration: (beta_3 * beta_5, beta_0 * beta_3 * beta_5, beta_1 * beta_3 * beta_5, beta_0 * beta_1 *
-            // beta_3 * beta_5)
-            // etc ...
-            for (size_t beta_idx = 0, window_size = 1; beta_idx < num_betas_per_thread; beta_idx++, window_size <<= 1) {
-                const auto& beta = betas.at(beta_idx);
-                for (size_t j = 0; j < window_size; j++) {
-                    beta_products.at(start + window_size + j) = beta * beta_products.at(start + j);
+                // Find the lowest set bit position and the predecessor index
+                size_t lsb_pos = numeric::get_lsb(i);
+                size_t predecessor = i ^ (static_cast<size_t>(1) << lsb_pos); // clear the lowest set bit
+
+                if (predecessor >= start) {
+                    // Predecessor is in our range, O(1) computation
+                    beta_products.at(i) = beta_products.at(predecessor) * betas[lsb_pos];
+                } else {
+                    // Predecessor is not in our range, compute directly from set bits only
+                    FF result = scaling_factor;
+                    size_t remaining = i;
+                    while (remaining != 0) {
+                        size_t bit = numeric::get_lsb(remaining);
+                        result *= betas[bit];
+                        remaining ^= static_cast<size_t>(1) << bit; // clear this bit
+                    }
+                    beta_products.at(i) = result;
                 }
             }
         });


### PR DESCRIPTION
Closes AztecProtocol/barretenberg#1277

This PR removes the unnecessary power-of-2 thread count restriction from `gemini_impl.hpp` and `gate_separator.hpp` by using `parallel_for_heuristic` with explicit field operation cost estimates.

## Changes

- **gemini_impl.hpp**: Use `parallel_for_heuristic` with cost `2 * FF_ADDITION_COST + FF_MULTIPLICATION_COST` (1 sub + 1 mul + 1 add per iteration)
- **gate_separator.hpp**: Replace the prefix/suffix algorithm with an LSB-based algorithm that works with any thread count, using `parallel_for_heuristic` with cost `FF_MULTIPLICATION_COST`
- **thread.hpp**: Remove the unused `parallel_for(work_size, min_iterations_per_thread, func)` overload

## Algorithm (gate_separator)

The new LSB-based algorithm computes `beta_products[i] = beta_products[predecessor] * betas[lsb_position]` where predecessor is `i` with the least significant bit cleared. When the predecessor is in the same thread's range, this is O(1). At chunk boundaries, we fall back to direct computation using O(popcount) multiplications.

## Benchmark Results

| Metric | 16 cores (v1→v2) | 15 cores (v1→v2) |
|--------|------------------|------------------|
| **GateSeparatorPolynomial::compute_beta_products** | 4.2ms → 4.5ms (+7%) | 6.5ms → 4.7ms (-28%) |
| **Gemini::compute_fold_polynomials** | 8.1ms → 8.2ms (+1%) | 10.9ms → 7.3ms (-33%) |

- With 16 cores (power-of-2): Minimal regression (~7% for GateSeparator, ~1% for Gemini)
- With 15 cores (non-power-of-2): Significant improvement (~28-33%), as expected since the old code was forced to use only 8 threads while the new code uses all 15