### PR TITLE
feat: optional nullifier computation

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -1,6 +1,9 @@
 use crate::{
     keys::constants::{NULLIFIER_INDEX, OUTGOING_INDEX},
-    oracle::{key_validation_request::get_key_validation_request, keys::get_public_keys_and_partial_address},
+    oracle::{
+        key_validation_request::get_key_validation_request,
+        keys::{get_public_keys_and_partial_address, try_get_public_keys_and_partial_address},
+    },
 };
 use crate::protocol::{address::AztecAddress, public_keys::PublicKeys};
 
@@ -18,6 +21,7 @@ pub unconstrained fn get_ovsk_app(ovpk_m_hash: Field) -> Field {
 // Returns all public keys for a given account, applying proper constraints to the context. We read all keys at once
 // since the constraints for reading them all are actually fewer than if we read them one at a time - any read keys
 // that are not required by the caller can simply be discarded.
+// Fails if the public keys are not registered
 pub fn get_public_keys(account: AztecAddress) -> PublicKeys {
     // Safety: Public keys are constrained by showing their inclusion in the address's preimage.
     let (public_keys, partial_address) = unsafe { get_public_keys_and_partial_address(account) };
@@ -26,10 +30,14 @@ pub fn get_public_keys(account: AztecAddress) -> PublicKeys {
     public_keys
 }
 
+/// Returns all public keys for a given account, or `None` if the public keys are not registered in the PXE.
+pub unconstrained fn try_get_public_keys(account: AztecAddress) -> Option<PublicKeys> {
+    try_get_public_keys_and_partial_address(account).map(|(public_keys, _)| public_keys)
+}
+
 mod test {
     use super::get_public_keys;
 
-    use crate::protocol::traits::Serialize;
     use crate::test::helpers::test_environment::TestEnvironment;
     use std::test::OracleMock;
 
@@ -63,8 +71,9 @@ mod test {
         // partial address
         random_keys_and_partial_address[12] = 0x236703e2cb00a182e024e98e9f759231b556d25ff19f98896cebb69e9e678cc9;
 
-        let _ = OracleMock::mock("utilityGetPublicKeysAndPartialAddress").returns(random_keys_and_partial_address
-            .serialize());
+        let _ = OracleMock::mock("utilityTryGetPublicKeysAndPartialAddress").returns(Option::some(
+            random_keys_and_partial_address,
+        ));
         let _ = get_public_keys(account);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -103,16 +103,21 @@ comptime fn generate_note_hash_trait_impl(s: TypeDefinition) -> Quoted {
                 self,
                 owner: aztec::protocol::address::AztecAddress,
                 note_hash_for_nullification: Field,
-            ) -> Field {
-                let owner_npk_m = aztec::keys::getters::get_public_keys(owner).npk_m;
-                // We invoke hash as a static trait function rather than calling owner_npk_m.hash() directly
-                // in the quote to avoid "trait not in scope" compiler warnings.
-                let owner_npk_m_hash = aztec::protocol::traits::Hash::hash(owner_npk_m);
-                let secret = aztec::keys::getters::get_nhk_app(owner_npk_m_hash);
-                aztec::protocol::hash::poseidon2_hash_with_separator(
-                    [note_hash_for_nullification, secret],
-                    aztec::protocol::constants::DOM_SEP__NOTE_NULLIFIER as Field,
-                )
+            ) -> Option<Field> {
+                // Note: In the current PXE implementation, if public keys are available then the nullifier
+                // hiding key (nhk) is also available, so we don't need to handle get_nhk_app potentially
+                // failing. The Option is only needed for the try_get_public_keys call.
+                aztec::keys::getters::try_get_public_keys(owner).map(|public_keys| {
+                    let owner_npk_m = public_keys.npk_m;
+                    // We invoke hash as a static trait function rather than calling owner_npk_m.hash() directly
+                    // in the quote to avoid "trait not in scope" compiler warnings.
+                    let owner_npk_m_hash = aztec::protocol::traits::Hash::hash(owner_npk_m);
+                    let secret = aztec::keys::getters::get_nhk_app(owner_npk_m_hash);
+                    aztec::protocol::hash::poseidon2_hash_with_separator(
+                        [note_hash_for_nullification, secret],
+                        aztec::protocol::constants::DOM_SEP__NOTE_NULLIFIER as Field,
+                    )
+                })
             }
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -20,8 +20,9 @@ use crate::{
 pub struct NoteHashAndNullifier {
     /// The result of NoteHash::compute_note_hash
     pub note_hash: Field,
-    /// The result of NoteHash::compute_nullifier_unconstrained (since all of message discovery is unconstrained)
-    pub inner_nullifier: Field,
+    /// The result of NoteHash::compute_nullifier_unconstrained (since all of message discovery is unconstrained).
+    /// This is `None` if the nullifier cannot be computed (e.g., because the nullifier hiding key is not available).
+    pub inner_nullifier: Option<Field>,
 }
 
 /// A function which takes a note's packed content, address of the emitting contract, note nonce, storage slot and note

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
@@ -76,7 +76,11 @@ pub unconstrained fn attempt_note_nonce_discovery<Env>(
                 DiscoveredNoteInfo {
                     note_nonce: candidate_nonce,
                     note_hash: hashes.note_hash,
-                    inner_nullifier: hashes.inner_nullifier,
+                    // TODO: The None case will be handled in a followup PR.
+                    // https://linear.app/aztec-labs/issue/F-265/store-external-notes
+                    inner_nullifier: hashes.inner_nullifier.expect(
+                        f"Failed to compute nullifier for note type {note_type_id}",
+                    ),
                 },
             );
 
@@ -223,8 +227,9 @@ mod test {
             note_nonce,
             compute_siloed_note_hash(CONTRACT_ADDRESS, note_hash),
         );
-        let inner_nullifier =
-            note.compute_nullifier_unconstrained(OWNER, compute_note_hash_for_nullification(hinted_note));
+        let inner_nullifier = note
+            .compute_nullifier_unconstrained(OWNER, compute_note_hash_for_nullification(hinted_note))
+            .expect(f"Could not compute nullifier for note owned by {OWNER}");
 
         NoteAndData { note, note_nonce, note_hash, unique_note_hash, inner_nullifier }
     }

--- a/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
@@ -37,11 +37,14 @@ pub trait NoteHash {
     /// Like `compute_nullifier`, except this variant is unconstrained: there are no guarantees on the returned value
     /// being correct. Because of that it doesn't need to take a context (since it won't perform any kernel key
     /// validation requests).
+    ///
+    /// Returns `None` if the nullifier cannot be computed (when the relevant keys needed for nullifier computation are
+    /// not available).
     unconstrained fn compute_nullifier_unconstrained(
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field;
+    ) -> Option<Field>;
 }
 
 pub trait NoteProperties<T> {

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -4,20 +4,26 @@ use crate::protocol::{
     public_keys::{IvpkM, NpkM, OvpkM, PublicKeys, TpkM},
 };
 
-#[oracle(utilityGetPublicKeysAndPartialAddress)]
-unconstrained fn get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> [Field; 13] {}
-
 pub unconstrained fn get_public_keys_and_partial_address(address: AztecAddress) -> (PublicKeys, PartialAddress) {
-    let result = get_public_keys_and_partial_address_oracle(address);
+    try_get_public_keys_and_partial_address(address).expect(f"Public keys not registered for account {address}")
+}
 
-    let keys = PublicKeys {
-        npk_m: NpkM { inner: Point { x: result[0], y: result[1], is_infinite: result[2] != 0 } },
-        ivpk_m: IvpkM { inner: Point { x: result[3], y: result[4], is_infinite: result[5] != 0 } },
-        ovpk_m: OvpkM { inner: Point { x: result[6], y: result[7], is_infinite: result[8] != 0 } },
-        tpk_m: TpkM { inner: Point { x: result[9], y: result[10], is_infinite: result[11] != 0 } },
-    };
+#[oracle(utilityTryGetPublicKeysAndPartialAddress)]
+unconstrained fn try_get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> Option<[Field; 13]> {}
 
-    let partial_address = PartialAddress::from_field(result[12]);
+pub unconstrained fn try_get_public_keys_and_partial_address(
+    address: AztecAddress,
+) -> Option<(PublicKeys, PartialAddress)> {
+    try_get_public_keys_and_partial_address_oracle(address).map(|result: [Field; 13]| {
+        let keys = PublicKeys {
+            npk_m: NpkM { inner: Point { x: result[0], y: result[1], is_infinite: result[2] != 0 } },
+            ivpk_m: IvpkM { inner: Point { x: result[3], y: result[4], is_infinite: result[5] != 0 } },
+            ovpk_m: OvpkM { inner: Point { x: result[6], y: result[7], is_infinite: result[8] != 0 } },
+            tpk_m: TpkM { inner: Point { x: result[9], y: result[10], is_infinite: result[11] != 0 } },
+        };
 
-    (keys, partial_address)
+        let partial_address = PartialAddress::from_field(result[12]);
+
+        (keys, partial_address)
+    })
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -4,7 +4,7 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 10;
+pub global ORACLE_VERSION: Field = 11;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim/test.nr
@@ -134,7 +134,7 @@ unconstrained fn claim_two_claim_ids_different_state_vars() {
     });
 }
 
-#[test(should_fail_with = "No public key registered")]
+#[test(should_fail_with = "Public keys not registered for account")]
 unconstrained fn claim_owner_unknown_public_keys() {
     let mut env = TestEnvironment::new();
 

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_note.nr
@@ -48,12 +48,14 @@ impl NoteHash for MockNote {
         self,
         _owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
+    ) -> Option<Field> {
         // We don't use any kind of secret here since this is only a mock note and having it here would make tests more
         // cumbersome
-        poseidon2_hash_with_separator(
-            [note_hash_for_nullification],
-            DOM_SEP__NOTE_NULLIFIER as Field,
+        Option::some(
+            poseidon2_hash_with_separator(
+                [note_hash_for_nullification],
+                DOM_SEP__NOTE_NULLIFIER as Field,
+            ),
         )
     }
 }

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -1,7 +1,7 @@
 use aztec::{
     context::{PrivateContext, PublicContext},
     history::nullifier::assert_nullifier_existed_by,
-    keys::getters::{get_nhk_app, get_public_keys},
+    keys::getters::{get_nhk_app, get_public_keys, try_get_public_keys},
     macros::notes::custom_note,
     messages::logs::partial_note::compute_partial_note_private_content_log,
     note::note_interface::{NoteHash, NoteType},
@@ -75,14 +75,16 @@ impl NoteHash for UintNote {
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
-        let owner_npk_m = get_public_keys(owner).npk_m;
-        let owner_npk_m_hash = owner_npk_m.hash();
-        let secret = get_nhk_app(owner_npk_m_hash);
-        poseidon2_hash_with_separator(
-            [note_hash_for_nullification, secret],
-            DOM_SEP__NOTE_NULLIFIER,
-        )
+    ) -> Option<Field> {
+        try_get_public_keys(owner).map(|public_keys| {
+            let owner_npk_m = public_keys.npk_m;
+            let owner_npk_m_hash = owner_npk_m.hash();
+            let secret = get_nhk_app(owner_npk_m_hash);
+            poseidon2_hash_with_separator(
+                [note_hash_for_nullification, secret],
+                DOM_SEP__NOTE_NULLIFIER,
+            )
+        })
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -1,6 +1,6 @@
 use dep::aztec::{
     context::{PrivateContext, PublicContext},
-    keys::getters::{get_nhk_app, get_public_keys},
+    keys::getters::{get_nhk_app, get_public_keys, try_get_public_keys},
     macros::notes::custom_note,
     messages::logs::partial_note::compute_partial_note_private_content_log,
     note::note_interface::{NoteHash, NoteType},
@@ -76,14 +76,16 @@ impl NoteHash for NFTNote {
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
-        let owner_npk_m = get_public_keys(owner).npk_m;
-        let owner_npk_m_hash = owner_npk_m.hash();
-        let secret = get_nhk_app(owner_npk_m_hash);
-        poseidon2_hash_with_separator(
-            [note_hash_for_nullification, secret],
-            DOM_SEP__NOTE_NULLIFIER,
-        )
+    ) -> Option<Field> {
+        try_get_public_keys(owner).map(|public_keys| {
+            let owner_npk_m = public_keys.npk_m;
+            let owner_npk_m_hash = owner_npk_m.hash();
+            let secret = get_nhk_app(owner_npk_m_hash);
+            poseidon2_hash_with_separator(
+                [note_hash_for_nullification, secret],
+                DOM_SEP__NOTE_NULLIFIER,
+            )
+        })
     }
 }
 

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/transparent_note.nr
@@ -57,8 +57,10 @@ impl NoteHash for TransparentNote {
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
+    ) -> Option<Field> {
         // compute_nullifier ignores context so we can reuse it here
-        self.compute_nullifier(zeroed(), owner, note_hash_for_nullification)
+        Option::some(
+            self.compute_nullifier(zeroed(), owner, note_hash_for_nullification),
+        )
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test_note.nr
@@ -43,9 +43,9 @@ impl NoteHash for TestNote {
         _self: Self,
         _owner: AztecAddress,
         _note_hash_for_nullification: Field,
-    ) -> Field {
+    ) -> Option<Field> {
         // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
         // implementation here.
-        0
+        Option::none()
     }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -85,7 +85,7 @@ export interface IUtilityExecutionOracle {
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
   utilityGetBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined>;
-  utilityGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress>;
+  utilityTryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined>;
   utilityGetAuthWitness(messageHash: Fr): Promise<Fr[] | undefined>;
   utilityGetNotes(
     owner: AztecAddress | undefined,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -248,12 +248,19 @@ export class Oracle {
     return [witness.map(toACVMField)];
   }
 
-  async utilityGetPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<ACVMField[][]> {
+  async utilityTryGetPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAddress = AztecAddress.fromField(Fr.fromString(address));
-    const { publicKeys, partialAddress } =
-      await this.handlerAsUtility().utilityGetPublicKeysAndPartialAddress(parsedAddress);
+    const result = await this.handlerAsUtility().utilityTryGetPublicKeysAndPartialAddress(parsedAddress);
 
-    return [[...publicKeys.toFields(), partialAddress].map(toACVMField)];
+    // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
+    // with two fields: `some` (a boolean) and `value` (a field array in this case).
+    if (result === undefined) {
+      // No data was found so we set `some` to 0 and pad `value` with zeros get the correct return size.
+      return [toACVMField(0), Array(13).fill(toACVMField(0))];
+    } else {
+      // Data was found so we set `some` to 1 and return it along with `value`.
+      return [toACVMField(1), [...result.publicKeys.toFields(), result.partialAddress].map(toACVMField)];
+    }
   }
 
   async utilityGetNotes(

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -242,7 +242,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     sender: AztecAddress,
     recipient: AztecAddress,
   ) {
-    const senderCompleteAddress = await this.getCompleteAddress(sender);
+    const senderCompleteAddress = await this.getCompleteAddressOrFail(sender);
     const senderIvsk = await this.keyStore.getMasterIncomingViewingSecretKey(sender);
     return DirectionalAppTaggingSecret.compute(
       senderCompleteAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -182,14 +182,13 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   /**
    * Retrieve the complete address associated to a given address.
    * @param account - The account address.
-   * @returns A complete address associated with the input address.
-   * @throws An error if the account is not registered in the database.
+   * @returns A complete address associated with the input address, or `undefined` if not registered.
    */
-  public utilityGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress> {
-    return this.getCompleteAddress(account);
+  public utilityTryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined> {
+    return this.addressStore.getCompleteAddress(account);
   }
 
-  protected async getCompleteAddress(account: AztecAddress): Promise<CompleteAddress> {
+  protected async getCompleteAddressOrFail(account: AztecAddress): Promise<CompleteAddress> {
     const completeAddress = await this.addressStore.getCompleteAddress(account);
     if (!completeAddress) {
       throw new Error(
@@ -535,7 +534,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
   protected async getSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
     // TODO(#12656): return an app-siloed secret
-    const recipientCompleteAddress = await this.getCompleteAddress(address);
+    const recipientCompleteAddress = await this.getCompleteAddressOrFail(address);
     const ivskM = await this.keyStore.getMasterSecretKey(
       recipientCompleteAddress.publicKeys.masterIncomingViewingPublicKey,
     );

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -4,9 +4,9 @@
 ///
 /// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-export const ORACLE_VERSION = 10;
+export const ORACLE_VERSION = 11;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant in this file and in
 /// `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = 'a3b284ee5abff0509986d6d2fa78a3e6e2ec212325674de78355c5e70b05784c';
+export const ORACLE_INTERFACE_HASH = '20c4d02d8cd5e448c11001a5f72ea2e0927630aeda75e537550872a9627bf40b';

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -545,12 +545,23 @@ export class RPCTranslator {
     );
   }
 
-  async utilityGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
+  async utilityTryGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const { publicKeys, partialAddress } = await this.handlerAsUtility().utilityGetPublicKeysAndPartialAddress(address);
+    const result = await this.handlerAsUtility().utilityTryGetPublicKeysAndPartialAddress(address);
 
-    return toForeignCallResult([toArray([...publicKeys.toFields(), partialAddress])]);
+    // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
+    // with two fields: `some` (a boolean) and `value` (a field array in this case).
+    if (result === undefined) {
+      // No data was found so we set `some` to 0 and pad `value` with zeros get the correct return size.
+      return toForeignCallResult([toSingle(new Fr(0)), toArray(Array(13).fill(new Fr(0)))]);
+    } else {
+      // Data was found so we set `some` to 1 and return it along with `value`.
+      return toForeignCallResult([
+        toSingle(new Fr(1)),
+        toArray([...result.publicKeys.toFields(), result.partialAddress]),
+      ]);
+    }
   }
 
   async utilityGetKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {


### PR DESCRIPTION
Users should have the capacity to discover and read notes that do not belong to them. Right now it isn't possible, but we'll fix this in several steps. This is the first one of those changes

Summary

  - Changed `compute_nullifier_unconstrained` in the `NoteHash` trait to return `Option<Field> `instead of `Field`
  - Added `try_get_public_keys` function that returns `Option<PublicKeys>` for graceful handling when keys are unavailable
- Renamed oracle from `utilityGetPublicKeysAndPartialAddress` to `utilityTryGetPublicKeysAndPartialAddress` with Option-based return type

