### PR TITLE
chore: (A-347) verify non-validator re-executes and stores mbps into archiver

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
@@ -10,7 +10,7 @@ import { waitForTx } from '@aztec/aztec.js/node';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import type { Operator } from '@aztec/ethereum/deploy-aztec-l1-contracts';
 import { asyncMap } from '@aztec/foundation/async-map';
-import { CheckpointNumber } from '@aztec/foundation/branded-types';
+import { CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { retryUntil } from '@aztec/foundation/retry';
@@ -362,5 +362,77 @@ describe('e2e_epochs/epochs_mbps', () => {
     logger.warn(`All ${consumeTxHashes.length} L1→L2 messages consumed`);
 
     await assertMultipleBlocksPerSlot(2, logger);
+  });
+
+  it('builds multiple blocks per slot and non-validator re-executes and stores proposed multi-block slots', async () => {
+    await setupTest({ syncChainTip: 'proposed', minTxsPerBlock: 1, maxTxsPerBlock: 1 });
+
+    logger.warn(`Creating non-validator node`);
+    const nonValidatorNode = await test.createNonValidatorNode({
+      alwaysReexecuteBlockProposals: true,
+      skipPushProposedBlocksToArchiver: false,
+    });
+
+    await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+    logger.warn(`Started all sequencers`);
+
+    logger.warn(`Pre-proving ${TX_COUNT / 2} transactions`);
+    const txs = await timesAsync(TX_COUNT / 2, i => {
+      const nullifier = new Fr(i + 100);
+      return proveInteraction(context.wallet, contract.methods.emit_nullifier(nullifier), { from });
+    });
+    logger.warn(`Pre-proved ${txs.length} transactions`);
+
+    const sentTxHashes = await Promise.all(txs.map(tx => tx.send({ wait: NO_WAIT })));
+    logger.warn(`Sent ${sentTxHashes.length} transactions`);
+
+    const nonValidatorArchiver = nonValidatorNode.getBlockSource();
+
+    let multiBlockSlotNumber: number | undefined;
+    let checkpointedBlockNumber: number | undefined;
+    await retryUntil(
+      async () => {
+        const tips = await nonValidatorArchiver.getL2Tips();
+        if (tips.proposed.number <= tips.checkpointed.block.number) {
+          return false;
+        }
+        const header = await nonValidatorArchiver.getBlockHeader(tips.proposed.number);
+        if (!header) {
+          return false;
+        }
+        const blocksInSlot = await nonValidatorArchiver.getBlocksForSlot(header.globalVariables.slotNumber);
+        if (blocksInSlot.length < 2) {
+          return false;
+        }
+        multiBlockSlotNumber = header.globalVariables.slotNumber;
+        checkpointedBlockNumber = tips.checkpointed.block.number;
+        return true;
+      },
+      'non-validator node to store multi-block proposed slot',
+      test.L2_SLOT_DURATION_IN_S * 5,
+      0.5,
+    );
+
+    // ensure the proposed multi-block slot has valid effects
+    expect(multiBlockSlotNumber).toBeDefined();
+    const blocksInSlot = await nonValidatorArchiver.getBlocksForSlot(SlotNumber(multiBlockSlotNumber!));
+    expect(blocksInSlot.length).toBeGreaterThanOrEqual(2);
+    expect(checkpointedBlockNumber).toBeDefined();
+    expect(blocksInSlot.every(block => block.number > checkpointedBlockNumber!)).toBe(true); // ensure the block is proposed
+    const txHashesInSlot = blocksInSlot.flatMap(block => block.body.txEffects.map(effect => effect.txHash));
+    expect(txHashesInSlot.length).toBeGreaterThan(0);
+    const effectsInSlot = await Promise.all(txHashesInSlot.map(txHash => nonValidatorArchiver.getTxEffect(txHash)));
+    expect(effectsInSlot.every(effect => effect !== undefined)).toBe(true);
+
+    const maxBlockNumberInSlot = Math.max(...blocksInSlot.map(block => block.number));
+    await retryUntil(
+      async () => {
+        const tips = await nonValidatorArchiver.getL2Tips();
+        return tips.checkpointed.block.number >= maxBlockNumberInSlot;
+      },
+      'non-validator node to sync checkpointed block',
+      test.L2_SLOT_DURATION_IN_S * 5,
+      0.5,
+    );
   });
 });


### PR DESCRIPTION
A test verifying that non-validators can reexecute and store multiple proposed blocks per slot into archiver since this process is already set up for mbps