### PR TITLE
chore: proposer should add to attestation pool immediately

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -326,8 +326,10 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     [Attributes.BLOCK_ARCHIVE]: proposal.archive.toString(),
     [Attributes.P2P_ID]: (await proposal.p2pMessageLoggingIdentifier()).toString(),
   }))
-  public broadcastProposal(proposal: BlockProposal): Promise<void> {
+  public async broadcastProposal(proposal: BlockProposal): Promise<void> {
     this.log.verbose(`Broadcasting proposal for slot ${proposal.slotNumber} to peers`);
+    // Store our own proposal so we can respond to req/resp requests for it
+    await this.attestationPool.addBlockProposal(proposal);
     return this.p2pService.propagate(proposal);
   }
 


### PR DESCRIPTION
Bug caught by our e2e tests!  http://ci.aztec-labs.com/d7587ba63f1749e0
This should fix it :) 

The proposer didn't have its own proposal in the attestation pool. 
This is an issue because, once the proposal is sent, it becomes a so-called `pinned_peer` for the peers that have received it.  
The pinned peer implementation logic is that we always expect it to have a proposal (since that defines a peer as "pinned peer"). The proposer not having its own proposal in the attestation pool undermines this assumption. 