### PR TITLE
feat: add Cloudflare R2 as primary CRS host with S3 fallback

### DIFF
--- a/barretenberg/cpp/src/barretenberg/srs/factories/bn254_crs_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/bn254_crs_data.hpp
@@ -15,7 +15,7 @@ inline constexpr g1::affine_element BN254_G1_FIRST_ELEMENT = g1::affine_one;
 /**
  * @brief Expected second G1 element from BN254 CRS
  * @details This is the second point in the BN254 CRS, corresponding to tau * G where tau is the secret from the
- * trusted setup. Reference: http://crs.aztec.network/g1.dat (bytes 64-127)
+ * trusted setup. Reference: https://crs.aztec-cdn.foundation/g1.dat (bytes 64-127)
  */
 inline g1::affine_element get_bn254_g1_second_element()
 {
@@ -32,7 +32,7 @@ inline g1::affine_element get_bn254_g1_second_element()
 /**
  * @brief Reference BN254 G2 element from the trusted setup CRS
  * @details This is the single G2 point used in the BN254 CRS for verification.
- * Reference: http://crs.aztec.network/g2.dat
+ * Reference: https://crs.aztec-cdn.foundation/g2.dat
  */
 inline g2::affine_element get_bn254_g2_crs_element()
 {

--- a/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/crs_factory.test.cpp
@@ -2,6 +2,8 @@
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/bn254/pairing.hpp"
+#include "barretenberg/srs/factories/bn254_crs_data.hpp"
+#include "barretenberg/srs/factories/get_bn254_crs.hpp"
 #include "barretenberg/srs/factories/mem_bn254_crs_factory.hpp"
 #include "barretenberg/srs/factories/mem_grumpkin_crs_factory.hpp"
 #include "barretenberg/srs/factories/native_crs_factory.hpp"
@@ -99,4 +101,24 @@ TEST(CrsFactory, grumpkin)
     // Tiny download check to test the 'net CRS' path
     ASSERT_ANY_THROW(check_grumpkin_consistency(temp_crs_path, 1, /*allow_download=*/false));
     check_grumpkin_consistency(temp_crs_path, 1, /*allow_download=*/true);
+}
+
+TEST(CrsFactory, Bn254Fallback)
+{
+    // Test that fallback works when primary URL fails
+    const std::filesystem::path& temp_crs_path = "barretenberg_srs_test_crs_bn254_fallback";
+    fs::remove_all(temp_crs_path);
+    fs::create_directories(temp_crs_path);
+
+    // Use a bad primary URL that will fail, forcing fallback to the real S3 URL
+    std::string bad_primary = "http://nonexistent.invalid/g1.dat";
+    std::string good_fallback = "http://crs.aztec-labs.com/g1.dat";
+
+    // This should succeed by falling back to the working URL
+    auto points = bb::get_bn254_g1_data(temp_crs_path, 1, /*allow_download=*/true, bad_primary, good_fallback);
+    EXPECT_EQ(points.size(), 1);
+    // Verify the downloaded point matches the expected first element
+    EXPECT_EQ(points[0], bb::srs::BN254_G1_FIRST_ELEMENT);
+
+    fs::remove_all(temp_crs_path);
 }

--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.cpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.cpp
@@ -8,12 +8,33 @@
 #include "http_download.hpp"
 
 namespace {
-std::vector<uint8_t> download_bn254_g1_data(size_t num_points)
+// Primary CRS URL (Cloudflare R2)
+constexpr const char* CRS_PRIMARY_URL = "http://crs.aztec-cdn.foundation/g1.dat";
+// Fallback CRS URL (AWS S3)
+constexpr const char* CRS_FALLBACK_URL = "http://crs.aztec-labs.com/g1.dat";
+
+std::vector<uint8_t> download_bn254_g1_data(size_t num_points,
+                                            const std::string& primary_url,
+                                            const std::string& fallback_url)
 {
     size_t g1_end = (num_points * sizeof(bb::g1::affine_element)) - 1;
 
-    // Download via HTTP with Range header
-    auto data = bb::srs::http_download("http://crs.aztec.network/g1.dat", 0, g1_end);
+    // Try primary URL first, with fallback on failure.
+    // Note: WASM is compiled with -fno-exceptions, so try/catch is not available.
+    // In practice, WASM never calls this function - it initializes CRS via srs_init_srs from JavaScript.
+    std::vector<uint8_t> data;
+#ifndef __wasm__
+    try {
+        data = bb::srs::http_download(primary_url, 0, g1_end);
+    } catch (const std::exception& e) {
+        vinfo("Primary CRS download failed: ", e.what(), ". Trying fallback...");
+        data = bb::srs::http_download(fallback_url, 0, g1_end);
+    }
+#else
+    // WASM fallback: just try primary (will abort on failure)
+    data = bb::srs::http_download(primary_url, 0, g1_end);
+    static_cast<void>(fallback_url);
+#endif
 
     if (data.size() < sizeof(bb::g1::affine_element)) {
         throw_or_abort("Downloaded g1 data is too small");
@@ -38,9 +59,13 @@ std::vector<uint8_t> download_bn254_g1_data(size_t num_points)
 } // namespace
 
 namespace bb {
+
+// Main implementation with configurable URLs
 std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& path,
                                                   size_t num_points,
-                                                  bool allow_download)
+                                                  bool allow_download,
+                                                  const std::string& primary_url,
+                                                  const std::string& fallback_url)
 {
     std::filesystem::create_directories(path);
 
@@ -84,7 +109,7 @@ std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& p
     }
 
     vinfo("downloading bn254 crs...");
-    auto data = download_bn254_g1_data(num_points);
+    auto data = download_bn254_g1_data(num_points, primary_url, fallback_url);
     write_file(g1_path, data);
 
     auto points = std::vector<g1::affine_element>(num_points);
@@ -92,6 +117,14 @@ std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& p
         points[i] = from_buffer<g1::affine_element>(data, i * sizeof(g1::affine_element));
     }
     return points;
+}
+
+// Default overload using production URLs
+std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& path,
+                                                  size_t num_points,
+                                                  bool allow_download)
+{
+    return get_bn254_g1_data(path, num_points, allow_download, CRS_PRIMARY_URL, CRS_FALLBACK_URL);
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/get_bn254_crs.hpp
@@ -9,5 +9,13 @@ namespace bb {
 std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& path,
                                                   size_t num_points,
                                                   bool allow_download = true);
+
+// Overload with custom URLs for testing fallback behavior
+std::vector<g1::affine_element> get_bn254_g1_data(const std::filesystem::path& path,
+                                                  size_t num_points,
+                                                  bool allow_download,
+                                                  const std::string& primary_url,
+                                                  const std::string& fallback_url);
+
 g2::affine_element get_bn254_g2_data(const std::filesystem::path& path, bool allow_download = true);
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/srs/factories/http_download.hpp
+++ b/barretenberg/cpp/src/barretenberg/srs/factories/http_download.hpp
@@ -28,7 +28,7 @@ namespace bb::srs {
 
 /**
  * @brief Download data from a URL with optional Range header support
- * @param url Full URL (e.g., "http://crs.aztec.network/g1.dat")
+ * @param url Full URL (e.g., "http://crs.aztec-cdn.foundation/g1.dat")
  * @param start_byte Starting byte for range request (0 for no range)
  * @param end_byte Ending byte for range request (0 for no range)
  * @return Downloaded data as bytes
@@ -56,7 +56,7 @@ inline std::vector<uint8_t> http_download([[maybe_unused]] const std::string& ur
     std::string path = url.substr(path_start);
 
     // Create HTTP client (non-SSL)
-    httplib::Client cli(("http://" + host).c_str());
+    httplib::Client cli("http://" + host);
     cli.set_follow_location(true);
     cli.set_connection_timeout(30);
     cli.set_read_timeout(60);

--- a/barretenberg/crs/bootstrap.sh
+++ b/barretenberg/crs/bootstrap.sh
@@ -9,6 +9,29 @@ shift || true
 # 2^25 points + 1 because the first is the generator, *64 bytes per point, -1 because Range is inclusive.
 # We make the file read only to ensure no test can attempt to grow it any larger. 2^25 is already huge...
 # TODO: Make bb just download and append/overwrite required range, then it becomes idempotent.
+
+# Primary CRS host (Cloudflare R2)
+CRS_PRIMARY_HOST="https://crs.aztec-cdn.foundation"
+# Fallback CRS host (AWS S3)
+CRS_FALLBACK_HOST="https://crs.aztec-labs.com"
+
+# Download with fallback: try primary first, then fallback on failure
+download_with_fallback() {
+  local output="$1"
+  local file="$2"
+  local range_header="${3:-}"
+
+  local curl_args=(-s -f -o "$output")
+  if [ -n "$range_header" ]; then
+    curl_args+=(-H "Range: $range_header")
+  fi
+
+  if ! curl "${curl_args[@]}" "${CRS_PRIMARY_HOST}/${file}" 2>/dev/null; then
+    echo "Primary CRS host failed, trying fallback..."
+    curl "${curl_args[@]}" "${CRS_FALLBACK_HOST}/${file}"
+  fi
+}
+
 function build {
   crs_path=$HOME/.bb-crs
   crs_size=$((2**25+1))
@@ -18,12 +41,11 @@ function build {
   if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
     echo "Downloading crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
     mkdir -p $crs_path
-    curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $g1 \
-      https://crs.aztec.network/g1.dat
+    download_with_fallback "$g1" "g1.dat" "bytes=0-$((crs_size_bytes-1))"
     chmod a-w $crs_path/bn254_g1.dat
   fi
   if [ ! -f "$g2" ]; then
-    curl -s https://crs.aztec.network/g2.dat -o $g2
+    download_with_fallback "$g2" "g2.dat"
   fi
 
   # TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
@@ -33,8 +55,7 @@ function build {
   gg1=$crs_path/grumpkin_g1.flat.dat
   if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
     echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-    curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $gg1 \
-      https://crs.aztec.network/grumpkin_g1.dat
+    download_with_fallback "$gg1" "grumpkin_g1.dat" "bytes=0-$((crs_size_bytes-1))"
   fi
 }
 

--- a/barretenberg/scripts/download_bb_crs.sh
+++ b/barretenberg/scripts/download_bb_crs.sh
@@ -6,6 +6,29 @@ set -eu
 # 2^25 points + 1 because the first is the generator, *64 bytes per point, -1 because Range is inclusive.
 # We make the file read only to ensure no test can attempt to grow it any larger. 2^25 is already huge...
 # TODO: Make bb just download and append/overwrite required range, then it becomes idempotent.
+
+# Primary CRS host (Cloudflare R2)
+CRS_PRIMARY_HOST="https://crs.aztec-cdn.foundation"
+# Fallback CRS host (AWS S3)
+CRS_FALLBACK_HOST="https://crs.aztec-labs.com"
+
+# Download with fallback: try primary first, then fallback on failure
+download_with_fallback() {
+  local output="$1"
+  local file="$2"
+  local range_header="${3:-}"
+
+  local curl_args=(-s -f -o "$output")
+  if [ -n "$range_header" ]; then
+    curl_args+=(-H "Range: $range_header")
+  fi
+
+  if ! curl "${curl_args[@]}" "${CRS_PRIMARY_HOST}/${file}" 2>/dev/null; then
+    echo "Primary CRS host failed, trying fallback..."
+    curl "${curl_args[@]}" "${CRS_FALLBACK_HOST}/${file}"
+  fi
+}
+
 crs_path=$HOME/.bb-crs
 crs_size=$((2**25+1))
 crs_size_bytes=$((crs_size*64))
@@ -14,12 +37,11 @@ g2=$crs_path/bn254_g2.dat
 if [ ! -f "$g1" ] || [ $(stat -c%s "$g1") -lt $crs_size_bytes ]; then
   echo "Downloading crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
   mkdir -p $crs_path
-  curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $g1 \
-    https://crs.aztec.network/g1.dat
+  download_with_fallback "$g1" "g1.dat" "bytes=0-$((crs_size_bytes-1))"
   chmod a-w $crs_path/bn254_g1.dat
 fi
 if [ ! -f "$g2" ]; then
-  curl -s https://crs.aztec.network/g2.dat -o $g2
+  download_with_fallback "$g2" "g2.dat"
 fi
 
 # TODO: This grumpkin CRS in S3 still has the 28 byte header on it. Remove.
@@ -29,6 +51,5 @@ crs_size_bytes=$((crs_size*64))
 gg1=$crs_path/grumpkin_g1.flat.dat
 if [ ! -f "$gg1" ] || [ $(stat -c%s "$gg1") -lt $crs_size_bytes ]; then
   echo "Downloading grumpkin crs of size: ${crs_size} ($((crs_size_bytes/(1024*1024)))MB)"
-  curl -s -H "Range: bytes=0-$((crs_size_bytes-1))" -o $gg1 \
-    https://crs.aztec.network/grumpkin_g1.dat
+  download_with_fallback "$gg1" "grumpkin_g1.dat" "bytes=0-$((crs_size_bytes-1))"
 fi

--- a/barretenberg/ts/src/crs/net_crs.test.ts
+++ b/barretenberg/ts/src/crs/net_crs.test.ts
@@ -1,0 +1,47 @@
+import { NetCrs, fetchWithFallback } from './net_crs.js';
+
+// Expected first G1 point from BN254 CRS (generator point with x=1, y=2 in big-endian)
+const BN254_G1_FIRST_ELEMENT = new Uint8Array([
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]);
+
+describe('NetCrs', () => {
+  it('should download CRS data from primary host', async () => {
+    const crs = new NetCrs(1);
+    await crs.init();
+
+    const g1Data = crs.getG1Data();
+    expect(g1Data.length).toBe(64); // 1 point * 64 bytes
+
+    // Verify first point matches expected generator
+    expect(g1Data).toEqual(BN254_G1_FIRST_ELEMENT);
+  }, 30000);
+
+  it('should download G2 data', async () => {
+    const crs = new NetCrs(1);
+    await crs.init();
+
+    const g2Data = crs.getG2Data();
+    expect(g2Data.length).toBe(128); // G2 point is 128 bytes
+  }, 30000);
+});
+
+describe('fetchWithFallback', () => {
+  it('should fallback to secondary URL when primary fails', async () => {
+    const badPrimaryUrl = 'https://nonexistent.invalid/g1.dat';
+    const goodFallbackUrl = 'https://crs.aztec-labs.com/g1.dat';
+    const options: RequestInit = {
+      headers: {
+        Range: 'bytes=0-63',
+      },
+    };
+
+    const response = await fetchWithFallback(badPrimaryUrl, goodFallbackUrl, options);
+    expect(response.ok || response.status === 206).toBe(true);
+
+    const data = new Uint8Array(await response.arrayBuffer());
+    expect(data.length).toBe(64);
+    expect(data).toEqual(BN254_G1_FIRST_ELEMENT);
+  }, 30000);
+});

--- a/barretenberg/ts/src/crs/net_crs.ts
+++ b/barretenberg/ts/src/crs/net_crs.ts
@@ -1,4 +1,30 @@
 import { retry, makeBackoff } from '../retry/index.js';
+
+// Primary CRS host (Cloudflare R2)
+const CRS_PRIMARY_HOST = 'https://crs.aztec-cdn.foundation';
+// Fallback CRS host (AWS S3)
+const CRS_FALLBACK_HOST = 'https://crs.aztec-labs.com';
+
+/**
+ * Fetches data from primary URL, falling back to secondary on failure
+ * @internal Exported for testing
+ */
+export async function fetchWithFallback(
+  primaryUrl: string,
+  fallbackUrl: string,
+  options: RequestInit,
+): Promise<Response> {
+  try {
+    const response = await fetch(primaryUrl, options);
+    if (response.ok || response.status === 206) {
+      return response;
+    }
+    throw new Error(`HTTP ${response.status}`);
+  } catch {
+    return await fetch(fallbackUrl, options);
+  }
+}
+
 /**
  * Downloader for CRS from the web or local.
  */
@@ -76,14 +102,14 @@ export class NetCrs {
     }
 
     const g1End = this.numPoints * 64 - 1;
+    const options: RequestInit = {
+      headers: {
+        Range: `bytes=0-${g1End}`,
+      },
+      cache: 'force-cache',
+    };
     return await retry(
-      () =>
-        fetch('https://crs.aztec.network/g1.dat', {
-          headers: {
-            Range: `bytes=0-${g1End}`,
-          },
-          cache: 'force-cache',
-        }),
+      () => fetchWithFallback(`${CRS_PRIMARY_HOST}/g1.dat`, `${CRS_FALLBACK_HOST}/g1.dat`, options),
       makeBackoff([5, 5, 5]),
     );
   }
@@ -92,11 +118,11 @@ export class NetCrs {
    * Fetches the appropriate range of points from a remote source
    */
   private async fetchG2Data(): Promise<Response> {
+    const options: RequestInit = {
+      cache: 'force-cache',
+    };
     return await retry(
-      () =>
-        fetch('https://crs.aztec.network/g2.dat', {
-          cache: 'force-cache',
-        }),
+      () => fetchWithFallback(`${CRS_PRIMARY_HOST}/g2.dat`, `${CRS_FALLBACK_HOST}/g2.dat`, options),
       makeBackoff([5, 5, 5]),
     );
   }
@@ -153,12 +179,17 @@ export class NetGrumpkinCrs {
     }
 
     const g1End = this.numPoints * 64 - 1;
-
-    return await fetch('https://crs.aztec.network/grumpkin_g1.dat', {
+    const options: RequestInit = {
       headers: {
         Range: `bytes=0-${g1End}`,
       },
       cache: 'force-cache',
-    });
+    };
+
+    return await fetchWithFallback(
+      `${CRS_PRIMARY_HOST}/grumpkin_g1.dat`,
+      `${CRS_FALLBACK_HOST}/grumpkin_g1.dat`,
+      options,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Adds Cloudflare R2 endpoint (`crs.aztec-cdn.foundation`) as primary CRS download source
- Falls back to existing AWS S3 bucket (`crs.aztec.network`) on failure
- Reduces costs (R2 has no egress fees) and improves reliability

## Changes
- **C++**: Added fallback logic in `get_bn254_crs.cpp` with HTTPS support for R2
- **TypeScript**: Added `fetchWithFallback` helper in `net_crs.ts`
- **Shell**: Added `download_with_fallback` function in `bootstrap.sh` and `download_bb_crs.sh`
- **Tests**: Added fallback tests for both C++ (`CrsFactory.Bn254Fallback`) and TypeScript

## Test plan
- [x] C++ `srs_tests` pass (including new `Bn254Fallback` test)
- [x] TypeScript `net_crs.test.ts` passes (tests primary download and fallback)
- [x] Shell script download verified manually

Resolves https://github.com/AztecProtocol/barretenberg/issues/1609