### PR TITLE
refactor: kernel circuit refactor

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/log_retrieval_request.nr
@@ -2,7 +2,7 @@ use crate::protocol::{address::AztecAddress, traits::Serialize};
 
 /// A request for the `bulk_retrieve_logs` oracle to fetch either:
 /// - a public log emitted by `contract_address` with `unsiloed_tag`
-/// - a private log with tag equal to `silo_private_log(unsiloed_tag, contract_address)`.
+/// - a private log with tag equal to `compute_siloed_private_log_first_field(contract_address, unsiloed_tag)`.
 #[derive(Serialize)]
 pub(crate) struct LogRetrievalRequest {
     pub contract_address: AztecAddress,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array/check_padded_items.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array/check_padded_items.nr
@@ -19,15 +19,18 @@ use types::traits::Empty;
 ///
 /// Note: Technically, values outside this range could be non-empty, since they are ignored. However, enforcing emptiness
 /// helps prevent unexpected output if the array is misconfigured.
+///
+/// Returns the number of padded items.
 pub unconstrained fn check_padded_items<T, let N: u32>(
     padded_items: [T; N],
     num_original_items: u32,
     capped_size: u32,
-)
+) -> u32
 where
     T: Empty,
 {
     let mut seen_empty = false;
+    let mut num_padded_items = 0;
     for i in 0..N {
         let item_is_empty = padded_items[i].is_empty();
         if i < num_original_items | i >= capped_size {
@@ -41,8 +44,11 @@ where
                 "non-empty padded items should be consecutive within the range [num_original_items, capped_size)",
             );
             seen_empty |= item_is_empty;
+            num_padded_items += 1 * !item_is_empty as u32;
         }
     }
+
+    num_padded_items
 }
 
 mod tests {
@@ -63,10 +69,10 @@ mod tests {
             }
         }
 
-        pub fn execute(self) {
+        pub fn execute(self) -> u32 {
             // Safety: `check_padded_items` is supposed to be called only in unconstrained functions.
             unsafe {
-                check_padded_items(self.padded_items, self.num_original_items, self.capped_size);
+                check_padded_items(self.padded_items, self.num_original_items, self.capped_size)
             }
         }
     }
@@ -74,24 +80,25 @@ mod tests {
     #[test]
     fn full_padded_items() {
         let builder = TestBuilder::new();
-        builder.execute();
+        assert_eq(builder.execute(), 3);
     }
 
     #[test]
     fn partially_full_padded_items() {
         let mut builder = TestBuilder::new();
+        let expected_num_padded_items = 3;
 
         // One empty padded item.
         builder.capped_size = 6;
-        builder.execute();
+        assert_eq(builder.execute(), expected_num_padded_items);
 
         // Two empty padded items.
         builder.capped_size = 7;
-        builder.execute();
+        assert_eq(builder.execute(), expected_num_padded_items);
 
         // Three empty padded items.
         builder.capped_size = 8;
-        builder.execute();
+        assert_eq(builder.execute(), expected_num_padded_items);
     }
 
     #[test]
@@ -100,7 +107,7 @@ mod tests {
 
         builder.padded_items = [0, 0, 0, 0, 0, 0, 0, 0];
 
-        builder.execute();
+        assert_eq(builder.execute(), 0);
     }
 
     #[test(should_fail_with = "padded items should be empty outside of the range [num_original_items, capped_size)")]
@@ -109,7 +116,7 @@ mod tests {
 
         builder.padded_items[0] = 99;
 
-        builder.execute();
+        let _ = builder.execute();
     }
 
     #[test(should_fail_with = "padded items should be empty outside of the range [num_original_items, capped_size)")]
@@ -118,7 +125,7 @@ mod tests {
 
         builder.capped_size = 4;
 
-        builder.execute();
+        let _ = builder.execute();
     }
 
     #[test(should_fail_with = "padded items should be empty outside of the range [num_original_items, capped_size)")]
@@ -127,7 +134,7 @@ mod tests {
 
         builder.padded_items[6] = 99;
 
-        builder.execute();
+        let _ = builder.execute();
     }
 
     #[test(should_fail_with = "non-empty padded items should be consecutive within the range [num_original_items, capped_size)")]
@@ -136,7 +143,7 @@ mod tests {
 
         builder.padded_items[2] = 0;
 
-        builder.execute();
+        let _ = builder.execute();
     }
 
     #[test(should_fail_with = "non-empty padded items should be consecutive within the range [num_original_items, capped_size)")]
@@ -145,6 +152,6 @@ mod tests {
 
         builder.padded_items[3] = 0;
 
-        builder.execute();
+        let _ = builder.execute();
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
@@ -32,7 +32,7 @@ use types::{
         validation_requests::PrivateValidationRequests,
     },
     address::AztecAddress,
-    hash::{create_protocol_nullifier, silo_nullifier},
+    hash::{compute_siloed_nullifier, create_protocol_nullifier},
     side_effect::Ordered,
     traits::Empty,
     utils::arrays::ClaimedLengthArray,
@@ -78,7 +78,10 @@ impl PrivateKernelCircuitOutputComposer {
         // If `first_nullifier_hint` equals the protocol nullifier, it is inserted at index 0. Otherwise, at least one
         // private call must emit a nullifier, and the hint should match the first nullifier emitted.
         let scoped_protocol_nullifier = create_protocol_nullifier(inputs.tx_request);
-        let protocol_nullifier = silo_nullifier(scoped_protocol_nullifier);
+        let protocol_nullifier = compute_siloed_nullifier(
+            scoped_protocol_nullifier.contract_address,
+            scoped_protocol_nullifier.innermost().value,
+        );
         let should_inject_protocol_nullifier = inputs.first_nullifier_hint == protocol_nullifier;
         if should_inject_protocol_nullifier {
             // Safety: we should ordinarily use `push`, so that the length correctly updates, but we know this is the very

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
@@ -23,10 +23,68 @@ use types::{
         MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIERS_PER_TX, MAX_PRIVATE_LOGS_PER_TX,
         MAX_U32_VALUE, SIDE_EFFECT_MASKING_ADDRESS,
     },
-    hash::{compute_unique_siloed_note_hash, silo_note_hash, silo_nullifier, silo_private_log},
+    hash::{
+        compute_note_nonce_and_unique_note_hash, compute_siloed_note_hash, compute_siloed_nullifier,
+        compute_siloed_private_log,
+    },
     side_effect::{Counted, Scoped},
     utils::arrays::ClaimedLengthArray,
 };
+
+pub fn silo_note_hash(note_hash: Scoped<Counted<NoteHash>>) -> Scoped<Counted<NoteHash>> {
+    let mut siloed = note_hash;
+    siloed.inner.inner =
+        compute_siloed_note_hash(note_hash.contract_address, note_hash.innermost());
+
+    // We set the contract address to zero to indicate that the note hash has been siloed.
+    // The reset output validator will check the contract address of the first note hash to ensure that siloing has not
+    // been performed in a previous reset.
+    siloed.contract_address = AztecAddress::zero();
+
+    siloed
+}
+
+pub fn uniquify_siloed_note_hash(
+    siloed_note_hash: Scoped<Counted<NoteHash>>,
+    first_nullifier: Field,
+    index_in_tx: u32,
+) -> Scoped<Counted<NoteHash>> {
+    let mut uniquified = siloed_note_hash;
+    uniquified.inner.inner = compute_note_nonce_and_unique_note_hash(
+        siloed_note_hash.inner.inner,
+        first_nullifier,
+        index_in_tx,
+    );
+    uniquified
+}
+
+pub fn silo_nullifier(nullifier: Scoped<Counted<Nullifier>>) -> Scoped<Counted<Nullifier>> {
+    let mut siloed = nullifier;
+    siloed.inner.inner.value =
+        compute_siloed_nullifier(nullifier.contract_address, nullifier.innermost().value);
+
+    // We set the contract address to zero to indicate that the nullifier has been siloed.
+    // The reset output validator will check the contract address of the first nullifier to ensure that siloing has not
+    // been performed in a previous reset.
+    siloed.contract_address = AztecAddress::zero();
+
+    siloed
+}
+
+pub fn silo_private_log(
+    private_log: Scoped<Counted<PrivateLogData>>,
+) -> Scoped<Counted<PrivateLogData>> {
+    let mut siloed = private_log;
+    siloed.inner.inner.log =
+        compute_siloed_private_log(private_log.contract_address, private_log.innermost().log);
+
+    // We set the contract address to zero to indicate that the private log has been siloed.
+    // The reset output validator will check the contract address of the first private log to ensure that siloing has not
+    // been performed in a previous reset.
+    siloed.contract_address = AztecAddress::zero();
+
+    siloed
+}
 
 pub struct ResetOutputComposer {
     pub previous_kernel: PrivateKernelCircuitPublicInputs,
@@ -142,7 +200,7 @@ impl ResetOutputComposer {
         // Calling this in the unconstrained context is not a problem. Since it doesn't matter if there are non-empty
         // items outside of the range [num_kept_note_hashes, NoteHashSiloingAmount). The values will simply be ignored.
         // Having the check here is useful to catch any bugs where the padded values are not configured correctly by mistake.
-        check_padded_items(
+        let num_padded_items = check_padded_items(
             padded_note_hashes,
             num_kept_note_hashes,
             NoteHashSiloingAmount,
@@ -150,11 +208,10 @@ impl ResetOutputComposer {
 
         let mut padded_unique_siloed_sorted_kept_note_hashes = sorted_kept_note_hashes;
 
-        for i in 0..sorted_kept_note_hashes.array.len() {
+        for i in 0..num_kept_note_hashes + num_padded_items {
             // Push padding:
-            if (i >= num_kept_note_hashes)
+            if i >= num_kept_note_hashes {
                 // We only apply padding if the executor of this circuit provides padding as input:
-                & (padded_note_hashes[i] != 0) {
                 // We 'push' so that the length increments.
                 // Note: beyond `NoteHashSiloingAmount`, these so-called "padded" note_hashes
                 // will be empty, because we just called `check_padded_items`.
@@ -176,7 +233,7 @@ impl ResetOutputComposer {
             let siloed_note_hash = silo_note_hash(note_hash);
 
             // Unique:
-            let unique_siloed_note_hash = compute_unique_siloed_note_hash(
+            let unique_siloed_note_hash = uniquify_siloed_note_hash(
                 siloed_note_hash,
                 self.previous_kernel.claimed_first_nullifier,
                 i,
@@ -224,7 +281,7 @@ impl ResetOutputComposer {
             // This means the "revertible from private-land" note_hashes cannot be made unique in
             // private-land, since the uniqueness can only be derived in public-land, because the
             // revertible notes' indices (within the note_hashes of the tx) will only be known in
-            // public-land. See `compute_unique_siloed_note_hash` for more explanation on how the
+            // public-land. See `compute_note_nonce_and_unique_note_hash` for more explanation on how the
             // uniqueness (aka note_nonce) is derived.
             //
             // In summary:
@@ -239,18 +296,11 @@ impl ResetOutputComposer {
                 self.previous_kernel.claimed_revertible_counter,
             );
 
-            padded_unique_siloed_sorted_kept_note_hashes.array[i].inner.inner = if is_non_revertible {
+            padded_unique_siloed_sorted_kept_note_hashes.array[i] = if is_non_revertible {
                 unique_siloed_note_hash
             } else {
                 siloed_note_hash
             };
-
-            // Why is it doing this? Is the contract_address being overloaded to mean something else?
-            // Oh, is it being used to say "This has already been siloed"?
-            // TODO: Why not use an extra bool to convey that?
-            // A contract address will be assigned to the padding within constrained-land (see validate_sorted_siloed_unique_padded_note_hashes).
-            padded_unique_siloed_sorted_kept_note_hashes.array[i].contract_address =
-                AztecAddress::zero();
         }
         padded_unique_siloed_sorted_kept_note_hashes
     }
@@ -270,7 +320,7 @@ impl ResetOutputComposer {
         // Calling this in the unconstrained context is not a problem. Since it doesn't matter if there are non-empty
         // items outside of the range [num_nullifiers, NullifierSiloingAmount). The values will simply be ignored.
         // Having the check here is useful to catch any bugs where the padded values are not configured correctly by mistake.
-        check_padded_items(
+        let num_padded_items = check_padded_items(
             padded_nullifiers,
             num_kept_nullifiers,
             NullifierSiloingAmount,
@@ -278,11 +328,10 @@ impl ResetOutputComposer {
 
         let mut padded_siloed_sorted_kept_nullifiers = sorted_kept_nullifiers;
 
-        for i in 0..sorted_kept_nullifiers.array.len() {
+        for i in 0..num_kept_nullifiers + num_padded_items {
             // Push padding:
-            if (i >= num_kept_nullifiers)
+            if i >= num_kept_nullifiers {
                 // we only apply padding if the executor of this circuit provides padding as input:
-                & (padded_nullifiers[i] != 0) {
                 padded_siloed_sorted_kept_nullifiers.push(Nullifier {
                     value: padded_nullifiers[i],
                     note_hash: 0,
@@ -295,11 +344,8 @@ impl ResetOutputComposer {
                     .scope(SIDE_EFFECT_MASKING_ADDRESS));
             }
 
-            // Silo:
-            padded_siloed_sorted_kept_nullifiers.array[i].inner.inner.value =
-                silo_nullifier(padded_siloed_sorted_kept_nullifiers.array[i]);
-            // A contract address will be assigned to the padding within constrained-land (see validate_sorted_siloed_padded_nullifiers).
-            padded_siloed_sorted_kept_nullifiers.array[i].contract_address = AztecAddress::zero();
+            let nullifier = padded_siloed_sorted_kept_nullifiers.array[i];
+            padded_siloed_sorted_kept_nullifiers.array[i] = silo_nullifier(nullifier);
         }
 
         padded_siloed_sorted_kept_nullifiers
@@ -320,7 +366,7 @@ impl ResetOutputComposer {
         // Calling this in the unconstrained context is not a problem. Since it doesn't matter if there are non-empty
         // items outside of the range [num_private_logs, PrivateLogSiloingAmount). The values will simply be ignored.
         // Having the check here is useful to catch any bugs where the padded values are not configured correctly by mistake.
-        check_padded_items(
+        let num_padded_items = check_padded_items(
             padded_private_logs,
             num_kept_private_logs,
             PrivateLogSiloingAmount,
@@ -329,11 +375,10 @@ impl ResetOutputComposer {
         // The ordering of adjectives in this name is intentional (back to front).
         let mut padded_siloed_sorted_kept_private_logs = sorted_kept_private_logs;
 
-        for i in 0..sorted_kept_private_logs.array.len() {
+        for i in 0..num_kept_private_logs + num_padded_items {
             // Pad:
-            if (i >= num_kept_private_logs)
+            if i >= num_kept_private_logs {
                 // we only apply padding if the executor of this circuit provides padding as input:
-                & (padded_private_logs[i].length != 0) {
                 padded_siloed_sorted_kept_private_logs.push(PrivateLogData {
                     log: padded_private_logs[i],
                     note_hash_counter: 0, // Recall: this is only used to hint which note (if any) this log corresponds to.
@@ -346,11 +391,8 @@ impl ResetOutputComposer {
                     .scope(SIDE_EFFECT_MASKING_ADDRESS));
             }
 
-            // Silo:
-            padded_siloed_sorted_kept_private_logs.array[i].inner.inner.log =
-                silo_private_log(padded_siloed_sorted_kept_private_logs.array[i]);
-            // A contract address will be assigned to the padding within constrained-land (see validate_sorted_siloed_padded_private_logs).
-            padded_siloed_sorted_kept_private_logs.array[i].contract_address = AztecAddress::zero();
+            let private_log = padded_siloed_sorted_kept_private_logs.array[i];
+            padded_siloed_sorted_kept_private_logs.array[i] = silo_private_log(private_log);
         }
 
         padded_siloed_sorted_kept_private_logs

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
@@ -19,8 +19,8 @@ use types::{
     address::AztecAddress,
     constants::{MAX_U32_VALUE, SIDE_EFFECT_MASKING_ADDRESS},
     hash::{
-        compute_note_nonce_and_unique_note_hash, compute_siloed_note_hash,
-        compute_siloed_private_log_first_field, silo_nullifier,
+        compute_note_nonce_and_unique_note_hash, compute_siloed_note_hash, compute_siloed_nullifier,
+        compute_siloed_private_log_first_field,
     },
     side_effect::{Counted, Scoped},
 };
@@ -37,10 +37,12 @@ fn assert_correctly_siloed_note_hash(
 ) {
     // We determine which of these two values is appropriate, based on the revertible-ness of the note:
     let (siloed_note_hash, unique_siloed_note_hash) = if prev.contract_address.is_zero() {
-        // Then this is a nullish note, so we don't touch it. (Given earlier checks in this circuit, we know this is not an
-        // already-siloed note, because we can only run a siloing reset circuit once).
-        (prev.innermost(), prev.innermost())
+        // If the note hash is not associated with a contract address, the siloed value is 0.
+        // Previous checks in this circuit guarantee that this is not an already-siloed note hash.
+        (0, 0)
     } else {
+        // The init and inner circuits assign non-zero contract addresses to note hashes emitted by private functions,
+        // so all such note hashes will always be siloed here.
         let siloed = compute_siloed_note_hash(prev.contract_address, prev.innermost());
         let unique =
             compute_note_nonce_and_unique_note_hash(siloed, claimed_first_nullifier, index);
@@ -73,6 +75,23 @@ fn assert_correctly_siloed_note_hash(
     );
 }
 
+fn assert_correctly_siloed_nullifier(out_nullifier: Field, prev: Scoped<Counted<Nullifier>>) {
+    let siloed_nullifier = if prev.contract_address.is_zero() {
+        // If the nullifier is not associated with a contract address, the siloed value is 0.
+        // Previous checks in this circuit guarantee that this is not an already-siloed nullifier.
+        0
+    } else {
+        // The init and inner circuits assign non-zero contract addresses to nullifiers emitted by private functions,
+        // so all such nullifiers will always be siloed here.
+        compute_siloed_nullifier(prev.contract_address, prev.innermost().value)
+    };
+    assert_eq(
+        out_nullifier,
+        siloed_nullifier,
+        "Output nullifier does not match correctly-siloed nullifier",
+    );
+}
+
 // Verifies that the first field of a private log is siloed with the contract address.
 // Apps can define the meaning of the first field: it could be a tag, part of a tag, or a random value embedded in the
 // content, etc.
@@ -80,21 +99,34 @@ fn assert_correctly_siloed_note_hash(
 // Without this check, an app could impersonate another by emitting a log identical to one from a different contract
 // or copying a tag from another contract while using entirely different content, potentially misleading the recipient.
 fn assert_valid_siloed_private_log(out: PrivateLog, prev: Scoped<Counted<PrivateLogData>>) -> () {
-    // Q: is checking `if prev.contract_address.is_zero()` being used to mean "if the prev is empty"?
+    let prev_log_fields = prev.innermost().log.fields;
     let expected_first_field = if prev.contract_address.is_zero() {
-        prev.innermost().log.fields[0]
+        // If the private log is not associated with a contract address, the siloed first field is 0.
+        // Previous checks in this circuit guarantee that this is not an already-siloed private log.
+        0
     } else {
-        compute_siloed_private_log_first_field(
-            prev.contract_address,
-            prev.innermost().log.fields[0],
-        )
+        // The init and inner circuits assign non-zero contract addresses to private logs emitted by private functions,
+        // so all such private logs will always be siloed here.
+        compute_siloed_private_log_first_field(prev.contract_address, prev_log_fields[0])
     };
-    assert_eq(out.fields[0], expected_first_field);
+    assert_eq(
+        out.fields[0],
+        expected_first_field,
+        "Output private log first field does not match correctly-siloed private log first field",
+    );
     for i in 1..out.fields.len() {
-        assert_eq(out.fields[i], prev.innermost().log.fields[i]);
+        assert_eq(
+            out.fields[i],
+            prev_log_fields[i],
+            "Fields of the private log not copied correctly",
+        );
     }
 
-    assert_eq(out.length, prev.innermost().log.length);
+    assert_eq(
+        out.length,
+        prev.innermost().log.length,
+        "Length of the private log not copied correctly",
+    );
 }
 
 pub struct ResetOutputValidator<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32, let NullifierPendingReadHintsLen: u32, let NullifierSettledReadHintsLen: u32, let KeyValidationHintsLen: u32, let TransientDataSquashingHintsLen: u32> {
@@ -291,6 +323,9 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
     fn validate_sorted_siloed_padded_data<let NoteHashSiloingAmount: u32, let NullifierSiloingAmount: u32, let PrivateLogSiloingAmount: u32>(
         self,
     ) {
+        // We can only run a siloing reset circuit once, and this codepath only triggers if we're running the variant of
+        // the reset circuit which does that one-off siloing.
+
         // Important note:
         // The reason we sort these side-effects by their counter is because we want the values in the output
         // to be in the same order as they were emitted.
@@ -396,7 +431,10 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
                     self.output.is_private_only,
                     self.output.claimed_revertible_counter,
                 );
-                assert(out.contract_address.is_zero());
+                assert(
+                    out.contract_address.is_zero(),
+                    "The contract_address of a siloed note hash should be set to 0",
+                );
                 // counter is checked in assert_sorted_padded_transformed_array_capped_size
             },
         );
@@ -435,11 +473,7 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
             siloed_nullifier_padding,
             self.output.end.nullifiers,
             |prev, out| {
-                assert_eq(
-                    out.innermost().value,
-                    silo_nullifier(prev),
-                    "Output nullifier does not match correctly-siloed nullifier",
-                );
+                assert_correctly_siloed_nullifier(out.innermost().value, prev);
                 assert_eq(
                     out.innermost().note_hash,
                     prev.innermost().note_hash,
@@ -447,7 +481,7 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
                 );
                 assert(
                     out.contract_address.is_zero(),
-                    "The contract_address of a siloed nullified should be set to 0",
+                    "The contract_address of a siloed nullifier should be set to 0",
                 );
                 // counter is checked in assert_sorted_padded_transformed_array_capped_size
             },
@@ -487,8 +521,15 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
             self.output.end.private_logs,
             |prev, out| {
                 assert_valid_siloed_private_log(out.innermost().log, prev);
-                assert_eq(out.innermost().note_hash_counter, prev.innermost().note_hash_counter);
-                assert(out.contract_address.is_zero());
+                assert_eq(
+                    out.innermost().note_hash_counter,
+                    prev.innermost().note_hash_counter,
+                    "Linked note_hash_counter of the private log not copied correctly",
+                );
+                assert(
+                    out.contract_address.is_zero(),
+                    "The contract_address of a siloed private log should be set to 0",
+                );
                 // counter is checked in assert_sorted_padded_transformed_array_capped_size
             },
         );
@@ -600,12 +641,12 @@ mod tests {
     // ==================== Zero contract_address (already siloed or empty) ====================
 
     #[test]
-    fn zero_contract_address_passes_through_unchanged() {
-        // When contract_address is zero, the value passes through unchanged
+    fn zero_contract_address_outputs_zero() {
+        // When contract_address is zero, the output should be 0
         let prev = Counted::new(NOTE_HASH_VALUE, 50).scope(AztecAddress::zero());
 
         assert_correctly_siloed_note_hash(
-            NOTE_HASH_VALUE, // unchanged!
+            0, // Output should be 0
             prev,
             0,
             CLAIMED_FIRST_NULLIFIER,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/derived_hints.nr
@@ -8,7 +8,7 @@ use note_log_linked_source_indices::build_note_log_linked_source_indices;
 pub(crate) use note_log_linked_source_indices::NoteLogLinkedSourceIndices;
 use nullifier_index_sorted_tuples::build_nullifier_index_sorted_tuples;
 pub(crate) use num_active_squashing_hints::get_num_active_squashing_hints;
-use squash_flags::{build_note_hash_squash_flags, build_nullifier_squash_flags};
+pub(crate) use squash_flags::{build_note_hash_squash_flags, build_nullifier_squash_flags};
 
 use types::{
     abis::{note_hash::NoteHash, nullifier::Nullifier, private_log::PrivateLogData},

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/squash_transient_data.nr
@@ -1,5 +1,7 @@
 use crate::reset::transient_data::{
-    derived_hints::get_num_active_squashing_hints,
+    derived_hints::{
+        build_note_hash_squash_flags, build_nullifier_squash_flags, get_num_active_squashing_hints,
+    },
     transient_data_squashing_hint::TransientDataSquashingHint,
 };
 use types::{
@@ -65,17 +67,15 @@ pub unconstrained fn squash_transient_data<let NoteHashesLen: u32, let Nullifier
     //     - log:               [ l0,  l3,  l4,  l5,  l6,  l7 |  0  0]
     //
 
-    // Create a flag for each note_hash and nullifier, indicating whether it is squashed.
-    let mut note_hash_squash_flags = [false; NoteHashesLen];
-    let mut nullifier_squash_flags = [false; NullifiersLen];
-
+    // Get the number of hints that are actually used to squash note hashes and nullifiers.
     let num_active_squashing_hints =
         get_num_active_squashing_hints(transient_data_squashing_hints, previous_kernel_nullifiers);
-    for i in 0..num_active_squashing_hints {
-        let hint = transient_data_squashing_hints[i];
-        note_hash_squash_flags[hint.note_hash_index] = true;
-        nullifier_squash_flags[hint.nullifier_index] = true;
-    }
+
+    // Get the arrays of flags for note_hashes and nullifiers, indicating whether they are squashed.
+    let note_hash_squash_flags: [bool; NoteHashesLen] =
+        build_note_hash_squash_flags(transient_data_squashing_hints, num_active_squashing_hints);
+    let nullifier_squash_flags: [bool; NullifiersLen] =
+        build_nullifier_squash_flags(transient_data_squashing_hints, num_active_squashing_hints);
 
     // Propagate note hashes that are not squashed:
     let mut kept_note_hashes = ClaimedLengthArray::empty();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_log_squashing.nr
@@ -122,8 +122,8 @@ pub fn validate_log_squashing<let LogsLen: u32, let SquashingHintsLen: u32, let 
             //
             // While it is unlikely that an app would want to retain a log linked to a discarded note hash, or discard
             // a log while its note hash is kept, it is still a valid scenario that must be handled.
-            let is_note_hash_revertible = hinted_squashed_note_hash.counter() >= split_counter;
-            let is_log_revertible = log.counter() >= split_counter;
+            let is_note_hash_revertible = hinted_squashed_note_hash.counter() > split_counter;
+            let is_log_revertible = log.counter() > split_counter;
             assert_eq(
                 is_note_hash_revertible,
                 is_log_revertible,
@@ -654,11 +654,11 @@ mod tests {
     fn fails_squashed_non_revertible_log_with_revertible_note_hash() {
         let mut builder = TransientDataFixtureBuilder::new();
 
-        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 6 }.count(5)]);
+        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 7 }.count(5)]);
 
-        builder.add_note_hashes([Counted::new(11, 6)]);
+        builder.add_note_hashes([Counted::new(11, 7)]);
 
-        builder.add_nullifiers([Nullifier { value: 505, note_hash: 11 }.count(7)]);
+        builder.add_nullifiers([Nullifier { value: 505, note_hash: 11 }.count(8)]);
 
         builder.add_squashing_hint(0, 0);
 
@@ -672,9 +672,9 @@ mod tests {
     fn succeeds_squashed_revertible_log_with_revertible_note_hash() {
         let mut builder = TransientDataFixtureBuilder::new();
 
-        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 1 }.count(5)]);
+        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 2 }.count(5)]);
 
-        builder.add_note_hashes([Counted::new(11, 1)]);
+        builder.add_note_hashes([Counted::new(11, 2)]);
 
         builder.add_nullifiers([Nullifier { value: 505, note_hash: 11 }.count(7)]);
 
@@ -690,7 +690,7 @@ mod tests {
     fn fails_squashed_revertible_log_with_non_revertible_note_hash() {
         let mut builder = TransientDataFixtureBuilder::new();
 
-        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 1 }.count(10)]);
+        builder.add_logs([PrivateLogData { log: mock_log(101), note_hash_counter: 1 }.count(13)]);
 
         builder.add_note_hashes([Counted::new(11, 1)]);
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing/validate_squashable_note_hash_nullifier_pair.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/transient_data/validate_note_hash_nullifier_squashing/validate_squashable_note_hash_nullifier_pair.nr
@@ -35,8 +35,7 @@ pub fn validate_squashable_note_hash_nullifier_pair(
         "Cannot nullify a note hash created afterwards",
     );
 
-    // If the nullifier is revertible (i.e., counter >= `split_counter`), the note hash must also
-    // be revertible.
+    // If the nullifier is revertible (i.e., counter > `split_counter`), the note hash must also be revertible.
     //
     // A revertible nullifier and non-revertible note hash pair can't be squashed; they must be propagated.
     // This is because if the tx were to then revert (in some public function), the revertible nullifier must be discarded
@@ -55,9 +54,9 @@ pub fn validate_squashable_note_hash_nullifier_pair(
     // side-effect counter to be `0` (as enforced by the init and inner kernel circuits).
     // Otherwise, `split_counter` is the `min_revertible_side_effect_counter` of the tx, which is
     // asserted to be distinct from all other counters in the init and inner kernel circuits.
-    if nullifier.counter() >= split_counter {
+    if nullifier.counter() > split_counter {
         assert(
-            note_hash.counter() >= split_counter,
+            note_hash.counter() > split_counter,
             "Cannot squash a non-revertible note hash with a revertible nullifier",
         );
     }
@@ -149,7 +148,7 @@ mod tests {
 
         builder.add_nullifiers([Nullifier { value: 505, note_hash: 11 }.count(9)]);
 
-        // Both counters (5 and 9) are >= split_counter (3), so both are revertible.
+        // Both counters (5 and 9) are > split_counter (3), so both are revertible.
         builder.split_counter = 3;
 
         builder.add_squashing_hint(0, 0);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_output_validator_builder/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_output_validator_builder/mod.nr
@@ -6,7 +6,7 @@ use crate::components::private_kernel_circuit_output_validator::PrivateKernelCir
 use types::{
     abis::{private_call_request::PrivateCallRequest, transaction::tx_request::TxRequest},
     constants::PRIVATE_KERNEL_INIT_VK_INDEX,
-    hash::{create_protocol_nullifier, silo_nullifier},
+    hash::{compute_siloed_nullifier, create_protocol_nullifier},
     tests::fixture_builder::FixtureBuilder,
     traits::Empty,
 };
@@ -52,7 +52,10 @@ impl PrivateKernelCircuitOutputValidatorBuilder {
         self.output.nullifiers.push(protocol_nullifier);
         self.previous_kernel.nullifiers.push(protocol_nullifier);
 
-        self.first_nullifier_hint = silo_nullifier(protocol_nullifier);
+        self.first_nullifier_hint = compute_siloed_nullifier(
+            protocol_nullifier.contract_address,
+            protocol_nullifier.innermost().value,
+        );
         self.previous_kernel.claimed_first_nullifier = self.first_nullifier_hint;
         self.output.claimed_first_nullifier = self.first_nullifier_hint;
     }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/mod.nr
@@ -11,7 +11,7 @@ use types::{
         transaction::tx_request::TxRequest,
     },
     address::AztecAddress,
-    hash::{create_protocol_nullifier, silo_nullifier},
+    hash::{compute_siloed_nullifier, create_protocol_nullifier},
     tests::fixture_builder::FixtureBuilder,
 };
 
@@ -87,7 +87,10 @@ impl TestBuilder {
         let mut accumulated_data = private_call.to_private_accumulated_data();
 
         let scoped_protocol_nullifier = create_protocol_nullifier(self.tx_request);
-        let protocol_nullifier = silo_nullifier(scoped_protocol_nullifier);
+        let protocol_nullifier = compute_siloed_nullifier(
+            scoped_protocol_nullifier.contract_address,
+            scoped_protocol_nullifier.innermost().value,
+        );
         if self.first_nullifier_hint == protocol_nullifier {
             accumulated_data.nullifiers.length = 1;
             accumulated_data.nullifiers.array[0] = scoped_protocol_nullifier;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/output_composition_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/output_composition_tests.nr
@@ -2,7 +2,7 @@ use super::TestBuilder;
 use types::{
     address::AztecAddress,
     constants::DEFAULT_UPDATE_DELAY,
-    hash::{create_protocol_nullifier, silo_nullifier},
+    hash::{compute_siloed_nullifier, create_protocol_nullifier},
     tests::utils::assert_claimed_length_array_eq,
     traits::Empty,
 };
@@ -46,7 +46,10 @@ fn with_protocol_nullifier_injected() {
     let mut builder = TestBuilder::new();
 
     let scoped_protocol_nullifier = create_protocol_nullifier(builder.tx_request);
-    let protocol_nullifier = silo_nullifier(scoped_protocol_nullifier);
+    let protocol_nullifier = compute_siloed_nullifier(
+        scoped_protocol_nullifier.contract_address,
+        scoped_protocol_nullifier.innermost().value,
+    );
     builder.first_nullifier_hint = protocol_nullifier;
 
     let pi = builder.execute();
@@ -64,7 +67,10 @@ fn with_nullifiers_emitted_and_protocol_nullifier_injected() {
     let mut builder = TestBuilder::new();
 
     let scoped_protocol_nullifier = create_protocol_nullifier(builder.tx_request);
-    let protocol_nullifier = silo_nullifier(scoped_protocol_nullifier);
+    let protocol_nullifier = compute_siloed_nullifier(
+        scoped_protocol_nullifier.contract_address,
+        scoped_protocol_nullifier.innermost().value,
+    );
     builder.first_nullifier_hint = protocol_nullifier;
 
     builder.private_call.append_nullifiers(1);

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/mod.nr
@@ -9,6 +9,9 @@ mod reset_output_validator;
 
 use crate::{
     abis::{PaddedSideEffects, PrivateKernelResetHints},
+    components::reset_output_composer::{
+        silo_note_hash, silo_nullifier, silo_private_log, uniquify_siloed_note_hash,
+    },
     private_kernel_reset::PrivateKernelResetCircuitPrivateInputs,
     reset::{KeyValidationHint, ReadRequestHintsBuilder, TransientDataSquashingHint},
 };
@@ -20,17 +23,13 @@ use types::{
         nullifier_leaf_preimage::NullifierLeafPreimage,
         private_kernel_data::PrivateKernelDataWithoutPublicInputs, private_log::PrivateLogData,
     },
-    address::AztecAddress,
     constants::{
         MAX_NOTE_HASH_READ_REQUESTS_PER_TX, MAX_NOTE_HASHES_PER_TX,
         MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIERS_PER_TX, NOTE_HASH_SUBTREE_HEIGHT,
         NOTE_HASH_TREE_HEIGHT, NULLIFIER_SUBTREE_HEIGHT, NULLIFIER_TREE_HEIGHT,
         PRIVATE_KERNEL_INNER_VK_INDEX,
     },
-    hash::{
-        compute_app_siloed_secret_key, compute_siloed_nullifier, compute_unique_siloed_note_hash,
-        silo_note_hash, silo_nullifier, silo_private_log,
-    },
+    hash::{compute_app_siloed_secret_key, compute_siloed_nullifier},
     merkle_tree::{LeafPreimage, MembershipWitness},
     side_effect::{Counted, Scoped},
     tests::{
@@ -238,10 +237,7 @@ impl TestBuilder {
         _self: Self,
         note_hash: Scoped<Counted<NoteHash>>,
     ) -> Scoped<Counted<NoteHash>> {
-        let mut siloed_note_hash = note_hash;
-        siloed_note_hash.inner.inner = silo_note_hash(note_hash);
-        siloed_note_hash.contract_address = AztecAddress::zero();
-        siloed_note_hash
+        silo_note_hash(note_hash)
     }
 
     pub fn compute_output_unique_siloed_note_hash(
@@ -249,41 +245,26 @@ impl TestBuilder {
         note_hash: Scoped<Counted<NoteHash>>,
         note_hash_index: u32,
     ) -> Scoped<Counted<NoteHash>> {
-        let siloed_note_hash = silo_note_hash(note_hash);
-        let mut unique_note_hash = note_hash;
-        unique_note_hash.inner.inner = compute_unique_siloed_note_hash(
+        let siloed_note_hash = self.compute_output_siloed_note_hash(note_hash);
+        uniquify_siloed_note_hash(
             siloed_note_hash,
             self.previous_kernel.claimed_first_nullifier,
             note_hash_index,
-        );
-        unique_note_hash.contract_address = AztecAddress::zero();
-        unique_note_hash
+        )
     }
 
     pub fn compute_output_nullifiers<let N: u32>(
         _self: Self,
         nullifiers: [Scoped<Counted<Nullifier>>; N],
     ) -> [Scoped<Counted<Nullifier>>; N] {
-        let mut output = nullifiers;
-        for i in 0..N {
-            output[i].inner.inner.value = silo_nullifier(nullifiers[i]);
-            output[i].contract_address = AztecAddress::zero();
-        }
-        output
+        nullifiers.map(|n| silo_nullifier(n))
     }
 
     pub fn compute_output_private_logs<let N: u32>(
         _self: Self,
         private_logs: [Scoped<Counted<PrivateLogData>>; N],
     ) -> [Scoped<Counted<PrivateLogData>>; N] {
-        private_logs.map(|l| {
-            PrivateLogData {
-                log: silo_private_log(l),
-                note_hash_counter: l.innermost().note_hash_counter,
-            }
-                .count(l.inner.counter)
-                .scope(AztecAddress::zero())
-        })
+        private_logs.map(|n| silo_private_log(n))
     }
 
     /// No siloing.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/mod.nr
@@ -1,5 +1,6 @@
 mod propagated_note_hashes_tests;
 mod propagated_nullifiers_tests;
+mod propagated_private_logs_tests;
 
 use crate::{
     abis::PrivateKernelResetHints,
@@ -60,7 +61,7 @@ impl TestBuilder {
             );
     }
 
-    pub fn validate_with_amounts<let NoteHashPendingReadAmount: u32, let NoteHashSettledReadAmount: u32, let NullifierPendingReadAmount: u32, let NullifierSettledReadAmount: u32, let KeyValidationAmount: u32, let TransientDataSquashingAmount: u32, let NoteHashSiloingAmount: u32, let NullifierSiloingAmount: u32, let PrivateLogSiloingAmount: u32>(
+    fn validate_with_amounts<let NoteHashPendingReadAmount: u32, let NoteHashSettledReadAmount: u32, let NullifierPendingReadAmount: u32, let NullifierSettledReadAmount: u32, let KeyValidationAmount: u32, let TransientDataSquashingAmount: u32, let NoteHashSiloingAmount: u32, let NullifierSiloingAmount: u32, let PrivateLogSiloingAmount: u32>(
         self,
         output_hints: SquashedOutputArrayHints,
     ) {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_note_hashes_tests.nr
@@ -49,6 +49,43 @@ fn extra_non_empty_note_hash_in_output() {
     builder.validate_siloing();
 }
 
+#[test(should_fail_with = "Output note hash does not match correctly-siloed note hash")]
+fn previous_note_hashes_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_note_hashes(2);
+    let note_hashes = builder.previous_kernel.note_hashes.storage();
+    builder.previous_kernel.note_hashes = BoundedVec::from_parts_unchecked(note_hashes, 1);
+
+    builder.output.append_siloed_note_hashes(2);
+    let output_note_hashes = builder.output.note_hashes.storage();
+    builder.output.note_hashes = BoundedVec::from_parts_unchecked(output_note_hashes, 1);
+
+    let mut output_hints = builder.get_output_hints();
+    // Add the extra note hash beyond the claimed length to the kept note hashes array.
+    output_hints.kept_note_hashes.array[1] = note_hashes[1];
+
+    builder.validate_siloing_with_output_hints(output_hints);
+
+    // This test fails because the validator compares the output note hashes beyond the claimed length with the padded
+    // note hashes, which don't match the siloed note hashes computed from the extra note hashes in the previous kernel.
+}
+
+#[test(should_fail_with = "The contract_address of a siloed note hash should be set to 0")]
+fn non_zero_contract_address_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_note_hashes(2);
+    builder.output.append_siloed_note_hashes(2);
+
+    // Copy the contract address of the note hash to the output.
+    let mut note_hash = builder.output.note_hashes.get(1);
+    note_hash.contract_address = builder.previous_kernel.note_hashes.get(1).contract_address;
+    builder.output.note_hashes.set(1, note_hash);
+
+    builder.validate_siloing();
+}
+
 #[test(should_fail_with = "Note hashes have been siloed in a previous reset")]
 fn first_note_hash_is_siloed() {
     let mut builder = TestBuilder::new();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_nullifiers_tests.nr
@@ -49,6 +49,58 @@ fn extra_non_empty_nullifier_in_output() {
     builder.validate_siloing();
 }
 
+#[test(should_fail_with = "Output nullifier does not match correctly-siloed nullifier")]
+fn previous_nullifiers_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_nullifiers(2);
+    let nullifiers = builder.previous_kernel.nullifiers.storage();
+    builder.previous_kernel.nullifiers = BoundedVec::from_parts_unchecked(nullifiers, 1);
+
+    builder.output.append_siloed_nullifiers(2);
+    let output_nullifiers = builder.output.nullifiers.storage();
+    builder.output.nullifiers = BoundedVec::from_parts_unchecked(output_nullifiers, 1);
+
+    let mut output_hints = builder.get_output_hints();
+    // Add the extra nullifier beyond the claimed length to the kept nullifiers array.
+    output_hints.kept_nullifiers.array[1] = nullifiers[1];
+
+    builder.validate_siloing_with_output_hints(output_hints);
+
+    // This test fails because the validator compares the output nullifiers beyond the claimed length with the padded
+    // nullifiers, which don't match the siloed nullifiers computed from the extra nullifiers in the previous kernel.
+}
+
+#[test(should_fail_with = "Linked note hash not copied correctly")]
+fn mismatch_linked_note_hash_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_nullifiers(2);
+    builder.output.append_siloed_nullifiers(2);
+
+    // Tweak the linked note hash of the nullifier at index 1.
+    let mut nullifier = builder.output.nullifiers.get(1);
+    nullifier.inner.inner.note_hash += 1;
+    builder.output.nullifiers.set(1, nullifier);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "The contract_address of a siloed nullifier should be set to 0")]
+fn non_zero_contract_address_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_nullifiers(2);
+    builder.output.append_siloed_nullifiers(2);
+
+    // Copy the contract address of the nullifier to the output.
+    let mut nullifier = builder.output.nullifiers.get(1);
+    nullifier.contract_address = builder.previous_kernel.nullifiers.get(1).contract_address;
+    builder.output.nullifiers.set(1, nullifier);
+
+    builder.validate_siloing();
+}
+
 #[test(should_fail_with = "Nullifiers have been siloed in a previous reset")]
 fn previous_nullifiers_already_siloed() {
     let mut builder = TestBuilder::new();

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/reset_output_validator/propagated_private_logs_tests.nr
@@ -1,0 +1,191 @@
+use crate::tests::private_kernel_reset::{PRIVATE_LOG_SILOING_AMOUNT, TestBuilder};
+use ::types::tests::utils::swap_items;
+
+#[test]
+fn previous_private_logs_sorted() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(4);
+    builder.output.append_siloed_private_logs(4);
+
+    builder.validate_siloing();
+}
+
+#[test]
+fn previous_private_logs_not_sorted() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(4);
+    // Swap 2 of the private logs in the previous kernel.
+    swap_items(&mut builder.previous_kernel.private_logs, 0, 2);
+
+    builder.output.append_siloed_private_logs(4);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Output private log first field does not match correctly-siloed private log first field")]
+fn output_private_logs_not_sorted() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(4);
+
+    builder.output.append_siloed_private_logs(4);
+    // Swap 2 of the private logs in the output.
+    swap_items(&mut builder.output.private_logs, 0, 2);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Output private log first field does not match correctly-siloed private log first field")]
+fn extra_non_empty_private_log_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+
+    // Append an extra item to the output.
+    builder.output.append_siloed_private_logs(3);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Output private log first field does not match correctly-siloed private log first field")]
+fn previous_private_logs_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+    let private_logs = builder.previous_kernel.private_logs.storage();
+    builder.previous_kernel.private_logs = BoundedVec::from_parts_unchecked(private_logs, 1);
+
+    builder.output.append_siloed_private_logs(2);
+    let output_private_logs = builder.output.private_logs.storage();
+    builder.output.private_logs = BoundedVec::from_parts_unchecked(output_private_logs, 1);
+
+    let mut output_hints = builder.get_output_hints();
+    // Add the extra private log beyond the claimed length to the kept private logs array.
+    output_hints.kept_private_logs.array[1] = private_logs[1];
+
+    builder.validate_siloing_with_output_hints(output_hints);
+
+    // This test fails because the validator compares the output private logs beyond the claimed length with the padded
+    // private logs, which don't match the siloed logs computed from the extra logs in the previous kernel.
+}
+
+#[test(should_fail_with = "Fields of the private log not copied correctly")]
+fn mismatch_private_log_field_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+    builder.output.append_siloed_private_logs(2);
+
+    // Tweak the log at index 1.
+    let mut private_log = builder.output.private_logs.get(1);
+    private_log.inner.inner.log.fields[2] += 1;
+    builder.output.private_logs.set(1, private_log);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Length of the private log not copied correctly")]
+fn mismatch_private_log_length_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+    builder.output.append_siloed_private_logs(2);
+
+    // Tweak the length of the private log at index 1.
+    let mut private_log = builder.output.private_logs.get(1);
+    private_log.inner.inner.log.length += 1;
+    builder.output.private_logs.set(1, private_log);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Linked note_hash_counter of the private log not copied correctly")]
+fn mismatch_linked_note_hash_counter_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+    builder.output.append_siloed_private_logs(2);
+
+    // Tweak the linked note_hash_counter of the private log at index 1.
+    let mut private_log = builder.output.private_logs.get(1);
+    private_log.inner.inner.note_hash_counter += 1;
+    builder.output.private_logs.set(1, private_log);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "The contract_address of a siloed private log should be set to 0")]
+fn non_zero_contract_address_in_output() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(2);
+    builder.output.append_siloed_private_logs(2);
+
+    // Copy the contract address of the private log to the output.
+    let mut private_log = builder.output.private_logs.get(1);
+    private_log.contract_address = builder.previous_kernel.private_logs.get(1).contract_address;
+    builder.output.private_logs.set(1, private_log);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Private logs have been siloed in a previous reset")]
+fn first_private_log_is_siloed() {
+    let mut builder = TestBuilder::new();
+
+    // Add a siloed private log to the previous kernel.
+    builder.previous_kernel.append_siloed_private_logs(1);
+    builder.previous_kernel.append_private_logs(2);
+
+    builder.output.append_siloed_private_logs(3);
+
+    builder.validate_siloing();
+}
+
+#[test]
+fn with_padded_private_logs() {
+    let mut builder = TestBuilder::new();
+
+    builder.previous_kernel.append_private_logs(3);
+
+    // Pop the last two private logs and use them as padded private logs.
+    builder.padded_side_effects.private_logs[2] =
+        builder.previous_kernel.private_logs.pop().innermost().log;
+    builder.padded_side_effects.private_logs[1] =
+        builder.previous_kernel.private_logs.pop().innermost().log;
+
+    builder.output.append_siloed_private_logs(1);
+    builder.output.append_padded_private_logs(2);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "CappedSize not large enough to cover all valid items in original_array")]
+fn previous_private_logs_more_than_capped_size() {
+    let mut builder = TestBuilder::new();
+
+    // Add one more than the amount to be siloed.
+    builder.previous_kernel.append_private_logs(PRIVATE_LOG_SILOING_AMOUNT + 1);
+    builder.output.append_siloed_private_logs(PRIVATE_LOG_SILOING_AMOUNT + 1);
+
+    builder.validate_siloing();
+}
+
+#[test(should_fail_with = "Trailing items must have counter 0")]
+fn total_private_logs_more_than_capped_size() {
+    let mut builder = TestBuilder::new();
+
+    // Add one more padding log that makes the total amount more than the capped size.
+    builder.previous_kernel.append_private_logs(PRIVATE_LOG_SILOING_AMOUNT + 1);
+
+    // Pop the last private log and use it as padding.
+    builder.padded_side_effects.private_logs[PRIVATE_LOG_SILOING_AMOUNT] =
+        builder.previous_kernel.private_logs.pop().innermost().log;
+
+    builder.output.append_siloed_private_logs(PRIVATE_LOG_SILOING_AMOUNT);
+    builder.output.append_padded_private_logs(1);
+
+    builder.validate_siloing();
+}

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/siloing_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/siloing_tests.nr
@@ -196,3 +196,54 @@ fn siloing_private_logs_again() {
         [private_logs[0], private_logs[1], siloed_logs[0], siloed_logs[1]],
     );
 }
+
+#[test(should_fail_with = "Propagated note hash does not match")]
+fn extra_note_hash_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    // 1 extra note hash beyond the claimed length.
+    builder.previous_kernel.append_note_hashes(2);
+    let note_hashes = builder.previous_kernel.note_hashes.storage();
+    builder.previous_kernel.note_hashes = BoundedVec::from_parts_unchecked(note_hashes, 1);
+
+    let _ = builder.execute_with_siloing();
+
+    // This test fails because the composer doesn't add siloed note hashes beyond the claimed length, but the transient
+    // data validator processes all items within NOTE_HASH_SILOING_AMOUNT and expects a siloed note hash in the output.
+    // If the output does contain the extra note hashes, the validator will still catch it and fail.
+    // See the test propagated_note_hashes_tests.nr > previous_note_hashes_beyond_claimed_length.
+}
+
+#[test(should_fail_with = "Propagated nullifier does not match")]
+fn extra_nullifiers_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    // 1 extra nullifier beyond the claimed length.
+    builder.previous_kernel.append_nullifiers(2);
+    let nullifiers = builder.previous_kernel.nullifiers.storage();
+    builder.previous_kernel.nullifiers = BoundedVec::from_parts_unchecked(nullifiers, 1);
+
+    let _ = builder.execute_with_siloing();
+
+    // This test fails because the composer doesn't add siloed nullifiers beyond the claimed length, but the transient
+    // data validator processes all items within NULLIFIER_SILOING_AMOUNT and expects a siloed nullifier in the output.
+    // If the output does contain extra nullifiers, the validator will still catch it and fail.
+    // See the test propagated_nullifiers_tests.nr > previous_nullifiers_beyond_claimed_length.
+}
+
+#[test(should_fail_with = "Propagated private log does not match")]
+fn extra_private_logs_beyond_claimed_length() {
+    let mut builder = TestBuilder::new();
+
+    // 1 extra private log beyond the claimed length.
+    builder.previous_kernel.append_private_logs(2);
+    let private_logs = builder.previous_kernel.private_logs.storage();
+    builder.previous_kernel.private_logs = BoundedVec::from_parts_unchecked(private_logs, 1);
+
+    let _ = builder.execute_with_siloing();
+
+    // This test fails because the composer doesn't add siloed private logs beyond the claimed length, but the transient
+    // data validator processes all items within PRIVATE_LOG_SILOING_AMOUNT and expects a siloed log in the output.
+    // If the output does contain extra private logs, the validator will still catch it and fail.
+    // See the test propagated_private_logs_tests.nr > previous_private_logs_beyond_claimed_length.
+}

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/private_tx_effect_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/private_tx_effect_builder.nr
@@ -11,7 +11,7 @@ use types::{
         MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
     },
     data::public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
-    hash::silo_l2_to_l1_message,
+    hash::compute_l2_to_l1_message_hash,
     traits::{Empty, Hash},
     utils::arrays::{array_length, array_length_until},
 };
@@ -27,11 +27,20 @@ pub fn build_tx_effect(
     // Compute siloed L2-to-L1 message hashes (siloed with the contract address of the function that
     // emitted the message). We do this sequencer-side, because the hashes are computed with sha256
     // for EVM compatibility.
-    let l2_to_l1_msgs = accumulated_data.l2_to_l1_msgs.map(|message| silo_l2_to_l1_message(
-        message,
-        private_to_rollup.constants.tx_context.version,
-        private_to_rollup.constants.tx_context.chain_id,
-    ));
+    // The private kernel init and inner circuits add l2_to_l1_msgs with non-zero contract addresses within the
+    // claimed length. The private kernel tail circuit ensures that items beyond the claimed length are empty.
+    // Therefore, the array is left-packed, and we can safely compute the hashes by checking the contract addresses.
+    let l2_to_l1_msgs = accumulated_data.l2_to_l1_msgs.map(|message| if message
+        .contract_address
+        .is_zero() {
+        0
+    } else {
+        compute_l2_to_l1_message_hash(
+            message,
+            private_to_rollup.constants.tx_context.version,
+            private_to_rollup.constants.tx_context.chain_id,
+        )
+    });
 
     // Compute the transaction fee.
     let transaction_fee = compute_transaction_fee(

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/public_tx_effect_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/components/public_tx_effect_builder.nr
@@ -6,7 +6,7 @@ use types::{
     },
     blob_data::{TxEffect, TxEffectArrayLengths},
     constants::{CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, MAX_CONTRACT_CLASS_LOGS_PER_TX},
-    hash::silo_l2_to_l1_message,
+    hash::compute_l2_to_l1_message_hash,
     traits::Hash,
     utils::arrays::{array_length_until, array_merge},
 };
@@ -21,9 +21,17 @@ pub fn build_tx_effect(
     let global_variables = avm.global_variables;
 
     // Compute siloed L2-to-L1 message hashes (siloed with the contract address of the function that
-    // emitted the message). We do this sequencer-side, because the hashes are computed with sha256.
-    let siloed_l2_to_l1_msgs = avm.accumulated_data.l2_to_l1_msgs.map(|message| {
-        silo_l2_to_l1_message(message, global_variables.version, global_variables.chain_id)
+    // emitted the message). We do this sequencer-side, because the hashes are computed with sha256
+    // for EVM compatibility.
+    // The private kernel init and inner circuits add l2_to_l1_msgs with non-zero contract addresses within the
+    // claimed length. The private kernel tail-to-public circuit ensures that items beyond the claimed length are empty.
+    // Therefore, the array is left-packed, and we can safely compute the hashes by checking the contract addresses.
+    let siloed_l2_to_l1_msgs = avm.accumulated_data.l2_to_l1_msgs.map(|message| if message
+        .contract_address
+        .is_zero() {
+        0
+    } else {
+        compute_l2_to_l1_message_hash(message, global_variables.version, global_variables.chain_id)
     });
 
     // If any of the public functions reverted within the `avm`, then the tx is considered to have reverted,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/private_tx_base/mod.nr
@@ -34,7 +34,7 @@ use types::{
         PUBLIC_DATA_TREE_HEIGHT,
     },
     data::public_data_tree_leaf_preimage::PublicDataTreeLeafPreimage,
-    hash::silo_l2_to_l1_message,
+    hash::compute_l2_to_l1_message_hash,
     merkle_tree::{LeafPreimage, MembershipWitness},
     tests::{
         fixture_builder::FixtureBuilder, merkle_tree_utils::SingleSubtreeMerkleTree, utils::pad_end,
@@ -176,7 +176,7 @@ impl TestBuilder {
     }
 
     pub fn get_siloed_l2_to_l1_msgs(self) -> [Field; MAX_L2_TO_L1_MSGS_PER_TX] {
-        self.private_tail.end.l2_to_l1_msgs.map(|msg| silo_l2_to_l1_message(
+        self.private_tail.end.l2_to_l1_msgs.map(|msg| compute_l2_to_l1_message_hash(
             msg,
             self.constants.global_variables.version,
             self.constants.global_variables.chain_id,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tx_base/tests/public_tx_base/mod.nr
@@ -20,7 +20,7 @@ use types::{
         ARCHIVE_HEIGHT, CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, MAX_CONTRACT_CLASS_LOGS_PER_TX,
         MAX_L2_TO_L1_MSGS_PER_TX, PUBLIC_CHONK_VERIFIER_VK_INDEX,
     },
-    hash::silo_l2_to_l1_message,
+    hash::compute_l2_to_l1_message_hash,
     tests::fixture_builder::FixtureBuilder,
 };
 
@@ -98,7 +98,7 @@ impl TestBuilder {
     }
 
     pub fn get_siloed_l2_to_l1_msgs(self) -> [Field; MAX_L2_TO_L1_MSGS_PER_TX] {
-        self.avm.accumulated_data.l2_to_l1_msgs.map(|msg| silo_l2_to_l1_message(
+        self.avm.accumulated_data.l2_to_l1_msgs.map(|msg| compute_l2_to_l1_message_hash(
             msg,
             self.avm.global_variables.version,
             self.avm.global_variables.chain_id,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -3,10 +3,7 @@ mod poseidon2_chunks;
 use crate::{
     abis::{
         contract_class_function_leaf_preimage::ContractClassFunctionLeafPreimage,
-        function_selector::FunctionSelector,
-        note_hash::NoteHash,
-        nullifier::Nullifier,
-        private_log::{PrivateLog, PrivateLogData},
+        function_selector::FunctionSelector, nullifier::Nullifier, private_log::PrivateLog,
         transaction::tx_request::TxRequest,
     },
     address::{AztecAddress, EthAddress},
@@ -52,29 +49,8 @@ pub fn private_functions_root_from_siblings(
     )
 }
 
-pub fn compute_note_hash_nonce(first_nullifier_in_tx: Field, note_index_in_tx: u32) -> Field {
-    // Hashing the first nullifier with note index in tx is guaranteed to be unique (because all nullifiers are also
-    // unique).
-    poseidon2_hash_with_separator(
-        [first_nullifier_in_tx, note_index_in_tx as Field],
-        DOM_SEP__NOTE_HASH_NONCE,
-    )
-}
-
-pub fn compute_unique_note_hash(note_nonce: Field, siloed_note_hash: Field) -> Field {
-    let inputs = [note_nonce, siloed_note_hash];
-    poseidon2_hash_with_separator(inputs, DOM_SEP__UNIQUE_NOTE_HASH)
-}
-
-pub fn compute_note_nonce_and_unique_note_hash(
-    siloed_note_hash: Field,
-    first_nullifier: Field,
-    note_index_in_tx: u32,
-) -> Field {
-    let note_nonce = compute_note_hash_nonce(first_nullifier, note_index_in_tx);
-    compute_unique_note_hash(note_nonce, siloed_note_hash)
-}
-
+/// Siloing in the context of Aztec refers to the process of hashing a note hash with a contract address (this way
+/// the note hash is scoped to a specific contract). This is used to prevent intermingling of notes between contracts.
 pub fn compute_siloed_note_hash(contract_address: AztecAddress, note_hash: Field) -> Field {
     poseidon2_hash_with_separator(
         [contract_address.to_field(), note_hash],
@@ -119,26 +95,27 @@ pub fn compute_siloed_note_hash(contract_address: AztecAddress, note_hash: Field
 /// We combine the `first_nullifier` with the note's index (its position within this tx's new
 /// note_hashes array) (`note_index_in_tx`) to get a truly unique value to inject into a note, which
 /// we call a `note_nonce`.
-pub fn compute_unique_siloed_note_hash(
+pub fn compute_unique_note_hash(note_nonce: Field, siloed_note_hash: Field) -> Field {
+    let inputs = [note_nonce, siloed_note_hash];
+    poseidon2_hash_with_separator(inputs, DOM_SEP__UNIQUE_NOTE_HASH)
+}
+
+pub fn compute_note_hash_nonce(first_nullifier_in_tx: Field, note_index_in_tx: u32) -> Field {
+    // Hashing the first nullifier with note index in tx is guaranteed to be unique (because all nullifiers are also
+    // unique).
+    poseidon2_hash_with_separator(
+        [first_nullifier_in_tx, note_index_in_tx as Field],
+        DOM_SEP__NOTE_HASH_NONCE,
+    )
+}
+
+pub fn compute_note_nonce_and_unique_note_hash(
     siloed_note_hash: Field,
     first_nullifier: Field,
     note_index_in_tx: u32,
 ) -> Field {
-    if siloed_note_hash == 0 {
-        0
-    } else {
-        compute_note_nonce_and_unique_note_hash(siloed_note_hash, first_nullifier, note_index_in_tx)
-    }
-}
-
-/// Siloing in the context of Aztec refers to the process of hashing a note hash with a contract address (this way
-/// the note hash is scoped to a specific contract). This is used to prevent intermingling of notes between contracts.
-pub fn silo_note_hash(note_hash: Scoped<Counted<NoteHash>>) -> Field {
-    if note_hash.contract_address.is_zero() {
-        0
-    } else {
-        compute_siloed_note_hash(note_hash.contract_address, note_hash.innermost())
-    }
+    let note_nonce = compute_note_hash_nonce(first_nullifier, note_index_in_tx);
+    compute_unique_note_hash(note_nonce, siloed_note_hash)
 }
 
 pub fn compute_siloed_nullifier(contract_address: AztecAddress, nullifier: Field) -> Field {
@@ -146,21 +123,6 @@ pub fn compute_siloed_nullifier(contract_address: AztecAddress, nullifier: Field
         [contract_address.to_field(), nullifier],
         DOM_SEP__SILOED_NULLIFIER,
     )
-}
-
-pub fn silo_nullifier(nullifier: Scoped<Counted<Nullifier>>) -> Field {
-    let value = nullifier.innermost().value;
-    // Q: shouldn't we be checking whether the _whole_ scoped, counted, nullifier struct is empty?
-    // A: We don't have to. The init and inner circuits add a contract address only to non-empty nullifiers.
-    // So we know we should silo it if the contract address is not empty.
-    if nullifier.contract_address.is_zero() {
-        // Return `.value` instead of 0, because already-siloed nullifiers also have a zero
-        // contract_address field, and we of course want to return that already-siloed nullifier
-        // (we just don't want to silo it a second time).
-        value
-    } else {
-        compute_siloed_nullifier(nullifier.contract_address, value)
-    }
 }
 
 pub fn create_protocol_nullifier(tx_request: TxRequest) -> Scoped<Counted<Nullifier>> {
@@ -181,15 +143,10 @@ pub fn compute_siloed_private_log_first_field(
     )
 }
 
-pub fn silo_private_log(private_log: Scoped<Counted<PrivateLogData>>) -> PrivateLog {
-    let log = private_log.innermost().log;
-    if private_log.contract_address.is_zero() {
-        log
-    } else {
-        let mut fields = log.fields;
-        fields[0] = compute_siloed_private_log_first_field(private_log.contract_address, fields[0]);
-        PrivateLog::new(fields, log.length)
-    }
+pub fn compute_siloed_private_log(contract_address: AztecAddress, log: PrivateLog) -> PrivateLog {
+    let mut fields = log.fields;
+    fields[0] = compute_siloed_private_log_first_field(contract_address, fields[0]);
+    PrivateLog::new(fields, log.length)
 }
 
 pub fn compute_contract_class_log_hash(log: [Field; CONTRACT_CLASS_LOG_SIZE_IN_FIELDS]) -> Field {
@@ -207,16 +164,14 @@ pub fn compute_app_siloed_secret_key(
     )
 }
 
-pub fn compute_l2_to_l1_hash(
-    contract_address: AztecAddress,
-    recipient: EthAddress,
-    content: Field,
+pub fn compute_l2_to_l1_message_hash(
+    message: Scoped<L2ToL1Message>,
     rollup_version_id: Field,
     chain_id: Field,
 ) -> Field {
-    let contract_address_bytes: [u8; 32] = contract_address.to_field().to_be_bytes();
-    let recipient_bytes: [u8; 20] = recipient.to_be_bytes();
-    let content_bytes: [u8; 32] = content.to_be_bytes();
+    let contract_address_bytes: [u8; 32] = message.contract_address.to_field().to_be_bytes();
+    let recipient_bytes: [u8; 20] = message.inner.recipient.to_be_bytes();
+    let content_bytes: [u8; 32] = message.inner.content.to_be_bytes();
     let rollup_version_id_bytes: [u8; 32] = rollup_version_id.to_be_bytes();
     let chain_id_bytes: [u8; 32] = chain_id.to_be_bytes();
 
@@ -234,24 +189,6 @@ pub fn compute_l2_to_l1_hash(
     }
 
     sha256_to_field(bytes)
-}
-
-pub fn silo_l2_to_l1_message(
-    msg: Scoped<L2ToL1Message>,
-    rollup_version_id: Field,
-    chain_id: Field,
-) -> Field {
-    if msg.contract_address.is_zero() {
-        0
-    } else {
-        compute_l2_to_l1_hash(
-            msg.contract_address,
-            msg.inner.recipient,
-            msg.inner.content,
-            rollup_version_id,
-            chain_id,
-        )
-    }
 }
 
 // TODO: consider a variant that enables domain separation with a u32 (we seem to have standardised u32s for domain separators)
@@ -285,14 +222,6 @@ where
 /// The caller is responsible for ensuring that the input is padded with zeros if required.
 #[no_predicates]
 pub fn poseidon2_hash_subarray<let N: u32>(input: [Field; N], in_len: u32) -> Field {
-    let mut sponge = poseidon2_absorb_in_chunks(input, in_len);
-    sponge.squeeze()
-}
-
-// NB the below is the same as poseidon::poseidon2::Poseidon2::hash(), but replacing a range check with a bit check,
-// and absorbing in chunks of 3 below.
-#[no_predicates]
-pub fn poseidon2_cheaper_variable_hash<let N: u32>(input: [Field; N], in_len: u32) -> Field {
     let mut sponge = poseidon2_absorb_in_chunks(input, in_len);
     sponge.squeeze()
 }
@@ -339,29 +268,27 @@ pub fn poseidon2_hash_bytes<let N: u32>(inputs: [u8; N]) -> Field {
 }
 
 #[test]
-fn poseidon_chunks_matches_fixed() {
-    let in_len = 501;
-    let mut input: [Field; 4096] = [0; 4096];
-    let mut fixed_input = [3; 501];
-    assert(in_len == fixed_input.len()); // sanity check
-    for i in 0..in_len {
-        input[i] = 3;
-    }
-    let sub_chunk_hash = poseidon2_hash_subarray(input, in_len);
-    let fixed_len_hash = poseidon::poseidon2::Poseidon2::hash(fixed_input, fixed_input.len());
-    assert(sub_chunk_hash == fixed_len_hash);
+fn subarray_hash_matches_fixed() {
+    let mut values_to_hash = [3; 17];
+    let mut padded = values_to_hash.concat([0; 11]);
+    let subarray_hash = poseidon2_hash_subarray(padded, values_to_hash.len());
+
+    // Hash the entire values_to_hash.
+    let fixed_len_hash = poseidon::poseidon2::Poseidon2::hash(values_to_hash, values_to_hash.len());
+
+    assert_eq(subarray_hash, fixed_len_hash);
 }
 
 #[test]
-fn poseidon_chunks_matches_variable() {
-    let in_len = 501;
-    let mut input: [Field; 4096] = [0; 4096];
-    for i in 0..in_len {
-        input[i] = 3;
-    }
-    let variable_chunk_hash = poseidon2_cheaper_variable_hash(input, in_len);
-    let variable_len_hash = poseidon::poseidon2::Poseidon2::hash(input, in_len);
-    assert(variable_chunk_hash == variable_len_hash);
+fn subarray_hash_matches_variable() {
+    let mut values_to_hash = [3; 17];
+    let mut padded = values_to_hash.concat([0; 11]);
+    let subarray_hash = poseidon2_hash_subarray(padded, values_to_hash.len());
+
+    // Hash up to values_to_hash.len() fields of the padded array.
+    let variable_len_hash = poseidon::poseidon2::Poseidon2::hash(padded, values_to_hash.len());
+
+    assert_eq(subarray_hash, variable_len_hash);
 }
 
 #[test]
@@ -389,35 +316,86 @@ fn smoke_sha256_to_field() {
 }
 
 #[test]
-fn compute_l2_l1_hash() {
-    // All zeroes
-    let hash_result =
-        compute_l2_to_l1_hash(AztecAddress::from_field(0), EthAddress::zero(), 0, 0, 0);
-    assert(hash_result == 0x3b18c58c739716e76429634a61375c45b3b5cd470c22ab6d3e14cee23dd992);
+fn unique_siloed_note_hash_matches_typescript() {
+    let inner_note_hash = 1;
+    let contract_address = AztecAddress::from_field(2);
+    let first_nullifier = 3;
+    let note_index_in_tx = 4;
 
-    // Non-zero case
-    let hash_result = compute_l2_to_l1_hash(
-        AztecAddress::from_field(1),
-        EthAddress::from_field(3),
-        5,
-        2,
-        4,
+    let siloed_note_hash = compute_siloed_note_hash(contract_address, inner_note_hash);
+    let siloed_note_hash_from_ts =
+        0x1986a4bea3eddb1fff917d629a13e10f63f514f401bdd61838c6b475db949169;
+    assert_eq(siloed_note_hash, siloed_note_hash_from_ts);
+
+    let nonce: Field = compute_note_hash_nonce(first_nullifier, note_index_in_tx);
+    let note_hash_nonce_from_ts =
+        0x28e7799791bf066a57bb51fdd0fbcaf3f0926414314c7db515ea343f44f5d58b;
+    assert_eq(nonce, note_hash_nonce_from_ts);
+
+    let unique_siloed_note_hash_from_nonce = compute_unique_note_hash(nonce, siloed_note_hash);
+    let unique_siloed_note_hash = compute_note_nonce_and_unique_note_hash(
+        siloed_note_hash,
+        first_nullifier,
+        note_index_in_tx,
     );
-    assert(hash_result == 0xaab2a5828156782b12a1dc6f336e2bc627eb1b9514b02d511f66296990c050);
+    assert_eq(unique_siloed_note_hash_from_nonce, unique_siloed_note_hash);
+
+    let unique_siloed_note_hash_from_ts =
+        0x29949aef207b715303b24639737c17fbfeb375c1d965ecfa85c7e4f0febb7d16;
+    assert_eq(unique_siloed_note_hash, unique_siloed_note_hash_from_ts);
 }
 
 #[test]
-fn silo_l2_to_l1_message_matches_typescript() {
+fn siloed_nullifier_matches_typescript() {
+    let contract_address = AztecAddress::from_field(123);
+    let nullifier = 456;
+
+    let res = compute_siloed_nullifier(contract_address, nullifier);
+
+    let siloed_nullifier_from_ts =
+        0x169b50336c1f29afdb8a03d955a81e485f5ac7d5f0b8065673d1e407e5877813;
+
+    assert_eq(res, siloed_nullifier_from_ts);
+}
+
+#[test]
+fn siloed_private_log_first_field_matches_typescript() {
+    let contract_address = AztecAddress::from_field(123);
+    let field = 456;
+    let res = compute_siloed_private_log_first_field(contract_address, field);
+
+    let siloed_private_log_first_field_from_ts =
+        0x29480984f7b9257fded523d50addbcfc8d1d33adcf2db73ef3390a8fd5cdffaa;
+
+    assert_eq(res, siloed_private_log_first_field_from_ts);
+}
+
+#[test]
+fn empty_l2_to_l1_message_hash_matches_typescript() {
+    // All zeroes
+    let res = compute_l2_to_l1_message_hash(
+        L2ToL1Message { recipient: EthAddress::zero(), content: 0 }.scope(AztecAddress::from_field(
+            0,
+        )),
+        0,
+        0,
+    );
+
+    let empty_l2_to_l1_msg_hash_from_ts =
+        0x003b18c58c739716e76429634a61375c45b3b5cd470c22ab6d3e14cee23dd992;
+
+    assert_eq(res, empty_l2_to_l1_msg_hash_from_ts);
+}
+
+#[test]
+fn l2_to_l1_message_hash_matches_typescript() {
+    let message = L2ToL1Message { recipient: EthAddress::from_field(1), content: 2 }.scope(
+        AztecAddress::from_field(3),
+    );
     let version = 4;
     let chainId = 5;
 
-    let hash = silo_l2_to_l1_message(
-        L2ToL1Message { recipient: EthAddress::from_field(1), content: 2 }.scope(
-            AztecAddress::from_field(3),
-        ),
-        version,
-        chainId,
-    );
+    let hash = compute_l2_to_l1_message_hash(message, version, chainId);
 
     // The following value was generated by `yarn-project/stdlib/src/hash/hash.test.ts`
     let l2_to_l1_message_hash_from_ts =

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -67,8 +67,8 @@ use crate::{
         with_hash::derive_storage_slot_of_packed_values_hash,
     },
     hash::{
-        compute_contract_class_log_hash, compute_siloed_note_hash, compute_siloed_nullifier,
-        compute_siloed_private_log_first_field, compute_unique_siloed_note_hash,
+        compute_contract_class_log_hash, compute_note_nonce_and_unique_note_hash,
+        compute_siloed_note_hash, compute_siloed_nullifier, compute_siloed_private_log_first_field,
         create_protocol_nullifier,
     },
     merkle_tree::membership::MembershipWitness,
@@ -761,7 +761,7 @@ impl FixtureBuilder {
     pub fn add_siloed_unique_note_hash(&mut self, value: Field) {
         let siloed_value = compute_siloed_note_hash(self.contract_address, value);
         let current_index = self.note_hashes.len();
-        let unique_siloed_value = compute_unique_siloed_note_hash(
+        let unique_siloed_value = compute_note_nonce_and_unique_note_hash(
             siloed_value,
             self.claimed_first_nullifier,
             current_index,
@@ -1090,7 +1090,7 @@ impl FixtureBuilder {
                 // Silo and clear the contract address here because the padded private logs are siloed when added in the
                 // reset circuit. We can only see the siloed version of it in the public inputs.
                 fields[0] =
-                    compute_siloed_private_log_first_field(self.contract_address, fields[0]);
+                    compute_siloed_private_log_first_field(SIDE_EFFECT_MASKING_ADDRESS, fields[0]);
                 self.private_logs.push(PrivateLogData {
                     log: PrivateLog { fields, length: fields.len() },
                     note_hash_counter: 0,

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -5,11 +5,9 @@ import type { Logger } from '@aztec/aztec.js/log';
 import { type AztecNode, waitForTx } from '@aztec/aztec.js/node';
 import { TxStatus } from '@aztec/aztec.js/tx';
 import { AnvilTestWatcher, CheatCodes } from '@aztec/aztec/testing';
-import { GeneratorIndex } from '@aztec/constants';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { BlockNumber, EpochNumber } from '@aztec/foundation/branded-types';
 import { times, unique } from '@aztec/foundation/collection';
-import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
@@ -18,6 +16,7 @@ import { TestContract } from '@aztec/noir-test-contracts.js/Test';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import type { TestSequencerClient } from '@aztec/sequencer-client/test';
 import { getProofSubmissionDeadlineEpoch } from '@aztec/stdlib/epoch-helpers';
+import { computeSiloedPrivateLogFirstField } from '@aztec/stdlib/hash';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import { TX_ERROR_EXISTING_NULLIFIER } from '@aztec/stdlib/tx';
 
@@ -439,9 +438,9 @@ describe('e2e_block_building', () => {
 
       // The last log is not encrypted.
       // The first field is the first value and is siloed with contract address by the kernel circuit.
-      const expectedFirstField = await poseidon2HashWithSeparator(
-        [testContract.address, valuesAsArray[0]],
-        GeneratorIndex.PRIVATE_LOG_FIRST_FIELD,
+      const expectedFirstField = await computeSiloedPrivateLogFirstField(
+        testContract.address,
+        new Fr(valuesAsArray[0]),
       );
       expect(privateLogs[2].fields.slice(0, 5).map((f: Fr) => f.toBigInt())).toEqual([
         expectedFirstField.toBigInt(),

--- a/yarn-project/protocol-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/protocol-contracts/src/scripts/generate_data.ts
@@ -4,18 +4,17 @@ import {
   CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE,
   CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS,
   FEE_JUICE_ADDRESS,
-  GeneratorIndex,
   MAX_PROTOCOL_CONTRACTS,
   MULTI_CALL_ENTRYPOINT_ADDRESS,
   PUBLIC_CHECKS_ADDRESS,
 } from '@aztec/constants';
 import { makeTuple } from '@aztec/foundation/array';
-import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createConsoleLogger } from '@aztec/foundation/log';
 import { loadContractArtifact } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
+import { computeSiloedPrivateLogFirstField } from '@aztec/stdlib/hash';
 import { type NoirCompiledContract } from '@aztec/stdlib/noir';
 import { ProtocolContracts } from '@aztec/stdlib/tx';
 
@@ -136,9 +135,9 @@ async function generateProtocolContractsList(names: string[], derivedAddresses: 
 // Generate the siloed log tags for events emitted via private logs.
 async function generateLogTags() {
   return `
-  export const CONTRACT_INSTANCE_PUBLISHED_EVENT_TAG = Fr.fromHexString('${await poseidon2HashWithSeparator(
-    [CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS, CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE],
-    GeneratorIndex.PRIVATE_LOG_FIRST_FIELD,
+  export const CONTRACT_INSTANCE_PUBLISHED_EVENT_TAG = Fr.fromHexString('${await computeSiloedPrivateLogFirstField(
+    new AztecAddress(new Fr(CONTRACT_INSTANCE_REGISTRY_CONTRACT_ADDRESS)),
+    new Fr(CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE),
   )}');
   `;
 }

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -7,7 +7,6 @@ import {
   FIXED_AVM_STARTUP_L2_GAS,
   FIXED_DA_GAS,
   FIXED_L2_GAS,
-  GeneratorIndex,
   L2_GAS_PER_CONTRACT_CLASS_LOG,
   L2_GAS_PER_L2_TO_L1_MSG,
   L2_GAS_PER_NOTE_HASH,
@@ -23,7 +22,6 @@ import {
   MAX_PRIVATE_LOGS_PER_TX,
 } from '@aztec/constants';
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
-import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
@@ -48,6 +46,7 @@ import { Gas } from '@aztec/stdlib/gas';
 import {
   computeNoteHashNonce,
   computeProtocolNullifier,
+  computeSiloedPrivateLogFirstField,
   computeUniqueNoteHash,
   siloNoteHash,
   siloNullifier,
@@ -450,11 +449,9 @@ export async function generateSimulatedProvingResult(
     taggedPrivateLogs.push(
       ...(await Promise.all(
         execution.publicInputs.privateLogs.getActiveItems().map(async metadata => {
-          metadata.log.fields[0] = await poseidon2HashWithSeparator(
-            [contractAddress, metadata.log.fields[0]],
-            GeneratorIndex.PRIVATE_LOG_FIRST_FIELD,
-          );
-          return new OrderedSideEffect(metadata.log, metadata.counter);
+          const log = PrivateLog.fromFields(metadata.log.toFields());
+          log.fields[0] = await computeSiloedPrivateLogFirstField(contractAddress, log.fields[0]);
+          return new OrderedSideEffect(log, metadata.counter);
         }),
       )),
     );

--- a/yarn-project/stdlib/src/hash/hash.test.ts
+++ b/yarn-project/stdlib/src/hash/hash.test.ts
@@ -11,6 +11,7 @@ import {
   computePublicDataTreeLeafSlot,
   computePublicDataTreeValue,
   computeSecretHash,
+  computeSiloedPrivateLogFirstField,
   computeUniqueNoteHash,
   computeVarArgsHash,
   siloNoteHash,
@@ -18,39 +19,74 @@ import {
 } from './hash.js';
 
 describe('hash', () => {
-  it('computes note hash nonce', async () => {
-    const nullifierZero = new Fr(123n);
-    const noteHashIndex = 456;
-    const res = await computeNoteHashNonce(nullifierZero, noteHashIndex);
-    expect(res.toString()).toMatchInlineSnapshot(
-      `"0x29ceb9ede6ce1c94c6ef90ee92d82048328ff9542fec22ee33b3795000ba6f7e"`,
-    );
-  });
+  it('computes unique siloed note hash', async () => {
+    const innerNoteHash = new Fr(1);
+    const contractAddress = new AztecAddress(new Fr(2));
+    const firstNullifier = new Fr(3);
+    const noteIndexInTx = 4;
 
-  it('computes unique note hash', async () => {
-    const noteNonce = new Fr(123n);
-    const noteHash = new Fr(456);
-    const res = await computeUniqueNoteHash(noteNonce, noteHash);
-    expect(res.toString()).toMatchInlineSnapshot(
-      `"0x2d05529612f55956384d8cd7cd0f3781ce4531b7c47261a27c1ddf547731e74c"`,
+    const siloedNoteHash = await siloNoteHash(contractAddress, innerNoteHash);
+    expect(siloedNoteHash.toString()).toMatchInlineSnapshot(
+      '"0x1986a4bea3eddb1fff917d629a13e10f63f514f401bdd61838c6b475db949169"',
     );
-  });
 
-  it('computes siloed note hash', async () => {
-    const contractAddress = new AztecAddress(new Fr(123n).toBuffer());
-    const uniqueNoteHash = new Fr(456);
-    const res = await siloNoteHash(contractAddress, uniqueNoteHash);
-    expect(res.toString()).toMatchInlineSnapshot(
-      `"0x23c41572a4ee6ae40225f937f8474149685691367ed8d89dcd92049787680968"`,
+    const noteNonce = await computeNoteHashNonce(firstNullifier, noteIndexInTx);
+    expect(noteNonce.toString()).toMatchInlineSnapshot(
+      '"0x28e7799791bf066a57bb51fdd0fbcaf3f0926414314c7db515ea343f44f5d58b"',
+    );
+
+    const uniqueSiloedNoteHash = await computeUniqueNoteHash(noteNonce, siloedNoteHash);
+    expect(uniqueSiloedNoteHash.toString()).toMatchInlineSnapshot(
+      '"0x29949aef207b715303b24639737c17fbfeb375c1d965ecfa85c7e4f0febb7d16"',
+    );
+
+    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'siloed_note_hash_from_ts',
+      siloedNoteHash.toString(),
+    );
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'note_hash_nonce_from_ts',
+      noteNonce.toString(),
+    );
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'unique_siloed_note_hash_from_ts',
+      uniqueSiloedNoteHash.toString(),
     );
   });
 
   it('computes siloed nullifier', async () => {
-    const contractAddress = new AztecAddress(new Fr(123n).toBuffer());
+    const contractAddress = new AztecAddress(new Fr(123));
     const innerNullifier = new Fr(456);
     const res = await siloNullifier(contractAddress, innerNullifier);
     expect(res.toString()).toMatchInlineSnapshot(
-      `"0x169b50336c1f29afdb8a03d955a81e485f5ac7d5f0b8065673d1e407e5877813"`,
+      '"0x169b50336c1f29afdb8a03d955a81e485f5ac7d5f0b8065673d1e407e5877813"',
+    );
+
+    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'siloed_nullifier_from_ts',
+      res.toString(),
+    );
+  });
+
+  it('computes siloed private log first field', async () => {
+    const contractAddress = new AztecAddress(new Fr(123));
+    const field = new Fr(456);
+    const res = await computeSiloedPrivateLogFirstField(contractAddress, field);
+    expect(res.toString()).toMatchInlineSnapshot(
+      '"0x29480984f7b9257fded523d50addbcfc8d1d33adcf2db73ef3390a8fd5cdffaa"',
+    );
+
+    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'siloed_private_log_first_field_from_ts',
+      res.toString(),
     );
   });
 
@@ -132,6 +168,27 @@ describe('hash', () => {
 
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
     updateInlineTestData('noir-projects/aztec-nr/aztec/src/hash.nr', 'calldata_hash_from_ts', res.toString());
+  });
+
+  it('empty L2ToL1Message siloing matches Noir', () => {
+    const nonEmptyHash = computeL2ToL1MessageHash({
+      l2Sender: AztecAddress.fromField(new Fr(0)),
+      l1Recipient: EthAddress.fromField(new Fr(0)),
+      content: new Fr(0),
+      rollupVersion: new Fr(0),
+      chainId: new Fr(0),
+    });
+
+    expect(nonEmptyHash.toString()).toMatchInlineSnapshot(
+      `"0x003b18c58c739716e76429634a61375c45b3b5cd470c22ab6d3e14cee23dd992"`,
+    );
+
+    // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
+    updateInlineTestData(
+      'noir-projects/noir-protocol-circuits/crates/types/src/hash.nr',
+      'empty_l2_to_l1_msg_hash_from_ts',
+      nonEmptyHash.toString(),
+    );
   });
 
   it('L2ToL1Message siloing matches Noir', () => {

--- a/yarn-project/stdlib/src/hash/hash.ts
+++ b/yarn-project/stdlib/src/hash/hash.ts
@@ -69,6 +69,10 @@ export function computeProtocolNullifier(txRequestHash: Fr): Promise<Fr> {
   return siloNullifier(AztecAddress.fromBigInt(NULL_MSG_SENDER_CONTRACT_ADDRESS), txRequestHash);
 }
 
+export function computeSiloedPrivateLogFirstField(contract: AztecAddress, field: Fr): Promise<Fr> {
+  return poseidon2HashWithSeparator([contract, field], GeneratorIndex.PRIVATE_LOG_FIRST_FIELD);
+}
+
 /**
  * Computes a public data tree value ready for insertion.
  * @param value - Raw public data tree value to hash into a tree-insertion-ready value.

--- a/yarn-project/stdlib/src/logs/siloed_tag.ts
+++ b/yarn-project/stdlib/src/logs/siloed_tag.ts
@@ -1,9 +1,8 @@
-import { GeneratorIndex } from '@aztec/constants';
-import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto/poseidon';
 import type { Fr } from '@aztec/foundation/curves/bn254';
 import type { ZodFor } from '@aztec/foundation/schemas';
 
 import type { AztecAddress } from '../aztec-address/index.js';
+import { computeSiloedPrivateLogFirstField } from '../hash/hash.js';
 import { schemas } from '../schemas/schemas.js';
 import type { Tag } from './tag.js';
 
@@ -23,7 +22,7 @@ export class SiloedTag {
   constructor(public readonly value: Fr) {}
 
   static async compute(tag: Tag, app: AztecAddress): Promise<SiloedTag> {
-    const siloedTag = await poseidon2HashWithSeparator([app, tag.value], GeneratorIndex.PRIVATE_LOG_FIRST_FIELD);
+    const siloedTag = await computeSiloedPrivateLogFirstField(app, tag.value);
     return new SiloedTag(siloedTag);
   }
 


### PR DESCRIPTION
- Change from `counter >= split_counter` to `counter > split_counter`
- Use existing utils to get squash flags to build kept arrays
- Remove if-else from general hash utils: having it in the general utils seems like a footgun. Moving the if-else to the parents that know if an item should be hashed or not.
- Remove duplicate util `poseidon2_cheaper_variable_hash`: it's exactly the same as `poseidon2_hash_subarray` now that poseidon2 does not add an extra field for variable length input.