### PR TITLE
chore: e2e gossip deflake

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -5,7 +5,6 @@ import { TxHash } from '@aztec/aztec.js/tx';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import type { ProverNode } from '@aztec/prover-node';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
@@ -64,7 +63,7 @@ describe('e2e_p2p_network', () => {
       startProverNode: false, // we'll start our own using p2p
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
-        aztecSlotDuration: 24,
+        aztecSlotDuration: 36,
         aztecEpochDuration: 4,
         slashingRoundSizeInEpochs: 2,
         slashingQuorum: 5,
@@ -145,8 +144,8 @@ describe('e2e_p2p_network', () => {
       shouldCollectMetrics(),
     );
 
-    // wait a bit for peers to discover each other
-    await sleep(8000);
+    t.logger.info('Waiting for nodes to connect');
+    await t.waitForP2PMeshConnectivity(nodes, NUM_VALIDATORS);
 
     // We need to `createNodes` before we setup account, because
     // those nodes actually form the committee, and so we cannot build


### PR DESCRIPTION
Should fix flakes: http://ci.aztec-labs.com/e8f258bd3a41989c
The issue was the short test slot duration.

The deadline from slot start to end is `20s`, which is expected, because: 
```
deadline = slotStart + (aztecSlotDuration - ethereumSlotDuration)
Test config:
  - aztecSlotDuration = 24s
  - ethereumSlotDuration = 4s
```

In the linked CI log, let's look at slot 14:
1. Slot 14 timestamp = 1769766568 → **09:49:28** (slot start denoted by `slotTs`)
2. checkpoint-builder validator-1 checkpoint-2 Building block 2 for slot 14 within checkpoint {"slot":14,"blockNumber":2,"maxTransactions":32,"maxBlockSize":1048576,"maxBlockGas":{"daGas":10000000000,"l2Gas":200000000},"maxBlobFields":24568,"currentTime":"2026-01-30T**09:49:44.097Z**"}
3. ERROR: validator validator-1 Timeout 2026-01-30T**09:49:48.000Z** waiting for 3 attestations for slot 14

So, from whenthe  block was built, we have only **4s** for:
1. gossip propagation
2. validator re-execution
3. attestation collection (needs 3/4)

Suggested fix: bump `aztecSlotDuration` 24s -> 36s, giving us +12s to do steps above. 

