### PR TITLE
refactor: dropping unused sibling path methods

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,26 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### [AztecNode] Removed sibling path RPC methods
+
+The following methods have been removed from the `AztecNode` interface:
+
+- `getNullifierSiblingPath`
+- `getNoteHashSiblingPath`
+- `getArchiveSiblingPath`
+- `getPublicDataSiblingPath`
+
+These methods were not used by PXE and returned a subset of the information already available through the corresponding membership witness methods:
+
+| Removed Method | Use Instead |
+|----------------|-------------|
+| `getNullifierSiblingPath` | `getNullifierMembershipWitness` |
+| `getNoteHashSiblingPath` | `getNoteHashMembershipWitness` |
+| `getArchiveSiblingPath` | `getArchiveMembershipWitness` |
+| `getPublicDataSiblingPath` | `getPublicDataWitness` |
+
+The membership witness methods return both the sibling path and additional context (leaf index, preimage data) needed for proofs.
+
 ### [Aztec.nr] `protocol_types` renamed to `protocol`
 
 The `protocol_types` re-export from the `aztec` crate has been renamed to `protocol`. Update all imports accordingly:

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1,13 +1,7 @@
 import { Archiver, createArchiver } from '@aztec/archiver';
 import { BBCircuitVerifier, QueuedIVCVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
 import { type BlobClientInterface, createBlobClientWithFileStores } from '@aztec/blob-client/client';
-import {
-  ARCHIVE_HEIGHT,
-  type L1_TO_L2_MSG_TREE_HEIGHT,
-  type NOTE_HASH_TREE_HEIGHT,
-  type NULLIFIER_TREE_HEIGHT,
-  type PUBLIC_DATA_TREE_HEIGHT,
-} from '@aztec/constants';
+import { ARCHIVE_HEIGHT, type L1_TO_L2_MSG_TREE_HEIGHT, type NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import { EpochCache, type EpochCacheInterface } from '@aztec/epoch-cache';
 import { createEthereumChain } from '@aztec/ethereum/chain';
 import { getPublicClient } from '@aztec/ethereum/client';
@@ -919,22 +913,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     });
   }
 
-  public async getNullifierSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState(block);
-    return committedDb.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, leafIndex);
-  }
-
-  public async getNoteHashSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState(block);
-    return committedDb.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
-  }
-
   public async getArchiveMembershipWitness(
     block: BlockParameter,
     archive: Fr,
@@ -1015,22 +993,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return blocksInCheckpoints.map(blocks =>
       blocks.map(block => block.body.txEffects.map(txEffect => txEffect.l2ToL1Msgs)),
     );
-  }
-
-  public async getArchiveSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof ARCHIVE_HEIGHT>> {
-    const committedDb = await this.#getWorldState(block);
-    return committedDb.getSiblingPath(MerkleTreeId.ARCHIVE, leafIndex);
-  }
-
-  public async getPublicDataSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>> {
-    const committedDb = await this.#getWorldState(block);
-    return committedDb.getSiblingPath(MerkleTreeId.PUBLIC_DATA_TREE, leafIndex);
   }
 
   public async getNullifierMembershipWitness(

--- a/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
+++ b/yarn-project/end-to-end/src/bench/node_rpc_perf.test.ts
@@ -358,34 +358,6 @@ describe('e2e_node_rpc_perf', () => {
       expect(stats.avg).toBeLessThan(2000);
     });
 
-    it('benchmarks getNullifierSiblingPath', async () => {
-      const { stats } = await benchmark('getNullifierSiblingPath', () =>
-        aztecNode.getNullifierSiblingPath('latest', 0n),
-      );
-      addResult('getNullifierSiblingPath', stats);
-      expect(stats.avg).toBeLessThan(2000);
-    });
-
-    it('benchmarks getNoteHashSiblingPath', async () => {
-      const { stats } = await benchmark('getNoteHashSiblingPath', () => aztecNode.getNoteHashSiblingPath('latest', 0n));
-      addResult('getNoteHashSiblingPath', stats);
-      expect(stats.avg).toBeLessThan(2000);
-    });
-
-    it('benchmarks getArchiveSiblingPath', async () => {
-      const { stats } = await benchmark('getArchiveSiblingPath', () => aztecNode.getArchiveSiblingPath('latest', 0n));
-      addResult('getArchiveSiblingPath', stats);
-      expect(stats.avg).toBeLessThan(2000);
-    });
-
-    it('benchmarks getPublicDataSiblingPath', async () => {
-      const { stats } = await benchmark('getPublicDataSiblingPath', () =>
-        aztecNode.getPublicDataSiblingPath('latest', 0n),
-      );
-      addResult('getPublicDataSiblingPath', stats);
-      expect(stats.avg).toBeLessThan(2000);
-    });
-
     it('benchmarks getNullifierMembershipWitness', async () => {
       const nullifier = Fr.random();
       const { stats } = await benchmark('getNullifierMembershipWitness', () =>

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -1,10 +1,4 @@
-import {
-  ARCHIVE_HEIGHT,
-  L1_TO_L2_MSG_TREE_HEIGHT,
-  NOTE_HASH_TREE_HEIGHT,
-  NULLIFIER_TREE_HEIGHT,
-  PUBLIC_DATA_TREE_HEIGHT,
-} from '@aztec/constants';
+import { ARCHIVE_HEIGHT, L1_TO_L2_MSG_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
 import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
@@ -116,16 +110,6 @@ describe('AztecNodeApiSchema', () => {
     ).rejects.toThrow();
   });
 
-  it('getNullifierSiblingPath', async () => {
-    const response = await context.client.getNullifierSiblingPath(BlockNumber(1), 1n);
-    expect(response).toBeInstanceOf(SiblingPath);
-  });
-
-  it('getNoteHashSiblingPath', async () => {
-    const response = await context.client.getNoteHashSiblingPath(BlockNumber(1), 1n);
-    expect(response).toBeInstanceOf(SiblingPath);
-  });
-
   it('getL1ToL2MessageMembershipWitness', async () => {
     const response = await context.client.getL1ToL2MessageMembershipWitness(BlockNumber(1), Fr.random());
     expect(response).toEqual([1n, expect.any(SiblingPath)]);
@@ -148,16 +132,6 @@ describe('AztecNodeApiSchema', () => {
     expect(response[0][0].length).toBe(2);
     expect(response[0][0][0].length).toBe(3);
     expect(response[0][0][0][0]).toBeInstanceOf(Fr);
-  });
-
-  it('getArchiveSiblingPath', async () => {
-    const response = await context.client.getArchiveSiblingPath(BlockNumber(1), 1n);
-    expect(response).toBeInstanceOf(SiblingPath);
-  });
-
-  it('getPublicDataSiblingPath', async () => {
-    const response = await context.client.getPublicDataSiblingPath(BlockNumber(1), 1n);
-    expect(response).toBeInstanceOf(SiblingPath);
   });
 
   it('getArchiveMembershipWitness', async () => {
@@ -572,19 +546,6 @@ class MockAztecNode implements AztecNode {
       undefined,
     ]);
   }
-  getNullifierSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>> {
-    expect(block === 'latest' || block instanceof Fr || typeof block === 'number').toBe(true);
-    expect(leafIndex).toBe(1n);
-    return Promise.resolve(SiblingPath.random(NULLIFIER_TREE_HEIGHT));
-  }
-  getNoteHashSiblingPath(block: BlockParameter, leafIndex: bigint): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>> {
-    expect(block === 'latest' || block instanceof Fr || typeof block === 'number').toBe(true);
-    expect(leafIndex).toBe(1n);
-    return Promise.resolve(SiblingPath.random(NOTE_HASH_TREE_HEIGHT));
-  }
   getL1ToL2MessageMembershipWitness(
     block: BlockParameter,
     l1ToL2Message: Fr,
@@ -627,19 +588,6 @@ class MockAztecNode implements AztecNode {
         ),
       ),
     );
-  }
-  getArchiveSiblingPath(block: BlockParameter, leafIndex: bigint): Promise<SiblingPath<typeof ARCHIVE_HEIGHT>> {
-    expect(block === 'latest' || block instanceof Fr || typeof block === 'number').toBe(true);
-    expect(leafIndex).toBe(1n);
-    return Promise.resolve(SiblingPath.random(ARCHIVE_HEIGHT));
-  }
-  getPublicDataSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>> {
-    expect(block === 'latest' || block instanceof Fr || typeof block === 'number').toBe(true);
-    expect(leafIndex).toBe(1n);
-    return Promise.resolve(SiblingPath.random(PUBLIC_DATA_TREE_HEIGHT));
   }
   getNullifierMembershipWitness(block: BlockParameter, nullifier: Fr): Promise<NullifierMembershipWitness | undefined> {
     expect(block === 'latest' || block instanceof Fr || typeof block === 'number').toBe(true);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -1,10 +1,4 @@
-import {
-  ARCHIVE_HEIGHT,
-  L1_TO_L2_MSG_TREE_HEIGHT,
-  NOTE_HASH_TREE_HEIGHT,
-  NULLIFIER_TREE_HEIGHT,
-  PUBLIC_DATA_TREE_HEIGHT,
-} from '@aztec/constants';
+import { ARCHIVE_HEIGHT, L1_TO_L2_MSG_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
 import {
   BlockNumber,
@@ -103,41 +97,6 @@ export interface AztecNode
     treeId: MerkleTreeId,
     leafValues: Fr[],
   ): Promise<(DataInBlock<bigint> | undefined)[]>;
-
-  /**
-   * Returns a sibling path for the given index in the nullifier tree.
-   * @param block - The block parameter (block number, block hash, or 'latest') at which to get the data.
-   * @param leafIndex - The index of the leaf for which the sibling path is required.
-   * @returns The sibling path for the leaf index.
-   */
-  getNullifierSiblingPath(block: BlockParameter, leafIndex: bigint): Promise<SiblingPath<typeof NULLIFIER_TREE_HEIGHT>>;
-
-  /**
-   * Returns a sibling path for the given index in the note hash tree.
-   * @param block - The block parameter (block number, block hash, or 'latest') at which to get the data.
-   * @param leafIndex - The index of the leaf for which the sibling path is required.
-   * @returns The sibling path for the leaf index.
-   */
-  getNoteHashSiblingPath(block: BlockParameter, leafIndex: bigint): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>>;
-
-  /**
-   * Returns a sibling path for a leaf in the committed historic blocks tree.
-   * @param block - The block parameter (block number, block hash, or 'latest') at which to get the data.
-   * @param leafIndex - Index of the leaf in the tree.
-   * @returns The sibling path.
-   */
-  getArchiveSiblingPath(block: BlockParameter, leafIndex: bigint): Promise<SiblingPath<typeof ARCHIVE_HEIGHT>>;
-
-  /**
-   * Returns a sibling path for a leaf in the committed public data tree.
-   * @param block - The block parameter (block number, block hash, or 'latest') at which to get the data.
-   * @param leafIndex - Index of the leaf in the tree.
-   * @returns The sibling path.
-   */
-  getPublicDataSiblingPath(
-    block: BlockParameter,
-    leafIndex: bigint,
-  ): Promise<SiblingPath<typeof PUBLIC_DATA_TREE_HEIGHT>>;
 
   /**
    * Returns a nullifier membership witness for a given nullifier at a given block.
@@ -517,26 +476,6 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     .function()
     .args(BlockParameterSchema, z.nativeEnum(MerkleTreeId), z.array(schemas.Fr).max(MAX_RPC_LEN))
     .returns(z.array(optional(dataInBlockSchemaFor(schemas.BigInt)))),
-
-  getNullifierSiblingPath: z
-    .function()
-    .args(BlockParameterSchema, schemas.BigInt)
-    .returns(SiblingPath.schemaFor(NULLIFIER_TREE_HEIGHT)),
-
-  getNoteHashSiblingPath: z
-    .function()
-    .args(BlockParameterSchema, schemas.BigInt)
-    .returns(SiblingPath.schemaFor(NOTE_HASH_TREE_HEIGHT)),
-
-  getArchiveSiblingPath: z
-    .function()
-    .args(BlockParameterSchema, schemas.BigInt)
-    .returns(SiblingPath.schemaFor(ARCHIVE_HEIGHT)),
-
-  getPublicDataSiblingPath: z
-    .function()
-    .args(BlockParameterSchema, schemas.BigInt)
-    .returns(SiblingPath.schemaFor(PUBLIC_DATA_TREE_HEIGHT)),
 
   getNullifierMembershipWitness: z
     .function()


### PR DESCRIPTION
The following methods have been removed from the `AztecNode` interface:

- `getNullifierSiblingPath`
- `getNoteHashSiblingPath`
- `getArchiveSiblingPath`
- `getPublicDataSiblingPath`

These methods were not used by PXE and returned a subset of the information already available through the corresponding membership witness methods. Hence doesn't make sense to keep them around.

This has been agreed upon with the alpha team [here](https://aztecprotocol.slack.com/archives/C04BTJAA694/p1769624408890879).