### PR TITLE
feat(docs): add copy page markdown button to documentation pages

### DIFF
--- a/docs/src/components/CopyMarkdownButton/htmlToMarkdown.ts
+++ b/docs/src/components/CopyMarkdownButton/htmlToMarkdown.ts
@@ -1,0 +1,221 @@
+/**
+ * Converts DOM content to clean markdown format.
+ * Handles headings, code blocks, links, lists, and strips Docusaurus UI elements.
+ */
+
+export function htmlToMarkdown(element: Element): string {
+  function processNode(node: Node, listDepth = 0, listType: 'ul' | 'ol' | null = null, listIndex = 0): string {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent || '';
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return '';
+    }
+
+    const el = node as Element;
+    const tagName = el.tagName.toLowerCase();
+
+    // Skip Docusaurus UI elements
+    if (
+      el.classList.contains('hash-link') ||
+      el.classList.contains('anchor') ||
+      el.classList.contains('table-of-contents') ||
+      el.classList.contains('tocCollapsible') ||
+      el.classList.contains('theme-doc-toc-mobile') ||
+      el.classList.contains('pagination-nav') ||
+      el.classList.contains('theme-doc-footer') ||
+      el.classList.contains('theme-doc-breadcrumbs') ||
+      el.classList.contains('theme-doc-version-badge') ||
+      tagName === 'button' ||
+      tagName === 'nav'
+    ) {
+      return '';
+    }
+
+    // Process children helper
+    const processChildren = (depth = listDepth, type = listType): string => {
+      return Array.from(el.childNodes)
+        .map((child, i) => processNode(child, depth, type, i))
+        .join('');
+    };
+
+    switch (tagName) {
+      case 'h1':
+        return `# ${processChildren().trim()}\n\n`;
+      case 'h2':
+        return `## ${processChildren().trim()}\n\n`;
+      case 'h3':
+        return `### ${processChildren().trim()}\n\n`;
+      case 'h4':
+        return `#### ${processChildren().trim()}\n\n`;
+      case 'h5':
+        return `##### ${processChildren().trim()}\n\n`;
+      case 'h6':
+        return `###### ${processChildren().trim()}\n\n`;
+
+      case 'p':
+        return `${processChildren().trim()}\n\n`;
+
+      case 'br':
+        return '\n';
+
+      case 'strong':
+      case 'b':
+        return `**${processChildren()}**`;
+
+      case 'em':
+      case 'i':
+        return `*${processChildren()}*`;
+
+      case 'code':
+        // Inline code (not inside pre)
+        if (el.parentElement?.tagName.toLowerCase() !== 'pre') {
+          return `\`${el.textContent || ''}\``;
+        }
+        return el.textContent || '';
+
+      case 'pre': {
+        // Code block - find the code element and extract language
+        const codeEl = el.querySelector('code');
+        const text = codeEl?.textContent || el.textContent || '';
+
+        // Try to extract language from class (e.g., "language-typescript")
+        let language = '';
+        const codeClasses = codeEl?.className || el.className || '';
+        const langMatch = codeClasses.match(/language-(\w+)/);
+        if (langMatch) {
+          language = langMatch[1];
+        }
+
+        return `\`\`\`${language}\n${text.trim()}\n\`\`\`\n\n`;
+      }
+
+      case 'a': {
+        const href = el.getAttribute('href') || '';
+        const text = processChildren().trim();
+        // Skip empty links or hash-only links
+        if (!text || href === '#') {
+          return text;
+        }
+        // Make relative URLs absolute
+        let fullHref = href;
+        if (href.startsWith('/')) {
+          fullHref = `https://docs.aztec.network${href}`;
+        }
+        return `[${text}](${fullHref})`;
+      }
+
+      case 'ul':
+        return Array.from(el.children)
+          .map((li, i) => processNode(li, listDepth, 'ul', i))
+          .join('') + '\n';
+
+      case 'ol':
+        return Array.from(el.children)
+          .map((li, i) => processNode(li, listDepth, 'ol', i))
+          .join('') + '\n';
+
+      case 'li': {
+        const indent = '  '.repeat(listDepth);
+        const marker = listType === 'ol' ? `${listIndex + 1}.` : '-';
+        const content = processChildren(listDepth + 1).trim();
+        return `${indent}${marker} ${content}\n`;
+      }
+
+      case 'blockquote':
+        return processChildren()
+          .trim()
+          .split('\n')
+          .map(line => `> ${line}`)
+          .join('\n') + '\n\n';
+
+      case 'hr':
+        return '---\n\n';
+
+      case 'table': {
+        const rows: string[][] = [];
+        const headerRow: string[] = [];
+
+        // Process thead
+        const thead = el.querySelector('thead');
+        if (thead) {
+          const ths = thead.querySelectorAll('th');
+          ths.forEach(th => {
+            headerRow.push(processNode(th).trim());
+          });
+          if (headerRow.length > 0) {
+            rows.push(headerRow);
+          }
+        }
+
+        // Process tbody
+        const tbody = el.querySelector('tbody') || el;
+        const trs = tbody.querySelectorAll('tr');
+        trs.forEach(tr => {
+          const row: string[] = [];
+          const cells = tr.querySelectorAll('td, th');
+          cells.forEach(cell => {
+            row.push(processNode(cell).trim());
+          });
+          if (row.length > 0) {
+            rows.push(row);
+          }
+        });
+
+        if (rows.length === 0) return '';
+
+        // Build markdown table
+        let table = '| ' + rows[0].join(' | ') + ' |\n';
+        table += '| ' + rows[0].map(() => '---').join(' | ') + ' |\n';
+        for (let i = 1; i < rows.length; i++) {
+          table += '| ' + rows[i].join(' | ') + ' |\n';
+        }
+        return table + '\n';
+      }
+
+      case 'img': {
+        const src = el.getAttribute('src') || '';
+        const alt = el.getAttribute('alt') || '';
+        let fullSrc = src;
+        if (src.startsWith('/')) {
+          fullSrc = `https://docs.aztec.network${src}`;
+        }
+        return `![${alt}](${fullSrc})`;
+      }
+
+      case 'div':
+      case 'span':
+      case 'section':
+      case 'article':
+      case 'main':
+      case 'header':
+      case 'footer':
+      case 'aside':
+        return processChildren();
+
+      case 'details': {
+        const summary = el.querySelector('summary');
+        const summaryText = summary ? processNode(summary).trim() : 'Details';
+        const content = Array.from(el.childNodes)
+          .filter(child => child !== summary)
+          .map(child => processNode(child))
+          .join('');
+        return `<details>\n<summary>${summaryText}</summary>\n\n${content.trim()}\n</details>\n\n`;
+      }
+
+      case 'summary':
+        return processChildren();
+
+      default:
+        return processChildren();
+    }
+  }
+
+  const result = processNode(element);
+
+  // Clean up excessive newlines
+  return result
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/docs/src/components/CopyMarkdownButton/index.tsx
+++ b/docs/src/components/CopyMarkdownButton/index.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useCallback } from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import styles from './styles.module.css';
+import { htmlToMarkdown } from './htmlToMarkdown';
+
+// Clipboard icon SVG
+const ClipboardIcon = () => (
+  <svg
+    className={styles.icon}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+// Checkmark icon SVG
+const CheckIcon = () => (
+  <svg
+    className={styles.icon}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+export default function CopyMarkdownButton() {
+  const [copied, setCopied] = useState(false);
+  const { metadata } = useDoc();
+
+  const handleCopy = useCallback(async () => {
+    // Find the markdown content container
+    const contentEl = document.querySelector('.theme-doc-markdown');
+    if (!contentEl) {
+      console.error('Could not find markdown content element');
+      return;
+    }
+
+    // Convert HTML to markdown
+    const markdownContent = htmlToMarkdown(contentEl);
+
+    // Build the final output with title and source URL
+    const title = metadata.title || document.title;
+    const sourceUrl = window.location.href;
+
+    const output = `# ${title}
+
+Source: ${sourceUrl}
+
+${markdownContent}`;
+
+    try {
+      await navigator.clipboard.writeText(output);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea');
+      textarea.value = output;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (e) {
+        console.error('Failed to copy:', e);
+      }
+      document.body.removeChild(textarea);
+    }
+  }, [metadata.title]);
+
+  return (
+    <div className={styles.copyButtonContainer}>
+      <button
+        className={`${styles.copyButton} ${copied ? styles.copied : ''}`}
+        onClick={handleCopy}
+        title="Copy page content as markdown"
+        type="button"
+      >
+        {copied ? <CheckIcon /> : <ClipboardIcon />}
+        <span className={styles.label}>{copied ? 'Copied!' : 'Copy page'}</span>
+      </button>
+    </div>
+  );
+}

--- a/docs/src/components/CopyMarkdownButton/styles.module.css
+++ b/docs/src/components/CopyMarkdownButton/styles.module.css
@@ -1,0 +1,76 @@
+.copyButtonContainer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 10;
+}
+
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.copyButton:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.copyButton:active {
+  transform: scale(0.98);
+}
+
+.copyButton.copied {
+  color: #31a67b;
+  border-color: #31a67b;
+  background: rgba(49, 166, 123, 0.1);
+}
+
+.icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.label {
+  white-space: nowrap;
+}
+
+/* Hide label on small screens */
+@media (max-width: 576px) {
+  .label {
+    display: none;
+  }
+
+  .copyButton {
+    padding: 0.4rem;
+  }
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .copyButton {
+  color: var(--ifm-color-emphasis-600);
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+[data-theme='dark'] .copyButton:hover {
+  color: var(--ifm-link-color);
+  border-color: var(--ifm-link-color);
+  background: rgba(169, 204, 31, 0.1);
+}
+
+[data-theme='dark'] .copyButton.copied {
+  color: #69b799;
+  border-color: #69b799;
+  background: rgba(105, 183, 153, 0.15);
+}

--- a/docs/src/theme/DocItem/Layout/index.js
+++ b/docs/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import { createPortal } from 'react-dom';
+import CopyMarkdownButton from '@site/src/components/CopyMarkdownButton';
+
+function PortalButton() {
+  const [container, setContainer] = React.useState(null);
+
+  useEffect(() => {
+    // Find the article element and inject the button
+    const article = document.querySelector('article');
+    if (article) {
+      article.style.position = 'relative';
+      setContainer(article);
+    }
+  }, []);
+
+  if (!container) return null;
+  return createPortal(<CopyMarkdownButton />, container);
+}
+
+export default function LayoutWrapper(props) {
+  return (
+    <>
+      <Layout {...props} />
+      <PortalButton />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a "Copy page" button to the top-right of every documentation page
- Copies page content as clean markdown for easy pasting into LLM chats
- Extracts rendered content (with preprocessed code snippets resolved)

## Features
- Converts HTML to clean markdown format (headings, code blocks, links, lists, tables)
- Includes page title and source URL in copied content
- Shows "Copied!" feedback for 2 seconds
- Supports light and dark themes
- Responsive design (icon-only on mobile)

## Test plan
- [ ] Run `yarn start` in docs/ directory
- [ ] Navigate to any documentation page
- [ ] Click "Copy page" button
- [ ] Verify button shows "Copied!" feedback
- [ ] Paste into text editor and verify markdown format
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)