### PR TITLE
chore: proper naming in BlockTxsRequest

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_batch_txs.test.ts
@@ -105,11 +105,11 @@ describe('p2p client integration batch txs', () => {
     await sleep(1000);
   };
 
-  const createBlockProposal = (blockNumber: number, blockHash: Fr, txHashes: TxHash[]) => {
+  const createBlockProposal = (blockNumber: number, archiveRoot: Fr, txHashes: TxHash[]) => {
     return makeBlockProposal({
       signer: Secp256k1Signer.random(),
       blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(blockNumber) }),
-      archiveRoot: blockHash,
+      archiveRoot,
       txHashes,
     });
   };
@@ -173,8 +173,8 @@ describe('p2p client integration batch txs', () => {
     const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
 
     const blockNumber = 5;
-    const blockHash = Fr.random();
-    const blockProposal = await createBlockProposal(blockNumber, blockHash, txHashes);
+    const archiveRoot = Fr.random();
+    const blockProposal = await createBlockProposal(blockNumber, archiveRoot, txHashes);
 
     // Distribute transactions across peers (simulating partial knowledge)
     // Peer 0 has no txs (client requesting)

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_block_txs.test.ts
@@ -41,7 +41,7 @@ describe('p2p client integration block txs protocol ', () => {
   let clients: P2PClient[] = [];
 
   const blockNumber = BlockNumber(5);
-  const blockHash = Fr.random();
+  const archiveRoot = Fr.random();
   let txs: Tx[];
   let txHashes: TxHash[];
   let blockProposal: BlockProposal;
@@ -100,7 +100,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     txs = await Promise.all(times(5, i => createMockTxWithMetadata(p2pBaseConfig, i)));
     txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
-    blockProposal = await createBlockProposal(BlockNumber(blockNumber), blockHash, txHashes);
+    blockProposal = await createBlockProposal(BlockNumber(blockNumber), archiveRoot, txHashes);
     attestationPool.getBlockProposal.mockResolvedValue(blockProposal);
   });
 
@@ -122,11 +122,11 @@ describe('p2p client integration block txs protocol ', () => {
     await sleep(1000);
   };
 
-  const createBlockProposal = (blockNumber: BlockNumber, blockHash: Fr, txHashes: TxHash[]) => {
+  const createBlockProposal = (blockNumber: BlockNumber, archiveRoot: Fr, txHashes: TxHash[]) => {
     return makeBlockProposal({
       signer: Secp256k1Signer.random(),
       blockHeader: makeBlockHeader(1, { blockNumber }),
-      archiveRoot: blockHash,
+      archiveRoot,
       txHashes,
     });
   };
@@ -171,11 +171,11 @@ describe('p2p client integration block txs protocol ', () => {
       blockProposal,
       txHashes.filter((_, i) => requestedIndices.includes(i)),
     );
-    //const response = await sendBlockTxsRequest(blockHash, requestedIndices, txs.length);
+    //const response = await sendBlockTxsRequest(archiveRoot, requestedIndices, txs.length);
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(requestedIndices.length);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 1, 2, 3, 4]);
 
@@ -211,7 +211,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(2); // Only txs at indices 0 and 2 are returned
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 2, 3]);
 
@@ -235,7 +235,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(0);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([]);
   });
@@ -260,7 +260,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(requestedIndices.length);
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([0, 1, 2, 3, 4]);
 
@@ -297,7 +297,7 @@ describe('p2p client integration block txs protocol ', () => {
 
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
-    expect(blockTxsResponse.blockHash.equals(blockHash)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(archiveRoot)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs returned
     expect(blockTxsResponse.txIndices.getTrueIndices()).toEqual([1, 3]); // Only indices 1 and 3 available
 
@@ -337,8 +337,8 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    // When peer doesn't have proposal but has txs, it returns Fr.ZERO as blockHash
-    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    // When peer doesn't have proposal but has txs, it returns Fr.ZERO as archive root
+    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(2); // Only 2 txs available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0); // Empty BitVector when no proposal
 
@@ -367,7 +367,7 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(1); // Only 1 tx available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0);
 
@@ -389,7 +389,7 @@ describe('p2p client integration block txs protocol ', () => {
     expect(response.status).toBe(ReqRespStatus.SUCCESS);
     const blockTxsResponse = BlockTxsResponse.fromBuffer(response.data);
 
-    expect(blockTxsResponse.blockHash.equals(Fr.ZERO)).toBe(true);
+    expect(blockTxsResponse.archiveRoot.equals(Fr.ZERO)).toBe(true);
     expect(blockTxsResponse.txs.length).toBe(0); // No txs available
     expect(blockTxsResponse.txIndices.getLength()).toBe(0);
   });

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -210,19 +210,19 @@ describe('LibP2PService', () => {
       service.createRequestedTxValidator = () => stubValidator;
     });
 
-    function makeRequest(blockHash: Fr, length: number, indices: number[]): BlockTxsRequest {
+    function makeRequest(archiveRoot: Fr, length: number, indices: number[]): BlockTxsRequest {
       return {
-        blockHash,
+        archiveRoot,
         txIndices: BitVector.init(length, indices),
       } as BlockTxsRequest;
     }
 
-    function makeResponse(blockHash: Fr, length: number, indices: number[], txHashes: string[]): BlockTxsResponse {
+    function makeResponse(archiveRoot: Fr, length: number, indices: number[], txHashes: string[]): BlockTxsResponse {
       const txs = txHashes.map(h => ({
         getTxHash: () => ({ toString: () => h }),
       })) as any[];
       return {
-        blockHash,
+        archiveRoot,
         txs,
         txIndices: BitVector.init(length, indices),
       } as BlockTxsResponse;
@@ -248,7 +248,7 @@ describe('LibP2PService', () => {
       };
     }
 
-    it('should penalize and reject on block hash mismatch', async () => {
+    it('should penalize and reject on archive root mismatch', async () => {
       const reqHash = Fr.random();
       const otherHash = Fr.random();
       const request = makeRequest(reqHash, 5, [0, 2]);

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1214,7 +1214,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
    * @returns True if the requested block transactions are valid, false otherwise.
    */
   @trackSpan('Libp2pService.validateRequestedBlockTxs', request => ({
-    [Attributes.BLOCK_HASH]: request.blockHash.toString(),
+    [Attributes.BLOCK_ARCHIVE]: request.archiveRoot.toString(),
   }))
   private async validateRequestedBlockTxs(
     request: BlockTxsRequest,
@@ -1224,10 +1224,10 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const requestedTxValidator = this.createRequestedTxValidator();
 
     try {
-      if (!response.blockHash.equals(request.blockHash)) {
+      if (!response.archiveRoot.equals(request.archiveRoot)) {
         this.peerManager.penalizePeer(peerId, PeerErrorSeverity.MidToleranceError);
         throw new ValidationError(
-          `Received block txs for unexpected block: expected ${request.blockHash.toString()}, got ${response.blockHash.toString()}`,
+          `Received block txs for unexpected archive root: expected ${request.archiveRoot.toString()}, got ${response.archiveRoot.toString()}`,
         );
       }
 
@@ -1257,7 +1257,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       }
 
       // Given proposal (should have locally), ensure returned txs are valid subset and match request indices
-      const proposal = await this.mempools.attestationPool.getBlockProposal(request.blockHash.toString());
+      const proposal = await this.mempools.attestationPool.getBlockProposal(request.archiveRoot.toString());
       if (proposal) {
         // Build intersected indices
         const intersectIdx = request.txIndices.getTrueIndices().filter(i => response.txIndices.isSet(i));
@@ -1277,7 +1277,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       } else {
         // No local proposal, cannot check the membership/order of the returned txs
         this.logger.warn(
-          `Block proposal not found for block hash ${request.blockHash.toString()}; cannot validate membership/order of returned txs`,
+          `Block proposal not found for archive root ${request.archiveRoot.toString()}; cannot validate membership/order of returned txs`,
         );
         return false;
       }

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/README.md
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/README.md
@@ -71,7 +71,7 @@ The requester classifies peers into three categories to optimize fetching:
 ### Blind Phase → Smart Phase Transition
 
 Peers transition from "dumb" to "smart" when they respond with a valid `BlockTxsResponse` containing:
-1. A matching `blockHash`
+1. A matching `archiveRoot`
 2. A non-empty `txIndices` BitVector indicating which transactions they have
 3. At least one transaction we're still missing
 
@@ -81,10 +81,10 @@ Peers transition from "dumb" to "smart" when they respond with a valid `BlockTxs
 │  ┌────────────────────────────────────────────────────────────────────────┐  │
 │  │  Initial State: All peers are "dumb" (except pinned peer)              │  │
 │  │                                                                        │  │
-│  │  Request: [blockHash, txHashes (full list), txIndices (BitVector)]     │  │
+│  │  Request: [archiveRoot, txHashes (full list), txIndices (BitVector)]   │  │
 │  │           └─ Include full hashes because peer may not have proposal    │  │
 │  │                                                                        │  │
-│  │  Response: [blockHash, txs[], txIndices (what peer has)]               │  │
+│  │  Response: [archiveRoot, txs[], txIndices (what peer has)]             │  │
 │  │            └─ Tells us exactly which txs this peer can provide         │  │
 │  └────────────────────────────────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -97,10 +97,10 @@ Peers transition from "dumb" to "smart" when they respond with a valid `BlockTxs
 │  ┌────────────────────────────────────────────────────────────────────────┐  │
 │  │  Peer promoted to "smart" - we know exactly what they have             │  │
 │  │                                                                        │  │
-│  │  Request: [blockHash, txIndices (BitVector only)]                      │  │
+│  │  Request: [archiveRoot, txIndices (BitVector only)]                    │  │
 │  │           └─ No need for full hashes, peer has the proposal            │  │
 │  │                                                                        │  │
-│  │  Response: [blockHash, txs[], txIndices (updated availability)]        │  │
+│  │  Response: [archiveRoot, txs[], txIndices (updated availability)]      │  │
 │  │            └─ May have received more txs since last response           │  │
 │  └────────────────────────────────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────────┘
@@ -152,7 +152,7 @@ The `BatchTxRequester` runs three types of workers concurrently:
 
 ```typescript
 class BlockTxsRequest {
-  blockHash: Fr;           // 32-byte hash of the proposed block header
+  archiveRoot: Fr;         // Archive root after the proposed block is applied
   txHashes: TxHashArray;   // Full tx hashes (for dumb peers without proposal)
   txIndices: BitVector;    // Which txs from proposal we're requesting (1 = want)
 }
@@ -162,7 +162,7 @@ class BlockTxsRequest {
 
 ```typescript
 class BlockTxsResponse {
-  blockHash: Fr;           // Echo back the block hash
+  archiveRoot: Fr;         // Echo back the proposal archive root
   txs: TxArray;            // Actual transaction data
   txIndices: BitVector;    // Which txs the peer has available (1 = have)
 }

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.test.ts
@@ -63,11 +63,11 @@ describe('BatchTxRequester', () => {
     txValidator = new AlwaysValidTxValidator();
 
     const signer = Secp256k1Signer.random();
-    const blockHash = Fr.random();
+    const archiveRoot = Fr.random();
     blockProposal = await makeBlockProposal({
       signer,
       blockHeader: makeBlockHeader(1, { blockNumber: BlockNumber(1) }),
-      archiveRoot: blockHash,
+      archiveRoot,
       txHashes: [],
     });
   });

--- a/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
+++ b/yarn-project/p2p/src/services/reqresp/batch-tx-requester/batch_tx_requester.ts
@@ -605,9 +605,9 @@ export class BatchTxRequester {
   }
 
   private isBlockResponseValid(response: BlockTxsResponse): boolean {
-    const blockIdsMatch = this.blockProposal.archive.toString() === response.blockHash.toString();
+    const archiveRootsMatch = this.blockProposal.archive.toString() === response.archiveRoot.toString();
     const peerHasSomeTxsFromProposal = !response.txIndices.isEmpty();
-    return blockIdsMatch && peerHasSomeTxsFromProposal;
+    return archiveRootsMatch && peerHasSomeTxsFromProposal;
   }
 
   private peerHasSomeTxsWeAreMissing(_peerId: PeerId, response: BlockTxsResponse): boolean {

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs.test.ts
@@ -22,15 +22,15 @@ describe('BlockTxRequest', () => {
   };
 
   it('should serialize and deserialize correctly', () => {
-    const blockHash = Fr.random();
+    const archiveRoot = Fr.random();
     const missing = new TxHashArray(...Array.from({ length: 4 }, () => TxHash.random()));
     const txIndices = BitVector.init(16, [0, 5, 10, 15]);
 
-    const original = new BlockTxsRequest(blockHash, missing, txIndices);
+    const original = new BlockTxsRequest(archiveRoot, missing, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.archiveRoot).toEqual(original.archiveRoot);
     expect(deserialized.txHashes.length).toBe(original.txHashes.length);
     expect(deserialized.txHashes).toEqual(original.txHashes);
     expect(deserialized.txIndices.getLength()).toBe(original.txIndices.getLength());
@@ -38,14 +38,14 @@ describe('BlockTxRequest', () => {
   });
 
   it('should handle empty BitVector', () => {
-    const blockHash = Fr.random();
+    const archiveRoot = Fr.random();
     const txIndices = BitVector.init(8, []);
 
-    const original = new BlockTxsRequest(blockHash, new TxHashArray(), txIndices);
+    const original = new BlockTxsRequest(archiveRoot, new TxHashArray(), txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(blockHash);
+    expect(deserialized.archiveRoot).toEqual(archiveRoot);
     expect(deserialized.txIndices.getTrueIndices()).toEqual([]);
   });
 
@@ -57,7 +57,7 @@ describe('BlockTxRequest', () => {
     const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, true);
 
     expect(request).toBeDefined();
-    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.archiveRoot).toEqual(blockProposal.archive);
     expect(request!.txHashes.length).toBe(2);
     expect(request!.txHashes).toEqual(new TxHashArray(...missingHashes));
     expect(request!.txIndices.getTrueIndices()).toEqual([1, 3]);
@@ -72,7 +72,7 @@ describe('BlockTxRequest', () => {
     const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes, false);
 
     expect(request).toBeDefined();
-    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.archiveRoot).toEqual(blockProposal.archive);
     expect(request!.txHashes.length).toBe(0);
     expect(request!.txIndices.getTrueIndices()).toEqual([0, 2, 4]);
     expect(request!.txIndices.getLength()).toBe(5);
@@ -86,7 +86,7 @@ describe('BlockTxRequest', () => {
     const request = BlockTxsRequest.fromBlockProposalAndMissingTxs(blockProposal, missingHashes);
 
     expect(request).toBeDefined();
-    expect(request!.blockHash).toEqual(blockProposal.archive);
+    expect(request!.archiveRoot).toEqual(blockProposal.archive);
     expect(request!.txHashes.length).toBe(0);
     expect(request!.txIndices.getTrueIndices()).toEqual([1]);
   });
@@ -120,7 +120,7 @@ describe('BlockTxRequest', () => {
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.archiveRoot).toEqual(original.archiveRoot);
     expect(deserialized.txHashes).toEqual(original.txHashes);
     expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
   });
@@ -134,7 +134,7 @@ describe('BlockTxRequest', () => {
     const buffer = original.toBuffer();
     const deserialized = BlockTxsRequest.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.archiveRoot).toEqual(original.archiveRoot);
     expect(deserialized.txHashes.length).toBe(0);
     expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
   });
@@ -142,15 +142,15 @@ describe('BlockTxRequest', () => {
 
 describe('BlockTxResponse', () => {
   it('should serialize and deserialize correctly', async () => {
-    const blockHash = Fr.random();
+    const archiveRoot = Fr.random();
     const txs = new TxArray(await mockTx(), await mockTx(), await mockTx());
     const txIndices = BitVector.init(8, [0, 2, 5]);
 
-    const original = new BlockTxsResponse(blockHash, txs, txIndices);
+    const original = new BlockTxsResponse(archiveRoot, txs, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsResponse.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(original.blockHash);
+    expect(deserialized.archiveRoot).toEqual(original.archiveRoot);
     expect(deserialized.txs.length).toBe(original.txs.length);
     expect(deserialized.txIndices.getLength()).toBe(original.txIndices.getLength());
     expect(deserialized.txIndices.getTrueIndices()).toEqual(original.txIndices.getTrueIndices());
@@ -163,15 +163,15 @@ describe('BlockTxResponse', () => {
   });
 
   it('should handle empty response', () => {
-    const blockHash = Fr.random();
+    const archiveRoot = Fr.random();
     const txs = new TxArray(); // No transactions
     const txIndices = BitVector.init(10, []); // No indices
 
-    const original = new BlockTxsResponse(blockHash, txs, txIndices);
+    const original = new BlockTxsResponse(archiveRoot, txs, txIndices);
     const buffer = original.toBuffer();
     const deserialized = BlockTxsResponse.fromBuffer(buffer);
 
-    expect(deserialized.blockHash).toEqual(blockHash);
+    expect(deserialized.archiveRoot).toEqual(archiveRoot);
     expect(deserialized.txs.length).toBe(0);
     expect(deserialized.txIndices.getTrueIndices()).toEqual([]);
   });

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_handler.ts
@@ -31,7 +31,7 @@ export function reqRespBlockTxsHandler(attestationPool: AttestationPool, txPool:
       throw new ReqRespStatusError(ReqRespStatus.BADLY_FORMED_REQUEST, { cause: err });
     }
 
-    const blockProposal = await attestationPool.getBlockProposal(request.blockHash.toString());
+    const blockProposal = await attestationPool.getBlockProposal(request.archiveRoot.toString());
 
     let requestedTxsHashes;
     if (request.txHashes.length > 0) {
@@ -60,7 +60,7 @@ export function reqRespBlockTxsHandler(attestationPool: AttestationPool, txPool:
     requestedTxsHashes = blockProposal.txHashes.filter((_, idx) => requestedIndices.has(idx));
 
     const responseTxs = (await txPool.getTxsByHash(requestedTxsHashes)).filter(tx => !!tx);
-    const response = new BlockTxsResponse(request.blockHash, new TxArray(...responseTxs), responseBitVector);
+    const response = new BlockTxsResponse(request.archiveRoot, new TxArray(...responseTxs), responseBitVector);
 
     return response.toBuffer();
   };

--- a/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/block_txs/block_txs_reqresp.ts
@@ -10,8 +10,8 @@ import { BitVector } from './bitvector.js';
  */
 export class BlockTxsRequest {
   constructor(
-    // 32 byte hash of the proposed block header
-    readonly blockHash: Fr,
+    // Archive root after the proposed block is applied (proposal identifier)
+    readonly archiveRoot: Fr,
     // Hashes of txs we are requesting
     readonly txHashes: TxHashArray,
     // BitVector indicating which txs from the proposal we are requesting
@@ -22,7 +22,7 @@ export class BlockTxsRequest {
   ) {}
 
   /**
-   * Crates new BlockTxsRequest given proposal and missing tx hashes
+   * Creates new BlockTxsRequest given proposal and missing tx hashes
    *
    * @param: blockProposal - The block proposal for which we are making request
    * @param: missingTxHashes - Tx hashes from the proposal we are missing
@@ -63,11 +63,11 @@ export class BlockTxsRequest {
    */
   static fromBuffer(buffer: Buffer | BufferReader): BlockTxsRequest {
     const reader = BufferReader.asReader(buffer);
-    const blockHash = Fr.fromBuffer(reader);
+    const archiveRoot = Fr.fromBuffer(reader);
     const txHashes = TxHashArray.fromBuffer(reader);
     const txIndices = BitVector.fromBuffer(reader);
 
-    return new BlockTxsRequest(blockHash, txHashes, txIndices);
+    return new BlockTxsRequest(archiveRoot, txHashes, txIndices);
   }
 
   /**
@@ -75,7 +75,7 @@ export class BlockTxsRequest {
    * @returns Buffer representation of the BlockTxRequest object
    */
   toBuffer(): Buffer {
-    return serializeToBuffer([this.blockHash, this.txHashes.toBuffer(), this.txIndices.toBuffer()]);
+    return serializeToBuffer([this.archiveRoot, this.txHashes.toBuffer(), this.txIndices.toBuffer()]);
   }
 }
 
@@ -84,7 +84,7 @@ export class BlockTxsRequest {
  */
 export class BlockTxsResponse {
   constructor(
-    readonly blockHash: Fr,
+    readonly archiveRoot: Fr,
     readonly txs: TxArray, // List of transactions we requested and peer has
     // BitVector indicating which txs from the proposal are available at the peer
     // 1 means the tx is available, 0 means it is not
@@ -98,11 +98,11 @@ export class BlockTxsResponse {
    */
   static fromBuffer(buffer: Buffer | BufferReader): BlockTxsResponse {
     const reader = BufferReader.asReader(buffer);
-    const blockHash = Fr.fromBuffer(reader);
+    const archiveRoot = Fr.fromBuffer(reader);
     const txs = TxArray.fromBuffer(reader);
     const txIndices = BitVector.fromBuffer(reader);
 
-    return new BlockTxsResponse(blockHash, txs, txIndices);
+    return new BlockTxsResponse(archiveRoot, txs, txIndices);
   }
 
   /**
@@ -112,7 +112,7 @@ export class BlockTxsResponse {
    * @returns Buffer representation of the BlockTxResponse object
    */
   toBuffer(): Buffer {
-    return serializeToBuffer([this.blockHash, this.txs.toBuffer(), this.txIndices.toBuffer()]);
+    return serializeToBuffer([this.archiveRoot, this.txs.toBuffer(), this.txIndices.toBuffer()]);
   }
 
   static empty(): BlockTxsResponse {


### PR DESCRIPTION
Rename blockHash -> archiveRoot in BlockTxs req/resp structs and handlers (as the previous naming was incorrect as @spalladino  discovered)

Underlying logic is the same, this is just name change (fix)