### PR TITLE
fix(sequencer): do not build empty blocks after first one in slot

### DIFF
--- a/yarn-project/foundation/src/types/index.test.ts
+++ b/yarn-project/foundation/src/types/index.test.ts
@@ -1,0 +1,36 @@
+import { isErrorClass } from './index.js';
+
+describe('isErrorClass', () => {
+  class CustomError extends Error {
+    constructor() {
+      super('This is a custom error');
+      this.name = 'CustomError';
+    }
+  }
+
+  class AnotherError extends Error {
+    constructor() {
+      super('This is a another error');
+      this.name = 'AnotherError';
+    }
+  }
+
+  it('should identify instances of the specified error class', () => {
+    const error = new CustomError();
+    expect(isErrorClass(error, CustomError)).toBe(true);
+    expect(isErrorClass(error, AnotherError)).toBe(false);
+  });
+
+  it('should handle non-error values correctly', () => {
+    expect(isErrorClass({}, CustomError)).toBe(false);
+    expect(isErrorClass(null, CustomError)).toBe(false);
+    expect(isErrorClass(undefined, CustomError)).toBe(false);
+    expect(isErrorClass('error', CustomError)).toBe(false);
+  });
+
+  it('should identify built-in Error instances', () => {
+    const error = new Error('Built-in error');
+    expect(isErrorClass(error, Error)).toBe(true);
+    expect(isErrorClass(error, CustomError)).toBe(false);
+  });
+});

--- a/yarn-project/foundation/src/types/index.ts
+++ b/yarn-project/foundation/src/types/index.ts
@@ -24,6 +24,11 @@ export function isDefined<T>(value: T | undefined): value is T {
   return value !== undefined;
 }
 
+/** Type guard for error classes */
+export function isErrorClass<T extends Error>(value: unknown, errorClass: new (...args: any[]) => T): value is T {
+  return value instanceof errorClass || (value instanceof Error && value.name === errorClass.name);
+}
+
 /** Resolves a record-like type. Lifted from viem. */
 export type Prettify<T> = {
   [K in keyof T]: T[K];

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.test.ts
@@ -5,7 +5,6 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractsList, protocolContractsHash } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
-import { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { EthAddress } from '@aztec/stdlib/block';
@@ -20,7 +19,9 @@ import { NativeWorldStateService } from '@aztec/world-state/native';
 
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
-describe('CheckpointBuilder', () => {
+import { LightweightCheckpointBuilder } from './lightweight_checkpoint_builder.js';
+
+describe('LightweightCheckpointBuilder', () => {
   let worldState: NativeWorldStateService;
   let feePayer: AztecAddress;
   let feePayerBalance: Fr;

--- a/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
+++ b/yarn-project/prover-client/src/light/lightweight_checkpoint_builder.ts
@@ -143,6 +143,11 @@ export class LightweightCheckpointBuilder {
     return builder;
   }
 
+  /** Returns how many blocks have been added to this checkpoint so far */
+  public getBlockCount() {
+    return this.blocks.length;
+  }
+
   /**
    * Adds a new block to the checkpoint. The tx effects must have already been inserted into the db if
    * this is called after tx processing, if that's not the case, then set `insertTxsEffects` to true.

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -23,21 +23,23 @@ import type { TypedEventEmitter } from '@aztec/foundation/types';
 import { type P2P, P2PClientState } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { CommitteeAttestation, type L2BlockSink, type L2BlockSource } from '@aztec/stdlib/block';
+import { CommitteeAttestation, L2Block, type L2BlockSink, type L2BlockSource } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
-import type {
-  MerkleTreeWriteOperations,
-  ResolvedSequencerConfig,
-  WorldStateSynchronizer,
+import {
+  type BuildBlockInCheckpointResult,
+  type MerkleTreeWriteOperations,
+  NoValidTxsError,
+  type ResolvedSequencerConfig,
+  type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { BlockProposal, CheckpointProposal } from '@aztec/stdlib/p2p';
-import { GlobalVariables, type Tx } from '@aztec/stdlib/tx';
+import { type FailedTx, GlobalVariables, type Tx } from '@aztec/stdlib/tx';
 import { AttestationTimeoutError } from '@aztec/stdlib/validators';
 import { getTelemetryClient } from '@aztec/telemetry-client';
-import type { FullNodeCheckpointsBuilder, ValidatorClient } from '@aztec/validator-client';
+import { CheckpointBuilder, type FullNodeCheckpointsBuilder, type ValidatorClient } from '@aztec/validator-client';
 import { DutyAlreadySignedError, SlashingProtectionError } from '@aztec/validator-ha-signer/errors';
 import { DutyType } from '@aztec/validator-ha-signer/types';
 
@@ -458,7 +460,7 @@ describe('CheckpointProposalJob', () => {
     const txs = await Promise.all(Array.from({ length: totalTxs }, (_, i) => makeTx(i + 1, chainId)));
 
     // Set up p2p mocks
-    p2p.getPendingTxCount.mockResolvedValue(10);
+    p2p.getPendingTxCount.mockResolvedValue(txs.length);
     p2p.iteratePendingTxs.mockImplementation(() => mockTxIterator(Promise.resolve(txs)));
 
     // Create blocks with incrementing block numbers
@@ -583,6 +585,92 @@ describe('CheckpointProposalJob', () => {
       expect(waitSpy).toHaveBeenCalledTimes(1);
       // The wait time is until the next block deadline
       expect(waitSpy.mock.calls[0][0]).toEqual(10);
+    });
+
+    it('builds a single empty block when no txs are available and no min txs required', async () => {
+      // Mock timetable to have two sub-slots
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 2, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 4, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      // Set up test data for an empty block
+      const { lastBlock } = await setupMultipleBlocks(1, [0]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(lastBlock));
+
+      // Install spy on waitUntilTimeInSlot to verify it's called with expected deadlines
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      job.updateConfig({ minTxsPerBlock: 0 });
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+
+      // Verify waitUntilTimeInSlot was called between blocks
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+      // The wait time is until the next block deadline
+      expect(waitSpy.mock.calls[0][0]).toEqual(2);
+    });
+
+    it('builds a single block when not enough txs are available but we build empty checkpoints', async () => {
+      // Mock timetable to have two sub-slots
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 2, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 4, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      // Set up test data for a block with only 2 txs, note that min txs is 5
+      const { lastBlock } = await setupMultipleBlocks(1, [2]);
+      validatorClient.collectAttestations.mockResolvedValue(getAttestations(lastBlock));
+
+      // Install spy on waitUntilTimeInSlot to verify it's called with expected deadlines
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      job.updateConfig({ minTxsPerBlock: 5, buildCheckpointIfEmpty: true });
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeDefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(1);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(1);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(1);
+
+      // Verify waitUntilTimeInSlot was called between blocks
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+      // The wait time is until the next block deadline
+      expect(waitSpy.mock.calls[0][0]).toEqual(2);
+    });
+
+    it('does not build anything if not enough txs and we do not build empty checkpoints', async () => {
+      // Mock timetable to have two sub-slots
+      jest
+        .spyOn(job.getTimetable(), 'canStartNextBlock')
+        .mockReturnValueOnce({ canStart: true, deadline: 2, isLastBlock: false })
+        .mockReturnValueOnce({ canStart: true, deadline: 4, isLastBlock: true })
+        .mockReturnValue({ canStart: false, deadline: undefined, isLastBlock: false });
+
+      // Not enough txs to build a block
+      p2p.getPendingTxCount.mockResolvedValue(2);
+
+      // Install spy on waitUntilTimeInSlot to verify it's called with expected deadlines
+      const waitSpy = jest.spyOn(job, 'waitUntilTimeInSlot');
+
+      job.updateConfig({ minTxsPerBlock: 5, buildCheckpointIfEmpty: false });
+      const checkpoint = await job.execute();
+
+      expect(checkpoint).toBeUndefined();
+      expect(checkpointBuilder.buildBlockCalls).toHaveLength(0);
+      expect(validatorClient.collectAttestations).toHaveBeenCalledTimes(0);
+      expect(publisher.enqueueProposeCheckpoint).toHaveBeenCalledTimes(0);
+
+      // Verify waitUntilTimeInSlot was called between blocks
+      expect(waitSpy).toHaveBeenCalledTimes(1);
+      // The wait time is until the next block deadline
+      expect(waitSpy.mock.calls[0][0]).toEqual(2);
     });
 
     it('stops building when canStartNextBlock returns false', async () => {
@@ -717,6 +805,53 @@ describe('CheckpointProposalJob', () => {
       const remainingAfterBlock1 = block1MaxBlobFields - block1BlobFieldsUsed;
       const block2MaxBlobFields = remainingAfterBlock1 - NUM_BLOCK_END_BLOB_FIELDS;
       expect(checkpointBuilder.buildBlockCalls[1].opts.maxBlobFields).toBe(block2MaxBlobFields);
+    });
+  });
+
+  describe('build single block', () => {
+    it('does not build a block if not enough valid txs are collected', async () => {
+      // We have enough txs, but not enough valid ones
+      job.updateConfig({ minTxsPerBlock: 3, minValidTxsPerBlock: 2 });
+      const txs = await timesAsync(3, i => makeTx(i + 1, chainId));
+      mockPendingTxs(p2p, txs);
+
+      const checkpointBuilder = mock<CheckpointBuilder>();
+      const failedTxs: FailedTx[] = txs.slice(1).map(tx => ({ tx, error: new Error('Invalid tx') }));
+      checkpointBuilder.buildBlock.mockResolvedValue({ failedTxs, numTxs: 1 } as BuildBlockInCheckpointResult);
+
+      const checkpoint = await job.buildSingleBlock(checkpointBuilder, {
+        blockNumber: newBlockNumber,
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+        buildDeadline: undefined,
+        blockTimestamp: 0n,
+        remainingBlobFields: 1,
+        txHashesAlreadyIncluded: new Set<string>(),
+      });
+
+      expect(checkpoint).toBeUndefined();
+      expect(p2p.deleteTxs).toHaveBeenCalledWith(failedTxs.map(ftx => ftx.tx.txHash));
+    });
+
+    it('does not build a block if checkpoint builder fails with invalid txs', async () => {
+      job.updateConfig({ minTxsPerBlock: 3 });
+      const txs = await timesAsync(3, i => makeTx(i + 1, chainId));
+      mockPendingTxs(p2p, txs);
+
+      const checkpointBuilder = mock<CheckpointBuilder>();
+      const failedTxs: FailedTx[] = txs.slice(1).map(tx => ({ tx, error: new Error('Invalid tx') }));
+      checkpointBuilder.buildBlock.mockRejectedValue(new NoValidTxsError(failedTxs));
+
+      const checkpoint = await job.buildSingleBlock(checkpointBuilder, {
+        blockNumber: newBlockNumber,
+        indexWithinCheckpoint: IndexWithinCheckpoint(1),
+        buildDeadline: undefined,
+        blockTimestamp: 0n,
+        remainingBlobFields: 1,
+        txHashesAlreadyIncluded: new Set<string>(),
+      });
+
+      expect(checkpoint).toBeUndefined();
+      expect(p2p.deleteTxs).toHaveBeenCalledWith(failedTxs.map(ftx => ftx.tx.txHash));
     });
   });
 
@@ -855,7 +990,7 @@ describe('CheckpointProposalJob', () => {
     });
   });
 
-  describe('HA error handling during block building', () => {
+  describe('high-availability error handling during block building', () => {
     it('should stop checkpoint building when block proposal throws DutyAlreadySignedError on first block', async () => {
       // Set up test data for 3 blocks (to verify it stops even with multiple blocks configured)
       const { lastBlock } = await setupMultipleBlocks(3, 1);
@@ -960,5 +1095,21 @@ class TestCheckpointProposalJob extends CheckpointProposalJob {
   /** Get timetable for testing - allows tests to spy on methods */
   public getTimetable(): SequencerTimetable {
     return this.timetable;
+  }
+
+  /** Expose internal buildSingleBlock method */
+  public override buildSingleBlock(
+    checkpointBuilder: CheckpointBuilder,
+    opts: {
+      forceCreate?: boolean;
+      blockTimestamp: bigint;
+      blockNumber: BlockNumber;
+      indexWithinCheckpoint: IndexWithinCheckpoint;
+      buildDeadline: Date | undefined;
+      txHashesAlreadyIncluded: Set<string>;
+      remainingBlobFields: number;
+    },
+  ): Promise<{ block: L2Block; usedTxs: Tx[]; remainingBlobFields: number } | { error: Error } | undefined> {
+    return super.buildSingleBlock(checkpointBuilder, opts);
   }
 }

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -1,7 +1,13 @@
 import { NUM_CHECKPOINT_END_MARKER_FIELDS, getNumBlockEndBlobFields } from '@aztec/blob-lib/encoding';
 import { BLOBS_PER_CHECKPOINT, FIELDS_PER_BLOB } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { BlockNumber, CheckpointNumber, EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import {
+  BlockNumber,
+  CheckpointNumber,
+  EpochNumber,
+  IndexWithinCheckpoint,
+  SlotNumber,
+} from '@aztec/foundation/branded-types';
 import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -10,7 +16,7 @@ import { filter } from '@aztec/foundation/iterator';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { sleep, sleepUntil } from '@aztec/foundation/sleep';
 import { type DateProvider, Timer } from '@aztec/foundation/timer';
-import { type TypedEventEmitter, unfreeze } from '@aztec/foundation/types';
+import { type TypedEventEmitter, isErrorClass, unfreeze } from '@aztec/foundation/types';
 import type { P2P } from '@aztec/p2p';
 import type { SlasherClientInterface } from '@aztec/slasher';
 import {
@@ -24,10 +30,11 @@ import {
 import type { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { getSlotStartBuildTimestamp } from '@aztec/stdlib/epoch-helpers';
 import { Gas } from '@aztec/stdlib/gas';
-import type {
-  PublicProcessorLimits,
-  ResolvedSequencerConfig,
-  WorldStateSynchronizer,
+import {
+  NoValidTxsError,
+  type PublicProcessorLimits,
+  type ResolvedSequencerConfig,
+  type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
 import { type L1ToL2MessageSource, computeInHashFromL1ToL2Messages } from '@aztec/stdlib/messaging';
 import type { BlockProposalOptions, CheckpointProposal, CheckpointProposalOptions } from '@aztec/stdlib/p2p';
@@ -372,7 +379,7 @@ export class CheckpointProposalJob implements Traceable {
 
     while (true) {
       const blocksBuilt = blocksInCheckpoint.length;
-      const indexWithinCheckpoint = blocksBuilt;
+      const indexWithinCheckpoint = IndexWithinCheckpoint(blocksBuilt);
       const blockNumber = BlockNumber(initialBlockNumber + blocksBuilt);
 
       const secondsIntoSlot = this.getSecondsIntoSlot();
@@ -402,6 +409,7 @@ export class CheckpointProposalJob implements Traceable {
         remainingBlobFields,
       });
 
+      // TODO(palla/mbps): Review these conditions. We may want to keep trying in some scenarios.
       if (!buildResult && timingInfo.isLastBlock) {
         // If no block was produced due to not enough txs and this was the last subslot, exit
         break;
@@ -488,13 +496,13 @@ export class CheckpointProposalJob implements Traceable {
 
   /** Builds a single block. Called from the main block building loop. */
   @trackSpan('CheckpointProposalJob.buildSingleBlock')
-  private async buildSingleBlock(
+  protected async buildSingleBlock(
     checkpointBuilder: CheckpointBuilder,
     opts: {
       forceCreate?: boolean;
       blockTimestamp: bigint;
       blockNumber: BlockNumber;
-      indexWithinCheckpoint: number;
+      indexWithinCheckpoint: IndexWithinCheckpoint;
       buildDeadline: Date | undefined;
       txHashesAlreadyIncluded: Set<string>;
       remainingBlobFields: number;
@@ -555,45 +563,38 @@ export class CheckpointProposalJob implements Traceable {
       };
 
       // Actually build the block by executing txs
-      const workTimer = new Timer();
-      const {
-        publicGas,
-        block,
-        publicProcessorDuration,
-        numTxs,
-        blockBuildingTimer,
-        usedTxs,
-        failedTxs,
-        usedTxBlobFields,
-      } = await checkpointBuilder.buildBlock(pendingTxs, blockNumber, blockTimestamp, blockBuilderOptions);
-      const blockBuildDuration = workTimer.ms();
+      const buildResult = await this.buildSingleBlockWithCheckpointBuilder(
+        checkpointBuilder,
+        pendingTxs,
+        blockNumber,
+        blockTimestamp,
+        blockBuilderOptions,
+      );
 
       // If any txs failed during execution, drop them from the mempool so we don't pick them up again
-      await this.dropFailedTxsFromP2P(failedTxs);
+      await this.dropFailedTxsFromP2P(buildResult.failedTxs);
 
       // Check if we have created a block with enough txs. If there were invalid txs in the pool, or if execution took
       // too long, then we may not get to minTxsPerBlock after executing public functions.
       const minValidTxs = this.config.minValidTxsPerBlock ?? minTxs;
-      if (!forceCreate && numTxs < minValidTxs) {
+      const numTxs = buildResult.status === 'no-valid-txs' ? 0 : buildResult.numTxs;
+      if (buildResult.status === 'no-valid-txs' || (!forceCreate && numTxs < minValidTxs)) {
         this.log.warn(
-          `Block ${blockNumber} at index ${indexWithinCheckpoint} on slot ${this.slot} has too few valid txs to be proposed (got ${numTxs} but required ${minValidTxs})`,
-          { slot: this.slot, blockNumber, numTxs, indexWithinCheckpoint },
+          `Block ${blockNumber} at index ${indexWithinCheckpoint} on slot ${this.slot} has too few valid txs to be proposed`,
+          { slot: this.slot, blockNumber, numTxs, indexWithinCheckpoint, minValidTxs, buildResult: buildResult.status },
         );
-        this.eventEmitter.emit('block-tx-count-check-failed', {
-          minTxs: minValidTxs,
-          availableTxs: numTxs,
-          slot: this.slot,
-        });
+        this.eventEmitter.emit('block-build-failed', { reason: `Insufficient valid txs`, slot: this.slot });
         this.metrics.recordBlockProposalFailed('insufficient_valid_txs');
         return undefined;
       }
 
       // Block creation succeeded, emit stats and metrics
+      const { publicGas, block, publicProcessorDuration, usedTxs, usedTxBlobFields, blockBuildDuration } = buildResult;
+
       const blockStats = {
         eventName: 'l2-block-built',
         duration: blockBuildDuration,
         publicProcessDuration: publicProcessorDuration,
-        rollupCircuitsDuration: blockBuildingTimer.ms(),
         ...block.getStats(),
       } satisfies L2BlockBuiltStats;
 
@@ -619,16 +620,39 @@ export class CheckpointProposalJob implements Traceable {
     }
   }
 
+  /** Uses the checkpoint builder to build a block, catching specific txs */
+  private async buildSingleBlockWithCheckpointBuilder(
+    checkpointBuilder: CheckpointBuilder,
+    pendingTxs: AsyncIterable<Tx>,
+    blockNumber: BlockNumber,
+    blockTimestamp: bigint,
+    blockBuilderOptions: PublicProcessorLimits,
+  ) {
+    try {
+      const workTimer = new Timer();
+      const result = await checkpointBuilder.buildBlock(pendingTxs, blockNumber, blockTimestamp, blockBuilderOptions);
+      const blockBuildDuration = workTimer.ms();
+      return { ...result, blockBuildDuration, status: 'success' as const };
+    } catch (err: unknown) {
+      if (isErrorClass(err, NoValidTxsError)) {
+        return { failedTxs: err.failedTxs, status: 'no-valid-txs' as const };
+      }
+      throw err;
+    }
+  }
+
   /** Waits until minTxs are available on the pool for building a block. */
   @trackSpan('CheckpointProposalJob.waitForMinTxs')
   private async waitForMinTxs(opts: {
     forceCreate?: boolean;
     blockNumber: BlockNumber;
-    indexWithinCheckpoint: number;
+    indexWithinCheckpoint: IndexWithinCheckpoint;
     buildDeadline: Date | undefined;
   }): Promise<{ canStartBuilding: boolean; availableTxs: number }> {
-    const minTxs = this.config.minTxsPerBlock;
     const { indexWithinCheckpoint, blockNumber, buildDeadline, forceCreate } = opts;
+
+    // We only allow a block with 0 txs in the first block of the checkpoint
+    const minTxs = indexWithinCheckpoint > 0 && this.config.minTxsPerBlock === 0 ? 1 : this.config.minTxsPerBlock;
 
     // Deadline is undefined if we are not enforcing the timetable, meaning we'll exit immediately when out of time
     const startBuildingDeadline = buildDeadline

--- a/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
+++ b/yarn-project/sequencer-client/src/test/mock_checkpoint_builder.ts
@@ -1,6 +1,5 @@
 import { type BlockNumber, CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { Timer } from '@aztec/foundation/timer';
 import { L2Block } from '@aztec/stdlib/block';
 import { Checkpoint } from '@aztec/stdlib/checkpoint';
 import { Gas } from '@aztec/stdlib/gas';
@@ -14,7 +13,7 @@ import type {
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
 import { makeAppendOnlyTreeSnapshot } from '@aztec/stdlib/testing';
 import type { CheckpointGlobalVariables, Tx } from '@aztec/stdlib/tx';
-import type { BuildBlockInCheckpointResultWithTimer } from '@aztec/validator-client';
+import type { BuildBlockInCheckpointResult } from '@aztec/validator-client';
 
 /**
  * A fake CheckpointBuilder for testing that implements the same interface as the real one.
@@ -76,7 +75,7 @@ export class MockCheckpointBuilder implements ICheckpointBlockBuilder {
     blockNumber: BlockNumber,
     timestamp: bigint,
     opts: PublicProcessorLimits,
-  ): Promise<BuildBlockInCheckpointResultWithTimer> {
+  ): Promise<BuildBlockInCheckpointResult> {
     this.buildBlockCalls.push({ blockNumber, timestamp, opts });
 
     if (this.errorOnBuild) {
@@ -117,7 +116,6 @@ export class MockCheckpointBuilder implements ICheckpointBlockBuilder {
       publicGas: Gas.empty(),
       publicProcessorDuration: 0,
       numTxs: block?.body?.txEffects?.length ?? usedTxs.length,
-      blockBuildingTimer: new Timer(),
       usedTxs,
       failedTxs: [],
       usedTxBlobFields: block?.body?.txEffects?.reduce((sum, tx) => sum + tx.getNumBlobFields(), 0) ?? 0,

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -62,8 +62,16 @@ export const FullNodeBlockBuilderConfigKeys: (keyof FullNodeBlockBuilderConfig)[
   'fakeThrowAfterProcessingTxCount',
 ] as const;
 
+/** Thrown when no valid transactions are available to include in a block after processing, and this is not the first block in a checkpoint. */
+export class NoValidTxsError extends Error {
+  constructor(public readonly failedTxs: FailedTx[]) {
+    super('No valid transactions to include in block');
+    this.name = 'NoValidTxsError';
+  }
+}
+
 /** Result of building a block within a checkpoint. */
-export interface BuildBlockInCheckpointResult {
+export type BuildBlockInCheckpointResult = {
   block: L2Block;
   publicGas: Gas;
   publicProcessorDuration: number;
@@ -71,7 +79,7 @@ export interface BuildBlockInCheckpointResult {
   failedTxs: FailedTx[];
   usedTxs: Tx[];
   usedTxBlobFields: number;
-}
+};
 
 /** Interface for building blocks within a checkpoint context. */
 export interface ICheckpointBlockBuilder {

--- a/yarn-project/stdlib/src/stats/stats.ts
+++ b/yarn-project/stdlib/src/stats/stats.ts
@@ -202,8 +202,6 @@ export type L2BlockBuiltStats = {
   duration: number;
   /** Time for processing public txs in ms. */
   publicProcessDuration: number;
-  /** Time for running rollup circuits in ms.  */
-  rollupCircuitsDuration: number;
 } & L2BlockStats;
 
 /** Stats for an L2 block processed by the world state synchronizer. */

--- a/yarn-project/validator-client/src/checkpoint_builder.test.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.test.ts
@@ -1,0 +1,146 @@
+import { BlockNumber, CheckpointNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { TestDateProvider } from '@aztec/foundation/timer';
+import type { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
+import type { PublicProcessor } from '@aztec/simulator/server';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2Block } from '@aztec/stdlib/block';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
+import { Gas, GasFees } from '@aztec/stdlib/gas';
+import {
+  type FullNodeBlockBuilderConfig,
+  type MerkleTreeWriteOperations,
+  NoValidTxsError,
+  type PublicProcessorValidator,
+} from '@aztec/stdlib/interfaces/server';
+import type { CheckpointGlobalVariables, GlobalVariables, ProcessedTx, Tx } from '@aztec/stdlib/tx';
+import type { TelemetryClient } from '@aztec/telemetry-client';
+
+import { describe, expect, it } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { CheckpointBuilder } from './checkpoint_builder.js';
+
+describe('CheckpointBuilder', () => {
+  let checkpointBuilder: CheckpointBuilder;
+  let lightweightCheckpointBuilder: MockProxy<LightweightCheckpointBuilder>;
+  let fork: MockProxy<MerkleTreeWriteOperations>;
+  let config: FullNodeBlockBuilderConfig;
+  let contractDataSource: MockProxy<ContractDataSource>;
+  let dateProvider: TestDateProvider;
+  let telemetryClient: MockProxy<TelemetryClient>;
+  let processor!: MockProxy<PublicProcessor>;
+  let validator!: MockProxy<PublicProcessorValidator>;
+
+  const checkpointNumber = CheckpointNumber(1);
+  const slotNumber = SlotNumber(10);
+  const blockNumber = BlockNumber(5);
+
+  const constants: CheckpointGlobalVariables = {
+    chainId: new Fr(1),
+    version: new Fr(1),
+    slotNumber,
+    coinbase: EthAddress.random(),
+    feeRecipient: AztecAddress.fromField(Fr.random()),
+    gasFees: GasFees.empty(),
+  };
+
+  class TestCheckpointBuilder extends CheckpointBuilder {
+    public override makeBlockBuilderDeps(_globalVariables: GlobalVariables, _fork: MerkleTreeWriteOperations) {
+      return Promise.resolve({ processor, validator });
+    }
+  }
+
+  beforeEach(() => {
+    lightweightCheckpointBuilder = mock<LightweightCheckpointBuilder>({ checkpointNumber, constants });
+
+    fork = mock<MerkleTreeWriteOperations>();
+    config = {
+      l1GenesisTime: 0n,
+      slotDuration: 24,
+      l1ChainId: 1,
+      rollupVersion: 1,
+    };
+    contractDataSource = mock<ContractDataSource>();
+    dateProvider = new TestDateProvider();
+    telemetryClient = mock<TelemetryClient>();
+    telemetryClient.getMeter.mockReturnValue(mock());
+    telemetryClient.getTracer.mockReturnValue(mock());
+
+    processor = mock<PublicProcessor>();
+    validator = mock<PublicProcessorValidator>();
+
+    checkpointBuilder = new TestCheckpointBuilder(
+      lightweightCheckpointBuilder as unknown as LightweightCheckpointBuilder,
+      fork,
+      config,
+      contractDataSource,
+      dateProvider,
+      telemetryClient,
+    );
+  });
+
+  describe('buildBlock', () => {
+    it('builds a block successfully when transactions are processed', async () => {
+      lightweightCheckpointBuilder.getBlockCount.mockReturnValue(0);
+
+      const expectedBlock = await L2Block.random(blockNumber);
+      lightweightCheckpointBuilder.addBlock.mockResolvedValue(expectedBlock);
+
+      processor.process.mockResolvedValue([
+        [{ hash: Fr.random(), gasUsed: { publicGas: Gas.empty() } } as unknown as ProcessedTx],
+        [], // failedTxs
+        [], // usedTxs
+        [], // returnValues
+        0, // usedTxBlobFields
+      ]);
+
+      const result = await checkpointBuilder.buildBlock([], blockNumber, 1000n);
+
+      expect(result.block).toBe(expectedBlock);
+      expect(result.numTxs).toBe(1);
+      expect(result.failedTxs).toEqual([]);
+      expect(lightweightCheckpointBuilder.addBlock).toHaveBeenCalled();
+    });
+
+    it('allows building an empty first block in a checkpoint', async () => {
+      lightweightCheckpointBuilder.getBlockCount.mockReturnValue(0);
+
+      const expectedBlock = await L2Block.random(blockNumber, { txsPerBlock: 0 });
+      lightweightCheckpointBuilder.addBlock.mockResolvedValue(expectedBlock);
+
+      // No transactions processed
+      processor.process.mockResolvedValue([
+        [], // processedTxs - empty
+        [], // failedTxs
+        [], // usedTxs
+        [], // returnValues
+        0, // usedTxBlobFields
+      ]);
+
+      const result = await checkpointBuilder.buildBlock([], blockNumber, 1000n);
+
+      expect(result.block).toBe(expectedBlock);
+      expect(result.numTxs).toBe(0);
+      expect(lightweightCheckpointBuilder.addBlock).toHaveBeenCalled();
+    });
+
+    it('throws NoValidTxsError when no valid transactions and not first block in checkpoint', async () => {
+      lightweightCheckpointBuilder.getBlockCount.mockReturnValue(1);
+
+      const failedTx = { tx: { txHash: Fr.random() } as unknown as Tx, error: new Error('tx failed') };
+      processor.process.mockResolvedValue([
+        [], // processedTxs - empty
+        [failedTx], // failedTxs
+        [], // usedTxs
+        [], // returnValues
+        0, // usedTxBlobFields
+      ]);
+
+      await expect(checkpointBuilder.buildBlock([], blockNumber, 1000n)).rejects.toThrow(NoValidTxsError);
+
+      expect(lightweightCheckpointBuilder.addBlock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/yarn-project/validator-client/src/checkpoint_builder.ts
+++ b/yarn-project/validator-client/src/checkpoint_builder.ts
@@ -3,7 +3,7 @@ import { merge, pick } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { bufferToHex } from '@aztec/foundation/string';
-import { DateProvider, Timer, elapsed } from '@aztec/foundation/timer';
+import { DateProvider, elapsed } from '@aztec/foundation/timer';
 import { getDefaultAllowedSetupFunctions } from '@aztec/p2p/msg_validators';
 import { LightweightCheckpointBuilder } from '@aztec/prover-client/light';
 import {
@@ -24,6 +24,7 @@ import {
   type ICheckpointBlockBuilder,
   type ICheckpointsBuilder,
   type MerkleTreeWriteOperations,
+  NoValidTxsError,
   type PublicProcessorLimits,
   type WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
@@ -35,11 +36,6 @@ import { createValidatorForBlockBuilding } from './tx_validator/tx_validator_fac
 
 // Re-export for backward compatibility
 export type { BuildBlockInCheckpointResult } from '@aztec/stdlib/interfaces/server';
-
-/** Result of building a block within a checkpoint. Extends the base interface with timer. */
-export interface BuildBlockInCheckpointResultWithTimer extends BuildBlockInCheckpointResult {
-  blockBuildingTimer: Timer;
-}
 
 /**
  * Builder for a single checkpoint. Handles building blocks within the checkpoint
@@ -75,8 +71,7 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     blockNumber: BlockNumber,
     timestamp: bigint,
     opts: PublicProcessorLimits & { expectedEndState?: StateReference } = {},
-  ): Promise<BuildBlockInCheckpointResultWithTimer> {
-    const blockBuildingTimer = new Timer();
+  ): Promise<BuildBlockInCheckpointResult> {
     const slot = this.checkpointBuilder.constants.slotNumber;
 
     this.log.verbose(`Building block ${blockNumber} for slot ${slot} within checkpoint`, {
@@ -103,6 +98,12 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
       processor.process(pendingTxs, opts, validator),
     );
 
+    // Throw if we didn't collect a single valid tx and we're not allowed to build empty blocks
+    // (only the first block in a checkpoint can be empty)
+    if (processedTxs.length === 0 && this.checkpointBuilder.getBlockCount() > 0) {
+      throw new NoValidTxsError(failedTxs);
+    }
+
     // Add block to checkpoint
     const block = await this.checkpointBuilder.addBlock(globalVariables, processedTxs, {
       expectedEndState: opts.expectedEndState,
@@ -111,18 +112,21 @@ export class CheckpointBuilder implements ICheckpointBlockBuilder {
     // How much public gas was processed
     const publicGas = processedTxs.reduce((acc, tx) => acc.add(tx.gasUsed.publicGas), Gas.empty());
 
-    const res = {
+    this.log.debug('Built block within checkpoint', {
+      header: block.header.toInspect(),
+      processedTxs: processedTxs.map(tx => tx.hash.toString()),
+      failedTxs: failedTxs.map(tx => tx.tx.txHash.toString()),
+    });
+
+    return {
       block,
       publicGas,
       publicProcessorDuration,
       numTxs: processedTxs.length,
       failedTxs,
-      blockBuildingTimer,
       usedTxs,
       usedTxBlobFields,
     };
-    this.log.debug('Built block within checkpoint', res.block.header);
-    return res;
   }
 
   /** Completes the checkpoint and returns it. */

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -9,7 +9,7 @@ import { Secp256k1Signer, makeEthSignDigest } from '@aztec/foundation/crypto/sec
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Hex } from '@aztec/foundation/string';
-import { TestDateProvider, Timer } from '@aztec/foundation/timer';
+import { TestDateProvider } from '@aztec/foundation/timer';
 import { type KeyStore, KeystoreManager } from '@aztec/node-keystore';
 import {
   AuthRequest,
@@ -45,7 +45,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { type PrivateKeyAccount, generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import type {
-  BuildBlockInCheckpointResultWithTimer,
+  BuildBlockInCheckpointResult,
   CheckpointBuilder,
   FullNodeCheckpointsBuilder,
 } from './checkpoint_builder.js';
@@ -280,7 +280,7 @@ describe('ValidatorClient', () => {
     let proposal: BlockProposal;
     let blockNumber: BlockNumber;
     let sender: PeerId;
-    let blockBuildResult: BuildBlockInCheckpointResultWithTimer;
+    let blockBuildResult: BuildBlockInCheckpointResult;
     let mockCheckpointBuilder: MockProxy<CheckpointBuilder>;
 
     const makeTxFromHash = (txHash: TxHash) => ({ getTxHash: () => txHash, txHash }) as Tx;
@@ -352,7 +352,6 @@ describe('ValidatorClient', () => {
       blockBuildResult = {
         publicProcessorDuration: 0,
         numTxs: proposal.txHashes.length,
-        blockBuildingTimer: new Timer(),
         failedTxs: [],
         publicGas: Gas.empty(),
         usedTxs: [],


### PR DESCRIPTION
Our circuits do not allow building a checkpoint with an empty (ie no txs) block other than the first one. This was leading to errors in block building when there were not enough txs.

This PR updates `waitForMinTxs` in the checkpoint proposal job so that it waits for at least one tx when building a block other than the first one in the checkpoint. It also updates the checkpoint builder so it doesn't try building a block if it didn't process at least one valid tx.