### PR TITLE
fix(slasher): use a tx db when storing offenses

### DIFF
--- a/yarn-project/slasher/src/stores/offenses_store.ts
+++ b/yarn-project/slasher/src/stores/offenses_store.ts
@@ -76,9 +76,11 @@ export class SlasherOffensesStore {
   /** Adds a new offense (defaults to pending, but will be slashed if markAsSlashed had been called for it) */
   public async addPendingOffense(offense: Offense): Promise<void> {
     const key = this.getOffenseKey(offense);
-    await this.offenses.set(key, serializeOffense(offense));
     const round = getRoundForOffense(offense, this.settings);
-    await this.roundsOffenses.set(this.getRoundKey(round), key);
+    await this.kvStore.transactionAsync(async () => {
+      await this.offenses.set(key, serializeOffense(offense));
+      await this.roundsOffenses.set(this.getRoundKey(round), key);
+    });
     this.log.trace(`Adding pending offense ${key} for round ${round}`);
   }
 


### PR DESCRIPTION
Should fix [this flake](http://ci.aztec-labs.com/1b4aac6e01f9b027). The test waits until `getPendingOffenses` in the store is not empty, but then the `getProposerActions` depends on `getOffensesForRound`, which gets updated _after_ `getPendingOffenses`.

We should be using txs for making all db updated atomic.