### PR TITLE
fix: ensure outhash is checked also in the escape hatch

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -295,6 +295,10 @@ library EpochProofLib {
     // Get the stored attestation hash and payload digest for the last checkpoint
     CompressedTempCheckpointLog storage checkpointLog = STFLib.getStorageTempCheckpointLog(_endCheckpointNumber);
 
+    // Verify that the out hash matches the stored value
+    // The stored out hash is part of the payloadDigest that was attested to.
+    require(checkpointLog.outHash == _outHash, Errors.Rollup__InvalidOutHash(checkpointLog.outHash, _outHash));
+
     // Verify that the provided attestations match the stored hash
     bytes32 providedAttestationsHash = keccak256(abi.encode(_attestations));
     require(providedAttestationsHash == checkpointLog.attestationsHash, Errors.Rollup__InvalidAttestations());
@@ -317,10 +321,6 @@ library EpochProofLib {
     }
 
     ValidatorSelectionLib.verifyAttestations(slot, epoch, _attestations, checkpointLog.payloadDigest);
-
-    // Verify that the out hash matches the stored value
-    // The stored out hash is part of the payloadDigest that was attested to.
-    require(checkpointLog.outHash == _outHash, Errors.Rollup__InvalidOutHash(checkpointLog.outHash, _outHash));
   }
 
   /**

--- a/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
+++ b/l1-contracts/test/escape-hatch/integration/EscapeHatchIntegrationBase.sol
@@ -315,7 +315,10 @@ abstract contract EscapeHatchIntegrationBase is ValidatorSelectionTestBase {
     bytes32 endArchive = rollup.archiveAt(_end);
 
     PublicInputArgs memory args = PublicInputArgs({
-      previousArchive: previousArchive, endArchive: endArchive, outHash: bytes32(0), proverId: _prover
+      previousArchive: previousArchive,
+      endArchive: endArchive,
+      outHash: endFull.checkpoint.header.outHash,
+      proverId: _prover
     });
 
     bytes32[] memory fees = new bytes32[](Constants.AZTEC_MAX_EPOCH_DURATION * 2);

--- a/l1-contracts/test/escape-hatch/integration/regression/OutHashValidationSkipped.t.sol
+++ b/l1-contracts/test/escape-hatch/integration/regression/OutHashValidationSkipped.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {EscapeHatchIntegrationBase} from "../EscapeHatchIntegrationBase.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Epoch} from "@aztec/shared/libraries/TimeMath.sol";
+import {CheckpointLog, SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {
+  CommitteeAttestations,
+  CommitteeAttestation,
+  Signature,
+  AttestationLib
+} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+
+/**
+ * @title OutHashValidationSkippedTest
+ * @notice Regression test for outHash validation being skipped during escape hatch epochs
+ *
+ * @dev This test verifies that the outHash is validated even when the escape hatch is open.
+ *      Previously, the early return in verifyLastCheckpointAttestationsAndOutHash() when
+ *      escape hatch was open would skip the outHash validation, allowing a malicious prover
+ *      to submit an arbitrary outHash that would be inserted into the outbox.
+ *
+ *      Bug location: EpochProofLib.sol::verifyLastCheckpointAttestationsAndOutHash()
+ *      The early `return` when escape hatch is open skipped the outHash check at the end.
+ */
+contract OutHashValidationSkippedTest is EscapeHatchIntegrationBase {
+  function test_RevertWhen_EscapeHatchIsOpenAndOutHashMismatch() external setup(4, 4) progressEpochsToInclusion {
+    // Deploy and configure escape hatch
+    _deployEscapeHatch();
+
+    full = load("empty_checkpoint_1");
+
+    // Setup escape hatch and warp to the escape hatch window
+    _joinCandidateSet(CANDIDATE1);
+    targetHatch = _selectCandidateForHatch();
+    _warpToHatch(targetHatch);
+
+    // Verify escape hatch is open
+    Epoch currentEpoch = rollup.getCurrentEpoch();
+    (bool isOpen,) = escapeHatch.isHatchOpen(currentEpoch);
+    assertTrue(isOpen, "Escape hatch should be open");
+
+    // Propose as escape hatch proposer
+    _proposeWithHatch(CANDIDATE1);
+    assertEq(rollup.getPendingCheckpointNumber(), 1, "Checkpoint should be proposed");
+
+    // Get the correct outHash from the checkpoint
+    CheckpointLog memory endCheckpoint = rollup.getCheckpoint(1);
+    bytes32 correctOutHash = endCheckpoint.outHash;
+
+    // Use a wrong outHash
+    bytes32 wrongOutHash = bytes32(uint256(0xdeadbeef));
+
+    assertNotEq(correctOutHash, wrongOutHash, "Correct outHash should not be equal to wrong outHash");
+
+    PublicInputArgs memory args = PublicInputArgs({
+      previousArchive: rollup.archiveAt(0),
+      endArchive: rollup.archiveAt(1),
+      outHash: wrongOutHash,
+      proverId: address(this)
+    });
+
+    bytes32[] memory fees = new bytes32[](Constants.AZTEC_MAX_EPOCH_DURATION * 2);
+    uint256 size = 1;
+    for (uint256 i = 0; i < size; i++) {
+      fees[i * 2] = bytes32(uint256(uint160(bytes20(("sequencer")))));
+      fees[i * 2 + 1] = bytes32(0);
+    }
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidOutHash.selector, correctOutHash, wrongOutHash));
+    rollup.submitEpochRootProof(
+      SubmitEpochRootProofArgs({
+        start: 1,
+        end: 1,
+        args: args,
+        fees: fees,
+        attestations: CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
+        blobInputs: full.checkpoint.batchedBlobInputs,
+        proof: ""
+      })
+    );
+  }
+}


### PR DESCRIPTION
When the updates to set out hash root in checkpoint was merged after the escape hatch, it inserted a subtle bug. When the escape hatch is open, the check was skipped because of an early return. This meant that during the escape hatch, it was possible for someone to propose completely sound blocks, but for someone else to then prove it with a different outhash if they found soundness bugs 😱. When the updates where made in `EscapeHAtchIntegrationBase` it simple inserted `bytes32(0)` as the `outhash` meaning that the actual test was doing exactly this (since they are run without a real verifier). 