### PR TITLE
fix: custom networks in playground

### DIFF
--- a/playground/src/components/navbar/components/WalletHub.tsx
+++ b/playground/src/components/navbar/components/WalletHub.tsx
@@ -130,11 +130,7 @@ export function WalletHub() {
       type: 'embedded',
       name: 'Embedded wallet',
       icon: new URL('../../../assets/aztec_logo.png', import.meta.url).href,
-      directConnect: () =>
-        EmbeddedWallet.create({
-          chainId: new Fr(network.chainId),
-          version: new Fr(network.version),
-        }),
+      directConnect: () => EmbeddedWallet.create(network.nodeURL),
       establishSecureChannel: async () => {
         throw new Error('Embedded wallet should use directConnect');
       },

--- a/playground/src/wallet/embedded_wallet.ts
+++ b/playground/src/wallet/embedded_wallet.ts
@@ -20,7 +20,6 @@ import { convertFromUTF8BufferAsString } from '../utils/conversion';
 import { WebLogger } from '../utils/web_logger';
 import { createStore } from '@aztec/kv-store/indexeddb';
 import type { DefaultAccountEntrypointOptions } from '@aztec/entrypoints/account';
-import { NETWORKS } from '../utils/networks';
 import type { SimulateInteractionOptions } from '@aztec/aztec.js/contracts';
 
 /**
@@ -50,16 +49,8 @@ export class EmbeddedWallet extends BaseWallet {
     super(pxe, aztecNode);
   }
 
-  static async create(chainInfo: ChainInfo) {
-    const network = NETWORKS.find(
-      network => new Fr(network.chainId).equals(chainInfo.chainId) && new Fr(network.version).equals(chainInfo.version),
-    );
-    if (!network) {
-      throw new Error(
-        `Cannot create an embedded wallet for chainId ${chainInfo.chainId} and rollup version ${chainInfo.version}`,
-      );
-    }
-    const aztecNode = createAztecNodeClient(network.nodeURL);
+  static async create(nodeURL: string) {
+    const aztecNode = createAztecNodeClient(nodeURL);
 
     const l1Contracts = await aztecNode.getL1ContractAddresses();
     const rollupAddress = l1Contracts.rollupAddress;


### PR DESCRIPTION
Fixes the logic so custom networks are allowed. This was broken when the wallet-sdk was introduced