### PR TITLE
fix: wrap multi-operation store mutations in db transactions

### DIFF
--- a/yarn-project/archiver/src/store/contract_class_store.ts
+++ b/yarn-project/archiver/src/store/contract_class_store.ts
@@ -28,18 +28,22 @@ export class ContractClassStore {
     bytecodeCommitment: Fr,
     blockNumber: number,
   ): Promise<void> {
-    await this.#contractClasses.setIfNotExists(
-      contractClass.id.toString(),
-      serializeContractClassPublic({ ...contractClass, l2BlockNumber: blockNumber }),
-    );
-    await this.#bytecodeCommitments.setIfNotExists(contractClass.id.toString(), bytecodeCommitment.toBuffer());
+    await this.db.transactionAsync(async () => {
+      await this.#contractClasses.setIfNotExists(
+        contractClass.id.toString(),
+        serializeContractClassPublic({ ...contractClass, l2BlockNumber: blockNumber }),
+      );
+      await this.#bytecodeCommitments.setIfNotExists(contractClass.id.toString(), bytecodeCommitment.toBuffer());
+    });
   }
 
   async deleteContractClasses(contractClass: ContractClassPublic, blockNumber: number): Promise<void> {
     const restoredContractClass = await this.#contractClasses.getAsync(contractClass.id.toString());
     if (restoredContractClass && deserializeContractClassPublic(restoredContractClass).l2BlockNumber >= blockNumber) {
-      await this.#contractClasses.delete(contractClass.id.toString());
-      await this.#bytecodeCommitments.delete(contractClass.id.toString());
+      await this.db.transactionAsync(async () => {
+        await this.#contractClasses.delete(contractClass.id.toString());
+        await this.#bytecodeCommitments.delete(contractClass.id.toString());
+      });
     }
   }
 

--- a/yarn-project/cli-wallet/src/storage/wallet_db.ts
+++ b/yarn-project/cli-wallet/src/storage/wallet_db.ts
@@ -12,6 +12,7 @@ export const Aliases = ['accounts', 'contracts', 'artifacts', 'secrets', 'transa
 export type AliasType = (typeof Aliases)[number];
 
 export class WalletDB {
+  #store!: AztecAsyncKVStore;
   #accounts!: AztecAsyncMap<string, Buffer>;
   #aliases!: AztecAsyncMap<string, Buffer>;
   #bridgedFeeJuice!: AztecAsyncMap<string, Buffer>;
@@ -29,6 +30,7 @@ export class WalletDB {
   }
 
   async init(store: AztecAsyncKVStore) {
+    this.#store = store;
     this.#accounts = store.openMap('accounts');
     this.#aliases = store.openMap('aliases');
     this.#bridgedFeeJuice = store.openMap('bridgedFeeJuice');
@@ -41,14 +43,17 @@ export class WalletDB {
   }
 
   async pushBridgedFeeJuice(recipient: AztecAddress, secret: Fr, amount: bigint, leafIndex: bigint, log: LogFn) {
-    let stackPointer = (await this.#bridgedFeeJuice.getAsync(`${recipient.toString()}:stackPointer`))?.readInt8() || 0;
-    stackPointer++;
-    await this.#bridgedFeeJuice.set(
-      `${recipient.toString()}:${stackPointer}`,
-      Buffer.from(`${amount.toString()}:${secret.toString()}:${leafIndex.toString()}`),
-    );
-    await this.#bridgedFeeJuice.set(`${recipient.toString()}:stackPointer`, Buffer.from([stackPointer]));
-    log(`Pushed ${amount} fee juice for recipient ${recipient.toString()}. Stack pointer ${stackPointer}`);
+    await this.#store.transactionAsync(async () => {
+      let stackPointer =
+        (await this.#bridgedFeeJuice.getAsync(`${recipient.toString()}:stackPointer`))?.readInt8() || 0;
+      stackPointer++;
+      await this.#bridgedFeeJuice.set(
+        `${recipient.toString()}:${stackPointer}`,
+        Buffer.from(`${amount.toString()}:${secret.toString()}:${leafIndex.toString()}`),
+      );
+      await this.#bridgedFeeJuice.set(`${recipient.toString()}:stackPointer`, Buffer.from([stackPointer]));
+      log(`Pushed ${amount} fee juice for recipient ${recipient.toString()}. Stack pointer ${stackPointer}`);
+    });
   }
 
   async popBridgedFeeJuice(recipient: AztecAddress, log: LogFn) {
@@ -76,19 +81,24 @@ export class WalletDB {
     }: { type: AccountType; secretKey: Fr; salt: Fr; alias: string | undefined; publicKey: string | undefined },
     log: LogFn,
   ) {
-    if (alias) {
-      await this.#aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
-    }
-    await this.#accounts.set(`${address.toString()}:type`, Buffer.from(type));
-    await this.#accounts.set(`${address.toString()}:sk`, secretKey.toBuffer());
-    await this.#accounts.set(`${address.toString()}:salt`, salt.toBuffer());
+    let publicSigningKey: Buffer | undefined;
     if (type === 'ecdsasecp256r1ssh' && publicKey) {
-      const publicSigningKey = extractECDSAPublicKeyFromBase64String(publicKey);
-      await this.storeAccountMetadata(address, 'publicSigningKey', publicSigningKey);
+      publicSigningKey = extractECDSAPublicKeyFromBase64String(publicKey);
     }
-    await this.#aliases.set('accounts:last', Buffer.from(address.toString()));
-    log(`Account stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
 
+    await this.#store.transactionAsync(async () => {
+      if (alias) {
+        await this.#aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
+      }
+      await this.#accounts.set(`${address.toString()}:type`, Buffer.from(type));
+      await this.#accounts.set(`${address.toString()}:sk`, secretKey.toBuffer());
+      await this.#accounts.set(`${address.toString()}:salt`, salt.toBuffer());
+      if (publicSigningKey) {
+        await this.#accounts.set(`${address.toString()}:publicSigningKey`, publicSigningKey);
+      }
+      await this.#aliases.set('accounts:last', Buffer.from(address.toString()));
+    });
+    log(`Account stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
     await this.refreshAliasCache();
   }
 
@@ -100,35 +110,38 @@ export class WalletDB {
   }
 
   async storeContract(address: AztecAddress, artifactPath: string, log: LogFn, alias?: string) {
-    if (alias) {
-      await this.#aliases.set(`contracts:${alias}`, Buffer.from(address.toString()));
-      await this.#aliases.set(`artifacts:${alias}`, Buffer.from(artifactPath));
-    }
-    await this.#aliases.set(`contracts:last`, Buffer.from(address.toString()));
-    await this.#aliases.set(`artifacts:last`, Buffer.from(artifactPath));
-    await this.#aliases.set(`artifacts:${address.toString()}`, Buffer.from(artifactPath));
+    await this.#store.transactionAsync(async () => {
+      if (alias) {
+        await this.#aliases.set(`contracts:${alias}`, Buffer.from(address.toString()));
+        await this.#aliases.set(`artifacts:${alias}`, Buffer.from(artifactPath));
+      }
+      await this.#aliases.set(`contracts:last`, Buffer.from(address.toString()));
+      await this.#aliases.set(`artifacts:last`, Buffer.from(artifactPath));
+      await this.#aliases.set(`artifacts:${address.toString()}`, Buffer.from(artifactPath));
+    });
     log(`Contract stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
-
     await this.refreshAliasCache();
   }
 
   async storeAuthwitness(authWit: AuthWitness, log: LogFn, alias?: string) {
-    if (alias) {
-      await this.#aliases.set(`authwits:${alias}`, Buffer.from(authWit.toString()));
-    }
-    await this.#aliases.set(`authwits:last`, Buffer.from(authWit.toString()));
+    await this.#store.transactionAsync(async () => {
+      if (alias) {
+        await this.#aliases.set(`authwits:${alias}`, Buffer.from(authWit.toString()));
+      }
+      await this.#aliases.set(`authwits:last`, Buffer.from(authWit.toString()));
+    });
     log(`Authorization witness stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
-
     await this.refreshAliasCache();
   }
 
   async storeTx({ txHash }: { txHash: TxHash }, log: LogFn, alias?: string) {
-    if (alias) {
-      await this.#aliases.set(`transactions:${alias}`, Buffer.from(txHash.toString()));
-    }
-    await this.#aliases.set(`transactions:last`, Buffer.from(txHash.toString()));
+    await this.#store.transactionAsync(async () => {
+      if (alias) {
+        await this.#aliases.set(`transactions:${alias}`, Buffer.from(txHash.toString()));
+      }
+      await this.#aliases.set(`transactions:last`, Buffer.from(txHash.toString()));
+    });
     log(`Transaction hash stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
-
     await this.refreshAliasCache();
   }
 

--- a/yarn-project/key-store/src/key_store.ts
+++ b/yarn-project/key-store/src/key_store.ts
@@ -22,9 +22,11 @@ import {
  */
 export class KeyStore {
   public static readonly SCHEMA_VERSION = 1;
+  #db: AztecAsyncKVStore;
   #keys: AztecAsyncMap<string, Buffer>;
 
   constructor(database: AztecAsyncKVStore) {
+    this.#db = database;
     this.#keys = database.openMap('key_store');
   }
 
@@ -56,27 +58,31 @@ export class KeyStore {
     const completeAddress = await CompleteAddress.fromSecretKeyAndPartialAddress(sk, partialAddress);
     const { address: account } = completeAddress;
 
-    // Naming of keys is as follows ${account}-${n/iv/ov/t}${sk/pk}_m
-    await this.#keys.set(`${account.toString()}-ivsk_m`, masterIncomingViewingSecretKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-ovsk_m`, masterOutgoingViewingSecretKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-tsk_m`, masterTaggingSecretKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-nsk_m`, masterNullifierSecretKey.toBuffer());
-
-    await this.#keys.set(`${account.toString()}-npk_m`, publicKeys.masterNullifierPublicKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-ivpk_m`, publicKeys.masterIncomingViewingPublicKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-ovpk_m`, publicKeys.masterOutgoingViewingPublicKey.toBuffer());
-    await this.#keys.set(`${account.toString()}-tpk_m`, publicKeys.masterTaggingPublicKey.toBuffer());
-
-    // We store pk_m_hash under `account-{n/iv/ov/t}pk_m_hash` key to be able to obtain address and key prefix
-    // using the #getKeyPrefixAndAccount function later on
+    // Compute hashes before transaction
     const masterNullifierPublicKeyHash = await publicKeys.masterNullifierPublicKey.hash();
-    await this.#keys.set(`${account.toString()}-npk_m_hash`, masterNullifierPublicKeyHash.toBuffer());
     const masterIncomingViewingPublicKeyHash = await publicKeys.masterIncomingViewingPublicKey.hash();
-    await this.#keys.set(`${account.toString()}-ivpk_m_hash`, masterIncomingViewingPublicKeyHash.toBuffer());
     const masterOutgoingViewingPublicKeyHash = await publicKeys.masterOutgoingViewingPublicKey.hash();
-    await this.#keys.set(`${account.toString()}-ovpk_m_hash`, masterOutgoingViewingPublicKeyHash.toBuffer());
     const masterTaggingPublicKeyHash = await publicKeys.masterTaggingPublicKey.hash();
-    await this.#keys.set(`${account.toString()}-tpk_m_hash`, masterTaggingPublicKeyHash.toBuffer());
+
+    await this.#db.transactionAsync(async () => {
+      // Naming of keys is as follows ${account}-${n/iv/ov/t}${sk/pk}_m
+      await this.#keys.set(`${account.toString()}-ivsk_m`, masterIncomingViewingSecretKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-ovsk_m`, masterOutgoingViewingSecretKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-tsk_m`, masterTaggingSecretKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-nsk_m`, masterNullifierSecretKey.toBuffer());
+
+      await this.#keys.set(`${account.toString()}-npk_m`, publicKeys.masterNullifierPublicKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-ivpk_m`, publicKeys.masterIncomingViewingPublicKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-ovpk_m`, publicKeys.masterOutgoingViewingPublicKey.toBuffer());
+      await this.#keys.set(`${account.toString()}-tpk_m`, publicKeys.masterTaggingPublicKey.toBuffer());
+
+      // We store pk_m_hash under `account-{n/iv/ov/t}pk_m_hash` key to be able to obtain address and key prefix
+      // using the #getKeyPrefixAndAccount function later on
+      await this.#keys.set(`${account.toString()}-npk_m_hash`, masterNullifierPublicKeyHash.toBuffer());
+      await this.#keys.set(`${account.toString()}-ivpk_m_hash`, masterIncomingViewingPublicKeyHash.toBuffer());
+      await this.#keys.set(`${account.toString()}-ovpk_m_hash`, masterOutgoingViewingPublicKeyHash.toBuffer());
+      await this.#keys.set(`${account.toString()}-tpk_m_hash`, masterTaggingPublicKeyHash.toBuffer());
+    });
 
     // At last, we return the newly derived account address
     return completeAddress;

--- a/yarn-project/p2p/src/services/data_store.ts
+++ b/yarn-project/p2p/src/services/data_store.ts
@@ -24,6 +24,7 @@ class KeyNotFoundError extends Error {
 }
 
 export class AztecDatastore implements Datastore {
+  #db: AztecAsyncKVStore;
   #memoryDatastore: Map<string, MemoryItem>;
   #dbDatastore: AztecAsyncMap<string, Uint8Array>;
 
@@ -32,9 +33,9 @@ export class AztecDatastore implements Datastore {
   private maxMemoryItems: number;
 
   constructor(db: AztecAsyncKVStore, { maxMemoryItems } = { maxMemoryItems: 50 }) {
+    this.#db = db;
     this.#memoryDatastore = new Map();
     this.#dbDatastore = db.openMap('p2p_datastore');
-
     this.maxMemoryItems = maxMemoryItems;
   }
 
@@ -106,13 +107,15 @@ export class AztecDatastore implements Datastore {
         });
       },
       commit: async () => {
-        for (const op of this.#batchOps) {
-          if (op.type === 'put' && op.value) {
-            await this.put(op.key, op.value);
-          } else if (op.type === 'del') {
-            await this.delete(op.key);
+        await this.#db.transactionAsync(async () => {
+          for (const op of this.#batchOps) {
+            if (op.type === 'put' && op.value) {
+              await this.put(op.key, op.value);
+            } else if (op.type === 'del') {
+              await this.delete(op.key);
+            }
           }
-        }
+        });
         this.#batchOps = []; // Clear operations after commit
       },
     };

--- a/yarn-project/slasher/src/stores/payloads_store.ts
+++ b/yarn-project/slasher/src/stores/payloads_store.ts
@@ -118,10 +118,13 @@ export class SlasherPayloadsStore {
 
   public async incrementPayloadVotes(payloadAddress: EthAddress, round: bigint): Promise<bigint> {
     const key = this.getPayloadVotesKey(round, payloadAddress);
-    const currentVotes = (await this.roundPayloadVotes.getAsync(key)) || 0n;
-    const newVotes = currentVotes + 1n;
-    await this.roundPayloadVotes.set(key, newVotes);
-    return newVotes;
+    let newVotes: bigint;
+    await this.kvStore.transactionAsync(async () => {
+      const currentVotes = (await this.roundPayloadVotes.getAsync(key)) || 0n;
+      newVotes = currentVotes + 1n;
+      await this.roundPayloadVotes.set(key, newVotes);
+    });
+    return newVotes!;
   }
 
   public async addPayload(payload: SlashPayloadRound): Promise<void> {


### PR DESCRIPTION
## Summary

Ensures atomicity for methods that perform multiple database operations by wrapping them in `transactionAsync()` calls.

- **archiver/ContractClassStore**: `addContractClass()`, `deleteContractClasses()` - wrap 2 operations each
- **key-store/KeyStore**: `addAccount()` - wrap 12 set operations
- **p2p/AztecDatastore**: `batch().commit()` - wrap loop of put/delete operations
- **cli-wallet/WalletDB**: `pushBridgedFeeJuice()`, `storeAccount()`, `storeContract()`, `storeAuthwitness()`, `storeTx()` - wrap multiple set operations
- **slasher/SlasherPayloadsStore**: `incrementPayloadVotes()` - wrap read-modify-write pattern

## Test plan

- [x] `yarn build` passes
- [x] `yarn format` passes
- [x] `yarn lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)