### PR TITLE
test: adding missing PrivateImmutable tests

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -18,6 +18,8 @@ use crate::protocol::{
     traits::{Hash, Packable},
 };
 
+mod test;
+
 /// Per-account immutable private state.
 ///
 /// PrivateImmutable is an owned state variable type that represents a private value that is set once and remains

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable/test.nr
@@ -1,0 +1,221 @@
+use crate::{
+    context::{PrivateContext, UtilityContext},
+    state_vars::{OwnedStateVariable, private_immutable::PrivateImmutable},
+    test::{helpers::test_environment::TestEnvironment, mocks::mock_note::MockNote},
+};
+use crate::protocol::address::AztecAddress;
+
+global STORAGE_SLOT: Field = 17;
+global VALUE: Field = 23;
+
+unconstrained fn in_private(
+    context: &mut PrivateContext,
+    owner: AztecAddress,
+) -> PrivateImmutable<MockNote, &mut PrivateContext> {
+    PrivateImmutable::new(context, STORAGE_SLOT, owner)
+}
+
+unconstrained fn in_utility(
+    context: UtilityContext,
+    owner: AztecAddress,
+) -> PrivateImmutable<MockNote, UtilityContext> {
+    PrivateImmutable::new(context, STORAGE_SLOT, owner)
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn get_uninitialized() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+        let _ = state_var.get_note();
+    });
+}
+
+#[test(should_fail_with = "Failed to get a note")]
+unconstrained fn view_uninitialized() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, owner);
+        let _ = state_var.view_note();
+    });
+}
+
+#[test]
+unconstrained fn is_uninitialized_by_default() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, owner);
+        assert_eq(state_var.is_initialized(), false);
+    });
+}
+
+#[test]
+unconstrained fn initialize() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        let note = MockNote::new(VALUE).build_note();
+
+        let note_message = state_var.initialize(note);
+
+        // During initialization we both create the new note and emit the initialization nullifier
+        assert_eq(context.note_hashes.len(), 1);
+        assert_eq(context.nullifiers.len(), 1);
+        assert_eq(context.nullifiers.get(0).inner.value, state_var.get_initialization_nullifier());
+
+        assert_eq(note_message.new_note.note, note);
+        assert_eq(note_message.new_note.storage_slot, STORAGE_SLOT);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_get_pending() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        let note = MockNote::new(VALUE).build_note();
+
+        let _ = state_var.initialize(note);
+
+        let note_hash_read_requests_pre_get = context.note_hash_read_requests.len();
+        let nullifiers_pre_get = context.nullifiers.len();
+        let note_hashes_pre_get = context.note_hashes.len();
+
+        let hinted_note = state_var.get_note();
+
+        assert_eq(hinted_note, note);
+
+        // Reading a PrivateImmutable results in:
+        // - a read request for the read value
+        //
+        // Note: Unlike PrivateMutable, PrivateImmutable doesn't nullify and recreate the note
+        assert_eq(context.note_hash_read_requests.len(), note_hash_read_requests_pre_get + 1);
+        assert_eq(context.nullifiers.len(), nullifiers_pre_get);
+        assert_eq(context.note_hashes.len(), note_hashes_pre_get);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_get_settled() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_note_message = env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_note_message);
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        let hinted_note = state_var.get_note();
+
+        assert_eq(hinted_note, note);
+
+        // Reading a PrivateImmutable results in:
+        // - a read request for the read value
+        assert_eq(context.note_hash_read_requests.len(), 1);
+        assert_eq(context.nullifiers.len(), 0);
+        assert_eq(context.note_hashes.len(), 0);
+    });
+}
+
+#[test]
+unconstrained fn initialize_and_view_settled() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_note_message = env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_note_message);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, owner);
+
+        assert_eq(state_var.view_note(), note);
+    });
+}
+
+#[test]
+unconstrained fn is_initialized_after_initialization() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_note_message = env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_note_message);
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context, owner);
+
+        assert_eq(state_var.is_initialized(), true);
+    });
+}
+
+#[test(should_fail_with = "Duplicate")]
+unconstrained fn initialize_twice_same_tx() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        let note = MockNote::new(VALUE).build_note();
+        let _ = state_var.initialize(note);
+
+        let another_note = MockNote::new(VALUE + 1).build_note();
+        let _ = state_var.initialize(another_note);
+    });
+}
+
+#[test(should_fail_with = "already present")]
+unconstrained fn initialize_twice_other_tx() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_light_account();
+
+    let note = MockNote::new(VALUE).build_note();
+
+    let init_note_message = env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        state_var.initialize(note)
+    });
+
+    env.discover_note(init_note_message);
+
+    env.private_context(|context| {
+        let state_var = in_private(context, owner);
+
+        let another_note = MockNote::new(VALUE + 1).build_note();
+        let _ = state_var.initialize(another_note);
+    });
+}


### PR DESCRIPTION
@ciaranightingale noticed that we were missing tests of `PrivateImmutable`. In this PR I add them. Note that the tests are basically a copy-paste of the tests for `SinglePrivateImmutable` since these 2 state vars have basically equivalent use.