### PR TITLE
fix: use claimed counter to split note hashes

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -363,6 +363,8 @@
     "unexclude",
     "unexcluded",
     "unfinalized",
+    "uniquified",
+    "uniquify",
     "unkonstrained",
     "unnullify",
     "unpadded",

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
@@ -24,7 +24,7 @@ use types::{
         MAX_U32_VALUE, SIDE_EFFECT_MASKING_ADDRESS,
     },
     hash::{compute_unique_siloed_note_hash, silo_note_hash, silo_nullifier, silo_private_log},
-    side_effect::{Counted, Ordered, Scoped},
+    side_effect::{Counted, Scoped},
     utils::arrays::ClaimedLengthArray,
 };
 
@@ -182,9 +182,6 @@ impl ResetOutputComposer {
                 i,
             );
 
-            let min_revertible_side_effect_counter =
-                self.previous_kernel.min_revertible_side_effect_counter;
-
             // We don't silo revertible note hashes with a note_nonce, since we don't know their final position in the tx.
             //
             // Elaboration:
@@ -237,11 +234,12 @@ impl ResetOutputComposer {
             //   - For "non-revertible from private-land" note hashes, the `unique_siloed_note_hash`es
             //     that we derived above are correct.
             //   - None of the `unique_siloed_note_hash`es for "revertible" note hashes are fit for use.
-            let is_non_revertible = note_hash.counter() < min_revertible_side_effect_counter;
-            let is_private_only = self.previous_kernel.is_private_only;
+            let is_non_revertible = note_hash.is_non_revertible(
+                self.previous_kernel.is_private_only,
+                self.previous_kernel.claimed_revertible_counter,
+            );
 
-            padded_unique_siloed_sorted_kept_note_hashes.array[i].inner.inner = if is_private_only
-                | is_non_revertible {
+            padded_unique_siloed_sorted_kept_note_hashes.array[i].inner.inner = if is_non_revertible {
                 unique_siloed_note_hash
             } else {
                 siloed_note_hash

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
@@ -22,7 +22,7 @@ use dep::types::{
         compute_note_nonce_and_unique_note_hash, compute_siloed_note_hash,
         compute_siloed_private_log_first_field, silo_nullifier,
     },
-    side_effect::{Counted, Ordered, Scoped},
+    side_effect::{Counted, Scoped},
 };
 use validate_note_logs_linked_to_note_hashes::validate_note_logs_linked_to_note_hashes;
 
@@ -33,7 +33,7 @@ fn assert_correctly_siloed_note_hash(
     index: u32,
     claimed_first_nullifier: Field,
     is_private_only: bool,
-    min_revertible_side_effect_counter: u32,
+    claimed_revertible_counter: u32,
 ) {
     // We determine which of these two values is appropriate, based on the revertible-ness of the note:
     let (siloed_note_hash, unique_siloed_note_hash) = if prev.contract_address.is_zero() {
@@ -54,8 +54,7 @@ fn assert_correctly_siloed_note_hash(
     // and just check that hint once, somewhere. In fact, that hint could be checked in the inner kernel
     // circuit, and propagated as a public input (via the data bus). That would save 3 inequality checks in this
     // reset circuit. Hmm.. but it would cost inequalities for every note & nullifier in a private call in the inner circuit... I wonder which is best...
-    let is_non_revertible = prev.counter() < min_revertible_side_effect_counter;
-    let computed_note_hash = if is_private_only | is_non_revertible {
+    let computed_note_hash = if prev.is_non_revertible(is_private_only, claimed_revertible_counter) {
         unique_siloed_note_hash
     } else {
         // Revertible note hashes are not siloed with a note_nonce if public execution will occur later
@@ -64,7 +63,7 @@ fn assert_correctly_siloed_note_hash(
         // at this point.
         //
         // Note: padded note hashes have a counter of `MAX_U32_VALUE`, which is always greater than
-        // `min_revertible_side_effect_counter`, so they are also not unique-ified with a note_nonce.
+        // `claimed_revertible_counter`, so they are not uniquified with a note_nonce either.
         siloed_note_hash
     };
     assert_eq(
@@ -244,7 +243,10 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
     }
 
     fn validate_transient_data<let TransientDataSquashingAmount: u32>(self) {
-        // For private-only txs, we squash all transient data.
+        // For private-only txs, all transient data are non-revertible and can be squashed.
+        // Although setting the `split_counter` to 0 might seem to imply that everything is revertible, this does not
+        // affect the logic in `validate_note_hash_nullifier_squashing.nr`. The key point is to ensure that all note
+        // hashes and nullifiers are on the same side of the split counter.
         let split_counter = if self.previous_kernel.is_private_only {
             0
         } else {
@@ -528,14 +530,7 @@ mod tests {
         let prev = make_note_hash(NOTE_HASH_VALUE, 10);
         let expected = compute_expected_unique(NOTE_HASH_VALUE, 0);
 
-        assert_correctly_siloed_note_hash(
-            expected,
-            prev,
-            0, // index
-            CLAIMED_FIRST_NULLIFIER,
-            false, // is_private_only
-            100, // min_revertible_side_effect_counter
-        );
+        assert_correctly_siloed_note_hash(expected, prev, 0, CLAIMED_FIRST_NULLIFIER, false, 100);
     }
 
     #[test]

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
@@ -31,7 +31,7 @@ use dep::types::{
         silo_note_hash, silo_nullifier, silo_private_log,
     },
     merkle_tree::{LeafPreimage, MembershipWitness},
-    side_effect::{Counted, Ordered, Scoped},
+    side_effect::{Counted, Scoped},
     tests::{
         fixture_builder::FixtureBuilder,
         merkle_tree_utils::SingleSubtreeMerkleTree,
@@ -60,7 +60,6 @@ struct TestBuilder {
     pub note_hash_read_request_hints: ReadRequestHintsBuilder<MAX_NOTE_HASH_READ_REQUESTS_PER_TX, NOTE_HASH_PENDING_READ_HINTS_LEN, NOTE_HASH_SETTLED_READ_HINTS_LEN, NOTE_HASH_TREE_HEIGHT, NoteHashLeafPreimage>,
     pub nullifier_read_request_hints: ReadRequestHintsBuilder<MAX_NULLIFIER_READ_REQUESTS_PER_TX, NULLIFIER_PENDING_READ_HINTS_LEN, NULLIFIER_SETTLED_READ_HINTS_LEN, NULLIFIER_TREE_HEIGHT, NullifierLeafPreimage>,
     pub key_validation_hints: BoundedVec<KeyValidationHint, KEY_VALIDATION_HINTS_LEN>,
-    pub min_revertible_side_effect_counter: u32,
     // `output` is used in tests for ResetOutputValidator.
     pub output: FixtureBuilder,
     note_hash_preimages: [NoteHashLeafPreimage; MAX_NOTE_HASHES_PER_TX],
@@ -114,10 +113,7 @@ impl TestBuilder {
         previous_kernel.anchor_block_header.state.partial.nullifier_tree.next_available_leaf_index =
             nullifier_tree.get_next_available_index();
 
-        let min_revertible_side_effect_counter = 0;
-
         let mut output = previous_kernel;
-        output.claimed_revertible_counter = min_revertible_side_effect_counter;
 
         Self {
             previous_kernel,
@@ -129,7 +125,6 @@ impl TestBuilder {
             note_hash_read_request_hints: ReadRequestHintsBuilder::new(),
             nullifier_read_request_hints: ReadRequestHintsBuilder::new(),
             key_validation_hints: BoundedVec::new(),
-            min_revertible_side_effect_counter,
             output,
             note_hash_preimages,
             note_hash_tree,
@@ -220,32 +215,49 @@ impl TestBuilder {
     }
 
     pub fn compute_output_note_hashes<let N: u32>(
-        self: Self,
+        self,
         note_hashes: [Scoped<Counted<NoteHash>>; N],
     ) -> [Scoped<Counted<NoteHash>>; N] {
         let is_private_only = self.previous_kernel.is_private_only;
-        let min_revertible_side_effect_counter =
-            self.previous_kernel.min_revertible_side_effect_counter;
+        let claimed_revertible_counter = self.previous_kernel.claimed_revertible_counter;
 
         let mut output = note_hashes;
         for i in 0..N {
             let note_hash = note_hashes[i];
-            let siloed_note_hash = silo_note_hash(note_hash);
-            let unique_note_hash = compute_unique_siloed_note_hash(
-                siloed_note_hash,
-                self.previous_kernel.claimed_first_nullifier,
-                i,
-            );
-            // We don't silo with nonce revertible note hashes, since we don't know their final position in the tx
-            output[i].inner.inner = if is_private_only
-                | (note_hash.counter() < min_revertible_side_effect_counter) {
-                unique_note_hash
+            // We don't silo revertible note hashes with nonces, since we don't know their final position in the tx
+            output[i] = if note_hash.is_non_revertible(is_private_only, claimed_revertible_counter) {
+                self.compute_output_unique_siloed_note_hash(note_hash, i)
             } else {
-                siloed_note_hash
+                self.compute_output_siloed_note_hash(note_hash)
             };
-            output[i].contract_address = AztecAddress::zero();
         }
         output
+    }
+
+    pub fn compute_output_siloed_note_hash(
+        _self: Self,
+        note_hash: Scoped<Counted<NoteHash>>,
+    ) -> Scoped<Counted<NoteHash>> {
+        let mut siloed_note_hash = note_hash;
+        siloed_note_hash.inner.inner = silo_note_hash(note_hash);
+        siloed_note_hash.contract_address = AztecAddress::zero();
+        siloed_note_hash
+    }
+
+    pub fn compute_output_unique_siloed_note_hash(
+        self,
+        note_hash: Scoped<Counted<NoteHash>>,
+        note_hash_index: u32,
+    ) -> Scoped<Counted<NoteHash>> {
+        let siloed_note_hash = silo_note_hash(note_hash);
+        let mut unique_note_hash = note_hash;
+        unique_note_hash.inner.inner = compute_unique_siloed_note_hash(
+            siloed_note_hash,
+            self.previous_kernel.claimed_first_nullifier,
+            note_hash_index,
+        );
+        unique_note_hash.contract_address = AztecAddress::zero();
+        unique_note_hash
     }
 
     pub fn compute_output_nullifiers<let N: u32>(

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/siloing_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/siloing_tests.nr
@@ -73,8 +73,12 @@ fn squashing_and_siloing_and_ordering() {
 }
 
 #[test]
-fn siloing_without_accumulated_nullifiers() {
+fn siloing_for_private_only_tx_without_accumulated_nullifiers() {
     let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.claimed_first_nullifier = 13579;
+
+    builder.previous_kernel.is_private_only = true;
 
     builder.previous_kernel.append_note_hashes(1);
 
@@ -82,9 +86,63 @@ fn siloing_without_accumulated_nullifiers() {
 
     let pi = builder.execute_with_siloing();
 
-    // Even though no nullifiers are present, the note hash can still be siloed (with the claimed first nullifier).
-    let output_note_hash = builder.compute_output_note_hashes([note_hash])[0];
-    assert_array_eq(pi.end.note_hashes.array, [output_note_hash]);
+    // Even though no nullifiers are present, the note hash can still be uniquified (with the claimed first nullifier).
+    let unique_note_hash = builder.compute_output_unique_siloed_note_hash(note_hash, 0);
+    assert_array_eq(pi.end.note_hashes.array, [unique_note_hash]);
+}
+
+#[test]
+fn siloing_for_private_only_tx_with_non_zero_revertible_counter() {
+    let mut builder = TestBuilder::new();
+
+    // The tx is private-only, so we must uniquify all note hashes with nonces.
+    builder.previous_kernel.is_private_only = true;
+    // The claimed counter is set to a non-zero value, which would make the note hash revertible if the tx was not private-only.
+    builder.previous_kernel.claimed_revertible_counter = 2;
+    builder.previous_kernel.counter = 3;
+
+    builder.previous_kernel.append_note_hashes(1);
+    let note_hash = builder.previous_kernel.note_hashes.get(0);
+    // Counter > claimed_revertible_counter implies it's revertible, but will be ignored since the tx is private-only.
+    assert(note_hash.inner.counter > builder.previous_kernel.claimed_revertible_counter);
+
+    let pi = builder.execute_with_siloing();
+
+    // This note hash is non-revertible and should be uniquified.
+    let unique_note_hash = builder.compute_output_unique_siloed_note_hash(note_hash, 0);
+    assert_array_eq(pi.end.note_hashes.array, [unique_note_hash]);
+}
+
+#[test]
+fn siloing_before_min_revertible_side_effect_counter_is_set() {
+    let mut builder = TestBuilder::new();
+
+    // The tx is not private-only, so we can't uniquify revertible note hashes with nonces.
+    builder.previous_kernel.is_private_only = false;
+    // The actual counter is set in a later iteration.
+    assert_eq(builder.previous_kernel.min_revertible_side_effect_counter, 0);
+
+    // This note hash is non-revertible and should be uniquified.
+    builder.previous_kernel.append_note_hashes(1);
+    let non_revertible_note_hash = builder.previous_kernel.note_hashes.get(0);
+
+    // The circuit should use the claimed counter to determine if the note hash is revertible.
+    builder.previous_kernel.claimed_revertible_counter = builder.previous_kernel.counter + 999;
+    builder.previous_kernel.counter = builder.previous_kernel.claimed_revertible_counter + 1;
+
+    // This note hash is revertible and should be siloed.
+    builder.previous_kernel.append_note_hashes(1);
+    let revertible_note_hash = builder.previous_kernel.note_hashes.get(1);
+
+    let pi = builder.execute_with_siloing();
+
+    let unique_siloed_note_hash =
+        builder.compute_output_unique_siloed_note_hash(non_revertible_note_hash, 0);
+    let siloed_note_hash = builder.compute_output_siloed_note_hash(revertible_note_hash);
+    assert_array_eq(
+        pi.end.note_hashes.array,
+        [unique_siloed_note_hash, siloed_note_hash],
+    );
 }
 
 #[test(should_fail_with = "Note hashes have been siloed in a previous reset")]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/counted.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/counted.nr
@@ -14,6 +14,12 @@ impl<T> Counted<T> {
     pub fn new(inner: T, counter: u32) -> Self {
         Self { inner, counter }
     }
+
+    pub fn is_non_revertible(self, is_private_only: bool, claimed_revertible_counter: u32) -> bool {
+        // If a tx is private-only, everything is non-revertible.
+        // Otherwise, it's only non-revertible if the counter is less than the claimed revertible counter.
+        is_private_only | (self.counter < claimed_revertible_counter)
+    }
 }
 
 impl<T> Eq for Counted<T>

--- a/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/scoped.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/side_effect/scoped.nr
@@ -45,6 +45,10 @@ impl<T> Scoped<Counted<T>> {
     pub fn innermost(self) -> T {
         self.inner.inner
     }
+
+    pub fn is_non_revertible(self, is_private_only: bool, claimed_revertible_counter: u32) -> bool {
+        self.inner.is_non_revertible(is_private_only, claimed_revertible_counter)
+    }
 }
 
 impl Scoped<Counted<Field>> {


### PR DESCRIPTION
Use `claimed_revertible_counter` instead of `min_revertible_side_effect_counter` in the reset circuit to determine whether a note hash is revertible.