### PR TITLE
feat(p2p): New transaction pool implementation

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -238,6 +238,7 @@ function bench_cmds {
   echo "$hash BENCH_OUTPUT=bench-out/native_world_state.bench.json yarn-project/scripts/run_test.sh world-state/src/native/native_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/kv_store.bench.json yarn-project/scripts/run_test.sh kv-store/src/bench/map_bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx_pool.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool/tx_pool_bench.test.ts"
+  echo "$hash BENCH_OUTPUT=bench-out/tx_pool_v2.bench.json yarn-project/scripts/run_test.sh p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=16:MEM=32g:TIMEOUT=1200 BENCH_OUTPUT=bench-out/p2p_client_proposal_tx_collector.bench.json yarn-project/scripts/run_test.sh p2p/src/client/test/tx_proposal_collector/p2p_client.proposal_tx_collector.bench.test.ts"
   echo "$hash BENCH_OUTPUT=bench-out/tx.bench.json yarn-project/scripts/run_test.sh stdlib/src/tx/tx_bench.test.ts"
   echo "$hash:ISOLATE=1:CPUS=10:MEM=16g:LOG_LEVEL=silent BENCH_OUTPUT=bench-out/proving_broker.bench.json yarn-project/scripts/run_test.sh prover-client/src/test/proving_broker_testbench.test.ts"

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/README.md
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/README.md
@@ -1,0 +1,188 @@
+# TxPoolV2
+
+Transaction pool implementation with explicit state management and pluggable eviction rules.
+
+## Overview
+
+TxPoolV2 manages transactions through a state machine with clear transitions:
+
+```
+              addPendingTxs()
+                    │
+                    ▼
+┌─────────────────────────────────────┐
+│              PENDING                │◄──────────────────┐
+│   (awaiting block inclusion)        │                   │
+└─────────────────────────────────────┘                   │
+        │                                                 │
+        │ protectTxs() / addProtectedTxs()               │
+        ▼                                                 │
+┌─────────────────────────────────────┐                   │
+│            PROTECTED                │───────────────────┘
+│   (in a block proposal)             │  prepareForSlot()
+└─────────────────────────────────────┘  (slot passed without mining)
+        │                                                 │
+        │ handleMinedBlock()                              │
+        ▼                                                 │
+┌─────────────────────────────────────┐                   │
+│              MINED                  │───────────────────┘
+│   (included in a block)             │  handlePrunedBlocks()
+└─────────────────────────────────────┘  (reorg)
+        │
+        │ handleFinalizedBlock()
+        ▼
+┌─────────────────────────────────────┐
+│             DELETED                 │
+│   (optionally archived)             │
+└─────────────────────────────────────┘
+```
+
+## Key Components
+
+### TxPoolV2 (`tx_pool_v2.ts`)
+
+The public API wrapper that serializes all operations through a queue to prevent race conditions. Delegates to `TxPoolV2Impl` for actual logic.
+
+### TxPoolV2Impl (`tx_pool_v2_impl.ts`)
+
+Core implementation containing:
+- KV store persistence for transactions and metadata
+- In-memory indices for fast lookups (by nullifier, fee payer, priority)
+- State transition logic
+- Pre-add rule execution
+- Post-event eviction rule execution
+
+### TxMetaData (`tx_metadata.ts`)
+
+Lightweight metadata stored alongside each transaction:
+- `txHash`: Transaction identifier
+- `state`: Current state (pending, protected, mined)
+- `priorityFee`: For priority ordering
+- `feePayer`: For balance-based eviction
+- `nullifiers`: For conflict detection
+- `estimatedTxFee`: For balance calculations
+- `blockId`: Block info when mined
+- `protectedSlot`: Slot number when protected
+
+## Eviction Rules
+
+The pool uses a pluggable rule system for managing transactions.
+
+### Pre-Add Rules
+
+Checked before adding a transaction to the pending pool:
+
+| Rule | Purpose |
+|------|---------|
+| `NullifierConflictRule` | Handles transactions with conflicting nullifiers. Higher priority tx wins. |
+| `FeePayerBalancePreAddRule` | Ensures fee payer has sufficient balance for all their pending txs. |
+| `LowPriorityPreAddRule` | Rejects txs when pool is full and new tx has lowest priority. |
+
+### Post-Event Eviction Rules
+
+Run after events to clean up the pool:
+
+| Rule | Trigger | Purpose |
+|------|---------|---------|
+| `LowPriorityEvictionRule` | `txs_added` | Evicts lowest priority txs when pool exceeds limit. |
+| `FeePayerBalanceEvictionRule` | `block_mined` | Evicts txs when fee payer balance decreases. |
+| `InvalidTxsAfterMiningRule` | `block_mined` | Evicts pending txs with nullifiers that were just mined. |
+| `InvalidTxsAfterReorgRule` | `chain_pruned` | Evicts txs with invalid anchor blocks after reorg. |
+
+## Usage
+
+### Creating a Pool
+
+```typescript
+import { AztecKVTxPoolV2 } from './tx_pool_v2.js';
+
+const pool = new AztecKVTxPoolV2(txStore, archiveStore, {
+  l2BlockSource: archiver,
+  worldStateSynchronizer: worldState,
+  pendingTxValidator: validator,
+});
+
+await pool.start();
+```
+
+### Adding Transactions
+
+```typescript
+// Add to pending pool (validates and runs pre-add rules)
+const result = await pool.addPendingTxs(txs, { source: 'gossip' });
+// result: { accepted: TxHash[], ignored: TxHash[], rejected: TxHash[] }
+
+// Check without modifying pool
+const canAdd = await pool.canAddPendingTx(tx);
+// canAdd: 'accepted' | 'ignored' | 'rejected'
+```
+
+### Block Building Flow
+
+```typescript
+// 1. Proposer protects txs for their block
+await pool.protectTxs(selectedTxHashes, blockHeader);
+
+// 2. On successful mining
+await pool.handleMinedBlock(minedTxHashes, blockHeader);
+
+// 3. If slot passes without mining
+await pool.prepareForSlot(nextSlotNumber);
+
+// 4. On finalization
+await pool.handleFinalizedBlock(finalizedBlockHeader);
+```
+
+### Handling Reorgs
+
+```typescript
+// When blocks are pruned, un-mine affected transactions
+await pool.handlePrunedBlocks(latestValidBlockId);
+```
+
+## Configuration
+
+```typescript
+await pool.updateConfig({
+  maxPendingTxCount: 10000,  // 0 = unlimited
+  archivedTxLimit: 1000,     // 0 = disabled
+});
+```
+
+## Return Values
+
+### AddTxsResult
+
+When adding pending transactions, each tx is categorized:
+
+| Status | Meaning |
+|--------|---------|
+| `accepted` | Successfully added to the pool |
+| `ignored` | Valid but not added (duplicate, lost nullifier conflict, insufficient balance) |
+| `rejected` | Failed validation (invalid proof, expired, etc.) |
+
+## Archive
+
+Finalized transactions can optionally be archived for historical queries:
+
+```typescript
+const archivedTx = await pool.getArchivedTxByHash(txHash);
+```
+
+The archive uses FIFO eviction when `archivedTxLimit` is reached.
+
+## Testing
+
+```bash
+# Unit tests (131 tests)
+yarn test src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+
+# Compatibility tests (25 tests)
+yarn test src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
+
+# Eviction rule tests
+yarn test src/mem_pools/tx_pool_v2/eviction/
+
+# Benchmarks
+yarn test src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts
+```

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/index.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/index.ts
@@ -1,0 +1,1 @@
+export { TxArchive } from './tx_archive.js';

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/tx_archive.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/tx_archive.test.ts
@@ -1,0 +1,324 @@
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { mockTx } from '@aztec/stdlib/testing';
+import type { Tx } from '@aztec/stdlib/tx';
+
+import { TxArchive } from './tx_archive.js';
+
+describe('TxArchive', () => {
+  /** Helper to verify a retrieved tx matches the original */
+  const expectTxMatch = (retrieved: Tx | undefined, original: Tx) => {
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.getTxHash().toString()).toBe(original.getTxHash().toString());
+  };
+
+  describe('isEnabled', () => {
+    it('returns false when limit is 0', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 0);
+
+      expect(archive.isEnabled()).toBe(false);
+    });
+
+    it('returns true when limit is greater than 0', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+
+      expect(archive.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('updateLimit', () => {
+    it('updates the limit', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 5);
+
+      expect(archive.getLimit()).toBe(5);
+
+      archive.updateLimit(10);
+
+      expect(archive.getLimit()).toBe(10);
+    });
+
+    it('can disable archiving by setting limit to 0', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 5);
+
+      expect(archive.isEnabled()).toBe(true);
+
+      archive.updateLimit(0);
+
+      expect(archive.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('archiveTxs', () => {
+    it('does nothing when disabled', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 0);
+      const tx = await mockTx(1);
+
+      await archive.archiveTxs([tx]);
+
+      expect(await archive.getCount()).toBe(0);
+    });
+
+    it('does nothing with empty array', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+
+      await archive.archiveTxs([]);
+
+      expect(await archive.getCount()).toBe(0);
+    });
+
+    it('archives a single transaction', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx = await mockTx(1);
+
+      await archive.archiveTxs([tx]);
+
+      expect(await archive.getCount()).toBe(1);
+      expectTxMatch(await archive.getTxByHash(tx.getTxHash()), tx);
+    });
+
+    it('archives multiple transactions', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      await archive.archiveTxs([tx1, tx2, tx3]);
+
+      expect(await archive.getCount()).toBe(3);
+      expectTxMatch(await archive.getTxByHash(tx1.getTxHash()), tx1);
+      expectTxMatch(await archive.getTxByHash(tx2.getTxHash()), tx2);
+      expectTxMatch(await archive.getTxByHash(tx3.getTxHash()), tx3);
+    });
+
+    it('archives transactions in multiple batches', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await archive.archiveTxs([tx1]);
+      await archive.archiveTxs([tx2]);
+
+      expect(await archive.getCount()).toBe(2);
+      expectTxMatch(await archive.getTxByHash(tx1.getTxHash()), tx1);
+      expectTxMatch(await archive.getTxByHash(tx2.getTxHash()), tx2);
+    });
+
+    it('strips proofs from archived transactions', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx = await mockTx(1);
+
+      await archive.archiveTxs([tx]);
+
+      const retrieved = await archive.getTxByHash(tx.getTxHash());
+      expectTxMatch(retrieved, tx);
+      expect(retrieved!.chonkProof.isEmpty()).toBe(true);
+    });
+  });
+
+  describe('FIFO eviction', () => {
+    it('evicts oldest transaction when limit is reached', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 2);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      await archive.archiveTxs([tx1]);
+      await archive.archiveTxs([tx2]);
+      expect(await archive.getCount()).toBe(2);
+
+      // Adding tx3 should evict tx1
+      await archive.archiveTxs([tx3]);
+
+      expect(await archive.getCount()).toBe(2);
+      expect(await archive.getTxByHash(tx1.getTxHash())).toBeUndefined();
+      expectTxMatch(await archive.getTxByHash(tx2.getTxHash()), tx2);
+      expectTxMatch(await archive.getTxByHash(tx3.getTxHash()), tx3);
+    });
+
+    it('evicts multiple transactions when adding batch exceeds limit', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 3);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+      const tx4 = await mockTx(4);
+      const tx5 = await mockTx(5);
+
+      await archive.archiveTxs([tx1, tx2]);
+      expect(await archive.getCount()).toBe(2);
+
+      // Adding 3 more txs should evict tx1 and tx2
+      await archive.archiveTxs([tx3, tx4, tx5]);
+
+      expect(await archive.getCount()).toBe(3);
+      expect(await archive.getTxByHash(tx1.getTxHash())).toBeUndefined();
+      expect(await archive.getTxByHash(tx2.getTxHash())).toBeUndefined();
+      expectTxMatch(await archive.getTxByHash(tx3.getTxHash()), tx3);
+      expectTxMatch(await archive.getTxByHash(tx4.getTxHash()), tx4);
+      expectTxMatch(await archive.getTxByHash(tx5.getTxHash()), tx5);
+    });
+
+    it('handles batch larger than limit', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 2);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+      const tx4 = await mockTx(4);
+
+      // Adding 4 txs with limit of 2 should only keep last 2
+      await archive.archiveTxs([tx1, tx2, tx3, tx4]);
+
+      expect(await archive.getCount()).toBe(2);
+      expect(await archive.getTxByHash(tx1.getTxHash())).toBeUndefined();
+      expect(await archive.getTxByHash(tx2.getTxHash())).toBeUndefined();
+      expectTxMatch(await archive.getTxByHash(tx3.getTxHash()), tx3);
+      expectTxMatch(await archive.getTxByHash(tx4.getTxHash()), tx4);
+    });
+
+    it('evicts in FIFO order across multiple batches', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 3);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+      const tx4 = await mockTx(4);
+      const tx5 = await mockTx(5);
+
+      await archive.archiveTxs([tx1]);
+      await archive.archiveTxs([tx2]);
+      await archive.archiveTxs([tx3]);
+      expect(await archive.getCount()).toBe(3);
+
+      await archive.archiveTxs([tx4]);
+      expect(await archive.getCount()).toBe(3);
+      expect(await archive.getTxByHash(tx1.getTxHash())).toBeUndefined();
+
+      await archive.archiveTxs([tx5]);
+      expect(await archive.getCount()).toBe(3);
+      expect(await archive.getTxByHash(tx2.getTxHash())).toBeUndefined();
+
+      // Only tx3, tx4, tx5 should remain
+      expectTxMatch(await archive.getTxByHash(tx3.getTxHash()), tx3);
+      expectTxMatch(await archive.getTxByHash(tx4.getTxHash()), tx4);
+      expectTxMatch(await archive.getTxByHash(tx5.getTxHash()), tx5);
+    });
+  });
+
+  describe('getTxByHash', () => {
+    it('returns undefined for non-existent transaction', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx = await mockTx(1);
+
+      const result = await archive.getTxByHash(tx.getTxHash());
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the archived transaction', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx = await mockTx(1);
+
+      await archive.archiveTxs([tx]);
+
+      expectTxMatch(await archive.getTxByHash(tx.getTxHash()), tx);
+    });
+
+    it('returns undefined after transaction is evicted', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 1);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await archive.archiveTxs([tx1]);
+      await archive.archiveTxs([tx2]);
+
+      expect(await archive.getTxByHash(tx1.getTxHash())).toBeUndefined();
+      expectTxMatch(await archive.getTxByHash(tx2.getTxHash()), tx2);
+    });
+  });
+
+  describe('getCount', () => {
+    it('returns 0 for empty archive', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+
+      expect(await archive.getCount()).toBe(0);
+    });
+
+    it('returns correct count after archiving', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 10);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await archive.archiveTxs([tx1, tx2]);
+
+      expect(await archive.getCount()).toBe(2);
+    });
+
+    it('returns correct count after eviction', async () => {
+      const store = await openTmpStore('archive');
+      const archive = new TxArchive(store, 2);
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      await archive.archiveTxs([tx1, tx2, tx3]);
+
+      expect(await archive.getCount()).toBe(2);
+    });
+  });
+
+  describe('persistence', () => {
+    it('persists archived transactions across instances', async () => {
+      const store = await openTmpStore('archive');
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      // Archive with first instance
+      const archive1 = new TxArchive(store, 10);
+      await archive1.archiveTxs([tx1, tx2]);
+
+      // Create new instance with same store
+      const archive2 = new TxArchive(store, 10);
+
+      expect(await archive2.getCount()).toBe(2);
+      expectTxMatch(await archive2.getTxByHash(tx1.getTxHash()), tx1);
+      expectTxMatch(await archive2.getTxByHash(tx2.getTxHash()), tx2);
+    });
+
+    it('continues FIFO eviction after restart', async () => {
+      const store = await openTmpStore('archive');
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      // Archive with first instance
+      const archive1 = new TxArchive(store, 2);
+      await archive1.archiveTxs([tx1, tx2]);
+
+      // Create new instance and add more
+      const archive2 = new TxArchive(store, 2);
+      await archive2.archiveTxs([tx3]);
+
+      // tx1 should be evicted
+      expect(await archive2.getCount()).toBe(2);
+      expect(await archive2.getTxByHash(tx1.getTxHash())).toBeUndefined();
+      expectTxMatch(await archive2.getTxByHash(tx2.getTxHash()), tx2);
+      expectTxMatch(await archive2.getTxByHash(tx3.getTxHash()), tx3);
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/tx_archive.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/archive/tx_archive.ts
@@ -1,0 +1,120 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { ChonkProof } from '@aztec/stdlib/proofs';
+import { Tx, TxHash } from '@aztec/stdlib/tx';
+
+/**
+ * Manages archived transactions with FIFO eviction.
+ * Archived transactions have their proofs stripped to save space.
+ */
+export class TxArchive {
+  #store: AztecAsyncKVStore;
+  #txs: AztecAsyncMap<string, Buffer>;
+  #indices: AztecAsyncMap<number, string>;
+  #limit: number;
+  #log: Logger;
+
+  constructor(store: AztecAsyncKVStore, limit: number, log?: Logger) {
+    this.#store = store;
+    this.#txs = store.openMap('archivedTxs');
+    this.#indices = store.openMap('archivedTxIndices');
+    this.#limit = limit;
+    this.#log = log ?? createLogger('p2p:tx_pool_v2:archive');
+  }
+
+  /**
+   * Updates the maximum number of archived transactions.
+   */
+  updateLimit(limit: number): void {
+    this.#limit = limit;
+  }
+
+  /**
+   * Gets the current archive limit.
+   */
+  getLimit(): number {
+    return this.#limit;
+  }
+
+  /**
+   * Checks if archiving is enabled.
+   */
+  isEnabled(): boolean {
+    return this.#limit > 0;
+  }
+
+  /**
+   * Archives transactions, stripping their proofs.
+   * Evicts oldest transactions if the limit is exceeded.
+   */
+  async archiveTxs(txs: Tx[]): Promise<void> {
+    if (!this.isEnabled() || txs.length === 0) {
+      return;
+    }
+
+    try {
+      await this.#store.transactionAsync(async () => {
+        // Get current head and tail indices
+        let headIdx = await this.getHeadIndex();
+        let tailIdx = await this.getTailIndex();
+
+        for (const tx of txs) {
+          // Evict oldest entries if at capacity
+          while (headIdx - tailIdx >= this.#limit) {
+            const txHashToEvict = await this.#indices.getAsync(tailIdx);
+            if (txHashToEvict) {
+              await this.#txs.delete(txHashToEvict);
+              await this.#indices.delete(tailIdx);
+            }
+            tailIdx++;
+          }
+
+          // Archive the transaction with stripped proof
+          const archivedTx = this.stripProof(tx);
+          const txHash = tx.getTxHash().toString();
+          await this.#txs.set(txHash, archivedTx.toBuffer());
+          await this.#indices.set(headIdx, txHash);
+          headIdx++;
+        }
+
+        this.#log.debug(`Archived ${txs.length} txs, total: ${headIdx - tailIdx}`);
+      });
+    } catch (error) {
+      this.#log.error('Error archiving transactions', { error });
+    }
+  }
+
+  /**
+   * Retrieves an archived transaction by its hash.
+   */
+  async getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+    const buffer = await this.#txs.getAsync(txHash.toString());
+    return buffer ? Tx.fromBuffer(buffer) : undefined;
+  }
+
+  /**
+   * Gets the current count of archived transactions.
+   */
+  async getCount(): Promise<number> {
+    const head = await this.getHeadIndex();
+    const tail = await this.getTailIndex();
+    return head - tail;
+  }
+
+  /**
+   * Strips the proof from a transaction for archival.
+   */
+  private stripProof(tx: Tx): Tx {
+    return new Tx(tx.txHash, tx.data, ChonkProof.empty(), tx.contractClassLogFields, tx.publicFunctionCalldata);
+  }
+
+  private async getHeadIndex(): Promise<number> {
+    const entry = await this.#indices.entriesAsync({ limit: 1, reverse: true }).next();
+    return (entry.value?.[0] ?? -1) + 1;
+  }
+
+  private async getTailIndex(): Promise<number> {
+    const entry = await this.#indices.entriesAsync({ limit: 1 }).next();
+    return entry.value?.[0] ?? 0;
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/eviction_manager.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/eviction_manager.test.ts
@@ -1,0 +1,418 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { createLogger } from '@aztec/foundation/log';
+import { BlockHeader } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import { EvictionManager } from './eviction_manager.js';
+import {
+  EvictionEvent,
+  type EvictionRule,
+  type PoolOperations,
+  type PreAddPoolAccess,
+  type PreAddRule,
+} from './interfaces.js';
+
+describe('EvictionManager', () => {
+  let pool: MockProxy<PoolOperations>;
+  let evictionManager: EvictionManager;
+  let mockRule1: MockProxy<EvictionRule>;
+  let mockRule2: MockProxy<EvictionRule>;
+
+  beforeEach(() => {
+    pool = mock<PoolOperations>();
+    evictionManager = new EvictionManager(pool, createLogger('test'));
+    mockRule1 = mock<EvictionRule>({ name: 'rule1' });
+    mockRule2 = mock<EvictionRule>({ name: 'rule2' });
+  });
+
+  describe('evictAfterNewTxs', () => {
+    it('calls evict on registered rules with correct context', async () => {
+      const newTxHashes = ['0x1111', '0x2222'];
+      const feePayers = ['0xfeepayer1', '0xfeepayer2'];
+
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      await evictionManager.evictAfterNewTxs(newTxHashes, feePayers);
+
+      expect(mockRule1.evict).toHaveBeenCalledWith(
+        {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes,
+          feePayers,
+        },
+        pool,
+      );
+    });
+
+    it('calls evict on multiple registered rules', async () => {
+      const newTxHashes = ['0x1111'];
+      const feePayers = ['0xfeepayer1'];
+
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test1',
+        success: true,
+      });
+      mockRule2.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test2',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      evictionManager.registerRule(mockRule2);
+      await evictionManager.evictAfterNewTxs(newTxHashes, feePayers);
+
+      expect(mockRule1.evict).toHaveBeenCalledTimes(1);
+      expect(mockRule2.evict).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty newTxHashes array', async () => {
+      const newTxHashes: string[] = [];
+      const feePayers: string[] = [];
+
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      await evictionManager.evictAfterNewTxs(newTxHashes, feePayers);
+
+      expect(mockRule1.evict).toHaveBeenCalledWith(
+        {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes,
+          feePayers,
+        },
+        pool,
+      );
+    });
+  });
+
+  describe('evictAfterNewBlock', () => {
+    it('calls evict on registered rules with correct context', async () => {
+      const block = BlockHeader.empty();
+
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      const newNullifiers = ['0xnull1'];
+      const feePayers = ['0xfeepayer1'];
+      await evictionManager.evictAfterNewBlock(block, newNullifiers, feePayers);
+
+      expect(mockRule1.evict).toHaveBeenCalledWith(
+        {
+          event: EvictionEvent.BLOCK_MINED,
+          block,
+          newNullifiers,
+          feePayers,
+        },
+        pool,
+      );
+    });
+
+    it('handles empty nullifiers and fee payers arrays', async () => {
+      const block = BlockHeader.empty();
+
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      await evictionManager.evictAfterNewBlock(block, [], []);
+
+      expect(mockRule1.evict).toHaveBeenCalledWith(
+        {
+          event: EvictionEvent.BLOCK_MINED,
+          block,
+          newNullifiers: [],
+          feePayers: [],
+        },
+        pool,
+      );
+    });
+  });
+
+  describe('evictAfterChainPrune', () => {
+    it('calls evict on registered rules with correct context', async () => {
+      mockRule1.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      await evictionManager.evictAfterChainPrune(BlockNumber(1));
+
+      expect(mockRule1.evict).toHaveBeenCalledWith(
+        {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        },
+        pool,
+      );
+    });
+  });
+
+  describe('pre-add rules', () => {
+    let preAddRule: MockProxy<PreAddRule>;
+    let poolAccess: MockProxy<PreAddPoolAccess>;
+
+    const createMeta = (txHash: string, priorityFee: bigint): TxMetaData => ({
+      txHash,
+      anchorBlockHeaderHash: '0x1234',
+      priorityFee,
+      feePayer: '0xfeepayer',
+      claimAmount: 0n,
+      feeLimit: 100n,
+      nullifiers: [`0x${txHash.slice(2)}null1`],
+      includeByTimestamp: 0n,
+    });
+
+    beforeEach(() => {
+      preAddRule = mock<PreAddRule>({ name: 'preAddRule' });
+      poolAccess = mock<PreAddPoolAccess>();
+    });
+
+    it('runs pre-add rules and returns combined result', async () => {
+      preAddRule.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x2222'],
+      });
+
+      evictionManager.registerPreAddRule(preAddRule);
+      const incomingMeta = createMeta('0x1111', 100n);
+
+      const result = await evictionManager.runPreAddRules(incomingMeta, poolAccess);
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toContain('0x2222');
+      expect(preAddRule.check).toHaveBeenCalledWith(incomingMeta, poolAccess);
+    });
+
+    it('returns ignore result immediately when a rule says to ignore', async () => {
+      const preAddRule2 = mock<PreAddRule>({ name: 'preAddRule2' });
+
+      preAddRule.check.mockResolvedValue({
+        shouldIgnore: true,
+        txHashesToEvict: [],
+        reason: 'test reason',
+      });
+      preAddRule2.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x3333'],
+      });
+
+      evictionManager.registerPreAddRule(preAddRule);
+      evictionManager.registerPreAddRule(preAddRule2);
+      const incomingMeta = createMeta('0x1111', 100n);
+
+      const result = await evictionManager.runPreAddRules(incomingMeta, poolAccess);
+
+      expect(result.shouldIgnore).toBe(true);
+      expect(result.reason).toBe('test reason');
+      expect(preAddRule.check).toHaveBeenCalledTimes(1);
+      // Second rule should not be called since first rule ignored
+      expect(preAddRule2.check).not.toHaveBeenCalled();
+    });
+
+    it('combines eviction lists from multiple rules', async () => {
+      const preAddRule2 = mock<PreAddRule>({ name: 'preAddRule2' });
+
+      preAddRule.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x2222'],
+      });
+      preAddRule2.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x3333'],
+      });
+
+      evictionManager.registerPreAddRule(preAddRule);
+      evictionManager.registerPreAddRule(preAddRule2);
+      const incomingMeta = createMeta('0x1111', 100n);
+
+      const result = await evictionManager.runPreAddRules(incomingMeta, poolAccess);
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toContain('0x2222');
+      expect(result.txHashesToEvict).toContain('0x3333');
+    });
+
+    it('deduplicates eviction lists', async () => {
+      const preAddRule2 = mock<PreAddRule>({ name: 'preAddRule2' });
+
+      preAddRule.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x2222', '0x3333'],
+      });
+      preAddRule2.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x3333', '0x4444'], // 0x3333 is duplicate
+      });
+
+      evictionManager.registerPreAddRule(preAddRule);
+      evictionManager.registerPreAddRule(preAddRule2);
+      const incomingMeta = createMeta('0x1111', 100n);
+
+      const result = await evictionManager.runPreAddRules(incomingMeta, poolAccess);
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toHaveLength(3); // No duplicates
+      expect(result.txHashesToEvict).toContain('0x2222');
+      expect(result.txHashesToEvict).toContain('0x3333');
+      expect(result.txHashesToEvict).toContain('0x4444');
+    });
+  });
+
+  describe('error handling', () => {
+    it('continues execution if a post-event rule throws an error', async () => {
+      const newTxHashes = ['0x1111'];
+      const feePayers = ['0xfeepayer1'];
+
+      mockRule1.evict.mockRejectedValue(new Error('Rule 1 failed'));
+      mockRule2.evict.mockResolvedValue({
+        txsEvicted: [],
+        reason: 'test2',
+        success: true,
+      });
+
+      evictionManager.registerRule(mockRule1);
+      evictionManager.registerRule(mockRule2);
+
+      await expect(evictionManager.evictAfterNewTxs(newTxHashes, feePayers)).resolves.not.toThrow();
+
+      expect(mockRule1.evict).toHaveBeenCalledTimes(1);
+      expect(mockRule2.evict).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns ignore result if a pre-add rule throws an error', async () => {
+      const preAddRule1 = mock<PreAddRule>({ name: 'failingRule' });
+      const preAddRule2 = mock<PreAddRule>({ name: 'secondRule' });
+      const poolAccess = mock<PreAddPoolAccess>();
+
+      const createMeta = (txHash: string, priorityFee: bigint): TxMetaData => ({
+        txHash,
+        anchorBlockHeaderHash: '0x1234',
+        priorityFee,
+        feePayer: '0xfeepayer',
+        claimAmount: 0n,
+        feeLimit: 100n,
+        nullifiers: [`0x${txHash.slice(2)}null1`],
+        includeByTimestamp: 0n,
+      });
+
+      preAddRule1.check.mockRejectedValue(new Error('Rule failed'));
+      preAddRule2.check.mockResolvedValue({
+        shouldIgnore: false,
+        txHashesToEvict: ['0x2222'],
+      });
+
+      evictionManager.registerPreAddRule(preAddRule1);
+      evictionManager.registerPreAddRule(preAddRule2);
+
+      const incomingMeta = createMeta('0x1111', 100n);
+      const result = await evictionManager.runPreAddRules(incomingMeta, poolAccess);
+
+      expect(result.shouldIgnore).toBe(true);
+      expect(result.reason).toContain('failingRule');
+      expect(result.txHashesToEvict).toHaveLength(0);
+      // Second rule should not be called since first rule threw
+      expect(preAddRule2.check).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rule execution order', () => {
+    it('executes post-event rules in registration order', async () => {
+      const newTxHashes = ['0x1111'];
+      const feePayers = ['0xfeepayer1'];
+      const callOrder: string[] = [];
+
+      mockRule1.evict.mockImplementation(() => {
+        callOrder.push('rule1');
+        return Promise.resolve({
+          txsEvicted: [],
+          reason: 'test1',
+          success: true,
+        });
+      });
+
+      mockRule2.evict.mockImplementation(() => {
+        callOrder.push('rule2');
+        return Promise.resolve({
+          txsEvicted: [],
+          reason: 'test2',
+          success: true,
+        });
+      });
+
+      evictionManager.registerRule(mockRule1);
+      evictionManager.registerRule(mockRule2);
+
+      await evictionManager.evictAfterNewTxs(newTxHashes, feePayers);
+
+      expect(callOrder).toEqual(['rule1', 'rule2']);
+    });
+
+    it('waits for each rule to complete before starting the next', async () => {
+      const newTxHashes = ['0x1111'];
+      const feePayers = ['0xfeepayer1'];
+
+      mockRule1.evict.mockImplementation(() => {
+        expect(mockRule2.evict).not.toHaveBeenCalled();
+        return Promise.resolve({
+          txsEvicted: [],
+          reason: 'test1',
+          success: true,
+        });
+      });
+
+      mockRule2.evict.mockImplementation(() => {
+        expect(mockRule1.evict).toHaveBeenCalled();
+        return Promise.resolve({
+          txsEvicted: [],
+          reason: 'test2',
+          success: true,
+        });
+      });
+
+      evictionManager.registerRule(mockRule1);
+      evictionManager.registerRule(mockRule2);
+
+      await evictionManager.evictAfterNewTxs(newTxHashes, feePayers);
+    });
+  });
+
+  describe('no rules registered', () => {
+    it('handles evictAfterNewTxs with no rules gracefully', async () => {
+      const newTxHashes = ['0x1111'];
+      const feePayers = ['0xfeepayer1'];
+
+      await expect(evictionManager.evictAfterNewTxs(newTxHashes, feePayers)).resolves.not.toThrow();
+    });
+
+    it('handles evictAfterNewBlock with no rules gracefully', async () => {
+      const block = BlockHeader.empty();
+      await expect(evictionManager.evictAfterNewBlock(block, [], [])).resolves.not.toThrow();
+    });
+
+    it('handles evictAfterChainPrune with no rules gracefully', async () => {
+      await expect(evictionManager.evictAfterChainPrune(BlockNumber(1))).resolves.not.toThrow();
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/eviction_manager.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/eviction_manager.ts
@@ -1,0 +1,147 @@
+import type { BlockNumber } from '@aztec/foundation/branded-types';
+import type { Logger } from '@aztec/foundation/log';
+import type { BlockHeader } from '@aztec/stdlib/tx';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import {
+  type EvictionConfig,
+  type EvictionContext,
+  EvictionEvent,
+  type EvictionRule,
+  type PoolOperations,
+  type PreAddPoolAccess,
+  type PreAddResult,
+  type PreAddRule,
+} from './interfaces.js';
+
+/**
+ * Manages eviction rules for the transaction pool.
+ * Coordinates pre-add rules (run during addPendingTxs) and post-event rules (run after events).
+ */
+export class EvictionManager {
+  private preAddRules: PreAddRule[] = [];
+  private postEventRules: EvictionRule[] = [];
+
+  constructor(
+    private pool: PoolOperations,
+    private log: Logger,
+  ) {}
+
+  /**
+   * Registers a pre-add rule that runs during transaction addition.
+   */
+  registerPreAddRule(rule: PreAddRule): void {
+    this.preAddRules.push(rule);
+    this.log.debug(`Registered pre-add rule: ${rule.name}`);
+  }
+
+  /**
+   * Registers a post-event eviction rule that runs after events.
+   */
+  registerRule(rule: EvictionRule): void {
+    this.postEventRules.push(rule);
+    this.log.debug(`Registered eviction rule: ${rule.name}`);
+  }
+
+  /**
+   * Runs all pre-add rules for an incoming transaction.
+   * Returns combined result of all rules.
+   */
+  async runPreAddRules(incomingMeta: TxMetaData, poolAccess: PreAddPoolAccess): Promise<PreAddResult> {
+    const allTxHashesToEvict: string[] = [];
+
+    for (const rule of this.preAddRules) {
+      try {
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        if (result.shouldIgnore) {
+          return result;
+        }
+
+        // Collect txs to evict from all rules
+        for (const txHash of result.txHashesToEvict) {
+          if (!allTxHashesToEvict.includes(txHash)) {
+            allTxHashesToEvict.push(txHash);
+          }
+        }
+      } catch (err) {
+        this.log.error(`Error running pre-add rule ${rule.name}`, { err, txHash: incomingMeta.txHash });
+        // On error, ignore the transaction to be safe
+        return {
+          shouldIgnore: true,
+          txHashesToEvict: [],
+          reason: `pre-add rule ${rule.name} error: ${err}`,
+        };
+      }
+    }
+
+    return {
+      shouldIgnore: false,
+      txHashesToEvict: allTxHashesToEvict,
+    };
+  }
+
+  /**
+   * Runs post-event eviction after new transactions are added.
+   */
+  async evictAfterNewTxs(newTxHashes: string[], feePayers: string[]): Promise<void> {
+    const context: EvictionContext = {
+      event: EvictionEvent.TXS_ADDED,
+      newTxHashes,
+      feePayers,
+    };
+
+    await this.runPostEventRules(context);
+  }
+
+  /**
+   * Runs post-event eviction after a block is mined.
+   */
+  async evictAfterNewBlock(block: BlockHeader, newNullifiers: string[], feePayers: string[]): Promise<void> {
+    const context: EvictionContext = {
+      event: EvictionEvent.BLOCK_MINED,
+      block,
+      newNullifiers,
+      feePayers,
+    };
+
+    await this.runPostEventRules(context);
+  }
+
+  /**
+   * Runs post-event eviction after a chain prune (reorg).
+   */
+  async evictAfterChainPrune(blockNumber: BlockNumber): Promise<void> {
+    const context: EvictionContext = {
+      event: EvictionEvent.CHAIN_PRUNED,
+      blockNumber,
+    };
+
+    await this.runPostEventRules(context);
+  }
+
+  /**
+   * Updates configuration for all rules.
+   */
+  updateConfig(config: EvictionConfig): void {
+    for (const rule of this.preAddRules) {
+      rule.updateConfig?.(config);
+    }
+    for (const rule of this.postEventRules) {
+      rule.updateConfig?.(config);
+    }
+  }
+
+  private async runPostEventRules(context: EvictionContext): Promise<void> {
+    for (const rule of this.postEventRules) {
+      try {
+        const result = await rule.evict(context, this.pool);
+        if (!result.success) {
+          this.log.warn(`Eviction rule ${rule.name} failed`, { error: result.error });
+        }
+      } catch (err) {
+        this.log.error(`Error running eviction rule ${rule.name}`, { err });
+      }
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.test.ts
@@ -1,0 +1,519 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import { FeePayerBalanceEvictionRule } from './fee_payer_balance_eviction_rule.js';
+import type { EvictionContext, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+
+describe('FeePayerBalanceEvictionRule', () => {
+  let rule: FeePayerBalanceEvictionRule;
+  let mockWorldState: MockProxy<WorldStateSynchronizer>;
+  let db: MockProxy<MerkleTreeReadOperations>;
+  let deleteTxsMock: jest.MockedFunction<PoolOperations['deleteTxs']>;
+
+  // Configurable balance per fee payer
+  let feePayerBalances: Map<string, bigint>;
+
+  const feePayer1 = '0x1111111111111111111111111111111111111111111111111111111111111111';
+  const feePayer2 = '0x2222222222222222222222222222222222222222222222222222222222222222';
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (
+    txHash: string,
+    opts: {
+      priorityFee?: bigint;
+      feeLimit?: bigint;
+      claimAmount?: bigint;
+      feePayer?: string;
+    } = {},
+  ): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash: '0x1234',
+    priorityFee: opts.priorityFee ?? 100n,
+    feePayer: opts.feePayer ?? feePayer1,
+    claimAmount: opts.claimAmount ?? 0n,
+    feeLimit: opts.feeLimit ?? 100n,
+    nullifiers: [`0x${txHash.slice(2)}null1`],
+    includeByTimestamp: 0n,
+  });
+
+  // Create mock pool operations
+  const createPoolOps = (txsByFeePayer: Map<string, TxMetaData[]>): PoolOperations => {
+    deleteTxsMock = jest.fn(() => Promise.resolve());
+    return {
+      getPendingTxs: () => [...txsByFeePayer.values()].flat(),
+      getPendingFeePayers: () => [...txsByFeePayer.keys()],
+      getFeePayerPendingTxs: (feePayer: string) => txsByFeePayer.get(feePayer) ?? [],
+      getPendingTxCount: () => [...txsByFeePayer.values()].flat().length,
+      getLowestPriorityPending: () => [],
+      deleteTxs: deleteTxsMock as (txHashes: string[]) => Promise<void>,
+    };
+  };
+
+  // Setup mock world state to return configured balances
+  const setupBalances = (balances: Map<string, bigint>) => {
+    feePayerBalances = balances;
+
+    // Mock the storage read to return the configured balance
+    db.getPreviousValueIndex.mockImplementation((_tree, slot) => {
+      return Promise.resolve({ index: slot, alreadyPresent: true });
+    });
+
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+        // Find the fee payer by matching the storage slot index
+        // For simplicity, we use a default balance if not found
+        const balance = feePayerBalances.get(feePayer1) ?? 0n;
+        return Promise.resolve(
+          new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(balance)), Fr.ONE, 1n),
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+  };
+
+  beforeEach(() => {
+    mockWorldState = mock<WorldStateSynchronizer>();
+    db = mock<MerkleTreeReadOperations>();
+    mockWorldState.getCommitted.mockReturnValue(db);
+    mockWorldState.getSnapshot.mockReturnValue(db);
+    mockWorldState.syncImmediate.mockResolvedValue(BlockNumber(1));
+
+    feePayerBalances = new Map();
+    setupBalances(feePayerBalances);
+
+    rule = new FeePayerBalanceEvictionRule(mockWorldState);
+  });
+
+  describe('constructor', () => {
+    it('has correct name and reason', () => {
+      expect(rule.name).toBe('FeePayerBalanceEviction');
+      expect(rule.reason).toBe('fee_payer_balance');
+    });
+  });
+
+  describe('evict method', () => {
+    describe('TXS_ADDED events', () => {
+      it('returns empty result when all txs fit within balance', async () => {
+        const meta1 = createMeta('0x1111', { feeLimit: 100n });
+        const meta2 = createMeta('0x2222', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta1, meta2]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance covers both txs
+        setupBalances(new Map([[feePayer1, 200n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(0);
+        expect(deleteTxsMock).not.toHaveBeenCalled();
+      });
+
+      it('evicts low-priority tx when balance is insufficient', async () => {
+        const lowPriorityMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 10n });
+        const highPriorityMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [lowPriorityMeta, highPriorityMeta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance only covers one tx
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']); // Low priority evicted
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x1111']);
+      });
+
+      it('evicts multiple low-priority txs when balance is insufficient', async () => {
+        const lowMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 10n });
+        const medMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 50n });
+        const highMeta = createMeta('0x3333', { feeLimit: 100n, priorityFee: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [lowMeta, medMeta, highMeta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance only covers one tx
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222', '0x3333'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        // Both low and medium priority should be evicted
+        expect(result.txsEvicted).toContain('0x1111');
+        expect(result.txsEvicted).toContain('0x2222');
+        expect(result.txsEvicted).not.toContain('0x3333');
+      });
+
+      it('priority ordering is correct - highest priority gets funded first', async () => {
+        // Create txs with clear priority ordering
+        const tx10 = createMeta('0xaaaa', { feeLimit: 100n, priorityFee: 10n });
+        const tx50 = createMeta('0xbbbb', { feeLimit: 100n, priorityFee: 50n });
+        const tx100 = createMeta('0xcccc', { feeLimit: 100n, priorityFee: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [tx10, tx50, tx100]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance covers 2 txs (200) - should keep tx100 and tx50, evict tx10
+        setupBalances(new Map([[feePayer1, 200n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0xaaaa', '0xbbbb', '0xcccc'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0xaaaa']); // Only lowest priority evicted
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0xaaaa']);
+      });
+
+      it('considers claim amount when calculating available balance', async () => {
+        // High priority tx claims funds that can be used by subsequent txs
+        const highWithClaim = createMeta('0x1111', {
+          feeLimit: 100n,
+          priorityFee: 100n,
+          claimAmount: 200n, // Claims 200, pays 100, net +100
+        });
+        const lowMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 10n });
+        const txsByFeePayer = new Map([[feePayer1, [highWithClaim, lowMeta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Initial balance is 100, but claim adds 200
+        // After high: balance = 100 + 200 - 100 = 200
+        // After low: balance = 200 - 100 = 100
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(0); // Both can be funded due to claim
+      });
+
+      it('evicts when claim amount is not enough', async () => {
+        const highWithClaim = createMeta('0x1111', {
+          feeLimit: 100n,
+          priorityFee: 100n,
+          claimAmount: 50n, // Claims 50, pays 100, net -50
+        });
+        const lowMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 10n });
+        const txsByFeePayer = new Map([[feePayer1, [highWithClaim, lowMeta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Initial balance is 100
+        // After high: balance = 100 + 50 - 100 = 50
+        // Low needs 100, only 50 available
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x2222']); // Low priority evicted
+      });
+
+      it('handles zero balance', async () => {
+        const meta = createMeta('0x1111', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        setupBalances(new Map([[feePayer1, 0n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']);
+      });
+
+      it('handles empty fee payers list', async () => {
+        const pool = createPoolOps(new Map());
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(0);
+      });
+
+      it('handles fee payer with no pending txs', async () => {
+        const pool = createPoolOps(new Map());
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: [],
+          feePayers: [feePayer1], // Fee payer with no txs
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(0);
+      });
+    });
+
+    describe('BLOCK_MINED events', () => {
+      const blockHeader = BlockHeader.empty({
+        globalVariables: GlobalVariables.empty({
+          blockNumber: BlockNumber(5),
+        }),
+      });
+
+      it('syncs world state before checking balances', async () => {
+        const meta = createMeta('0x1111', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers: [],
+          feePayers: [feePayer1],
+        };
+
+        await rule.evict(context, pool);
+
+        expect(mockWorldState.syncImmediate).toHaveBeenCalledWith(5);
+        expect(mockWorldState.getSnapshot).toHaveBeenCalledWith(5);
+      });
+
+      it('evicts low-priority tx when balance is insufficient after block', async () => {
+        const lowMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 10n });
+        const highMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [lowMeta, highMeta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance only covers one tx
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers: [],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']);
+      });
+    });
+
+    describe('CHAIN_PRUNED events', () => {
+      it('checks all pending fee payers after prune', async () => {
+        const meta1 = createMeta('0x1111', { feeLimit: 100n, feePayer: feePayer1 });
+        const meta2 = createMeta('0x2222', { feeLimit: 100n, feePayer: feePayer2 });
+        const txsByFeePayer = new Map([
+          [feePayer1, [meta1]],
+          [feePayer2, [meta2]],
+        ]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Both fee payers have sufficient balance
+        setupBalances(
+          new Map([
+            [feePayer1, 100n],
+            [feePayer2, 100n],
+          ]),
+        );
+
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(3),
+        };
+
+        await rule.evict(context, pool);
+
+        expect(mockWorldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(3));
+        expect(mockWorldState.getSnapshot).toHaveBeenCalledWith(BlockNumber(3));
+      });
+
+      it('evicts txs when balance changed after prune', async () => {
+        const meta = createMeta('0x1111', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance insufficient after prune
+        setupBalances(new Map([[feePayer1, 50n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(3),
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']);
+      });
+    });
+
+    describe('unknown events', () => {
+      it('returns empty result for unknown event type', async () => {
+        const pool = createPoolOps(new Map());
+
+        // Force an unknown event type by casting
+        const context = {
+          event: 'unknown_event' as any,
+        } as EvictionContext;
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(0);
+      });
+    });
+
+    describe('error handling', () => {
+      it('returns error result when world state sync fails', async () => {
+        const meta = createMeta('0x1111', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        mockWorldState.syncImmediate.mockRejectedValue(new Error('Sync failed'));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(5) }) }),
+          newNullifiers: [],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(false);
+        expect(result.txsEvicted).toHaveLength(0);
+        expect(result.error?.message).toContain('Failed to evict txs due to fee payer balance');
+      });
+
+      it('returns error result when deleteTxs fails', async () => {
+        const meta = createMeta('0x1111', { feeLimit: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [meta]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        setupBalances(new Map([[feePayer1, 0n]])); // Zero balance to trigger eviction
+        deleteTxsMock.mockRejectedValue(new Error('Delete failed'));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.message).toContain('Failed to evict txs due to fee payer balance');
+      });
+    });
+
+    describe('priority ordering verification', () => {
+      it('funds high priority tx before low priority when balance is limited', async () => {
+        // This test specifically verifies that comparePriority sorts correctly
+        // by ensuring the highest priority tx is funded and lowest is evicted
+        const tx1 = createMeta('0xaaaa', { feeLimit: 50n, priorityFee: 1n }); // Lowest priority
+        const tx2 = createMeta('0xbbbb', { feeLimit: 50n, priorityFee: 2n });
+        const tx3 = createMeta('0xcccc', { feeLimit: 50n, priorityFee: 3n }); // Highest priority
+        const txsByFeePayer = new Map([[feePayer1, [tx1, tx2, tx3]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance covers exactly 2 txs (100)
+        setupBalances(new Map([[feePayer1, 100n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0xaaaa', '0xbbbb', '0xcccc'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        // tx1 (lowest priority) should be evicted
+        expect(result.txsEvicted).toEqual(['0xaaaa']);
+        // tx2 and tx3 should be kept
+        expect(result.txsEvicted).not.toContain('0xbbbb');
+        expect(result.txsEvicted).not.toContain('0xcccc');
+      });
+
+      it('uses txHash as tiebreaker when priorities are equal', async () => {
+        // When priorities are equal, larger txHash should be lower priority
+        // Fr.cmp returns negative if a < b, so smaller hash = higher priority in sort
+        const txSmallHash = createMeta('0x0001', { feeLimit: 50n, priorityFee: 100n });
+        const txLargeHash = createMeta('0xffff', { feeLimit: 50n, priorityFee: 100n });
+        const txsByFeePayer = new Map([[feePayer1, [txSmallHash, txLargeHash]]]);
+        const pool = createPoolOps(txsByFeePayer);
+
+        // Balance only covers one tx
+        setupBalances(new Map([[feePayer1, 50n]]));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x0001', '0xffff'],
+          feePayers: [feePayer1],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        // One tx should be evicted - the one with lower priority in the tiebreaker
+        expect(result.txsEvicted).toHaveLength(1);
+        // The result should be deterministic
+        const evictedFirst = result.txsEvicted[0];
+
+        // Run again to verify determinism
+        const result2 = await rule.evict(context, pool);
+        expect(result2.txsEvicted[0]).toEqual(evictedFirst);
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.ts
@@ -1,0 +1,118 @@
+import { createLogger } from '@aztec/foundation/log';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
+import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { DatabasePublicStateSource, type MerkleTreeReadOperations } from '@aztec/stdlib/trees';
+
+import { type TxMetaData, comparePriority } from '../tx_metadata.js';
+import type { EvictionContext, EvictionResult, EvictionRule, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+
+/**
+ * Eviction rule that removes transactions when fee payers have insufficient balance.
+ * Triggers on TXS_ADDED, BLOCK_MINED, and CHAIN_PRUNED events.
+ */
+export class FeePayerBalanceEvictionRule implements EvictionRule {
+  public readonly name = 'FeePayerBalanceEviction';
+  public readonly reason = 'fee_payer_balance';
+
+  private log = createLogger('p2p:tx_pool_v2:fee_payer_balance_eviction_rule');
+
+  constructor(private worldState: WorldStateSynchronizer) {}
+
+  async evict(context: EvictionContext, pool: PoolOperations): Promise<EvictionResult> {
+    try {
+      if (context.event === EvictionEvent.TXS_ADDED) {
+        return await this.evictForFeePayers(context.feePayers, this.worldState.getCommitted(), pool);
+      }
+
+      if (context.event === EvictionEvent.BLOCK_MINED) {
+        const blockNumber = context.block.getBlockNumber();
+        await this.worldState.syncImmediate(blockNumber);
+        return await this.evictForFeePayers(context.feePayers, this.worldState.getSnapshot(blockNumber), pool);
+      }
+
+      if (context.event === EvictionEvent.CHAIN_PRUNED) {
+        await this.worldState.syncImmediate(context.blockNumber);
+        const feePayers = pool.getPendingFeePayers();
+        return await this.evictForFeePayers(feePayers, this.worldState.getSnapshot(context.blockNumber), pool);
+      }
+
+      return {
+        reason: this.reason,
+        success: true,
+        txsEvicted: [],
+      };
+    } catch (err) {
+      this.log.error('Failed to evict txs due to fee payer balance', { err });
+      return {
+        reason: this.reason,
+        success: false,
+        txsEvicted: [],
+        error: new Error('Failed to evict txs due to fee payer balance', { cause: err }),
+      };
+    }
+  }
+
+  private async evictForFeePayers(
+    feePayers: string[],
+    db: MerkleTreeReadOperations,
+    pool: PoolOperations,
+  ): Promise<EvictionResult> {
+    const publicStateSource = new DatabasePublicStateSource(db);
+
+    const txsToEvict = (
+      await Promise.all(feePayers.map(feePayer => this.getEvictionsForFeePayer(feePayer, publicStateSource, pool)))
+    ).flat();
+
+    if (txsToEvict.length > 0) {
+      await pool.deleteTxs(txsToEvict);
+    }
+
+    return {
+      reason: this.reason,
+      success: true,
+      txsEvicted: txsToEvict,
+    };
+  }
+
+  private async getEvictionsForFeePayer(
+    feePayerStr: string,
+    publicStateSource: DatabasePublicStateSource,
+    pool: PoolOperations,
+  ): Promise<string[]> {
+    const feePayer = AztecAddress.fromString(feePayerStr);
+    const initialBalance = (
+      await publicStateSource.storageRead(
+        ProtocolContractAddress.FeeJuice,
+        await computeFeePayerBalanceStorageSlot(feePayer),
+      )
+    ).toBigInt();
+
+    const txs: TxMetaData[] = pool.getFeePayerPendingTxs(feePayerStr);
+
+    if (txs.length === 0) {
+      return [];
+    }
+
+    const txsToEvict: string[] = [];
+    let balance = initialBalance;
+
+    // Sort by priority descending (highest first), with hash as tiebreaker
+    txs.sort((a, b) => comparePriority(b, a));
+
+    for (const tx of txs) {
+      const available = balance + tx.claimAmount;
+      if (available >= tx.feeLimit) {
+        balance = available - tx.feeLimit;
+        continue;
+      }
+
+      // This tx cannot be covered - mark for eviction
+      txsToEvict.push(tx.txHash);
+    }
+
+    return txsToEvict;
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_pre_add_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_pre_add_rule.test.ts
@@ -1,0 +1,267 @@
+import type { TxMetaData } from '../tx_metadata.js';
+import { FeePayerBalancePreAddRule } from './fee_payer_balance_pre_add_rule.js';
+import type { PreAddPoolAccess } from './interfaces.js';
+
+describe('FeePayerBalancePreAddRule', () => {
+  let rule: FeePayerBalancePreAddRule;
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (
+    txHash: string,
+    opts: {
+      priorityFee?: bigint;
+      feeLimit?: bigint;
+      claimAmount?: bigint;
+      feePayer?: string;
+    } = {},
+  ): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash: '0x1234',
+    priorityFee: opts.priorityFee ?? 100n,
+    feePayer: opts.feePayer ?? '0xfeepayer',
+    claimAmount: opts.claimAmount ?? 0n,
+    feeLimit: opts.feeLimit ?? 100n,
+    nullifiers: [`0x${txHash.slice(2)}null1`],
+    includeByTimestamp: 0n,
+  });
+
+  // Mock pool access with configurable behavior
+  const createPoolAccess = (balance: bigint, existingTxs: TxMetaData[] = []): PreAddPoolAccess => ({
+    getMetadata: (txHashStr: string) => existingTxs.find(t => t.txHash === txHashStr),
+    getTxHashByNullifier: () => undefined,
+    getFeePayerBalance: () => Promise.resolve(balance),
+    getFeePayerPendingTxs: () => existingTxs,
+    getPendingTxCount: () => existingTxs.length,
+    getLowestPriorityPendingTx: () =>
+      existingTxs.length > 0 ? existingTxs.reduce((min, t) => (t.priorityFee < min.priorityFee ? t : min)) : undefined,
+  });
+
+  beforeEach(() => {
+    rule = new FeePayerBalancePreAddRule();
+  });
+
+  describe('when pool access methods are available', () => {
+    describe('single transaction scenarios', () => {
+      it('accepts tx when fee payer has sufficient balance', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(1000n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('ignores tx when fee payer has insufficient balance', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(50n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict).toHaveLength(0);
+        expect(result.reason).toContain('insufficient balance');
+      });
+
+      it('accepts tx when balance exactly equals fee limit', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+      });
+
+      it('ignores tx when balance is just under fee limit', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(99n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+      });
+    });
+
+    describe('multiple transactions for same fee payer', () => {
+      it('accepts tx when combined with existing txs still fits in balance', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 50n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 100n });
+
+        const poolAccess = createPoolAccess(300n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('ignores low-priority tx when balance is exhausted by higher-priority existing txs', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 200n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 50n });
+
+        // Balance only covers existing tx
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.reason).toContain('insufficient balance');
+      });
+
+      it('evicts lower-priority existing tx when high-priority tx is added', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 50n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 200n });
+
+        // Balance only covers one tx
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+      });
+
+      it('evicts multiple lower-priority txs when high-priority tx is added', async () => {
+        const existingMeta1 = createMeta('0x2222', { feeLimit: 50n, priorityFee: 30n });
+        const existingMeta2 = createMeta('0x3333', { feeLimit: 50n, priorityFee: 40n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 200n });
+
+        // Balance only covers the incoming tx
+        const poolAccess = createPoolAccess(100n, [existingMeta1, existingMeta2]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+        expect(result.txHashesToEvict).toContain('0x3333');
+      });
+
+      it('handles priority ordering correctly - highest priority gets funded first', async () => {
+        const lowPriorityMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 30n });
+        const medPriorityMeta = createMeta('0x3333', { feeLimit: 100n, priorityFee: 50n });
+        const highPriorityMeta = createMeta('0x4444', { feeLimit: 100n, priorityFee: 200n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 75n });
+
+        // Balance covers 3 txs (high + incoming + med), but not low
+        const poolAccess = createPoolAccess(300n, [lowPriorityMeta, medPriorityMeta, highPriorityMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222'); // Low priority evicted
+        expect(result.txHashesToEvict).not.toContain('0x4444'); // High priority kept
+        expect(result.txHashesToEvict).not.toContain('0x3333'); // Med priority kept
+      });
+    });
+
+    describe('claim amount handling', () => {
+      it('considers claim amount when calculating available balance', async () => {
+        const existingMeta = createMeta('0x2222', {
+          feeLimit: 100n,
+          claimAmount: 200n, // Claims enough to cover both txs
+          priorityFee: 200n, // Higher priority, processed first
+        });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 50n });
+
+        // Initial balance is low, but the existing tx's claim will add to it
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        // After existing tx: balance = 100 + 200 - 100 = 200, enough for incoming
+        expect(result.shouldIgnore).toBe(false);
+      });
+
+      it('ignores tx when claim amount is not enough', async () => {
+        const existingMeta = createMeta('0x2222', {
+          feeLimit: 100n,
+          claimAmount: 50n, // Claims half of what's needed
+          priorityFee: 200n, // Higher priority
+        });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 50n });
+
+        // Initial balance only covers existing tx
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        // After existing tx: balance = 100 + 50 - 100 = 50, not enough for incoming
+        expect(result.shouldIgnore).toBe(true);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles empty existing txs list', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(1000n, []);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('handles zero balance', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(0n, []);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+      });
+
+      it('does not evict tx with equal priority (tiebreaker goes to larger hash)', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 100n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 100n });
+
+        // Balance only covers one tx
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        // With equal priority, the tiebreaker is based on txHash
+        // The rule should make a deterministic decision
+        expect(typeof result.shouldIgnore).toBe('boolean');
+      });
+    });
+
+    describe('result status accuracy', () => {
+      it('returns correct eviction list when tx replaces another', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 50n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 200n });
+
+        const poolAccess = createPoolAccess(100n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(1);
+        expect(result.txHashesToEvict[0]).toEqual('0x2222');
+      });
+
+      it('returns empty eviction list when no evictions needed', async () => {
+        const existingMeta = createMeta('0x2222', { feeLimit: 100n, priorityFee: 10n });
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n, priorityFee: 200n });
+
+        // Plenty of balance for both
+        const poolAccess = createPoolAccess(1000n, [existingMeta]);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('provides reason when ignoring tx', async () => {
+        const incomingMeta = createMeta('0x1111', { feeLimit: 100n });
+        const poolAccess = createPoolAccess(0n, []);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.reason).toBeDefined();
+        expect(result.reason).toContain('insufficient balance');
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_pre_add_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_pre_add_rule.ts
@@ -1,0 +1,111 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import { type TxMetaData, comparePriority } from '../tx_metadata.js';
+import type { PreAddPoolAccess, PreAddResult, PreAddRule } from './interfaces.js';
+
+/**
+ * Pre-add rule that checks if a fee payer has sufficient balance to cover the incoming transaction.
+ *
+ * When an incoming tx is added:
+ * - Get the fee payer's on-chain balance
+ * - Get all existing pending txs for this fee payer
+ * - Insert incoming tx in priority order
+ * - Walk through in priority order, tracking running balance
+ * - If incoming tx can be covered: accept, mark lower-priority txs for eviction if needed
+ * - If incoming tx cannot be covered: ignore it
+ */
+export class FeePayerBalancePreAddRule implements PreAddRule {
+  public readonly name = 'FeePayerBalancePreAdd';
+
+  private log = createLogger('p2p:tx_pool_v2:fee_payer_balance_pre_add_rule');
+
+  async check(incomingMeta: TxMetaData, poolAccess: PreAddPoolAccess): Promise<PreAddResult> {
+    // Get fee payer's on-chain balance
+    const initialBalance = await poolAccess.getFeePayerBalance(incomingMeta.feePayer);
+
+    // Get existing pending txs for this fee payer
+    const existingTxs = poolAccess.getFeePayerPendingTxs(incomingMeta.feePayer);
+
+    // Create combined list with incoming tx
+    const allTxs: Array<{
+      txHash: string;
+      priorityFee: bigint;
+      feeLimit: bigint;
+      claimAmount: bigint;
+      isIncoming: boolean;
+    }> = [
+      ...existingTxs.map(t => ({
+        txHash: t.txHash,
+        priorityFee: t.priorityFee,
+        feeLimit: t.feeLimit,
+        claimAmount: t.claimAmount,
+        isIncoming: false,
+      })),
+      {
+        txHash: incomingMeta.txHash,
+        priorityFee: incomingMeta.priorityFee,
+        feeLimit: incomingMeta.feeLimit,
+        claimAmount: incomingMeta.claimAmount,
+        isIncoming: true,
+      },
+    ];
+
+    // Sort by priority descending (highest first), with hash as tiebreaker
+    allTxs.sort((a, b) => comparePriority(b, a));
+
+    // Walk through in priority order, tracking balance
+    let balance = initialBalance;
+    let incomingTxCovered = false;
+    const txsToEvict: string[] = [];
+
+    for (const txInfo of allTxs) {
+      const available = balance + txInfo.claimAmount;
+
+      if (available >= txInfo.feeLimit) {
+        // This tx can be covered
+        balance = available - txInfo.feeLimit;
+        if (txInfo.isIncoming) {
+          incomingTxCovered = true;
+        }
+      } else {
+        // This tx cannot be covered
+        if (txInfo.isIncoming) {
+          // Incoming tx cannot be covered - ignore it
+          this.log.debug(
+            `Ignoring tx ${incomingMeta.txHash}: fee payer ${incomingMeta.feePayer} has insufficient balance`,
+            { balance: initialBalance, feeLimit: incomingMeta.feeLimit, claimAmount: incomingMeta.claimAmount },
+          );
+          return {
+            shouldIgnore: true,
+            txHashesToEvict: [],
+            reason: `fee payer ${incomingMeta.feePayer} has insufficient balance`,
+          };
+        } else {
+          // Existing tx cannot be covered after adding incoming - mark for eviction
+          txsToEvict.push(txInfo.txHash);
+        }
+      }
+    }
+
+    if (!incomingTxCovered) {
+      // This shouldn't happen if the logic above is correct, but just in case
+      this.log.warn(`Incoming tx ${incomingMeta.txHash} was not covered but also not ignored - this is a bug`);
+      return {
+        shouldIgnore: true,
+        txHashesToEvict: [],
+        reason: 'internal error: tx coverage not determined',
+      };
+    }
+
+    if (txsToEvict.length > 0) {
+      this.log.debug(
+        `Accepting tx ${incomingMeta.txHash}, evicting ${txsToEvict.length} lower-priority txs due to fee payer balance`,
+      );
+    }
+
+    return {
+      shouldIgnore: false,
+      txHashesToEvict: txsToEvict,
+    };
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/index.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/index.ts
@@ -1,0 +1,23 @@
+export { EvictionManager } from './eviction_manager.js';
+export {
+  type EvictionConfig,
+  type EvictionContext,
+  EvictionEvent,
+  type EvictionResult,
+  type EvictionRule,
+  type PoolOperations,
+  type PreAddPoolAccess,
+  type PreAddResult,
+  type PreAddRule,
+} from './interfaces.js';
+
+// Pre-add rules
+export { NullifierConflictRule } from './nullifier_conflict_rule.js';
+export { FeePayerBalancePreAddRule } from './fee_payer_balance_pre_add_rule.js';
+export { LowPriorityPreAddRule } from './low_priority_pre_add_rule.js';
+
+// Post-event eviction rules
+export { InvalidTxsAfterMiningRule } from './invalid_txs_after_mining_rule.js';
+export { InvalidTxsAfterReorgRule } from './invalid_txs_after_reorg_rule.js';
+export { FeePayerBalanceEvictionRule } from './fee_payer_balance_eviction_rule.js';
+export { LowPriorityEvictionRule } from './low_priority_eviction_rule.js';

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/interfaces.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/interfaces.ts
@@ -1,0 +1,164 @@
+import type { BlockNumber } from '@aztec/foundation/branded-types';
+import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
+
+import type { TxMetaData } from '../tx_metadata.js';
+
+/**
+ * Events that trigger eviction checks.
+ */
+export const EvictionEvent = {
+  TXS_ADDED: 'txs_added',
+  BLOCK_MINED: 'block_mined',
+  CHAIN_PRUNED: 'chain_pruned',
+} as const;
+
+export type EvictionEventType = (typeof EvictionEvent)[keyof typeof EvictionEvent];
+
+/**
+ * Context passed to eviction rules based on the triggering event.
+ */
+export type EvictionContext =
+  | {
+      event: typeof EvictionEvent.TXS_ADDED;
+      newTxHashes: string[];
+      feePayers: string[];
+    }
+  | {
+      event: typeof EvictionEvent.CHAIN_PRUNED;
+      blockNumber: BlockNumber;
+    }
+  | {
+      event: typeof EvictionEvent.BLOCK_MINED;
+      block: BlockHeader;
+      newNullifiers: string[];
+      feePayers: string[];
+    };
+
+/**
+ * Result of an eviction operation.
+ */
+export interface EvictionResult {
+  readonly txsEvicted: string[];
+  readonly reason: string;
+  readonly success: boolean;
+  readonly error?: Error;
+}
+
+/**
+ * Read-only access to pool state for pre-add checks.
+ */
+export interface PreAddPoolAccess {
+  /** Get metadata for a pending tx by its hash string */
+  getMetadata(txHashStr: string): TxMetaData | undefined;
+
+  /** Get the pending tx hash that uses a specific nullifier (as string) */
+  getTxHashByNullifier(nullifier: string): string | undefined;
+
+  /** Get on-chain balance for a fee payer address */
+  getFeePayerBalance(feePayer: string): Promise<bigint>;
+
+  /** Get metadata for all pending txs from a specific fee payer */
+  getFeePayerPendingTxs(feePayer: string): TxMetaData[];
+
+  /** Get current count of pending transactions */
+  getPendingTxCount(): number;
+
+  /** Get the lowest priority pending tx metadata */
+  getLowestPriorityPendingTx(): TxMetaData | undefined;
+}
+
+/**
+ * Result of a pre-add check for a single transaction.
+ */
+export interface PreAddResult {
+  /** Whether the incoming tx should be ignored (valid but not desired) */
+  readonly shouldIgnore: boolean;
+  /** Tx hashes (as strings) that should be evicted if this tx is added */
+  readonly txHashesToEvict: string[];
+  /** Optional reason for ignoring */
+  readonly reason?: string;
+}
+
+/**
+ * Pre-add rule interface. Rules check incoming txs before they're added to the pool.
+ * All methods work with TxMetaData for efficiency.
+ */
+export interface PreAddRule {
+  readonly name: string;
+
+  /**
+   * Check if incoming tx should be added and which existing txs to evict.
+   * @param incomingMeta - Metadata for the incoming transaction
+   * @param poolAccess - Read-only access to current pool state
+   * @returns Result indicating whether to ignore and what to evict
+   */
+  check(incomingMeta: TxMetaData, poolAccess: PreAddPoolAccess): Promise<PreAddResult>;
+
+  /**
+   * Updates the configuration for this rule.
+   */
+  updateConfig?(config: EvictionConfig): void;
+}
+
+/**
+ * Operations that post-event eviction rules can perform on the pool.
+ * All methods work with metadata and strings for efficiency.
+ */
+export interface PoolOperations {
+  /** Get all pending tx metadata */
+  getPendingTxs(): TxMetaData[];
+
+  /** Get unique fee payers from pending transactions */
+  getPendingFeePayers(): string[];
+
+  /** Get metadata for all pending txs from a specific fee payer */
+  getFeePayerPendingTxs(feePayer: string): TxMetaData[];
+
+  /** Get current count of pending transactions */
+  getPendingTxCount(): number;
+
+  /** Get the N lowest priority pending tx hashes */
+  getLowestPriorityPending(limit: number): string[];
+
+  /** Delete transactions by hash */
+  deleteTxs(txHashes: string[]): Promise<void>;
+}
+
+/**
+ * Post-event eviction rule interface. Rules run after events to clean up the pool.
+ */
+export interface EvictionRule {
+  readonly name: string;
+
+  /**
+   * Performs the eviction logic after an event.
+   */
+  evict(context: EvictionContext, pool: PoolOperations): Promise<EvictionResult>;
+
+  /**
+   * Updates the configuration for this rule.
+   */
+  updateConfig?(config: EvictionConfig): void;
+}
+
+/**
+ * Configuration options for eviction rules.
+ */
+export interface EvictionConfig {
+  /** Maximum number of pending transactions (0 = unlimited) */
+  maxPendingTxCount?: number;
+}
+
+/**
+ * Converts a TxHash to its string representation for use in eviction results.
+ */
+export function txHashToString(txHash: TxHash): string {
+  return txHash.toString();
+}
+
+/**
+ * Converts an array of TxHash to string array.
+ */
+export function txHashesToStrings(txHashes: TxHash[]): string[] {
+  return txHashes.map(h => h.toString());
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_mining_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_mining_rule.test.ts
@@ -1,0 +1,263 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockHeader } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import type { EvictionContext, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+import { InvalidTxsAfterMiningRule } from './invalid_txs_after_mining_rule.js';
+
+describe('InvalidTxsAfterMiningRule', () => {
+  let pool: PoolOperations;
+  let rule: InvalidTxsAfterMiningRule;
+
+  let deleteTxsMock: jest.MockedFunction<any>;
+
+  // Default timestamp used in tests - must be > block timestamp (1000n) to avoid expiration
+  const DEFAULT_INCLUDE_BY_TIMESTAMP = 2000n;
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (
+    txHash: string,
+    opts: {
+      nullifiers?: string[];
+      includeByTimestamp?: bigint;
+    } = {},
+  ): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash: '0x1234',
+    priorityFee: 100n,
+    feePayer: '0xfeepayer',
+    claimAmount: 0n,
+    feeLimit: 100n,
+    nullifiers: opts.nullifiers ?? [`0x${txHash.slice(2)}null1`],
+    includeByTimestamp: opts.includeByTimestamp ?? DEFAULT_INCLUDE_BY_TIMESTAMP,
+  });
+
+  // Create mock pool operations
+  const createPoolOps = (pendingTxs: TxMetaData[]): PoolOperations => {
+    deleteTxsMock = jest.fn(() => Promise.resolve());
+    return {
+      getPendingTxs: () => pendingTxs,
+      getPendingFeePayers: () => [...new Set(pendingTxs.map(t => t.feePayer))],
+      getFeePayerPendingTxs: (feePayer: string) => pendingTxs.filter(t => t.feePayer === feePayer),
+      getPendingTxCount: () => pendingTxs.length,
+      getLowestPriorityPending: () => [],
+      deleteTxs: deleteTxsMock as (txHashes: string[]) => Promise<void>,
+    };
+  };
+
+  beforeEach(() => {
+    pool = createPoolOps([]);
+    rule = new InvalidTxsAfterMiningRule();
+  });
+
+  describe('evict method', () => {
+    describe('non-BLOCK_MINED events', () => {
+      it('returns empty result for TXS_ADDED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'block_mined_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('returns empty result for CHAIN_PRUNED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'block_mined_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+    });
+
+    describe('BLOCK_MINED events', () => {
+      let blockHeader: BlockHeader;
+      let newNullifiers: string[];
+
+      beforeEach(() => {
+        blockHeader = BlockHeader.empty();
+        blockHeader.globalVariables.blockNumber = BlockNumber(100);
+        blockHeader.globalVariables.timestamp = 1000n;
+
+        newNullifiers = ['0xnull1', '0xnull2'];
+      });
+
+      it('evicts transactions with duplicate nullifiers', async () => {
+        const tx1 = createMeta('0x1111', { nullifiers: [newNullifiers[0]] }); // Has duplicate
+        const tx2 = createMeta('0x2222', { nullifiers: ['0xunique'] }); // No duplicate
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']); // Only tx1 has duplicate nullifier
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x1111']);
+      });
+
+      it('evicts transactions with expired timestamps', async () => {
+        const tx1 = createMeta('0x1111', { includeByTimestamp: 500n }); // Expired (500 <= 1000)
+        const tx2 = createMeta('0x2222', { includeByTimestamp: 1500n }); // Not expired (1500 > 1000)
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']); // Only tx1 is expired
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x1111']);
+      });
+
+      it('evicts transactions with timestamp equal to block timestamp', async () => {
+        const tx1 = createMeta('0x1111', { includeByTimestamp: 1000n }); // Exactly at timestamp
+        const tx2 = createMeta('0x2222', { includeByTimestamp: 1001n }); // Just after
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']); // tx1 has timestamp <= block timestamp
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x1111']);
+      });
+
+      it('handles transactions with both duplicate nullifiers and expired timestamps', async () => {
+        const tx1 = createMeta('0x1111', { nullifiers: [newNullifiers[0]], includeByTimestamp: 500n }); // Both reasons
+        const tx2 = createMeta('0x2222', { nullifiers: ['0xunique'], includeByTimestamp: 1500n }); // Neither
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']);
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x1111']);
+      });
+
+      it('handles empty pending transactions list', async () => {
+        pool = createPoolOps([]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'block_mined_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+        expect(deleteTxsMock).not.toHaveBeenCalled();
+      });
+
+      it('handles transactions with multiple nullifiers where only one matches', async () => {
+        const tx1 = createMeta('0x1111', { nullifiers: ['0xunique1', newNullifiers[0], '0xunique2'] }); // One match
+        const tx2 = createMeta('0x2222', { nullifiers: ['0xunique3', '0xunique4'] }); // No match
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x1111']);
+      });
+
+      it('evicts all matching transactions when multiple share nullifiers with mined block', async () => {
+        const tx1 = createMeta('0x1111', { nullifiers: [newNullifiers[0]] });
+        const tx2 = createMeta('0x2222', { nullifiers: [newNullifiers[1]] });
+        const tx3 = createMeta('0x3333', { nullifiers: ['0xunique'] });
+
+        pool = createPoolOps([tx1, tx2, tx3]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toContain('0x1111');
+        expect(result.txsEvicted).toContain('0x2222');
+        expect(result.txsEvicted).not.toContain('0x3333');
+      });
+
+      it('handles error from deleteTxs operation', async () => {
+        const tx1 = createMeta('0x1111', { nullifiers: [newNullifiers[0]] });
+        pool = createPoolOps([tx1]);
+        deleteTxsMock.mockRejectedValue(new Error('Test error'));
+
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: blockHeader,
+          newNullifiers,
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(false);
+        expect(result.txsEvicted).toEqual([]);
+        expect(result.error).toBeDefined();
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_mining_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_mining_rule.ts
@@ -1,0 +1,74 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import type { EvictionContext, EvictionResult, EvictionRule, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+
+/**
+ * Eviction rule that removes invalid transactions after a block is mined.
+ * Only triggers on BLOCK_MINED events.
+ *
+ * Eviction criteria includes:
+ * - Transactions with nullifiers that are already included in the mined block
+ * - Transactions with an expiration timestamp less than or equal to the mined block timestamp
+ */
+export class InvalidTxsAfterMiningRule implements EvictionRule {
+  public readonly name = 'InvalidTxsAfterMining';
+
+  private log = createLogger('p2p:tx_pool_v2:invalid_txs_after_mining_rule');
+
+  async evict(context: EvictionContext, pool: PoolOperations): Promise<EvictionResult> {
+    if (context.event !== EvictionEvent.BLOCK_MINED) {
+      return {
+        reason: 'block_mined_invalid_txs',
+        success: true,
+        txsEvicted: [],
+      };
+    }
+
+    try {
+      const { timestamp } = context.block.globalVariables;
+      const minedNullifiers = new Set(context.newNullifiers);
+
+      const txsToEvict: string[] = [];
+      const pendingTxs = pool.getPendingTxs();
+
+      for (const meta of pendingTxs) {
+        // Evict pending txs that share nullifiers with mined txs
+        if (meta.nullifiers.some(nullifier => minedNullifiers.has(nullifier))) {
+          this.log.verbose(`Evicting tx ${meta.txHash} from pool due to a duplicate nullifier with a mined tx`);
+          txsToEvict.push(meta.txHash);
+          continue;
+        }
+
+        // Evict pending txs with an expiration timestamp less than or equal to the mined block timestamp
+        if (meta.includeByTimestamp <= timestamp) {
+          this.log.verbose(
+            `Evicting tx ${meta.txHash} from pool due to the tx being expired (includeByTimestamp: ${meta.includeByTimestamp}, mined block timestamp: ${timestamp})`,
+          );
+          txsToEvict.push(meta.txHash);
+          continue;
+        }
+      }
+
+      if (txsToEvict.length > 0) {
+        await pool.deleteTxs(txsToEvict);
+      }
+
+      this.log.debug(`Evicted ${txsToEvict.length} invalid txs after block mined`);
+
+      return {
+        reason: 'block_mined_invalid_txs',
+        success: true,
+        txsEvicted: txsToEvict,
+      };
+    } catch (err) {
+      this.log.error('Failed to evict invalid transactions after mining', { err });
+      return {
+        reason: 'block_mined_invalid_txs',
+        success: false,
+        txsEvicted: [],
+        error: new Error('Failed to evict invalid txs after mining', { cause: err }),
+      };
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.test.ts
@@ -1,0 +1,274 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type { MerkleTreeReadOperations } from '@aztec/stdlib/trees';
+import { BlockHeader } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import type { EvictionContext, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+import { InvalidTxsAfterReorgRule } from './invalid_txs_after_reorg_rule.js';
+
+describe('InvalidTxsAfterReorgRule', () => {
+  let pool: PoolOperations;
+  let worldState: MockProxy<WorldStateSynchronizer>;
+  let db: MockProxy<MerkleTreeReadOperations>;
+  let rule: InvalidTxsAfterReorgRule;
+
+  let deleteTxsMock: jest.MockedFunction<any>;
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (txHash: string, anchorBlockHeaderHash: string): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash,
+    priorityFee: 100n,
+    feePayer: '0xfeepayer',
+    claimAmount: 0n,
+    feeLimit: 100n,
+    nullifiers: [`0x${txHash.slice(2)}null1`],
+    includeByTimestamp: 0n,
+  });
+
+  // Create mock pool operations
+  const createPoolOps = (pendingTxs: TxMetaData[]): PoolOperations => {
+    deleteTxsMock = jest.fn(() => Promise.resolve());
+    return {
+      getPendingTxs: () => pendingTxs,
+      getPendingFeePayers: () => [...new Set(pendingTxs.map(t => t.feePayer))],
+      getFeePayerPendingTxs: (feePayer: string) => pendingTxs.filter(t => t.feePayer === feePayer),
+      getPendingTxCount: () => pendingTxs.length,
+      getLowestPriorityPending: () => [],
+      deleteTxs: deleteTxsMock as (txHashes: string[]) => Promise<void>,
+    };
+  };
+
+  beforeEach(() => {
+    pool = createPoolOps([]);
+
+    db = mock<MerkleTreeReadOperations>();
+    // Default mock implementation - no blocks exist in the tree
+    db.findLeafIndices.mockImplementation((_, indices) => Promise.resolve((indices as Fr[]).map(_ => undefined)));
+
+    worldState = mock<WorldStateSynchronizer>();
+    worldState.getSnapshot.mockReturnValue(db);
+    worldState.syncImmediate.mockResolvedValue(BlockNumber(1));
+
+    rule = new InvalidTxsAfterReorgRule(worldState);
+  });
+
+  describe('evict method', () => {
+    describe('non-CHAIN_PRUNED events', () => {
+      it('returns empty result for TXS_ADDED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'reorg_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('returns empty result for BLOCK_MINED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: BlockHeader.empty(),
+          newNullifiers: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'reorg_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+    });
+
+    describe('CHAIN_PRUNED events', () => {
+      it('handles no pending transactions', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        pool = createPoolOps([]);
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'reorg_invalid_txs',
+          success: true,
+          txsEvicted: [],
+        });
+
+        expect(deleteTxsMock).not.toHaveBeenCalled();
+      });
+
+      it('evicts all transactions that reference pruned blocks', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const headerHash1 = Fr.random().toString();
+        const headerHash2 = Fr.random().toString();
+        const tx1 = createMeta('0x1111', headerHash1);
+        const tx2 = createMeta('0x2222', headerHash2);
+
+        pool = createPoolOps([tx1, tx2]);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        // Both txs reference pruned blocks (default mock returns undefined)
+        expect(result.txsEvicted).toContain('0x1111');
+        expect(result.txsEvicted).toContain('0x2222');
+        // Ensure syncImmediate is called before accessing the world state snapshot
+        expect(worldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(1));
+      });
+
+      it('handles large number of transactions efficiently', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const pendingTxs: TxMetaData[] = [];
+
+        // Create 1000 transactions
+        for (let i = 0; i < 1000; i++) {
+          const txHash = `0x${i.toString(16).padStart(4, '0')}`;
+          const headerHash = Fr.random().toString();
+          pendingTxs.push(createMeta(txHash, headerHash));
+        }
+
+        pool = createPoolOps(pendingTxs);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted.length).toBe(pendingTxs.length);
+        expect(deleteTxsMock).toHaveBeenCalledWith(result.txsEvicted);
+      });
+
+      it('handles error from deleteTxs operation', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const headerHash = Fr.random().toString();
+        const tx1 = createMeta('0x1111', headerHash);
+
+        pool = createPoolOps([tx1]);
+        deleteTxsMock.mockRejectedValue(new Error('Test error'));
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.cause).toEqual(new Error('Test error'));
+      });
+    });
+
+    describe('edge cases', () => {
+      it('deduplicates block hashes when multiple txs reference the same block', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const sharedBlockHash = Fr.random().toString();
+        const tx1 = createMeta('0x1111', sharedBlockHash);
+        const tx2 = createMeta('0x2222', sharedBlockHash);
+        const tx3 = createMeta('0x3333', sharedBlockHash);
+
+        pool = createPoolOps([tx1, tx2, tx3]);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(3);
+        expect(result.txsEvicted).toContain('0x1111');
+        expect(result.txsEvicted).toContain('0x2222');
+        expect(result.txsEvicted).toContain('0x3333');
+        // Only one unique block hash to look up
+        expect(db.findLeafIndices).toHaveBeenCalledTimes(1);
+        const calledHashes = db.findLeafIndices.mock.calls[0][1] as Fr[];
+        expect(calledHashes).toHaveLength(1);
+      });
+
+      it('only evicts txs referencing pruned blocks, keeps txs referencing valid blocks', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const validBlockHash = Fr.random();
+        const prunedBlockHash = Fr.random();
+        const tx1 = createMeta('0x1111', validBlockHash.toString());
+        const tx2 = createMeta('0x2222', prunedBlockHash.toString());
+        const tx3 = createMeta('0x3333', validBlockHash.toString());
+
+        pool = createPoolOps([tx1, tx2, tx3]);
+
+        db.findLeafIndices.mockImplementation((_, hashes) =>
+          Promise.resolve((hashes as Fr[]).map(h => (h.equals(validBlockHash) ? 42n : undefined))),
+        );
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(1);
+        expect(result.txsEvicted).toContain('0x2222');
+        expect(result.txsEvicted).not.toContain('0x1111');
+        expect(result.txsEvicted).not.toContain('0x3333');
+      });
+
+      it('handles mix of shared and unique block hashes with some valid and some pruned', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const validSharedHash = Fr.random();
+        const prunedSharedHash = Fr.random();
+        const prunedUniqueHash = Fr.random();
+
+        const tx1 = createMeta('0x1111', validSharedHash.toString());
+        const tx2 = createMeta('0x2222', validSharedHash.toString());
+        const tx3 = createMeta('0x3333', prunedSharedHash.toString());
+        const tx4 = createMeta('0x4444', prunedSharedHash.toString());
+        const tx5 = createMeta('0x5555', prunedUniqueHash.toString());
+
+        pool = createPoolOps([tx1, tx2, tx3, tx4, tx5]);
+
+        db.findLeafIndices.mockImplementation((_, hashes) =>
+          Promise.resolve((hashes as Fr[]).map(h => (h.equals(validSharedHash) ? 10n : undefined))),
+        );
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toHaveLength(3);
+        expect(result.txsEvicted).toContain('0x3333');
+        expect(result.txsEvicted).toContain('0x4444');
+        expect(result.txsEvicted).toContain('0x5555');
+        expect(result.txsEvicted).not.toContain('0x1111');
+        expect(result.txsEvicted).not.toContain('0x2222');
+        expect(db.findLeafIndices).toHaveBeenCalledTimes(1);
+        const calledHashes = db.findLeafIndices.mock.calls[0][1] as Fr[];
+        expect(calledHashes).toHaveLength(3);
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.ts
@@ -1,0 +1,101 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { MerkleTreeId } from '@aztec/stdlib/trees';
+
+import type { EvictionContext, EvictionResult, EvictionRule, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+
+/**
+ * Eviction rule that removes invalid transactions after a blockchain reorganization.
+ * Only triggers on CHAIN_PRUNED events.
+ *
+ * Eviction criteria includes:
+ * - Transactions that reference pruned block hashes (invalid by definition)
+ */
+export class InvalidTxsAfterReorgRule implements EvictionRule {
+  public readonly name = 'InvalidTxsAfterReorg';
+
+  private log = createLogger('p2p:tx_pool_v2:invalid_txs_after_reorg_rule');
+
+  constructor(private worldState: WorldStateSynchronizer) {}
+
+  async evict(context: EvictionContext, pool: PoolOperations): Promise<EvictionResult> {
+    if (context.event !== EvictionEvent.CHAIN_PRUNED) {
+      return {
+        reason: 'reorg_invalid_txs',
+        success: true,
+        txsEvicted: [],
+      };
+    }
+
+    try {
+      const pendingTxs = pool.getPendingTxs();
+
+      // Deduplicate block hashes to reduce redundant DB lookups
+      const uniqueBlockHashes = new Map<string, Fr>();
+      const txsByBlockHash = new Map<string, string[]>();
+
+      for (const meta of pendingTxs) {
+        const blockHashStr = meta.anchorBlockHeaderHash;
+        if (!txsByBlockHash.has(blockHashStr)) {
+          txsByBlockHash.set(blockHashStr, []);
+          uniqueBlockHashes.set(blockHashStr, Fr.fromHexString(blockHashStr));
+        }
+        txsByBlockHash.get(blockHashStr)!.push(meta.txHash);
+      }
+
+      // Ensure world state is synced to this block before accessing the snapshot
+      await this.worldState.syncImmediate(context.blockNumber);
+      const db = this.worldState.getSnapshot(context.blockNumber);
+
+      // Check which blocks exist in the archive
+      const blockHashArray = Array.from(uniqueBlockHashes.values());
+      const blocksFromDb = await db.findLeafIndices(MerkleTreeId.ARCHIVE, blockHashArray);
+
+      // Build set of pruned block hashes
+      const prunedBlockHashes = new Set<string>();
+      let i = 0;
+      for (const [blockHashStr] of uniqueBlockHashes) {
+        if (blocksFromDb[i] === undefined) {
+          prunedBlockHashes.add(blockHashStr);
+        }
+        i++;
+      }
+
+      // Identify txs whose anchor block was pruned
+      const txsToEvict: string[] = [];
+      for (const [blockHashStr, txHashes] of txsByBlockHash) {
+        if (prunedBlockHashes.has(blockHashStr)) {
+          txsToEvict.push(...txHashes);
+        }
+      }
+
+      if (txsToEvict.length > 0) {
+        this.log.verbose(`Evicting ${txsToEvict.length} txs from pool due to referencing pruned blocks`);
+        await pool.deleteTxs(txsToEvict);
+      }
+
+      const keptCount = pendingTxs.length - txsToEvict.length;
+      if (keptCount > 0) {
+        this.log.verbose(`Kept ${keptCount} txs that did not reference pruned blocks`);
+      }
+
+      this.log.debug(`Evicted ${txsToEvict.length} invalid txs after reorg`);
+
+      return {
+        reason: 'reorg_invalid_txs',
+        success: true,
+        txsEvicted: txsToEvict,
+      };
+    } catch (err) {
+      this.log.error('Failed to evict invalid transactions after reorg', { err });
+      return {
+        reason: 'reorg_invalid_txs',
+        success: false,
+        txsEvicted: [],
+        error: new Error('Failed to evict invalid txs after reorg', { cause: err }),
+      };
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_eviction_rule.test.ts
@@ -1,0 +1,180 @@
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { BlockHeader } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+
+import type { EvictionContext, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+import { LowPriorityEvictionRule } from './low_priority_eviction_rule.js';
+
+describe('LowPriorityEvictionRule', () => {
+  let pool: PoolOperations;
+  let rule: LowPriorityEvictionRule;
+
+  let deleteTxsMock: jest.MockedFunction<any>;
+
+  // Create mock pool operations
+  const createPoolOps = (pendingTxCount: number, lowestPriorityPending: string[] = []): PoolOperations => {
+    deleteTxsMock = jest.fn(() => Promise.resolve());
+    return {
+      getPendingTxs: () => [],
+      getPendingFeePayers: () => [],
+      getFeePayerPendingTxs: () => [],
+      getPendingTxCount: () => pendingTxCount,
+      getLowestPriorityPending: () => lowestPriorityPending,
+      deleteTxs: deleteTxsMock as (txHashes: string[]) => Promise<void>,
+    };
+  };
+
+  beforeEach(() => {
+    pool = createPoolOps(0);
+    rule = new LowPriorityEvictionRule({ maxPoolSize: 100 });
+  });
+
+  describe('constructor and configuration', () => {
+    it('initializes with provided config', () => {
+      expect(rule.name).toBe('LowPriorityEviction');
+    });
+
+    it('updates the config', () => {
+      rule.updateConfig({ maxPendingTxCount: 200 });
+      // Config is updated internally - tested via behavior
+    });
+  });
+
+  describe('evict method', () => {
+    describe('non-TXS_ADDED events', () => {
+      it('returns empty result for BLOCK_MINED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.BLOCK_MINED,
+          block: BlockHeader.empty(),
+          newNullifiers: [],
+          feePayers: [],
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('returns empty result for CHAIN_PRUNED event', async () => {
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+    });
+
+    describe('TXS_ADDED events', () => {
+      let context: EvictionContext;
+
+      beforeEach(() => {
+        context = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [],
+        };
+      });
+
+      it('returns empty result when maxPoolSize is 0', async () => {
+        rule.updateConfig({ maxPendingTxCount: 0 });
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('returns empty result when mempool size is below threshold', async () => {
+        pool = createPoolOps(50);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('returns empty result when mempool size equals threshold', async () => {
+        pool = createPoolOps(100);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+      });
+
+      it('evicts transactions when mempool size exceeds threshold', async () => {
+        rule.updateConfig({ maxPendingTxCount: 1 });
+        pool = createPoolOps(3, ['0x3333', '0x4444']);
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x3333', '0x4444']);
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x3333', '0x4444']);
+      });
+
+      it('tracks newly added transactions that were evicted', async () => {
+        rule.updateConfig({ maxPendingTxCount: 1 });
+        context = {
+          event: EvictionEvent.TXS_ADDED,
+          newTxHashes: ['0x1111', '0x2222'],
+          feePayers: [],
+        };
+        pool = createPoolOps(3, ['0x3333', '0x1111']); // One new tx is in eviction list
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual(['0x3333', '0x1111']);
+        expect(deleteTxsMock).toHaveBeenCalledWith(['0x3333', '0x1111']);
+      });
+
+      it('handles all transactions being non-evictable', async () => {
+        pool = createPoolOps(101, []); // Over threshold but nothing evictable
+
+        const result = await rule.evict(context, pool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+        expect(deleteTxsMock).not.toHaveBeenCalled();
+      });
+
+      it('handles error from deleteTxs operation', async () => {
+        rule.updateConfig({ maxPendingTxCount: 1 });
+        pool = createPoolOps(2, ['0x3333', '0x4444']);
+        deleteTxsMock.mockRejectedValue(new Error('Test error'));
+
+        const result = await rule.evict(context, pool);
+
+        expect(result.success).toBe(false);
+        expect(result.txsEvicted).toEqual([]);
+        expect(result.error?.message).toContain('Failed to evict low priority txs');
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_eviction_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_eviction_rule.ts
@@ -1,0 +1,86 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import type { EvictionConfig, EvictionContext, EvictionResult, EvictionRule, PoolOperations } from './interfaces.js';
+import { EvictionEvent } from './interfaces.js';
+
+/**
+ * Eviction rule that removes low-priority transactions when the pool exceeds configured limits.
+ * Only triggers on TXS_ADDED events.
+ */
+export class LowPriorityEvictionRule implements EvictionRule {
+  public readonly name = 'LowPriorityEviction';
+
+  private log = createLogger('p2p:tx_pool_v2:low_priority_eviction_rule');
+  private maxPoolSize: number;
+
+  constructor(config: { maxPoolSize: number }) {
+    this.maxPoolSize = config.maxPoolSize;
+  }
+
+  async evict(context: EvictionContext, pool: PoolOperations): Promise<EvictionResult> {
+    if (context.event !== EvictionEvent.TXS_ADDED) {
+      return {
+        reason: 'low_priority',
+        success: true,
+        txsEvicted: [],
+      };
+    }
+
+    if (this.maxPoolSize === 0) {
+      return {
+        reason: 'low_priority',
+        success: true,
+        txsEvicted: [],
+      };
+    }
+
+    try {
+      const currentTxCount = pool.getPendingTxCount();
+
+      if (currentTxCount <= this.maxPoolSize) {
+        this.log.trace(
+          `Not evicting low priority txs. Pending tx count below limit ${currentTxCount} <= ${this.maxPoolSize}`,
+        );
+        return {
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        };
+      }
+
+      this.log.verbose(
+        `Evicting low priority txs. Pending tx count above limit: ${currentTxCount} > ${this.maxPoolSize}`,
+      );
+      const numberToEvict = currentTxCount - this.maxPoolSize;
+      const txsToEvict = pool.getLowestPriorityPending(numberToEvict);
+
+      if (txsToEvict.length > 0) {
+        await pool.deleteTxs(txsToEvict);
+      }
+
+      const numNewTxsEvicted = context.newTxHashes.filter(newTxHash => txsToEvict.includes(newTxHash)).length;
+
+      this.log.verbose(`Evicted ${txsToEvict.length} low priority txs, including ${numNewTxsEvicted} newly added txs`);
+
+      return {
+        reason: 'low_priority',
+        success: true,
+        txsEvicted: txsToEvict,
+      };
+    } catch (err) {
+      this.log.error('Failed to evict low priority transactions', { err });
+      return {
+        reason: 'low_priority',
+        success: false,
+        txsEvicted: [],
+        error: new Error('Failed to evict low priority txs', { cause: err }),
+      };
+    }
+  }
+
+  updateConfig(config: EvictionConfig): void {
+    if (config.maxPendingTxCount !== undefined) {
+      this.maxPoolSize = config.maxPendingTxCount;
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_pre_add_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_pre_add_rule.test.ts
@@ -1,0 +1,149 @@
+import type { TxMetaData } from '../tx_metadata.js';
+import type { PreAddPoolAccess } from './interfaces.js';
+import { LowPriorityPreAddRule } from './low_priority_pre_add_rule.js';
+
+describe('LowPriorityPreAddRule', () => {
+  let rule: LowPriorityPreAddRule;
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (txHash: string, priorityFee: bigint): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash: '0x1234',
+    priorityFee,
+    feePayer: '0xfeepayer',
+    claimAmount: 0n,
+    feeLimit: 100n,
+    nullifiers: [`0x${txHash.slice(2)}null1`],
+    includeByTimestamp: 0n,
+  });
+
+  // Mock pool access with configurable behavior
+  const createPoolAccess = (pendingCount: number, lowestPriorityTx?: TxMetaData): PreAddPoolAccess => ({
+    getMetadata: () => undefined,
+    getTxHashByNullifier: () => undefined,
+    getFeePayerBalance: () => Promise.resolve(10n ** 18n),
+    getFeePayerPendingTxs: () => [],
+    getPendingTxCount: () => pendingCount,
+    getLowestPriorityPendingTx: () => lowestPriorityTx,
+  });
+
+  beforeEach(() => {
+    rule = new LowPriorityPreAddRule({ maxPoolSize: 100 });
+  });
+
+  describe('constructor and configuration', () => {
+    it('initializes with provided config', () => {
+      expect(rule.name).toBe('LowPriorityPreAdd');
+    });
+
+    it('updates the config', () => {
+      rule.updateConfig({ maxPendingTxCount: 200 });
+      // Config is updated internally - tested via behavior below
+    });
+  });
+
+  describe('check method', () => {
+    describe('when pool is not at capacity', () => {
+      it('accepts tx when pool size is below max', async () => {
+        const poolAccess = createPoolAccess(50);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('accepts tx when maxPoolSize is 0 (unlimited)', async () => {
+        rule.updateConfig({ maxPendingTxCount: 0 });
+        const poolAccess = createPoolAccess(1000);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('accepts tx when pool size equals max minus one', async () => {
+        const poolAccess = createPoolAccess(99);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+    });
+
+    describe('when pool is at capacity', () => {
+      it('evicts lowest priority tx when incoming has higher priority', async () => {
+        const lowestPriorityMeta = createMeta('0x2222', 50n);
+        const poolAccess = createPoolAccess(100, lowestPriorityMeta);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+        expect(result.txHashesToEvict).toHaveLength(1);
+      });
+
+      it('ignores tx when incoming has lower priority than lowest', async () => {
+        const lowestPriorityMeta = createMeta('0x2222', 100n);
+        const poolAccess = createPoolAccess(100, lowestPriorityMeta);
+        const incomingMeta = createMeta('0x1111', 50n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict).toHaveLength(0);
+        expect(result.reason).toContain('lower priority');
+      });
+
+      it('ignores tx when incoming has equal priority to lowest', async () => {
+        const lowestPriorityMeta = createMeta('0x2222', 100n);
+        const poolAccess = createPoolAccess(100, lowestPriorityMeta);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+
+      it('accepts tx when no lowest priority tx found (edge case)', async () => {
+        // This shouldn't happen if count > 0, but handle gracefully
+        const poolAccess = createPoolAccess(100, undefined);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+    });
+
+    describe('after config updates', () => {
+      it('respects updated maxPoolSize', async () => {
+        // Initially at capacity with max=100
+        const lowestPriorityMeta = createMeta('0x2222', 50n);
+        const poolAccess = createPoolAccess(100, lowestPriorityMeta);
+        const incomingMeta = createMeta('0x1111', 100n);
+
+        // Before update: should evict
+        let result = await rule.check(incomingMeta, poolAccess);
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(1);
+
+        // Update to larger max
+        rule.updateConfig({ maxPendingTxCount: 200 });
+
+        // After update: pool not at capacity, no eviction
+        result = await rule.check(incomingMeta, poolAccess);
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_pre_add_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/low_priority_pre_add_rule.ts
@@ -1,0 +1,72 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import type { TxMetaData } from '../tx_metadata.js';
+import type { EvictionConfig, PreAddPoolAccess, PreAddResult, PreAddRule } from './interfaces.js';
+
+/**
+ * Pre-add rule that checks if the pool is at capacity and handles low-priority eviction.
+ *
+ * When the pool is at capacity:
+ * - If incoming tx has higher priority than the lowest priority tx, evict the lowest and accept incoming
+ * - If incoming tx has equal or lower priority than the lowest, ignore incoming (it would be evicted anyway)
+ */
+export class LowPriorityPreAddRule implements PreAddRule {
+  public readonly name = 'LowPriorityPreAdd';
+
+  private log = createLogger('p2p:tx_pool_v2:low_priority_pre_add_rule');
+  private maxPoolSize: number;
+
+  constructor(config: { maxPoolSize: number }) {
+    this.maxPoolSize = config.maxPoolSize;
+  }
+
+  check(incomingMeta: TxMetaData, poolAccess: PreAddPoolAccess): Promise<PreAddResult> {
+    // Skip if max pool size is disabled (0 = unlimited)
+    if (this.maxPoolSize === 0) {
+      return Promise.resolve({ shouldIgnore: false, txHashesToEvict: [] });
+    }
+
+    const currentCount = poolAccess.getPendingTxCount();
+
+    // If pool is not at capacity, accept the tx
+    if (currentCount < this.maxPoolSize) {
+      return Promise.resolve({ shouldIgnore: false, txHashesToEvict: [] });
+    }
+
+    // Pool is at capacity - need to compare priorities
+    const lowestPriorityMeta = poolAccess.getLowestPriorityPendingTx();
+    if (!lowestPriorityMeta) {
+      // No pending txs (shouldn't happen if count > 0, but handle gracefully)
+      return Promise.resolve({ shouldIgnore: false, txHashesToEvict: [] });
+    }
+
+    // If incoming tx has strictly higher priority, evict the lowest priority tx
+    if (incomingMeta.priorityFee > lowestPriorityMeta.priorityFee) {
+      this.log.debug(
+        `Pool at capacity (${currentCount}/${this.maxPoolSize}), evicting ${lowestPriorityMeta.txHash} ` +
+          `(priority ${lowestPriorityMeta.priorityFee}) for ${incomingMeta.txHash} (priority ${incomingMeta.priorityFee})`,
+      );
+      return Promise.resolve({
+        shouldIgnore: false,
+        txHashesToEvict: [lowestPriorityMeta.txHash],
+      });
+    }
+
+    // Incoming tx has equal or lower priority - ignore it (it would be evicted anyway)
+    this.log.debug(
+      `Pool at capacity (${currentCount}/${this.maxPoolSize}), ignoring ${incomingMeta.txHash} ` +
+        `(priority ${incomingMeta.priorityFee}) - lower than existing minimum (priority ${lowestPriorityMeta.priorityFee})`,
+    );
+    return Promise.resolve({
+      shouldIgnore: true,
+      txHashesToEvict: [],
+      reason: `pool at capacity and tx has lower priority than existing transactions`,
+    });
+  }
+
+  updateConfig(config: EvictionConfig): void {
+    if (config.maxPendingTxCount !== undefined) {
+      this.maxPoolSize = config.maxPendingTxCount;
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/nullifier_conflict_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/nullifier_conflict_rule.test.ts
@@ -1,0 +1,302 @@
+import type { TxMetaData } from '../tx_metadata.js';
+import type { PreAddPoolAccess } from './interfaces.js';
+import { NullifierConflictRule } from './nullifier_conflict_rule.js';
+
+describe('NullifierConflictRule', () => {
+  let poolAccess: PreAddPoolAccess;
+  let rule: NullifierConflictRule;
+
+  // Helper to create TxMetaData for testing
+  const createMeta = (
+    txHash: string,
+    priorityFee: bigint,
+    nullifiers: string[] = [`0x${txHash.slice(2)}null1`],
+  ): TxMetaData => ({
+    txHash,
+    anchorBlockHeaderHash: '0x1234',
+    priorityFee,
+    feePayer: '0xfeepayer',
+    claimAmount: 0n,
+    feeLimit: 1000n,
+    nullifiers,
+    includeByTimestamp: 0n,
+  });
+
+  // Mock pool access with configurable behavior
+  const createPoolAccess = (
+    nullifierMap: Map<string, string> = new Map(),
+    metadataMap: Map<string, TxMetaData> = new Map(),
+  ): PreAddPoolAccess => ({
+    getMetadata: (txHashStr: string) => metadataMap.get(txHashStr),
+    getTxHashByNullifier: (nullifier: string) => nullifierMap.get(nullifier),
+    getFeePayerBalance: () => Promise.resolve(10n ** 18n),
+    getFeePayerPendingTxs: () => [],
+    getPendingTxCount: () => metadataMap.size,
+    getLowestPriorityPendingTx: () => undefined,
+  });
+
+  beforeEach(() => {
+    poolAccess = createPoolAccess();
+    rule = new NullifierConflictRule();
+  });
+
+  describe('check method', () => {
+    describe('no conflicts', () => {
+      it('accepts tx when no nullifier conflicts exist', async () => {
+        const incomingMeta = createMeta('0x1111', 5n);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('accepts tx with different nullifiers than existing txs', async () => {
+        const existingMeta = createMeta('0x2222', 10n, ['0xnull_existing']);
+        const incomingMeta = createMeta('0x1111', 5n, ['0xnull_incoming']);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set('0xnull_existing', '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('basic conflict resolution', () => {
+      it('ignores tx when existing tx has same nullifier with higher fee', async () => {
+        const sharedNullifier = '0xshared_null';
+        const existingMeta = createMeta('0x2222', 10n, [sharedNullifier]);
+        const incomingMeta = createMeta('0x1111', 5n, [sharedNullifier]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(sharedNullifier, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('evicts existing tx when incoming tx has same nullifier with higher fee', async () => {
+        const sharedNullifier = '0xshared_null';
+        const existingMeta = createMeta('0x2222', 5n, [sharedNullifier]);
+        const incomingMeta = createMeta('0x1111', 10n, [sharedNullifier]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(sharedNullifier, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+        expect(result.txHashesToEvict.length).toBe(1);
+      });
+
+      it('ignores tx with equal fee (no replacement on tie)', async () => {
+        const sharedNullifier = '0xshared_null';
+        const existingMeta = createMeta('0x2222', 5n, [sharedNullifier]);
+        const incomingMeta = createMeta('0x1111', 5n, [sharedNullifier]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(sharedNullifier, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('partial nullifier overlap', () => {
+      it('detects conflict when txs share only ONE nullifier', async () => {
+        const sharedNullifier = '0xshared_null';
+        const existingMeta = createMeta('0x2222', 5n, [sharedNullifier, '0xother_existing']);
+        const incomingMeta = createMeta('0x1111', 10n, [sharedNullifier, '0xother_incoming']);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(sharedNullifier, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+      });
+
+      it('ignores tx with partial overlap when existing has higher fee', async () => {
+        const sharedNullifier = '0xshared_null';
+        const existingMeta = createMeta('0x2222', 10n, [sharedNullifier, '0xother_existing']);
+        const incomingMeta = createMeta('0x1111', 5n, [sharedNullifier, '0xother_incoming']);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(sharedNullifier, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+
+    describe('multiple conflicts', () => {
+      it('evicts multiple txs when incoming tx beats all of them', async () => {
+        const nullifier1 = '0xnull1';
+        const nullifier2 = '0xnull2';
+        const existingMeta1 = createMeta('0x2222', 3n, [nullifier1]);
+        const existingMeta2 = createMeta('0x3333', 4n, [nullifier2]);
+        const incomingMeta = createMeta('0x1111', 10n, [nullifier1, nullifier2]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta1);
+        metadataMap.set('0x3333', existingMeta2);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier1, '0x2222');
+        nullifierMap.set(nullifier2, '0x3333');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+        expect(result.txHashesToEvict).toContain('0x3333');
+        expect(result.txHashesToEvict.length).toBe(2);
+      });
+
+      it('ignores incoming tx if it cannot beat ALL conflicting txs', async () => {
+        const nullifier1 = '0xnull1';
+        const nullifier2 = '0xnull2';
+        const existingMeta1 = createMeta('0x2222', 3n, [nullifier1]);
+        const existingMeta2 = createMeta('0x3333', 100n, [nullifier2]); // Higher fee than incoming
+        const incomingMeta = createMeta('0x1111', 10n, [nullifier1, nullifier2]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta1);
+        metadataMap.set('0x3333', existingMeta2);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier1, '0x2222');
+        nullifierMap.set(nullifier2, '0x3333');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(true);
+        expect(result.txHashesToEvict.length).toBe(0); // Atomic: no partial evictions
+      });
+    });
+
+    describe('same tx with multiple shared nullifiers', () => {
+      it('handles two txs sharing multiple nullifiers', async () => {
+        const nullifier1 = '0xnull1';
+        const nullifier2 = '0xnull2';
+        const existingMeta = createMeta('0x2222', 5n, [nullifier1, nullifier2]);
+        const incomingMeta = createMeta('0x1111', 10n, [nullifier1, nullifier2]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier1, '0x2222');
+        nullifierMap.set(nullifier2, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict).toContain('0x2222');
+        expect(result.txHashesToEvict.length).toBe(1); // Only added once, not duplicated
+      });
+
+      it('does not double-count when same tx conflicts on multiple nullifiers', async () => {
+        const nullifier1 = '0xnull1';
+        const nullifier2 = '0xnull2';
+        const nullifier3 = '0xnull3';
+        const existingMeta = createMeta('0x2222', 5n, [nullifier1, nullifier2, nullifier3]);
+        const incomingMeta = createMeta('0x1111', 10n, [nullifier1, nullifier2, nullifier3]);
+
+        const metadataMap = new Map<string, TxMetaData>();
+        metadataMap.set('0x2222', existingMeta);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier1, '0x2222');
+        nullifierMap.set(nullifier2, '0x2222');
+        nullifierMap.set(nullifier3, '0x2222');
+
+        poolAccess = createPoolAccess(nullifierMap, metadataMap);
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(1); // Existing tx only in array once
+      });
+    });
+
+    describe('edge cases', () => {
+      it('skips self-reference (incoming tx hash in conflict list)', async () => {
+        const nullifier = '0xnull1';
+        const incomingMeta = createMeta('0x1111', 5n, [nullifier]);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier, '0x1111'); // Self-reference
+
+        poolAccess = createPoolAccess(nullifierMap, new Map());
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+
+      it('handles missing conflicting tx gracefully', async () => {
+        const nullifier = '0xnull1';
+        const incomingMeta = createMeta('0x1111', 10n, [nullifier]);
+
+        const nullifierMap = new Map<string, string>();
+        nullifierMap.set(nullifier, '0x2222'); // Points to non-existent tx
+
+        poolAccess = createPoolAccess(nullifierMap, new Map()); // Empty metadata map
+
+        const result = await rule.check(incomingMeta, poolAccess);
+
+        expect(result.shouldIgnore).toBe(false);
+        expect(result.txHashesToEvict.length).toBe(0);
+      });
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/nullifier_conflict_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/nullifier_conflict_rule.ts
@@ -1,0 +1,31 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import { type TxMetaData, checkNullifierConflict } from '../tx_metadata.js';
+import type { PreAddPoolAccess, PreAddResult, PreAddRule } from './interfaces.js';
+
+/**
+ * Pre-add rule that checks for nullifier conflicts between incoming and existing transactions.
+ *
+ * When an incoming tx shares nullifiers with existing pending txs:
+ * - If the incoming tx has strictly higher priority, evict all conflicting txs
+ * - If any conflicting tx has equal or higher priority, ignore the incoming tx
+ */
+export class NullifierConflictRule implements PreAddRule {
+  public readonly name = 'NullifierConflict';
+
+  private log = createLogger('p2p:tx_pool_v2:nullifier_conflict_rule');
+
+  check(incomingMeta: TxMetaData, poolAccess: PreAddPoolAccess): Promise<PreAddResult> {
+    const result = checkNullifierConflict(
+      incomingMeta,
+      nullifier => poolAccess.getTxHashByNullifier(nullifier),
+      txHash => poolAccess.getMetadata(txHash),
+    );
+
+    if (result.shouldIgnore) {
+      this.log.debug(`Ignoring tx ${incomingMeta.txHash}: ${result.reason}`);
+    }
+
+    return Promise.resolve(result);
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/index.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/index.ts
@@ -1,0 +1,11 @@
+export { AztecKVTxPoolV2 } from './tx_pool_v2.js';
+export {
+  type TxPoolV2,
+  type TxPoolV2Config,
+  type TxPoolV2Events,
+  type AddTxsResult,
+  type PoolReadAccess,
+  DEFAULT_TX_POOL_V2_CONFIG,
+} from './interfaces.js';
+export { type TxMetaData, type TxState, buildTxMetaData, comparePriority } from './tx_metadata.js';
+export { TxArchive } from './archive/index.js';

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/interfaces.ts
@@ -1,0 +1,225 @@
+import type { SlotNumber } from '@aztec/foundation/branded-types';
+import type { TypedEventEmitter } from '@aztec/foundation/types';
+import type { L2Block, L2BlockId, L2BlockSource } from '@aztec/stdlib/block';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type { BlockHeader, Tx, TxHash, TxValidator } from '@aztec/stdlib/tx';
+
+import type { TxMetaData, TxState } from './tx_metadata.js';
+
+/**
+ * Result of adding transactions to the pending pool.
+ * Categorizes transactions by their outcome.
+ */
+export type AddTxsResult = {
+  /** Transactions successfully added to the pool */
+  accepted: TxHash[];
+  /** Transactions ignored because they're valid but undesirable (e.g., duplicate, lower priority nullifier conflict) */
+  ignored: TxHash[];
+  /** Transactions rejected because they failed validation (e.g., invalid proof, expired timestamp) */
+  rejected: TxHash[];
+};
+
+/**
+ * Events emitted by TxPoolV2.
+ */
+export type TxPoolV2Events = {
+  /** Emitted when transactions are successfully added to the pool */
+  'txs-added': (args: { txs: Tx[]; source?: string }) => void;
+};
+
+/**
+ * Configuration options for TxPoolV2.
+ */
+export type TxPoolV2Config = {
+  /** Maximum number of pending transactions before low-priority eviction */
+  maxPendingTxCount: number;
+  /** Maximum number of archived transactions to retain (0 = disabled) */
+  archivedTxLimit: number;
+};
+
+/**
+ * Default configuration values for TxPoolV2.
+ */
+export const DEFAULT_TX_POOL_V2_CONFIG: TxPoolV2Config = {
+  maxPendingTxCount: 0, // 0 = disabled
+  archivedTxLimit: 0, // 0 = disabled
+};
+
+/**
+ * Dependencies required by TxPoolV2.
+ */
+export type TxPoolV2Dependencies = {
+  /** Block source (Archiver) for checking mined status and verifying pruned blocks */
+  l2BlockSource: L2BlockSource;
+  /** World state synchronizer for validating transactions after chain prunes */
+  worldStateSynchronizer: WorldStateSynchronizer;
+  /** Validator for transactions entering the pending pool */
+  pendingTxValidator: TxValidator<Tx>;
+};
+
+/**
+ * Read-only access to pool state for pre-add checks.
+ * Used by eviction rules to inspect pool state during transaction addition.
+ */
+export interface PoolReadAccess {
+  /** Get metadata for a transaction by its hash (as string) */
+  getMetadata(txHash: string): TxMetaData | undefined;
+  /** Get the transaction hash that uses a specific nullifier (as string) */
+  getTxHashByNullifier(nullifier: string): string | undefined;
+  /** Get all transaction hashes for a fee payer (as string) */
+  getTxHashesByFeePayer(feePayer: string): Set<string> | undefined;
+  /** Get the current pending transaction count */
+  getPendingTxCount(): number;
+}
+
+/**
+ *
+ * The pool manages transactions through a state machine:
+ * - Pending: Transaction is awaiting inclusion in a block
+ * - Protected: Transaction is being considered for a block proposal
+ * - Mined: Transaction has been included in a block
+ * - Deleted: Transaction has been removed from the pool
+ *
+ * All state-mutating operations are serialized through a handler queue
+ * to prevent race conditions.
+ */
+export interface TxPoolV2 extends TypedEventEmitter<TxPoolV2Events> {
+  // === Core Operations ===
+
+  /**
+   * Adds transactions to the pending pool with challenge and validation.
+   * Handles nullifier conflicts via the challenge mechanism.
+   * @param txs - Transactions to add
+   * @param opts - Optional metadata (e.g., source for logging)
+   * @returns Result categorizing each transaction as accepted, rejected, or ignored
+   */
+  addPendingTxs(txs: Tx[], opts?: { source?: string }): Promise<AddTxsResult>;
+
+  /**
+   * Checks if a transaction can be added without modifying the pool.
+   * Performs the same validation as addPendingTxs but doesn't persist changes.
+   * @param tx - Transaction to check
+   * @returns Result: 'accepted', 'ignored' (if already in pool or undesirable), or 'rejected' (if validation fails)
+   */
+  canAddPendingTx(tx: Tx): Promise<'accepted' | 'ignored' | 'rejected'>;
+
+  /**
+   * Adds transactions as immediately protected for a given slot.
+   * Used when receiving transactions from a block proposal we're validating.
+   * @param txs - Transactions to add as protected
+   * @param block - Block header providing slot context
+   * @param opts - Optional metadata (e.g., source for logging)
+   */
+  addProtectedTxs(txs: Tx[], block: BlockHeader, opts?: { source?: string }): Promise<void>;
+
+  /**
+   * Protects existing transactions by hash for a given slot.
+   * Returns hashes of transactions that weren't found in the pool.
+   * Records unknown hashes for automatic protection when received via gossip.
+   * @param txHashes - Hashes of transactions to protect
+   * @param block - Block header providing slot context
+   * @returns Hashes of transactions not found in the pool
+   */
+  protectTxs(txHashes: TxHash[], block: BlockHeader): Promise<TxHash[]>;
+
+  /**
+   * Adds transactions as already mined.
+   * Used by prover nodes fetching transactions via request/response.
+   * @param txs - Transactions to add as mined
+   * @param block - Block header the transactions were mined in
+   * @param opts - Optional metadata (e.g., source for logging)
+   */
+  addMinedTxs(txs: Tx[], block: BlockHeader, opts?: { source?: string }): Promise<void>;
+
+  // === State Transition Handlers ===
+
+  /**
+   * Handles a mined block - marks transactions as mined and evicts conflicting pending txs.
+   * Uses nullifiers directly from the block to evict pending transactions with conflicts.
+   * @param block - The complete mined block
+   */
+  handleMinedBlock(block: L2Block): Promise<void>;
+
+  /**
+   * Prepares the pool for a new slot.
+   * Unprotects transactions from earlier slots and validates them before
+   * returning to pending state.
+   * @param slotNumber - The slot number to prepare for
+   */
+  prepareForSlot(slotNumber: SlotNumber): Promise<void>;
+
+  /**
+   * Handles pruned blocks during a reorg.
+   * Un-mines all transactions mined in blocks beyond the given latest block
+   * and validates them before returning to pending.
+   * @param latestBlock - The latest valid block ID after the prune
+   */
+  handlePrunedBlocks(latestBlock: L2BlockId): Promise<void>;
+
+  /**
+   * Handles failed transaction execution.
+   * Deletes transactions that failed during block building.
+   * @param txHashes - Hashes of transactions that failed
+   */
+  handleFailedExecution(txHashes: TxHash[]): Promise<void>;
+
+  /**
+   * Handles a finalized block.
+   * Permanently deletes mined transactions and optionally archives them.
+   * @param block - Header of the finalized block
+   */
+  handleFinalizedBlock(block: BlockHeader): Promise<void>;
+
+  /** Gets a transaction by its hash */
+  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+
+  /** Gets multiple transactions by their hashes */
+  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+
+  /** Checks if transactions exist in the pool */
+  hasTxs(txHashes: TxHash[]): Promise<boolean[]>;
+
+  /** Gets the status of a transaction */
+  getTxStatus(txHash: TxHash): Promise<TxState | 'deleted' | undefined>;
+
+  /** Gets pending transaction hashes sorted by priority (highest first) */
+  getPendingTxHashes(): Promise<TxHash[]>;
+
+  /** Gets the count of pending transactions */
+  getPendingTxCount(): Promise<number>;
+
+  /** Gets mined transaction hashes with their block IDs */
+  getMinedTxHashes(): Promise<[TxHash, L2BlockId][]>;
+
+  /** Gets the count of mined transactions */
+  getMinedTxCount(): Promise<number>;
+
+  /** Checks if the pool is empty */
+  isEmpty(): Promise<boolean>;
+
+  /** Gets an archived transaction by its hash */
+  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+
+  /** Gets the lowest priority pending transactions */
+  getLowestPriorityPending(limit: number): Promise<TxHash[]>;
+
+  // === Configuration ===
+
+  /** Updates the pool configuration */
+  updateConfig(config: Partial<TxPoolV2Config>): Promise<void>;
+
+  // === Lifecycle ===
+
+  /**
+   * Starts the pool and initializes state from persistence.
+   * Must be called before other operations.
+   * - Reads all transactions from the database
+   * - Checks each against the Archiver to determine mined status
+   * - Validates all non-mined transactions
+   * - Populates in-memory indices
+   */
+  start(): Promise<void>;
+
+  /** Stops the pool and releases resources */
+  stop(): Promise<void>;
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_metadata.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_metadata.test.ts
@@ -1,0 +1,246 @@
+import { mockTx } from '@aztec/stdlib/testing';
+
+import { type TxMetaData, buildTxMetaData, checkNullifierConflict, comparePriority } from './tx_metadata.js';
+
+describe('TxMetaData', () => {
+  describe('buildTxMetaData', () => {
+    it('extracts all fields from a transaction', async () => {
+      const tx = await mockTx(1);
+      const meta = await buildTxMetaData(tx);
+
+      expect(meta.txHash).toBe(tx.getTxHash().toString());
+      expect(meta.anchorBlockHeaderHash).toBe((await tx.data.constants.anchorBlockHeader.hash()).toString());
+      expect(meta.feePayer).toBe(tx.data.feePayer.toString());
+      expect(meta.includeByTimestamp).toBe(tx.data.includeByTimestamp);
+      expect(meta.minedL2BlockId).toBeUndefined();
+
+      // Nullifiers should match the non-empty nullifiers from the tx
+      const expectedNullifiers = tx.data.getNonEmptyNullifiers().map(n => n.toString());
+      expect(meta.nullifiers).toEqual(expectedNullifiers);
+    });
+
+    it('extracts nullifiers as hex strings', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      const meta = await buildTxMetaData(tx);
+
+      expect(meta.nullifiers.length).toBeGreaterThan(0);
+      for (const nullifier of meta.nullifiers) {
+        expect(typeof nullifier).toBe('string');
+        expect(nullifier).toMatch(/^0x[0-9a-f]+$/i);
+      }
+    });
+  });
+
+  describe('comparePriority', () => {
+    const makeMeta = (fee: bigint, txHash = '0x1234'): TxMetaData => ({
+      txHash,
+      anchorBlockHeaderHash: '0x5678',
+      priorityFee: fee,
+      feePayer: '0xabcd',
+      claimAmount: 0n,
+      feeLimit: 1000n,
+      nullifiers: [],
+      includeByTimestamp: 0n,
+    });
+
+    it('returns negative when first has lower priority fee', () => {
+      expect(comparePriority(makeMeta(100n), makeMeta(200n))).toBe(-1);
+    });
+
+    it('returns positive when first has higher priority fee', () => {
+      expect(comparePriority(makeMeta(200n), makeMeta(100n))).toBe(1);
+    });
+
+    it('uses txHash as tiebreaker when priority fees are equal', () => {
+      // Lower hash comes first
+      expect(comparePriority(makeMeta(100n, '0x1111'), makeMeta(100n, '0x2222'))).toBe(-1);
+      expect(comparePriority(makeMeta(100n, '0x2222'), makeMeta(100n, '0x1111'))).toBe(1);
+    });
+
+    it('returns zero when both priority fee and txHash are equal', () => {
+      expect(comparePriority(makeMeta(100n, '0x1234'), makeMeta(100n, '0x1234'))).toBe(0);
+    });
+  });
+
+  describe('checkNullifierConflict', () => {
+    const makeMeta = (txHash: string, priorityFee: bigint, nullifiers: string[]): TxMetaData => ({
+      txHash,
+      anchorBlockHeaderHash: '0x5678',
+      priorityFee,
+      feePayer: '0xabcd',
+      claimAmount: 0n,
+      feeLimit: 1000n,
+      nullifiers,
+      includeByTimestamp: 0n,
+    });
+
+    it('returns no conflict when nullifiers do not overlap', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1', '0xnull2']);
+      const existing = makeMeta('0x2222', 50n, ['0xnull3', '0xnull4']);
+
+      const nullifierIndex = new Map<string, string>();
+      for (const n of existing.nullifiers) {
+        nullifierIndex.set(n, existing.txHash);
+      }
+
+      const result = checkNullifierConflict(
+        incoming,
+        n => nullifierIndex.get(n),
+        () => existing,
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+
+    it('evicts existing tx when incoming has higher priority', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1']);
+      const existing = makeMeta('0x2222', 50n, ['0xnull1']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => existing.txHash,
+        () => existing,
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([existing.txHash]);
+    });
+
+    it('ignores incoming tx when existing has higher priority', () => {
+      const incoming = makeMeta('0x1111', 50n, ['0xnull1']);
+      const existing = makeMeta('0x2222', 100n, ['0xnull1']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => existing.txHash,
+        () => existing,
+      );
+
+      expect(result.shouldIgnore).toBe(true);
+      expect(result.txHashesToEvict).toEqual([]);
+      expect(result.reason).toContain(existing.txHash);
+    });
+
+    it('ignores incoming tx when existing has equal priority (tie goes to existing)', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1']);
+      const existing = makeMeta('0x2222', 100n, ['0xnull1']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => existing.txHash,
+        () => existing,
+      );
+
+      expect(result.shouldIgnore).toBe(true);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+
+    it('skips nullifiers that belong to the same transaction', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => incoming.txHash, // Same tx owns the nullifier
+        () => incoming,
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+
+    it('handles multiple conflicting transactions', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1', '0xnull2', '0xnull3']);
+      const existing1 = makeMeta('0x2222', 50n, ['0xnull1']);
+      const existing2 = makeMeta('0x3333', 40n, ['0xnull2']);
+      const existing3 = makeMeta('0x4444', 30n, ['0xnull3']);
+
+      const nullifierIndex = new Map([
+        ['0xnull1', existing1.txHash],
+        ['0xnull2', existing2.txHash],
+        ['0xnull3', existing3.txHash],
+      ]);
+      const metadataIndex = new Map([
+        [existing1.txHash, existing1],
+        [existing2.txHash, existing2],
+        [existing3.txHash, existing3],
+      ]);
+
+      const result = checkNullifierConflict(
+        incoming,
+        n => nullifierIndex.get(n),
+        h => metadataIndex.get(h),
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toHaveLength(3);
+      expect(result.txHashesToEvict).toContain(existing1.txHash);
+      expect(result.txHashesToEvict).toContain(existing2.txHash);
+      expect(result.txHashesToEvict).toContain(existing3.txHash);
+    });
+
+    it('stops and ignores when any conflicting tx has higher priority', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1', '0xnull2']);
+      const existing1 = makeMeta('0x2222', 50n, ['0xnull1']); // Lower priority
+      const existing2 = makeMeta('0x3333', 200n, ['0xnull2']); // Higher priority
+
+      const nullifierIndex = new Map([
+        ['0xnull1', existing1.txHash],
+        ['0xnull2', existing2.txHash],
+      ]);
+      const metadataIndex = new Map([
+        [existing1.txHash, existing1],
+        [existing2.txHash, existing2],
+      ]);
+
+      const result = checkNullifierConflict(
+        incoming,
+        n => nullifierIndex.get(n),
+        h => metadataIndex.get(h),
+      );
+
+      expect(result.shouldIgnore).toBe(true);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+
+    it('deduplicates eviction list when same tx conflicts on multiple nullifiers', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1', '0xnull2']);
+      const existing = makeMeta('0x2222', 50n, ['0xnull1', '0xnull2']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => existing.txHash, // Same tx owns both nullifiers
+        () => existing,
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([existing.txHash]); // Only listed once
+    });
+
+    it('skips nullifiers with no matching tx in pool', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1', '0xnull2']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => undefined, // No tx owns these nullifiers
+        () => undefined,
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+
+    it('skips when metadata lookup returns undefined', () => {
+      const incoming = makeMeta('0x1111', 100n, ['0xnull1']);
+
+      const result = checkNullifierConflict(
+        incoming,
+        () => '0x2222', // Nullifier owned by 0x2222
+        () => undefined, // But metadata not found
+      );
+
+      expect(result.shouldIgnore).toBe(false);
+      expect(result.txHashesToEvict).toEqual([]);
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_metadata.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_metadata.ts
@@ -1,0 +1,160 @@
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
+import type { L2BlockId } from '@aztec/stdlib/block';
+import type { Tx } from '@aztec/stdlib/tx';
+
+import { getFeePayerBalanceDelta } from '../../msg_validators/tx_validator/fee_payer_balance.js';
+import { getTxPriorityFee } from '../tx_pool/priority.js';
+import type { PreAddResult } from './eviction/interfaces.js';
+
+/**
+ * Lightweight in-memory representation of a transaction.
+ * Stored for every tx in the pool to enable efficient queries and challenges
+ * without deserializing full transaction data.
+ *
+ * Uses strings for txHash and nullifiers to enable fast Map/Set lookups
+ * without repeated .toString() conversions.
+ */
+export type TxMetaData = {
+  /** The transaction hash as hex string */
+  readonly txHash: string;
+
+  /** Block ID (number and hash) in which the transaction was mined (undefined if not mined) */
+  minedL2BlockId?: L2BlockId;
+
+  /** Hash of the block header the transaction uses as its anchor (hex string) */
+  readonly anchorBlockHeaderHash: string;
+
+  /** The total priority fee (used for ordering and challenges) */
+  readonly priorityFee: bigint;
+
+  /** The fee payer address as hex string */
+  readonly feePayer: string;
+
+  /** The claim amount for the fee payer */
+  readonly claimAmount: bigint;
+
+  /** The fee limit */
+  readonly feeLimit: bigint;
+
+  /** Non-empty nullifiers emitted by the transaction (hex strings) */
+  readonly nullifiers: readonly string[];
+
+  /** Timestamp by which the transaction must be included (for expiration checks) */
+  readonly includeByTimestamp: bigint;
+};
+
+/** Transaction state derived from TxMetaData fields and pool protection status */
+export type TxState = 'pending' | 'protected' | 'mined';
+
+/**
+ * Builds TxMetaData from a full Tx object.
+ * Extracts all relevant fields for efficient in-memory storage and querying.
+ */
+export async function buildTxMetaData(tx: Tx): Promise<TxMetaData> {
+  const txHash = tx.getTxHash().toString();
+  const anchorBlockHeaderHash = (await tx.data.constants.anchorBlockHeader.hash()).toString();
+  const priorityFee = getTxPriorityFee(tx);
+  const feePayer = tx.data.feePayer.toString();
+  const nullifiers = tx.data.getNonEmptyNullifiers().map(n => n.toString());
+  const includeByTimestamp = tx.data.includeByTimestamp;
+
+  const { feeLimit, claimAmount } = await getFeePayerBalanceDelta(tx, ProtocolContractAddress.FeeJuice);
+
+  return {
+    txHash,
+    anchorBlockHeaderHash,
+    priorityFee,
+    feePayer,
+    claimAmount,
+    feeLimit,
+    nullifiers,
+    includeByTimestamp,
+  };
+}
+
+/** Minimal fields required for priority comparison. */
+type PriorityComparable = Pick<TxMetaData, 'txHash' | 'priorityFee'>;
+
+/**
+ * Compares two priority fees in ascending order.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ */
+export function compareFee(a: bigint, b: bigint): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Compares two tx hashes in ascending order.
+ * Uses field element comparison for deterministic ordering.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ */
+export function compareTxHash(a: string, b: string): number {
+  const fieldA = Fr.fromHexString(a);
+  const fieldB = Fr.fromHexString(b);
+  return fieldA.cmp(fieldB);
+}
+
+/**
+ * Compares two transactions by priority fee, with txHash as tiebreaker.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ * Use with sort() for ascending order, or negate/reverse for descending.
+ */
+export function comparePriority(a: PriorityComparable, b: PriorityComparable): number {
+  const feeComparison = compareFee(a.priorityFee, b.priorityFee);
+  if (feeComparison !== 0) {
+    return feeComparison;
+  }
+  return compareTxHash(a.txHash, b.txHash);
+}
+
+/**
+ * Checks for nullifier conflicts between an incoming transaction and existing pool state.
+ *
+ * When the incoming tx shares nullifiers with existing pending txs:
+ * - If the incoming tx has strictly higher priority, mark conflicting txs for eviction
+ * - If any conflicting tx has equal or higher priority, ignore the incoming tx
+ *
+ * @param incomingMeta - Metadata for the incoming transaction
+ * @param getTxHashByNullifier - Accessor to find which tx uses a nullifier
+ * @param getMetadata - Accessor to get metadata for a tx hash
+ */
+export function checkNullifierConflict(
+  incomingMeta: TxMetaData,
+  getTxHashByNullifier: (nullifier: string) => string | undefined,
+  getMetadata: (txHash: string) => TxMetaData | undefined,
+): PreAddResult {
+  const txHashesToEvict: string[] = [];
+
+  for (const nullifier of incomingMeta.nullifiers) {
+    const conflictingHashStr = getTxHashByNullifier(nullifier);
+
+    if (!conflictingHashStr || conflictingHashStr === incomingMeta.txHash) {
+      continue;
+    }
+
+    // Skip if already marked for eviction
+    if (txHashesToEvict.includes(conflictingHashStr)) {
+      continue;
+    }
+
+    const conflictingMeta = getMetadata(conflictingHashStr);
+    if (!conflictingMeta) {
+      continue;
+    }
+
+    // If incoming tx has strictly higher priority, mark for eviction
+    // Otherwise, ignore incoming tx (ties go to existing tx)
+    if (incomingMeta.priorityFee > conflictingMeta.priorityFee) {
+      txHashesToEvict.push(conflictingHashStr);
+    } else {
+      return {
+        shouldIgnore: true,
+        txHashesToEvict: [],
+        reason: `nullifier conflict with ${conflictingHashStr}`,
+      };
+    }
+  }
+
+  return { shouldIgnore: false, txHashesToEvict };
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_bench_metrics.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_bench_metrics.ts
@@ -1,0 +1,77 @@
+/**
+ * Metrics types for tx pool benchmarks.
+ */
+
+export enum TxPoolOperation {
+  ADD_PENDING_TXS = 'addPendingTxs',
+  CAN_ADD_PENDING_TX = 'canAddPendingTx',
+  GET_PENDING_TX_HASHES = 'getPendingTxHashes',
+  GET_TX_BY_HASH = 'getTxByHash',
+  GET_TXS_BY_HASH = 'getTxsByHash',
+  HAS_TXS = 'hasTxs',
+  HANDLE_MINED_BLOCK = 'handleMinedBlock',
+  PREPARE_FOR_SLOT = 'prepareForSlot',
+  HANDLE_PRUNED_BLOCKS = 'handlePrunedBlocks',
+  GET_LOWEST_PRIORITY_PENDING = 'getLowestPriorityPending',
+  HYDRATE_FROM_DATABASE = 'hydrateFromDatabase',
+}
+
+type OperationMetric = {
+  operation: TxPoolOperation;
+  poolSize: number;
+  batchSize: number;
+  value: number;
+};
+
+/**
+ * Collects and formats tx pool benchmark metrics.
+ */
+export class TxPoolBenchMetrics {
+  private metrics: OperationMetric[] = [];
+
+  public addMetric(operation: TxPoolOperation, poolSize: number, batchSize: number, value: number) {
+    this.metrics.push({ operation, poolSize, batchSize, value });
+  }
+
+  public toPrettyString(): string {
+    let pretty = 'TxPool Benchmark Metrics:\n';
+    pretty += '='.repeat(60) + '\n';
+
+    // Group by operation
+    const byOperation = new Map<TxPoolOperation, OperationMetric[]>();
+    for (const metric of this.metrics) {
+      if (!byOperation.has(metric.operation)) {
+        byOperation.set(metric.operation, []);
+      }
+      byOperation.get(metric.operation)!.push(metric);
+    }
+
+    for (const [operation, opMetrics] of byOperation) {
+      pretty += `\n${operation}:\n`;
+      for (const metric of opMetrics) {
+        const poolSizeStr = metric.poolSize > 0 ? `pool=${metric.poolSize}` : '';
+        const batchSizeStr = metric.batchSize > 0 ? `batch=${metric.batchSize}` : '';
+        const params = [poolSizeStr, batchSizeStr].filter(Boolean).join(', ');
+        pretty += `  ${params ? `(${params})` : ''}: ${metric.value.toFixed(3)} ms\n`;
+      }
+    }
+
+    return pretty;
+  }
+
+  public toGithubActionBenchmarkJSON(indent = 2): string {
+    const data = this.metrics.map(metric => {
+      const poolSizeStr = metric.poolSize > 0 ? `${metric.poolSize} txs in pool` : '';
+      const batchSizeStr = metric.batchSize > 0 ? `batch of ${metric.batchSize}` : '';
+      const params = [poolSizeStr, batchSizeStr].filter(Boolean).join('/');
+
+      return {
+        name: `TxPool/${metric.operation}${params ? `/${params}` : ''}`,
+        value: metric.value,
+        unit: 'ms',
+      };
+    });
+
+    return JSON.stringify(data, null, indent);
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
@@ -1,0 +1,771 @@
+/**
+ * Compatibility test suite for TxPoolV2.
+ * These tests mirror the original TxPool test suite (aztec_kv_tx_pool.test.ts)
+ * but use the new TxPoolV2 interface.
+ */
+import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint } from '@aztec/foundation/branded-types';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { map, sort, toArray } from '@aztec/foundation/iterable';
+import { unfreeze } from '@aztec/foundation/types';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
+import { RevertCode } from '@aztec/stdlib/avm';
+import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
+import { GasFees } from '@aztec/stdlib/gas';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { mockTx } from '@aztec/stdlib/testing';
+import {
+  AppendOnlyTreeSnapshot,
+  MerkleTreeId,
+  NullifierLeaf,
+  NullifierLeafPreimage,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
+} from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { AztecKVTxPoolV2 } from './tx_pool_v2.js';
+
+/** A validator that accepts all transactions. */
+const alwaysValidValidator: TxValidator<Tx> = {
+  validateTx: () => Promise.resolve({ result: 'valid' }),
+};
+
+describe('TxPoolV2 Compatibility Tests', () => {
+  let pool: AztecKVTxPoolV2;
+  let mockL2BlockSource: MockProxy<L2BlockSource>;
+  let mockWorldState: MockProxy<WorldStateSynchronizer>;
+  let db: MockProxy<MerkleTreeReadOperations>;
+  let nextTxSeed: number;
+  const mockFixedTxSize = 100;
+
+  const block1Header = BlockHeader.empty({
+    globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(1), timestamp: 0n }),
+  });
+
+  // L2BlockId for the latest valid block after a prune
+  // When block 1 is pruned, the latest valid block is block 0
+  const block0Id: L2BlockId = { number: BlockNumber(0), hash: '0x0' };
+
+  const checkPendingTxConsistency = async () => {
+    const pendingTxHashCount = (await pool.getPendingTxHashes()).length;
+    expect(await pool.getPendingTxCount()).toEqual(pendingTxHashCount);
+  };
+
+  beforeEach(async () => {
+    nextTxSeed = 1;
+
+    mockL2BlockSource = mock<L2BlockSource>();
+    mockL2BlockSource.getTxEffect.mockResolvedValue(undefined);
+
+    mockWorldState = mock<WorldStateSynchronizer>();
+    db = mock<MerkleTreeReadOperations>();
+    mockWorldState.getCommitted.mockReturnValue(db);
+    mockWorldState.getSnapshot.mockReturnValue(db);
+
+    db.findLeafIndices.mockImplementation((_tree, leaves) => {
+      return Promise.resolve(times(leaves.length, () => 1n));
+    });
+
+    db.getPreviousValueIndex.mockImplementation((_tree, slot) => {
+      return Promise.resolve({ index: slot, alreadyPresent: true });
+    });
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      return Promise.resolve(
+        tree === MerkleTreeId.NULLIFIER_TREE
+          ? new NullifierLeafPreimage(new NullifierLeaf(new Fr(index)), Fr.ONE, 1n)
+          : new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(1e18)), Fr.ONE, 1n),
+      );
+    });
+
+    pool = new AztecKVTxPoolV2(await openTmpStore('p2p'), await openTmpStore('archive'), {
+      l2BlockSource: mockL2BlockSource,
+      worldStateSynchronizer: mockWorldState,
+      pendingTxValidator: alwaysValidValidator,
+    });
+    await pool.start();
+  });
+
+  afterEach(async () => {
+    await checkPendingTxConsistency();
+    await pool.stop();
+  });
+
+  const mockFixedSizeTx = async (maxPriorityFeesPerGas?: GasFees) => {
+    const tx = await mockTx(nextTxSeed++, { maxPriorityFeesPerGas });
+    jest.spyOn(tx, 'getSize').mockReturnValue(mockFixedTxSize);
+    return tx;
+  };
+
+  /** Creates an L2Block from transactions and a header */
+  const makeBlock = (txs: Tx[], header: BlockHeader): L2Block => {
+    const txEffects = txs.map(tx => {
+      const nullifiers = tx.data.getNonEmptyNullifiers();
+      return new TxEffect(RevertCode.OK, tx.getTxHash(), Fr.ZERO, [], nullifiers, [], [], [], [], []);
+    });
+    const body = new Body(txEffects);
+    const archive = new AppendOnlyTreeSnapshot(Fr.random(), header.globalVariables.blockNumber + 1);
+    return new L2Block(
+      archive,
+      header,
+      body,
+      CheckpointNumber(Number(header.globalVariables.blockNumber)),
+      IndexWithinCheckpoint(0),
+    );
+  };
+
+  // === Shared test suite tests (from tx_pool_test_suite.ts) ===
+
+  describe('basic operations', () => {
+    it('adds txs to the pool as pending', async () => {
+      const tx1 = await mockTx(1);
+
+      await pool.addPendingTxs([tx1]);
+      const poolTx = await pool.getTxByHash(tx1.getTxHash());
+      expect(poolTx!.getTxHash()).toEqual(tx1.getTxHash());
+      expect(await pool.getTxStatus(tx1.getTxHash())).toEqual('pending');
+      expect(await pool.getPendingTxHashes()).toEqual([tx1.getTxHash()]);
+      expect(await pool.getPendingTxCount()).toEqual(1);
+    });
+
+    it('emits txs-added event with new txs', async () => {
+      const tx1 = await mockTx(1); // existing and pending
+      const tx2 = await mockTx(2); // mined but not known
+      const tx3 = await mockTx(3); // brand new
+
+      await pool.addPendingTxs([tx1]);
+      // Mark tx2 as mined without adding it first
+      await pool.addMinedTxs([tx2], block1Header);
+
+      let txsFromEvent: Tx[] | undefined = undefined;
+      pool.once('txs-added', ({ txs }) => {
+        txsFromEvent = txs;
+      });
+
+      await pool.addPendingTxs([tx1, tx3]); // tx1 is duplicate, tx3 is new
+      expect(txsFromEvent).toBeDefined();
+      expect(txsFromEvent).toHaveLength(1);
+      const eventHashes = txsFromEvent!.map(tx => tx.getTxHash());
+      expect(eventHashes).toContainEqual(tx3.getTxHash());
+    });
+
+    it('removes pending txs from the pool via handleFailedExecution', async () => {
+      const pendingTx = await mockTx(1);
+      const minedTx = await mockTx(2);
+
+      await pool.addPendingTxs([pendingTx, minedTx]);
+      await pool.handleMinedBlock(makeBlock([minedTx], block1Header));
+
+      // Delete a pending tx via handleFailedExecution - should be permanently deleted
+      await pool.handleFailedExecution([pendingTx.getTxHash()]);
+      expect(await pool.getTxByHash(pendingTx.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(pendingTx.getTxHash())).toBeUndefined();
+
+      expect(await pool.getPendingTxCount()).toEqual(0);
+    });
+
+    it('marks txs as mined', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await pool.addPendingTxs([tx1, tx2]);
+      await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+
+      const retrievedTx = await pool.getTxByHash(tx1.getTxHash());
+      expect(retrievedTx?.getTxHash()).toEqual(tx1.getTxHash());
+      expect(await pool.getTxStatus(tx1.getTxHash())).toEqual('mined');
+      const minedHashes = await pool.getMinedTxHashes();
+      expect(minedHashes.length).toEqual(1);
+      expect(minedHashes[0][0]).toEqual(tx1.getTxHash());
+      expect(minedHashes[0][1].number).toEqual(BlockNumber(1));
+      expect(await pool.getPendingTxHashes()).toEqual([tx2.getTxHash()]);
+      expect(await pool.getPendingTxCount()).toEqual(1);
+    });
+
+    it('marks txs as pending after being mined (reorg via handlePrunedBlocks)', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await pool.addPendingTxs([tx1, tx2]);
+      await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getMinedTxHashes()).toEqual([]);
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toHaveLength(2);
+      expect(pending).toEqual(expect.arrayContaining([tx1.getTxHash(), tx2.getTxHash()]));
+      expect(await pool.getPendingTxCount()).toEqual(2);
+    });
+
+    it('only marks txs as pending if they are known (after reorg)', async () => {
+      const tx1 = await mockTx(1);
+      // simulate a situation where not all peers have all the txs
+      const tx2 = await mockTx(2);
+      await pool.addPendingTxs([tx1]);
+      // this peer knows that tx2 was mined, but it does not have the tx object
+      // In V2, we need to use protectTxs to mark it as protected, then handleMinedBlock
+      await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+      // For tx2, we can add it as mined directly
+      await pool.addMinedTxs([tx2], block1Header);
+
+      const minedHashes = await pool.getMinedTxHashes();
+      expect(minedHashes.length).toBe(2);
+
+      // reorg: both txs should now become available again
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getMinedTxHashes()).toEqual([]);
+      // Both should be pending now since tx2 was added via addMinedTxs
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toHaveLength(2);
+      expect(pending).toEqual(expect.arrayContaining([tx1.getTxHash(), tx2.getTxHash()]));
+    });
+
+    it('returns txs by their hash', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      const requestedTxs = await pool.getTxsByHash([tx1.getTxHash(), tx3.getTxHash()]);
+      expect(requestedTxs).toHaveLength(2);
+      const requestedHashes = requestedTxs.filter(tx => tx !== undefined).map(tx => tx!.getTxHash());
+      expect(requestedHashes).toEqual(expect.arrayContaining([tx1.getTxHash(), tx3.getTxHash()]));
+    });
+
+    it('returns a large number of transactions by their hash', async () => {
+      const numTxs = 1_000;
+      const txs = await Promise.all(Array.from({ length: numTxs }, (_, i) => mockTx(i)));
+      const hashes = txs.map(tx => tx.getTxHash());
+      await pool.addPendingTxs(txs);
+      const requestedTxs = await pool.getTxsByHash(hashes);
+      expect(requestedTxs.filter(tx => tx !== undefined)).toHaveLength(numTxs);
+      const requestedHashes = requestedTxs.filter(tx => tx !== undefined).map(tx => tx!.getTxHash());
+      expect(requestedHashes).toEqual(expect.arrayContaining(hashes));
+    });
+
+    it('returns whether or not txs exist', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      const tx4 = await mockTx(4);
+      const tx5 = await mockTx(5);
+
+      const availability = await pool.hasTxs([
+        tx1.getTxHash(),
+        tx2.getTxHash(),
+        tx3.getTxHash(),
+        tx4.getTxHash(),
+        tx5.getTxHash(),
+      ]);
+      expect(availability).toHaveLength(5);
+      expect(availability).toEqual([true, true, true, false, false]);
+    });
+
+    it('returns pending tx hashes sorted by priority', async () => {
+      const withPriorityFee = (tx: Tx, fee: number) => {
+        unfreeze(tx.data.constants.txContext.gasSettings).maxPriorityFeesPerGas = new GasFees(fee, fee);
+        return tx;
+      };
+
+      const tx1 = withPriorityFee(await mockTx(0), 1000);
+      const tx2 = withPriorityFee(await mockTx(1), 100);
+      const tx3 = withPriorityFee(await mockTx(2), 200);
+      const tx4 = withPriorityFee(await mockTx(3), 3000);
+
+      await pool.addPendingTxs([tx1, tx2, tx3, tx4]);
+
+      const poolTxHashes = await pool.getPendingTxHashes();
+      expect(poolTxHashes).toHaveLength(4);
+      expect(poolTxHashes).toEqual([tx4, tx1, tx3, tx2].map(tx => tx.getTxHash()));
+    });
+  });
+
+  describe('finalization and deletion', () => {
+    it('deletes mined txs via handleFinalizedBlock', async () => {
+      const txs = await Promise.all([mockTx(1), mockTx(2), mockTx(3)]);
+      await pool.addPendingTxs(txs);
+
+      // Mark first tx as mined
+      await pool.handleMinedBlock(makeBlock([txs[0]], block1Header));
+
+      // Verify initial state
+      expect(await pool.getPendingTxCount()).toBe(2);
+      expect(await pool.getTxByHash(txs[0].getTxHash())).toBeDefined();
+      expect(await pool.getTxByHash(txs[1].getTxHash())).toBeDefined();
+
+      // Delete mined tx via finalization
+      await pool.handleFinalizedBlock(block1Header);
+
+      // Verify mined tx is deleted
+      expect(await pool.getTxStatus(txs[0].getTxHash())).toBeUndefined();
+
+      // Verify remaining pending count
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+  });
+
+  // === Implementation-specific tests (from aztec_kv_tx_pool.test.ts) ===
+
+  it('Returns archived txs and purges archived txs once the archived tx limit is reached', async () => {
+    // set the archived tx limit to 2
+    await pool.stop();
+    pool = new AztecKVTxPoolV2(
+      await openTmpStore('p2p'),
+      await openTmpStore('archive'),
+      {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: alwaysValidValidator,
+      },
+      undefined, // telemetry
+      { archivedTxLimit: 2 },
+    );
+    await pool.start();
+
+    const txs = await timesAsync(5, i => mockTx(i + 1));
+    await pool.addPendingTxs(txs);
+
+    // Only mined txs should be archived, pending are never archived
+    await pool.handleMinedBlock(makeBlock(txs, block1Header));
+
+    const expectArchivedTx = async (txHash: TxHash, shouldExist: boolean) => {
+      const archived = await pool.getArchivedTxByHash(txHash);
+      if (shouldExist) {
+        expect(archived).toBeDefined();
+        expect(archived!.getTxHash()).toEqual(txHash);
+      } else {
+        expect(archived).toBeUndefined();
+      }
+    };
+
+    // delete two txs via finalization and assert that they are properly archived
+    await pool.handleFinalizedBlock(block1Header);
+    // All 5 txs were mined in block1, so they should all be deleted and 2 should be archived
+    await expectArchivedTx(txs[3].getTxHash(), true);
+    await expectArchivedTx(txs[4].getTxHash(), true);
+    await expectArchivedTx(txs[0].getTxHash(), false);
+    await expectArchivedTx(txs[1].getTxHash(), false);
+    await expectArchivedTx(txs[2].getTxHash(), false);
+  });
+
+  it('Evicts low priority txs to satisfy the pending tx count limit', async () => {
+    await pool.stop();
+    pool = new AztecKVTxPoolV2(
+      await openTmpStore('p2p'),
+      await openTmpStore('archive'),
+      {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: alwaysValidValidator,
+      },
+      undefined, // telemetry
+      { maxPendingTxCount: 3 },
+    );
+    await pool.start();
+
+    const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+    const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) });
+    await pool.addPendingTxs([tx1, tx2, tx3]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx3.getTxHash(), tx2.getTxHash(), tx1.getTxHash()]);
+
+    // once the tx pool count limit is reached, the lowest priority txs (tx1, tx2) should be evicted
+    const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4) });
+    const tx5 = await mockTx(5, { maxPriorityFeesPerGas: new GasFees(5, 5) });
+    await pool.addPendingTxs([tx4, tx5]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx3.getTxHash()]);
+
+    // if another low priority tx is added after the tx pool count limit is reached, it should be evicted
+    const tx6 = await mockTx(6, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    await pool.addPendingTxs([tx6]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx3.getTxHash()]);
+
+    // if a tx is deleted via handleFailedExecution, any txs can be added until the limit is reached
+    await pool.handleFailedExecution([tx3.getTxHash()]);
+    const tx7 = await mockTx(7, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+    await pool.addPendingTxs([tx7]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx7.getTxHash()]);
+
+    // if a tx is mined, any txs can be added until the limit is reached
+    await pool.handleMinedBlock(makeBlock([tx4], block1Header));
+    const tx8 = await mockTx(8, { maxPriorityFeesPerGas: new GasFees(3, 3) });
+    await pool.addPendingTxs([tx8]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx8.getTxHash(), tx7.getTxHash()]);
+
+    // verify that the tx pool count limit is respected after mining and deletions
+    const tx9 = await mockTx(9, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    await pool.addPendingTxs([tx9]);
+    await checkPendingTxConsistency();
+    expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx8.getTxHash(), tx7.getTxHash()]);
+  });
+
+  it('respects the maximum transaction count configured', async () => {
+    await pool.stop();
+    pool = new AztecKVTxPoolV2(
+      await openTmpStore('p2p'),
+      await openTmpStore('archive'),
+      {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: alwaysValidValidator,
+      },
+      undefined, // telemetry
+      { maxPendingTxCount: 10 },
+    );
+    await pool.start();
+
+    const cmp = (a: TxHash, b: TxHash) => (a.toBigInt() < b.toBigInt() ? -1 : a.toBigInt() > b.toBigInt() ? 1 : 0);
+
+    const firstBatch = await timesAsync(10, () => mockFixedSizeTx());
+    await pool.addPendingTxs(firstBatch);
+
+    // we've just added 10 txs. They should all be available
+    expect(await toArray(sort(await pool.getPendingTxHashes(), cmp))).toEqual(
+      await toArray(
+        sort(
+          map(firstBatch, tx => tx.getTxHash()),
+          cmp,
+        ),
+      ),
+    );
+
+    const secondBatch = await timesAsync(2, () => mockFixedSizeTx());
+    await pool.addPendingTxs(secondBatch);
+
+    // pool should evict 2 txs to bring it back to 10
+    expect(await pool.getPendingTxCount()).toBe(10);
+
+    const lastTx = await mockFixedSizeTx();
+    await pool.addPendingTxs([lastTx]);
+
+    // the pool should evict enough txs to stay below the limit
+    expect(await pool.getPendingTxCount()).toBe(10);
+  });
+
+  it('evicts based on the updated size limit', async () => {
+    await pool.stop();
+    pool = new AztecKVTxPoolV2(
+      await openTmpStore('p2p'),
+      await openTmpStore('archive'),
+      {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: alwaysValidValidator,
+      },
+      undefined, // telemetry
+      { maxPendingTxCount: 10 },
+    );
+    await pool.start();
+
+    const cmp = (a: TxHash, b: TxHash) => (a.toBigInt() < b.toBigInt() ? -1 : a.toBigInt() > b.toBigInt() ? 1 : 0);
+
+    const firstBatch = await timesAsync(10, (i: number) => mockFixedSizeTx(new GasFees(i + 1, i + 1)));
+    const expectedRemainingTxs = firstBatch.slice(6);
+    await pool.addPendingTxs(firstBatch);
+
+    // we've just added 10 txs. They should all be available
+    expect(await toArray(sort(await pool.getPendingTxHashes(), cmp))).toEqual(
+      await toArray(
+        sort(
+          map(firstBatch, tx => tx.getTxHash()),
+          cmp,
+        ),
+      ),
+    );
+
+    // now set the limit to 5 txs
+    const numRemainingTxs = 5;
+    await pool.updateConfig({ maxPendingTxCount: numRemainingTxs });
+
+    // txs are not immediately evicted
+    expect(await toArray(sort(await pool.getPendingTxHashes(), cmp))).toEqual(
+      await toArray(
+        sort(
+          map(firstBatch, tx => tx.getTxHash()),
+          cmp,
+        ),
+      ),
+    );
+
+    // now add one more transaction
+    const lastTx = await mockFixedSizeTx(new GasFees(20, 20));
+    await pool.addPendingTxs([lastTx]);
+
+    const finalExpectedPool = expectedRemainingTxs.concat(lastTx);
+
+    // There should now just be numRemainingTxs txs in the pool
+    expect(await pool.getPendingTxCount()).toEqual(finalExpectedPool.length);
+
+    expect(await toArray(sort(await pool.getPendingTxHashes(), cmp))).toEqual(
+      await toArray(
+        sort(
+          map(finalExpectedPool, tx => tx.getTxHash()),
+          cmp,
+        ),
+      ),
+    );
+  });
+
+  it('Evicts txs with nullifiers that are already included in the mined block', async () => {
+    const tx1 = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+    const tx2 = await mockTx(2, { numberOfNonRevertiblePublicCallRequests: 1 });
+    const tx3 = await mockTx(3, { numberOfNonRevertiblePublicCallRequests: 1 });
+    const tx4 = await mockTx(4, { numberOfNonRevertiblePublicCallRequests: 1 });
+
+    // simulate a situation where tx1, tx2, and tx3 have the same nullifier
+    tx2.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] =
+      tx1.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0];
+    tx3.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] =
+      tx1.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0];
+
+    // Add tx1 first, then the others - tx2 and tx3 should replace tx1 via challenge
+    // but since they have the same fee, only one will be accepted
+    await pool.addPendingTxs([tx1, tx2, tx3, tx4]);
+    // tx2 and tx3 can't replace tx1 since they have same fee (challenge fails)
+
+    // Mine tx1
+    await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+
+    // tx4 should be the only pending tx
+    expect(await pool.getPendingTxHashes()).toEqual([tx4.getTxHash()]);
+  });
+
+  it('Evicts txs with an insufficient fee payer balance after a block is mined', async () => {
+    const tx1 = await mockTx(1);
+    const tx2 = await mockTx(2);
+    const tx3 = await mockTx(3);
+    const tx4 = await mockTx(4);
+
+    // modify tx1 to have the same fee payer as the mined tx and an insufficient fee payer balance
+    tx1.data.feePayer = tx4.data.feePayer;
+    const prev = db.getLeafPreimage.getMockImplementation()!;
+    const expectedSlot = await computeFeePayerBalanceLeafSlot(tx1.data.feePayer);
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      if (index === expectedSlot.toBigInt() && tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+        return Promise.resolve(
+          // this feePayer has a balance of 0 now
+          new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(tx1.data.feePayer.toField(), Fr.ZERO), Fr.ONE, 1n),
+        );
+      } else {
+        return prev(tree, index);
+      }
+    });
+
+    await pool.addPendingTxs([tx1, tx2, tx3, tx4]);
+    await pool.handleMinedBlock(makeBlock([tx4], block1Header));
+
+    const pendingTxHashes = await pool.getPendingTxHashes();
+    expect(pendingTxHashes).toEqual(expect.arrayContaining([tx2.getTxHash(), tx3.getTxHash()]));
+    expect(pendingTxHashes).toHaveLength(2);
+  });
+
+  it('Evicts txs with invalid archive roots after a reorg', async () => {
+    const tx1 = await mockTx(1);
+    const tx2 = await mockTx(2);
+    const tx3 = await mockTx(3);
+
+    // modify tx1 to return no archive indices
+    tx1.data.constants.anchorBlockHeader.globalVariables.blockNumber = BlockNumber(1);
+    const tx1HeaderHash = await tx1.data.constants.anchorBlockHeader.hash();
+    db.findLeafIndices.mockImplementation((tree, leaves) => {
+      if (tree === MerkleTreeId.ARCHIVE) {
+        return Promise.resolve((leaves as Fr[]).map(l => (l.equals(tx1HeaderHash) ? undefined : 1n)));
+      }
+      return Promise.resolve([]);
+    });
+
+    await pool.addPendingTxs([tx1, tx2, tx3]);
+    await pool.handleMinedBlock(makeBlock([tx1, tx2, tx3], block1Header));
+    await pool.handlePrunedBlocks(block0Id);
+
+    const pendingTxHashes = await pool.getPendingTxHashes();
+    expect(pendingTxHashes).toEqual(expect.arrayContaining([tx2.getTxHash(), tx3.getTxHash()]));
+    expect(pendingTxHashes).toHaveLength(2);
+  });
+
+  it('Evicts txs with invalid fee payer balances after a reorg', async () => {
+    const tx1 = await mockTx(1);
+    const tx2 = await mockTx(2);
+    const tx3 = await mockTx(3);
+
+    await pool.addPendingTxs([tx1, tx2, tx3]);
+    await pool.handleMinedBlock(makeBlock([tx2], block1Header));
+    await checkPendingTxConsistency();
+
+    const prev = db.getLeafPreimage.getMockImplementation()!;
+    const expectedSlot = await computeFeePayerBalanceLeafSlot(tx1.data.feePayer);
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      if (index === expectedSlot.toBigInt() && tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+        return Promise.resolve(
+          // this feePayer has a balance of 0 now
+          new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(tx1.data.feePayer.toField(), Fr.ZERO), Fr.ONE, 1n),
+        );
+      } else {
+        return prev(tree, index);
+      }
+    });
+
+    await pool.handlePrunedBlocks(block0Id);
+    await checkPendingTxConsistency();
+
+    const pendingTxHashes = await pool.getPendingTxHashes();
+    expect(pendingTxHashes).toEqual(expect.arrayContaining([tx2.getTxHash(), tx3.getTxHash()]));
+    expect(pendingTxHashes).toHaveLength(2);
+  });
+
+  describe('getLowestPriorityPending', () => {
+    it('returns the lowest-priority evictable tx hashes up to limit', async () => {
+      await pool.stop();
+      pool = new AztecKVTxPoolV2(
+        await openTmpStore('p2p'),
+        await openTmpStore('archive'),
+        {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        },
+        undefined, // telemetry
+        { maxPendingTxCount: 0 },
+      );
+      await pool.start();
+
+      const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+      const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+      const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) });
+      const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4) });
+      await pool.addPendingTxs([tx3, tx1, tx4, tx2]);
+
+      const res1 = await pool.getLowestPriorityPending(1);
+      expect(res1).toEqual([tx1.getTxHash()]);
+
+      const res2 = await pool.getLowestPriorityPending(2);
+      expect(res2).toEqual([tx1.getTxHash(), tx2.getTxHash()]);
+
+      const res3 = await pool.getLowestPriorityPending(10);
+      expect(res3).toEqual([tx1.getTxHash(), tx2.getTxHash(), tx3.getTxHash(), tx4.getTxHash()]);
+    });
+
+    it('respects zero limit', async () => {
+      const tx1 = await mockTx(10, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+      await pool.addPendingTxs([tx1]);
+
+      expect(await pool.getLowestPriorityPending(0)).toEqual([]);
+    });
+  });
+
+  /**
+   * Nullifier Index Consistency Tests
+   *
+   * These integration tests verify that the nullifier index is maintained
+   * correctly across all pool operations (add, delete, mine, reorg).
+   */
+  describe('Nullifier index consistency', () => {
+    // Tx type alias for cleaner type annotations
+    type MockTx = Awaited<ReturnType<typeof mockTx>>;
+
+    // Helper to create a public tx (forPublic path) with a specific fee
+    const mockPublicTx = (seed: number, fee: number) =>
+      mockTx(seed, {
+        maxPriorityFeesPerGas: new GasFees(fee, fee),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+    // Helper to set a specific nullifier on a transaction
+    const setNullifier = (tx: MockTx, index: number, value: Fr) => {
+      if (tx.data.forPublic) {
+        tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index] = value;
+      } else if (tx.data.forRollup) {
+        tx.data.forRollup.end.nullifiers[index] = value;
+      }
+    };
+
+    const getNullifier = (tx: MockTx, index: number): Fr => {
+      if (tx.data.forPublic) {
+        return tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index];
+      } else if (tx.data.forRollup) {
+        return tx.data.forRollup.end.nullifiers[index];
+      }
+      throw new Error('Transaction has no nullifiers');
+    };
+
+    it('removes nullifier entries when tx is deleted', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleFailedExecution([tx1.getTxHash()]);
+
+      // Add a new tx with the same nullifier - should succeed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx2]);
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+    });
+
+    it('removes nullifier entries when tx is mined', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+
+      // Add a new tx with the same nullifier, it should succeed
+      // (In practice this would fail world state nullifier check,
+      // but we're testing pool index consistency)
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx2]);
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+    });
+
+    it('restores nullifier entries on reorg (handlePrunedBlocks)', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleMinedBlock(makeBlock([tx1], block1Header));
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Now tx1 is pending again - nullifier should be claimed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx2]);
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx1.getTxHash());
+      expect(pending).not.toContainEqual(tx2.getTxHash()); // tx2 has lower fee, should be rejected
+    });
+
+    it('cleans up nullifier index when replacement happens', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx1]);
+      await pool.addPendingTxs([tx2]); // Replaces tx1
+
+      // Now add tx3 with the same nullifier as tx2 but lower fee
+      // It should be rejected because tx2 owns that nullifier now
+      const tx3 = await mockPublicTx(3, 3);
+      setNullifier(tx3, 0, getNullifier(tx2, 0));
+
+      await pool.addPendingTxs([tx3]);
+      const pending = await pool.getPendingTxHashes();
+      expect(pending).toContainEqual(tx2.getTxHash());
+      expect(pending).not.toContainEqual(tx3.getTxHash());
+      expect(pending.length).toBe(1);
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -1,0 +1,3737 @@
+import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
+import { timesAsync } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { RevertCode } from '@aztec/stdlib/avm';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
+import { GasFees, GasSettings } from '@aztec/stdlib/gas';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { mockTx } from '@aztec/stdlib/testing';
+import {
+  AppendOnlyTreeSnapshot,
+  MerkleTreeId,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
+} from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { AztecKVTxPoolV2 } from './tx_pool_v2.js';
+
+// Tx type alias for cleaner type annotations
+type MockTx = Awaited<ReturnType<typeof mockTx>>;
+
+/** A validator that accepts all transactions. Used in tests that don't need validation. */
+const alwaysValidValidator: TxValidator<Tx> = {
+  validateTx: () => Promise.resolve({ result: 'valid' }),
+};
+
+describe('TxPoolV2', () => {
+  let pool: AztecKVTxPoolV2;
+  let store: Awaited<ReturnType<typeof openTmpStore>>;
+  let archiveStore: Awaited<ReturnType<typeof openTmpStore>>;
+  let mockL2BlockSource: MockProxy<L2BlockSource>;
+  let mockWorldState: MockProxy<WorldStateSynchronizer>;
+  let db: MockProxy<MerkleTreeReadOperations>;
+
+  const slot1Header = BlockHeader.empty({
+    globalVariables: GlobalVariables.empty({
+      blockNumber: BlockNumber(1),
+      slotNumber: SlotNumber(1),
+      timestamp: 0n,
+    }),
+  });
+
+  const slot2Header = BlockHeader.empty({
+    globalVariables: GlobalVariables.empty({
+      blockNumber: BlockNumber(2),
+      slotNumber: SlotNumber(2),
+      timestamp: 36n,
+    }),
+  });
+
+  // L2BlockId for the latest valid block after a prune
+  // When block 1 is pruned, the latest valid block is block 0
+  const block0Id: L2BlockId = { number: BlockNumber(0), hash: '0x0' };
+
+  beforeEach(async () => {
+    mockL2BlockSource = mock<L2BlockSource>();
+    mockL2BlockSource.getTxEffect.mockResolvedValue(undefined);
+
+    // Setup world state mock with proper fee payer balance support
+    mockWorldState = mock<WorldStateSynchronizer>();
+    db = mock<MerkleTreeReadOperations>();
+    mockWorldState.getCommitted.mockReturnValue(db);
+    mockWorldState.getSnapshot.mockReturnValue(db);
+
+    // Mock fee payer balance lookups to return sufficient balance (1e18)
+    db.getPreviousValueIndex.mockImplementation((_tree, slot) => {
+      return Promise.resolve({ index: slot, alreadyPresent: true });
+    });
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+        // Return a balance of 1e18 for any fee payer
+        return Promise.resolve(
+          new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(1e18)), Fr.ONE, 1n),
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    store = await openTmpStore('p2p');
+    archiveStore = await openTmpStore('archive');
+    pool = new AztecKVTxPoolV2(store, archiveStore, {
+      l2BlockSource: mockL2BlockSource,
+      worldStateSynchronizer: mockWorldState,
+      pendingTxValidator: alwaysValidValidator,
+    });
+    await pool.start();
+  });
+
+  afterEach(async () => {
+    await pool.stop();
+    await store.delete();
+    await archiveStore.delete();
+  });
+
+  const mockTxWithFee = (seed: number, fee: number) => mockTx(seed, { maxPriorityFeesPerGas: new GasFees(fee, fee) });
+
+  // Helper functions for string-based TxHash comparisons
+  const toStrings = (hashes: TxHash[]) => hashes.map(h => h.toString());
+  const hashOf = (tx: Tx) => tx.getTxHash().toString();
+
+  const mockPublicTx = (seed: number, fee: number = 1) =>
+    mockTx(seed, {
+      maxPriorityFeesPerGas: new GasFees(fee, fee),
+      numberOfNonRevertiblePublicCallRequests: 1,
+    });
+
+  // Helper to set a specific nullifier on a transaction
+  const setNullifier = (tx: MockTx, index: number, value: Fr) => {
+    if (tx.data.forPublic) {
+      tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index] = value;
+    }
+  };
+
+  const getNullifier = (tx: MockTx, index: number): Fr => {
+    if (tx.data.forPublic) {
+      return tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index];
+    }
+    throw new Error('Transaction has no nullifiers');
+  };
+
+  /**
+   * Creates an L2Block from transactions and a header.
+   * Extracts nullifiers from txs to create matching TxEffects.
+   */
+  const makeBlock = (txs: Tx[], header: BlockHeader): L2Block => {
+    const txEffects = txs.map(tx => {
+      const nullifiers = tx.data.getNonEmptyNullifiers();
+      return new TxEffect(
+        RevertCode.OK,
+        tx.getTxHash(),
+        Fr.ZERO, // transactionFee
+        [], // noteHashes
+        nullifiers,
+        [], // l2ToL1Msgs
+        [], // publicDataWrites
+        [], // privateLogs
+        [], // publicLogs
+        [], // contractClassLogs
+      );
+    });
+    const body = new Body(txEffects);
+    const archive = new AppendOnlyTreeSnapshot(Fr.random(), header.globalVariables.blockNumber + 1);
+    return new L2Block(
+      archive,
+      header,
+      body,
+      CheckpointNumber(Number(header.globalVariables.blockNumber)),
+      IndexWithinCheckpoint(0),
+    );
+  };
+
+  /** Creates an empty L2Block with no transactions */
+  const makeEmptyBlock = (header: BlockHeader): L2Block => {
+    const body = new Body([]);
+    const archive = new AppendOnlyTreeSnapshot(Fr.random(), header.globalVariables.blockNumber + 1);
+    return new L2Block(
+      archive,
+      header,
+      body,
+      CheckpointNumber(Number(header.globalVariables.blockNumber)),
+      IndexWithinCheckpoint(0),
+    );
+  };
+
+  describe('addPendingTxs', () => {
+    it('adds valid transactions to pending pool', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      const result = await pool.addPendingTxs([tx1, tx2]);
+
+      expect(result.accepted).toHaveLength(2);
+      expect(result.ignored).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+
+    it('ignores duplicate transactions', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(1);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('challenges transactions with conflicting nullifiers - higher fee wins', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+
+      // Set tx2 to have the same nullifier as tx1
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx1]);
+      const result = await pool.addPendingTxs([tx2]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(tx2));
+      expect(pending).not.toContain(hashOf(tx1));
+    });
+
+    it('challenges transactions with conflicting nullifiers - existing wins on tie', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      const tx2 = await mockPublicTx(2, 10);
+
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx1]);
+      const result = await pool.addPendingTxs([tx2]);
+
+      // tx2 is valid but ignored due to nullifier conflict with equal-priority tx1
+      expect(toStrings(result.ignored)).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(tx1));
+      expect(pending).not.toContain(hashOf(tx2));
+    });
+
+    it('emits txs-added event with source', async () => {
+      const tx = await mockTx(1);
+      const eventPromise = new Promise<{ txs: Tx[]; source?: string }>(resolve => {
+        pool.on('txs-added', args => resolve(args));
+      });
+
+      await pool.addPendingTxs([tx], { source: 'gossip' });
+
+      const event = await eventPromise;
+      expect(event.txs).toHaveLength(1);
+      expect(event.source).toBe('gossip');
+    });
+
+    it('respects maxPendingTxCount limit', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 3 });
+
+      const tx1 = await mockTxWithFee(1, 1);
+      const tx2 = await mockTxWithFee(2, 2);
+      const tx3 = await mockTxWithFee(3, 3);
+      const tx4 = await mockTxWithFee(4, 4);
+      const tx5 = await mockTxWithFee(5, 5);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      // Adding more txs should evict lowest priority
+      await pool.addPendingTxs([tx4, tx5]);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(tx5));
+      expect(pending).toContain(hashOf(tx4));
+      expect(pending).toContain(hashOf(tx3));
+      expect(pending).not.toContain(hashOf(tx1));
+      expect(pending).not.toContain(hashOf(tx2));
+    });
+  });
+
+  describe('canAddPendingTx', () => {
+    it('returns same result as addPendingTxs without modifying state', async () => {
+      const tx = await mockTx(1);
+
+      const canAddResult = await pool.canAddPendingTx(tx);
+
+      expect(canAddResult).toBe('accepted');
+      expect(await pool.getPendingTxCount()).toBe(0); // State unchanged
+
+      const addResult = await pool.addPendingTxs([tx]);
+      expect(addResult.accepted).toHaveLength(1);
+      expect(addResult.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('returns ignored for duplicate transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      const canAddResult = await pool.canAddPendingTx(tx);
+      expect(canAddResult).toBe('ignored');
+    });
+  });
+
+  describe('duplicate handling across states', () => {
+    it('addPendingTxs ignores tx that is already pending', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(1);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('addPendingTxs ignores tx that is already protected', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(1);
+      expect(result.rejected).toHaveLength(0);
+      // Status should remain protected
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    it('addPendingTxs ignores tx that is already mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addMinedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(1);
+      expect(result.rejected).toHaveLength(0);
+      // Status should remain mined
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+
+    it('canAddPendingTx returns ignored for tx that is already pending', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      const result = await pool.canAddPendingTx(tx);
+
+      expect(result).toBe('ignored');
+    });
+
+    it('canAddPendingTx returns ignored for tx that is already protected', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      const result = await pool.canAddPendingTx(tx);
+
+      expect(result).toBe('ignored');
+    });
+
+    it('canAddPendingTx returns ignored for tx that is already mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addMinedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      const result = await pool.canAddPendingTx(tx);
+
+      expect(result).toBe('ignored');
+    });
+
+    it('addPendingTxs handles duplicate tx in same batch', async () => {
+      const tx = await mockTx(1);
+
+      // Add same tx twice in one batch
+      const result = await pool.addPendingTxs([tx, tx]);
+
+      // First occurrence accepted, second ignored
+      expect(result.accepted).toHaveLength(1);
+      expect(result.ignored).toHaveLength(1);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('addProtectedTxs handles duplicate tx in same batch', async () => {
+      const tx = await mockTx(1);
+
+      // Add same tx twice in one batch
+      await pool.addProtectedTxs([tx, tx], slot1Header);
+
+      // Should only have one tx in pool
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      // Verify we can retrieve the tx
+      const retrieved = await pool.getTxByHash(tx.getTxHash());
+      expect(retrieved).toBeDefined();
+    });
+
+    it('addMinedTxs handles duplicate tx in same batch', async () => {
+      const tx = await mockTx(1);
+
+      // Add same tx twice in one batch
+      await pool.addMinedTxs([tx, tx], slot1Header);
+
+      // Should only have one tx in pool
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+      expect(await pool.getMinedTxCount()).toBe(1);
+    });
+
+    it('addPendingTxs handles multiple duplicates in batch with other txs', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      // Batch: tx1, tx2, tx1, tx2, tx1
+      const result = await pool.addPendingTxs([tx1, tx2, tx1, tx2, tx1]);
+
+      // First occurrence of each accepted, rest ignored
+      expect(result.accepted).toHaveLength(2);
+      expect(result.ignored).toHaveLength(3);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+  });
+
+  describe('validator rejection', () => {
+    let rejectingPool: AztecKVTxPoolV2;
+    let rejectingValidator: TxValidator<Tx>;
+    let txsToReject: Set<string>;
+    let rejectingStore: Awaited<ReturnType<typeof openTmpStore>>;
+    let rejectingArchiveStore: Awaited<ReturnType<typeof openTmpStore>>;
+
+    beforeEach(async () => {
+      // Create a validator that rejects specific transactions
+      txsToReject = new Set<string>();
+      rejectingValidator = {
+        validateTx: (tx: Tx) => {
+          const txHash = tx.getTxHash().toString();
+          if (txsToReject.has(txHash)) {
+            return Promise.resolve({ result: 'invalid', reason: ['test rejection'] });
+          }
+          return Promise.resolve({ result: 'valid' });
+        },
+      };
+
+      rejectingStore = await openTmpStore('p2p');
+      rejectingArchiveStore = await openTmpStore('archive');
+      rejectingPool = new AztecKVTxPoolV2(rejectingStore, rejectingArchiveStore, {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: rejectingValidator,
+      });
+      await rejectingPool.start();
+    });
+
+    afterEach(async () => {
+      await rejectingPool.stop();
+      await rejectingStore.delete();
+      await rejectingArchiveStore.delete();
+    });
+
+    it('addPendingTxs returns rejected for transaction that fails validation', async () => {
+      const tx = await mockTx(1);
+      txsToReject.add(tx.getTxHash().toString());
+
+      const result = await rejectingPool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(0);
+      expect(toStrings(result.rejected)).toContain(hashOf(tx));
+      expect(await rejectingPool.getPendingTxCount()).toBe(0);
+    });
+
+    it('canAddPendingTx returns rejected for transaction that fails validation', async () => {
+      const tx = await mockTx(1);
+      txsToReject.add(tx.getTxHash().toString());
+
+      const result = await rejectingPool.canAddPendingTx(tx);
+
+      expect(result).toBe('rejected');
+      expect(await rejectingPool.getPendingTxCount()).toBe(0); // State unchanged
+    });
+
+    it('addPendingTxs handles batch with mixed accepted and rejected', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+      // Reject tx2 only
+      txsToReject.add(tx2.getTxHash().toString());
+
+      const result = await rejectingPool.addPendingTxs([tx1, tx2, tx3]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(tx1));
+      expect(toStrings(result.accepted)).toContain(hashOf(tx3));
+      expect(result.ignored).toHaveLength(0);
+      expect(toStrings(result.rejected)).toContain(hashOf(tx2));
+      expect(await rejectingPool.getPendingTxCount()).toBe(2);
+    });
+
+    it('addPendingTxs handles batch with accepted, ignored, and rejected', async () => {
+      // First add a tx
+      const existingTx = await mockTx(1);
+      await rejectingPool.addPendingTxs([existingTx]);
+
+      const newTx = await mockTx(2);
+      const duplicateTx = existingTx; // Same tx, should be ignored
+      const rejectedTx = await mockTx(3);
+      txsToReject.add(rejectedTx.getTxHash().toString());
+
+      const result = await rejectingPool.addPendingTxs([newTx, duplicateTx, rejectedTx]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(newTx));
+      expect(toStrings(result.ignored)).toContain(hashOf(duplicateTx));
+      expect(toStrings(result.rejected)).toContain(hashOf(rejectedTx));
+      expect(await rejectingPool.getPendingTxCount()).toBe(2); // existingTx + newTx
+    });
+
+    it('rejected tx does not affect existing pool state', async () => {
+      // First add a valid tx
+      const tx1 = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await rejectingPool.addPendingTxs([tx1]);
+      expect(await rejectingPool.getPendingTxCount()).toBe(1);
+
+      // Try to add a rejected tx with same nullifier (validation happens before nullifier check)
+      const tx2 = await mockTx(2, { numberOfNonRevertiblePublicCallRequests: 1 });
+      setNullifier(tx2, 0, getNullifier(tx1, 0)); // Same nullifier
+      txsToReject.add(tx2.getTxHash().toString());
+
+      const result = await rejectingPool.addPendingTxs([tx2]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(0);
+      expect(toStrings(result.rejected)).toContain(hashOf(tx2));
+      // Original tx should still be there
+      expect(await rejectingPool.getTxStatus(tx1.getTxHash())).toBe('pending');
+    });
+
+    it('validation happens before pre-add rules', async () => {
+      // Even if a tx would be ignored by pre-add rules (e.g., nullifier conflict),
+      // it should be rejected first if it fails validation
+      const tx1 = await mockTx(1, {
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await rejectingPool.addPendingTxs([tx1]);
+
+      // tx2 has same nullifier but lower priority - would be ignored if valid
+      // but should be rejected since it fails validation
+      const tx2 = await mockTx(2, {
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+      txsToReject.add(tx2.getTxHash().toString());
+
+      const result = await rejectingPool.addPendingTxs([tx2]);
+
+      // Should be rejected, not ignored (validation first)
+      expect(result.accepted).toHaveLength(0);
+      expect(result.ignored).toHaveLength(0);
+      expect(toStrings(result.rejected)).toContain(hashOf(tx2));
+    });
+  });
+
+  describe('addProtectedTxs', () => {
+    it('adds new transactions as protected', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      expect(await pool.getPendingTxCount()).toBe(0); // Not in pending
+    });
+
+    it('updates existing pending transactions to protected', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('does not modify mined transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addMinedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.addProtectedTxs([tx], slot2Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+  });
+
+  describe('addMinedTxs', () => {
+    it('adds new transactions as mined', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addMinedTxs([tx], slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('updates existing pending transactions to mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      await pool.addMinedTxs([tx], slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('updates existing protected transactions to mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      await pool.addMinedTxs([tx], slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+
+    it('is idempotent for already mined transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addMinedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // Adding same tx as mined again should be a no-op
+      await pool.addMinedTxs([tx], slot2Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+  });
+
+  describe('protectTxs', () => {
+    it('protects existing transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      const missing = await pool.protectTxs([tx.getTxHash()], slot1Header);
+
+      expect(missing).toHaveLength(0);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    it('returns missing transaction hashes', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      await pool.addPendingTxs([tx1]);
+
+      const missing = await pool.protectTxs([tx1.getTxHash(), tx2.getTxHash()], slot1Header);
+
+      expect(toStrings(missing)).toContain(hashOf(tx2));
+      expect(missing).toHaveLength(1);
+    });
+
+    it('immediately protects transactions received via gossip if pre-recorded', async () => {
+      const tx = await mockTx(1);
+
+      // Pre-record protection for a tx we don't have yet
+      const missing = await pool.protectTxs([tx.getTxHash()], slot1Header);
+      expect(toStrings(missing)).toContain(hashOf(tx));
+
+      // Now add the tx via gossip - it should be immediately protected
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    it('updates slot number when re-protecting via protectTxs', async () => {
+      const tx = await mockTx(1);
+
+      // Add and protect for slot 1
+      await pool.addPendingTxs([tx]);
+      await pool.protectTxs([tx.getTxHash()], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // Re-protect for slot 2 via protectTxs
+      await pool.protectTxs([tx.getTxHash()], slot2Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // prepareForSlot(2) should NOT unprotect since slot was updated to 2
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // prepareForSlot(3) should unprotect
+      await pool.prepareForSlot(SlotNumber(3));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('updates pre-protected slot when called again before tx arrives', async () => {
+      const tx = await mockTx(1);
+
+      // Pre-record protection for slot 1
+      const missing1 = await pool.protectTxs([tx.getTxHash()], slot1Header);
+      expect(toStrings(missing1)).toContain(hashOf(tx));
+
+      // Pre-record protection for slot 2 (overwrites slot 1)
+      const missing2 = await pool.protectTxs([tx.getTxHash()], slot2Header);
+      expect(toStrings(missing2)).toContain(hashOf(tx));
+
+      // Now add the tx - it should be protected for slot 2
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // prepareForSlot(2) should NOT unprotect since it's for slot 2
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    describe('pre-protected tx behavior via addPendingTxs', () => {
+      // Helper to set fee payer balance in the mock
+      const setFeePayerBalanceForPreProtect = (balance: bigint) => {
+        db.getLeafPreimage.mockImplementation((tree, index) => {
+          if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+            return Promise.resolve(
+              new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(balance)), Fr.ONE, 1n),
+            );
+          }
+          return Promise.resolve(undefined);
+        });
+      };
+
+      it('pre-protected tx is accepted and goes directly to protected status', async () => {
+        const tx = await mockTx(1);
+
+        // Pre-record protection
+        await pool.protectTxs([tx.getTxHash()], slot1Header);
+
+        // Add via gossip
+        const result = await pool.addPendingTxs([tx]);
+
+        // Should be accepted, not ignored
+        expect(toStrings(result.accepted)).toContain(hashOf(tx));
+        expect(result.ignored).toHaveLength(0);
+        expect(result.rejected).toHaveLength(0);
+        // Should be protected, not pending
+        expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      });
+
+      it('pre-protected tx bypasses insufficient balance pre-add rule', async () => {
+        const sharedFeePayer = AztecAddress.fromBigInt(999n);
+        // Set balance to 0 - normally tx would be ignored
+        setFeePayerBalanceForPreProtect(0n);
+
+        const tx = await mockTx(1, {
+          feePayer: sharedFeePayer,
+          numberOfNonRevertiblePublicCallRequests: 1,
+        });
+
+        // Pre-record protection
+        await pool.protectTxs([tx.getTxHash()], slot1Header);
+
+        // Add via gossip - should bypass balance check
+        const result = await pool.addPendingTxs([tx]);
+
+        expect(toStrings(result.accepted)).toContain(hashOf(tx));
+
+        expect(result.ignored).toHaveLength(0);
+        expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      });
+
+      it('pre-protected tx bypasses nullifier conflict pre-add rule', async () => {
+        // Add a pending tx first
+        const txPending = await mockPublicTx(1, 10); // Higher priority
+        await pool.addPendingTxs([txPending]);
+        expect(await pool.getPendingTxCount()).toBe(1);
+
+        // Pre-protected tx has same nullifier but lower priority
+        // Normally would be ignored due to nullifier conflict
+        const txPreProtected = await mockPublicTx(2, 5);
+        setNullifier(txPreProtected, 0, getNullifier(txPending, 0));
+
+        // Pre-record protection
+        await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+        // Add via gossip - should bypass nullifier conflict check
+        const result = await pool.addPendingTxs([txPreProtected]);
+
+        expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+        expect(result.ignored).toHaveLength(0);
+        expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        // Original tx should still be pending
+        expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+      });
+
+      it('pre-protected tx bypasses low priority pre-add rule when pool is full', async () => {
+        await pool.updateConfig({ maxPendingTxCount: 2 });
+
+        // Fill pool with high priority txs
+        const tx1 = await mockTxWithFee(1, 100);
+        const tx2 = await mockTxWithFee(2, 200);
+        await pool.addPendingTxs([tx1, tx2]);
+        expect(await pool.getPendingTxCount()).toBe(2);
+
+        // Pre-protected tx has lowest priority - normally would be ignored
+        const txPreProtected = await mockTxWithFee(3, 1);
+
+        // Pre-record protection
+        await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+        // Add via gossip - should bypass low priority check
+        const result = await pool.addPendingTxs([txPreProtected]);
+
+        expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+        expect(result.ignored).toHaveLength(0);
+        expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+      });
+
+      it('pre-protected tx does NOT evict other transactions', async () => {
+        // Add a pending tx with conflicting nullifier and lower priority
+        const txPending = await mockPublicTx(1, 5);
+        await pool.addPendingTxs([txPending]);
+        expect(await pool.getPendingTxCount()).toBe(1);
+
+        // Pre-protected tx has same nullifier and higher priority
+        // Without pre-protection, it would evict txPending
+        const txPreProtected = await mockPublicTx(2, 100);
+        setNullifier(txPreProtected, 0, getNullifier(txPending, 0));
+
+        // Pre-record protection
+        await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+        // Add via gossip - should NOT evict txPending
+        const result = await pool.addPendingTxs([txPreProtected]);
+
+        expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+        expect(result.ignored).toHaveLength(0);
+        // Both txs should be in pool
+        expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+      });
+
+      it('pre-protected tx does not trigger post-add eviction rules', async () => {
+        const sharedFeePayer = AztecAddress.fromBigInt(999n);
+        // Balance covers only one tx
+        setFeePayerBalanceForPreProtect(BigInt(2e8));
+
+        // Add a pending tx first
+        const txPending = await mockTx(1, {
+          feePayer: sharedFeePayer,
+          maxPriorityFeesPerGas: new GasFees(5, 5),
+          numberOfNonRevertiblePublicCallRequests: 1,
+        });
+        await pool.addPendingTxs([txPending]);
+        expect(await pool.getPendingTxCount()).toBe(1);
+
+        // Pre-protected tx from same fee payer
+        // Without pre-protection, adding this would trigger fee payer balance eviction
+        const txPreProtected = await mockTx(2, {
+          feePayer: sharedFeePayer,
+          maxPriorityFeesPerGas: new GasFees(10, 10),
+          numberOfNonRevertiblePublicCallRequests: 1,
+        });
+
+        // Pre-record protection
+        await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+        // Add via gossip - should NOT trigger post-add eviction
+        const result = await pool.addPendingTxs([txPreProtected]);
+
+        expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+        expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        // txPending should still be in pool (not evicted by post-add rules)
+        expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+      });
+
+      describe('batch with pre-protected tx', () => {
+        it('pre-protected tx in batch does not interfere with other txs in batch', async () => {
+          // txNormal should be processed normally (accepted)
+          const txNormal = await mockTx(1);
+
+          // txPreProtected should bypass rules and become protected
+          const txPreProtected = await mockTx(2);
+
+          // Pre-record protection for one tx
+          await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+          // Add both in same batch
+          const result = await pool.addPendingTxs([txNormal, txPreProtected]);
+
+          // Both should be accepted
+          expect(toStrings(result.accepted)).toContain(hashOf(txNormal));
+          expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+          expect(result.ignored).toHaveLength(0);
+          expect(result.rejected).toHaveLength(0);
+
+          // Normal tx should be pending, pre-protected should be protected
+          expect(await pool.getTxStatus(txNormal.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        });
+
+        it('pre-protected tx with nullifier conflict in batch does not evict batch mate', async () => {
+          // Two txs in batch with same nullifier - normally higher priority evicts lower
+          const txLowPriority = await mockPublicTx(1, 5);
+          const txHighPriority = await mockPublicTx(2, 100);
+          setNullifier(txHighPriority, 0, getNullifier(txLowPriority, 0));
+
+          // Pre-protect the high priority tx - it should NOT evict the low priority tx
+          await pool.protectTxs([txHighPriority.getTxHash()], slot1Header);
+
+          // Add both in same batch
+          const result = await pool.addPendingTxs([txLowPriority, txHighPriority]);
+
+          // Both should be accepted
+          expect(toStrings(result.accepted)).toContain(hashOf(txLowPriority));
+          expect(toStrings(result.accepted)).toContain(hashOf(txHighPriority));
+          expect(result.ignored).toHaveLength(0);
+
+          // Both should be in pool
+          expect(await pool.getTxStatus(txLowPriority.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(txHighPriority.getTxHash())).toBe('protected');
+        });
+
+        it('normal tx in batch still evicts other normal txs despite pre-protected tx present', async () => {
+          // txExisting is in pool
+          const txExisting = await mockPublicTx(1, 5);
+          await pool.addPendingTxs([txExisting]);
+          expect(await pool.getPendingTxCount()).toBe(1);
+
+          // txNormal has higher priority and conflicts with txExisting - should evict it
+          const txNormal = await mockPublicTx(2, 100);
+          setNullifier(txNormal, 0, getNullifier(txExisting, 0));
+
+          // txPreProtected is unrelated
+          const txPreProtected = await mockTx(3);
+          await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+          // Add both in same batch
+          const result = await pool.addPendingTxs([txNormal, txPreProtected]);
+
+          // Both new txs accepted
+          expect(toStrings(result.accepted)).toContain(hashOf(txNormal));
+          expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+
+          // txExisting was evicted by txNormal (normal eviction still works)
+          expect(await pool.getTxStatus(txExisting.getTxHash())).toBeUndefined();
+          expect(await pool.getTxStatus(txNormal.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        });
+
+        it('pre-protected tx in batch does not count towards pool size limit for others', async () => {
+          await pool.updateConfig({ maxPendingTxCount: 2 });
+
+          // Fill pool
+          const tx1 = await mockTxWithFee(1, 100);
+          const tx2 = await mockTxWithFee(2, 200);
+          await pool.addPendingTxs([tx1, tx2]);
+          expect(await pool.getPendingTxCount()).toBe(2);
+
+          // txNormal has high priority - should evict lowest priority in pool
+          const txNormal = await mockTxWithFee(3, 150);
+
+          // txPreProtected has low priority - should bypass limit
+          const txPreProtected = await mockTxWithFee(4, 1);
+          await pool.protectTxs([txPreProtected.getTxHash()], slot1Header);
+
+          // Add both in same batch
+          const result = await pool.addPendingTxs([txNormal, txPreProtected]);
+
+          // Both should be accepted
+          expect(toStrings(result.accepted)).toContain(hashOf(txNormal));
+          expect(toStrings(result.accepted)).toContain(hashOf(txPreProtected));
+
+          // Pool should have: tx2 (200), txNormal (150), txPreProtected (1 - protected)
+          // tx1 (100) was evicted to make room for txNormal
+          expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined();
+          expect(await pool.getTxStatus(tx2.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(txNormal.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(txPreProtected.getTxHash())).toBe('protected');
+        });
+      });
+
+      describe('ignored tx succeeds after pre-protection', () => {
+        it('tx ignored due to nullifier conflict succeeds after pre-protection', async () => {
+          // Add a high priority tx
+          const txExisting = await mockPublicTx(1, 100);
+          await pool.addPendingTxs([txExisting]);
+
+          // Try to add conflicting lower priority tx - should be ignored
+          const txConflicting = await mockPublicTx(2, 5);
+          setNullifier(txConflicting, 0, getNullifier(txExisting, 0));
+
+          const result1 = await pool.addPendingTxs([txConflicting]);
+          expect(toStrings(result1.ignored)).toContain(hashOf(txConflicting));
+          expect(await pool.getTxStatus(txConflicting.getTxHash())).toBeUndefined();
+
+          // Now pre-protect and try again - should succeed
+          await pool.protectTxs([txConflicting.getTxHash()], slot1Header);
+          const result2 = await pool.addPendingTxs([txConflicting]);
+
+          expect(toStrings(result2.accepted)).toContain(hashOf(txConflicting));
+          expect(result2.ignored).toHaveLength(0);
+          expect(await pool.getTxStatus(txConflicting.getTxHash())).toBe('protected');
+          // Original tx still in pool
+          expect(await pool.getTxStatus(txExisting.getTxHash())).toBe('pending');
+        });
+
+        it('tx ignored due to insufficient balance succeeds after pre-protection', async () => {
+          const sharedFeePayer = AztecAddress.fromBigInt(999n);
+          // Set balance to 0
+          setFeePayerBalanceForPreProtect(0n);
+
+          const tx = await mockTx(1, {
+            feePayer: sharedFeePayer,
+            numberOfNonRevertiblePublicCallRequests: 1,
+          });
+
+          // Try to add - should be ignored due to insufficient balance
+          const result1 = await pool.addPendingTxs([tx]);
+          expect(toStrings(result1.ignored)).toContain(hashOf(tx));
+          expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+
+          // Now pre-protect and try again - should succeed
+          await pool.protectTxs([tx.getTxHash()], slot1Header);
+          const result2 = await pool.addPendingTxs([tx]);
+
+          expect(toStrings(result2.accepted)).toContain(hashOf(tx));
+          expect(result2.ignored).toHaveLength(0);
+          expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+        });
+
+        it('tx ignored due to pool full succeeds after pre-protection', async () => {
+          await pool.updateConfig({ maxPendingTxCount: 2 });
+
+          // Fill pool with high priority txs
+          const tx1 = await mockTxWithFee(1, 100);
+          const tx2 = await mockTxWithFee(2, 200);
+          await pool.addPendingTxs([tx1, tx2]);
+          expect(await pool.getPendingTxCount()).toBe(2);
+
+          // Try to add lowest priority tx - should be ignored
+          const txLow = await mockTxWithFee(3, 1);
+          const result1 = await pool.addPendingTxs([txLow]);
+          expect(toStrings(result1.ignored)).toContain(hashOf(txLow));
+          expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+
+          // Now pre-protect and try again - should succeed
+          await pool.protectTxs([txLow.getTxHash()], slot1Header);
+          const result2 = await pool.addPendingTxs([txLow]);
+
+          expect(toStrings(result2.accepted)).toContain(hashOf(txLow));
+          expect(result2.ignored).toHaveLength(0);
+          expect(await pool.getTxStatus(txLow.getTxHash())).toBe('protected');
+          // Original txs still in pool
+          expect(await pool.getTxStatus(tx1.getTxHash())).toBe('pending');
+          expect(await pool.getTxStatus(tx2.getTxHash())).toBe('pending');
+        });
+      });
+    });
+  });
+
+  describe('handleMinedBlock', () => {
+    it('marks protected transactions as mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+
+    it('marks pending transactions as mined', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('handles empty block gracefully', async () => {
+      // Should not throw when processing an empty block
+      await pool.handleMinedBlock(makeEmptyBlock(slot1Header));
+    });
+
+    it('deletes pending transactions with conflicting nullifiers', async () => {
+      // Create two transactions with the same nullifier
+      const txLow = await mockPublicTx(1, 5);
+      const txHigh = await mockPublicTx(2, 10);
+      setNullifier(txHigh, 0, getNullifier(txLow, 0));
+
+      // Add low priority tx as pending
+      await pool.addPendingTxs([txLow]);
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBe('pending');
+
+      // Add high priority tx as protected (bypasses nullifier conflict check)
+      await pool.addProtectedTxs([txHigh], slot1Header);
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('protected');
+
+      // Unprotect - nullifier conflict resolution should delete the lower priority pending tx
+      await pool.prepareForSlot(SlotNumber(2));
+
+      // High priority tx should now be pending, low priority tx should be deleted
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+  });
+
+  describe('prepareForSlot', () => {
+    it('unprotects transactions from earlier slots', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('does not unprotect transactions from current or future slots', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      await pool.addProtectedTxs([tx1], slot1Header);
+      await pool.addProtectedTxs([tx2], slot2Header);
+
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBe('protected');
+    });
+
+    it('keeps tx protected when re-protected for later slot before late prepareForSlot', async () => {
+      // Race condition: tx protected for slot 1, then re-protected for slot 2,
+      // then prepareForSlot(2) called late - tx should stay protected
+      const tx = await mockTx(1);
+
+      // Initially protected for slot 1
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // Re-protected for slot 2 (new proposer takes over)
+      await pool.addProtectedTxs([tx], slot2Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // Late prepareForSlot(2) - tx should NOT be unprotected since it's now for slot 2
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    it('keeps tx protected when re-protected for even later slot', async () => {
+      const slot3Header = BlockHeader.empty({
+        globalVariables: GlobalVariables.empty({
+          blockNumber: BlockNumber(3),
+          slotNumber: SlotNumber(3),
+          timestamp: 72n,
+        }),
+      });
+
+      const tx = await mockTx(1);
+
+      // Protected for slot 1
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      // Re-protected for slot 3 (skipping slot 2)
+      await pool.addProtectedTxs([tx], slot3Header);
+
+      // prepareForSlot(2) - tx should stay protected (it's for slot 3)
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // prepareForSlot(3) - tx should still be protected (current slot)
+      await pool.prepareForSlot(SlotNumber(3));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // prepareForSlot(4) - NOW tx should be unprotected
+      await pool.prepareForSlot(SlotNumber(4));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('cleans up stale pre-protected hash records', async () => {
+      const tx = await mockTx(1);
+
+      // Pre-record protection
+      await pool.protectTxs([tx.getTxHash()], slot1Header);
+
+      // Prepare for a later slot - should clean up the stale record
+      await pool.prepareForSlot(SlotNumber(2));
+
+      // Now add the tx - it should be pending, not protected
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('is idempotent for same slot', async () => {
+      const tx = await mockTx(1);
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      await pool.prepareForSlot(SlotNumber(2));
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('unprotected tx with higher priority evicts conflicting pending tx', async () => {
+      const txPending = await mockPublicTx(1, 5);
+      const txProtected = await mockPublicTx(2, 10);
+
+      // Give protected tx the same nullifier as pending tx
+      setNullifier(txProtected, 0, getNullifier(txPending, 0));
+
+      // Add pending tx
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Add protected tx (has higher priority, shares nullifier)
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      // Unprotect - txProtected should evict txPending due to nullifier conflict
+      await pool.prepareForSlot(SlotNumber(2));
+
+      // Only the higher priority tx (previously protected) should remain
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txProtected));
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBeUndefined();
+    });
+
+    it('unprotected tx with lower priority is deleted when conflicting with pending tx', async () => {
+      const txPending = await mockPublicTx(1, 10);
+      const txProtected = await mockPublicTx(2, 5);
+
+      // Give protected tx the same nullifier as pending tx
+      setNullifier(txProtected, 0, getNullifier(txPending, 0));
+
+      // Add pending tx (higher priority)
+      await pool.addPendingTxs([txPending]);
+
+      // Add protected tx (lower priority, shares nullifier)
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      // Unprotect - txProtected should be deleted, txPending should remain
+      await pool.prepareForSlot(SlotNumber(2));
+
+      // Only the higher priority pending tx should remain
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txPending));
+      expect(await pool.getTxStatus(txProtected.getTxHash())).toBeUndefined();
+    });
+
+    it('multiple unprotected txs with same nullifier - highest priority wins', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 15);
+      const tx3 = await mockPublicTx(3, 10);
+
+      // All share the same nullifier
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+      setNullifier(tx3, 0, getNullifier(tx1, 0));
+
+      // Add all as protected for slot 1
+      await pool.addProtectedTxs([tx1, tx2, tx3], slot1Header);
+
+      // Unprotect all - only highest priority should survive
+      await pool.prepareForSlot(SlotNumber(2));
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(tx2)); // tx2 has fee=15, highest
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBeUndefined();
+    });
+
+    it('unprotected tx evicts multiple conflicting pending txs with lower priority', async () => {
+      const txPending1 = await mockPublicTx(1, 3);
+      const txPending2 = await mockPublicTx(2, 4);
+      const txProtected = await mockPublicTx(3, 10);
+
+      // txProtected conflicts with both pending txs (has nullifiers from both)
+      setNullifier(txProtected, 0, getNullifier(txPending1, 0));
+      setNullifier(txProtected, 1, getNullifier(txPending2, 0));
+
+      // Add pending txs
+      await pool.addPendingTxs([txPending1, txPending2]);
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // Add protected tx
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      // Unprotect - txProtected should evict both pending txs
+      await pool.prepareForSlot(SlotNumber(2));
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txProtected));
+      expect(await pool.getTxStatus(txPending1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(txPending2.getTxHash())).toBeUndefined();
+    });
+
+    it('unprotected tx with one winning and one losing conflict is deleted', async () => {
+      const txPendingHigh = await mockPublicTx(1, 20);
+      const txPendingLow = await mockPublicTx(2, 3);
+      const txProtected = await mockPublicTx(3, 10);
+
+      // txProtected conflicts with both (would beat txPendingLow but lose to txPendingHigh)
+      setNullifier(txProtected, 0, getNullifier(txPendingHigh, 0));
+      setNullifier(txProtected, 1, getNullifier(txPendingLow, 0));
+
+      // Add pending txs
+      await pool.addPendingTxs([txPendingHigh, txPendingLow]);
+
+      // Add protected tx
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      // Unprotect - txProtected should be deleted because it can't beat txPendingHigh
+      await pool.prepareForSlot(SlotNumber(2));
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(2);
+      expect(pending).toContain(hashOf(txPendingHigh));
+      expect(pending).toContain(hashOf(txPendingLow));
+      expect(await pool.getTxStatus(txProtected.getTxHash())).toBeUndefined();
+    });
+  });
+
+  describe('handlePrunedBlocks', () => {
+    it('un-mines transactions from pruned block', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('un-mined tx with higher priority evicts conflicting pending tx', async () => {
+      // Ensure anchor block is valid
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const txPending = await mockPublicTx(1, 5);
+      const txMined = await mockPublicTx(2, 10);
+
+      // Give mined tx the same nullifier as pending tx
+      setNullifier(txMined, 0, getNullifier(txPending, 0));
+
+      // Add mined tx first and mine it
+      await pool.addPendingTxs([txMined]);
+      await pool.handleMinedBlock(makeBlock([txMined], slot1Header));
+      expect(await pool.getTxStatus(txMined.getTxHash())).toBe('mined');
+
+      // Now txPending can be added since txMined's nullifier is no longer in pending
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Reorg - txMined returns to pending and should evict txPending
+      await pool.handlePrunedBlocks(block0Id);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txMined));
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBeUndefined();
+    });
+
+    it('un-mined tx with lower priority is deleted when conflicting with pending tx', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const txPending = await mockPublicTx(1, 10);
+      const txMined = await mockPublicTx(2, 5);
+
+      // Give mined tx the same nullifier as pending tx
+      setNullifier(txMined, 0, getNullifier(txPending, 0));
+
+      // Add mined tx first and mine it
+      await pool.addPendingTxs([txMined]);
+      await pool.handleMinedBlock(makeBlock([txMined], slot1Header));
+
+      // Now txPending can be added (higher priority)
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Reorg - txMined tries to return but should be deleted (lower priority)
+      await pool.handlePrunedBlocks(block0Id);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txPending));
+      expect(await pool.getTxStatus(txMined.getTxHash())).toBeUndefined();
+    });
+
+    it('multiple un-mined txs with same nullifier - highest priority wins', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 15);
+      const tx3 = await mockPublicTx(3, 10);
+
+      // All share the same nullifier
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+      setNullifier(tx3, 0, getNullifier(tx1, 0));
+
+      // Add all as pending, then mine them all in one block
+      await pool.addPendingTxs([tx1]);
+      await pool.handleMinedBlock(makeBlock([tx1], slot1Header));
+
+      // After tx1 is mined, we can add tx2 (same nullifier but tx1 no longer pending)
+      await pool.addPendingTxs([tx2]);
+      await pool.handleMinedBlock(makeBlock([tx2], slot1Header));
+
+      // After tx2 is mined, we can add tx3
+      await pool.addPendingTxs([tx3]);
+      await pool.handleMinedBlock(makeBlock([tx3], slot1Header));
+
+      // Reorg all - only highest priority should survive
+      await pool.handlePrunedBlocks(block0Id);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(tx2)); // tx2 has fee=15, highest
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBeUndefined();
+    });
+
+    it('un-mined tx evicts multiple conflicting pending txs with lower priority', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const txPending1 = await mockPublicTx(1, 3);
+      const txPending2 = await mockPublicTx(2, 4);
+      const txMined = await mockPublicTx(3, 10);
+
+      // txMined conflicts with both pending txs
+      setNullifier(txMined, 0, getNullifier(txPending1, 0));
+      setNullifier(txMined, 1, getNullifier(txPending2, 0));
+
+      // Mine txMined first
+      await pool.addPendingTxs([txMined]);
+      await pool.handleMinedBlock(makeBlock([txMined], slot1Header));
+
+      // Now add the pending txs (no conflict since txMined is mined)
+      await pool.addPendingTxs([txPending1, txPending2]);
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // Reorg - txMined returns and should evict both pending txs
+      await pool.handlePrunedBlocks(block0Id);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txMined));
+      expect(await pool.getTxStatus(txPending1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(txPending2.getTxHash())).toBeUndefined();
+    });
+
+    it('un-mined tx with one winning and one losing conflict is deleted', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const txPendingHigh = await mockPublicTx(1, 20);
+      const txPendingLow = await mockPublicTx(2, 3);
+      const txMined = await mockPublicTx(3, 10);
+
+      // txMined conflicts with both (would beat txPendingLow but lose to txPendingHigh)
+      setNullifier(txMined, 0, getNullifier(txPendingHigh, 0));
+      setNullifier(txMined, 1, getNullifier(txPendingLow, 0));
+
+      // Mine txMined first
+      await pool.addPendingTxs([txMined]);
+      await pool.handleMinedBlock(makeBlock([txMined], slot1Header));
+
+      // Add the pending txs
+      await pool.addPendingTxs([txPendingHigh, txPendingLow]);
+
+      // Reorg - txMined should be deleted because it can't beat txPendingHigh
+      await pool.handlePrunedBlocks(block0Id);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(2);
+      expect(pending).toContain(hashOf(txPendingHigh));
+      expect(pending).toContain(hashOf(txPendingLow));
+      expect(await pool.getTxStatus(txMined.getTxHash())).toBeUndefined();
+    });
+  });
+
+  describe('validation during restore', () => {
+    let mockValidator: MockProxy<TxValidator<Tx>>;
+    let poolWithValidator: AztecKVTxPoolV2;
+    let validatorStore: Awaited<ReturnType<typeof openTmpStore>>;
+    let validatorArchiveStore: Awaited<ReturnType<typeof openTmpStore>>;
+
+    beforeEach(async () => {
+      mockValidator = mock<TxValidator<Tx>>();
+      // Default to valid
+      mockValidator.validateTx.mockResolvedValue({ result: 'valid' });
+
+      validatorStore = await openTmpStore('p2p-val');
+      validatorArchiveStore = await openTmpStore('archive-val');
+      poolWithValidator = new AztecKVTxPoolV2(validatorStore, validatorArchiveStore, {
+        l2BlockSource: mockL2BlockSource,
+        worldStateSynchronizer: mockWorldState,
+        pendingTxValidator: mockValidator,
+      });
+      await poolWithValidator.start();
+    });
+
+    afterEach(async () => {
+      await poolWithValidator.stop();
+      await validatorStore.delete();
+      await validatorArchiveStore.delete();
+    });
+
+    it('prepareForSlot deletes tx that fails validation when unprotecting', async () => {
+      const tx = await mockTx(1);
+
+      // Add and protect the tx
+      await poolWithValidator.addProtectedTxs([tx], slot1Header);
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      // Make validator reject this tx
+      mockValidator.validateTx.mockResolvedValue({
+        result: 'invalid',
+        reason: ['tx expired'],
+      });
+
+      // Unprotect - tx should be deleted due to validation failure
+      await poolWithValidator.prepareForSlot(SlotNumber(2));
+
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBeUndefined();
+      expect(await poolWithValidator.getPendingTxCount()).toBe(0);
+    });
+
+    it('prepareForSlot keeps tx that passes validation when unprotecting', async () => {
+      const tx = await mockTx(1);
+
+      // Add and protect the tx
+      await poolWithValidator.addProtectedTxs([tx], slot1Header);
+
+      // Validator returns valid (default)
+      await poolWithValidator.prepareForSlot(SlotNumber(2));
+
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getPendingTxCount()).toBe(1);
+    });
+
+    it('prepareForSlot handles mixed valid/invalid txs', async () => {
+      const txValid = await mockTx(1);
+      const txInvalid = await mockTx(2);
+      const txAlsoValid = await mockTx(3);
+
+      // Add and protect all txs
+      await poolWithValidator.addProtectedTxs([txValid, txInvalid, txAlsoValid], slot1Header);
+
+      // Configure validator to reject only txInvalid
+      mockValidator.validateTx.mockImplementation((tx: Tx) => {
+        if (tx.getTxHash().equals(txInvalid.getTxHash())) {
+          return Promise.resolve({ result: 'invalid', reason: ['invalid proof'] });
+        }
+        return Promise.resolve({ result: 'valid' });
+      });
+
+      await poolWithValidator.prepareForSlot(SlotNumber(2));
+
+      expect(await poolWithValidator.getTxStatus(txValid.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getTxStatus(txInvalid.getTxHash())).toBeUndefined();
+      expect(await poolWithValidator.getTxStatus(txAlsoValid.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getPendingTxCount()).toBe(2);
+    });
+
+    it('handlePrunedBlocks deletes tx that fails validation when un-mining', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor block valid
+
+      const tx = await mockTx(1);
+
+      // Add, mine
+      await poolWithValidator.addPendingTxs([tx]);
+      await poolWithValidator.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // Make validator reject this tx
+      mockValidator.validateTx.mockResolvedValue({
+        result: 'invalid',
+        reason: ['timestamp expired'],
+      });
+
+      // Reorg - tx should be deleted due to validation failure
+      await poolWithValidator.handlePrunedBlocks(block0Id);
+
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBeUndefined();
+      expect(await poolWithValidator.getPendingTxCount()).toBe(0);
+    });
+
+    it('handlePrunedBlocks keeps tx that passes validation when un-mining', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor block valid
+
+      const tx = await mockTx(1);
+
+      // Add, mine
+      await poolWithValidator.addPendingTxs([tx]);
+      await poolWithValidator.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      // Validator returns valid (default)
+      await poolWithValidator.handlePrunedBlocks(block0Id);
+
+      expect(await poolWithValidator.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getPendingTxCount()).toBe(1);
+    });
+
+    it('handlePrunedBlocks handles mixed valid/invalid txs', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor block valid
+
+      const txValid = await mockTx(1);
+      const txInvalid = await mockTx(2);
+      const txAlsoValid = await mockTx(3);
+
+      // Add and mine all txs
+      await poolWithValidator.addPendingTxs([txValid, txInvalid, txAlsoValid]);
+      await poolWithValidator.handleMinedBlock(makeBlock([txValid, txInvalid, txAlsoValid], slot1Header));
+
+      // Configure validator to reject only txInvalid
+      mockValidator.validateTx.mockImplementation((tx: Tx) => {
+        if (tx.getTxHash().equals(txInvalid.getTxHash())) {
+          return Promise.resolve({ result: 'invalid', reason: ['nullifier exists'] });
+        }
+        return Promise.resolve({ result: 'valid' });
+      });
+
+      await poolWithValidator.handlePrunedBlocks(block0Id);
+
+      expect(await poolWithValidator.getTxStatus(txValid.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getTxStatus(txInvalid.getTxHash())).toBeUndefined();
+      expect(await poolWithValidator.getTxStatus(txAlsoValid.getTxHash())).toBe('pending');
+      expect(await poolWithValidator.getPendingTxCount()).toBe(2);
+    });
+
+    it('validation runs before nullifier conflict check in prepareForSlot', async () => {
+      const txPending = await mockPublicTx(1, 5);
+      const txProtected = await mockPublicTx(2, 10);
+
+      // Give protected tx the same nullifier as pending tx
+      setNullifier(txProtected, 0, getNullifier(txPending, 0));
+
+      // Add pending tx
+      await poolWithValidator.addPendingTxs([txPending]);
+
+      // Add protected tx with higher priority
+      await poolWithValidator.addProtectedTxs([txProtected], slot1Header);
+
+      // Make validator reject the protected tx
+      mockValidator.validateTx.mockImplementation((tx: Tx) => {
+        if (tx.getTxHash().equals(txProtected.getTxHash())) {
+          return Promise.resolve({ result: 'invalid', reason: ['invalid'] });
+        }
+        return Promise.resolve({ result: 'valid' });
+      });
+
+      // Unprotect - protected tx should be deleted (validation fails before conflict check)
+      // So pending tx should remain even though it has lower priority
+      await poolWithValidator.prepareForSlot(SlotNumber(2));
+
+      const pending = toStrings(await poolWithValidator.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txPending));
+      expect(await poolWithValidator.getTxStatus(txProtected.getTxHash())).toBeUndefined();
+    });
+  });
+
+  describe('handleFailedExecution', () => {
+    it('deletes failed transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      await pool.handleFailedExecution([tx.getTxHash()]);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+  });
+
+  describe('handleFinalizedBlock', () => {
+    it('permanently deletes mined transactions', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      await pool.handleFinalizedBlock(slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+      expect(await pool.getTxByHash(tx.getTxHash())).toBeUndefined();
+    });
+
+    it('archives transactions if configured', async () => {
+      await pool.updateConfig({ archivedTxLimit: 10 });
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      await pool.handleFinalizedBlock(slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+      const archived = await pool.getArchivedTxByHash(tx.getTxHash());
+      expect(archived).toBeDefined();
+      expect(archived!.getTxHash().toString()).toEqual(hashOf(tx));
+    });
+  });
+
+  describe('state transitions', () => {
+    it('pending -> protected -> mined -> deleted (happy path)', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.handleFinalizedBlock(slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+    });
+
+    it('pending -> protected -> pending (slot passed)', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('pending -> protected -> mined -> protected (reorg, still valid)', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.addProtectedTxs([tx], slot1Header);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // After reorg, tx retains its protection status (protection is managed by prepareForSlot)
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+    });
+
+    it('N/A -> protected -> mined -> deleted (req/resp flow)', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.handleFinalizedBlock(slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+    });
+
+    it('N/A -> mined -> deleted (prover flow)', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addMinedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.handleFinalizedBlock(slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+    });
+  });
+
+  describe('queries', () => {
+    it('getPendingTxHashes returns txs sorted by priority (highest first)', async () => {
+      const tx1 = await mockTxWithFee(1, 1);
+      const tx2 = await mockTxWithFee(2, 3);
+      const tx3 = await mockTxWithFee(3, 2);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending[0].toString()).toEqual(hashOf(tx2));
+      expect(pending[1].toString()).toEqual(hashOf(tx3));
+      expect(pending[2].toString()).toEqual(hashOf(tx1));
+    });
+
+    it('getPendingTxHashes uses tx hash as tiebreaker when fees are equal', async () => {
+      // Create transactions with the same priority fee
+      const tx1 = await mockTxWithFee(1, 5);
+      const tx2 = await mockTxWithFee(2, 5);
+      const tx3 = await mockTxWithFee(3, 5);
+
+      // Add in random order
+      await pool.addPendingTxs([tx2, tx1, tx3]);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(3);
+
+      // All have the same fee, so they should be sorted by hash (highest first)
+      const hashes = [tx1.getTxHash(), tx2.getTxHash(), tx3.getTxHash()];
+      const sortedByHashDesc = [...hashes].sort((a, b) => b.toString().localeCompare(a.toString()));
+
+      expect(pending.map(h => h.toString())).toEqual(sortedByHashDesc.map(h => h.toString()));
+    });
+
+    it('getPendingTxHashes sorts by fee first, then by hash for equal fees', async () => {
+      // Create transactions: some with same fee, some with different
+      const txHighFee1 = await mockTxWithFee(10, 100);
+      const txHighFee2 = await mockTxWithFee(11, 100);
+      const txMidFee = await mockTxWithFee(20, 50);
+      const txLowFee1 = await mockTxWithFee(30, 10);
+      const txLowFee2 = await mockTxWithFee(31, 10);
+
+      // Add in random order
+      await pool.addPendingTxs([txLowFee2, txHighFee1, txMidFee, txLowFee1, txHighFee2]);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(5);
+
+      // Group by expected order: high fees first (sorted by hash), then mid, then low (sorted by hash)
+      const highFeeHashes = [txHighFee1.getTxHash(), txHighFee2.getTxHash()].sort((a, b) =>
+        b.toString().localeCompare(a.toString()),
+      );
+      const lowFeeHashes = [txLowFee1.getTxHash(), txLowFee2.getTxHash()].sort((a, b) =>
+        b.toString().localeCompare(a.toString()),
+      );
+
+      // First should be high fee txs (by hash), then mid fee, then low fee txs (by hash)
+      expect(pending[0].toString()).toEqual(highFeeHashes[0].toString());
+      expect(pending[1].toString()).toEqual(highFeeHashes[1].toString());
+      expect(pending[2].toString()).toEqual(txMidFee.getTxHash().toString());
+      expect(pending[3].toString()).toEqual(lowFeeHashes[0].toString());
+      expect(pending[4].toString()).toEqual(lowFeeHashes[1].toString());
+    });
+
+    it('getMinedTxHashes returns mined txs with block IDs', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await pool.addPendingTxs([tx1, tx2]);
+      await pool.handleMinedBlock(makeBlock([tx1], slot1Header));
+      await pool.handleMinedBlock(makeBlock([tx2], slot2Header));
+
+      const mined = await pool.getMinedTxHashes();
+      expect(mined).toHaveLength(2);
+
+      // Find entries by tx hash and check block ID structure
+      const tx1Entry = mined.find(([hash]) => hash.equals(tx1.getTxHash()));
+      const tx2Entry = mined.find(([hash]) => hash.equals(tx2.getTxHash()));
+
+      expect(tx1Entry).toBeDefined();
+      expect(tx1Entry![1].number).toBe(BlockNumber(1));
+      expect(tx1Entry![1].hash).toBeDefined();
+
+      expect(tx2Entry).toBeDefined();
+      expect(tx2Entry![1].number).toBe(BlockNumber(2));
+      expect(tx2Entry![1].hash).toBeDefined();
+    });
+
+    it('getLowestPriorityPending returns lowest priority txs', async () => {
+      const tx1 = await mockTxWithFee(1, 1);
+      const tx2 = await mockTxWithFee(2, 2);
+      const tx3 = await mockTxWithFee(3, 3);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      const lowest = await pool.getLowestPriorityPending(2);
+      expect(lowest).toHaveLength(2);
+      expect(toStrings(lowest)).toContain(hashOf(tx1));
+      expect(toStrings(lowest)).toContain(hashOf(tx2));
+    });
+  });
+
+  describe('archive', () => {
+    it('archives mined transactions on deletion', async () => {
+      await pool.updateConfig({ archivedTxLimit: 5 });
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      await pool.handleFinalizedBlock(slot1Header);
+
+      const archived = await pool.getArchivedTxByHash(tx.getTxHash());
+      expect(archived).toBeDefined();
+    });
+
+    it('enforces archivedTxLimit with FIFO eviction', async () => {
+      await pool.updateConfig({ archivedTxLimit: 2 });
+
+      const txs = await timesAsync(5, i => mockTx(i + 1));
+
+      // Add and finalize all txs
+      for (let i = 0; i < txs.length; i++) {
+        const header = BlockHeader.empty({
+          globalVariables: GlobalVariables.empty({
+            blockNumber: BlockNumber(i + 1),
+            slotNumber: SlotNumber(i + 1),
+          }),
+        });
+        await pool.addPendingTxs([txs[i]]);
+        await pool.handleMinedBlock(makeBlock([txs[i]], header));
+        await pool.handleFinalizedBlock(header);
+      }
+
+      // Only the last 2 should be archived
+      expect(await pool.getArchivedTxByHash(txs[0].getTxHash())).toBeUndefined();
+      expect(await pool.getArchivedTxByHash(txs[1].getTxHash())).toBeUndefined();
+      expect(await pool.getArchivedTxByHash(txs[2].getTxHash())).toBeUndefined();
+      expect(await pool.getArchivedTxByHash(txs[3].getTxHash())).toBeDefined();
+      expect(await pool.getArchivedTxByHash(txs[4].getTxHash())).toBeDefined();
+    });
+  });
+
+  describe('nullifier index consistency', () => {
+    it('removes nullifier entries when tx is deleted', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleFailedExecution([tx1.getTxHash()]);
+
+      // Add a new tx with the same nullifier - should succeed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx2]);
+      expect(toStrings(result.accepted)).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('removes nullifier entries when tx is mined', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleMinedBlock(makeBlock([tx1], slot1Header));
+
+      // Add a new tx with the same nullifier - should succeed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx2]);
+      expect(toStrings(result.accepted)).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('restores nullifier entries on reorg', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      await pool.addPendingTxs([tx1]);
+      await pool.handleMinedBlock(makeBlock([tx1], slot1Header));
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Now tx1 is pending again - nullifier should be claimed
+      const tx2 = await mockPublicTx(2, 1);
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx2]);
+      // tx2 is valid but ignored due to nullifier conflict with higher-priority tx1
+      expect(toStrings(result.ignored)).toContain(hashOf(tx2)); // tx2 has lower fee
+      expect(result.rejected).toHaveLength(0);
+    });
+  });
+
+  describe('fee payer balance pre-add rule', () => {
+    // Helper to set fee payer balance in the mock
+    const setFeePayerBalance = (balance: bigint) => {
+      db.getLeafPreimage.mockImplementation((tree, index) => {
+        if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+          return Promise.resolve(
+            new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(balance)), Fr.ONE, 1n),
+          );
+        }
+        return Promise.resolve(undefined);
+      });
+    };
+
+    it('ignores tx when fee payer has insufficient balance', async () => {
+      // Set balance to 0 - no tx can be covered
+      setFeePayerBalance(0n);
+
+      const tx = await mockPublicTx(1);
+
+      const result = await pool.addPendingTxs([tx]);
+
+      // Tx is valid but ignored due to insufficient balance
+      expect(toStrings(result.ignored)).toContain(hashOf(tx));
+      expect(result.accepted).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('canAddPendingTx returns ignored when fee payer has insufficient balance', async () => {
+      setFeePayerBalance(0n);
+
+      const tx = await mockPublicTx(1);
+
+      const result = await pool.canAddPendingTx(tx);
+      expect(result).toBe('ignored');
+
+      // Pool state unchanged
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('accepts tx when fee payer has sufficient balance', async () => {
+      // Default balance is 1e18, which is sufficient
+      const tx = await mockPublicTx(1);
+
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(tx));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('high priority tx evicts lower priority tx from same fee payer', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Fee limit per tx is ~186M (DEFAULT_L2_GAS_LIMIT * 10 + DEFAULT_DA_GAS_LIMIT * 10)
+      // Set balance to cover only one tx
+      setFeePayerBalance(BigInt(2e8));
+
+      // Add low priority tx first
+      const txLow = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await pool.addPendingTxs([txLow]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Add high priority tx from same fee payer - should evict low priority
+      const txHigh = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const result = await pool.addPendingTxs([txHigh]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(txHigh));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined(); // evicted
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+    });
+
+    it('low priority tx ignored when fee payer balance exhausted by existing tx', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Balance covers only one tx
+      setFeePayerBalance(BigInt(2e8));
+
+      // Add high priority tx first
+      const txHigh = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await pool.addPendingTxs([txHigh]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Try to add low priority tx - should be ignored (balance exhausted)
+      const txLow = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const result = await pool.addPendingTxs([txLow]);
+
+      expect(toStrings(result.ignored)).toContain(hashOf(txLow));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+    });
+
+    it('batch from same fee payer - only top N by priority accepted', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Balance covers exactly 2 tx fee limits (~372M for 2 txs)
+      setFeePayerBalance(BigInt(4e8));
+
+      // Add 3 txs in one batch, all from same fee payer
+      const tx1 = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5), // lowest
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const tx2 = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(15, 15), // highest
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const tx3 = await mockTx(3, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10), // middle
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+      const result = await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      // tx2 (highest) and tx3 (middle) should be accepted, tx1 (lowest) ignored
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(tx2));
+      expect(accepted).toContain(hashOf(tx3));
+      expect(ignored).toContain(hashOf(tx1));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+  });
+
+  describe('fee payer balance eviction rule (post-event)', () => {
+    // Helper to set fee payer balance in the mock
+    const setFeePayerBalance = (balance: bigint) => {
+      db.getLeafPreimage.mockImplementation((tree, index) => {
+        if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+          return Promise.resolve(
+            new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(balance)), Fr.ONE, 1n),
+          );
+        }
+        return Promise.resolve(undefined);
+      });
+    };
+
+    it('evicts low-priority txs after BLOCK_MINED when balance is insufficient', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Initial balance covers all 3 txs
+      setFeePayerBalance(BigInt(6e8));
+
+      // Add three txs from same fee payer
+      const txLow = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txMed = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txHigh = await mockTx(3, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(15, 15),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+      await pool.addPendingTxs([txLow, txMed, txHigh]);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      // Simulate block mined that reduced fee payer's balance
+      // After mining txHigh, balance only covers one more tx
+      setFeePayerBalance(BigInt(2e8));
+
+      // Mine the highest priority tx - this triggers balance check for sharedFeePayer
+      // The fee payer balance rule will check remaining pending txs from this fee payer
+      await pool.handleMinedBlock(makeBlock([txHigh], slot1Header));
+
+      // txHigh is now mined
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('mined');
+      // txMed (higher priority) should remain pending
+      expect(await pool.getTxStatus(txMed.getTxHash())).toBe('pending');
+      // txLow (lower priority) should be evicted due to insufficient balance
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+    });
+
+    it('evicts low-priority txs after CHAIN_PRUNED when balance is insufficient', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Initial balance covers both txs
+      setFeePayerBalance(BigInt(4e8));
+
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor blocks valid
+
+      // Add two txs from same fee payer
+      const txLow = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txHigh = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+      await pool.addPendingTxs([txLow, txHigh]);
+      await pool.handleMinedBlock(makeBlock([txLow, txHigh], slot1Header));
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBe('mined');
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('mined');
+
+      // Simulate reorg - balance reduced (e.g., another tx was restored)
+      setFeePayerBalance(BigInt(2e8)); // Only enough for one tx
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Low priority tx should be evicted, high priority should be pending
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+    });
+
+    it('priority ordering is correct - highest priority funded first', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Balance covers only 2 out of 3 txs
+      setFeePayerBalance(BigInt(4e8));
+
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor blocks valid
+
+      // Create 3 txs with distinct priorities
+      const txPriority1 = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(1, 1), // Lowest
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txPriority5 = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5), // Middle
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txPriority10 = await mockTx(3, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10), // Highest
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+      // Add and mine all
+      await pool.addPendingTxs([txPriority1, txPriority5, txPriority10]);
+      await pool.handleMinedBlock(makeBlock([txPriority1, txPriority5, txPriority10], slot1Header));
+
+      // Reorg - triggers balance eviction
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Highest (priority 10) and middle (priority 5) should remain
+      // Lowest (priority 1) should be evicted
+      expect(await pool.getTxStatus(txPriority10.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txPriority5.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txPriority1.getTxHash())).toBeUndefined();
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+
+    it('does not evict when balance is sufficient', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Balance covers all txs
+      setFeePayerBalance(BigInt(1e18));
+
+      db.findLeafIndices.mockResolvedValue([1n]); // Anchor blocks valid
+
+      const txLow = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const txHigh = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+
+      await pool.addPendingTxs([txLow, txHigh]);
+      await pool.handleMinedBlock(makeBlock([txLow, txHigh], slot1Header));
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Both should be pending - balance is sufficient
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+  });
+
+  describe('anchor block validation (reorg)', () => {
+    it('evicts txs with pruned anchor blocks after reorg', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // Simulate reorg - anchor block is no longer in archive
+      db.findLeafIndices.mockResolvedValue([undefined]); // Block not found
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Tx should be deleted because its anchor block was pruned
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+    });
+
+    it('keeps txs with valid anchor blocks after reorg', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+
+      // Anchor block still exists in archive
+      db.findLeafIndices.mockResolvedValue([1n]); // Block found at index 1
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Tx should be restored to pending
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('handles mixed valid/invalid anchor blocks in batch', async () => {
+      const txValid = await mockTx(1);
+      const txInvalid = await mockTx(2);
+
+      // Give txInvalid a different anchor block header
+      txInvalid.data.constants.anchorBlockHeader = BlockHeader.empty({
+        globalVariables: GlobalVariables.empty({
+          blockNumber: BlockNumber(999),
+        }),
+      });
+
+      await pool.addPendingTxs([txValid, txInvalid]);
+      await pool.handleMinedBlock(makeBlock([txValid, txInvalid], slot1Header));
+
+      // Get the anchor block hashes
+      const validAnchorHash = await txValid.data.constants.anchorBlockHeader.hash();
+
+      // Mock: valid anchor exists, invalid anchor does not
+      db.findLeafIndices.mockImplementation((_treeId, leaves) => {
+        return Promise.resolve((leaves as Fr[]).map(leaf => (leaf.equals(validAnchorHash) ? 1n : undefined)));
+      });
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Valid tx should be restored to pending, invalid tx should be deleted
+      expect(await pool.getTxStatus(txValid.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(txInvalid.getTxHash())).toBeUndefined();
+    });
+
+    it('evicts all txs when shared anchor block is pruned', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+
+      await pool.addPendingTxs([tx1, tx2]);
+      await pool.handleMinedBlock(makeBlock([tx1, tx2], slot1Header));
+
+      // Mock: anchor block does not exist (pruned)
+      db.findLeafIndices.mockResolvedValue([undefined]);
+
+      await pool.handlePrunedBlocks(block0Id);
+
+      // Both should be deleted since their anchor block was pruned
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBeUndefined();
+    });
+  });
+
+  describe('complex reorg scenarios', () => {
+    const slot3Header = BlockHeader.empty({
+      globalVariables: GlobalVariables.empty({
+        blockNumber: BlockNumber(3),
+        slotNumber: SlotNumber(3),
+        timestamp: 72n,
+      }),
+    });
+
+    const slot4Header = BlockHeader.empty({
+      globalVariables: GlobalVariables.empty({
+        blockNumber: BlockNumber(4),
+        slotNumber: SlotNumber(4),
+        timestamp: 72n,
+      }),
+    });
+
+    const block1Id: L2BlockId = { number: BlockNumber(1), hash: '0x1' };
+    const block2Id: L2BlockId = { number: BlockNumber(2), hash: '0x2' };
+
+    it('handles multiple blocks being pruned', async () => {
+      // Ensure anchor blocks are valid
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      // Mine txs in different blocks
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+      await pool.handleMinedBlock(makeBlock([tx1], slot1Header));
+      await pool.handleMinedBlock(makeBlock([tx2], slot2Header));
+      await pool.handleMinedBlock(makeBlock([tx3], slot3Header));
+
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBe('mined');
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBe('mined');
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBe('mined');
+
+      // Prune back to block 1 - tx2 and tx3 should be un-mined
+      await pool.handlePrunedBlocks(block1Id);
+
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBe('mined');
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+
+    it('handles reorg followed by re-mining', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const tx = await mockTx(1);
+
+      // Mine, prune, re-mine cycle
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      await pool.handleMinedBlock(makeBlock([tx], slot2Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+
+    it('handles consecutive reorgs', async () => {
+      db.findLeafIndices.mockResolvedValue([1n]);
+
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot3Header));
+
+      // First reorg to block 2
+      await pool.handlePrunedBlocks(block2Id);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+
+      // Re-mine in block 3
+      await pool.handleMinedBlock(makeBlock([tx], slot4Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // Second reorg all the way to block 0
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('evicts pending tx when mined tx has conflicting nullifier', async () => {
+      const txPending = await mockPublicTx(1, 5);
+      const txToMine = await mockPublicTx(2, 10);
+
+      // Give txToMine the same nullifier as txPending
+      setNullifier(txToMine, 0, getNullifier(txPending, 0));
+
+      // Add txPending to the pool
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+
+      // Add txToMine as protected (bypasses nullifier conflict check)
+      await pool.addProtectedTxs([txToMine], slot1Header);
+
+      // Mine txToMine - this should evict txPending because its nullifier is now in the mined block
+      await pool.handleMinedBlock(makeBlock([txToMine], slot1Header));
+
+      // txPending should be evicted (nullifier conflict with mined tx)
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBeUndefined();
+      // txToMine should be mined
+      expect(await pool.getTxStatus(txToMine.getTxHash())).toBe('mined');
+    });
+
+    it('evicts pending tx when block contains conflicting nullifier from unknown tx', async () => {
+      // This tests the key behavior: we extract nullifiers directly from the block's txEffects,
+      // so we can evict pending txs even if we never had the mined transaction in our pool
+
+      const txPending = await mockPublicTx(1, 5);
+
+      // Create a tx that the pool will never see - we'll only use it to create the block
+      const txUnknown = await mockPublicTx(2, 10);
+      // Give it the same nullifier as txPending
+      setNullifier(txUnknown, 0, getNullifier(txPending, 0));
+
+      // Add txPending to the pool
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+
+      // The pool has never seen txUnknown
+      expect(await pool.getTxStatus(txUnknown.getTxHash())).toBeUndefined();
+
+      // Mine a block containing txUnknown - pool doesn't have this tx but gets its nullifiers from the block
+      await pool.handleMinedBlock(makeBlock([txUnknown], slot1Header));
+
+      // txPending should be evicted because the block contains a conflicting nullifier
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBeUndefined();
+      // txUnknown should NOT be in the pool (we never added it)
+      expect(await pool.getTxStatus(txUnknown.getTxHash())).toBeUndefined();
+    });
+
+    it('evicts multiple pending txs when block contains multiple conflicting nullifiers', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 5);
+      const tx3 = await mockPublicTx(3, 5); // This one won't conflict
+
+      // Create unknown txs with conflicting nullifiers
+      const unknownTx1 = await mockPublicTx(10, 10);
+      const unknownTx2 = await mockPublicTx(11, 10);
+      setNullifier(unknownTx1, 0, getNullifier(tx1, 0));
+      setNullifier(unknownTx2, 0, getNullifier(tx2, 0));
+
+      // Add pending txs
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      // Mine block with unknown txs - tx1 and tx2 should be evicted, tx3 should remain
+      await pool.handleMinedBlock(makeBlock([unknownTx1, unknownTx2], slot1Header));
+
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('evicts pending tx when any nullifier in the block conflicts', async () => {
+      // A transaction can have multiple nullifiers - test that we check all of them
+      const txPending = await mockPublicTx(1, 5);
+
+      // Create unknown tx with multiple nullifiers, one of which conflicts
+      const txUnknown = await mockPublicTx(2, 10);
+      // Set the second nullifier (index 1) to conflict with txPending's first nullifier
+      setNullifier(txUnknown, 1, getNullifier(txPending, 0));
+
+      await pool.addPendingTxs([txPending]);
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBe('pending');
+
+      await pool.handleMinedBlock(makeBlock([txUnknown], slot1Header));
+
+      // txPending should be evicted even though only the second nullifier conflicts
+      expect(await pool.getTxStatus(txPending.getTxHash())).toBeUndefined();
+    });
+
+    it('does not evict protected txs when block contains conflicting nullifiers', async () => {
+      const txProtected = await mockPublicTx(1, 5);
+      const txUnknown = await mockPublicTx(2, 10);
+      setNullifier(txUnknown, 0, getNullifier(txProtected, 0));
+
+      // Add as protected
+      await pool.addProtectedTxs([txProtected], slot1Header);
+      expect(await pool.getTxStatus(txProtected.getTxHash())).toBe('protected');
+
+      // Mine block with conflicting nullifier
+      await pool.handleMinedBlock(makeBlock([txUnknown], slot1Header));
+
+      // Protected tx should still exist (eviction rules skip protected txs)
+      expect(await pool.getTxStatus(txProtected.getTxHash())).toBe('protected');
+    });
+  });
+
+  describe('protected tx behavior', () => {
+    it('protected txs are not evicted by low priority rule', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 2 });
+
+      const tx1 = await mockTxWithFee(1, 1);
+      const tx2 = await mockTxWithFee(2, 2);
+      const txProtected = await mockTxWithFee(3, 0); // Lowest priority but protected
+
+      // Add and protect tx3
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      // Add pending txs
+      await pool.addPendingTxs([tx1, tx2]);
+
+      // Protected tx should still exist
+      expect(await pool.getTxStatus(txProtected.getTxHash())).toBe('protected');
+    });
+
+    it('protected txs become pending on slot transition', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('protected');
+      expect(await pool.getPendingTxCount()).toBe(0);
+
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+
+    it('cannot transition mined tx back to protected', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+
+      // Try to protect - should remain mined
+      await pool.addProtectedTxs([tx], slot2Header);
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+  });
+
+  describe('pool size limits', () => {
+    it('evicts lowest priority when adding beyond limit', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 3 });
+
+      const txs = await Promise.all([
+        mockTxWithFee(1, 10),
+        mockTxWithFee(2, 20),
+        mockTxWithFee(3, 30),
+        mockTxWithFee(4, 5), // Lowest priority
+      ]);
+
+      await pool.addPendingTxs(txs);
+
+      expect(await pool.getPendingTxCount()).toBe(3);
+      expect(await pool.getTxStatus(txs[3].getTxHash())).toBeUndefined(); // Lowest evicted
+    });
+
+    it('handles limit exactly at capacity', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 3 });
+
+      const txs = await Promise.all([mockTxWithFee(1, 10), mockTxWithFee(2, 20), mockTxWithFee(3, 30)]);
+
+      await pool.addPendingTxs(txs);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      // Adding one more should evict lowest
+      const tx4 = await mockTxWithFee(4, 15);
+      await pool.addPendingTxs([tx4]);
+
+      expect(await pool.getPendingTxCount()).toBe(3);
+      expect(await pool.getTxStatus(txs[0].getTxHash())).toBeUndefined(); // fee=10 evicted
+      expect(await pool.getTxStatus(tx4.getTxHash())).toBe('pending'); // fee=15 kept
+    });
+
+    it('new tx with lowest priority is ignored when pool is full', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 3 });
+
+      const txs = await Promise.all([mockTxWithFee(1, 10), mockTxWithFee(2, 20), mockTxWithFee(3, 30)]);
+
+      await pool.addPendingTxs(txs);
+
+      // Add new tx with lowest priority - should be ignored by pre-add rule (not added then evicted)
+      const txLow = await mockTxWithFee(4, 5);
+      const result = await pool.addPendingTxs([txLow]);
+
+      // The tx should be in the ignored array (pre-add rule handled it)
+      expect(toStrings(result.ignored)).toContain(hashOf(txLow));
+      expect(result.accepted).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+
+      // Pool count unchanged, tx not in pool
+      expect(await pool.getPendingTxCount()).toBe(3);
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+    });
+
+    it('unprotecting txs respects pool size limit', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 2 });
+
+      const tx1 = await mockTxWithFee(1, 10);
+      const tx2 = await mockTxWithFee(2, 20);
+      const txProtected = await mockTxWithFee(3, 5); // Will be unprotected
+
+      await pool.addPendingTxs([tx1, tx2]);
+      await pool.addProtectedTxs([txProtected], slot1Header);
+
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // Unprotect tx3 - should trigger eviction
+      await pool.prepareForSlot(SlotNumber(2));
+
+      // Pool should maintain limit
+      expect(await pool.getPendingTxCount()).toBe(2);
+    });
+  });
+
+  describe('multiple nullifier conflicts', () => {
+    it('handles tx with multiple nullifiers conflicting with different txs', async () => {
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 5);
+      const txConflicting = await mockPublicTx(3, 10); // Higher fee
+
+      // Set txConflicting to conflict with both tx1 and tx2
+      setNullifier(txConflicting, 0, getNullifier(tx1, 0));
+      setNullifier(txConflicting, 1, getNullifier(tx2, 0));
+
+      await pool.addPendingTxs([tx1, tx2]);
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // Adding txConflicting should evict both tx1 and tx2
+      const result = await pool.addPendingTxs([txConflicting]);
+      expect(toStrings(result.accepted)).toContain(hashOf(txConflicting));
+      expect(result.rejected).toHaveLength(0);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(txConflicting));
+      expect(pending).not.toContain(hashOf(tx1));
+      expect(pending).not.toContain(hashOf(tx2));
+    });
+
+    it('ignores tx when one conflict would win but another would lose', async () => {
+      const tx1 = await mockPublicTx(1, 10); // High fee
+      const tx2 = await mockPublicTx(2, 1); // Low fee
+      const txConflicting = await mockPublicTx(3, 5); // Medium fee
+
+      // txConflicting conflicts with tx1 (would lose) and tx2 (would win)
+      setNullifier(txConflicting, 0, getNullifier(tx1, 0));
+      setNullifier(txConflicting, 1, getNullifier(tx2, 0));
+
+      await pool.addPendingTxs([tx1, tx2]);
+
+      // Should be ignored because it can't beat tx1 (valid tx but not desired)
+      const result = await pool.addPendingTxs([txConflicting]);
+      expect(toStrings(result.ignored)).toContain(hashOf(txConflicting));
+      expect(result.rejected).toHaveLength(0);
+
+      // Original txs should remain
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(tx1));
+      expect(pending).toContain(hashOf(tx2));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty pool operations gracefully', async () => {
+      expect(await pool.getPendingTxCount()).toBe(0);
+      expect(await pool.getPendingTxHashes()).toHaveLength(0);
+      expect(await pool.getMinedTxHashes()).toHaveLength(0);
+      expect(await pool.getLowestPriorityPending(10)).toHaveLength(0);
+
+      // Operations on empty pool
+      await pool.handleMinedBlock(makeEmptyBlock(slot1Header));
+      await pool.handleFailedExecution([TxHash.random()]);
+      await pool.handlePrunedBlocks(block0Id);
+      await pool.handleFinalizedBlock(slot1Header);
+
+      expect(await pool.getPendingTxCount()).toBe(0);
+    });
+
+    it('handles tx added, mined, finalized in quick succession', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      await pool.handleFinalizedBlock(slot1Header);
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBeUndefined();
+      expect(await pool.getTxByHash(tx.getTxHash())).toBeUndefined();
+    });
+
+    it('handles duplicate handleMinedBlock calls', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header)); // Duplicate
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('mined');
+    });
+
+    it('handles finalization of already-deleted tx', async () => {
+      const tx = await mockTx(1);
+
+      await pool.addPendingTxs([tx]);
+      await pool.handleFailedExecution([tx.getTxHash()]);
+
+      // Should not throw
+      await pool.handleFinalizedBlock(slot1Header);
+    });
+
+    it('handles prepareForSlot with no protected txs', async () => {
+      const tx = await mockTx(1);
+      await pool.addPendingTxs([tx]);
+
+      // Should not throw or change anything
+      await pool.prepareForSlot(SlotNumber(2));
+
+      expect(await pool.getTxStatus(tx.getTxHash())).toBe('pending');
+    });
+
+    it('handles large batch of txs', async () => {
+      const txs = await timesAsync(100, i => mockTxWithFee(i, i));
+
+      const result = await pool.addPendingTxs(txs);
+
+      expect(result.accepted).toHaveLength(100);
+      expect(result.ignored).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(100);
+
+      // Verify ordering is correct (highest fee first)
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending[0].toString()).toEqual(hashOf(txs[99])); // fee=99
+      expect(pending[99].toString()).toEqual(hashOf(txs[0])); // fee=0
+    });
+
+    it('handles txs with zero priority fee', async () => {
+      const txZeroFee = await mockTxWithFee(1, 0);
+      const txLowFee = await mockTxWithFee(2, 1);
+
+      await pool.addPendingTxs([txZeroFee, txLowFee]);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending[0].toString()).toEqual(hashOf(txLowFee));
+      expect(pending[1].toString()).toEqual(hashOf(txZeroFee));
+    });
+  });
+
+  describe('persistence and recovery', () => {
+    it('maintains indices after adding and removing txs', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      const tx2 = await mockPublicTx(2, 20);
+      const tx3 = await mockPublicTx(3, 15);
+
+      await pool.addPendingTxs([tx1, tx2, tx3]);
+      expect(await pool.getPendingTxCount()).toBe(3);
+
+      // Delete middle priority tx
+      await pool.handleFailedExecution([tx3.getTxHash()]);
+
+      // Check remaining txs are still accessible and ordered correctly
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(2);
+      expect(pending[0].toString()).toEqual(hashOf(tx2)); // fee=20
+      expect(pending[1].toString()).toEqual(hashOf(tx1)); // fee=10
+    });
+
+    it('fee payer index is maintained through state transitions', async () => {
+      const tx = await mockTx(1);
+
+      // Add as pending
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Protect
+      await pool.addProtectedTxs([tx], slot1Header);
+      expect(await pool.getPendingTxCount()).toBe(0);
+
+      // Unprotect
+      await pool.prepareForSlot(SlotNumber(2));
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Mine
+      await pool.handleMinedBlock(makeBlock([tx], slot1Header));
+      expect(await pool.getPendingTxCount()).toBe(0);
+
+      // Reorg
+      db.findLeafIndices.mockResolvedValue([1n]);
+      await pool.handlePrunedBlocks(block0Id);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // Verify tx is still retrievable
+      const retrieved = await pool.getTxByHash(tx.getTxHash());
+      expect(retrieved).toBeDefined();
+    });
+  });
+
+  describe('canAddPendingTx edge cases', () => {
+    it('returns ignored for nullifier conflict with higher priority tx', async () => {
+      const txExisting = await mockPublicTx(1, 10);
+      const txNew = await mockPublicTx(2, 5);
+      setNullifier(txNew, 0, getNullifier(txExisting, 0));
+
+      await pool.addPendingTxs([txExisting]);
+
+      // tx is valid but ignored due to nullifier conflict with higher-priority tx
+      const result = await pool.canAddPendingTx(txNew);
+      expect(result).toBe('ignored');
+    });
+
+    it('returns accepted for nullifier conflict with lower priority tx', async () => {
+      const txExisting = await mockPublicTx(1, 5);
+      const txNew = await mockPublicTx(2, 10);
+      setNullifier(txNew, 0, getNullifier(txExisting, 0));
+
+      await pool.addPendingTxs([txExisting]);
+
+      const result = await pool.canAddPendingTx(txNew);
+      expect(result).toBe('accepted');
+
+      // Verify pool state unchanged
+      expect(await pool.getPendingTxCount()).toBe(1);
+      expect((await pool.getPendingTxHashes())[0].toString()).toEqual(hashOf(txExisting));
+    });
+
+    it('returns accepted when pool has capacity', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 10 });
+      const tx = await mockTx(1);
+
+      const result = await pool.canAddPendingTx(tx);
+      expect(result).toBe('accepted');
+    });
+  });
+
+  describe('AddTxsResult status accuracy', () => {
+    it('returns correct status for mixed accepted/ignored txs', async () => {
+      const tx1 = await mockTx(1);
+      const tx2 = await mockTx(2);
+      const tx3 = await mockTx(3);
+
+      // Add tx1 first
+      await pool.addPendingTxs([tx1]);
+
+      // Add tx1 again (duplicate) along with new txs
+      const result = await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toHaveLength(2);
+      expect(accepted).toContain(hashOf(tx2));
+      expect(accepted).toContain(hashOf(tx3));
+      expect(ignored).toHaveLength(1);
+      expect(ignored).toContain(hashOf(tx1));
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('returns correct status when nullifier conflict causes ignore', async () => {
+      const tx1 = await mockPublicTx(1, 10);
+      const tx2 = await mockPublicTx(2, 5);
+
+      // Give tx2 the same nullifier as tx1
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      await pool.addPendingTxs([tx1]);
+
+      // tx2 should be ignored (not rejected) due to nullifier conflict with higher priority
+      const result = await pool.addPendingTxs([tx2]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(toStrings(result.ignored)).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('returns correct status when nullifier conflict causes eviction', async () => {
+      const txLow = await mockPublicTx(1, 5);
+      const txHigh = await mockPublicTx(2, 10);
+
+      // Give txHigh the same nullifier as txLow
+      setNullifier(txHigh, 0, getNullifier(txLow, 0));
+
+      await pool.addPendingTxs([txLow]);
+
+      // txHigh should be accepted, and txLow should be evicted
+      const result = await pool.addPendingTxs([txHigh]);
+
+      expect(toStrings(result.accepted)).toContain(hashOf(txHigh));
+      expect(result.ignored).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+
+      // Verify txLow was evicted
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toContain(hashOf(txHigh));
+      expect(pending).not.toContain(hashOf(txLow));
+    });
+
+    it('returns ignored for fee payer balance insufficient', async () => {
+      // Set balance to 0 - insufficient for any tx
+      db.getLeafPreimage.mockImplementation((tree, index) => {
+        if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+          return Promise.resolve(
+            new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), Fr.ZERO), Fr.ONE, 1n),
+          );
+        }
+        return Promise.resolve(undefined);
+      });
+
+      const tx = await mockPublicTx(1);
+
+      const result = await pool.addPendingTxs([tx]);
+
+      expect(result.accepted).toHaveLength(0);
+      expect(toStrings(result.ignored)).toContain(hashOf(tx));
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('batch with mixed outcomes: accepted, duplicate, nullifier conflict, insufficient balance', async () => {
+      const existingTx = await mockPublicTx(1, 10);
+      const duplicateTx = existingTx; // Same tx
+      const newTx = await mockPublicTx(2);
+      const conflictingTx = await mockPublicTx(3, 5);
+
+      // Create a tx with very high maxFeesPerGas so fee limit exceeds 1e18 balance
+      // Fee limit = gasLimits.l2 * maxFees.l2 + gasLimits.da * maxFees.da
+      // Default gas limits are ~1e7 each, so with maxFees of 1e12 we get ~1e19 fee limit
+      const highFeeTx = await mockTx(4, { numberOfNonRevertiblePublicCallRequests: 1 });
+      highFeeTx.data.constants.txContext.gasSettings = GasSettings.default({
+        maxFeesPerGas: new GasFees(1e12, 1e12),
+      });
+
+      // Give conflictingTx a nullifier conflict with existingTx
+      setNullifier(conflictingTx, 0, getNullifier(existingTx, 0));
+
+      // Add existingTx first
+      await pool.addPendingTxs([existingTx]);
+
+      // Now add all in one batch
+      const result = await pool.addPendingTxs([duplicateTx, newTx, conflictingTx, highFeeTx]);
+
+      // duplicateTx is ignored (already in pool)
+      // newTx is accepted (no conflicts)
+      // conflictingTx is ignored (loses to existingTx)
+      // highFeeTx is ignored (fee limit exceeds balance)
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(newTx));
+      expect(ignored).toContain(hashOf(duplicateTx));
+      expect(ignored).toContain(hashOf(conflictingTx));
+      expect(ignored).toContain(hashOf(highFeeTx));
+      expect(result.rejected).toHaveLength(0);
+    });
+  });
+
+  describe('intra-batch eviction', () => {
+    it('later tx in batch evicts earlier tx with same nullifier', async () => {
+      const txLow = await mockPublicTx(1, 5);
+      const txHigh = await mockPublicTx(2, 10);
+
+      // Give txHigh the same nullifier as txLow
+      setNullifier(txHigh, 0, getNullifier(txLow, 0));
+
+      // Add both in same batch - txLow first, then txHigh
+      const result = await pool.addPendingTxs([txLow, txHigh]);
+
+      // txLow should be ignored (evicted by txHigh within the same batch)
+      // txHigh should be accepted
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(txHigh));
+      expect(ignored).toContain(hashOf(txLow));
+      expect(accepted).not.toContain(hashOf(txLow));
+      expect(result.rejected).toHaveLength(0);
+
+      // Only txHigh should be in the pool
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txHigh));
+    });
+
+    it('earlier tx in batch is NOT evicted if it has higher priority', async () => {
+      const txHigh = await mockPublicTx(1, 10);
+      const txLow = await mockPublicTx(2, 5);
+
+      // Give txLow the same nullifier as txHigh
+      setNullifier(txLow, 0, getNullifier(txHigh, 0));
+
+      // Add both in same batch - txHigh first, then txLow
+      const result = await pool.addPendingTxs([txHigh, txLow]);
+
+      // txHigh should be accepted
+      // txLow should be ignored (loses to txHigh)
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(txHigh));
+      expect(ignored).toContain(hashOf(txLow));
+      expect(result.rejected).toHaveLength(0);
+
+      // Only txHigh should be in the pool
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(txHigh));
+    });
+
+    it('chain of evictions within batch', async () => {
+      // tx1 (fee=5), tx2 (fee=10), tx3 (fee=15) - all share same nullifier
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+      const tx3 = await mockPublicTx(3, 15);
+
+      // All share the same nullifier
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+      setNullifier(tx3, 0, getNullifier(tx1, 0));
+
+      // Add all three in same batch
+      const result = await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      // Only tx3 should survive (highest priority)
+      // tx1 and tx2 should be ignored
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(tx3));
+      expect(ignored).toContain(hashOf(tx1));
+      expect(ignored).toContain(hashOf(tx2));
+      expect(result.rejected).toHaveLength(0);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(1);
+      expect(pending).toContain(hashOf(tx3));
+    });
+
+    it('mixed batch with some evictions and some independent txs', async () => {
+      // tx1 and tx2 share nullifier A (tx2 has higher fee)
+      // tx3 is independent
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+      const tx3 = await mockPublicTx(3, 7); // Independent, different nullifiers
+
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx1, tx2, tx3]);
+
+      // tx1 should be ignored (evicted by tx2)
+      // tx2 and tx3 should be accepted
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(tx2));
+      expect(accepted).toContain(hashOf(tx3));
+      expect(ignored).toContain(hashOf(tx1));
+      expect(result.rejected).toHaveLength(0);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(2);
+      expect(pending).toContain(hashOf(tx2));
+      expect(pending).toContain(hashOf(tx3));
+    });
+
+    it('multiple independent nullifier conflicts within batch', async () => {
+      // tx1 and tx2 share nullifier A (tx2 wins)
+      // tx3 and tx4 share nullifier B (tx4 wins)
+      const tx1 = await mockPublicTx(1, 5);
+      const tx2 = await mockPublicTx(2, 10);
+      const tx3 = await mockPublicTx(3, 3);
+      const tx4 = await mockPublicTx(4, 8);
+
+      setNullifier(tx2, 0, getNullifier(tx1, 0)); // tx2 shares with tx1
+      setNullifier(tx4, 0, getNullifier(tx3, 0)); // tx4 shares with tx3
+
+      const result = await pool.addPendingTxs([tx1, tx2, tx3, tx4]);
+
+      // tx1 and tx3 should be ignored (evicted)
+      // tx2 and tx4 should be accepted
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(tx2));
+      expect(accepted).toContain(hashOf(tx4));
+      expect(ignored).toContain(hashOf(tx1));
+      expect(ignored).toContain(hashOf(tx3));
+      expect(result.rejected).toHaveLength(0);
+
+      const pending = toStrings(await pool.getPendingTxHashes());
+      expect(pending).toHaveLength(2);
+    });
+  });
+
+  describe('rule interactions in addPendingTxs', () => {
+    // Helper to set a specific nullifier on a transaction
+    const setNullifier = (tx: MockTx, index: number, value: Fr) => {
+      if (tx.data.forPublic) {
+        tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index] = value;
+      }
+    };
+
+    const getNullifier = (tx: MockTx, index: number): Fr => {
+      if (tx.data.forPublic) {
+        return tx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[index];
+      }
+      throw new Error('Transaction is not for public');
+    };
+
+    it('nullifier conflict + pool size limit - conflict resolved first', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 2 });
+
+      // Fill pool with 2 txs
+      const tx1 = await mockTx(1, {
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const tx2 = await mockTx(2, {
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await pool.addPendingTxs([tx1, tx2]);
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // New tx conflicts with tx1 (lower priority) and has higher priority than both
+      const tx3 = await mockTx(3, {
+        maxPriorityFeesPerGas: new GasFees(15, 15),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      setNullifier(tx3, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx3]);
+
+      // tx3 should be accepted (evicts tx1 due to nullifier conflict)
+      expect(toStrings(result.accepted)).toContain(hashOf(tx3));
+      expect(result.ignored).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(2);
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBeUndefined(); // evicted
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(tx3.getTxHash())).toBe('pending');
+    });
+
+    it('pool full + new tx lower priority than all but conflicts with lowest', async () => {
+      await pool.updateConfig({ maxPendingTxCount: 2 });
+
+      // Fill pool with 2 txs
+      const tx1 = await mockTx(1, {
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const tx2 = await mockTx(2, {
+        maxPriorityFeesPerGas: new GasFees(15, 15),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await pool.addPendingTxs([tx1, tx2]);
+      expect(await pool.getPendingTxCount()).toBe(2);
+
+      // New tx has lowest priority but conflicts with tx1
+      const tx3 = await mockTx(3, {
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      setNullifier(tx3, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx3]);
+
+      // tx3 should be ignored - loses nullifier conflict to tx1
+      expect(result.accepted).toHaveLength(0);
+      expect(toStrings(result.ignored)).toContain(hashOf(tx3));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(2);
+      expect(await pool.getTxStatus(tx1.getTxHash())).toBe('pending');
+      expect(await pool.getTxStatus(tx2.getTxHash())).toBe('pending');
+    });
+
+    it('fee payer balance + nullifier conflict - higher priority wins both', async () => {
+      const sharedFeePayer = AztecAddress.fromBigInt(999n);
+      // Set balance to only cover 1 tx
+      db.getLeafPreimage.mockImplementation((tree, index) => {
+        if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+          return Promise.resolve(
+            new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(new Fr(index), new Fr(BigInt(2e8))), Fr.ONE, 1n),
+          );
+        }
+        return Promise.resolve(undefined);
+      });
+
+      // Add low priority tx
+      const txLow = await mockTx(1, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      await pool.addPendingTxs([txLow]);
+      expect(await pool.getPendingTxCount()).toBe(1);
+
+      // New tx: same fee payer, same nullifier, higher priority
+      const txHigh = await mockTx(2, {
+        feePayer: sharedFeePayer,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      setNullifier(txHigh, 0, getNullifier(txLow, 0));
+
+      const result = await pool.addPendingTxs([txHigh]);
+
+      // txHigh wins - evicts txLow due to both nullifier conflict and fee payer balance
+      expect(toStrings(result.accepted)).toContain(hashOf(txHigh));
+      expect(result.ignored).toHaveLength(0);
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+      expect(await pool.getTxStatus(txLow.getTxHash())).toBeUndefined();
+      expect(await pool.getTxStatus(txHigh.getTxHash())).toBe('pending');
+    });
+
+    it('batch with nullifier conflicts across different fee payers', async () => {
+      const feePayerA = AztecAddress.fromBigInt(111n);
+      const feePayerB = AztecAddress.fromBigInt(222n);
+
+      // tx1 (fee payer A, low priority) and tx2 (fee payer B, high priority) share nullifier
+      const tx1 = await mockTx(1, {
+        feePayer: feePayerA,
+        maxPriorityFeesPerGas: new GasFees(5, 5),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      const tx2 = await mockTx(2, {
+        feePayer: feePayerB,
+        maxPriorityFeesPerGas: new GasFees(10, 10),
+        numberOfNonRevertiblePublicCallRequests: 1,
+      });
+      setNullifier(tx2, 0, getNullifier(tx1, 0));
+
+      const result = await pool.addPendingTxs([tx1, tx2]);
+
+      // tx2 wins nullifier conflict
+      const accepted = toStrings(result.accepted);
+      const ignored = toStrings(result.ignored);
+      expect(accepted).toContain(hashOf(tx2));
+      expect(ignored).toContain(hashOf(tx1));
+      expect(result.rejected).toHaveLength(0);
+      expect(await pool.getPendingTxCount()).toBe(1);
+    });
+  });
+
+  describe('hydration and rebuild', () => {
+    it('resolves nullifier conflicts during hydration - higher priority wins', async () => {
+      // First, we need to bypass the normal addPendingTxs conflict resolution
+      // by adding txs directly to separate pools, then merging at DB level
+      const testStore = await openTmpStore('p2p-hydration-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-test');
+
+      try {
+        // Create first pool and add low priority tx
+        const pool1 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        const txLowPriority = await mockPublicTx(1, 5);
+        await pool1.addPendingTxs([txLowPriority]);
+        expect(await pool1.getPendingTxCount()).toBe(1);
+
+        // Now add a conflicting high priority tx - this will evict the low priority one
+        const txHighPriority = await mockPublicTx(2, 10);
+        setNullifier(txHighPriority, 0, getNullifier(txLowPriority, 0));
+        await pool1.addPendingTxs([txHighPriority]);
+
+        // Verify high priority won
+        expect(await pool1.getPendingTxCount()).toBe(1);
+        const pending = toStrings(await pool1.getPendingTxHashes());
+        expect(pending).toContain(hashOf(txHighPriority));
+        expect(pending).not.toContain(hashOf(txLowPriority));
+
+        await pool1.stop();
+
+        // Create new pool with same stores - hydration should maintain the state
+        const pool2 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool2.start();
+
+        // Verify only high priority tx survived
+        expect(await pool2.getPendingTxCount()).toBe(1);
+        const pendingAfterHydration = toStrings(await pool2.getPendingTxHashes());
+        expect(pendingAfterHydration).toContain(hashOf(txHighPriority));
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+
+    it('enforces pool size limit during hydration', async () => {
+      const testStore = await openTmpStore('p2p-hydration-size-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-size-test');
+
+      try {
+        // Create pool with large limit and add many txs
+        const pool1 = new AztecKVTxPoolV2(
+          testStore,
+          testArchiveStore,
+          {
+            l2BlockSource: mockL2BlockSource,
+            worldStateSynchronizer: mockWorldState,
+            pendingTxValidator: alwaysValidValidator,
+          },
+          undefined, // telemetry
+          { maxPendingTxCount: 100 },
+        );
+        await pool1.start();
+
+        // Add 5 txs with different priorities
+        const tx1 = await mockTxWithFee(1, 1);
+        const tx2 = await mockTxWithFee(2, 2);
+        const tx3 = await mockTxWithFee(3, 3);
+        const tx4 = await mockTxWithFee(4, 4);
+        const tx5 = await mockTxWithFee(5, 5);
+
+        await pool1.addPendingTxs([tx1, tx2, tx3, tx4, tx5]);
+        expect(await pool1.getPendingTxCount()).toBe(5);
+
+        await pool1.stop();
+
+        // Create new pool with smaller limit
+        const pool2 = new AztecKVTxPoolV2(
+          testStore,
+          testArchiveStore,
+          {
+            l2BlockSource: mockL2BlockSource,
+            worldStateSynchronizer: mockWorldState,
+            pendingTxValidator: alwaysValidValidator,
+          },
+          undefined, // telemetry
+          { maxPendingTxCount: 3 },
+        );
+        await pool2.start();
+
+        // Only top 3 priority txs should survive
+        expect(await pool2.getPendingTxCount()).toBe(3);
+        const pending = toStrings(await pool2.getPendingTxHashes());
+        expect(pending).toContain(hashOf(tx5)); // fee=5
+        expect(pending).toContain(hashOf(tx4)); // fee=4
+        expect(pending).toContain(hashOf(tx3)); // fee=3
+        expect(pending).not.toContain(hashOf(tx2)); // fee=2 - evicted
+        expect(pending).not.toContain(hashOf(tx1)); // fee=1 - evicted
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+
+    it('processes txs through pre-add rules during hydration', async () => {
+      const testStore = await openTmpStore('p2p-hydration-rules-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-rules-test');
+
+      try {
+        // Create pool and add txs
+        const pool1 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        const tx1 = await mockTxWithFee(1, 10);
+        const tx2 = await mockTxWithFee(2, 20);
+        const tx3 = await mockTxWithFee(3, 15);
+
+        await pool1.addPendingTxs([tx1, tx2, tx3]);
+        expect(await pool1.getPendingTxCount()).toBe(3);
+
+        await pool1.stop();
+
+        // Hydrate into new pool
+        const pool2 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool2.start();
+
+        // All txs should survive (no conflicts, within limits)
+        expect(await pool2.getPendingTxCount()).toBe(3);
+
+        // Verify they're in correct priority order
+        const pending = await pool2.getPendingTxHashes();
+        expect(pending[0].toString()).toEqual(hashOf(tx2)); // fee=20
+        expect(pending[1].toString()).toEqual(hashOf(tx3)); // fee=15
+        expect(pending[2].toString()).toEqual(hashOf(tx1)); // fee=10
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+
+    it('mined txs are not subject to pending pool rules during hydration', async () => {
+      const testStore = await openTmpStore('p2p-hydration-mined-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-mined-test');
+
+      try {
+        // Create pool and add tx, then mark as mined
+        const pool1 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        const tx = await mockTxWithFee(1, 10);
+        await pool1.addPendingTxs([tx]);
+        const block = makeBlock([tx], slot1Header);
+        await pool1.handleMinedBlock(block);
+
+        expect(await pool1.getPendingTxCount()).toBe(0);
+        expect(await pool1.getMinedTxCount()).toBe(1);
+
+        await pool1.stop();
+
+        // Mock the block source to return mined status
+        mockL2BlockSource.getTxEffect.mockImplementation(async (txHash: TxHash) => {
+          if (txHash.toString() === tx.getTxHash().toString()) {
+            return {
+              l2BlockNumber: BlockNumber(1),
+              l2BlockHash: await block.hash(),
+              data: block.body.txEffects[0],
+              txIndexInBlock: 0,
+            };
+          }
+          return undefined;
+        });
+
+        // Hydrate into new pool with small limit
+        const pool2 = new AztecKVTxPoolV2(
+          testStore,
+          testArchiveStore,
+          {
+            l2BlockSource: mockL2BlockSource,
+            worldStateSynchronizer: mockWorldState,
+            pendingTxValidator: alwaysValidValidator,
+          },
+          undefined, // telemetry
+          { maxPendingTxCount: 0 }, // No pending txs allowed
+        );
+        await pool2.start();
+
+        // Mined tx should still be present (not subject to pending limits)
+        expect(await pool2.getPendingTxCount()).toBe(0);
+        expect(await pool2.getMinedTxCount()).toBe(1);
+        expect(await pool2.getTxByHash(tx.getTxHash())).toBeDefined();
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+
+    it('rejects invalid txs during hydration validation', async () => {
+      const testStore = await openTmpStore('p2p-hydration-validation-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-validation-test');
+
+      try {
+        // Create pool with always-valid validator and add txs
+        const pool1 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        const tx1 = await mockTxWithFee(1, 10);
+        const tx2 = await mockTxWithFee(2, 20);
+
+        await pool1.addPendingTxs([tx1, tx2]);
+        expect(await pool1.getPendingTxCount()).toBe(2);
+
+        await pool1.stop();
+
+        // Create validator that rejects tx1
+        const selectiveValidator: TxValidator<Tx> = {
+          validateTx: (tx: Tx) => {
+            if (tx.getTxHash().toString() === tx1.getTxHash().toString()) {
+              return Promise.resolve({ result: 'invalid', reason: ['test rejection'] });
+            }
+            return Promise.resolve({ result: 'valid' });
+          },
+        };
+
+        // Hydrate into new pool with selective validator
+        const pool2 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: selectiveValidator,
+        });
+        await pool2.start();
+
+        // Only tx2 should survive (tx1 rejected by validator)
+        expect(await pool2.getPendingTxCount()).toBe(1);
+        const pending = toStrings(await pool2.getPendingTxHashes());
+        expect(pending).toContain(hashOf(tx2));
+        expect(pending).not.toContain(hashOf(tx1));
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+
+    it('resolves nullifier conflict between pending and protected txs during hydration', async () => {
+      const testStore = await openTmpStore('p2p-hydration-pending-protected-test');
+      const testArchiveStore = await openTmpStore('archive-hydration-pending-protected-test');
+
+      try {
+        const pool1 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        // Add low priority tx as pending
+        const txPendingLowPriority = await mockPublicTx(1, 5);
+        await pool1.addPendingTxs([txPendingLowPriority]);
+        expect(await pool1.getPendingTxCount()).toBe(1);
+
+        // Add high priority tx with same nullifier as protected
+        const txProtectedHighPriority = await mockPublicTx(2, 10);
+        setNullifier(txProtectedHighPriority, 0, getNullifier(txPendingLowPriority, 0));
+        await pool1.addProtectedTxs([txProtectedHighPriority], slot1Header);
+
+        // Verify both are in pool (pending + protected don't conflict)
+        expect(await pool1.getPendingTxCount()).toBe(1);
+        expect(await pool1.getTxStatus(txPendingLowPriority.getTxHash())).toBe('pending');
+        expect(await pool1.getTxStatus(txProtectedHighPriority.getTxHash())).toBe('protected');
+
+        await pool1.stop();
+
+        // Hydrate into new pool - protected status is lost, conflict must be resolved
+        const pool2 = new AztecKVTxPoolV2(testStore, testArchiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool2.start();
+
+        // Only one tx should survive - the higher priority one
+        expect(await pool2.getPendingTxCount()).toBe(1);
+        const pending = toStrings(await pool2.getPendingTxHashes());
+        expect(pending).toContain(hashOf(txProtectedHighPriority));
+        expect(pending).not.toContain(hashOf(txPendingLowPriority));
+
+        await pool2.stop();
+      } finally {
+        await testStore.delete();
+        await testArchiveStore.delete();
+      }
+    });
+  });
+
+  describe('late arrival scenarios', () => {
+    it('tx arriving via gossip after being mined is marked as mined when pre-protected', async () => {
+      const tx = await mockTx(1);
+      const txHash = tx.getTxHash();
+
+      // Scenario: Validator proposes a block with a tx we don't have yet
+      // 1. protectTxs is called for the tx (pre-records protection, tx not in pool)
+      const missing = await pool.protectTxs([txHash], slot1Header);
+      expect(missing).toHaveLength(1);
+      expect(missing[0].equals(txHash)).toBe(true);
+
+      // 2. Block is mined with this tx
+      // Since tx isn't in pool yet, handleMinedBlock just processes the block (no tx to mark as mined)
+      await pool.handleMinedBlock(makeEmptyBlock(slot1Header));
+
+      // 3. Mock the block source to return mined status for this tx
+      mockL2BlockSource.getTxEffect.mockImplementation(async (hash: TxHash) => {
+        if (hash.equals(txHash)) {
+          return {
+            l2BlockNumber: 1,
+            l2BlockHash: (await slot1Header.hash()).toString(),
+          } as any;
+        }
+        return undefined;
+      });
+
+      // 4. Tx finally arrives via gossip
+      const result = await pool.addPendingTxs([tx]);
+      expect(result.accepted).toHaveLength(1);
+
+      // Expected: tx should be mined (not pending, not just protected)
+      // because we received it after the block was already mined
+      const status = await pool.getTxStatus(txHash);
+      expect(status).toBe('mined');
+
+      // Verify it's in mined list, not pending
+      expect(await pool.getPendingTxCount()).toBe(0);
+      expect(await pool.getMinedTxCount()).toBe(1);
+    });
+
+    it('regular pending tx arriving after being mined is marked as mined and not in pending indices', async () => {
+      const txMined = await mockTx(1);
+      const txMinedHash = txMined.getTxHash();
+      const txNotMined = await mockTx(2);
+
+      // Mock the block source to return mined status ONLY for txMined
+      mockL2BlockSource.getTxEffect.mockImplementation(async (hash: TxHash) => {
+        if (hash.equals(txMinedHash)) {
+          return {
+            l2BlockNumber: 1,
+            l2BlockHash: (await slot1Header.hash()).toString(),
+          } as any;
+        }
+        return undefined;
+      });
+
+      // Add both txs via gossip
+      const result = await pool.addPendingTxs([txMined, txNotMined]);
+      expect(result.accepted).toHaveLength(2);
+
+      // txMined should be mined (detected as already mined)
+      expect(await pool.getTxStatus(txMinedHash)).toBe('mined');
+
+      // txNotMined should be pending (not mined)
+      expect(await pool.getTxStatus(txNotMined.getTxHash())).toBe('pending');
+
+      // Verify counts
+      expect(await pool.getPendingTxCount()).toBe(1);
+      expect(await pool.getMinedTxCount()).toBe(1);
+
+      // Verify getPendingTxHashes contains only the non-mined tx
+      const pendingHashes = await pool.getPendingTxHashes();
+      expect(pendingHashes).toHaveLength(1);
+      expect(toStrings(pendingHashes)).toContain(hashOf(txNotMined));
+      expect(toStrings(pendingHashes)).not.toContain(hashOf(txMined));
+    });
+
+    it('addProtectedTxs marks new tx as mined if already mined', async () => {
+      const tx = await mockTx(1);
+      const txHash = tx.getTxHash();
+
+      // Mock the block source to return mined status for this tx
+      mockL2BlockSource.getTxEffect.mockImplementation(async (hash: TxHash) => {
+        if (hash.equals(txHash)) {
+          return {
+            l2BlockNumber: 1,
+            l2BlockHash: (await slot1Header.hash()).toString(),
+          } as any;
+        }
+        return undefined;
+      });
+
+      // Add tx directly as protected
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      // Expected: tx should be mined (protection is set, but mined status takes precedence)
+      const status = await pool.getTxStatus(txHash);
+      expect(status).toBe('mined');
+
+      expect(await pool.getPendingTxCount()).toBe(0);
+      expect(await pool.getMinedTxCount()).toBe(1);
+    });
+
+    it('addProtectedTxs marks existing pending tx as mined if already mined', async () => {
+      const tx = await mockTx(1);
+      const txHash = tx.getTxHash();
+
+      // First add as pending (not mined yet)
+      await pool.addPendingTxs([tx]);
+      expect(await pool.getTxStatus(txHash)).toBe('pending');
+
+      // Now mock the block source to return mined status
+      mockL2BlockSource.getTxEffect.mockImplementation(async (hash: TxHash) => {
+        if (hash.equals(txHash)) {
+          return {
+            l2BlockNumber: 1,
+            l2BlockHash: (await slot1Header.hash()).toString(),
+          } as any;
+        }
+        return undefined;
+      });
+
+      // Call addProtectedTxs - this should detect the tx is mined
+      await pool.addProtectedTxs([tx], slot1Header);
+
+      // Expected: tx should be mined
+      const status = await pool.getTxStatus(txHash);
+      expect(status).toBe('mined');
+
+      expect(await pool.getPendingTxCount()).toBe(0);
+      expect(await pool.getMinedTxCount()).toBe(1);
+    });
+
+    it('pre-protected tx arriving not yet mined is marked as protected', async () => {
+      const tx = await mockTx(1);
+      const txHash = tx.getTxHash();
+
+      // Pre-protect the tx
+      const missing = await pool.protectTxs([txHash], slot1Header);
+      expect(missing).toHaveLength(1);
+
+      // Block source returns undefined (not mined)
+      mockL2BlockSource.getTxEffect.mockResolvedValue(undefined);
+
+      // Tx arrives via gossip
+      const result = await pool.addPendingTxs([tx]);
+      expect(result.accepted).toHaveLength(1);
+
+      // Expected: tx should be protected (not mined, not pending)
+      const status = await pool.getTxStatus(txHash);
+      expect(status).toBe('protected');
+
+      expect(await pool.getPendingTxCount()).toBe(0);
+      expect(await pool.getMinedTxCount()).toBe(0);
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.ts
@@ -1,0 +1,209 @@
+import { SlotNumber } from '@aztec/foundation/branded-types';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { SerialQueue } from '@aztec/foundation/queue';
+import type { TypedEventEmitter } from '@aztec/foundation/types';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import type { L2Block, L2BlockId } from '@aztec/stdlib/block';
+import { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
+import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
+
+import EventEmitter from 'node:events';
+
+import { PoolInstrumentation, PoolName } from '../instrumentation.js';
+import type { AddTxsResult, TxPoolV2, TxPoolV2Config, TxPoolV2Dependencies, TxPoolV2Events } from './interfaces.js';
+import type { TxState } from './tx_metadata.js';
+import { TxPoolV2Impl } from './tx_pool_v2_impl.js';
+
+/**
+ * Implementation of TxPoolV2 with explicit state management.
+ *
+ * This class is a thin wrapper that manages the serial queue and delegates
+ * all operations to TxPoolV2Impl.
+ */
+export class AztecKVTxPoolV2 extends (EventEmitter as new () => TypedEventEmitter<TxPoolV2Events>) implements TxPoolV2 {
+  #queue: SerialQueue;
+  #impl: TxPoolV2Impl;
+  #metrics?: PoolInstrumentation<Tx>;
+  #store: AztecAsyncKVStore;
+  #telemetry: TelemetryClient;
+  #log: Logger;
+  #started = false;
+
+  constructor(
+    store: AztecAsyncKVStore,
+    archiveStore: AztecAsyncKVStore,
+    deps: TxPoolV2Dependencies,
+    telemetry: TelemetryClient = getTelemetryClient(),
+    config: Partial<TxPoolV2Config> = {},
+    log = createLogger('p2p:tx_pool_v2'),
+  ) {
+    super();
+
+    this.#store = store;
+    this.#telemetry = telemetry;
+    this.#log = log;
+    this.#queue = new SerialQueue();
+
+    // Create callbacks that the impl uses to notify us about events and metrics
+    const callbacks = {
+      onTxsAdded: (txs: Tx[], opts: { source?: string }) => {
+        this.#metrics?.transactionsAdded(txs);
+        this.emit('txs-added', { txs, ...opts });
+      },
+      onTxsRemoved: (txHashes: string[] | bigint[]) => {
+        this.#metrics?.transactionsRemoved(txHashes);
+      },
+    };
+
+    // Create the implementation
+    this.#impl = new TxPoolV2Impl(store, archiveStore, deps, callbacks, config, log);
+  }
+
+  // ============================================================================
+  // PUBLIC API - All methods queue to the implementation
+  // ============================================================================
+
+  // === Core Operations ===
+
+  addPendingTxs(txs: Tx[], opts: { source?: string } = {}): Promise<AddTxsResult> {
+    return this.#queue.put(() => this.#impl.addPendingTxs(txs, opts));
+  }
+
+  canAddPendingTx(tx: Tx): Promise<'accepted' | 'ignored' | 'rejected'> {
+    return this.#queue.put(() => this.#impl.canAddPendingTx(tx));
+  }
+
+  addProtectedTxs(txs: Tx[], block: BlockHeader, opts: { source?: string } = {}): Promise<void> {
+    return this.#queue.put(() => this.#impl.addProtectedTxs(txs, block, opts));
+  }
+
+  protectTxs(txHashes: TxHash[], block: BlockHeader): Promise<TxHash[]> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.protectTxs(txHashes, block)));
+  }
+
+  addMinedTxs(txs: Tx[], block: BlockHeader, opts: { source?: string } = {}): Promise<void> {
+    return this.#queue.put(() => this.#impl.addMinedTxs(txs, block, opts));
+  }
+
+  // === State Transition Handlers ===
+
+  handleMinedBlock(block: L2Block): Promise<void> {
+    return this.#queue.put(() => this.#impl.handleMinedBlock(block));
+  }
+
+  prepareForSlot(slotNumber: SlotNumber): Promise<void> {
+    return this.#queue.put(() => this.#impl.prepareForSlot(slotNumber));
+  }
+
+  handlePrunedBlocks(latestBlock: L2BlockId): Promise<void> {
+    return this.#queue.put(() => this.#impl.handlePrunedBlocks(latestBlock));
+  }
+
+  handleFailedExecution(txHashes: TxHash[]): Promise<void> {
+    return this.#queue.put(() => this.#impl.handleFailedExecution(txHashes));
+  }
+
+  handleFinalizedBlock(block: BlockHeader): Promise<void> {
+    return this.#queue.put(() => this.#impl.handleFinalizedBlock(block));
+  }
+
+  // === Queries ===
+
+  getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+    return this.#queue.put(() => this.#impl.getTxByHash(txHash));
+  }
+
+  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
+    return this.#queue.put(() => this.#impl.getTxsByHash(txHashes));
+  }
+
+  hasTxs(txHashes: TxHash[]): Promise<boolean[]> {
+    return this.#queue.put(() => this.#impl.hasTxs(txHashes));
+  }
+
+  getTxStatus(txHash: TxHash): Promise<TxState | 'deleted' | undefined> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getTxStatus(txHash)));
+  }
+
+  getPendingTxHashes(): Promise<TxHash[]> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getPendingTxHashes()));
+  }
+
+  getPendingTxCount(): Promise<number> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getPendingTxCount()));
+  }
+
+  getMinedTxHashes(): Promise<[TxHash, L2BlockId][]> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getMinedTxHashes()));
+  }
+
+  getMinedTxCount(): Promise<number> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getMinedTxCount()));
+  }
+
+  isEmpty(): Promise<boolean> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.isEmpty()));
+  }
+
+  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+    return this.#queue.put(() => this.#impl.getArchivedTxByHash(txHash));
+  }
+
+  getLowestPriorityPending(limit: number): Promise<TxHash[]> {
+    return this.#queue.put(() => Promise.resolve(this.#impl.getLowestPriorityPending(limit)));
+  }
+
+  // === Configuration ===
+
+  updateConfig(config: Partial<TxPoolV2Config>): Promise<void> {
+    return this.#queue.put(() => {
+      this.#impl.updateConfig(config);
+      return Promise.resolve();
+    });
+  }
+
+  // === Lifecycle ===
+
+  /**
+   * Starts the pool and initializes state from persistence.
+   */
+  async start(): Promise<void> {
+    if (this.#started) {
+      return;
+    }
+
+    this.#log.info('Starting transaction pool...');
+
+    // Start the serial queue
+    this.#queue.start();
+    this.#started = true;
+
+    // Setup metrics - created after queue is started so callbacks can safely queue
+    this.#metrics = new PoolInstrumentation(
+      this.#telemetry,
+      PoolName.TX_POOL,
+      () =>
+        this.#queue.put(() => {
+          const counts = this.#impl.countTxs();
+          return Promise.resolve({
+            itemCount: { pending: counts.pending, protected: counts.protected, mined: counts.mined },
+          });
+        }),
+      () => this.#store.estimateSize(),
+    );
+
+    // Hydrate state from persistence (runs in queue)
+    await this.#queue.put(() => this.#impl.hydrateFromDatabase());
+
+    this.#log.info(
+      `Transaction pool started with ${this.#impl.getTxCount()} transactions (${this.#impl.getPendingTxCount()} pending, ${this.#impl.getMinedTxCount()} mined)`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    if (this.#started) {
+      await this.#queue.end();
+      this.#started = false;
+    }
+  }
+}

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts
@@ -1,0 +1,533 @@
+import { BlockNumber, CheckpointNumber, IndexWithinCheckpoint, SlotNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
+import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
+import { RevertCode } from '@aztec/stdlib/avm';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
+import { GasFees } from '@aztec/stdlib/gas';
+import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { mockTx } from '@aztec/stdlib/testing';
+import {
+  AppendOnlyTreeSnapshot,
+  MerkleTreeId,
+  PublicDataTreeLeaf,
+  PublicDataTreeLeafPreimage,
+} from '@aztec/stdlib/trees';
+import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+
+import { jest } from '@jest/globals';
+import { mkdir, writeFile } from 'fs/promises';
+import { type MockProxy, mock } from 'jest-mock-extended';
+import path from 'path';
+
+import { TxPoolBenchMetrics, TxPoolOperation } from './tx_pool_bench_metrics.js';
+import { AztecKVTxPoolV2 } from './tx_pool_v2.js';
+
+/** A validator that accepts all transactions. */
+const alwaysValidValidator: TxValidator<Tx> = {
+  validateTx: () => Promise.resolve({ result: 'valid' }),
+};
+
+jest.setTimeout(300_000);
+
+describe('TxPoolV2: benchmarks', () => {
+  const logger = createLogger('p2p:tx_pool_v2:bench');
+  const metrics = new TxPoolBenchMetrics();
+
+  // Use a fixed set of fee payers to test fee payer index with multiple txs per payer
+  const feePayers = [AztecAddress.fromBigInt(1n), AztecAddress.fromBigInt(2n), AztecAddress.fromBigInt(3n)];
+
+  // Pre-created transaction pools for different sizes
+  const POOL_SIZES = [10, 100, 1000] as const;
+  const preCreatedTxs: Map<number, Tx[]> = new Map();
+
+  // Block headers for benchmarks
+  const slot1Header = BlockHeader.empty({
+    globalVariables: GlobalVariables.empty({
+      blockNumber: BlockNumber(1),
+      slotNumber: SlotNumber(1),
+    }),
+  });
+
+  const slot2Header = BlockHeader.empty({
+    globalVariables: GlobalVariables.empty({
+      blockNumber: BlockNumber(2),
+      slotNumber: SlotNumber(2),
+    }),
+  });
+
+  // Shared mocks
+  let mockL2BlockSource: MockProxy<L2BlockSource>;
+  let mockWorldState: MockProxy<WorldStateSynchronizer>;
+  let db: MockProxy<MerkleTreeReadOperations>;
+
+  /**
+   * Creates a batch of mock transactions with varied priority fees and cycling fee payers.
+   * Uses unique seeds with large spacing to avoid nullifier conflicts between transactions.
+   */
+  const createTxBatch = async (count: number, startSeed = 1): Promise<Tx[]> => {
+    const txs: Tx[] = [];
+    for (let i = 0; i < count; i++) {
+      const priorityFee = ((startSeed + i) % 100) + 1;
+      const feePayer = feePayers[(startSeed + i) % feePayers.length];
+      // Use large seed spacing to prevent nullifier overlaps between transactions
+      // Each tx generates nullifiers from seed+1 onwards, so spacing by 100 ensures no overlap
+      txs.push(
+        await mockTx((startSeed + i) * 100, {
+          numberOfNonRevertiblePublicCallRequests: 1,
+          maxPriorityFeesPerGas: new GasFees(priorityFee, priorityFee),
+          feePayer,
+        }),
+      );
+    }
+    return txs;
+  };
+
+  /** Creates an L2Block from transactions and a header */
+  const makeBlock = (txs: Tx[], header: BlockHeader): L2Block => {
+    const txEffects = txs.map(tx => {
+      const nullifiers = tx.data.getNonEmptyNullifiers();
+      return new TxEffect(RevertCode.OK, tx.getTxHash(), Fr.ZERO, [], nullifiers, [], [], [], [], []);
+    });
+    const body = new Body(txEffects);
+    const archive = new AppendOnlyTreeSnapshot(Fr.random(), header.globalVariables.blockNumber + 1);
+    return new L2Block(
+      archive,
+      header,
+      body,
+      CheckpointNumber(Number(header.globalVariables.blockNumber)),
+      IndexWithinCheckpoint(0),
+    );
+  };
+
+  const setupMocks = () => {
+    mockL2BlockSource = mock<L2BlockSource>();
+    mockL2BlockSource.getTxEffect.mockResolvedValue(undefined);
+
+    mockWorldState = mock<WorldStateSynchronizer>();
+    db = mock<MerkleTreeReadOperations>();
+    mockWorldState.getCommitted.mockReturnValue(db);
+    mockWorldState.getSnapshot.mockReturnValue(db);
+
+    db.getPreviousValueIndex.mockImplementation((_tree, slot) => {
+      return Promise.resolve({ index: slot, alreadyPresent: true });
+    });
+    db.getLeafPreimage.mockImplementation((tree, index) => {
+      if (tree === MerkleTreeId.PUBLIC_DATA_TREE) {
+        // Return a very high balance (1e24) to ensure fee payer balance checks pass
+        // with 1000 txs split across 3 fee payers (~333 txs each with high fee limits)
+        return Promise.resolve(
+          new PublicDataTreeLeafPreimage(
+            new PublicDataTreeLeaf(new Fr(index), new Fr(BigInt('1000000000000000000000000'))),
+            Fr.ONE,
+            1n,
+          ),
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+    // Return indices for all archive lookups (all blocks exist)
+    db.findLeafIndices.mockImplementation((_tree, leaves) => {
+      return Promise.resolve((leaves as Fr[]).map((_, i) => BigInt(i + 1)));
+    });
+  };
+
+  const createPool = async (): Promise<{ pool: AztecKVTxPoolV2; cleanup: () => Promise<void> }> => {
+    const store = await openTmpStore('p2p-bench');
+    const archiveStore = await openTmpStore('archive-bench');
+    const pool = new AztecKVTxPoolV2(store, archiveStore, {
+      l2BlockSource: mockL2BlockSource,
+      worldStateSynchronizer: mockWorldState,
+      pendingTxValidator: alwaysValidValidator,
+    });
+    await pool.start();
+    const cleanup = async () => {
+      await pool.stop();
+      await store.delete();
+      await archiveStore.delete();
+    };
+    return { pool, cleanup };
+  };
+
+  const populatePool = async (pool: AztecKVTxPoolV2, count: number): Promise<Tx[]> => {
+    const txs = preCreatedTxs.get(count);
+    if (!txs) {
+      throw new Error(`No pre-created txs for count ${count}`);
+    }
+    await pool.addPendingTxs(txs);
+    return txs;
+  };
+
+  const measureOperation = async (operation: () => Promise<void>, iterations: number): Promise<number> => {
+    const startTime = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      await operation();
+    }
+    const endTime = performance.now();
+    return (endTime - startTime) / iterations;
+  };
+
+  // Pre-create all transactions before running any benchmarks
+  beforeAll(async () => {
+    logger.info('Pre-creating transactions for benchmarks...');
+
+    // Create txs for the largest pool size (others will use subsets)
+    const maxSize = Math.max(...POOL_SIZES);
+    const allTxs = await createTxBatch(maxSize);
+
+    // Store subsets for each pool size
+    for (const size of POOL_SIZES) {
+      preCreatedTxs.set(size, allTxs.slice(0, size));
+    }
+
+    // Also create extra txs for addPendingTxs benchmarks (to add to existing pools)
+    const extraTxs = await createTxBatch(100, maxSize + 1);
+    preCreatedTxs.set(-1, extraTxs); // Use -1 as key for "extra" txs
+
+    logger.info(`Pre-created ${maxSize} transactions + 100 extra for add benchmarks`);
+  });
+
+  afterAll(async () => {
+    if (process.env.BENCH_OUTPUT) {
+      await mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
+      await writeFile(process.env.BENCH_OUTPUT, metrics.toGithubActionBenchmarkJSON());
+    } else if (process.env.BENCH_OUTPUT_MD) {
+      await writeFile(process.env.BENCH_OUTPUT_MD, metrics.toPrettyString());
+    } else {
+      logger.info(`\n`);
+      logger.info(metrics.toPrettyString());
+      logger.info(`\n`);
+    }
+  });
+
+  // ============================================================================
+  // Read-only benchmarks - can share pools within each size group
+  // ============================================================================
+
+  describe.each(POOL_SIZES)('read-only operations: pool=%d', (poolSize: number) => {
+    let pool: AztecKVTxPoolV2;
+    let cleanup: () => Promise<void>;
+    let txs: Tx[];
+
+    beforeAll(async () => {
+      setupMocks();
+      ({ pool, cleanup } = await createPool());
+      txs = await populatePool(pool, poolSize);
+    });
+
+    afterAll(async () => {
+      await cleanup();
+    });
+
+    it('getPendingTxHashes', async () => {
+      const duration = await measureOperation(async () => {
+        await pool.getPendingTxHashes();
+      }, 100);
+
+      metrics.addMetric(TxPoolOperation.GET_PENDING_TX_HASHES, poolSize, 0, duration);
+    });
+
+    it('getTxByHash', async () => {
+      const randomTxHash = txs[Math.floor(Math.random() * txs.length)].getTxHash();
+
+      const duration = await measureOperation(async () => {
+        await pool.getTxByHash(randomTxHash);
+      }, 1000);
+
+      metrics.addMetric(TxPoolOperation.GET_TX_BY_HASH, poolSize, 0, duration);
+    });
+
+    it.each([1, 10, Math.min(50, poolSize)])('getTxsByHash: batch=%d', async (batchSize: number) => {
+      const hashes: TxHash[] = [];
+      for (let i = 0; i < batchSize; i++) {
+        hashes.push(txs[Math.floor(Math.random() * txs.length)].getTxHash());
+      }
+
+      const duration = await measureOperation(async () => {
+        await pool.getTxsByHash(hashes);
+      }, 100);
+
+      metrics.addMetric(TxPoolOperation.GET_TXS_BY_HASH, poolSize, batchSize, duration);
+    });
+
+    it.each([1, 10, Math.min(50, poolSize)])('hasTxs: batch=%d', async (batchSize: number) => {
+      const hashes: TxHash[] = [];
+      for (let i = 0; i < batchSize; i++) {
+        if (i % 2 === 0) {
+          hashes.push(txs[Math.floor(Math.random() * txs.length)].getTxHash());
+        } else {
+          hashes.push(TxHash.random());
+        }
+      }
+
+      const duration = await measureOperation(async () => {
+        await pool.hasTxs(hashes);
+      }, 100);
+
+      metrics.addMetric(TxPoolOperation.HAS_TXS, poolSize, batchSize, duration);
+    });
+
+    it.each([10, Math.min(50, poolSize)])('getLowestPriorityPending: limit=%d', async (limit: number) => {
+      const duration = await measureOperation(async () => {
+        await pool.getLowestPriorityPending(limit);
+      }, 100);
+
+      metrics.addMetric(TxPoolOperation.GET_LOWEST_PRIORITY_PENDING, poolSize, limit, duration);
+    });
+
+    it('canAddPendingTx', async () => {
+      const extraTxs = preCreatedTxs.get(-1)!;
+      const newTx = extraTxs[0];
+
+      const duration = await measureOperation(async () => {
+        await pool.canAddPendingTx(newTx);
+      }, 100);
+
+      metrics.addMetric(TxPoolOperation.CAN_ADD_PENDING_TX, poolSize, 0, duration);
+    });
+  });
+
+  // ============================================================================
+  // Mutating benchmarks - run each operation multiple times with reset
+  // ============================================================================
+
+  const MUTATION_ITERATIONS = 5;
+
+  describe('addPendingTxs', () => {
+    beforeAll(() => {
+      setupMocks();
+    });
+
+    it.each([
+      [0, 1],
+      [0, 10],
+      [0, 100],
+      [100, 1],
+      [100, 10],
+      [100, 100],
+      [1000, 1],
+      [1000, 10],
+      [1000, 100],
+    ])('pool=%d, batch=%d', async (poolSize: number, batchSize: number) => {
+      const { pool, cleanup } = await createPool();
+
+      try {
+        // Populate pool if needed
+        if (poolSize > 0) {
+          await populatePool(pool, poolSize);
+        }
+
+        // Get batch to add from extra txs
+        const extraTxs = preCreatedTxs.get(-1)!;
+        const txsToAdd = extraTxs.slice(0, batchSize);
+        const hashesToRemove = txsToAdd.map(tx => tx.getTxHash());
+
+        let totalDuration = 0;
+        for (let i = 0; i < MUTATION_ITERATIONS; i++) {
+          const startTime = performance.now();
+          await pool.addPendingTxs(txsToAdd);
+          totalDuration += performance.now() - startTime;
+
+          // Reset: remove added txs
+          await pool.handleFailedExecution(hashesToRemove);
+        }
+
+        metrics.addMetric(TxPoolOperation.ADD_PENDING_TXS, poolSize, batchSize, totalDuration / MUTATION_ITERATIONS);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe('handleMinedBlock', () => {
+    beforeAll(() => {
+      setupMocks();
+    });
+
+    it.each([
+      [100, 10],
+      [100, 50],
+      [1000, 10],
+      [1000, 100],
+    ])('pool=%d, mined=%d', async (poolSize: number, minedCount: number) => {
+      const { pool, cleanup } = await createPool();
+
+      try {
+        const txs = await populatePool(pool, poolSize);
+        const txsToMine = txs.slice(0, minedCount);
+        const block = makeBlock(txsToMine, slot1Header);
+
+        // Pre-compute block IDs for reset
+        const block0Hash = await BlockHeader.empty().hash();
+        const block0Id: L2BlockId = { number: BlockNumber(0), hash: block0Hash.toString() };
+
+        let totalDuration = 0;
+        for (let i = 0; i < MUTATION_ITERATIONS; i++) {
+          const startTime = performance.now();
+          await pool.handleMinedBlock(block);
+          totalDuration += performance.now() - startTime;
+
+          // Reset: un-mine by pruning back to block 0
+          await pool.handlePrunedBlocks(block0Id);
+        }
+
+        metrics.addMetric(
+          TxPoolOperation.HANDLE_MINED_BLOCK,
+          poolSize,
+          minedCount,
+          totalDuration / MUTATION_ITERATIONS,
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe('prepareForSlot', () => {
+    beforeAll(() => {
+      setupMocks();
+    });
+
+    it.each([
+      [100, 10],
+      [100, 50],
+      [1000, 10],
+      [1000, 100],
+    ])('pool=%d, protected=%d', async (poolSize: number, protectedCount: number) => {
+      const { pool, cleanup } = await createPool();
+
+      try {
+        // Get txs and split into pending and protected
+        const txs = preCreatedTxs.get(poolSize)!;
+        const pendingTxs = txs.slice(0, poolSize - protectedCount);
+        const protectedTxs = txs.slice(poolSize - protectedCount);
+
+        await pool.addPendingTxs(pendingTxs);
+
+        let totalDuration = 0;
+        for (let i = 0; i < MUTATION_ITERATIONS; i++) {
+          // Protect txs for slot N
+          const slotN = SlotNumber(i * 2 + 1);
+          const slotNHeader = BlockHeader.empty({
+            globalVariables: GlobalVariables.empty({
+              blockNumber: BlockNumber(i * 2 + 1),
+              slotNumber: slotN,
+            }),
+          });
+          await pool.addProtectedTxs(protectedTxs, slotNHeader);
+
+          // Measure prepareForSlot(N+1) which unprotects slot N txs
+          const startTime = performance.now();
+          await pool.prepareForSlot(SlotNumber(i * 2 + 2));
+          totalDuration += performance.now() - startTime;
+        }
+
+        metrics.addMetric(
+          TxPoolOperation.PREPARE_FOR_SLOT,
+          poolSize,
+          protectedCount,
+          totalDuration / MUTATION_ITERATIONS,
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe('handlePrunedBlocks', () => {
+    beforeAll(() => {
+      setupMocks();
+    });
+
+    it.each([
+      [100, 10],
+      [100, 50],
+      [1000, 10],
+      [1000, 100],
+    ])('pool=%d, mined=%d', async (poolSize: number, minedCount: number) => {
+      const { pool, cleanup } = await createPool();
+
+      try {
+        const txs = await populatePool(pool, poolSize);
+        const txsToMine = txs.slice(0, minedCount);
+        const block = makeBlock(txsToMine, slot2Header);
+
+        // Pre-compute block IDs
+        const block1Hash = await slot1Header.hash();
+        const block1Id: L2BlockId = { number: BlockNumber(1), hash: block1Hash.toString() };
+
+        let totalDuration = 0;
+        for (let i = 0; i < MUTATION_ITERATIONS; i++) {
+          // Mine transactions at block 2
+          await pool.handleMinedBlock(block);
+
+          // Measure: prune back to block 1 (un-mines the transactions)
+          const startTime = performance.now();
+          await pool.handlePrunedBlocks(block1Id);
+          totalDuration += performance.now() - startTime;
+        }
+
+        metrics.addMetric(
+          TxPoolOperation.HANDLE_PRUNED_BLOCKS,
+          poolSize,
+          minedCount,
+          totalDuration / MUTATION_ITERATIONS,
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe('hydrateFromDatabase', () => {
+    it('hydrate 1000 pending txs', async () => {
+      setupMocks();
+
+      // Create persistent stores that survive pool restart
+      const store = await openTmpStore('p2p-hydrate-bench');
+      const archiveStore = await openTmpStore('archive-hydrate-bench');
+
+      try {
+        // Create pool and populate with 1000 txs (default config has no limit)
+        const pool1 = new AztecKVTxPoolV2(store, archiveStore, {
+          l2BlockSource: mockL2BlockSource,
+          worldStateSynchronizer: mockWorldState,
+          pendingTxValidator: alwaysValidValidator,
+        });
+        await pool1.start();
+
+        const txs = preCreatedTxs.get(1000)!;
+        expect(txs.length).toBe(1000); // Verify we have 1000 pre-created txs
+        await pool1.addPendingTxs(txs);
+        expect(await pool1.getPendingTxCount()).toBe(1000);
+
+        await pool1.stop();
+
+        // Measure hydration time
+        let totalDuration = 0;
+        for (let i = 0; i < MUTATION_ITERATIONS; i++) {
+          const pool2 = new AztecKVTxPoolV2(store, archiveStore, {
+            l2BlockSource: mockL2BlockSource,
+            worldStateSynchronizer: mockWorldState,
+            pendingTxValidator: alwaysValidValidator,
+          });
+
+          const startTime = performance.now();
+          await pool2.start();
+          totalDuration += performance.now() - startTime;
+
+          // Verify hydration was successful
+          expect(await pool2.getPendingTxCount()).toBe(1000);
+
+          await pool2.stop();
+        }
+
+        metrics.addMetric(TxPoolOperation.HYDRATE_FROM_DATABASE, 1000, 0, totalDuration / MUTATION_ITERATIONS);
+      } finally {
+        await store.delete();
+        await archiveStore.delete();
+      }
+    });
+  });
+});

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_impl.ts
@@ -1,0 +1,1265 @@
+import { SlotNumber } from '@aztec/foundation/branded-types';
+import type { Logger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
+import { ProtocolContractAddress } from '@aztec/protocol-contracts';
+import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee-juice';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { L2Block, L2BlockId, L2BlockSource } from '@aztec/stdlib/block';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { DatabasePublicStateSource } from '@aztec/stdlib/trees';
+import { BlockHeader, Tx, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+
+import { TxArchive } from './archive/index.js';
+import {
+  EvictionManager,
+  FeePayerBalanceEvictionRule,
+  FeePayerBalancePreAddRule,
+  InvalidTxsAfterMiningRule,
+  InvalidTxsAfterReorgRule,
+  LowPriorityEvictionRule,
+  LowPriorityPreAddRule,
+  NullifierConflictRule,
+  type PoolOperations,
+  type PreAddPoolAccess,
+} from './eviction/index.js';
+import {
+  type AddTxsResult,
+  DEFAULT_TX_POOL_V2_CONFIG,
+  type PoolReadAccess,
+  type TxPoolV2Config,
+  type TxPoolV2Dependencies,
+} from './interfaces.js';
+import {
+  type TxMetaData,
+  type TxState,
+  buildTxMetaData,
+  checkNullifierConflict,
+  compareFee,
+  compareTxHash,
+} from './tx_metadata.js';
+
+/**
+ * Callbacks for the implementation to notify the outer class about events and metrics.
+ */
+export interface TxPoolV2Callbacks {
+  onTxsAdded: (txs: Tx[], opts: { source?: string }) => void;
+  onTxsRemoved: (txHashes: string[] | bigint[]) => void;
+}
+
+/**
+ * Implementation of TxPoolV2 logic.
+ *
+ * This class contains all the actual transaction pool logic.
+ */
+export class TxPoolV2Impl {
+  // === Persistence ===
+  #store: AztecAsyncKVStore;
+  #txsDB: AztecAsyncMap<string, Buffer>;
+
+  // === Dependencies ===
+  #l2BlockSource: L2BlockSource;
+  #worldStateSynchronizer: WorldStateSynchronizer;
+  #pendingTxValidator: TxValidator<Tx>;
+
+  // === In-Memory Indices ===
+  /** Primary metadata store: txHash -> TxMetaData */
+  #metadata: Map<string, TxMetaData> = new Map();
+  /** Nullifier to txHash index (pending txs only) */
+  #nullifierToTxHash: Map<string, string> = new Map();
+  /** Fee payer to txHashes index (pending txs only) */
+  #feePayerToTxHashes: Map<string, Set<string>> = new Map();
+  /**
+   * Pending txHashes grouped by priority fee.
+   * Outer map: priorityFee -> Set of txHashes at that fee level.
+   */
+  #pendingByPriority: Map<bigint, Set<string>> = new Map();
+  /** Protected transactions: txHash -> slotNumber. Includes txs we have and txs we expect to receive. */
+  #protectedTransactions: Map<string, SlotNumber> = new Map();
+
+  // === Config & Services ===
+  #config: TxPoolV2Config;
+  #archive: TxArchive;
+  #evictionManager: EvictionManager;
+  #log: Logger;
+  #callbacks: TxPoolV2Callbacks;
+
+  constructor(
+    store: AztecAsyncKVStore,
+    archiveStore: AztecAsyncKVStore,
+    deps: TxPoolV2Dependencies,
+    callbacks: TxPoolV2Callbacks,
+    config: Partial<TxPoolV2Config> = {},
+    log: Logger,
+  ) {
+    this.#store = store;
+    this.#txsDB = store.openMap('txs');
+
+    this.#l2BlockSource = deps.l2BlockSource;
+    this.#worldStateSynchronizer = deps.worldStateSynchronizer;
+    this.#pendingTxValidator = deps.pendingTxValidator;
+
+    this.#config = { ...DEFAULT_TX_POOL_V2_CONFIG, ...config };
+    this.#archive = new TxArchive(archiveStore, this.#config.archivedTxLimit, log);
+    this.#log = log;
+    this.#callbacks = callbacks;
+
+    // Setup eviction manager with rules
+    this.#evictionManager = new EvictionManager(this.#createPoolOperations(), log);
+
+    // Pre-add rules (run during addPendingTxs) - work with TxMetaData
+    this.#evictionManager.registerPreAddRule(new NullifierConflictRule());
+    this.#evictionManager.registerPreAddRule(new FeePayerBalancePreAddRule());
+    this.#evictionManager.registerPreAddRule(
+      new LowPriorityPreAddRule({ maxPoolSize: this.#config.maxPendingTxCount }),
+    );
+
+    // Post-event eviction rules (run after events to check ALL pending txs)
+    this.#evictionManager.registerRule(new InvalidTxsAfterMiningRule());
+    this.#evictionManager.registerRule(new InvalidTxsAfterReorgRule(deps.worldStateSynchronizer));
+    this.#evictionManager.registerRule(new FeePayerBalanceEvictionRule(deps.worldStateSynchronizer));
+    // LowPriorityEvictionRule handles cases where txs become pending via prepareForSlot (unprotect)
+    // The pre-add rule handles the addPendingTxs case, but post-event is needed for unprotect
+    this.#evictionManager.registerRule(new LowPriorityEvictionRule({ maxPoolSize: this.#config.maxPendingTxCount }));
+  }
+
+  // ============================================================================
+  // PUBLIC IMPLEMENTATION METHODS
+  // ============================================================================
+
+  /**
+   * Hydrates the in-memory state from the database on startup.
+   * Pipeline: Load → Check Mined Status → Partition → Validate Non-Mined → Rebuild Pending Pool → Delete Invalid
+   *
+   * Note: Protected status is lost on restart. All non-mined txs are rebuilt as pending
+   * by running pre-add rules to resolve nullifier conflicts, balance checks, and pool size limits.
+   */
+  async hydrateFromDatabase(): Promise<void> {
+    // Step 1: Load all transactions from DB
+    const { loaded, errors: deserializationErrors } = await this.#loadAllTxsFromDb();
+
+    // Step 2: Check mined status for each tx
+    await this.#markMinedStatusBatch(loaded.map(l => l.meta));
+
+    // Step 3: Partition by mined status
+    const { mined, nonMined } = this.#partitionByMinedStatus(loaded);
+
+    // Step 4: Validate non-mined transactions
+    const { valid, invalid } = await this.#validateNonMinedTxs(nonMined);
+
+    // Step 5: Populate mined indices (these don't need conflict resolution)
+    this.#populateMinedIndices(mined);
+
+    // Step 6: Rebuild pending pool by running pre-add rules for each tx
+    // This resolves nullifier conflicts, fee payer balance issues, and pool size limits
+    const { rejected } = await this.#rebuildPendingPool(valid);
+
+    // Step 7: Delete invalid and rejected txs from DB
+    const toDelete = [...deserializationErrors, ...invalid, ...rejected];
+    if (toDelete.length === 0) {
+      return;
+    }
+    await this.#store.transactionAsync(async () => {
+      for (const txHashStr of toDelete) {
+        await this.#txsDB.delete(txHashStr);
+      }
+    });
+    this.#log.info(`Deleted ${toDelete.length} invalid/rejected transactions on startup`);
+  }
+
+  async addPendingTxs(txs: Tx[], opts: { source?: string }): Promise<AddTxsResult> {
+    const accepted: TxHash[] = [];
+    const ignored: TxHash[] = [];
+    const rejected: TxHash[] = [];
+    const newlyAdded: Tx[] = [];
+    const acceptedPending = new Set<string>();
+
+    const poolAccess = this.#createPreAddPoolAccess();
+
+    await this.#store.transactionAsync(async () => {
+      for (const tx of txs) {
+        const txHash = tx.getTxHash();
+        const txHashStr = txHash.toString();
+
+        // Skip duplicates
+        if (this.#isDuplicateTx(txHashStr)) {
+          ignored.push(txHash);
+          continue;
+        }
+
+        // Check mined status first (applies to all paths)
+        const minedBlockId = await this.#getMinedBlockId(txHash);
+        const preProtectedSlot = this.#protectedTransactions.get(txHashStr);
+
+        if (minedBlockId) {
+          // Already mined - add directly (protection already set if pre-protected)
+          await this.#addNewMinedTx(tx, minedBlockId);
+          accepted.push(txHash);
+          newlyAdded.push(tx);
+        } else if (preProtectedSlot !== undefined) {
+          // Pre-protected and not mined - add as protected (bypass validation)
+          await this.#addNewProtectedTx(tx, preProtectedSlot);
+          accepted.push(txHash);
+          newlyAdded.push(tx);
+        } else {
+          // Regular pending tx - validate and run pre-add rules
+          const result = await this.#tryAddRegularPendingTx(tx, poolAccess, acceptedPending, ignored);
+          if (result.status === 'accepted') {
+            acceptedPending.add(txHashStr);
+            newlyAdded.push(tx);
+          } else if (result.status === 'rejected') {
+            rejected.push(txHash);
+          } else {
+            ignored.push(txHash);
+          }
+        }
+      }
+    });
+
+    // Build final accepted list for pending txs (excludes intra-batch evictions)
+    for (const txHashStr of acceptedPending) {
+      accepted.push(TxHash.fromString(txHashStr));
+    }
+
+    // Run post-add eviction rules for pending txs
+    if (acceptedPending.size > 0) {
+      const feePayers = Array.from(acceptedPending).map(txHash => this.#metadata.get(txHash)!.feePayer);
+      const uniqueFeePayers = new Set<string>(feePayers);
+      await this.#evictionManager.evictAfterNewTxs(Array.from(acceptedPending), [...uniqueFeePayers]);
+    }
+
+    // Emit events
+    if (newlyAdded.length > 0) {
+      this.#callbacks.onTxsAdded(newlyAdded, opts);
+    }
+
+    return { accepted, ignored, rejected };
+  }
+
+  /** Validates and adds a regular pending tx. Returns status. */
+  async #tryAddRegularPendingTx(
+    tx: Tx,
+    poolAccess: PreAddPoolAccess,
+    acceptedPending: Set<string>,
+    ignored: TxHash[],
+  ): Promise<{ status: 'accepted' | 'ignored' | 'rejected' }> {
+    const txHash = tx.getTxHash();
+    const txHashStr = txHash.toString();
+
+    // Validate transaction
+    const validationResult = await this.#pendingTxValidator.validateTx(tx);
+    if (validationResult.result !== 'valid') {
+      this.#log.info(`Rejecting tx ${txHashStr}: ${validationResult.reason?.join(', ')}`);
+      return { status: 'rejected' };
+    }
+
+    // Build metadata and run pre-add rules
+    const meta = await buildTxMetaData(tx);
+    const preAddResult = await this.#evictionManager.runPreAddRules(meta, poolAccess);
+
+    if (preAddResult.shouldIgnore) {
+      this.#log.debug(`Ignoring tx ${txHashStr}: ${preAddResult.reason}`);
+      return { status: 'ignored' };
+    }
+
+    // Evict conflicts (tracking intra-batch evictions)
+    for (const evictHashStr of preAddResult.txHashesToEvict) {
+      await this.#deleteTx(evictHashStr);
+      this.#log.debug(`Evicted tx ${evictHashStr} due to higher-fee tx ${txHashStr}`);
+      if (acceptedPending.has(evictHashStr)) {
+        acceptedPending.delete(evictHashStr);
+        ignored.push(TxHash.fromString(evictHashStr));
+      }
+    }
+
+    // Add the transaction
+    await this.#addNewPendingTx(tx);
+    return { status: 'accepted' };
+  }
+
+  async canAddPendingTx(tx: Tx): Promise<'accepted' | 'ignored' | 'rejected'> {
+    const txHashStr = tx.getTxHash().toString();
+
+    // Check if already in pool
+    if (this.#metadata.has(txHashStr)) {
+      return 'ignored';
+    }
+
+    // Validate transaction
+    const validationResult = await this.#pendingTxValidator.validateTx(tx);
+    if (validationResult.result !== 'valid') {
+      return 'rejected';
+    }
+
+    // Build metadata and use pre-add rules
+    const meta = await buildTxMetaData(tx);
+    const poolAccess = this.#createPreAddPoolAccess();
+    const preAddResult = await this.#evictionManager.runPreAddRules(meta, poolAccess);
+
+    return preAddResult.shouldIgnore ? 'ignored' : 'accepted';
+  }
+
+  async addProtectedTxs(txs: Tx[], block: BlockHeader, opts: { source?: string }): Promise<void> {
+    const slotNumber = block.globalVariables.slotNumber;
+    const newlyAdded: Tx[] = [];
+
+    await this.#store.transactionAsync(async () => {
+      for (const tx of txs) {
+        const txHash = tx.getTxHash();
+        const txHashStr = txHash.toString();
+        const isNew = !this.#metadata.has(txHashStr);
+        const minedBlockId = await this.#getMinedBlockId(txHash);
+
+        if (isNew) {
+          // New tx - add as mined or protected
+          if (minedBlockId) {
+            await this.#addNewMinedTx(tx, minedBlockId);
+            this.#protectedTransactions.set(txHashStr, slotNumber);
+          } else {
+            await this.#addNewProtectedTx(tx, slotNumber);
+          }
+          newlyAdded.push(tx);
+        } else {
+          // Existing tx - update protection and mined status
+          this.#updateProtection(txHashStr, slotNumber);
+          if (minedBlockId) {
+            this.#markAsMined(this.#metadata.get(txHashStr)!, minedBlockId);
+          }
+        }
+      }
+    });
+
+    if (newlyAdded.length > 0) {
+      this.#callbacks.onTxsAdded(newlyAdded, opts);
+    }
+  }
+
+  protectTxs(txHashes: TxHash[], block: BlockHeader): TxHash[] {
+    const slotNumber = block.globalVariables.slotNumber;
+    const missing: TxHash[] = [];
+
+    for (const txHash of txHashes) {
+      const txHashStr = txHash.toString();
+
+      if (this.#metadata.has(txHashStr)) {
+        // Step 1a: Update protection for existing tx
+        this.#updateProtection(txHashStr, slotNumber);
+      } else {
+        // Step 1b: Pre-record protection for tx we don't have yet
+        this.#protectedTransactions.set(txHashStr, slotNumber);
+        missing.push(txHash);
+      }
+    }
+
+    return missing;
+  }
+
+  async addMinedTxs(txs: Tx[], block: BlockHeader, opts: { source?: string }): Promise<void> {
+    // Step 1: Build block ID
+    const blockId = await this.#buildBlockId(block);
+    const newlyAdded: Tx[] = [];
+
+    await this.#store.transactionAsync(async () => {
+      for (const tx of txs) {
+        const txHashStr = tx.getTxHash().toString();
+        const existingMeta = this.#metadata.get(txHashStr);
+
+        if (existingMeta) {
+          // Step 2a: Mark existing tx as mined
+          this.#markAsMined(existingMeta, blockId);
+        } else {
+          // Step 2b: Add new mined tx
+          await this.#addNewMinedTx(tx, blockId);
+          newlyAdded.push(tx);
+        }
+      }
+    });
+
+    // Step 3: Emit events for newly added txs
+    if (newlyAdded.length > 0) {
+      this.#callbacks.onTxsAdded(newlyAdded, opts);
+    }
+  }
+
+  async handleMinedBlock(block: L2Block): Promise<void> {
+    // Step 1: Build block ID
+    const blockId = await this.#buildBlockId(block.header);
+
+    // Step 2: Extract tx hashes and nullifiers directly from the block
+    const txHashes = block.body.txEffects.map(tx => tx.txHash);
+    const nullifiers = block.body.txEffects.flatMap(tx => tx.nullifiers.map(n => n.toString()));
+
+    // Step 3: Collect fee payers from txs we have in the pool (for balance-based eviction)
+    const feePayers: string[] = [];
+    const found: TxMetaData[] = [];
+    for (const txHash of txHashes) {
+      const meta = this.#metadata.get(txHash.toString());
+      if (meta) {
+        feePayers.push(meta.feePayer);
+        found.push(meta);
+      }
+    }
+
+    // Step 4: Mark txs as mined (only those we have in the pool)
+    this.#markTxsAsMined(found, blockId);
+
+    // Step 5: Run eviction rules (remove pending txs with conflicting nullifiers/expired timestamps)
+    await this.#evictionManager.evictAfterNewBlock(block.header, nullifiers, feePayers);
+
+    this.#callbacks.onTxsRemoved(txHashes.map(h => h.toBigInt()));
+    this.#log.info(`Marked ${found.length} txs as mined in block ${blockId.number}`);
+  }
+
+  async prepareForSlot(slotNumber: SlotNumber): Promise<void> {
+    // Step 1: Find expired protected txs
+    const expiredProtected = this.#findExpiredProtectedTxs(slotNumber);
+
+    // Step 2: Clear protection for all expired entries (including those without metadata)
+    this.#clearProtection(expiredProtected);
+
+    // Step 3: Filter to only txs that have metadata and are not mined
+    const txsToRestore = this.#filterRestorable(expiredProtected);
+    if (txsToRestore.length === 0) {
+      return;
+    }
+
+    this.#log.info(`Preparing for slot ${slotNumber}: unprotecting ${txsToRestore.length} txs`);
+
+    // Step 4: Validate for pending pool
+    const { valid, invalid } = await this.#validateForPending(txsToRestore);
+
+    // Step 5: Resolve nullifier conflicts and add winners to pending indices
+    const { added, toEvict } = this.#applyNullifierConflictResolution(valid);
+
+    // Step 6: Delete invalid and evicted txs
+    await this.#deleteTxsBatch([...invalid, ...toEvict]);
+
+    // Step 7: Run eviction rules (enforce pool size limit)
+    if (added.length > 0) {
+      const feePayers = added.map(meta => meta.feePayer);
+      const uniqueFeePayers = new Set<string>(feePayers);
+      await this.#evictionManager.evictAfterNewTxs(
+        added.map(m => m.txHash),
+        [...uniqueFeePayers],
+      );
+    }
+  }
+
+  async handlePrunedBlocks(latestBlock: L2BlockId): Promise<void> {
+    // Step 1: Find transactions mined after the prune point
+    const txsToUnmine = this.#findTxsMinedAfter(latestBlock.number);
+    if (txsToUnmine.length === 0) {
+      this.#log.debug(`No transactions to un-mine for prune to block ${latestBlock.number}`);
+      return;
+    }
+
+    this.#log.info(`Handling prune to block ${latestBlock.number}: un-mining ${txsToUnmine.length} txs`);
+
+    // Step 2: Unmine - clear mined status from metadata
+    this.#unmineTxs(txsToUnmine);
+
+    // Step 3: Filter out protected txs (they'll be handled by prepareForSlot)
+    const unprotectedTxs = this.#filterUnprotected(txsToUnmine);
+
+    // Step 4: Validate for pending pool
+    const { valid, invalid } = await this.#validateForPending(unprotectedTxs);
+
+    // Step 5: Resolve nullifier conflicts and add winners to pending indices
+    const { toEvict } = this.#applyNullifierConflictResolution(valid);
+
+    // Step 6: Delete invalid and evicted txs
+    await this.#deleteTxsBatch([...invalid, ...toEvict]);
+
+    // Step 7: Run eviction rules for ALL pending txs (not just restored ones)
+    // This handles cases like existing pending txs with invalid fee payer balances
+    await this.#evictionManager.evictAfterChainPrune(latestBlock.number);
+  }
+
+  async handleFailedExecution(txHashes: TxHash[]): Promise<void> {
+    // Step 1: Delete failed txs
+    await this.#deleteTxsBatch(txHashes.map(h => h.toString()));
+
+    this.#log.info(`Deleted ${txHashes.length} failed txs`);
+  }
+
+  async handleFinalizedBlock(block: BlockHeader): Promise<void> {
+    const blockNumber = block.globalVariables.blockNumber;
+
+    // Step 1: Find txs mined at or before finalized block
+    const txsToFinalize = this.#findTxsMinedAtOrBefore(blockNumber);
+    if (txsToFinalize.length === 0) {
+      return;
+    }
+
+    // Step 2: Collect txs for archiving (before deletion)
+    const txsToArchive: Tx[] = [];
+    if (this.#archive.isEnabled()) {
+      for (const txHashStr of txsToFinalize) {
+        const buffer = await this.#txsDB.getAsync(txHashStr);
+        if (buffer) {
+          txsToArchive.push(Tx.fromBuffer(buffer));
+        }
+      }
+    }
+
+    // Step 3: Delete from active pool
+    await this.#deleteTxsBatch(txsToFinalize);
+
+    // Step 4: Archive
+    if (txsToArchive.length > 0) {
+      await this.#archive.archiveTxs(txsToArchive);
+    }
+
+    this.#log.info(`Finalized ${txsToFinalize.length} txs from blocks up to ${blockNumber}`);
+  }
+
+  // === Query Methods ===
+
+  async getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+    const buffer = await this.#txsDB.getAsync(txHash.toString());
+    return buffer ? Tx.fromBuffer(buffer) : undefined;
+  }
+
+  async getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
+    const results: (Tx | undefined)[] = [];
+    for (const h of txHashes) {
+      const buffer = await this.#txsDB.getAsync(h.toString());
+      results.push(buffer ? Tx.fromBuffer(buffer) : undefined);
+    }
+    return results;
+  }
+
+  hasTxs(txHashes: TxHash[]): boolean[] {
+    return txHashes.map(h => this.#metadata.has(h.toString()));
+  }
+
+  getTxStatus(txHash: TxHash): TxState | undefined {
+    const meta = this.#metadata.get(txHash.toString());
+    if (!meta) {
+      return undefined;
+    }
+    return this.#getTxState(meta);
+  }
+
+  getPendingTxHashes(): TxHash[] {
+    return [...this.#iteratePendingByPriority('desc')].map(hash => TxHash.fromString(hash));
+  }
+
+  getPendingTxCount(): number {
+    let count = 0;
+    for (const hashes of this.#pendingByPriority.values()) {
+      count += hashes.size;
+    }
+    return count;
+  }
+
+  getMinedTxHashes(): [TxHash, L2BlockId][] {
+    const result: [TxHash, L2BlockId][] = [];
+    for (const [txHash, meta] of this.#metadata) {
+      if (meta.minedL2BlockId !== undefined) {
+        result.push([TxHash.fromString(txHash), meta.minedL2BlockId]);
+      }
+    }
+    return result;
+  }
+
+  getMinedTxCount(): number {
+    let count = 0;
+    for (const meta of this.#metadata.values()) {
+      if (meta.minedL2BlockId !== undefined) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  isEmpty(): boolean {
+    return this.#metadata.size === 0;
+  }
+
+  getTxCount(): number {
+    return this.#metadata.size;
+  }
+
+  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined> {
+    return this.#archive.getTxByHash(txHash);
+  }
+
+  getLowestPriorityPending(limit: number): TxHash[] {
+    if (limit <= 0) {
+      return [];
+    }
+
+    const result: TxHash[] = [];
+    for (const hash of this.#iteratePendingByPriority('asc')) {
+      result.push(TxHash.fromString(hash));
+      if (result.length >= limit) {
+        break;
+      }
+    }
+    return result;
+  }
+
+  // === Configuration ===
+
+  updateConfig(config: Partial<TxPoolV2Config>): void {
+    if (config.maxPendingTxCount !== undefined) {
+      this.#config.maxPendingTxCount = config.maxPendingTxCount;
+    }
+    if (config.archivedTxLimit !== undefined) {
+      this.#config.archivedTxLimit = config.archivedTxLimit;
+      this.#archive.updateLimit(config.archivedTxLimit);
+    }
+    // Update eviction rules with new config
+    this.#evictionManager.updateConfig(config);
+  }
+
+  // === Pool Read Access ===
+
+  getPoolReadAccess(): PoolReadAccess {
+    return {
+      getMetadata: (txHash: string) => this.#metadata.get(txHash),
+      getTxHashByNullifier: (nullifier: string) => this.#nullifierToTxHash.get(nullifier),
+      getTxHashesByFeePayer: (feePayer: string) => this.#feePayerToTxHashes.get(feePayer),
+      getPendingTxCount: () => this.getPendingTxCount(),
+    };
+  }
+
+  // === Metrics ===
+
+  countTxs(): { pending: number; protected: number; mined: number } {
+    let pending = 0;
+    let protected_ = 0;
+    let mined = 0;
+
+    for (const meta of this.#metadata.values()) {
+      const state = this.#getTxState(meta);
+      if (state === 'pending') {
+        pending++;
+      } else if (state === 'protected') {
+        protected_++;
+      } else if (state === 'mined') {
+        mined++;
+      }
+    }
+
+    return { pending, protected: protected_, mined };
+  }
+
+  // ============================================================================
+  // PRIVATE QUERY IMPLEMENTATIONS
+  // ============================================================================
+
+  /**
+   * Derives the transaction state from its metadata and protection status.
+   * A transaction is:
+   * - 'mined' if it has a minedL2BlockId
+   * - 'protected' if it's in the protectedTransactions map (but not mined)
+   * - 'pending' otherwise
+   */
+  #getTxState(meta: TxMetaData): TxState {
+    if (meta.minedL2BlockId !== undefined) {
+      return 'mined';
+    } else if (this.#protectedTransactions.has(meta.txHash)) {
+      return 'protected';
+    } else {
+      return 'pending';
+    }
+  }
+
+  /**
+   * Iterates pending transaction hashes in priority order.
+   * @param order - 'desc' for highest priority first, 'asc' for lowest priority first
+   */
+  *#iteratePendingByPriority(order: 'asc' | 'desc'): Generator<string> {
+    // Use shared comparators, negating for descending order
+    const feeCompareFn =
+      order === 'desc' ? (a: bigint, b: bigint) => compareFee(b, a) : (a: bigint, b: bigint) => compareFee(a, b);
+    const hashCompareFn =
+      order === 'desc' ? (a: string, b: string) => compareTxHash(b, a) : (a: string, b: string) => compareTxHash(a, b);
+
+    const sortedFees = [...this.#pendingByPriority.keys()].sort(feeCompareFn);
+
+    for (const fee of sortedFees) {
+      const hashesAtFee = this.#pendingByPriority.get(fee)!;
+      const sortedHashes = [...hashesAtFee].sort(hashCompareFn);
+      for (const hash of sortedHashes) {
+        yield hash;
+      }
+    }
+  }
+
+  // ============================================================================
+  // HELPER FUNCTIONS - Pipeline Step Functions
+  // ============================================================================
+
+  // --- Finding & Filtering Steps ---
+
+  /** Finds all transactions mined in blocks after the given block number */
+  #findTxsMinedAfter(blockNumber: number): TxMetaData[] {
+    const result: TxMetaData[] = [];
+    for (const meta of this.#metadata.values()) {
+      if (meta.minedL2BlockId !== undefined && meta.minedL2BlockId.number > blockNumber) {
+        result.push(meta);
+      }
+    }
+    return result;
+  }
+
+  /** Finds tx hashes mined at or before the given block number */
+  #findTxsMinedAtOrBefore(blockNumber: number): string[] {
+    const result: string[] = [];
+    for (const [txHashStr, meta] of this.#metadata) {
+      if (meta.minedL2BlockId !== undefined && meta.minedL2BlockId.number <= blockNumber) {
+        result.push(txHashStr);
+      }
+    }
+    return result;
+  }
+
+  /** Finds protected tx hashes from slots earlier than the given slot number */
+  #findExpiredProtectedTxs(slotNumber: SlotNumber): string[] {
+    const result: string[] = [];
+    for (const [txHashStr, protectedSlot] of this.#protectedTransactions) {
+      if (protectedSlot < slotNumber) {
+        result.push(txHashStr);
+      }
+    }
+    return result;
+  }
+
+  /** Filters out transactions that are currently protected */
+  #filterUnprotected(txs: TxMetaData[]): TxMetaData[] {
+    return txs.filter(meta => !this.#protectedTransactions.has(meta.txHash));
+  }
+
+  /** Filters to transactions that have metadata and are not mined */
+  #filterRestorable(txHashes: string[]): TxMetaData[] {
+    const result: TxMetaData[] = [];
+    for (const txHashStr of txHashes) {
+      const meta = this.#metadata.get(txHashStr);
+      if (meta && meta.minedL2BlockId === undefined) {
+        result.push(meta);
+      }
+    }
+    return result;
+  }
+
+  // --- Validation & Conflict Resolution Steps ---
+
+  /** Validates transactions for pending pool, returning valid and invalid groups */
+  async #validateForPending(txs: TxMetaData[]): Promise<{ valid: TxMetaData[]; invalid: string[] }> {
+    const valid: TxMetaData[] = [];
+    const invalid: string[] = [];
+
+    for (const meta of txs) {
+      const buffer = await this.#txsDB.getAsync(meta.txHash);
+      if (!buffer) {
+        this.#log.warn(`Tx ${meta.txHash} not found in DB during validation`);
+        invalid.push(meta.txHash);
+        continue;
+      }
+
+      const tx = Tx.fromBuffer(buffer);
+      const result = await this.#pendingTxValidator.validateTx(tx);
+
+      if (result.result === 'valid') {
+        valid.push(meta);
+      } else {
+        this.#log.info(`Tx ${meta.txHash} failed validation: ${result.reason?.join(', ')}`);
+        invalid.push(meta.txHash);
+      }
+    }
+
+    return { valid, invalid };
+  }
+
+  /**
+   * Resolves nullifier conflicts between incoming txs and existing pending txs.
+   * Modifies the pending indices during iteration to maintain consistent state
+   * for subsequent conflict checks within the same batch.
+   */
+  #applyNullifierConflictResolution(txs: TxMetaData[]): { added: TxMetaData[]; toEvict: string[] } {
+    const added: TxMetaData[] = [];
+    const toEvict: string[] = [];
+
+    for (const meta of txs) {
+      const conflict = checkNullifierConflict(
+        meta,
+        nullifier => this.#nullifierToTxHash.get(nullifier),
+        txHash => this.#metadata.get(txHash),
+      );
+      if (conflict.shouldIgnore) {
+        // Lower priority than existing - don't add, mark for deletion
+        toEvict.push(meta.txHash);
+      } else {
+        // Higher priority - evict existing conflicts
+        toEvict.push(...conflict.txHashesToEvict);
+        // Remove evicted from indices immediately for subsequent checks
+        for (const evictHash of conflict.txHashesToEvict) {
+          const evictMeta = this.#metadata.get(evictHash);
+          if (evictMeta) {
+            this.#removeFromPendingIndices(evictMeta);
+          }
+        }
+        // Add to pending indices immediately so subsequent txs in the batch see this tx
+        this.#addToPendingIndices(meta);
+        added.push(meta);
+      }
+    }
+
+    return { added, toEvict };
+  }
+
+  // --- State Transition Steps ---
+
+  /** Clears the mined status from transactions, returning them for further processing */
+  #unmineTxs(txs: TxMetaData[]): TxMetaData[] {
+    for (const meta of txs) {
+      meta.minedL2BlockId = undefined;
+    }
+    return txs;
+  }
+
+  /** Removes protection from tx hashes and clears them from the protected map */
+  #clearProtection(txHashes: string[]): void {
+    for (const txHashStr of txHashes) {
+      this.#protectedTransactions.delete(txHashStr);
+    }
+  }
+
+  // --- Batch Operation Steps ---
+
+  /** Deletes a batch of transactions permanently */
+  async #deleteTxsBatch(txHashes: string[]): Promise<void> {
+    if (txHashes.length === 0) {
+      return;
+    }
+
+    await this.#store.transactionAsync(async () => {
+      for (const txHashStr of txHashes) {
+        await this.#deleteTx(txHashStr);
+      }
+    });
+
+    this.#callbacks.onTxsRemoved(txHashes);
+  }
+
+  // --- Block & Tx Info Steps ---
+
+  /** Builds a block ID from a block header */
+  async #buildBlockId(block: BlockHeader): Promise<L2BlockId> {
+    return {
+      number: block.globalVariables.blockNumber,
+      hash: (await block.hash()).toString(),
+    };
+  }
+
+  /** Checks if a tx is already mined and returns its block ID if so */
+  async #getMinedBlockId(txHash: TxHash): Promise<L2BlockId | undefined> {
+    const txEffect = await this.#l2BlockSource.getTxEffect(txHash);
+    if (!txEffect) {
+      return undefined;
+    }
+    return {
+      number: txEffect.l2BlockNumber,
+      hash: txEffect.l2BlockHash.toString(),
+    };
+  }
+
+  /** Marks a batch of transactions as mined */
+  #markTxsAsMined(metas: TxMetaData[], blockId: L2BlockId): void {
+    for (const meta of metas) {
+      this.#markAsMined(meta, blockId);
+    }
+  }
+
+  // --- Add Transaction Steps ---
+
+  /** Persists a transaction to the database */
+  async #persistTx(txHashStr: string, tx: Tx): Promise<void> {
+    await this.#txsDB.set(txHashStr, tx.toBuffer());
+  }
+
+  /** Adds a new transaction as protected, returning its metadata */
+  async #addNewProtectedTx(tx: Tx, slotNumber: SlotNumber): Promise<TxMetaData> {
+    const txHashStr = tx.getTxHash().toString();
+    const meta = await buildTxMetaData(tx);
+
+    this.#protectedTransactions.set(txHashStr, slotNumber);
+    await this.#persistTx(txHashStr, tx);
+    this.#metadata.set(txHashStr, meta);
+    // Don't add to pending indices since it's protected
+
+    this.#log.verbose(`Added protected tx ${txHashStr} for slot ${slotNumber}`);
+    return meta;
+  }
+
+  /** Adds a new transaction as mined, returning its metadata */
+  async #addNewMinedTx(tx: Tx, blockId: L2BlockId): Promise<TxMetaData> {
+    const txHashStr = tx.getTxHash().toString();
+    const meta = await buildTxMetaData(tx);
+    meta.minedL2BlockId = blockId;
+
+    await this.#persistTx(txHashStr, tx);
+    this.#metadata.set(txHashStr, meta);
+    // Don't add to pending indices since it's mined
+
+    this.#log.verbose(`Added mined tx ${txHashStr} from block ${blockId.number}`);
+    return meta;
+  }
+
+  // --- Hydration Steps ---
+
+  /** Loads all transactions from the database, returning loaded txs and deserialization errors */
+  async #loadAllTxsFromDb(): Promise<{
+    loaded: { tx: Tx; meta: TxMetaData }[];
+    errors: string[];
+  }> {
+    const loaded: { tx: Tx; meta: TxMetaData }[] = [];
+    const errors: string[] = [];
+
+    for await (const [txHashStr, buffer] of this.#txsDB.entriesAsync()) {
+      try {
+        const tx = Tx.fromBuffer(buffer);
+        const meta = await buildTxMetaData(tx);
+        loaded.push({ tx, meta });
+      } catch (err) {
+        this.#log.warn(`Failed to deserialize tx ${txHashStr}, deleting`, { err });
+        errors.push(txHashStr);
+      }
+    }
+
+    return { loaded, errors };
+  }
+
+  /** Queries block source and marks mined status on transaction metadata */
+  async #markMinedStatusBatch(metas: TxMetaData[]): Promise<void> {
+    for (const meta of metas) {
+      try {
+        const txEffect = await this.#l2BlockSource.getTxEffect(TxHash.fromString(meta.txHash));
+        if (txEffect) {
+          meta.minedL2BlockId = {
+            number: txEffect.l2BlockNumber,
+            hash: txEffect.l2BlockHash.toString(),
+          };
+        }
+      } catch (err) {
+        this.#log.warn(`Failed to check mined status for tx ${meta.txHash}`, { err });
+      }
+    }
+  }
+
+  /** Partitions transactions by mined status */
+  #partitionByMinedStatus(txs: { tx: Tx; meta: TxMetaData }[]): {
+    mined: TxMetaData[];
+    nonMined: { tx: Tx; meta: TxMetaData }[];
+  } {
+    const mined: TxMetaData[] = [];
+    const nonMined: { tx: Tx; meta: TxMetaData }[] = [];
+
+    for (const entry of txs) {
+      if (entry.meta.minedL2BlockId !== undefined) {
+        mined.push(entry.meta);
+      } else {
+        nonMined.push(entry);
+      }
+    }
+
+    return { mined, nonMined };
+  }
+
+  /** Validates non-mined transactions, returning valid metadata and invalid hashes */
+  async #validateNonMinedTxs(txs: { tx: Tx; meta: TxMetaData }[]): Promise<{ valid: TxMetaData[]; invalid: string[] }> {
+    const valid: TxMetaData[] = [];
+    const invalid: string[] = [];
+
+    for (const { tx, meta } of txs) {
+      const result = await this.#pendingTxValidator.validateTx(tx);
+      if (result.result === 'valid') {
+        valid.push(meta);
+      } else {
+        this.#log.info(`Removing invalid tx ${meta.txHash} on startup: ${result.reason?.join(', ')}`);
+        invalid.push(meta.txHash);
+      }
+    }
+
+    return { valid, invalid };
+  }
+
+  /** Populates metadata index for mined transactions */
+  #populateMinedIndices(metas: TxMetaData[]): void {
+    for (const meta of metas) {
+      this.#metadata.set(meta.txHash, meta);
+    }
+  }
+
+  /**
+   * Rebuilds the pending pool by processing each tx through pre-add rules.
+   * Starts with an empty pending pool and adds txs one by one, resolving conflicts.
+   * Returns the list of accepted and rejected tx hashes.
+   */
+  async #rebuildPendingPool(metas: TxMetaData[]): Promise<{ accepted: string[]; rejected: string[] }> {
+    const accepted = new Set<string>();
+    const rejected: string[] = [];
+    const poolAccess = this.#createPreAddPoolAccess();
+
+    for (const meta of metas) {
+      // Run pre-add rules against current pending pool state (metadata not yet in pool)
+      const preAddResult = await this.#evictionManager.runPreAddRules(meta, poolAccess);
+
+      if (preAddResult.shouldIgnore) {
+        // Transaction rejected - mark for deletion from DB
+        rejected.push(meta.txHash);
+        this.#log.debug(`Rejected tx ${meta.txHash} during rebuild: ${preAddResult.reason}`);
+        continue;
+      }
+
+      // Evict any conflicting txs identified by pre-add rules
+      for (const evictHashStr of preAddResult.txHashesToEvict) {
+        const evictMeta = this.#metadata.get(evictHashStr);
+        if (evictMeta) {
+          this.#removeFromPendingIndices(evictMeta);
+          this.#metadata.delete(evictHashStr);
+          rejected.push(evictHashStr);
+          accepted.delete(evictHashStr);
+          this.#log.debug(`Evicted tx ${evictHashStr} during rebuild due to conflict with ${meta.txHash}`);
+        }
+      }
+
+      // Add to metadata and pending indices
+      this.#addToIndices(meta);
+      accepted.add(meta.txHash);
+    }
+
+    this.#log.info(`Rebuilt pending pool: ${accepted.size} accepted, ${rejected.length} rejected`);
+    return { accepted: [...accepted], rejected };
+  }
+
+  // --- Add Pending Tx Steps ---
+
+  /** Checks if a tx is a duplicate (already in pool) */
+  #isDuplicateTx(txHashStr: string): boolean {
+    return this.#metadata.has(txHashStr);
+  }
+
+  /** Adds a new pending tx to the pool, returning its metadata */
+  async #addNewPendingTx(tx: Tx): Promise<TxMetaData> {
+    const txHashStr = tx.getTxHash().toString();
+    const meta = await buildTxMetaData(tx);
+
+    await this.#persistTx(txHashStr, tx);
+    this.#addToIndices(meta);
+
+    this.#log.verbose(`Added tx ${txHashStr} to pool`, {
+      eventName: 'tx-added-to-pool',
+      state: this.#getTxState(meta),
+    });
+
+    return meta;
+  }
+
+  // ============================================================================
+  // HELPER FUNCTIONS - Index Management
+  // ============================================================================
+
+  #addToIndices(meta: TxMetaData): void {
+    this.#metadata.set(meta.txHash, meta);
+
+    if (this.#getTxState(meta) === 'pending') {
+      this.#addToPendingIndices(meta);
+    }
+    // Protected and mined txs don't go into pending indices
+  }
+
+  #addToPendingIndices(meta: TxMetaData): void {
+    // Add to nullifier index
+    for (const nullifier of meta.nullifiers) {
+      this.#nullifierToTxHash.set(nullifier, meta.txHash);
+    }
+
+    // Add to fee payer index
+    let feePayerSet = this.#feePayerToTxHashes.get(meta.feePayer);
+    if (!feePayerSet) {
+      feePayerSet = new Set();
+      this.#feePayerToTxHashes.set(meta.feePayer, feePayerSet);
+    }
+    feePayerSet.add(meta.txHash);
+
+    // Add to priority bucket
+    let prioritySet = this.#pendingByPriority.get(meta.priorityFee);
+    if (!prioritySet) {
+      prioritySet = new Set();
+      this.#pendingByPriority.set(meta.priorityFee, prioritySet);
+    }
+    prioritySet.add(meta.txHash);
+  }
+
+  #removeFromPendingIndices(meta: TxMetaData): void {
+    // Remove from nullifier index
+    for (const nullifier of meta.nullifiers) {
+      this.#nullifierToTxHash.delete(nullifier);
+    }
+
+    // Remove from fee payer index
+    const feePayerSet = this.#feePayerToTxHashes.get(meta.feePayer);
+    if (feePayerSet) {
+      feePayerSet.delete(meta.txHash);
+      if (feePayerSet.size === 0) {
+        this.#feePayerToTxHashes.delete(meta.feePayer);
+      }
+    }
+
+    // Remove from priority map
+    const hashSet = this.#pendingByPriority.get(meta.priorityFee);
+    if (hashSet) {
+      hashSet.delete(meta.txHash);
+      if (hashSet.size === 0) {
+        this.#pendingByPriority.delete(meta.priorityFee);
+      }
+    }
+  }
+
+  #updateProtection(txHashStr: string, slotNumber: SlotNumber): void {
+    const currentSlot = this.#protectedTransactions.get(txHashStr);
+
+    // Only update if not already protected at an equal or later slot
+    if (currentSlot !== undefined && currentSlot >= slotNumber) {
+      return;
+    }
+
+    // Remove from pending indices if transitioning from pending to protected
+    if (currentSlot === undefined) {
+      const meta = this.#metadata.get(txHashStr);
+      if (meta) {
+        this.#removeFromPendingIndices(meta);
+      }
+    }
+
+    this.#protectedTransactions.set(txHashStr, slotNumber);
+  }
+
+  #markAsMined(meta: TxMetaData, blockId: L2BlockId): void {
+    meta.minedL2BlockId = blockId;
+    // Safe to call unconditionally - removeFromPendingIndices is idempotent
+    this.#removeFromPendingIndices(meta);
+  }
+
+  async #deleteTx(txHashStr: string): Promise<void> {
+    const meta = this.#metadata.get(txHashStr);
+    if (!meta) {
+      return;
+    }
+
+    // Remove from all indices
+    this.#metadata.delete(txHashStr);
+    this.#protectedTransactions.delete(txHashStr);
+    this.#removeFromPendingIndices(meta);
+
+    // Remove from persistence
+    await this.#txsDB.delete(txHashStr);
+  }
+
+  // ============================================================================
+  // HELPER FUNCTIONS - Adapters
+  // ============================================================================
+
+  /** Gets all pending transactions for a given fee payer. */
+  #getFeePayerPendingTxs(feePayer: string): TxMetaData[] {
+    const txHashes = this.#feePayerToTxHashes.get(feePayer);
+    if (!txHashes) {
+      return [];
+    }
+    const result: TxMetaData[] = [];
+    for (const txHashStr of txHashes) {
+      const meta = this.#metadata.get(txHashStr);
+      if (meta && this.#getTxState(meta) === 'pending') {
+        result.push(meta);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Creates a PoolOperations adapter for use with the eviction manager.
+   */
+  #createPoolOperations(): PoolOperations {
+    return {
+      getPendingTxs: (): TxMetaData[] => {
+        const result: TxMetaData[] = [];
+        for (const hashSet of this.#pendingByPriority.values()) {
+          for (const txHashStr of hashSet) {
+            const meta = this.#metadata.get(txHashStr);
+            if (meta) {
+              result.push(meta);
+            }
+          }
+        }
+        return result;
+      },
+      getPendingFeePayers: (): string[] => {
+        return Array.from(this.#feePayerToTxHashes.keys());
+      },
+      getFeePayerPendingTxs: (feePayer: string): TxMetaData[] => {
+        return this.#getFeePayerPendingTxs(feePayer);
+      },
+      getPendingTxCount: (): number => {
+        return this.getPendingTxCount();
+      },
+      getLowestPriorityPending: (limit: number): string[] => {
+        return this.getLowestPriorityPending(limit).map(h => h.toString());
+      },
+      deleteTxs: async (txHashes: string[]): Promise<void> => {
+        await this.#store.transactionAsync(async () => {
+          for (const txHashStr of txHashes) {
+            await this.#deleteTx(txHashStr);
+          }
+        });
+        this.#callbacks.onTxsRemoved(txHashes);
+      },
+    };
+  }
+
+  /**
+   * Creates a PreAddPoolAccess adapter for use with pre-add eviction rules.
+   * All methods work with strings and TxMetaData for efficiency.
+   */
+  #createPreAddPoolAccess(): PreAddPoolAccess {
+    return {
+      getMetadata: (txHashStr: string): TxMetaData | undefined => {
+        const meta = this.#metadata.get(txHashStr);
+        if (!meta || this.#getTxState(meta) !== 'pending') {
+          return undefined;
+        }
+        return meta;
+      },
+      getTxHashByNullifier: (nullifier: string): string | undefined => {
+        return this.#nullifierToTxHash.get(nullifier);
+      },
+      getFeePayerBalance: async (feePayer: string): Promise<bigint> => {
+        const db = this.#worldStateSynchronizer.getCommitted();
+        const publicStateSource = new DatabasePublicStateSource(db);
+        const balance = await publicStateSource.storageRead(
+          ProtocolContractAddress.FeeJuice,
+          await computeFeePayerBalanceStorageSlot(AztecAddress.fromString(feePayer)),
+        );
+        return balance.toBigInt();
+      },
+      getFeePayerPendingTxs: (feePayer: string): TxMetaData[] => {
+        return this.#getFeePayerPendingTxs(feePayer);
+      },
+      getPendingTxCount: (): number => {
+        return this.getPendingTxCount();
+      },
+      getLowestPriorityPendingTx: (): TxMetaData | undefined => {
+        // Iterate in ascending order to find the lowest priority
+        for (const txHashStr of this.#iteratePendingByPriority('asc')) {
+          const meta = this.#metadata.get(txHashStr);
+          if (meta) {
+            return meta;
+          }
+        }
+        return undefined;
+      },
+    };
+  }
+}


### PR DESCRIPTION
Addresses Issue [A-481](https://linear.app/aztec-labs/issue/A-481/implement-new-transaction-pool-design)

## Summary

- Introduces a new transaction pool implementation (`TxPoolV2`) with explicit state management
- Transactions flow through states: pending → protected → mined → deleted
- Implements a pluggable eviction rules system for managing pool size and transaction validity
- Adds transaction validation using `pendingTxValidator` before adding to pending pool
- Includes archive support for finalized transactions

### Key Components

- **State Management**: Transactions have explicit states (pending, protected, mined) with clear transitions
- **Eviction Rules**: Modular rules for nullifier conflicts, fee payer balance limits, pool size limits, and post-reorg validation
- **Pre-add Rules**: Validation before adding transactions (duplicates, nullifier conflicts, fee payer balance)
- **Archive**: Optional archiving of finalized transactions for historical queries

### Test Coverage

- 131 unit tests covering all state transitions and edge cases
- Compatibility tests ensuring feature parity with existing pool
- Benchmarks for performance measurement (`addPendingTxs`, `canAddPendingTx`, `handlePrunedBlocks`, etc.)

## Test plan

- [x] Unit tests pass: `yarn test src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts` (131 tests)
- [x] Compatibility tests pass: `yarn test src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts` (25 tests)
- [x] Eviction rule tests pass: `yarn test src/mem_pools/tx_pool_v2/eviction/` (86 tests)
- [x] Benchmarks run: `yarn test src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)