### PR TITLE
fix: using ABIs for error handling & update L1 TX gas limits

### DIFF
--- a/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
@@ -6,7 +6,6 @@ import { EmpireSlashingProposerAbi } from '@aztec/l1-artifacts/EmpireSlashingPro
 
 import EventEmitter from 'events';
 import {
-  type EncodeFunctionDataParameters,
   type GetContractReturnType,
   type Hex,
   type Log,
@@ -100,6 +99,7 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
   public createSignalRequest(payload: Hex): L1TxRequest {
     return {
       to: this.address.toString(),
+      abi: EmpireSlashingProposerAbi,
       data: encodeSignal(payload),
     };
   }
@@ -121,6 +121,7 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
     );
     return {
       to: this.address.toString(),
+      abi: EmpireSlashingProposerAbi,
       data: encodeSignalWithSignature(payload, signature),
     };
   }
@@ -180,6 +181,7 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
   public buildExecuteRoundRequest(round: bigint): L1TxRequest {
     return {
       to: this.address.toString(),
+      abi: EmpireSlashingProposerAbi,
       data: encodeFunctionData({
         abi: EmpireSlashingProposerAbi,
         functionName: 'submitRoundWinner',
@@ -222,24 +224,13 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
     if (typeof round === 'number') {
       round = BigInt(round);
     }
-    const args: EncodeFunctionDataParameters<typeof EmpireSlashingProposerAbi, 'submitRoundWinner'> = {
-      abi: EmpireSlashingProposerAbi,
-      functionName: 'submitRoundWinner',
-      args: [round],
-    };
-    const data = encodeFunctionData(args);
+    const request = this.buildExecuteRoundRequest(round);
     const response = await txUtils
-      .sendAndMonitorTransaction(
-        {
-          to: this.address.toString(),
-          data,
-        },
-        {
-          // Gas estimation is way off for this, likely because we are creating the contract/selector to call
-          // for the actual slashing dynamically.
-          gasLimitBufferPercentage: 50, // +50% gas
-        },
-      )
+      .sendAndMonitorTransaction(request, {
+        // Gas estimation is way off for this, likely because we are creating the contract/selector to call
+        // for the actual slashing dynamically.
+        gasLimitBufferPercentage: 50, // +50% gas
+      })
       .catch(err => {
         if (err instanceof FormattedViemError && err.message.includes('ProposalAlreadyExecuted')) {
           throw new ProposalAlreadyExecutedError(round);
@@ -248,15 +239,13 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
       });
 
     if (response.receipt.status === 'reverted') {
-      const error = await txUtils.tryGetErrorFromRevertedTx(
-        data,
-        {
-          ...args,
-          address: this.address.toString(),
-        },
-        undefined,
-        [],
-      );
+      const args = {
+        abi: EmpireSlashingProposerAbi,
+        functionName: 'submitRoundWinner' as const,
+        args: [round] as const,
+        address: this.address.toString(),
+      };
+      const error = await txUtils.tryGetErrorFromRevertedTx(request.data!, args, undefined, []);
       if (error?.includes('ProposalAlreadyExecuted')) {
         throw new ProposalAlreadyExecutedError(round);
       }

--- a/yarn-project/ethereum/src/contracts/fee_asset_handler.ts
+++ b/yarn-project/ethereum/src/contracts/fee_asset_handler.ts
@@ -43,6 +43,7 @@ export class FeeAssetHandlerContract {
     }
     return txUtils.sendAndMonitorTransaction({
       to: this.address.toString(),
+      abi: FeeAssetHandlerAbi,
       data: encodeFunctionData({
         abi: FeeAssetHandlerAbi,
         functionName: 'mint',
@@ -54,6 +55,7 @@ export class FeeAssetHandlerContract {
   public setMintAmount(txUtils: L1TxUtils, amount: bigint) {
     return txUtils.sendAndMonitorTransaction({
       to: this.address.toString(),
+      abi: FeeAssetHandlerAbi,
       data: encodeFunctionData({
         abi: FeeAssetHandlerAbi,
         functionName: 'setMintAmount',

--- a/yarn-project/ethereum/src/contracts/governance.ts
+++ b/yarn-project/ethereum/src/contracts/governance.ts
@@ -211,6 +211,7 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
 
         const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
           to: this.governanceContract.address,
+          abi: GovernanceAbi,
           data: encodedVoteData,
         });
 
@@ -265,6 +266,7 @@ export class GovernanceContract extends ReadOnlyGovernanceContract {
 
         const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
           to: this.governanceContract.address,
+          abi: GovernanceAbi,
           data: encodedExecuteData,
         });
 

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -83,6 +83,7 @@ export class GovernanceProposerContract implements IEmpireBase {
   public createSignalRequest(payload: Hex): L1TxRequest {
     return {
       to: this.address.toString(),
+      abi: GovernanceProposerAbi,
       data: encodeSignal(payload),
     };
   }
@@ -104,6 +105,7 @@ export class GovernanceProposerContract implements IEmpireBase {
     );
     return {
       to: this.address.toString(),
+      abi: GovernanceProposerAbi,
       data: encodeSignalWithSignature(payload, signature),
     };
   }
@@ -117,8 +119,9 @@ export class GovernanceProposerContract implements IEmpireBase {
   }> {
     const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
       to: this.address.toString(),
+      abi: GovernanceProposerAbi,
       data: encodeFunctionData({
-        abi: this.proposer.abi,
+        abi: GovernanceProposerAbi,
         functionName: 'submitRoundWinner',
         args: [round],
       }),

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -34,10 +34,13 @@ export class Multicall3 {
     };
 
     const encodedForwarderData = encodeFunctionData(forwarderFunctionData);
-
     try {
       const { receipt, state } = await l1TxUtils.sendAndMonitorTransaction(
-        { to: MULTI_CALL_3_ADDRESS, data: encodedForwarderData },
+        {
+          to: MULTI_CALL_3_ADDRESS,
+          data: encodedForwarderData,
+          abi: multicall3Abi,
+        },
         gasConfig,
         blobConfig,
       );

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -805,6 +805,7 @@ export class RollupContract {
   ): L1TxRequest {
     return {
       to: this.address,
+      abi: RollupAbi,
       data: encodeFunctionData({
         abi: RollupAbi,
         functionName: 'invalidateBadAttestation',
@@ -826,6 +827,7 @@ export class RollupContract {
   ): L1TxRequest {
     return {
       to: this.address,
+      abi: RollupAbi,
       data: encodeFunctionData({
         abi: RollupAbi,
         functionName: 'invalidateInsufficientAttestations',
@@ -959,6 +961,7 @@ export class RollupContract {
   setupEpoch(l1TxUtils: L1TxUtils) {
     return l1TxUtils.sendAndMonitorTransaction({
       to: this.address,
+      abi: RollupAbi,
       data: encodeFunctionData({
         abi: RollupAbi,
         functionName: 'setupEpoch',
@@ -970,6 +973,7 @@ export class RollupContract {
   vote(l1TxUtils: L1TxUtils, proposalId: bigint) {
     return l1TxUtils.sendAndMonitorTransaction({
       to: this.address,
+      abi: RollupAbi,
       data: encodeFunctionData({
         abi: RollupAbi,
         functionName: 'vote',

--- a/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/tally_slashing_proposer.ts
@@ -1,11 +1,12 @@
 import type { L1TxRequest } from '@aztec/ethereum/l1-tx-utils';
 import type { ViemClient } from '@aztec/ethereum/types';
-import { tryExtractEvent } from '@aztec/ethereum/utils';
+import { mergeAbis, tryExtractEvent } from '@aztec/ethereum/utils';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { hexToBuffer } from '@aztec/foundation/string';
+import { SlasherAbi } from '@aztec/l1-artifacts/SlasherAbi';
 import { TallySlashingProposerAbi } from '@aztec/l1-artifacts/TallySlashingProposerAbi';
 
 import {
@@ -160,6 +161,7 @@ export class TallySlashingProposerContract {
 
     return {
       to: this.contract.address,
+      abi: TallySlashingProposerAbi,
       data: encodeFunctionData({
         abi: TallySlashingProposerAbi,
         functionName: 'vote',
@@ -207,6 +209,7 @@ export class TallySlashingProposerContract {
   public buildVoteRequestWithSignature(votes: Hex, signature: { v: number; r: Hex; s: Hex }): L1TxRequest {
     return {
       to: this.contract.address,
+      abi: TallySlashingProposerAbi,
       data: encodeFunctionData({
         abi: TallySlashingProposerAbi,
         functionName: 'vote',
@@ -224,6 +227,7 @@ export class TallySlashingProposerContract {
   public buildExecuteRoundRequest(round: bigint, committees: EthAddress[][]): L1TxRequest {
     return {
       to: this.contract.address,
+      abi: mergeAbis([TallySlashingProposerAbi, SlasherAbi]),
       data: encodeFunctionData({
         abi: TallySlashingProposerAbi,
         functionName: 'executeRound',

--- a/yarn-project/ethereum/src/l1_tx_utils/constants.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/constants.ts
@@ -3,8 +3,8 @@
 // 1_000_000_000_000_000_000 Wei = 1 ETH
 export const WEI_CONST = 1_000_000_000n;
 
-// @note using this large gas limit to avoid the issue of `gas limit too low` when estimating gas in reth
-export const LARGE_GAS_LIMIT = 12_000_000n;
+// EIP-7825: protocol-level cap on tx gas limit (2^24). Clients reject above this.
+export const MAX_L1_TX_LIMIT = 16_777_216n;
 
 // setting a minimum bump percentage to 10% due to geth's implementation
 // https://github.com/ethereum/go-ethereum/blob/e3d61e6db028c412f74bc4d4c7e117a9e29d0de0/core/txpool/legacypool/list.go#L298

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -37,6 +37,7 @@ import {
   type L1TxRequest,
   type L1TxState,
   type L1TxUtilsConfig,
+  MAX_L1_TX_LIMIT,
   ReadOnlyL1TxUtils,
   TxUtilsState,
   UnknownMinedTxError,
@@ -1416,7 +1417,7 @@ describe('L1TxUtils', () => {
       expect(newState.receipt!.status).toBe('success');
     }, 10_000);
 
-    it('ensures block gas limit is set when using LARGE_GAS_LIMIT', async () => {
+    it('ensures block gas limit is set when using MAX_L1_TX_LIMIT', async () => {
       let capturedBlockOverrides: any = {};
       const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
 
@@ -1430,7 +1431,7 @@ describe('L1TxUtils', () => {
       try {
         // Test with ensureBlockGasLimit: true (default)
         await gasUtils.simulate(request, {}, [], undefined, { ignoreBlockGasLimit: false });
-        expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n);
+        expect(capturedBlockOverrides.gasLimit).toBe(MAX_L1_TX_LIMIT);
 
         // Test with ensureBlockGasLimit: false
         capturedBlockOverrides = {};
@@ -1446,7 +1447,7 @@ describe('L1TxUtils', () => {
       }
     });
 
-    it('ensures block gas limit is set when using LARGE_GAS_LIMIT with custom block overrides', async () => {
+    it('ensures block gas limit is set when using MAX_L1_TX_LIMIT with custom block overrides', async () => {
       let capturedBlockOverrides: any = {};
       const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
 
@@ -1463,7 +1464,7 @@ describe('L1TxUtils', () => {
         await gasUtils.simulate(request, myCustomBlockOverrides, [], undefined, { ignoreBlockGasLimit: false });
 
         // Verify that block gas limit is set while preserving custom overrides
-        expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n); // 12_000_000 * 2
+        expect(capturedBlockOverrides.gasLimit).toBe(MAX_L1_TX_LIMIT);
         expect(capturedBlockOverrides.baseFeePerGas).toBe(1000000000n);
       } finally {
         spy.mockRestore();

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -27,7 +27,7 @@ import { jsonRpc } from 'viem/nonce';
 import type { ViemClient } from '../types.js';
 import { formatViemError } from '../utils.js';
 import { type L1TxUtilsConfig, l1TxUtilsConfigMappings } from './config.js';
-import { LARGE_GAS_LIMIT } from './constants.js';
+import { MAX_L1_TX_LIMIT } from './constants.js';
 import type { IL1TxMetrics, IL1TxStore } from './interfaces.js';
 import { ReadOnlyL1TxUtils } from './readonly_l1_tx_utils.js';
 import {
@@ -207,7 +207,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
 
       let gasLimit: bigint;
       if (this.debugMaxGasLimit) {
-        gasLimit = LARGE_GAS_LIMIT;
+        gasLimit = MAX_L1_TX_LIMIT;
       } else if (gasConfig.gasLimit) {
         gasLimit = gasConfig.gasLimit;
       } else {
@@ -283,7 +283,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       return { txHash, state: l1TxState };
     } catch (err: any) {
       const viemError = formatViemError(err, request.abi);
-      this.logger.error(`Failed to send L1 transaction`, viemError, {
+      this.logger.error(`Failed to send L1 transaction: ${viemError.message}`, viemError, {
         request: pick(request, 'to', 'value'),
       });
       throw viemError;
@@ -631,12 +631,12 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       from: request.from ?? this.getSenderAddress().toString(),
       maxFeePerGas: gasPrice.maxFeePerGas,
       maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
-      gas: request.gas ?? LARGE_GAS_LIMIT,
+      gas: request.gas ?? MAX_L1_TX_LIMIT,
     };
 
     if (!request.gas && !gasConfig.ignoreBlockGasLimit) {
-      // LARGE_GAS_LIMIT is set as call.gas, increase block gasLimit
-      blockOverrides.gasLimit = LARGE_GAS_LIMIT * 2n;
+      // MAX_L1_TX_LIMIT is set as call.gas, ensure block gasLimit is sufficient
+      blockOverrides.gasLimit = MAX_L1_TX_LIMIT;
     }
 
     return this._simulate(call, blockOverrides, stateOverrides, gasConfig, abi);

--- a/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/readonly_l1_tx_utils.ts
@@ -27,7 +27,7 @@ import type { ViemClient } from '../types.js';
 import { type L1TxUtilsConfig, defaultL1TxUtilsConfig, l1TxUtilsConfigMappings } from './config.js';
 import {
   BLOCK_TIME_MS,
-  LARGE_GAS_LIMIT,
+  MAX_L1_TX_LIMIT,
   MIN_BLOB_REPLACEMENT_BUMP_PERCENTAGE,
   MIN_REPLACEMENT_BUMP_PERCENTAGE,
   WEI_CONST,
@@ -249,7 +249,7 @@ export class ReadOnlyL1TxUtils {
         ...request,
         ..._blobInputs,
         maxFeePerBlobGas: gasPrice.maxFeePerBlobGas!,
-        gas: LARGE_GAS_LIMIT,
+        gas: MAX_L1_TX_LIMIT,
         blockTag: 'latest',
       });
 
@@ -258,7 +258,7 @@ export class ReadOnlyL1TxUtils {
       initialEstimate = await this.client.estimateGas({
         account,
         ...request,
-        gas: LARGE_GAS_LIMIT,
+        gas: MAX_L1_TX_LIMIT,
         blockTag: 'latest',
       });
       this.logger?.trace(`Estimated gas for non-blob tx: ${initialEstimate}`);

--- a/yarn-project/ethereum/src/utils.test.ts
+++ b/yarn-project/ethereum/src/utils.test.ts
@@ -1,0 +1,61 @@
+import type { Abi } from 'viem';
+
+import { mergeAbis } from './utils.js';
+
+describe('mergeAbis', () => {
+  it('dedupes identical function items', () => {
+    const fn = {
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'view',
+      inputs: [{ name: 'a', type: 'uint256' }],
+      outputs: [{ name: '', type: 'uint256' }],
+    } as const;
+
+    const abi1: Abi = [fn];
+    const abi2: Abi = [fn];
+    const merged = mergeAbis([abi1, abi2]);
+
+    expect(merged).toHaveLength(1);
+  });
+
+  it('keeps function items that differ by output types', () => {
+    const fn1 = {
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'view',
+      inputs: [{ name: 'a', type: 'uint256' }],
+      outputs: [{ name: '', type: 'uint256' }],
+    } as const;
+
+    const fn2 = {
+      type: 'function',
+      name: 'foo',
+      stateMutability: 'view',
+      inputs: [{ name: 'a', type: 'uint256' }],
+      outputs: [{ name: '', type: 'bool' }],
+    } as const;
+
+    const merged = mergeAbis([[fn1], [fn2]]);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it('keeps event items that differ by indexed flags', () => {
+    const eventIndexed = {
+      type: 'event',
+      name: 'DidThing',
+      inputs: [{ name: 'who', type: 'address', indexed: true }],
+    } as const;
+
+    const eventNonIndexed = {
+      type: 'event',
+      name: 'DidThing',
+      inputs: [{ name: 'who', type: 'address', indexed: false }],
+    } as const;
+
+    const merged = mergeAbis([[eventIndexed], [eventNonIndexed]]);
+
+    expect(merged).toHaveLength(2);
+  });
+});

--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -4,6 +4,7 @@ import { ErrorsAbi } from '@aztec/l1-artifacts/ErrorsAbi';
 
 import {
   type Abi,
+  type AbiItem,
   BaseError,
   type ContractEventName,
   ContractFunctionRevertedError,
@@ -14,6 +15,7 @@ import {
   decodeErrorResult,
   decodeEventLog,
 } from 'viem';
+import { formatAbiItem, formatAbiParams } from 'viem/utils';
 
 export interface L2Claim {
   claimSecret: Fr;
@@ -91,6 +93,57 @@ export function prettyLogViemErrorMsg(err: any) {
     }
   }
   return err?.message ?? err;
+}
+
+export function mergeAbis(abis: Abi[]): Abi {
+  let merged: Abi = [];
+  const seen = new Set<string>();
+
+  for (const abi of abis) {
+    for (const item of abi) {
+      const key = getAbiItemKey(item);
+      if (!seen.has(key)) {
+        seen.add(key);
+        merged = [...merged, item];
+      }
+    }
+  }
+
+  return merged;
+}
+
+function getAbiItemKey(item: AbiItem): string {
+  if (item.type === 'function') {
+    const signature = formatAbiItem(item);
+    const outputs = formatAbiParams(item.outputs);
+    const stateMutability = typeof item.stateMutability === 'string' ? item.stateMutability : '';
+    return `function:${signature}:${outputs}:${stateMutability}`;
+  }
+
+  if (item.type === 'event') {
+    const signature = formatAbiItem(item);
+    const indexed = (item.inputs ?? []).map(input => ((input as { indexed?: boolean }).indexed ? '1' : '0')).join('');
+    const anonymous = item.anonymous ? 'anonymous' : 'not-anonymous';
+    return `event:${signature}:${indexed}:${anonymous}`;
+  }
+
+  if (item.type === 'error') {
+    const signature = formatAbiItem(item);
+    return `error:${signature}`;
+  }
+
+  if (item.type === 'constructor') {
+    const inputs = formatAbiParams(item.inputs);
+    const stateMutability = typeof item.stateMutability === 'string' ? item.stateMutability : '';
+    return `constructor::${inputs}:${stateMutability}`;
+  }
+
+  if (item.type === 'fallback' || item.type === 'receive') {
+    const stateMutability = typeof item.stateMutability === 'string' ? item.stateMutability : '';
+    return `${item.type}:::${stateMutability}`;
+  }
+
+  return 'unknown';
 }
 
 function getNestedErrorData(error: unknown): string | undefined {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -18,11 +18,12 @@ import {
   type L1BlobInputs,
   type L1TxConfig,
   type L1TxRequest,
+  MAX_L1_TX_LIMIT,
   type TransactionStats,
   WEI_CONST,
 } from '@aztec/ethereum/l1-tx-utils';
 import type { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
-import { FormattedViemError, formatViemError, tryExtractEvent } from '@aztec/ethereum/utils';
+import { FormattedViemError, formatViemError, mergeAbis, tryExtractEvent } from '@aztec/ethereum/utils';
 import { sumBigint } from '@aztec/foundation/bigint';
 import { toHex as toPaddedHex } from '@aztec/foundation/bigint-buffer';
 import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
@@ -122,11 +123,6 @@ export class SequencerPublisher {
 
   /** L1 fee analyzer for fisherman mode */
   private l1FeeAnalyzer?: L1FeeAnalyzer;
-  // @note - with blobs, the below estimate seems too large.
-  // Total used for full block from int_l1_pub e2e test: 1m (of which 86k is 1x blob)
-  // Total used for emptier block from above test: 429k (of which 84k is 1x blob)
-  public static PROPOSE_GAS_GUESS: bigint = 12_000_000n;
-
   // A CALL to a cold address is 2700 gas
   public static MULTICALL_OVERHEAD_GAS_GUESS = 5000n;
 
@@ -273,7 +269,7 @@ export class SequencerPublisher {
     // Start the analysis
     const analysisId = await this.l1FeeAnalyzer.startAnalysis(
       l2SlotNumber,
-      gasLimit > 0n ? gasLimit : SequencerPublisher.PROPOSE_GAS_GUESS,
+      gasLimit > 0n ? gasLimit : MAX_L1_TX_LIMIT,
       l1Requests,
       blobConfig,
       onComplete,
@@ -346,7 +342,16 @@ export class SequencerPublisher {
 
     // Merge gasConfigs. Yields the sum of gasLimits, and the earliest txTimeoutAt, or undefined if no gasConfig sets them.
     const gasLimits = gasConfigs.map(g => g?.gasLimit).filter((g): g is bigint => g !== undefined);
-    const gasLimit = gasLimits.length > 0 ? sumBigint(gasLimits) : undefined; // sum
+    let gasLimit = gasLimits.length > 0 ? sumBigint(gasLimits) : undefined; // sum
+    // Cap at L1 block gas limit so the node accepts the tx ("gas limit too high" otherwise).
+    const maxGas = MAX_L1_TX_LIMIT;
+    if (gasLimit !== undefined && gasLimit > maxGas) {
+      this.log.debug('Capping bundled tx gas limit to L1 max', {
+        requested: gasLimit,
+        capped: maxGas,
+      });
+      gasLimit = maxGas;
+    }
     const txTimeoutAts = gasConfigs.map(g => g?.txTimeoutAt).filter((g): g is Date => g !== undefined);
     const txTimeoutAt = txTimeoutAts.length > 0 ? new Date(Math.min(...txTimeoutAts.map(g => g.getTime()))) : undefined; // earliest
     const txConfig: RequestWithExpiry['gasConfig'] = { gasLimit, txTimeoutAt };
@@ -517,7 +522,12 @@ export class SequencerPublisher {
     this.log.debug(`Simulating invalidate checkpoint ${checkpointNumber}`, { ...logData, request });
 
     try {
-      const { gasUsed } = await this.l1TxUtils.simulate(request, undefined, undefined, ErrorsAbi);
+      const { gasUsed } = await this.l1TxUtils.simulate(
+        request,
+        undefined,
+        undefined,
+        mergeAbis([request.abi ?? [], ErrorsAbi]),
+      );
       this.log.verbose(`Simulation for invalidate checkpoint ${checkpointNumber} succeeded`, {
         ...logData,
         request,
@@ -536,7 +546,7 @@ export class SequencerPublisher {
 
       // If the error is due to the checkpoint not being in the pending chain, and it was indeed removed by someone else,
       // we can safely ignore it and return undefined so we go ahead with checkpoint building.
-      if (viemError.message?.includes('Rollup__BlockNotInPendingChain')) {
+      if (viemError.message?.includes('Rollup__CheckpointNotInPendingChain')) {
         this.log.verbose(
           `Simulation for invalidate checkpoint ${checkpointNumber} failed due to checkpoint not being in pending chain`,
           { ...logData, request, error: viemError.message },
@@ -700,7 +710,7 @@ export class SequencerPublisher {
     });
 
     try {
-      await this.l1TxUtils.simulate(request, { time: timestamp }, [], ErrorsAbi);
+      await this.l1TxUtils.simulate(request, { time: timestamp }, [], mergeAbis([request.abi ?? [], ErrorsAbi]));
       this.log.debug(`Simulation for ${action} at slot ${slotNumber} succeeded`, { request });
     } catch (err) {
       this.log.error(`Failed simulation for ${action} at slot ${slotNumber} (enqueuing the action anyway)`, err);
@@ -999,12 +1009,14 @@ export class SequencerPublisher {
     this.log.debug(`Simulating ${action} for slot ${slotNumber}`, logData);
 
     let gasUsed: bigint;
+    const simulateAbi = mergeAbis([request.abi ?? [], ErrorsAbi]);
     try {
-      ({ gasUsed } = await this.l1TxUtils.simulate(request, { time: timestamp }, [], ErrorsAbi)); // TODO(palla/slash): Check the timestamp logic
+      ({ gasUsed } = await this.l1TxUtils.simulate(request, { time: timestamp }, [], simulateAbi)); // TODO(palla/slash): Check the timestamp logic
       this.log.verbose(`Simulation for ${action} succeeded`, { ...logData, request, gasUsed });
     } catch (err) {
-      const viemError = formatViemError(err);
+      const viemError = formatViemError(err, simulateAbi);
       this.log.error(`Simulation for ${action} at ${slotNumber} failed`, viemError, logData);
+
       return false;
     }
 
@@ -1012,10 +1024,14 @@ export class SequencerPublisher {
     const gasLimit = this.l1TxUtils.bumpGasLimit(BigInt(Math.ceil((Number(gasUsed) * 64) / 63)));
     logData.gasLimit = gasLimit;
 
+    // Store the ABI used for simulation on the request so Multicall3.forward can decode errors
+    // when the tx is sent and a revert is diagnosed via simulation.
+    const requestWithAbi = { ...request, abi: simulateAbi };
+
     this.log.debug(`Enqueuing ${action}`, logData);
     this.addRequest({
       action,
-      request,
+      request: requestWithAbi,
       gasConfig: { gasLimit },
       lastValidL2Slot: slotNumber,
       checkSuccess: (_req, result) => {
@@ -1171,20 +1187,20 @@ export class SequencerPublisher {
         {
           to: this.rollupContract.address,
           data: rollupData,
-          gas: SequencerPublisher.PROPOSE_GAS_GUESS,
+          gas: MAX_L1_TX_LIMIT,
           ...(this.proposerAddressForSimulation && { from: this.proposerAddressForSimulation.toString() }),
         },
         {
           // @note we add 1n to the timestamp because geth implementation doesn't like simulation timestamp to be equal to the current block timestamp
           time: timestamp + 1n,
           // @note reth should have a 30m gas limit per block but throws errors that this tx is beyond limit so we increase here
-          gasLimit: SequencerPublisher.PROPOSE_GAS_GUESS * 2n,
+          gasLimit: MAX_L1_TX_LIMIT * 2n,
         },
         stateOverrides,
         RollupAbi,
         {
           // @note fallback gas estimate to use if the node doesn't support simulation API
-          fallbackGasEstimate: SequencerPublisher.PROPOSE_GAS_GUESS,
+          fallbackGasEstimate: MAX_L1_TX_LIMIT,
         },
       )
       .catch(err => {
@@ -1194,7 +1210,7 @@ export class SequencerPublisher {
           this.log.debug(`Ignoring expected ValidatorSelection__MissingProposerSignature error in fisherman mode`);
           // Return a minimal simulation result with the fallback gas estimate
           return {
-            gasUsed: SequencerPublisher.PROPOSE_GAS_GUESS,
+            gasUsed: MAX_L1_TX_LIMIT,
             logs: [],
           };
         }

--- a/yarn-project/stdlib/src/l1-contracts/slash_factory.ts
+++ b/yarn-project/stdlib/src/l1-contracts/slash_factory.ts
@@ -41,6 +41,7 @@ export class SlashFactoryContract {
 
     return {
       to: this.contract.address,
+      abi: SlashFactoryAbi,
       data: encodeFunctionData({
         abi: SlashFactoryAbi,
         functionName: 'createSlashPayload',


### PR DESCRIPTION
Fixes [A-479](https://linear.app/aztec-labs/issue/A-479/recreate-next-net-reorg-and-investigate-the-slashing-failures)

Some updates that came up from re-creating a slashing issue in `next-net`.
- passing relevant ABIs to L1 calls so errors can be reported properly
- Updating `LARGE_GAS_LIMIT` and `PROPOSE_GAS_GUESS` (that were equal) to `MAX_L1_TX_LIMIT`. This is the maximum gas a single tx can use so if simulation goes over it, we should throw

Follow-up to fix the actual size of `execute-slash` transaction for Tally slasher: https://linear.app/aztec-labs/issue/A-507/tally-slasher-execution-can-run-out-of-gas