### PR TITLE
feat: add download functionality to barretenberg-rs build.rs

### DIFF
--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -1,18 +1,99 @@
+use std::path::PathBuf;
+
 fn main() {
-    // Only for ffi feature - link libbb-external from cpp build
+    // Only for ffi feature - link libbb-external
     #[cfg(feature = "ffi")]
     {
-        // Find the cpp build lib directory relative to this crate
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let lib_dir = std::path::Path::new(&manifest_dir)
-            .join("../../cpp/build/lib")
-            .canonicalize()
-            .expect("Failed to find cpp/build/lib - run barretenberg/cpp/bootstrap.sh first");
-
+        let lib_dir = get_lib_dir();
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
 
         // libbb-external.a contains everything needed: barretenberg + env + vm2_stub
         println!("cargo:rustc-link-lib=static=bb-external");
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
+}
+
+#[cfg(feature = "ffi")]
+fn get_lib_dir() -> PathBuf {
+    // First, check for local cpp build (for development)
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let local_lib_dir = std::path::Path::new(&manifest_dir).join("../../cpp/build/lib");
+    if local_lib_dir.join("libbb-external.a").exists() {
+        return local_lib_dir.canonicalize().unwrap();
+    }
+
+    // Otherwise, download from GitHub releases
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let lib_path = out_dir.join("libbb-external.a");
+
+    if !lib_path.exists() {
+        download_lib(&out_dir);
+    }
+
+    out_dir
+}
+
+#[cfg(feature = "ffi")]
+fn download_lib(out_dir: &PathBuf) {
+    let target = std::env::var("TARGET").unwrap();
+    let arch = match target.as_str() {
+        t if t.contains("x86_64") && t.contains("linux") => "amd64-linux",
+        t if t.contains("aarch64") && t.contains("linux") => "arm64-linux",
+        _ => panic!(
+            "Unsupported target for FFI backend: {}. Supported: x86_64-linux, aarch64-linux",
+            target
+        ),
+    };
+
+    // Use BARRETENBERG_VERSION env var, or fall back to crate version
+    let version = std::env::var("BARRETENBERG_VERSION")
+        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+
+    // Skip download for test versions (0.0.1)
+    if version == "0.0.1" {
+        panic!(
+            "Cannot download pre-built library for test version 0.0.1. \
+             Build barretenberg locally: cd barretenberg/cpp && ./bootstrap.sh"
+        );
+    }
+
+    let url = format!(
+        "https://github.com/AztecProtocol/aztec-packages/releases/download/v{}/barretenberg-static-{}.tar.gz",
+        version, arch
+    );
+
+    println!("cargo:warning=Downloading barretenberg static library from {}", url);
+
+    // Download and extract
+    let tar_gz_path = out_dir.join("barretenberg-static.tar.gz");
+
+    let status = std::process::Command::new("curl")
+        .args(["-L", "-f", "-o"])
+        .arg(&tar_gz_path)
+        .arg(&url)
+        .status()
+        .expect("Failed to run curl");
+
+    if !status.success() {
+        panic!(
+            "Failed to download barretenberg static library from {}. \
+             Make sure version v{} exists as a GitHub release.",
+            url, version
+        );
+    }
+
+    let status = std::process::Command::new("tar")
+        .args(["-xzf"])
+        .arg(&tar_gz_path)
+        .arg("-C")
+        .arg(out_dir)
+        .status()
+        .expect("Failed to run tar");
+
+    if !status.success() {
+        panic!("Failed to extract barretenberg static library");
+    }
+
+    // Clean up tar.gz
+    std::fs::remove_file(&tar_gz_path).ok();
 }

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -15,18 +15,16 @@ fn main() {
 
 #[cfg(feature = "ffi")]
 fn get_lib_dir() -> PathBuf {
-    // Check if user wants to force local build only (for development)
-    let require_local = std::env::var("BB_LOCAL_BUILD").is_ok();
+    // Check if user wants to use local build (for development in monorepo)
+    let use_local = std::env::var("BB_LOCAL_BUILD").is_ok();
 
-    // First, check for local cpp build (for development)
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let local_lib_dir = std::path::Path::new(&manifest_dir).join("../../cpp/build/lib");
-    if local_lib_dir.join("libbb-external.a").exists() {
-        return local_lib_dir.canonicalize().unwrap();
-    }
-
-    // If local build is required but not found, fail with helpful message
-    if require_local {
+    if use_local {
+        // Use local cpp build
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let local_lib_dir = std::path::Path::new(&manifest_dir).join("../../cpp/build/lib");
+        if local_lib_dir.join("libbb-external.a").exists() {
+            return local_lib_dir.canonicalize().unwrap();
+        }
         panic!(
             "BB_LOCAL_BUILD is set but libbb-external.a not found at {:?}. \
              Build barretenberg locally: cd barretenberg/cpp && ./bootstrap.sh",
@@ -34,7 +32,7 @@ fn get_lib_dir() -> PathBuf {
         );
     }
 
-    // Otherwise, download from GitHub releases
+    // Download from GitHub releases
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let lib_path = out_dir.join("libbb-external.a");
 

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -15,20 +15,16 @@ fn main() {
 
 #[cfg(feature = "ffi")]
 fn get_lib_dir() -> PathBuf {
-    // Check if user wants to use local build (for development in monorepo)
-    let use_local = std::env::var("BB_LOCAL_BUILD").is_ok();
-
-    if use_local {
-        // Use local cpp build
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let local_lib_dir = std::path::Path::new(&manifest_dir).join("../../cpp/build/lib");
-        if local_lib_dir.join("libbb-external.a").exists() {
-            return local_lib_dir.canonicalize().unwrap();
+    // Check if user provided a custom library path
+    if let Ok(lib_dir) = std::env::var("BB_LIB_DIR") {
+        let lib_dir = PathBuf::from(&lib_dir);
+        if lib_dir.join("libbb-external.a").exists() {
+            return lib_dir.canonicalize().unwrap();
         }
         panic!(
-            "BB_LOCAL_BUILD is set but libbb-external.a not found at {:?}. \
+            "BB_LIB_DIR is set to {:?} but libbb-external.a not found there. \
              Build barretenberg locally: cd barretenberg/cpp && ./bootstrap.sh",
-            local_lib_dir
+            lib_dir
         );
     }
 

--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -15,11 +15,23 @@ fn main() {
 
 #[cfg(feature = "ffi")]
 fn get_lib_dir() -> PathBuf {
+    // Check if user wants to force local build only (for development)
+    let require_local = std::env::var("BB_LOCAL_BUILD").is_ok();
+
     // First, check for local cpp build (for development)
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let local_lib_dir = std::path::Path::new(&manifest_dir).join("../../cpp/build/lib");
     if local_lib_dir.join("libbb-external.a").exists() {
         return local_lib_dir.canonicalize().unwrap();
+    }
+
+    // If local build is required but not found, fail with helpful message
+    if require_local {
+        panic!(
+            "BB_LOCAL_BUILD is set but libbb-external.a not found at {:?}. \
+             Build barretenberg locally: cd barretenberg/cpp && ./bootstrap.sh",
+            local_lib_dir
+        );
     }
 
     // Otherwise, download from GitHub releases

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -38,7 +38,8 @@ function test {
   denoise "cargo test --release"
 
   # Run FFI backend tests (requires libbb-external.a from cpp build)
-  RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" denoise "cargo test --release --features ffi"
+  # BB_LIB_DIR tells build.rs to use local lib instead of downloading
+  BB_LIB_DIR="../cpp/build/lib" RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" denoise "cargo test --release --features ffi"
 }
 
 function test_download {

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -64,9 +64,29 @@ function test_download {
   local version=${BARRETENBERG_VERSION:-$(gh release list --repo AztecProtocol/aztec-packages --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')}
   echo "Testing download with version: $version"
 
-  # Only run barretenberg-rs tests (not barretenberg-tests which has additional deps)
-  BARRETENBERG_VERSION=$version RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" \
-    denoise "cargo test --release --features ffi -p barretenberg-rs"
+  # Retry logic for network flakiness (GitHub releases can be flaky)
+  local max_retries=3
+  local retry=0
+  local success=false
+  while [ $retry -lt $max_retries ]; do
+    if BARRETENBERG_VERSION=$version RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" \
+        cargo test --release --features ffi -p barretenberg-rs 2>&1; then
+      success=true
+      break
+    fi
+    retry=$((retry + 1))
+    if [ $retry -lt $max_retries ]; then
+      echo "Attempt $retry failed, retrying in 5 seconds..."
+      sleep 5
+      # Clean to force re-download
+      cargo clean -p barretenberg-rs 2>/dev/null || true
+    fi
+  done
+
+  if [ "$success" = false ]; then
+    echo "Download test failed after $max_retries attempts"
+    exit 1
+  fi
 
   # Restore the local library (trap handles this, but be explicit)
   if [ -f "$lib_path.bak" ]; then

--- a/barretenberg/rust/bootstrap.sh
+++ b/barretenberg/rust/bootstrap.sh
@@ -41,6 +41,40 @@ function test {
   RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" denoise "cargo test --release --features ffi"
 }
 
+function test_download {
+  echo_header "barretenberg-rs download test"
+
+  # Ensure Cargo is in PATH
+  if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+  fi
+
+  # Test that build.rs can download pre-built libraries from GitHub releases
+  # Hide the local library to force download path
+  local lib_path="../cpp/build/lib/libbb-external.a"
+  if [ -f "$lib_path" ]; then
+    mv "$lib_path" "$lib_path.bak"
+    trap "mv '$lib_path.bak' '$lib_path' 2>/dev/null" EXIT
+  fi
+
+  # Clean cargo cache to force rebuild
+  cargo clean -p barretenberg-rs 2>/dev/null || true
+
+  # Build with a known release version
+  local version=${BARRETENBERG_VERSION:-$(gh release list --repo AztecProtocol/aztec-packages --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')}
+  echo "Testing download with version: $version"
+
+  # Only run barretenberg-rs tests (not barretenberg-tests which has additional deps)
+  BARRETENBERG_VERSION=$version RUSTFLAGS="-C link-arg=-Wl,--allow-multiple-definition" \
+    denoise "cargo test --release --features ffi -p barretenberg-rs"
+
+  # Restore the local library (trap handles this, but be explicit)
+  if [ -f "$lib_path.bak" ]; then
+    mv "$lib_path.bak" "$lib_path"
+    trap - EXIT
+  fi
+}
+
 case "$cmd" in
   "clean")
     git clean -fdx
@@ -58,7 +92,7 @@ case "$cmd" in
   bench|bench_cmds)
     # Empty handling just to make this command valid.
     ;;
-  test|test_cmds)
+  test|test_cmds|test_download)
     $cmd
     ;;
   *)


### PR DESCRIPTION
## Summary

This PR adds download functionality to barretenberg-rs `build.rs` to fetch pre-built static libraries from GitHub releases.

**What this PR does:**
- `build.rs` now downloads `libbb-external.a` from GitHub releases when local cpp build is not available
- Add `test_download` command to `bootstrap.sh` to verify download path works
- Uses `BARRETENBERG_VERSION` env var or falls back to crate version
- Blocks version `0.0.1` to prevent accidental downloads during development

**Download logic:**
1. First checks for local `../../cpp/build/lib/libbb-external.a` (for development)
2. If not found, downloads from `https://github.com/AztecProtocol/aztec-packages/releases/download/v{version}/barretenberg-static-{arch}-linux.tar.gz`
3. Extracts to cargo's `OUT_DIR`

**Test command:**
```bash
BARRETENBERG_VERSION=0.0.1-commit.d431d1c ./bootstrap.sh test_download
```

## Test plan
- [x] Tested locally with `BARRETENBERG_VERSION=0.0.1-commit.d431d1c ./bootstrap.sh test_download`
- [x] Verified FFI tests pass with downloaded library
- [x] Verified local library is restored after test