### PR TITLE
feat: not re-syncing contracts at the same block

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -306,6 +306,10 @@ comptime fn generate_process_message() -> Quoted {
                 message_ciphertext,
                 message_context,
             );
+
+            // At this point, the note is pending validation and storage in the database. We must call
+            // validate_and_store_enqueued_notes_and_events to complete that process.
+            aztec::messages::processing::validate_and_store_enqueued_notes_and_events(address);
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -140,7 +140,7 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
 /// queryable via `get_notes` oracle and our TS API (PXE::getPrivateEvents).
 ///
 /// This automatically clears both validation request queues, so no further work needs to be done by the caller.
-pub(crate) unconstrained fn validate_and_store_enqueued_notes_and_events(contract_address: AztecAddress) {
+pub unconstrained fn validate_and_store_enqueued_notes_and_events(contract_address: AztecAddress) {
     oracle::message_processing::validate_and_store_enqueued_notes_and_events(
         contract_address,
         NOTE_VALIDATION_REQUESTS_ARRAY_BASE_SLOT,

--- a/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
@@ -39,9 +39,14 @@ pub contract SimulatedAccount {
         true
     }
 
-    /// Since this contract normally emulates an account that uses a note to store the public key, we completely bypass
-    /// state synchronization here to avoid losing time on useless processing and also enabling the emulation of
-    /// different accounts with differently sized public key notes.
+    // This contract override exists solely to enable simulation without requiring users to sign anything. Therefore,
+    // this function should never be called - this contract should never be used to sync the state of the original
+    // contract! Doing so could result in an undefined behavior.
     #[external("utility")]
-    unconstrained fn sync_state() {}
+    unconstrained fn sync_state() {
+        assert(
+            false,
+            "BUG ALERT: sync_state on a simulated account contract should never be triggered.",
+        );
+    }
 }

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -25,6 +25,7 @@ pub contract TokenBlacklist {
         },
         messages::{
             discovery::private_notes::attempt_note_discovery, message_delivery::MessageDelivery,
+            processing::validate_and_store_enqueued_notes_and_events,
         },
         note::{
             note_getter_options::NoteGetterOptions,
@@ -298,5 +299,9 @@ pub contract TokenBlacklist {
             note_type_id,
             packed_note,
         );
+
+        // At this point, the note is pending validation and storage in the database. We must call
+        // validate_and_store_enqueued_notes_and_events to complete that process.
+        validate_and_store_enqueued_notes_and_events(contract_address);
     }
 }

--- a/yarn-project/cli-wallet/test/test.sh
+++ b/yarn-project/cli-wallet/test/test.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+
+# To run these tests against a local network:
+# 1. Start a local Ethereum node (Anvil):
+#    anvil --host 127.0.0.1 --port 8545
+#
+# 2. Start the Aztec local network:
+#    cd yarn-project/aztec
+#    NODE_NO_WARNINGS=1 ETHEREUM_HOSTS=http://127.0.0.1:8545 node ./dest/bin/index.js start --local-network
+#
+# 3. Run the tests:
+#    ./test.sh 
+
 set -e
 
 LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.test.ts
@@ -12,6 +12,7 @@ import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import type { BlockSynchronizerConfig } from '../config/index.js';
+import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
 import { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import { NoteStore } from '../storage/note_store/note_store.js';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
@@ -26,6 +27,7 @@ describe('BlockSynchronizer', () => {
   let privateEventStore: PrivateEventStore;
   let aztecNode: MockProxy<AztecNode>;
   let blockStream: MockProxy<L2BlockStream>;
+  let contractSyncService: MockProxy<ContractSyncService>;
 
   const TestSynchronizer = class extends BlockSynchronizer {
     protected override createBlockStream(): L2BlockStream {
@@ -34,7 +36,16 @@ describe('BlockSynchronizer', () => {
   };
 
   const createSynchronizer = (config: Partial<BlockSynchronizerConfig> = {}) => {
-    return new TestSynchronizer(aztecNode, store, anchorBlockStore, noteStore, privateEventStore, tipsStore, config);
+    return new TestSynchronizer(
+      aztecNode,
+      store,
+      anchorBlockStore,
+      noteStore,
+      privateEventStore,
+      tipsStore,
+      contractSyncService,
+      config,
+    );
   };
 
   beforeEach(async () => {
@@ -45,6 +56,7 @@ describe('BlockSynchronizer', () => {
     anchorBlockStore = new AnchorBlockStore(store);
     noteStore = new NoteStore(store);
     privateEventStore = new PrivateEventStore(store);
+    contractSyncService = mock<ContractSyncService>();
     synchronizer = createSynchronizer();
   });
 

--- a/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
+++ b/yarn-project/pxe/src/block_synchronizer/block_synchronizer.ts
@@ -7,6 +7,7 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import type { BlockSynchronizerConfig } from '../config/index.js';
+import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
 import type { AnchorBlockStore } from '../storage/anchor_block_store/anchor_block_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 import type { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
@@ -28,6 +29,7 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
     private noteStore: NoteStore,
     private privateEventStore: PrivateEventStore,
     private l2TipsStore: L2TipsKVStore,
+    private contractSyncService: ContractSyncService,
     private config: Partial<BlockSynchronizerConfig> = {},
     bindings?: LoggerBindings,
   ) {
@@ -125,6 +127,10 @@ export class BlockSynchronizer implements L2BlockStreamEventHandler {
 
   /** Updates the anchor block header to the target block */
   private async updateAnchorBlockHeader(blockHeader: BlockHeader) {
+    // Whenever the anchor block header is updated, we need to synchronize the private state of contracts again.
+    // Therefore, we clear the contract synchronization cache here such that the sync is re-triggered upon new
+    // execution.
+    this.contractSyncService.wipe();
     this.log.verbose(`Updated pxe last block to ${blockHeader.getBlockNumber()}`, blockHeader.toInspect());
     await this.anchorBlockStore.setHeader(blockHeader);
   }

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -72,6 +72,7 @@ import {
   getFinalMinRevertibleSideEffectCounter,
 } from '@aztec/stdlib/tx';
 
+import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
 import type { AddressStore } from '../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../storage/capsule_store/capsule_store.js';
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
@@ -107,6 +108,7 @@ export class ContractFunctionSimulator {
     private capsuleStore: CapsuleStore,
     private privateEventStore: PrivateEventStore,
     private simulator: CircuitSimulator,
+    private contractSyncService: ContractSyncService,
   ) {
     this.log = createLogger('simulator');
   }
@@ -186,6 +188,7 @@ export class ContractFunctionSimulator {
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
+      this.contractSyncService,
       jobId,
       0, // totalPublicArgsCount
       startSideEffectCounter,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -12,6 +12,7 @@ import { BlockHeader, HashedValues, TxContext, TxExecutionRequest } from '@aztec
 import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
+import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
 import type { ContractStore } from '../../storage/contract_store/contract_store.js';
@@ -36,6 +37,7 @@ describe('Oracle Version Check test suite', () => {
   let senderAddressBookStore: ReturnType<typeof mock<SenderAddressBookStore>>;
   let capsuleStore: ReturnType<typeof mock<CapsuleStore>>;
   let privateEventStore: ReturnType<typeof mock<PrivateEventStore>>;
+  let contractSyncService: ReturnType<typeof mock<ContractSyncService>>;
   let acirSimulator: ContractFunctionSimulator;
   let contractAddress: AztecAddress;
   let anchorBlockHeader: BlockHeader;
@@ -54,6 +56,7 @@ describe('Oracle Version Check test suite', () => {
     senderAddressBookStore = mock<SenderAddressBookStore>();
     capsuleStore = mock<CapsuleStore>();
     privateEventStore = mock<PrivateEventStore>();
+    contractSyncService = mock<ContractSyncService>();
     utilityAssertCompatibleOracleVersionSpy = jest.spyOn(
       UtilityExecutionOracle.prototype,
       'utilityAssertCompatibleOracleVersion',
@@ -99,6 +102,7 @@ describe('Oracle Version Check test suite', () => {
       capsuleStore,
       privateEventStore,
       simulator,
+      contractSyncService,
     );
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -27,6 +27,7 @@ import { TestContractArtifact } from '@aztec/noir-test-contracts.js/Test';
 import { WASMSimulator } from '@aztec/simulator/client';
 import {
   type ContractArtifact,
+  type FunctionCall,
   FunctionSelector,
   encodeArguments,
   getFunctionArtifact,
@@ -64,6 +65,8 @@ import { jest } from '@jest/globals';
 import { Matcher, type MatcherCreator, type MockProxy, mock } from 'jest-mock-extended';
 import { toFunctionSelector } from 'viem';
 
+import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
+import { syncState } from '../../contract_sync/helpers.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
 import type { ContractStore } from '../../storage/contract_store/contract_store.js';
@@ -120,6 +123,7 @@ describe('Private Execution test suite', () => {
   let aztecNode: MockProxy<AztecNode>;
   let capsuleStore: MockProxy<CapsuleStore>;
   let privateEventStore: MockProxy<PrivateEventStore>;
+  let contractSyncService: MockProxy<ContractSyncService>;
   let acirSimulator: ContractFunctionSimulator;
   let anchorBlockHeader = BlockHeader.empty();
   let logger: Logger;
@@ -320,6 +324,28 @@ describe('Private Execution test suite', () => {
     capsuleStore = mock<CapsuleStore>();
     privateEventStore = mock<PrivateEventStore>();
     senderAddressBookStore = mock<SenderAddressBookStore>();
+    contractSyncService = mock<ContractSyncService>();
+    // Configure mock to actually perform sync_state calls (needed for nested call tests)
+    contractSyncService.ensureContractSynced.mockImplementation(
+      async (
+        contractAddress: AztecAddress,
+        functionToInvokeAfterSync: FunctionSelector | null,
+        utilityExecutor: (call: FunctionCall) => Promise<unknown>,
+        header: BlockHeader,
+        jobId: string,
+      ) => {
+        await syncState(
+          contractAddress,
+          contractStore,
+          functionToInvokeAfterSync,
+          utilityExecutor,
+          noteStore,
+          aztecNode,
+          header,
+          jobId,
+        );
+      },
+    );
     contracts = {};
     anchorBlockHeader = makeBlockHeader();
     capsuleStore.readCapsuleArray.mockResolvedValue([]);
@@ -470,6 +496,7 @@ describe('Private Execution test suite', () => {
       capsuleStore,
       privateEventStore,
       simulator,
+      contractSyncService,
     );
   });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -30,7 +30,7 @@ import {
   type TxContext,
 } from '@aztec/stdlib/tx';
 
-import { ensureContractSynced } from '../../contract_sync/index.js';
+import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import { NoteService } from '../../notes/note_service.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
@@ -93,6 +93,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     senderAddressBookStore: SenderAddressBookStore,
     capsuleStore: CapsuleStore,
     privateEventStore: PrivateEventStore,
+    private readonly contractSyncService: ContractSyncService,
     jobId: string,
     private totalPublicCalldataCount: number = 0,
     protected sideEffectCounter: number = 0,
@@ -537,13 +538,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     isStaticCall = isStaticCall || this.callContext.isStaticCall;
 
-    await ensureContractSynced(
+    await this.contractSyncService.ensureContractSynced(
       targetContractAddress,
       functionSelector,
       this.utilityExecutor,
-      this.aztecNode,
-      this.contractStore,
-      this.noteStore,
       this.anchorBlockHeader,
       this.jobId,
     );
@@ -578,6 +576,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
+      this.contractSyncService,
       this.jobId,
       this.totalPublicCalldataCount,
       sideEffectCounter,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -17,6 +17,7 @@ import { BlockHeader, GlobalVariables, TxHash } from '@aztec/stdlib/tx';
 import { mock } from 'jest-mock-extended';
 import type { _MockProxy } from 'jest-mock-extended/lib/Mock.js';
 
+import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import type { AddressStore } from '../../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
 import type { ContractStore } from '../../storage/contract_store/contract_store.js';
@@ -41,6 +42,7 @@ describe('Utility Execution test suite', () => {
   let senderAddressBookStore: ReturnType<typeof mock<SenderAddressBookStore>>;
   let capsuleStore: ReturnType<typeof mock<CapsuleStore>>;
   let privateEventStore: ReturnType<typeof mock<PrivateEventStore>>;
+  let contractSyncService: ReturnType<typeof mock<ContractSyncService>>;
   let acirSimulator: ContractFunctionSimulator;
   let owner: AztecAddress;
   let ownerCompleteAddress: CompleteAddress;
@@ -62,6 +64,7 @@ describe('Utility Execution test suite', () => {
     senderAddressBookStore = mock<SenderAddressBookStore>();
     capsuleStore = mock<CapsuleStore>();
     privateEventStore = mock<PrivateEventStore>();
+    contractSyncService = mock<ContractSyncService>();
     const capsuleArrays = new Map<string, Fr[][]>();
     anchorBlockHeader = BlockHeader.random();
     senderTaggingStore.getLastFinalizedIndex.mockResolvedValue(undefined);
@@ -99,6 +102,7 @@ describe('Utility Execution test suite', () => {
       capsuleStore,
       privateEventStore,
       simulator,
+      contractSyncService,
     );
 
     const ownerPartialAddress = Fr.random();

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
@@ -1,0 +1,129 @@
+import type { Logger } from '@aztec/foundation/log';
+import type { FunctionCall, FunctionSelector } from '@aztec/stdlib/abi';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { AztecNode } from '@aztec/stdlib/interfaces/client';
+import type { BlockHeader } from '@aztec/stdlib/tx';
+
+import type { StagedStore } from '../job_coordinator/job_coordinator.js';
+import type { ContractStore } from '../storage/contract_store/contract_store.js';
+import type { NoteStore } from '../storage/note_store/note_store.js';
+import { syncState, verifyCurrentClassId } from './helpers.js';
+
+/**
+ * Service for syncing the private state of contracts and verifying that the PXE holds the current class artifact.
+ * It uses a cache to avoid redundant sync operations - the cache is wiped when the anchor block changes.
+ *
+ * TODO: The StagedStore naming is broken here. Figure out a better name.
+ */
+export class ContractSyncService implements StagedStore {
+  readonly storeName = 'contract_sync';
+
+  // Tracks contracts synced since last wipe. Key is contract address string, value is a promise that resolves when
+  // the contract is synced.
+  private syncedContracts: Map<string, Promise<void>> = new Map();
+
+  // Per-job overridden contract addresses - these contracts should not be synced.
+  private overriddenContracts: Map<string, Set<string>> = new Map();
+
+  constructor(
+    private aztecNode: AztecNode,
+    private contractStore: ContractStore,
+    private noteStore: NoteStore,
+    private log: Logger,
+  ) {}
+
+  /** Sets contracts that should be skipped during sync for a specific job. */
+  setOverriddenContracts(jobId: string, addresses: Set<string>): void {
+    this.overriddenContracts.set(jobId, addresses);
+  }
+
+  /**
+   * Ensures a contract's private state is synchronized and that the PXE holds the current class artifact.
+   * Uses a cache to avoid redundant sync operations - the cache is wiped when the anchor block changes.
+   * @param contractAddress - The address of the contract to sync.
+   * @param functionToInvokeAfterSync - The function selector that will be called after sync (used to validate it's
+   * not sync_state itself).
+   * @param utilityExecutor - Executor function for running the sync_state utility function.
+   */
+  async ensureContractSynced(
+    contractAddress: AztecAddress,
+    functionToInvokeAfterSync: FunctionSelector | null,
+    utilityExecutor: (call: FunctionCall) => Promise<any>,
+    anchorBlockHeader: BlockHeader,
+    jobId: string,
+  ): Promise<void> {
+    const key = contractAddress.toString();
+
+    // Skip sync if this contract has an override for this job
+    const overrides = this.overriddenContracts.get(jobId);
+    if (overrides?.has(key)) {
+      return;
+    }
+
+    const existing = this.syncedContracts.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const syncPromise = this.#doSync(
+      contractAddress,
+      functionToInvokeAfterSync,
+      utilityExecutor,
+      anchorBlockHeader,
+      jobId,
+    );
+    this.syncedContracts.set(key, syncPromise);
+
+    try {
+      await syncPromise;
+    } catch (err) {
+      // There was an error syncing the contract, so we remove it from the cache so that it can be retried.
+      this.syncedContracts.delete(key);
+      throw err;
+    }
+  }
+
+  async #doSync(
+    contractAddress: AztecAddress,
+    functionToInvokeAfterSync: FunctionSelector | null,
+    utilityExecutor: (call: FunctionCall) => Promise<any>,
+    anchorBlockHeader: BlockHeader,
+    jobId: string,
+  ): Promise<void> {
+    this.log.debug(`Syncing contract ${contractAddress}`);
+    await Promise.all([
+      syncState(
+        contractAddress,
+        this.contractStore,
+        functionToInvokeAfterSync,
+        utilityExecutor,
+        this.noteStore,
+        this.aztecNode,
+        anchorBlockHeader,
+        jobId,
+      ),
+      verifyCurrentClassId(contractAddress, this.aztecNode, this.contractStore, anchorBlockHeader),
+    ]);
+    this.log.debug(`Contract ${contractAddress} synced`);
+  }
+
+  /** Clears sync cache. Called by BlockSynchronizer when anchor block changes. */
+  wipe(): void {
+    this.log.debug(`Wiping contract sync cache (${this.syncedContracts.size} entries)`);
+    this.syncedContracts.clear();
+  }
+
+  commit(jobId: string): Promise<void> {
+    // Clear overridden contracts for this job
+    this.overriddenContracts.delete(jobId);
+    return Promise.resolve();
+  }
+
+  discardStaged(jobId: string): Promise<void> {
+    // We clear the synced contracts cache here because, when the job is discarded, any associated database writes from
+    // the sync are also undone.
+    this.syncedContracts.clear();
+    this.overriddenContracts.delete(jobId);
+    return Promise.resolve();
+  }
+}

--- a/yarn-project/pxe/src/contract_sync/helpers.ts
+++ b/yarn-project/pxe/src/contract_sync/helpers.ts
@@ -45,7 +45,7 @@ export async function syncState(
   utilityExecutor: (privateSyncCall: FunctionCall) => Promise<any>,
   noteStore: NoteStore,
   aztecNode: AztecNode,
-  header: BlockHeader,
+  anchorBlockHeader: BlockHeader,
   jobId: string,
 ) {
   // Protocol contracts don't have private state to sync
@@ -57,7 +57,7 @@ export async function syncState(
       );
     }
 
-    const noteService = new NoteService(noteStore, aztecNode, header, jobId);
+    const noteService = new NoteService(noteStore, aztecNode, anchorBlockHeader, jobId);
 
     // Both sync_state and syncNoteNullifiers interact with the note store, but running them in parallel is safe
     // because note store is designed to handle concurrent operations.
@@ -68,9 +68,12 @@ export async function syncState(
 /**
  * Verify that the current class id of a contract obtained from AztecNode is the same as the one in contract data
  * provider (i.e. PXE's own storage).
+ * @param contractAddress - The address of the contract to verify.
+ * @param aztecNode - The Aztec node to query for storage.
+ * @param contractStore - The contract store to fetch the local instance from.
  * @param header - The header of the block at which to verify the current class id.
  */
-async function verifyCurrentClassId(
+export async function verifyCurrentClassId(
   contractAddress: AztecAddress,
   aztecNode: AztecNode,
   contractStore: ContractStore,
@@ -87,33 +90,4 @@ async function verifyCurrentClassId(
       `Contract ${contractAddress} is outdated, current class id is ${currentClassId}, local class id is ${instance.currentContractClassId}`,
     );
   }
-}
-
-/**
- * Ensures the contract's private state is synchronized and that the PXE holds the current class artifact for
- * the contract.
- */
-export async function ensureContractSynced(
-  contractAddress: AztecAddress,
-  functionToInvokeAfterSync: FunctionSelector | null,
-  utilityExecutor: (call: FunctionCall) => Promise<any>,
-  aztecNode: AztecNode,
-  contractStore: ContractStore,
-  noteStore: NoteStore,
-  header: BlockHeader,
-  jobId: string,
-): Promise<void> {
-  await Promise.all([
-    syncState(
-      contractAddress,
-      contractStore,
-      functionToInvokeAfterSync,
-      utilityExecutor,
-      noteStore,
-      aztecNode,
-      header,
-      jobId,
-    ),
-    verifyCurrentClassId(contractAddress, aztecNode, contractStore, header),
-  ]);
 }

--- a/yarn-project/pxe/src/entrypoints/server/index.ts
+++ b/yarn-project/pxe/src/entrypoints/server/index.ts
@@ -7,4 +7,4 @@ export { NoteService } from '../../notes/note_service.js';
 export { ORACLE_VERSION } from '../../oracle_version.js';
 export { type PXECreationOptions } from '../pxe_creation_options.js';
 export { JobCoordinator } from '../../job_coordinator/job_coordinator.js';
-export { syncState } from '../../contract_sync/index.js';
+export { ContractSyncService } from '../../contract_sync/contract_sync_service.js';

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -59,7 +59,8 @@ import {
   generateSimulatedProvingResult,
 } from './contract_function_simulator/contract_function_simulator.js';
 import { ProxiedContractStoreFactory } from './contract_function_simulator/proxied_contract_data_source.js';
-import { ensureContractSynced, readCurrentClassId } from './contract_sync/index.js';
+import { ContractSyncService } from './contract_sync/contract_sync_service.js';
+import { readCurrentClassId } from './contract_sync/helpers.js';
 import { PXEDebugUtils } from './debug/pxe_debug_utils.js';
 import { enrichPublicSimulationError, enrichSimulationError } from './error_enriching.js';
 import { PrivateEventFilterValidator } from './events/private_event_filter_validator.js';
@@ -102,6 +103,7 @@ export class PXE {
     private recipientTaggingStore: RecipientTaggingStore,
     private addressStore: AddressStore,
     private privateEventStore: PrivateEventStore,
+    private contractSyncService: ContractSyncService,
     private simulator: CircuitSimulator,
     private proverEnabled: boolean,
     private proofCreator: PrivateKernelProver,
@@ -149,6 +151,12 @@ export class PXE {
     const capsuleStore = new CapsuleStore(store);
     const keyStore = new KeyStore(store);
     const tipsStore = new L2TipsKVStore(store, 'pxe');
+    const contractSyncService = new ContractSyncService(
+      node,
+      contractStore,
+      noteStore,
+      createLogger('pxe:contract_sync', bindings),
+    );
     const synchronizer = new BlockSynchronizer(
       node,
       store,
@@ -156,6 +164,7 @@ export class PXE {
       noteStore,
       privateEventStore,
       tipsStore,
+      contractSyncService,
       config,
       bindings,
     );
@@ -167,6 +176,7 @@ export class PXE {
       recipientTaggingStore,
       privateEventStore,
       noteStore,
+      contractSyncService,
     ]);
 
     const debugUtils = new PXEDebugUtils(contractStore, noteStore, synchronizer, anchorBlockStore);
@@ -186,6 +196,7 @@ export class PXE {
       recipientTaggingStore,
       addressStore,
       privateEventStore,
+      contractSyncService,
       simulator,
       proverEnabled,
       proofCreator,
@@ -223,6 +234,7 @@ export class PXE {
       this.capsuleStore,
       this.privateEventStore,
       this.simulator,
+      this.contractSyncService,
     );
   }
 
@@ -297,13 +309,10 @@ export class PXE {
     try {
       const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
 
-      await ensureContractSynced(
+      await this.contractSyncService.ensureContractSynced(
         contractAddress,
         functionSelector,
         privateSyncCall => this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
-        this.node,
-        this.contractStore,
-        this.noteStore,
         anchorBlockHeader,
         jobId,
       );
@@ -850,7 +859,14 @@ export class PXE {
         // Temporary: in case there are overrides, we have to skip the kernels or validations
         // will fail. Consider handing control to the user/wallet on whether they want to run them
         // or not.
-        const skipKernels = overrides?.contracts !== undefined && Object.keys(overrides.contracts ?? {}).length > 0;
+        const overriddenContracts = overrides?.contracts ? new Set(Object.keys(overrides.contracts)) : undefined;
+        const hasOverriddenContracts = overriddenContracts !== undefined && overriddenContracts.size > 0;
+        const skipKernels = hasOverriddenContracts;
+
+        // Set overridden contracts on the sync service so it knows to skip syncing them
+        if (hasOverriddenContracts) {
+          this.contractSyncService.setOverriddenContracts(jobId, overriddenContracts);
+        }
 
         // Execution of private functions only; no proving, and no kernel logic.
         const privateExecutionResult = await this.#executePrivate(contractFunctionSimulator, txRequest, scopes, jobId);
@@ -972,13 +988,10 @@ export class PXE {
         const contractFunctionSimulator = this.#getSimulatorForTx();
 
         const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
-        await ensureContractSynced(
+        await this.contractSyncService.ensureContractSynced(
           call.to,
           call.selector,
           privateSyncCall => this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
-          this.node,
-          this.contractStore,
-          this.noteStore,
           anchorBlockHeader,
           jobId,
         );
@@ -1044,14 +1057,11 @@ export class PXE {
 
       const contractFunctionSimulator = this.#getSimulatorForTx();
 
-      await ensureContractSynced(
+      await this.contractSyncService.ensureContractSynced(
         filter.contractAddress,
         null,
         async privateSyncCall =>
           await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
-        this.node,
-        this.contractStore,
-        this.noteStore,
         anchorBlockHeader,
         jobId,
       );

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -22,7 +22,6 @@ import {
   SenderAddressBookStore,
   SenderTaggingStore,
   enrichPublicSimulationError,
-  syncState,
 } from '@aztec/pxe/server';
 import {
   ExecutionNoteCache,
@@ -303,13 +302,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     };
 
     const blockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();
-    await syncState(
+    await this.stateMachine.contractSyncService.ensureContractSynced(
       targetContractAddress,
-      this.contractStore,
       functionSelector,
       utilityExecutor,
-      this.noteStore,
-      this.stateMachine.node,
       blockHeader,
       this.jobId,
     );
@@ -359,6 +355,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
+      this.stateMachine.contractSyncService,
       this.jobId,
       0, // totalPublicArgsCount
       minRevertibleSideEffectCounter, // (start) sideEffectCounter
@@ -672,15 +669,12 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     // Sync notes before executing utility function to discover notes from previous transactions
     const blockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();
-    await syncState(
+    await this.stateMachine.contractSyncService.ensureContractSynced(
       targetContractAddress,
-      this.contractStore,
       functionSelector,
       async call => {
         await this.executeUtilityCall(call);
       },
-      this.noteStore,
-      this.stateMachine.node,
       blockHeader,
       this.jobId,
     );

--- a/yarn-project/txe/src/state_machine/index.ts
+++ b/yarn-project/txe/src/state_machine/index.ts
@@ -3,8 +3,7 @@ import { TestCircuitVerifier } from '@aztec/bb-prover/test';
 import { CheckpointNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
-import type { AztecAsyncKVStore } from '@aztec/kv-store';
-import { AnchorBlockStore } from '@aztec/pxe/server';
+import { type AnchorBlockStore, type ContractStore, ContractSyncService, type NoteStore } from '@aztec/pxe/server';
 import { L2Block } from '@aztec/stdlib/block';
 import { Checkpoint, L1PublishedData, PublishedCheckpoint } from '@aztec/stdlib/checkpoint';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
@@ -26,13 +25,16 @@ export class TXEStateMachine {
     public synchronizer: TXESynchronizer,
     public archiver: TXEArchiver,
     public anchorBlockStore: AnchorBlockStore,
+    public contractSyncService: ContractSyncService,
   ) {}
 
-  public static async create(db: AztecAsyncKVStore) {
-    const archiver = new TXEArchiver(db);
+  public static async create(
+    archiver: TXEArchiver,
+    anchorBlockStore: AnchorBlockStore,
+    contractStore: ContractStore,
+    noteStore: NoteStore,
+  ) {
     const synchronizer = await TXESynchronizer.create();
-    const anchorBlockStore = new AnchorBlockStore(db);
-
     const aztecNodeConfig = {} as AztecNodeConfig;
 
     const log = createLogger('txe_node');
@@ -58,7 +60,14 @@ export class TXEStateMachine {
       log,
     );
 
-    return new this(node, synchronizer, archiver, anchorBlockStore);
+    const contractSyncService = new ContractSyncService(
+      node,
+      contractStore,
+      noteStore,
+      createLogger('txe:contract_sync'),
+    );
+
+    return new this(node, synchronizer, archiver, anchorBlockStore, contractSyncService);
   }
 
   public async handleL2Block(block: L2Block) {
@@ -91,6 +100,9 @@ export class TXEStateMachine {
       ),
       [],
     );
+    // Wipe contract sync cache when anchor block changes (mirrors BlockSynchronizer behavior)
+    this.contractSyncService.wipe();
+
     await Promise.all([
       this.synchronizer.handleL2Block(block),
       this.archiver.addCheckpoints([publishedCheckpoint], undefined),

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -6,6 +6,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
 import {
   AddressStore,
+  AnchorBlockStore,
   CapsuleStore,
   JobCoordinator,
   NoteService,
@@ -49,6 +50,7 @@ import type { IAvmExecutionOracle, ITxeExecutionOracle } from './oracle/interfac
 import { TXEOraclePublicContext } from './oracle/txe_oracle_public_context.js';
 import { TXEOracleTopLevelContext } from './oracle/txe_oracle_top_level_context.js';
 import { RPCTranslator } from './rpc_translator.js';
+import { TXEArchiver } from './state_machine/archiver.js';
 import { TXEStateMachine } from './state_machine/index.js';
 import type { ForeignCallArgs, ForeignCallResult } from './util/encoding.js';
 import { TXEAccountStore } from './util/txe_account_store.js';
@@ -176,7 +178,9 @@ export class TXESession implements TXESessionStateHandler {
       await contractStore.addContractInstance(instance);
     }
 
-    const stateMachine = await TXEStateMachine.create(store);
+    const archiver = new TXEArchiver(store);
+    const anchorBlockStore = new AnchorBlockStore(store);
+    const stateMachine = await TXEStateMachine.create(archiver, anchorBlockStore, contractStore, noteStore);
 
     const nextBlockTimestamp = BigInt(Math.floor(new Date().getTime() / 1000));
     const version = new Fr(await stateMachine.node.getVersion());
@@ -356,6 +360,7 @@ export class TXESession implements TXESessionStateHandler {
       this.senderAddressBookStore,
       this.capsuleStore,
       this.privateEventStore,
+      this.stateMachine.contractSyncService,
       this.currentJobId,
     );
 


### PR DESCRIPTION
Re-syncing contracts when a new anchor block was not synced was very wasteful as it's common that we execute a multiple functions of the same contract at the same block. This was wasting time as the re-sync is not necessary. In this PR I cache the information of whether a contract was synced at the current anchor block and if it is the case the sync is skipped.

This information is wiped when a new anchor block is loaded.

This PR uncovered an issue with `process_message` and `process_transparent_note` functions where we didn't finalize the note processing by performing a call to `validate_and_store_enqueued_notes_and_events` but it worked before due to us always running the contract sync before invocation of any utility or private function.

Another unexpected problem was that contract overrides resulted in a state sync not being actually run (due to an empty `sync_state` function implementation in the `SimulatedAccount`) while the sync caching system then marked it as synced and the sync then didn't run in the future on the real contract because of this resulting in notes not being synced and tests failing.

Closes https://linear.app/aztec-labs/issue/F-269/consider-not-re-rerunning-sync-on-private-functions-at-the-same-anchor