### PR TITLE
fix(ci): build noir packages before yarn-project in nightly docs workflow

### DIFF
--- a/.github/workflows/nightly-docs-release.yml
+++ b/.github/workflows/nightly-docs-release.yml
@@ -139,6 +139,15 @@ jobs:
           chmod +x /tmp/bb-bin/bb
           echo "BB_PATH=/tmp/bb-bin" >> $GITHUB_ENV
 
+      - name: Build noir packages
+        run: |
+          # Initialize noir submodule (required for yarn-project portal dependencies)
+          git submodule update --init --recursive noir/noir-repo
+          # Build noir JS packages (creates noir/packages/ directory needed by yarn-project)
+          cd noir
+          ./bootstrap.sh install_deps
+          ./bootstrap.sh build_packages
+
       - name: Build aztec CLI
         working-directory: ./yarn-project
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -187,6 +187,15 @@ jobs:
           ./bootstrap.sh build_native
           echo "BB_PATH=$(pwd)/build/bin" >> $GITHUB_ENV
 
+      - name: Build noir packages
+        run: |
+          # Initialize noir submodule (required for yarn-project portal dependencies)
+          git submodule update --init --recursive noir/noir-repo
+          # Build noir JS packages (creates noir/packages/ directory needed by yarn-project)
+          cd noir
+          ./bootstrap.sh install_deps
+          ./bootstrap.sh build_packages
+
       - name: Build aztec CLI
         working-directory: ./yarn-project
         run: |


### PR DESCRIPTION
## Summary
- Fixes the nightly-docs-release workflow which has been failing since Jan 27
- Fixes the same issue in release-please workflow (preventive)

## Problem
PR #19284 added a "Build aztec CLI" step that runs `yarn-project/bootstrap.sh`, but this fails because yarn-project has portal dependencies on `noir/packages/` (e.g., `@aztec/noir-acvm_js`). This directory is only created by `noir/bootstrap.sh` and is not tracked in git.

**Error:**
```
Error: @aztec/noir-acvm_js@portal:../noir/packages/acvm_js: Manifest not found
```

## Solution
Add a step to initialize the noir submodule and build the JS packages before running yarn-project bootstrap in both workflows.

## Test plan
- [ ] Trigger the nightly docs workflow manually and verify it succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)