### PR TITLE
feat(telemetry-client): export Aztec client version as service.version metric

### DIFF
--- a/yarn-project/telemetry-client/src/otel_resource.ts
+++ b/yarn-project/telemetry-client/src/otel_resource.ts
@@ -7,9 +7,25 @@ import {
   osDetectorSync,
   serviceInstanceIdDetectorSync,
 } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { AZTEC_NODE_ROLE, AZTEC_REGISTRY_ADDRESS, AZTEC_ROLLUP_ADDRESS, AZTEC_ROLLUP_VERSION } from './attributes.js';
+
+/** Reads the Aztec client version from the release manifest. */
+function getAztecVersion(): string | undefined {
+  try {
+    const releasePleasePath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../.release-please-manifest.json',
+    );
+    return JSON.parse(readFileSync(releasePleasePath, 'utf-8'))['.'];
+  } catch {
+    return undefined;
+  }
+}
 
 export function getOtelResource(): IResource {
   const resource = detectResourcesSync({
@@ -42,7 +58,8 @@ const aztecNetworkDetectorSync: DetectorSync = {
     }
     const aztecAttributes = {
       // this gets overwritten by OTEL_RESOURCE_ATTRIBUTES (if set)
-      [SEMRESATTRS_SERVICE_NAME]: role ? `aztec-${role}` : undefined,
+      [ATTR_SERVICE_NAME]: role ? `aztec-${role}` : undefined,
+      [ATTR_SERVICE_VERSION]: getAztecVersion(),
       [AZTEC_NODE_ROLE]: role,
       [AZTEC_ROLLUP_VERSION]: process.env.ROLLUP_VERSION ?? 'canonical',
       [AZTEC_ROLLUP_ADDRESS]: process.env.ROLLUP_CONTRACT_ADDRESS,


### PR DESCRIPTION
Fix A-362

## Summary
- Reads the Aztec version from `.release-please-manifest.json` and exports it as the `service.version` resource attribute
- This allows tracking which release each node is running in observability dashboards
- Updates deprecated `SEMRESATTRS_SERVICE_NAME` to `ATTR_SERVICE_NAME`

## Test plan
- Unit tests pass
- Deploy and verify `service.version` appears in metrics/traces