### PR TITLE
refactor: IndexedDB-friendly PXE stores 

### DIFF
--- a/yarn-project/pxe/src/storage/address_store/address_store.ts
+++ b/yarn-project/pxe/src/storage/address_store/address_store.ts
@@ -43,23 +43,23 @@ export class AddressStore {
     });
   }
 
-  async #getCompleteAddress(address: AztecAddress): Promise<CompleteAddress | undefined> {
-    const index = await this.#completeAddressIndex.getAsync(address.toString());
-    if (index === undefined) {
-      return undefined;
-    }
-
-    const value = await this.#completeAddresses.atAsync(index);
-    return value ? await CompleteAddress.fromBuffer(value) : undefined;
-  }
-
   getCompleteAddress(account: AztecAddress): Promise<CompleteAddress | undefined> {
-    return this.#getCompleteAddress(account);
+    return this.#store.transactionAsync(async () => {
+      const index = await this.#completeAddressIndex.getAsync(account.toString());
+      if (index === undefined) {
+        return undefined;
+      }
+
+      const value = await this.#completeAddresses.atAsync(index);
+      return value ? await CompleteAddress.fromBuffer(value) : undefined;
+    });
   }
 
-  async getCompleteAddresses(): Promise<CompleteAddress[]> {
-    return await Promise.all(
-      (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v)),
-    );
+  getCompleteAddresses(): Promise<CompleteAddress[]> {
+    return this.#store.transactionAsync(async () => {
+      return await Promise.all(
+        (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v)),
+      );
+    });
   }
 }

--- a/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
+++ b/yarn-project/pxe/src/storage/anchor_block_store/anchor_block_store.ts
@@ -10,6 +10,14 @@ export class AnchorBlockStore {
     this.#synchronizedHeader = this.#store.openSingleton('header');
   }
 
+  /**
+   * Sets the currently synchronized block
+   *
+   * Important: this method is only called from BlockSynchronizer, and since we need it to run atomically with other
+   * stores in the case of a reorg, it MUST NOT be wrapped in a `transactionAsync` call. Doing so would result in a
+   * deadlock when the backend is IndexedDB, because `transactionAsync` is not designed to support reentrancy.
+   *
+   */
   async setHeader(header: BlockHeader): Promise<void> {
     await this.#synchronizedHeader.set(header.toBuffer());
   }

--- a/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
+++ b/yarn-project/pxe/src/storage/capsule_store/capsule_store.ts
@@ -57,14 +57,14 @@ export class CapsuleStore implements StagedStore {
    */
   async #getFromStage(jobId: string, dbSlotKey: string): Promise<Buffer | null | undefined> {
     const jobStagedCapsules = this.#getJobStagedCapsules(jobId);
-    let staged: Buffer | null | undefined = jobStagedCapsules.get(dbSlotKey);
-    // Note that if staged === null, we marked it for deletion, so we don't want to
-    // re-read it from DB
-    if (staged === undefined) {
-      // If we don't have a staged version of this dbSlotKey, first we check if there's one in DB
-      staged = await this.#loadCapsuleFromDb(dbSlotKey);
-    }
-    return staged;
+    const staged: Buffer | null | undefined = jobStagedCapsules.get(dbSlotKey);
+
+    // Always issue DB read to keep IndexedDB transaction alive, even if the value is in the job staged data. This
+    // keeps IndexedDB transactions alive (they auto-commit when a new micro-task starts and there are no pending read
+    // requests). The staged value still takes precedence if it exists (including null for deletions).
+    const dbValue = await this.#loadCapsuleFromDb(dbSlotKey);
+
+    return staged !== undefined ? staged : dbValue;
   }
 
   /**

--- a/yarn-project/pxe/src/storage/contract_store/contract_store.ts
+++ b/yarn-project/pxe/src/storage/contract_store/contract_store.ts
@@ -42,10 +42,12 @@ export class ContractStore {
   /** Map from contract address to contract class id */
   #contractClassIdMap: Map<string, Fr> = new Map();
 
+  #store: AztecAsyncKVStore;
   #contractArtifacts: AztecAsyncMap<string, Buffer>;
   #contractInstances: AztecAsyncMap<string, Buffer>;
 
   constructor(store: AztecAsyncKVStore) {
+    this.#store = store;
     this.#contractArtifacts = store.openMap('contract_artifacts');
     this.#contractInstances = store.openMap('contracts_instances');
   }
@@ -53,6 +55,7 @@ export class ContractStore {
   // Setters
 
   public async addContractArtifact(id: Fr, contract: ContractArtifact): Promise<void> {
+    // Validation outside transactionAsync - these are not DB operations
     const privateFunctions = contract.functions.filter(
       functionArtifact => functionArtifact.functionType === FunctionType.PRIVATE,
     );
@@ -69,7 +72,9 @@ export class ContractStore {
       throw new Error('Repeated function selectors of private functions');
     }
 
-    await this.#contractArtifacts.set(id.toString(), contractArtifactToBuffer(contract));
+    await this.#store.transactionAsync(() =>
+      this.#contractArtifacts.set(id.toString(), contractArtifactToBuffer(contract)),
+    );
   }
 
   async addContractInstance(contract: ContractInstanceWithAddress): Promise<void> {
@@ -123,21 +128,27 @@ export class ContractStore {
 
   // Public getters
 
-  async getContractsAddresses(): Promise<AztecAddress[]> {
-    const keys = await toArray(this.#contractInstances.keysAsync());
-    return keys.map(AztecAddress.fromString);
+  getContractsAddresses(): Promise<AztecAddress[]> {
+    return this.#store.transactionAsync(async () => {
+      const keys = await toArray(this.#contractInstances.keysAsync());
+      return keys.map(AztecAddress.fromString);
+    });
   }
 
   /** Returns a contract instance for a given address. Throws if not found. */
-  public async getContractInstance(contractAddress: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    const contract = await this.#contractInstances.getAsync(contractAddress.toString());
-    return contract && SerializableContractInstance.fromBuffer(contract).withAddress(contractAddress);
+  public getContractInstance(contractAddress: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    return this.#store.transactionAsync(async () => {
+      const contract = await this.#contractInstances.getAsync(contractAddress.toString());
+      return contract && SerializableContractInstance.fromBuffer(contract).withAddress(contractAddress);
+    });
   }
 
-  public async getContractArtifact(contractClassId: Fr): Promise<ContractArtifact | undefined> {
-    const contract = await this.#contractArtifacts.getAsync(contractClassId.toString());
-    // TODO(@spalladino): AztecAsyncMap lies and returns Uint8Arrays instead of Buffers, hence the extra Buffer.from.
-    return contract && contractArtifactFromBuffer(Buffer.from(contract));
+  public getContractArtifact(contractClassId: Fr): Promise<ContractArtifact | undefined> {
+    return this.#store.transactionAsync(async () => {
+      const contract = await this.#contractArtifacts.getAsync(contractClassId.toString());
+      // TODO(@spalladino): AztecAsyncMap lies and returns Uint8Arrays instead of Buffers, hence the extra Buffer.from.
+      return contract && contractArtifactFromBuffer(Buffer.from(contract));
+    });
   }
 
   /** Returns a contract class for a given class id. Throws if not found. */

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -1,4 +1,3 @@
-import { toArray } from '@aztec/foundation/iterable';
 import { Semaphore } from '@aztec/foundation/queue';
 import type { Fr } from '@aztec/foundation/schemas';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
@@ -17,6 +16,8 @@ import { StoredNote } from './stored_note.js';
  **/
 export class NoteStore implements StagedStore {
   readonly storeName: string = 'note';
+
+  #store: AztecAsyncKVStore;
 
   // Note that we use the siloedNullifier as the note id in the store as it's guaranteed to be unique.
 
@@ -46,6 +47,7 @@ export class NoteStore implements StagedStore {
   #jobLocks: Map<string, Semaphore>;
 
   constructor(store: AztecAsyncKVStore) {
+    this.#store = store;
     this.#notes = store.openMap('notes');
     this.#nullifiersByContractAddress = store.openMultiMap('note_nullifiers_by_contract');
     this.#nullifiersByNullificationBlockNumber = store.openMultiMap('note_block_number_to_nullifier');
@@ -65,32 +67,26 @@ export class NoteStore implements StagedStore {
    * @param jobId - The job context for staged writes
    */
   public addNotes(notes: NoteDao[], scope: AztecAddress, jobId: string): Promise<void[]> {
-    return this.#withJobLock(jobId, () => Promise.all(notes.map(noteDao => this.#addNote(noteDao, scope, jobId))));
-  }
-
-  async #addNote(note: NoteDao, scope: AztecAddress, jobId: string) {
-    const noteForJob =
-      (await this.#readNote(note.siloedNullifier.toString(), jobId)) ?? new StoredNote(note, new Set());
-
-    // Make sure the note is linked to the scope and staged for this job
-    noteForJob.addScope(scope.toString());
-    this.#writeNote(noteForJob, jobId);
+    return this.#withJobLock(jobId, () =>
+      this.#store.transactionAsync(() =>
+        Promise.all(
+          notes.map(async note => {
+            const noteForJob =
+              (await this.#readNote(note.siloedNullifier.toString(), jobId)) ?? new StoredNote(note, new Set());
+            noteForJob.addScope(scope.toString());
+            this.#writeNote(noteForJob, jobId);
+          }),
+        ),
+      ),
+    );
   }
 
   async #readNote(nullifier: string, jobId: string): Promise<StoredNote | undefined> {
-    // First check staged notes for this job
-    const noteForJob = this.#getNotesForJob(jobId).get(nullifier);
-    if (noteForJob) {
-      return noteForJob;
-    }
-
-    // Then check persistent storage
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
     const noteBuffer = await this.#notes.getAsync(nullifier);
-    if (noteBuffer) {
-      return StoredNote.fromBuffer(noteBuffer);
-    }
-
-    return undefined;
+    const noteForJob = this.#getNotesForJob(jobId).get(nullifier);
+    return noteForJob ?? (noteBuffer ? StoredNote.fromBuffer(noteBuffer) : undefined);
   }
 
   #writeNote(note: StoredNote, jobId: string) {
@@ -109,57 +105,98 @@ export class NoteStore implements StagedStore {
    * returned once if this is the case)
    * @throws If filtering by an empty scopes array. Scopes have to be set to undefined or to a non-empty array.
    */
-  async getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
+  getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
     if (filter.scopes !== undefined && filter.scopes.length === 0) {
-      throw new Error('Trying to get notes with an empty scopes array');
+      return Promise.reject(new Error('Trying to get notes with an empty scopes array'));
     }
 
-    const targetStatus = filter.status ?? NoteStatus.ACTIVE;
+    return this.#store.transactionAsync(async () => {
+      const targetStatus = filter.status ?? NoteStatus.ACTIVE;
 
-    const foundNotes: Map<string, NoteDao> = new Map();
+      // The code below might read a bit unnatural, the reason is that we need to be careful in how we use `await` inside
+      // `transactionAsync`, otherwise browsers might choose to auto-commit the IndexedDB transaction forcing us to
+      // explicitly handle that condition. The rule we need to honor is: do not await unless you generate a database
+      // read or write or you're done using the DB for the remainder of the transaction. The following sequence is
+      // unsafe in IndexedDB:
+      //
+      // 1. start transactionAsync()
+      // 2. await readDb() <-- OK, transaction alive because we issued DB ops
+      // 3. run a bunch of computations (no await involved) <-- OK, tx alive because we are in the same microtask
+      // 4. await doSthNotInDb() <-- no DB ops issued in this task, browser's free to decide to commit the tx
+      // 5. await readDb() <-- BOOM, TransactionInactiveError
+      //
+      // Note that the real issue is in step number 5: we try to continue using a transaction that the browser might
+      // have already committed.
+      //
+      // We need to read candidate notes which are either indexed by contract address in the DB (in
+      // #nullifiersByContractAddress), or lie in memory for the not yet committed `jobId`.
+      // So we collect promises based on both sources without awaiting for them.
+      const noteReadPromises: Map<string, Promise<StoredNote | undefined>> = new Map();
 
-    const nullifiersOfContract = await this.#nullifiersOfContract(filter.contractAddress, jobId);
-    for (const nullifier of nullifiersOfContract) {
-      const note = await this.#readNote(nullifier, jobId);
-
-      // Defensive: hitting this case means we're mishandling contract indices or in-memory job data
-      if (!note) {
-        throw new Error('PXE note database is corrupted.');
+      // Awaiting the getValuesAsync iterator is fine because it's reading from the DB
+      for await (const nullifier of this.#nullifiersByContractAddress.getValuesAsync(
+        filter.contractAddress.toString(),
+      )) {
+        // Each #readNote will perform a DB read
+        noteReadPromises.set(nullifier, this.#readNote(nullifier, jobId));
       }
 
-      // Apply filters
-      if (targetStatus === NoteStatus.ACTIVE && note.isNullified()) {
-        continue;
+      // Add staged nullifiers from job, no awaits involved, so we are fine
+      for (const storedNote of this.#getNotesForJob(jobId).values()) {
+        if (storedNote.noteDao.contractAddress.equals(filter.contractAddress)) {
+          const nullifier = storedNote.noteDao.siloedNullifier.toString();
+          if (!noteReadPromises.has(nullifier)) {
+            noteReadPromises.set(nullifier, Promise.resolve(storedNote));
+          }
+        }
       }
 
-      if (filter.owner && !note.noteDao.owner.equals(filter.owner)) {
-        continue;
+      // By now we have pending DB requests from all the #readNote calls. Await them all together.
+      const notes = await Promise.all(noteReadPromises.values());
+
+      // The rest of the function is await-free, and just deals with filtering and sorting our findings.
+      const foundNotes: Map<string, NoteDao> = new Map();
+
+      for (const note of notes) {
+        // Defensive: hitting this case means we're mishandling contract indices or in-memory job data
+        if (!note) {
+          throw new Error('PXE note database is corrupted.');
+        }
+
+        // Apply filters
+        if (targetStatus === NoteStatus.ACTIVE && note.isNullified()) {
+          continue;
+        }
+
+        if (filter.owner && !note.noteDao.owner.equals(filter.owner)) {
+          continue;
+        }
+
+        if (filter.storageSlot && !note.noteDao.storageSlot.equals(filter.storageSlot)) {
+          continue;
+        }
+
+        if (filter.siloedNullifier && !note.noteDao.siloedNullifier.equals(filter.siloedNullifier)) {
+          continue;
+        }
+
+        if (filter.scopes && note.scopes.intersection(new Set(filter.scopes.map(s => s.toString()))).size === 0) {
+          continue;
+        }
+
+        foundNotes.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
       }
 
-      if (filter.storageSlot && !note.noteDao.storageSlot.equals(filter.storageSlot)) {
-        continue;
-      }
-
-      if (filter.siloedNullifier && !note.noteDao.siloedNullifier.equals(filter.siloedNullifier)) {
-        continue;
-      }
-
-      if (filter.scopes && note.scopes.intersection(new Set(filter.scopes.map(s => s.toString()))).size === 0) {
-        continue;
-      }
-
-      foundNotes.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
-    }
-
-    // Sort by block number, then by tx index within block, then by note index within tx
-    return [...foundNotes.values()].sort((a, b) => {
-      if (a.l2BlockNumber !== b.l2BlockNumber) {
-        return a.l2BlockNumber - b.l2BlockNumber;
-      }
-      if (a.txIndexInBlock !== b.txIndexInBlock) {
-        return a.txIndexInBlock - b.txIndexInBlock;
-      }
-      return a.noteIndexInTx - b.noteIndexInTx;
+      // Sort by block number, then by tx index within block, then by note index within tx
+      return [...foundNotes.values()].sort((a, b) => {
+        if (a.l2BlockNumber !== b.l2BlockNumber) {
+          return a.l2BlockNumber - b.l2BlockNumber;
+        }
+        if (a.txIndexInBlock !== b.txIndexInBlock) {
+          return a.txIndexInBlock - b.txIndexInBlock;
+        }
+        return a.noteIndexInTx - b.noteIndexInTx;
+      });
     });
   }
 
@@ -179,41 +216,42 @@ export class NoteStore implements StagedStore {
    * @throws Error if any nullifier is not found in this notes store
    */
   applyNullifiers(nullifiers: DataInBlock<Fr>[], jobId: string): Promise<NoteDao[]> {
-    return this.#withJobLock(jobId, async () => {
-      if (nullifiers.length === 0) {
-        return [];
-      }
+    if (nullifiers.length === 0) {
+      return Promise.resolve([]);
+    }
 
-      const notesToNullify = await Promise.all(
-        nullifiers.map(async nullifierInBlock => {
-          const nullifier = nullifierInBlock.data.toString();
+    return this.#withJobLock(jobId, () =>
+      this.#store.transactionAsync(async () => {
+        const notesToNullify = await Promise.all(
+          nullifiers.map(async nullifierInBlock => {
+            const nullifier = nullifierInBlock.data.toString();
 
-          const storedNote = await this.#readNote(nullifier, jobId);
-          if (!storedNote) {
-            throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB`);
+            const storedNote = await this.#readNote(nullifier, jobId);
+            if (!storedNote) {
+              throw new Error(`Attempted to mark a note as nullified which does not exist in PXE DB`);
+            }
+
+            return { storedNote, blockNumber: nullifierInBlock.l2BlockNumber };
+          }),
+        );
+
+        const notesNullifiedInThisCall: Map<string, NoteDao> = new Map();
+        for (const noteToNullify of notesToNullify) {
+          const note = noteToNullify.storedNote;
+
+          // Skip already nullified notes
+          if (note.isNullified()) {
+            continue;
           }
 
-          return { storedNote: await this.#readNote(nullifier, jobId), blockNumber: nullifierInBlock.l2BlockNumber };
-        }),
-      );
-
-      const notesNullifiedInThisCall: Map<string, NoteDao> = new Map();
-      for (const noteToNullify of notesToNullify) {
-        // Safe to coerce (!) because we throw if we find any undefined above
-        const note = noteToNullify.storedNote!;
-
-        // Skip already nullified notes
-        if (note.isNullified()) {
-          continue;
+          note.markAsNullified(noteToNullify.blockNumber);
+          this.#writeNote(note, jobId);
+          notesNullifiedInThisCall.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
         }
 
-        note.markAsNullified(noteToNullify.blockNumber);
-        this.#writeNote(note, jobId);
-        notesNullifiedInThisCall.set(note.noteDao.siloedNullifier.toString(), note.noteDao);
-      }
-
-      return [...notesNullifiedInThisCall.values()];
-    });
+        return [...notesNullifiedInThisCall.values()];
+      }),
+    );
   }
 
   /**
@@ -244,17 +282,22 @@ export class NoteStore implements StagedStore {
    * @param blockNumber - Notes created after this block number will be deleted
    */
   async #deleteActiveNotesAfterBlock(blockNumber: number): Promise<void> {
-    const notes = await toArray(this.#notes.valuesAsync());
-    for (const noteBuffer of notes) {
+    // Collect notes to delete during iteration to keep IndexedDB transaction alive.
+    const notesToDelete: { nullifier: string; contractAddress: string }[] = [];
+    for await (const noteBuffer of this.#notes.valuesAsync()) {
       const storedNote = StoredNote.fromBuffer(noteBuffer);
       if (storedNote.noteDao.l2BlockNumber > blockNumber) {
-        const noteNullifier = storedNote.noteDao.siloedNullifier.toString();
-        await this.#notes.delete(noteNullifier);
-        await this.#nullifiersByContractAddress.deleteValue(
-          storedNote.noteDao.contractAddress.toString(),
-          noteNullifier,
-        );
+        notesToDelete.push({
+          nullifier: storedNote.noteDao.siloedNullifier.toString(),
+          contractAddress: storedNote.noteDao.contractAddress.toString(),
+        });
       }
+    }
+
+    // Delete all collected notes. Each delete is a DB operation that keeps the transaction alive.
+    for (const { nullifier, contractAddress } of notesToDelete) {
+      await this.#notes.delete(nullifier);
+      await this.#nullifiersByContractAddress.deleteValue(contractAddress, nullifier);
     }
   }
 
@@ -268,62 +311,69 @@ export class NoteStore implements StagedStore {
    * @param anchorBlockNumber - Upper bound for the block range to process
    */
   async #rewindNullifiedNotesAfterBlock(blockNumber: number, anchorBlockNumber: number): Promise<void> {
-    const currentBlockNumber = blockNumber + 1;
-    for (let i = currentBlockNumber; i <= anchorBlockNumber; i++) {
-      const noteNullifiersToReinsert: string[] = await toArray(
-        this.#nullifiersByNullificationBlockNumber.getValuesAsync(i),
-      );
+    // First pass: collect all nullifiers for all blocks, starting reads during iteration to keep tx alive.
+    const nullifiersByBlock: Map<number, { nullifier: string; noteReadPromise: Promise<Buffer | undefined> }[]> =
+      new Map();
 
-      const nullifiedNoteBuffers = await Promise.all(
-        noteNullifiersToReinsert.map(async noteNullifier => {
-          const note = await this.#notes.getAsync(noteNullifier);
+    for (let i = blockNumber + 1; i <= anchorBlockNumber; i++) {
+      const blockNullifiers: { nullifier: string; noteReadPromise: Promise<Buffer | undefined> }[] = [];
+      for await (const nullifier of this.#nullifiersByNullificationBlockNumber.getValuesAsync(i)) {
+        // Start read immediately during iteration to keep IndexedDB transaction alive
+        blockNullifiers.push({ nullifier, noteReadPromise: this.#notes.getAsync(nullifier) });
+      }
+      if (blockNullifiers.length > 0) {
+        nullifiersByBlock.set(i, blockNullifiers);
+      }
+    }
 
-          if (!note) {
-            throw new Error(`PXE DB integrity error: no note found with nullifier ${noteNullifier}`);
-          }
+    // Second pass: await reads and perform writes
+    for (const [block, nullifiers] of nullifiersByBlock) {
+      for (const { nullifier, noteReadPromise } of nullifiers) {
+        const noteBuffer = await noteReadPromise;
+        if (!noteBuffer) {
+          throw new Error(`PXE DB integrity error: no note found with nullifier ${nullifier}`);
+        }
 
-          return note;
-        }),
-      );
-
-      const storedNotes = nullifiedNoteBuffers.map(buffer => StoredNote.fromBuffer(buffer));
-
-      for (const storedNote of storedNotes) {
-        const noteNullifier = storedNote.noteDao.siloedNullifier.toString();
-        const scopes = storedNote.scopes;
-
-        if (scopes.size === 0) {
-          // We should never run into this error because notes always have a scope assigned to them - either on initial
-          // insertion via `addNotes` or when removing their nullifiers.
-          throw new Error(`No scopes found for nullified note with nullifier ${noteNullifier}`);
+        const storedNote = StoredNote.fromBuffer(noteBuffer);
+        if (storedNote.scopes.size === 0) {
+          throw new Error(`No scopes found for nullified note with nullifier ${nullifier}`);
         }
 
         storedNote.markAsActive();
 
         await Promise.all([
-          this.#notes.set(noteNullifier, storedNote.toBuffer()),
-          this.#nullifiersByNullificationBlockNumber.deleteValue(i, noteNullifier),
+          this.#notes.set(nullifier, storedNote.toBuffer()),
+          this.#nullifiersByNullificationBlockNumber.deleteValue(block, nullifier),
         ]);
       }
     }
   }
 
-  commit(jobId: string): Promise<void> {
-    return this.#withJobLock(jobId, async () => {
-      for (const [nullifier, storedNote] of this.#getNotesForJob(jobId)) {
-        await this.#notes.set(nullifier, storedNote.toBuffer());
-        await this.#nullifiersByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
-        if (storedNote.nullifiedAt !== undefined) {
-          await this.#nullifiersByNullificationBlockNumber.set(storedNote.nullifiedAt, nullifier);
-        }
+  /**
+   * Commits in memory job data to persistent storage.
+   *
+   * Called by JobCoordinator when a job completes successfully.
+   *
+   * Note: JobCoordinator wraps all commits in a single transaction, so we don't need our own transactionAsync here
+   * (and using one would throw on IndexedDB as it does not support nested txs).
+   *
+   * @param jobId - The jobId identifying which staged data to commit
+   */
+  async commit(jobId: string): Promise<void> {
+    for (const [nullifier, storedNote] of this.#getNotesForJob(jobId)) {
+      await this.#notes.set(nullifier, storedNote.toBuffer());
+      await this.#nullifiersByContractAddress.set(storedNote.noteDao.contractAddress.toString(), nullifier);
+      if (storedNote.nullifiedAt !== undefined) {
+        await this.#nullifiersByNullificationBlockNumber.set(storedNote.nullifiedAt, nullifier);
       }
+    }
 
-      this.#clearJobData(jobId);
-    });
+    this.#clearJobData(jobId);
   }
 
   discardStaged(jobId: string): Promise<void> {
-    return this.#withJobLock(jobId, () => Promise.resolve(this.#clearJobData(jobId)));
+    this.#clearJobData(jobId);
+    return Promise.resolve();
   }
 
   #clearJobData(jobId: string) {
@@ -357,20 +407,5 @@ export class NoteStore implements StagedStore {
       this.#notesForJob.set(jobId, notesForJob);
     }
     return notesForJob;
-  }
-
-  async #nullifiersOfContract(contractAddress: AztecAddress, jobId: string): Promise<Set<string>> {
-    // Collect persisted nullifiers for this contract
-    const persistedNullifiers: string[] = await toArray(
-      this.#nullifiersByContractAddress.getValuesAsync(contractAddress.toString()),
-    );
-
-    // Collect staged nullifiers from the job where the note's contract matches
-    const stagedNullifiers = this.#getNotesForJob(jobId)
-      .values()
-      .filter(storedNote => storedNote.noteDao.contractAddress.equals(contractAddress))
-      .map(storedNote => storedNote.noteDao.siloedNullifier.toString());
-
-    return new Set([...persistedNullifiers, ...stagedNullifiers]);
   }
 }

--- a/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
+++ b/yarn-project/pxe/src/storage/private_event_store/private_event_store.ts
@@ -1,6 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
 import { Semaphore } from '@aztec/foundation/queue';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncMultiMap } from '@aztec/kv-store';
@@ -81,43 +80,45 @@ export class PrivateEventStore implements StagedStore {
     metadata: PrivateEventMetadata,
     jobId: string,
   ) {
-    return this.#withJobLock(jobId, async () => {
-      const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
-      const eventId = siloedEventCommitment.toString();
+    return this.#withJobLock(jobId, () =>
+      this.#store.transactionAsync(async () => {
+        const { contractAddress, scope, txHash, l2BlockNumber, l2BlockHash, txIndexInBlock, eventIndexInTx } = metadata;
+        const eventId = siloedEventCommitment.toString();
 
-      this.logger.verbose('storing private event log (job stage)', {
-        eventId,
-        contractAddress,
-        scope,
-        msgContent,
-        l2BlockNumber,
-      });
-
-      const existing = await this.#readEvent(eventId, jobId);
-
-      if (existing) {
-        // If we already stored this event, we still want to make sure to track it for the given scope
-        existing.addScope(scope.toString());
-        this.#writeEvent(eventId, existing, jobId);
-      } else {
-        this.#writeEvent(
+        this.logger.verbose('storing private event log (job stage)', {
           eventId,
-          new StoredPrivateEvent(
-            randomness,
-            msgContent,
-            l2BlockNumber,
-            l2BlockHash,
-            txHash,
-            txIndexInBlock,
-            eventIndexInTx,
-            contractAddress,
-            eventSelector,
-            new Set([scope.toString()]),
-          ),
-          jobId,
-        );
-      }
-    });
+          contractAddress,
+          scope,
+          msgContent,
+          l2BlockNumber,
+        });
+
+        const existing = await this.#readEvent(eventId, jobId);
+
+        if (existing) {
+          // If we already stored this event, we still want to make sure to track it for the given scope
+          existing.addScope(scope.toString());
+          this.#writeEvent(eventId, existing, jobId);
+        } else {
+          this.#writeEvent(
+            eventId,
+            new StoredPrivateEvent(
+              randomness,
+              msgContent,
+              l2BlockNumber,
+              l2BlockHash,
+              txHash,
+              txIndexInBlock,
+              eventIndexInTx,
+              contractAddress,
+              eventSelector,
+              new Set([scope.toString()]),
+            ),
+            jobId,
+          );
+        }
+      }),
+    );
   }
 
   /**
@@ -131,76 +132,88 @@ export class PrivateEventStore implements StagedStore {
    * @returns - The event log contents, augmented with metadata about the transaction and block in which the event was
    * included.
    */
-  public async getPrivateEvents(
+  public getPrivateEvents(
     eventSelector: EventSelector,
     filter: PrivateEventStoreFilter,
   ): Promise<PackedPrivateEvent[]> {
-    const events: Array<{
-      l2BlockNumber: number;
-      txIndexInBlock: number;
-      eventIndexInTx: number;
-      event: PackedPrivateEvent;
-    }> = [];
+    return this.#store.transactionAsync(async () => {
+      const key = this.#keyFor(filter.contractAddress, eventSelector);
+      const targetScopes = new Set(filter.scopes.map(s => s.toString()));
 
-    const key = this.#keyFor(filter.contractAddress, eventSelector);
-    const targetScopes = new Set(filter.scopes.map(s => s.toString()));
+      // Map from eventId to the promise that reads the event buffer.
+      // We start reads during iteration to keep DB requests pending and avoid IndexedDB auto-commit.
+      const eventReadPromises: Map<string, Promise<Buffer | undefined>> = new Map();
 
-    const eventIds: string[] = await toArray(this.#eventsByContractAndEventSelector.getValuesAsync(key));
-
-    for (const eventId of eventIds) {
-      const eventBuffer = await this.#events.getAsync(eventId);
-
-      // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
-      if (!eventBuffer) {
-        this.logger.verbose(
-          `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
-        );
-        continue;
+      for await (const eventId of this.#eventsByContractAndEventSelector.getValuesAsync(key)) {
+        eventReadPromises.set(eventId, this.#events.getAsync(eventId));
       }
 
-      const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
+      const eventIds = [...eventReadPromises.keys()];
+      const eventBuffers = await Promise.all(eventReadPromises.values());
 
-      // Filter by block range
-      if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
-        continue;
+      const events: Array<{
+        l2BlockNumber: number;
+        txIndexInBlock: number;
+        eventIndexInTx: number;
+        event: PackedPrivateEvent;
+      }> = [];
+
+      for (let i = 0; i < eventIds.length; i++) {
+        const eventId = eventIds[i];
+        const eventBuffer = eventBuffers[i];
+
+        // Defensive, if it happens, there's a problem with how we're handling #eventsByContractAndEventSelector
+        if (!eventBuffer) {
+          this.logger.verbose(
+            `EventId ${eventId} does not exist in main index but it is referenced from contract event selector index`,
+          );
+          continue;
+        }
+
+        const storedPrivateEvent = StoredPrivateEvent.fromBuffer(eventBuffer);
+
+        // Filter by block range
+        if (storedPrivateEvent.l2BlockNumber < filter.fromBlock || storedPrivateEvent.l2BlockNumber >= filter.toBlock) {
+          continue;
+        }
+
+        // Filter by scopes
+        if (storedPrivateEvent.scopes.intersection(targetScopes).size === 0) {
+          continue;
+        }
+
+        // Filter by txHash
+        if (filter.txHash && !storedPrivateEvent.txHash.equals(filter.txHash)) {
+          continue;
+        }
+
+        events.push({
+          l2BlockNumber: storedPrivateEvent.l2BlockNumber,
+          txIndexInBlock: storedPrivateEvent.txIndexInBlock,
+          eventIndexInTx: storedPrivateEvent.eventIndexInTx,
+          event: {
+            packedEvent: storedPrivateEvent.msgContent,
+            l2BlockNumber: BlockNumber(storedPrivateEvent.l2BlockNumber),
+            txHash: storedPrivateEvent.txHash,
+            l2BlockHash: storedPrivateEvent.l2BlockHash,
+            eventSelector,
+          },
+        });
       }
 
-      // Filter by scopes
-      if (storedPrivateEvent.scopes.intersection(targetScopes).size === 0) {
-        continue;
-      }
-
-      // Filter by txHash
-      if (filter.txHash && !storedPrivateEvent.txHash.equals(filter.txHash)) {
-        continue;
-      }
-
-      events.push({
-        l2BlockNumber: storedPrivateEvent.l2BlockNumber,
-        txIndexInBlock: storedPrivateEvent.txIndexInBlock,
-        eventIndexInTx: storedPrivateEvent.eventIndexInTx,
-        event: {
-          packedEvent: storedPrivateEvent.msgContent,
-          l2BlockNumber: BlockNumber(storedPrivateEvent.l2BlockNumber),
-          txHash: storedPrivateEvent.txHash,
-          l2BlockHash: storedPrivateEvent.l2BlockHash,
-          eventSelector,
-        },
+      // Sort by block number, then by tx index within block, then by event index within tx
+      events.sort((a, b) => {
+        if (a.l2BlockNumber !== b.l2BlockNumber) {
+          return a.l2BlockNumber - b.l2BlockNumber;
+        }
+        if (a.txIndexInBlock !== b.txIndexInBlock) {
+          return a.txIndexInBlock - b.txIndexInBlock;
+        }
+        return a.eventIndexInTx - b.eventIndexInTx;
       });
-    }
 
-    // Sort by block number, then by tx index within block, then by event index within tx
-    events.sort((a, b) => {
-      if (a.l2BlockNumber !== b.l2BlockNumber) {
-        return a.l2BlockNumber - b.l2BlockNumber;
-      }
-      if (a.txIndexInBlock !== b.txIndexInBlock) {
-        return a.txIndexInBlock - b.txIndexInBlock;
-      }
-      return a.eventIndexInTx - b.eventIndexInTx;
+      return events.map(ev => ev.event);
     });
-
-    return events.map(ev => ev.event);
   }
 
   /**
@@ -221,29 +234,39 @@ export class PrivateEventStore implements StagedStore {
    * IMPORTANT: This method must be called within a transaction to ensure atomicity.
    */
   public async rollback(blockNumber: number, synchedBlockNumber: number): Promise<void> {
-    let removedCount = 0;
+    // First pass: collect all event IDs for all blocks, starting reads during iteration to keep tx alive.
+    const eventsByBlock: Map<number, { eventId: string; eventReadPromise: Promise<Buffer | undefined> }[]> = new Map();
 
     for (let block = blockNumber + 1; block <= synchedBlockNumber; block++) {
-      const eventIds: string[] = await toArray(this.#eventsByBlockNumber.getValuesAsync(block));
+      const blockEvents: { eventId: string; eventReadPromise: Promise<Buffer | undefined> }[] = [];
+      for await (const eventId of this.#eventsByBlockNumber.getValuesAsync(block)) {
+        // Start read immediately during iteration to keep IndexedDB transaction alive
+        blockEvents.push({ eventId, eventReadPromise: this.#events.getAsync(eventId) });
+      }
+      if (blockEvents.length > 0) {
+        eventsByBlock.set(block, blockEvents);
+      }
+    }
 
-      if (eventIds.length > 0) {
-        await this.#eventsByBlockNumber.delete(block);
+    // Second pass: await reads and perform deletes
+    let removedCount = 0;
+    for (const [block, events] of eventsByBlock) {
+      await this.#eventsByBlockNumber.delete(block);
 
-        for (const eventId of eventIds) {
-          const buffer = await this.#events.getAsync(eventId);
-          if (!buffer) {
-            throw new Error(`Event not found for eventId ${eventId}`);
-          }
-
-          const entry = StoredPrivateEvent.fromBuffer(buffer);
-          await this.#events.delete(eventId);
-          await this.#eventsByContractAndEventSelector.deleteValue(
-            this.#keyFor(entry.contractAddress, entry.eventSelector),
-            eventId,
-          );
-
-          removedCount++;
+      for (const { eventId, eventReadPromise } of events) {
+        const buffer = await eventReadPromise;
+        if (!buffer) {
+          throw new Error(`Event not found for eventId ${eventId}`);
         }
+
+        const entry = StoredPrivateEvent.fromBuffer(buffer);
+        await this.#events.delete(eventId);
+        await this.#eventsByContractAndEventSelector.deleteValue(
+          this.#keyFor(entry.contractAddress, entry.eventSelector),
+          eventId,
+        );
+
+        removedCount++;
       }
     }
 
@@ -260,28 +283,30 @@ export class PrivateEventStore implements StagedStore {
    *
    * @param jobId - The jobId identifying which staged data to commit
    */
-  commit(jobId: string): Promise<void> {
-    return this.#withJobLock(jobId, async () => {
-      for (const [eventId, entry] of this.#getEventsForJob(jobId).entries()) {
-        const lookupKey = this.#keyFor(entry.contractAddress, entry.eventSelector);
-        this.logger.verbose('storing private event log', { eventId, lookupKey });
+  async commit(jobId: string): Promise<void> {
+    // Note: Don't use #withJobLock here - commit runs within JobCoordinator's transactionAsync,
+    // and awaiting the lock would create a microtask boundary with no pending DB request,
+    // causing IndexedDB to auto-commit the transaction.
+    for (const [eventId, entry] of this.#getEventsForJob(jobId).entries()) {
+      const lookupKey = this.#keyFor(entry.contractAddress, entry.eventSelector);
+      this.logger.verbose('storing private event log', { eventId, lookupKey });
 
-        await Promise.all([
-          this.#events.set(eventId, entry.toBuffer()),
-          this.#eventsByContractAndEventSelector.set(lookupKey, eventId),
-          this.#eventsByBlockNumber.set(entry.l2BlockNumber, eventId),
-        ]);
-      }
+      await Promise.all([
+        this.#events.set(eventId, entry.toBuffer()),
+        this.#eventsByContractAndEventSelector.set(lookupKey, eventId),
+        this.#eventsByBlockNumber.set(entry.l2BlockNumber, eventId),
+      ]);
+    }
 
-      this.#clearJobData(jobId);
-    });
+    this.#clearJobData(jobId);
   }
 
   /**
    * Discards in memory job data without persisting it.
    */
   discardStaged(jobId: string): Promise<void> {
-    return this.#withJobLock(jobId, () => Promise.resolve(this.#clearJobData(jobId)));
+    this.#clearJobData(jobId);
+    return Promise.resolve();
   }
 
   /**
@@ -290,13 +315,11 @@ export class PrivateEventStore implements StagedStore {
    * Returns undefined if the event does not exist in the store overall.
    */
   async #readEvent(eventId: string, jobId: string): Promise<StoredPrivateEvent | undefined> {
-    const eventForJob = this.#getEventsForJob(jobId).get(eventId);
-    if (eventForJob) {
-      return eventForJob;
-    }
-
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
     const buffer = await this.#events.getAsync(eventId);
-    return buffer ? StoredPrivateEvent.fromBuffer(buffer) : undefined;
+    const eventForJob = this.#getEventsForJob(jobId).get(eventId);
+    return eventForJob ?? (buffer ? StoredPrivateEvent.fromBuffer(buffer) : undefined);
   }
 
   /**

--- a/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/recipient_tagging_store.ts
@@ -45,7 +45,11 @@ export class RecipientTaggingStore implements StagedStore {
   }
 
   async #readHighestAgedIndex(jobId: string, secret: string): Promise<number | undefined> {
-    return this.#getHighestAgedIndexForJob(jobId).get(secret) ?? (await this.#highestAgedIndex.getAsync(secret));
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
+    const dbValue = await this.#highestAgedIndex.getAsync(secret);
+    const staged = this.#getHighestAgedIndexForJob(jobId).get(secret);
+    return staged ?? dbValue;
   }
 
   #writeHighestAgedIndex(jobId: string, secret: string, index: number) {
@@ -62,9 +66,11 @@ export class RecipientTaggingStore implements StagedStore {
   }
 
   async #readHighestFinalizedIndex(jobId: string, secret: string): Promise<number | undefined> {
-    return (
-      this.#getHighestFinalizedIndexForJob(jobId).get(secret) ?? (await this.#highestFinalizedIndex.getAsync(secret))
-    );
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
+    const dbValue = await this.#highestFinalizedIndex.getAsync(secret);
+    const staged = this.#getHighestFinalizedIndexForJob(jobId).get(secret);
+    return staged ?? dbValue;
   }
 
   #writeHighestFinalizedIndex(jobId: string, secret: string, index: number) {
@@ -101,29 +107,33 @@ export class RecipientTaggingStore implements StagedStore {
   }
 
   getHighestAgedIndex(secret: DirectionalAppTaggingSecret, jobId: string): Promise<number | undefined> {
-    return this.#readHighestAgedIndex(jobId, secret.toString());
+    return this.#store.transactionAsync(() => this.#readHighestAgedIndex(jobId, secret.toString()));
   }
 
-  async updateHighestAgedIndex(secret: DirectionalAppTaggingSecret, index: number, jobId: string): Promise<void> {
-    const currentIndex = await this.#readHighestAgedIndex(jobId, secret.toString());
-    if (currentIndex !== undefined && index <= currentIndex) {
-      // Log sync should never set a lower highest aged index.
-      throw new Error(`New highest aged index (${index}) must be higher than the current one (${currentIndex})`);
-    }
-    this.#writeHighestAgedIndex(jobId, secret.toString(), index);
+  updateHighestAgedIndex(secret: DirectionalAppTaggingSecret, index: number, jobId: string): Promise<void> {
+    return this.#store.transactionAsync(async () => {
+      const currentIndex = await this.#readHighestAgedIndex(jobId, secret.toString());
+      if (currentIndex !== undefined && index <= currentIndex) {
+        // Log sync should never set a lower highest aged index.
+        throw new Error(`New highest aged index (${index}) must be higher than the current one (${currentIndex})`);
+      }
+      this.#writeHighestAgedIndex(jobId, secret.toString(), index);
+    });
   }
 
   getHighestFinalizedIndex(secret: DirectionalAppTaggingSecret, jobId: string): Promise<number | undefined> {
-    return this.#readHighestFinalizedIndex(jobId, secret.toString());
+    return this.#store.transactionAsync(() => this.#readHighestFinalizedIndex(jobId, secret.toString()));
   }
 
-  async updateHighestFinalizedIndex(secret: DirectionalAppTaggingSecret, index: number, jobId: string): Promise<void> {
-    const currentIndex = await this.#readHighestFinalizedIndex(jobId, secret.toString());
-    if (currentIndex !== undefined && index < currentIndex) {
-      // Log sync should never set a lower highest finalized index but it can happen that it would try to set the same
-      // one because we are loading logs from highest aged index + 1 and not from the highest finalized index.
-      throw new Error(`New highest finalized index (${index}) must be higher than the current one (${currentIndex})`);
-    }
-    this.#writeHighestFinalizedIndex(jobId, secret.toString(), index);
+  updateHighestFinalizedIndex(secret: DirectionalAppTaggingSecret, index: number, jobId: string): Promise<void> {
+    return this.#store.transactionAsync(async () => {
+      const currentIndex = await this.#readHighestFinalizedIndex(jobId, secret.toString());
+      if (currentIndex !== undefined && index < currentIndex) {
+        // Log sync should never set a lower highest finalized index but it can happen that it would try to set the same
+        // one because we are loading logs from highest aged index + 1 and not from the highest finalized index.
+        throw new Error(`New highest finalized index (${index}) must be higher than the current one (${currentIndex})`);
+      }
+      this.#writeHighestFinalizedIndex(jobId, secret.toString(), index);
+    });
   }
 }

--- a/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_address_book_store.ts
@@ -16,27 +16,33 @@ export class SenderAddressBookStore {
     this.#addressBook = this.#store.openMap('address_book');
   }
 
-  async addSender(address: AztecAddress): Promise<boolean> {
-    if (await this.#addressBook.hasAsync(address.toString())) {
-      return false;
-    }
+  addSender(address: AztecAddress): Promise<boolean> {
+    return this.#store.transactionAsync(async () => {
+      if (await this.#addressBook.hasAsync(address.toString())) {
+        return false;
+      }
 
-    await this.#addressBook.set(address.toString(), true);
+      await this.#addressBook.set(address.toString(), true);
 
-    return true;
+      return true;
+    });
   }
 
-  async getSenders(): Promise<AztecAddress[]> {
-    return (await toArray(this.#addressBook.keysAsync())).map(AztecAddress.fromString);
+  getSenders(): Promise<AztecAddress[]> {
+    return this.#store.transactionAsync(async () => {
+      return (await toArray(this.#addressBook.keysAsync())).map(AztecAddress.fromString);
+    });
   }
 
-  async removeSender(address: AztecAddress): Promise<boolean> {
-    if (!(await this.#addressBook.hasAsync(address.toString()))) {
-      return false;
-    }
+  removeSender(address: AztecAddress): Promise<boolean> {
+    return this.#store.transactionAsync(async () => {
+      if (!(await this.#addressBook.hasAsync(address.toString()))) {
+        return false;
+      }
 
-    await this.#addressBook.delete(address.toString());
+      await this.#addressBook.delete(address.toString());
 
-    return true;
+      return true;
+    });
   }
 }

--- a/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
+++ b/yarn-project/pxe/src/storage/tagging_store/sender_tagging_store.ts
@@ -1,4 +1,3 @@
-import { toArray } from '@aztec/foundation/iterable';
 import type { AztecAsyncKVStore, AztecAsyncMap } from '@aztec/kv-store';
 import type { DirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
@@ -70,31 +69,23 @@ export class SenderTaggingStore implements StagedStore {
   }
 
   async #readPendingIndexes(jobId: string, secret: string): Promise<{ index: number; txHash: string }[]> {
-    const jobStagedPendingIndexes = this.#getPendingIndexesForJob(jobId);
-    const pendingIndexes = jobStagedPendingIndexes.get(secret);
-    // We return the staged version of this if it exists, if not, we read from the DB.
-    // If the DB also has nothing, we return an empty array [].
-    return pendingIndexes !== undefined ? pendingIndexes : ((await this.#pendingIndexes.getAsync(secret)) ?? []);
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
+    const dbValue = await this.#pendingIndexes.getAsync(secret);
+    const staged = this.#getPendingIndexesForJob(jobId).get(secret);
+    return staged !== undefined ? staged : (dbValue ?? []);
   }
 
   #writePendingIndexes(jobId: string, secret: string, pendingIndexes: { index: number; txHash: string }[]) {
     this.#getPendingIndexesForJob(jobId).set(secret, pendingIndexes);
   }
 
-  /**
-   * Returns a job view of all the secrets that have a corresponding list of pending indexes either in persistent
-   * storage or the current job.
-   */
-  async #readSecretsWithPendingIndexes(jobId: string): Promise<string[]> {
-    const storedSecrets = new Set(await toArray(this.#pendingIndexes.keysAsync()));
-    const stagedSecrets = this.#getPendingIndexesForJob(jobId).keys();
-    return [...storedSecrets.union(new Set(stagedSecrets))];
-  }
-
   async #readLastFinalizedIndex(jobId: string, secret: string): Promise<number | undefined> {
-    return (
-      this.#getLastFinalizedIndexesForJob(jobId).get(secret) ?? (await this.#lastFinalizedIndexes.getAsync(secret))
-    );
+    // Always issue DB read to keep IndexedDB transaction alive (they auto-commit when a new micro-task starts and there
+    // are no pending read requests). The staged value still takes precedence if it exists.
+    const dbValue = await this.#lastFinalizedIndexes.getAsync(secret);
+    const staged = this.#getLastFinalizedIndexesForJob(jobId).get(secret);
+    return staged ?? dbValue;
   }
 
   #writeLastFinalizedIndex(jobId: string, secret: string, lastFinalizedIndex: number) {
@@ -156,55 +147,80 @@ export class SenderTaggingStore implements StagedStore {
    * This is enforced because this should never happen if the syncing is done correctly as we look for logs from higher
    * indexes than finalized ones.
    */
-  async storePendingIndexes(preTags: PreTag[], txHash: TxHash, jobId: string) {
+  storePendingIndexes(preTags: PreTag[], txHash: TxHash, jobId: string): Promise<void> {
+    if (preTags.length === 0) {
+      return Promise.resolve();
+    }
+
     // The secrets in pre-tags should be unique because we always store just the highest index per given secret-txHash
     // pair. Below we check that this is the case.
     const secretsSet = new Set(preTags.map(preTag => preTag.secret.toString()));
     if (secretsSet.size !== preTags.length) {
-      throw new Error(`Duplicate secrets found when storing pending indexes`);
+      return Promise.reject(new Error(`Duplicate secrets found when storing pending indexes`));
     }
 
-    for (const { secret, index } of preTags) {
-      // First we check that for any secret the highest used index in tx is not further than window length from
-      // the highest finalized index.
-      const finalizedIndex = (await this.getLastFinalizedIndex(secret, jobId)) ?? 0;
-      if (index > finalizedIndex + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN) {
-        throw new Error(
-          `Highest used index ${index} is further than window length from the highest finalized index ${finalizedIndex}.
-          Tagging window length ${UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN} is configured too low. Contact the Aztec team
-          to increase it!`,
-        );
-      }
+    const txHashStr = txHash.toString();
 
-      // Throw if the new pending index is lower than or equal to the last finalized index
-      const secretStr = secret.toString();
-      const lastFinalizedIndex = await this.#readLastFinalizedIndex(jobId, secretStr);
-      if (lastFinalizedIndex !== undefined && index <= lastFinalizedIndex) {
-        throw new Error(
-          `Cannot store pending index ${index} for secret ${secretStr}: ` +
-            `it is lower than or equal to the last finalized index ${lastFinalizedIndex}`,
-        );
-      }
+    return this.#store.transactionAsync(async () => {
+      // Prefetch all data, start reads during iteration to keep IndexedDB transaction alive
+      const preTagReadPromises = preTags.map(({ secret, index }) => {
+        const secretStr = secret.toString();
+        return {
+          secret,
+          secretStr,
+          index,
+          pending: this.#readPendingIndexes(jobId, secretStr),
+          finalized: this.#readLastFinalizedIndex(jobId, secretStr),
+        };
+      });
 
-      // Check if this secret + txHash combination already exists
-      const txHashStr = txHash.toString();
-      const existingForSecret = await this.#readPendingIndexes(jobId, secretStr);
-      const existingForSecretAndTx = existingForSecret.find(entry => entry.txHash === txHashStr);
+      // Await all reads together
+      const preTagData = await Promise.all(
+        preTagReadPromises.map(async item => ({
+          ...item,
+          pendingData: await item.pending,
+          finalizedIndex: await item.finalized,
+        })),
+      );
 
-      if (existingForSecretAndTx) {
-        // If it exists with a different index, throw an error
-        if (existingForSecretAndTx.index !== index) {
+      // Process in memory and validate
+      for (const { secretStr, index, pendingData, finalizedIndex } of preTagData) {
+        // First we check that for any secret the highest used index in tx is not further than window length from
+        // the highest finalized index.
+        if (index > (finalizedIndex ?? 0) + UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN) {
           throw new Error(
-            `Cannot store index ${index} for secret ${secretStr} and txHash ${txHashStr}: ` +
-              `a different index ${existingForSecretAndTx.index} already exists for this secret-txHash pair`,
+            `Highest used index ${index} is further than window length from the highest finalized index ${finalizedIndex ?? 0}.
+            Tagging window length ${UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN} is configured too low. Contact the Aztec team
+            to increase it!`,
           );
         }
-        // If it exists with the same index, ignore the update (no-op)
-      } else {
-        // If it doesn't exist, add it
-        this.#writePendingIndexes(jobId, secretStr, [...existingForSecret, { index, txHash: txHashStr }]);
+
+        // Throw if the new pending index is lower than or equal to the last finalized index
+        if (finalizedIndex !== undefined && index <= finalizedIndex) {
+          throw new Error(
+            `Cannot store pending index ${index} for secret ${secretStr}: ` +
+              `it is lower than or equal to the last finalized index ${finalizedIndex}`,
+          );
+        }
+
+        // Check if this secret + txHash combination already exists
+        const existingForSecretAndTx = pendingData.find(entry => entry.txHash === txHashStr);
+
+        if (existingForSecretAndTx) {
+          // If it exists with a different index, throw an error
+          if (existingForSecretAndTx.index !== index) {
+            throw new Error(
+              `Cannot store index ${index} for secret ${secretStr} and txHash ${txHashStr}: ` +
+                `a different index ${existingForSecretAndTx.index} already exists for this secret-txHash pair`,
+            );
+          }
+          // If it exists with the same index, ignore the update (no-op)
+        } else {
+          // If it doesn't exist, add it
+          this.#writePendingIndexes(jobId, secretStr, [...pendingData, { index, txHash: txHashStr }]);
+        }
       }
-    }
+    });
   }
 
   /**
@@ -216,17 +232,19 @@ export class SenderTaggingStore implements StagedStore {
    * @returns An array of unique transaction hashes for pending transactions that contain indexes in the range
    * [startIndex, endIndex). Returns an empty array if no pending indexes exist in the range.
    */
-  async getTxHashesOfPendingIndexes(
+  getTxHashesOfPendingIndexes(
     secret: DirectionalAppTaggingSecret,
     startIndex: number,
     endIndex: number,
     jobId: string,
   ): Promise<TxHash[]> {
-    const existing = await this.#readPendingIndexes(jobId, secret.toString());
-    const txHashes = existing
-      .filter(entry => entry.index >= startIndex && entry.index < endIndex)
-      .map(entry => entry.txHash);
-    return Array.from(new Set(txHashes)).map(TxHash.fromString);
+    return this.#store.transactionAsync(async () => {
+      const existing = await this.#readPendingIndexes(jobId, secret.toString());
+      const txHashes = existing
+        .filter(entry => entry.index >= startIndex && entry.index < endIndex)
+        .map(entry => entry.txHash);
+      return Array.from(new Set(txHashes)).map(TxHash.fromString);
+    });
   }
 
   /**
@@ -235,7 +253,7 @@ export class SenderTaggingStore implements StagedStore {
    * @returns The last (highest) finalized index for the given secret.
    */
   getLastFinalizedIndex(secret: DirectionalAppTaggingSecret, jobId: string): Promise<number | undefined> {
-    return this.#readLastFinalizedIndex(jobId, secret.toString());
+    return this.#store.transactionAsync(() => this.#readLastFinalizedIndex(jobId, secret.toString()));
   }
 
   /**
@@ -244,102 +262,168 @@ export class SenderTaggingStore implements StagedStore {
    * @param secret - The directional app tagging secret to query the last used index for.
    * @returns The last used index.
    */
-  async getLastUsedIndex(secret: DirectionalAppTaggingSecret, jobId: string): Promise<number | undefined> {
+  getLastUsedIndex(secret: DirectionalAppTaggingSecret, jobId: string): Promise<number | undefined> {
     const secretStr = secret.toString();
-    const pendingTxScopedIndexes = await this.#readPendingIndexes(jobId, secretStr);
-    const pendingIndexes = pendingTxScopedIndexes.map(entry => entry.index);
 
-    if (pendingTxScopedIndexes.length === 0) {
-      return this.#readLastFinalizedIndex(jobId, secretStr);
-    }
+    return this.#store.transactionAsync(async () => {
+      const pendingPromise = this.#readPendingIndexes(jobId, secretStr);
+      const finalizedPromise = this.#readLastFinalizedIndex(jobId, secretStr);
 
-    // As the last used index we return the highest one from the pending indexes. Note that this value will be always
-    // higher than the last finalized index because we prune lower pending indexes when a tx is finalized.
-    return Math.max(...pendingIndexes);
+      const [pendingTxScopedIndexes, lastFinalized] = await Promise.all([pendingPromise, finalizedPromise]);
+      const pendingIndexes = pendingTxScopedIndexes.map(entry => entry.index);
+
+      if (pendingTxScopedIndexes.length === 0) {
+        return lastFinalized;
+      }
+
+      // As the last used index we return the highest one from the pending indexes. Note that this value will be always
+      // higher than the last finalized index because we prune lower pending indexes when a tx is finalized.
+      return Math.max(...pendingIndexes);
+    });
   }
 
   /**
    * Drops all pending indexes corresponding to the given transaction hashes.
    */
-  async dropPendingIndexes(txHashes: TxHash[], jobId: string) {
+  dropPendingIndexes(txHashes: TxHash[], jobId: string): Promise<void> {
     if (txHashes.length === 0) {
-      return;
+      return Promise.resolve();
     }
 
     const txHashStrings = new Set<string>(txHashes.map(txHash => txHash.toString()));
-    const allSecrets = await this.#readSecretsWithPendingIndexes(jobId);
 
-    for (const secret of allSecrets) {
-      const pendingData = await this.#readPendingIndexes(jobId, secret);
-      if (pendingData) {
-        const filtered = pendingData.filter(item => !txHashStrings.has(item.txHash));
-        if (filtered.length === 0) {
-          this.#writePendingIndexes(jobId, secret, []);
-        } else if (filtered.length !== pendingData.length) {
-          // Some items were filtered out, so update the pending data
-          this.#writePendingIndexes(jobId, secret, filtered);
-        }
-        // else: No items were filtered out (txHashes not found for this secret) --> no-op
+    return this.#store.transactionAsync(async () => {
+      // Prefetch all data, start reads during iteration to keep IndexedDB transaction alive
+      const secretReadPromises: Map<string, Promise<{ index: number; txHash: string }[]>> = new Map();
+
+      for await (const secret of this.#pendingIndexes.keysAsync()) {
+        secretReadPromises.set(secret, this.#readPendingIndexes(jobId, secret));
       }
-    }
+
+      // Add staged-only secrets (sync, no DB)
+      for (const secret of this.#getPendingIndexesForJob(jobId).keys()) {
+        if (!secretReadPromises.has(secret)) {
+          secretReadPromises.set(secret, Promise.resolve(this.#getPendingIndexesForJob(jobId).get(secret) ?? []));
+        }
+      }
+
+      // Await all reads together
+      const secrets = [...secretReadPromises.keys()];
+      const pendingDataResults = await Promise.all(secretReadPromises.values());
+
+      // Process in memory
+      for (let i = 0; i < secrets.length; i++) {
+        const secret = secrets[i];
+        const pendingData = pendingDataResults[i];
+
+        if (pendingData && pendingData.length > 0) {
+          const filtered = pendingData.filter(item => !txHashStrings.has(item.txHash));
+          if (filtered.length === 0) {
+            this.#writePendingIndexes(jobId, secret, []);
+          } else if (filtered.length !== pendingData.length) {
+            // Some items were filtered out, so update the pending data
+            this.#writePendingIndexes(jobId, secret, filtered);
+          }
+          // else: No items were filtered out (txHashes not found for this secret) --> no-op
+        }
+      }
+    });
   }
 
   /**
    * Updates pending indexes corresponding to the given transaction hashes to be finalized and prunes any lower pending
    * indexes.
    */
-  async finalizePendingIndexes(txHashes: TxHash[], jobId: string) {
+  finalizePendingIndexes(txHashes: TxHash[], jobId: string): Promise<void> {
     if (txHashes.length === 0) {
-      return;
+      return Promise.resolve();
     }
 
-    for (const txHash of txHashes) {
-      const txHashStr = txHash.toString();
+    const txHashStrings = new Set(txHashes.map(tx => tx.toString()));
 
-      const allSecrets = await this.#readSecretsWithPendingIndexes(jobId);
+    return this.#store.transactionAsync(async () => {
+      // Prefetch all data, start reads during iteration to keep IndexedDB transaction alive
+      const secretDataPromises: Map<
+        string,
+        { pending: Promise<{ index: number; txHash: string }[]>; finalized: Promise<number | undefined> }
+      > = new Map();
 
-      for (const secret of allSecrets) {
-        const pendingData = await this.#readPendingIndexes(jobId, secret);
-        if (!pendingData) {
-          continue;
-        }
+      for await (const secret of this.#pendingIndexes.keysAsync()) {
+        secretDataPromises.set(secret, {
+          pending: this.#readPendingIndexes(jobId, secret),
+          finalized: this.#readLastFinalizedIndex(jobId, secret),
+        });
+      }
 
-        const matchingIndexes = pendingData.filter(item => item.txHash === txHashStr).map(item => item.index);
-        if (matchingIndexes.length === 0) {
-          continue;
-        }
-
-        if (matchingIndexes.length > 1) {
-          // We should always just store the highest pending index for a given tx hash and secret because the lower
-          // values are irrelevant.
-          throw new Error(`Multiple pending indexes found for tx hash ${txHashStr} and secret ${secret}`);
-        }
-
-        let lastFinalized = await this.#readLastFinalizedIndex(jobId, secret);
-        const newFinalized = matchingIndexes[0];
-
-        if (newFinalized < (lastFinalized ?? 0)) {
-          // This should never happen because when last finalized index was finalized we should have pruned the lower
-          // pending indexes.
-          throw new Error(
-            `New finalized index ${newFinalized} is smaller than the current last finalized index ${lastFinalized}`,
-          );
-        }
-
-        this.#writeLastFinalizedIndex(jobId, secret, newFinalized);
-        lastFinalized = newFinalized;
-
-        // When we add pending indexes, we ensure they are higher than the last finalized index. However, because we
-        // cannot control the order in which transactions are finalized, there may be pending indexes that are now
-        // obsolete because they are lower than the most recently finalized index. For this reason, we prune these
-        // outdated pending indexes.
-        const remainingItemsOfHigherIndex = pendingData.filter(item => item.index > (lastFinalized ?? 0));
-        if (remainingItemsOfHigherIndex.length === 0) {
-          this.#writePendingIndexes(jobId, secret, []);
-        } else {
-          this.#writePendingIndexes(jobId, secret, remainingItemsOfHigherIndex);
+      // Add staged-only secrets (sync, no DB)
+      for (const secret of this.#getPendingIndexesForJob(jobId).keys()) {
+        if (!secretDataPromises.has(secret)) {
+          secretDataPromises.set(secret, {
+            pending: Promise.resolve(this.#getPendingIndexesForJob(jobId).get(secret) ?? []),
+            finalized: Promise.resolve(this.#getLastFinalizedIndexesForJob(jobId).get(secret)),
+          });
         }
       }
-    }
+
+      // Await all reads together
+      const secrets = [...secretDataPromises.keys()];
+      const dataResults = await Promise.all(
+        secrets.map(async secret => ({
+          secret,
+          pendingData: await secretDataPromises.get(secret)!.pending,
+          lastFinalized: await secretDataPromises.get(secret)!.finalized,
+        })),
+      );
+
+      // Process all txHashes for each secret in memory
+      for (const { secret, pendingData, lastFinalized } of dataResults) {
+        if (!pendingData || pendingData.length === 0) {
+          continue;
+        }
+
+        let currentPending = pendingData;
+        let currentFinalized = lastFinalized;
+
+        // Process all txHashes for this secret
+        for (const txHashStr of txHashStrings) {
+          const matchingIndexes = currentPending.filter(item => item.txHash === txHashStr).map(item => item.index);
+          if (matchingIndexes.length === 0) {
+            continue;
+          }
+
+          if (matchingIndexes.length > 1) {
+            // We should always just store the highest pending index for a given tx hash and secret because the lower
+            // values are irrelevant.
+            throw new Error(`Multiple pending indexes found for tx hash ${txHashStr} and secret ${secret}`);
+          }
+
+          const newFinalized = matchingIndexes[0];
+
+          if (newFinalized < (currentFinalized ?? 0)) {
+            // This should never happen because when last finalized index was finalized we should have pruned the lower
+            // pending indexes.
+            throw new Error(
+              `New finalized index ${newFinalized} is smaller than the current last finalized index ${currentFinalized}`,
+            );
+          }
+
+          currentFinalized = newFinalized;
+
+          // When we add pending indexes, we ensure they are higher than the last finalized index. However, because we
+          // cannot control the order in which transactions are finalized, there may be pending indexes that are now
+          // obsolete because they are lower than the most recently finalized index. For this reason, we prune these
+          // outdated pending indexes.
+          currentPending = currentPending.filter(item => item.index > currentFinalized!);
+        }
+
+        // Write final state if changed
+        if (currentFinalized !== lastFinalized) {
+          this.#writeLastFinalizedIndex(jobId, secret, currentFinalized!);
+        }
+        if (currentPending !== pendingData) {
+          this.#writePendingIndexes(jobId, secret, currentPending);
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
In the past few days we've seen multiple instances of IndexedDB related issues, mostly due to the fact that [browsers are free to decide to commit transactions when a microtask doesn't generate new work for the DB](https://github.com/jakearchibald/idb?tab=readme-ov-file#transaction-lifetime).

This PR introduces a number of changes to PXE stores to prevent that class of errors.

The driving ideas for this PR are two:

1. Use `transactionAsync` for every store operation.
2. Write `transactionAsync` callbacks in such a way that auto-commits are guaranteed not to occur (at least according to specs).
 