### PR TITLE
chore(slasher): remove sleeps on slasher stop

### DIFF
--- a/yarn-project/slasher/src/empire_slasher_client.ts
+++ b/yarn-project/slasher/src/empire_slasher_client.ts
@@ -4,7 +4,6 @@ import { SlotNumber } from '@aztec/foundation/branded-types';
 import { compactArray, filterAsync, maxBy, pick } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import type { DateProvider } from '@aztec/foundation/timer';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
@@ -196,13 +195,6 @@ export class EmpireSlasherClient implements ProposerSlashActionProvider, Slasher
     this.roundMonitor.stop();
     await this.offensesCollector.stop();
 
-    // Viem calls eth_uninstallFilter under the hood when uninstalling event watchers, but these calls are not awaited,
-    // meaning that any error that happens during the uninstallation will not be caught. This causes errors during jest teardowns,
-    // where we stop anvil after all other processes are stopped, so sometimes the eth_uninstallFilter call fails because anvil
-    // is already stopped. We add a sleep here to give the uninstallation some time to complete, but the proper fix is for
-    // viem to await the eth_uninstallFilter calls, or to catch any errors that happen during the uninstallation.
-    // See https://github.com/wevm/viem/issues/3714.
-    await sleep(2000);
     this.log.info('Empire Slasher client stopped');
   }
 

--- a/yarn-project/slasher/src/tally_slasher_client.test.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.test.ts
@@ -5,7 +5,6 @@ import { times } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryFastUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
@@ -1002,20 +1001,5 @@ class TestTallySlasherClient extends TallySlasherClient {
 
   public handleWantToSlash(args: WantToSlashArgs[]) {
     return this.offensesCollector.handleWantToSlash(args);
-  }
-
-  public override async stop() {
-    for (const unwatchCallback of this.unwatchCallbacks) {
-      unwatchCallback();
-    }
-
-    this.roundMonitor.stop();
-    await this.offensesCollector.stop();
-
-    // Remove sleep if not running in CI for faster dev iteration
-    // This is here just to avoid a viem issue when uninstalling event listeners
-    if (process.env.CI) {
-      await sleep(2000);
-    }
   }
 }

--- a/yarn-project/slasher/src/tally_slasher_client.ts
+++ b/yarn-project/slasher/src/tally_slasher_client.ts
@@ -5,7 +5,6 @@ import { maxBigint } from '@aztec/foundation/bigint';
 import { SlotNumber } from '@aztec/foundation/branded-types';
 import { compactArray, partition, times } from '@aztec/foundation/collection';
 import { createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import type { DateProvider } from '@aztec/foundation/timer';
 import type { Prettify } from '@aztec/foundation/types';
 import type { SlasherConfig } from '@aztec/stdlib/interfaces/server';
@@ -138,8 +137,6 @@ export class TallySlasherClient implements ProposerSlashActionProvider, SlasherC
     this.roundMonitor.stop();
     await this.offensesCollector.stop();
 
-    // Sleeping to sidestep viem issue with unwatching events
-    await sleep(2000);
     this.log.info('Tally Slasher client stopped');
   }
 


### PR DESCRIPTION
We had added sleeps to the slasher stop method to workaround [this viem bug](https://github.com/wevm/viem/issues/3714), but it was fixed in [version 2.31.2](https://github.com/wevm/viem/commit/ac4f03600bc628bf0d8aa4eda75c2918b9f98143), and we're using `2.38.2`.

This removes those sleeps so tests run fast on CI.
