### PR TITLE
fix: another hotfix to deploy_rollup_upgrade.sh

### DIFF
--- a/spartan/scripts/deploy_rollup_upgrade.sh
+++ b/spartan/scripts/deploy_rollup_upgrade.sh
@@ -104,7 +104,7 @@ fi
 
 # Compute genesis values using the Aztec CLI (see: yarn-project/cli/src/cmds/l1/compute_genesis_values.ts)
 # The CLI reads SPONSORED_FPC and TEST_ACCOUNTS from the environment.
-export SPONSORED_FPC="${SPONSORED_FPC:-false}"
+export SPONSORED_FPC="${SPONSORED_FPC:-true}"
 export TEST_ACCOUNTS="${TEST_ACCOUNTS:-false}"
 log "Computing genesis with SPONSORED_FPC=$SPONSORED_FPC, TEST_ACCOUNTS=$TEST_ACCOUNTS"
 


### PR DESCRIPTION
Change default value of SPONSORED_FPC from false to true. This was addressing review feedback, but we can't really change the default here without changing it everywhere as this shouldn't change the interpretation of our env file.