### PR TITLE
chore: scripts to run opcode spam proving benchmarks

### DIFF
--- a/yarn-project/bb-prover/bootstrap.sh
+++ b/yarn-project/bb-prover/bootstrap.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
+
+hash=$(../bootstrap.sh hash)
+
+function test_cmds {
+	local run_test_script="yarn-project/bb-prover/scripts/run_test.sh"
+	local prefix="$hash:ISOLATE=1"
+
+	# AVM Opcode Spam Full Proving - Heavy resource requirements
+	# This test is normally skipped; RUN_AVM_OPCODE_SPAM=1 enables it
+	echo "$prefix:TIMEOUT=60m:CPUS=32:MEM=128g:NAME=avm_opcode_spam_proving RUN_AVM_OPCODE_SPAM=1 $run_test_script src/avm_proving_tests/avm_opcode_spam.test.ts"
+}
+
+function test {
+	echo_header "bb-prover avm proving tests"
+	test_cmds | filter_test_cmds | parallelize
+}
+
+function spam_bench_cmds {
+	local run_test_script="yarn-project/bb-prover/scripts/run_test.sh"
+	local prefix="$hash:ISOLATE=1"
+
+	# AVM Opcode Spam benchmarks with JSON output
+	# SEED=42 ensures reproducible random values across runs
+	echo "$prefix:TIMEOUT=180m:CPUS=32:MEM=128g:NAME=avm_opcode_spam_bench RUN_AVM_OPCODE_SPAM=1 SEED=42 BENCH_OUTPUT=bench-out/avm_opcode_spam.bench.json $run_test_script src/avm_proving_tests/avm_opcode_spam.test.ts"
+}
+
+function spam_bench {
+	mkdir -p bench-out
+	spam_bench_cmds | STRICT_SCHEDULING=1 parallelize
+}
+
+function bench {
+	rm -rf bench-out
+	mkdir -p bench-out
+	spam_bench_cmds | STRICT_SCHEDULING=1 parallelize
+}
+
+case "$cmd" in
+*)
+	default_cmd_handler "$@"
+	;;
+esac

--- a/yarn-project/bb-prover/scripts/run_test.sh
+++ b/yarn-project/bb-prover/scripts/run_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Simplified test runner for bb-prover proving tests.
+# Unlike end-to-end's test_simple.sh, this is tailored for proving workloads.
+set -eu
+
+cd $(dirname $0)/..
+
+export HARDWARE_CONCURRENCY=${CPUS:-31}
+export RAYON_NUM_THREADS=${RAYON_NUM_THREADS:-1}
+export TOKIO_WORKER_THREADS=${TOKIO_WORKER_THREADS:-1}
+export LOG_LEVEL=${LOG_LEVEL:-verbose}
+export NODE_NO_WARNINGS=1
+export FORCE_COLOR=1
+
+# Pass through test control and benchmark output vars
+export RUN_AVM_OPCODE_SPAM=${RUN_AVM_OPCODE_SPAM:-}
+export RUN_AVM_TOKEN_BENCH=${RUN_AVM_TOKEN_BENCH:-}
+export RUN_AVM_MEGA_BULK=${RUN_AVM_MEGA_BULK:-}
+export BENCH_OUTPUT=${BENCH_OUTPUT:-}
+export BENCH_OUTPUT_MD=${BENCH_OUTPUT_MD:-}
+
+# Pass through SEED for reproducible random value generation
+export SEED=${SEED:-}
+
+test_file=$1
+shift
+
+node --experimental-vm-modules ../node_modules/.bin/jest \
+  --testTimeout=${TEST_TIMEOUT:-600000} \
+  --forceExit \
+  --no-cache \
+  --runInBand \
+  "$test_file" "$@"


### PR DESCRIPTION
run: `./bootstrap.sh spam_bench` which takes like 45 minutes and runs all of the tests serially with dedicated resources.

That gives JSON benchmarks and then i ask claude to give me a table:
`Summarize the @bench-out/ results. In particular, show a table with each test case and total times and breakdown (sim all, tracegen all, proving all, and total: sum of the three), sorted with slowest runs first.`

<img width="1177" height="829" alt="image" src="https://github.com/user-attachments/assets/bc08da75-782f-44cc-aca3-5800f12bf99b" />