### PR TITLE
fix(docs): fix TypeScript validation errors in docs examples

### DIFF
--- a/docs/examples/ts/aztecjs_advanced/index.ts
+++ b/docs/examples/ts/aztecjs_advanced/index.ts
@@ -104,14 +104,19 @@ try {
 // docs:start:register_external_contract
 // wallet is from the connection guide; contractAddress is the address of the deployed contract
 const contractAddress = token.address;
-const externalContract = await TokenContract.at(contractAddress, wallet);
+
+// Get the contract metadata from the node (includes the instance)
+const metadata = await wallet.getContractMetadata(contractAddress);
 
 // Register the contract with the wallet
 // The registerContract method takes positional parameters:
 // - instance: ContractInstanceWithAddress (required)
 // - artifact: ContractArtifact (optional)
 // - secretKey: Fr (optional)
-await wallet.registerContract(externalContract.instance, TokenContract.artifact);
+await wallet.registerContract(metadata.instance!, TokenContract.artifact);
+
+// Now you can interact with the contract
+const externalContract = await TokenContract.at(contractAddress, wallet);
 // docs:end:register_external_contract
 
 await token.methods

--- a/docs/examples/ts/aztecjs_connection/config.yaml
+++ b/docs/examples/ts/aztecjs_connection/config.yaml
@@ -12,3 +12,4 @@ dependencies:
   - "@aztec/accounts"
   - "@aztec/test-wallet"
   - "@aztec/noir-contracts.js"
+  - "@aztec/stdlib"


### PR DESCRIPTION
## Summary
- **aztecjs_advanced**: Fixed `Property 'instance' does not exist on type 'TokenContract'` error by using `wallet.getContractMetadata()` to get the contract instance instead of accessing non-existent `.instance` property
- **aztecjs_connection**: Added missing `@aztec/stdlib` dependency needed for `getContractInstanceFromInstantiationParams` import

## Test plan
- [ ] CI docs examples validation passes

🤖 Generated with [Claude Code](https://claude.ai/code)