### PR TITLE
fix: strip platform-specific solc binary from l1-artifacts npm package

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -247,6 +247,14 @@ function bench_cmds {
 function release_packages {
   echo "Computing packages to publish..."
   local packages=$(get_projects topological)
+
+  # Strip platform-specific solc binary from l1-artifacts before npm publish.
+  # Replace solc="./solc-X.Y.Z" with solc_version="X.Y.Z" so forge auto-downloads
+  # the correct binary via SVM on the end-user's machine.
+  local l1_artifacts="l1-artifacts/l1-contracts"
+  rm -f "$l1_artifacts"/solc-*
+  sed -i 's|^solc = "\./solc-\(.*\)"|solc_version = "\1"|' "$l1_artifacts/foundry.toml"
+
   local package_list=()
   for package in $packages; do
     (cd $package && retry "deploy_npm $1 $2")

--- a/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_aztec_l1_contracts.ts
@@ -168,6 +168,9 @@ export function prepareL1ContractsForDeployment(): string {
   const foundryTomlPath = join(basePath, 'foundry.toml');
   let foundryToml = readFileSync(foundryTomlPath, 'utf-8');
   const solcPathMatch = foundryToml.match(/solc\s*=\s*"\.\/solc-([^"]+)"/);
+  // Did we find a hardcoded solc path that we need to make absolute?
+  // This code path happens in CI currently as we bundle solc there to avoid race conditions when
+  // downloading solc.
   if (solcPathMatch) {
     const solcVersion = solcPathMatch[1];
     const absoluteSolcPath = join(basePath, `solc-${solcVersion}`);


### PR DESCRIPTION
## Summary

- The `@aztec/l1-artifacts` npm package was bundling a Linux `solc-0.8.30` binary (~16MB), causing `cannot execute binary file` on macOS when deploying L1 contracts
- In the `release_packages` flow (before npm publish), strip the solc binary and rewrite `foundry.toml` to use `solc_version = "0.8.30"` instead of `solc = "./solc-0.8.30"`
- Forge then auto-downloads the correct platform-specific solc via SVM at runtime
- CI and Docker builds are unaffected (they still use the bundled binary from `copy-foundry-artifacts.sh`)

## Test plan

- Simulated end-user deploy flow: copied l1-artifacts to a temp dir (as `prepareL1ContractsForDeployment` does), verified forge resolves solc via SVM with the rewritten config
- `deploy_aztec_l1_contracts.ts` already handles both formats — its `if (solcPathMatch)` guard skips rewriting when there's no bundled binary path