### PR TITLE
chore: add block proposal to attestation pool during chekpoint

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -338,8 +338,13 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     [Attributes.BLOCK_ARCHIVE]: proposal.archive.toString(),
     [Attributes.P2P_ID]: (await proposal.p2pMessageLoggingIdentifier()).toString(),
   }))
-  public broadcastCheckpointProposal(proposal: CheckpointProposal): Promise<void> {
+  public async broadcastCheckpointProposal(proposal: CheckpointProposal): Promise<void> {
     this.log.verbose(`Broadcasting checkpoint proposal for slot ${proposal.slotNumber} to peers`);
+    const blockProposal = proposal.getBlockProposal();
+    if (blockProposal) {
+      // Store our own last-block proposal so we can respond to req/resp requests for it.
+      await this.attestationPool.addBlockProposal(blockProposal);
+    }
     return this.p2pService.propagate(proposal);
   }
 


### PR DESCRIPTION
Attempt to deflake http://ci.aztec-labs.com/6becd0b8fdd067db

The fix is to store the checkpoint proposal’s last block into the local attestations pool.
This allows req/resp block_txs to find the proposal immediately and prevents `NOT_FOUND/timeouts` when validators fetch txs for the final block in a checkpoint.