### PR TITLE
fix: tx_collector_bench -  increase memory

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -238,7 +238,7 @@ function bench_cmds {
   echo "$hash BENCH_OUTPUT=bench-out/native_world_state.bench.json yarn-project/scripts/run_test.sh world-state/src/native/native_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/kv_store.bench.json yarn-project/scripts/run_test.sh kv-store/src/bench/map_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx_pool.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts"
-  echo "$hash:ISOLATE=1:CPUS=16:MEM=8g:TIMEOUT=600 BENCH_OUTPUT=bench-out/p2p_client_proposal_tx_collector.bench.json yarn-project/scripts/run_test.sh p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector.bench.test.ts"
+  echo "$hash:ISOLATE=1:CPUS=16:MEM=32g:TIMEOUT=600 BENCH_OUTPUT=bench-out/p2p_client_proposal_tx_collector.bench.json yarn-project/scripts/run_test.sh p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector.bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx.bench.json yarn-project/scripts/run_test.sh stdlib/src/tx/tx_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=10:MEM=16g:LOG_LEVEL=silent BENCH_OUTPUT=bench-out/proving_broker.bench.json yarn-project/scripts/run_test.sh prover-client/src/test/proving_broker_testbench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=16:MEM=16g BENCH_OUTPUT=bench-out/avm_bulk_test.bench.json yarn-project/scripts/run_test.sh bb-prover/src/avm_proving_tests/avm_bulk.test.ts"

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector.bench.test.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector.bench.test.ts
@@ -102,7 +102,7 @@ describe('ProposalTxCollector Benchmarks', () => {
     await workerManager.makeWorkerClients(PEERS_PER_RUN, {
       bootstrapMode: 'all',
       batchSize: 5,
-      batchDelayMs: 500,
+      batchDelayMs: 1000,
     });
     await sleep(5000);
   });

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
@@ -104,7 +104,7 @@ async function startClient(config: P2PConfig, clientIndex: number) {
   const worldState = createMockWorldStateSynchronizer();
   const l2BlockSource = new MockL2BlockSource();
   const proofVerifier = new AlwaysTrueCircuitVerifier();
-  kvStore = await openTmpStore(`proposal-bench-${clientIndex}`);
+  kvStore = await openTmpStore(`proposal-bench-${clientIndex}`, true, BENCHMARK_CONSTANTS.KV_STORE_MAP_SIZE_KB);
   logger = createLogger(`p2p:proposal-bench:${clientIndex}`);
 
   const telemetry = getTelemetryClient();

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -321,6 +321,8 @@ export const BENCHMARK_CONSTANTS = {
   FIXED_MAX_PEERS: 10,
   /** Fixed max retry attempts for fair benchmarking */
   FIXED_MAX_RETRY_ATTEMPTS: 3,
+  /** LMDB map size for temp stores used in benchmarks (in KB). */
+  KV_STORE_MAP_SIZE_KB: 256 * 1024,
 } as const;
 
 /**

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -345,7 +345,7 @@ process.on('message', async msg => {
       const l2BlockSource = new MockL2BlockSource();
 
       const proofVerifier = new AlwaysTrueCircuitVerifier();
-      kvStore = await openTmpStore(`test-${clientIndex}`);
+      kvStore = await openTmpStore(`test-${clientIndex}`, true, BENCHMARK_CONSTANTS.KV_STORE_MAP_SIZE_KB);
       workerLogger = createLogger(`p2p:${clientIndex}`);
       workerTxPool.setLogger(workerLogger);
       const telemetry = getTelemetryClient();


### PR DESCRIPTION
In a previous PR, https://github.com/AztecProtocol/aztec-packages/pull/20014, we fixed the benchmark being run as an actual benchmark instead of a test.
Unfortunatelly this [still fails on CI](http://ci.aztec-labs.com/de7eb65687fb67e4), hopefully this will fix it.