### PR TITLE
feat: add txHash to AztecNode#getPublicLogs response

### DIFF
--- a/yarn-project/archiver/src/store/kv_archiver_store.test.ts
+++ b/yarn-project/archiver/src/store/kv_archiver_store.test.ts
@@ -2740,6 +2740,19 @@ describe('KVArchiverDataStore', () => {
       expect(logs.every(log => log.id.blockHash.equals(expectedBlockHash))).toBe(true);
     });
 
+    it('returns tx hash on public log ids', async () => {
+      const targetBlock = publishedCheckpoints[0].checkpoint.blocks[0];
+
+      const logs = (await store.getPublicLogs({ fromBlock: targetBlock.number, toBlock: targetBlock.number + 1 })).logs;
+
+      expect(logs.length).toBeGreaterThan(0);
+      const expectedTxHashes = targetBlock.body.txEffects.map(txEffect => txEffect.txHash);
+      for (const log of logs) {
+        const expectedTxHash = expectedTxHashes[log.id.txIndex];
+        expect(log.id.txHash.equals(expectedTxHash)).toBe(true);
+      }
+    });
+
     it('"fromBlock" and "toBlock" filter params are respected', async () => {
       // Set "fromBlock" and "toBlock"
       const fromBlock = 3;
@@ -2792,9 +2805,11 @@ describe('KVArchiverDataStore', () => {
       const targetLogIndex = numLogsInTx > 0 ? randomInt(numLogsInTx) : 0;
       const targetBlockHash = await targetBlock.header.hash();
 
+      const targetTxHash = targetBlock.body.txEffects[targetTxIndex].txHash;
       const afterLog = new LogId(
         BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
         targetBlockHash,
+        targetTxHash,
         targetTxIndex,
         targetLogIndex,
       );
@@ -2819,7 +2834,7 @@ describe('KVArchiverDataStore', () => {
     it('"txHash" filter param is ignored when "afterLog" is set', async () => {
       // Get random txHash
       const txHash = TxHash.random();
-      const afterLog = new LogId(BlockNumber(1), BlockHash.random(), 0, 0);
+      const afterLog = new LogId(BlockNumber(1), BlockHash.random(), TxHash.random(), 0, 0);
 
       const response = await store.getPublicLogs({ txHash, afterLog });
       expect(response.logs.length).toBeGreaterThan(1);
@@ -2851,7 +2866,7 @@ describe('KVArchiverDataStore', () => {
         await store.getPublicLogs({
           fromBlock: BlockNumber(2),
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(4), BlockHash.random(), 0, 0),
+          afterLog: new LogId(BlockNumber(4), BlockHash.random(), TxHash.random(), 0, 0),
         })
       ).logs;
       blockNumbers = new Set(logs.map(log => log.id.blockNumber));
@@ -2860,7 +2875,7 @@ describe('KVArchiverDataStore', () => {
       logs = (
         await store.getPublicLogs({
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(5), BlockHash.random(), 1, 0),
+          afterLog: new LogId(BlockNumber(5), BlockHash.random(), TxHash.random(), 1, 0),
         })
       ).logs;
       expect(logs.length).toBe(0);
@@ -2869,7 +2884,7 @@ describe('KVArchiverDataStore', () => {
         await store.getPublicLogs({
           fromBlock: BlockNumber(2),
           toBlock: BlockNumber(5),
-          afterLog: new LogId(BlockNumber(100), BlockHash.random(), 0, 0),
+          afterLog: new LogId(BlockNumber(100), BlockHash.random(), TxHash.random(), 0, 0),
         })
       ).logs;
       expect(logs.length).toBe(0);
@@ -2883,10 +2898,12 @@ describe('KVArchiverDataStore', () => {
       const numLogsInTx = targetBlock.body.txEffects[targetTxIndex].publicLogs.length;
       const targetLogIndex = numLogsInTx > 0 ? randomInt(numLogsInTx) : 0;
       const targetBlockHash = await targetBlock.header.hash();
+      const targetTxHash = targetBlock.body.txEffects[targetTxIndex].txHash;
 
       const afterLog = new LogId(
         BlockNumber(targetBlockIndex + INITIAL_L2_BLOCK_NUM),
         targetBlockHash,
+        targetTxHash,
         targetTxIndex,
         targetLogIndex,
       );

--- a/yarn-project/archiver/src/store/log_store.ts
+++ b/yarn-project/archiver/src/store/log_store.ts
@@ -20,6 +20,7 @@ import {
   Tag,
   TxScopedL2Log,
 } from '@aztec/stdlib/logs';
+import { TxHash } from '@aztec/stdlib/tx';
 
 import type { BlockStore } from './block_store.js';
 
@@ -219,6 +220,7 @@ export class LogStore {
         .map((txEffect, txIndex) =>
           [
             numToUInt32BE(txIndex),
+            txEffect.txHash.toBuffer(),
             numToUInt32BE(txEffect.publicLogs.length),
             txEffect.publicLogs.map(log => log.toBuffer()),
           ].flat(),
@@ -242,6 +244,7 @@ export class LogStore {
         .map((txEffect, txIndex) =>
           [
             numToUInt32BE(txIndex),
+            txEffect.txHash.toBuffer(),
             numToUInt32BE(txEffect.contractClassLogs.length),
             txEffect.contractClassLogs.map(log => log.toBuffer()),
           ].flat(),
@@ -386,24 +389,33 @@ export class LogStore {
     }
 
     const buffer = (await this.#publicLogsByBlock.getAsync(blockNumber)) ?? Buffer.alloc(0);
-    const publicLogsInBlock: [PublicLog[]] = [[]];
+    const publicLogsInBlock: { txHash: TxHash; logs: PublicLog[] }[] = [];
     const reader = new BufferReader(buffer);
 
     const blockHash = this.#unpackBlockHash(reader);
 
     while (reader.remainingBytes() > 0) {
       const indexOfTx = reader.readNumber();
+      const txHash = reader.readObject(TxHash);
       const numLogsInTx = reader.readNumber();
-      publicLogsInBlock[indexOfTx] = [];
+      publicLogsInBlock[indexOfTx] = { txHash, logs: [] };
       for (let i = 0; i < numLogsInTx; i++) {
-        publicLogsInBlock[indexOfTx].push(reader.readObject(PublicLog));
+        publicLogsInBlock[indexOfTx].logs.push(reader.readObject(PublicLog));
       }
     }
 
-    const txLogs = publicLogsInBlock[txIndex];
+    const txData = publicLogsInBlock[txIndex];
 
     const logs: ExtendedPublicLog[] = [];
-    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
+    const maxLogsHit = this.#accumulatePublicLogs(
+      logs,
+      blockNumber,
+      blockHash,
+      txIndex,
+      txData.txHash,
+      txData.logs,
+      filter,
+    );
 
     return { logs, maxLogsHit };
   }
@@ -424,22 +436,31 @@ export class LogStore {
 
     let maxLogsHit = false;
     loopOverBlocks: for await (const [blockNumber, logBuffer] of this.#publicLogsByBlock.entriesAsync({ start, end })) {
-      const publicLogsInBlock: [PublicLog[]] = [[]];
+      const publicLogsInBlock: { txHash: TxHash; logs: PublicLog[] }[] = [];
       const reader = new BufferReader(logBuffer);
 
       const blockHash = this.#unpackBlockHash(reader);
 
       while (reader.remainingBytes() > 0) {
         const indexOfTx = reader.readNumber();
+        const txHash = reader.readObject(TxHash);
         const numLogsInTx = reader.readNumber();
-        publicLogsInBlock[indexOfTx] = [];
+        publicLogsInBlock[indexOfTx] = { txHash, logs: [] };
         for (let i = 0; i < numLogsInTx; i++) {
-          publicLogsInBlock[indexOfTx].push(reader.readObject(PublicLog));
+          publicLogsInBlock[indexOfTx].logs.push(reader.readObject(PublicLog));
         }
       }
       for (let txIndex = filter.afterLog?.txIndex ?? 0; txIndex < publicLogsInBlock.length; txIndex++) {
-        const txLogs = publicLogsInBlock[txIndex];
-        maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
+        const txData = publicLogsInBlock[txIndex];
+        maxLogsHit = this.#accumulatePublicLogs(
+          logs,
+          blockNumber,
+          blockHash,
+          txIndex,
+          txData.txHash,
+          txData.logs,
+          filter,
+        );
         if (maxLogsHit) {
           this.#log.debug(`Max logs hit at block ${blockNumber}`);
           break loopOverBlocks;
@@ -475,24 +496,33 @@ export class LogStore {
       return { logs: [], maxLogsHit: false };
     }
     const contractClassLogsBuffer = (await this.#contractClassLogsByBlock.getAsync(blockNumber)) ?? Buffer.alloc(0);
-    const contractClassLogsInBlock: [ContractClassLog[]] = [[]];
+    const contractClassLogsInBlock: { txHash: TxHash; logs: ContractClassLog[] }[] = [];
 
     const reader = new BufferReader(contractClassLogsBuffer);
     const blockHash = this.#unpackBlockHash(reader);
 
     while (reader.remainingBytes() > 0) {
       const indexOfTx = reader.readNumber();
+      const txHash = reader.readObject(TxHash);
       const numLogsInTx = reader.readNumber();
-      contractClassLogsInBlock[indexOfTx] = [];
+      contractClassLogsInBlock[indexOfTx] = { txHash, logs: [] };
       for (let i = 0; i < numLogsInTx; i++) {
-        contractClassLogsInBlock[indexOfTx].push(reader.readObject(ContractClassLog));
+        contractClassLogsInBlock[indexOfTx].logs.push(reader.readObject(ContractClassLog));
       }
     }
 
-    const txLogs = contractClassLogsInBlock[txIndex];
+    const txData = contractClassLogsInBlock[txIndex];
 
     const logs: ExtendedContractClassLog[] = [];
-    const maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
+    const maxLogsHit = this.#accumulateContractClassLogs(
+      logs,
+      blockNumber,
+      blockHash,
+      txIndex,
+      txData.txHash,
+      txData.logs,
+      filter,
+    );
 
     return { logs, maxLogsHit };
   }
@@ -516,20 +546,29 @@ export class LogStore {
       start,
       end,
     })) {
-      const contractClassLogsInBlock: [ContractClassLog[]] = [[]];
+      const contractClassLogsInBlock: { txHash: TxHash; logs: ContractClassLog[] }[] = [];
       const reader = new BufferReader(logBuffer);
       const blockHash = this.#unpackBlockHash(reader);
       while (reader.remainingBytes() > 0) {
         const indexOfTx = reader.readNumber();
+        const txHash = reader.readObject(TxHash);
         const numLogsInTx = reader.readNumber();
-        contractClassLogsInBlock[indexOfTx] = [];
+        contractClassLogsInBlock[indexOfTx] = { txHash, logs: [] };
         for (let i = 0; i < numLogsInTx; i++) {
-          contractClassLogsInBlock[indexOfTx].push(reader.readObject(ContractClassLog));
+          contractClassLogsInBlock[indexOfTx].logs.push(reader.readObject(ContractClassLog));
         }
       }
       for (let txIndex = filter.afterLog?.txIndex ?? 0; txIndex < contractClassLogsInBlock.length; txIndex++) {
-        const txLogs = contractClassLogsInBlock[txIndex];
-        maxLogsHit = this.#accumulateLogs(logs, blockNumber, blockHash, txIndex, txLogs, filter);
+        const txData = contractClassLogsInBlock[txIndex];
+        maxLogsHit = this.#accumulateContractClassLogs(
+          logs,
+          blockNumber,
+          blockHash,
+          txIndex,
+          txData.txHash,
+          txData.logs,
+          filter,
+        );
         if (maxLogsHit) {
           this.#log.debug(`Max logs hit at block ${blockNumber}`);
           break loopOverBlocks;
@@ -540,12 +579,13 @@ export class LogStore {
     return { logs, maxLogsHit };
   }
 
-  #accumulateLogs(
-    results: (ExtendedContractClassLog | ExtendedPublicLog)[],
+  #accumulatePublicLogs(
+    results: ExtendedPublicLog[],
     blockNumber: number,
     blockHash: BlockHash,
     txIndex: number,
-    txLogs: (ContractClassLog | PublicLog)[],
+    txHash: TxHash,
+    txLogs: PublicLog[],
     filter: LogFilter = {},
   ): boolean {
     let maxLogsHit = false;
@@ -553,15 +593,37 @@ export class LogStore {
     for (; logIndex < txLogs.length; logIndex++) {
       const log = txLogs[logIndex];
       if (!filter.contractAddress || log.contractAddress.equals(filter.contractAddress)) {
-        if (log instanceof ContractClassLog) {
-          results.push(
-            new ExtendedContractClassLog(new LogId(BlockNumber(blockNumber), blockHash, txIndex, logIndex), log),
-          );
-        } else if (log instanceof PublicLog) {
-          results.push(new ExtendedPublicLog(new LogId(BlockNumber(blockNumber), blockHash, txIndex, logIndex), log));
-        } else {
-          throw new Error('Unknown log type');
+        results.push(
+          new ExtendedPublicLog(new LogId(BlockNumber(blockNumber), blockHash, txHash, txIndex, logIndex), log),
+        );
+
+        if (results.length >= this.#logsMaxPageSize) {
+          maxLogsHit = true;
+          break;
         }
+      }
+    }
+
+    return maxLogsHit;
+  }
+
+  #accumulateContractClassLogs(
+    results: ExtendedContractClassLog[],
+    blockNumber: number,
+    blockHash: BlockHash,
+    txIndex: number,
+    txHash: TxHash,
+    txLogs: ContractClassLog[],
+    filter: LogFilter = {},
+  ): boolean {
+    let maxLogsHit = false;
+    let logIndex = typeof filter.afterLog?.logIndex === 'number' ? filter.afterLog.logIndex + 1 : 0;
+    for (; logIndex < txLogs.length; logIndex++) {
+      const log = txLogs[logIndex];
+      if (!filter.contractAddress || log.contractAddress.equals(filter.contractAddress)) {
+        results.push(
+          new ExtendedContractClassLog(new LogId(BlockNumber(blockNumber), blockHash, txHash, txIndex, logIndex), log),
+        );
 
         if (results.length >= this.#logsMaxPageSize) {
           maxLogsHit = true;

--- a/yarn-project/stdlib/src/logs/log_id.ts
+++ b/yarn-project/stdlib/src/logs/log_id.ts
@@ -8,20 +8,17 @@ import { z } from 'zod';
 
 import { BlockHash } from '../block/block_hash.js';
 import { schemas } from '../schemas/index.js';
+import { TxHash } from '../tx/tx_hash.js';
 
 /** A globally unique log id. */
 export class LogId {
-  /**
-   * Parses a log id from a string.
-   * @param blockNumber - The block number.
-   * @param txIndex - The transaction index.
-   * @param logIndex - The log index.
-   */
   constructor(
     /** The block number the log was emitted in. */
     public readonly blockNumber: BlockNumber,
     /** The hash of the block the log was emitted in. */
     public readonly blockHash: BlockHash,
+    /** The hash of the transaction the log was emitted in. */
+    public readonly txHash: TxHash,
     /** The index of a tx in a block the log was emitted in. */
     public readonly txIndex: number,
     /** The index of a log the tx was emitted in. */
@@ -42,6 +39,7 @@ export class LogId {
     return new LogId(
       BlockNumber(Math.floor(Math.random() * 1000) + 1),
       BlockHash.random(),
+      TxHash.random(),
       Math.floor(Math.random() * 1000),
       Math.floor(Math.random() * 100),
     );
@@ -52,11 +50,13 @@ export class LogId {
       .object({
         blockNumber: BlockNumberSchema,
         blockHash: BlockHash.schema,
+        txHash: TxHash.schema,
         txIndex: schemas.Integer,
         logIndex: schemas.Integer,
       })
       .transform(
-        ({ blockNumber, blockHash, txIndex, logIndex }) => new LogId(blockNumber, blockHash, txIndex, logIndex),
+        ({ blockNumber, blockHash, txHash, txIndex, logIndex }) =>
+          new LogId(blockNumber, blockHash, txHash, txIndex, logIndex),
       );
   }
 
@@ -68,6 +68,7 @@ export class LogId {
     return Buffer.concat([
       toBufferBE(BigInt(this.blockNumber), 4),
       this.blockHash.toBuffer(),
+      this.txHash.toBuffer(),
       toBufferBE(BigInt(this.txIndex), 4),
       toBufferBE(BigInt(this.logIndex), 4),
     ]);
@@ -83,10 +84,11 @@ export class LogId {
 
     const blockNumber = BlockNumber(reader.readNumber());
     const blockHash = new BlockHash(reader.readObject(Fr));
+    const txHash = reader.readObject(TxHash);
     const txIndex = reader.readNumber();
     const logIndex = reader.readNumber();
 
-    return new LogId(blockNumber, blockHash, txIndex, logIndex);
+    return new LogId(blockNumber, blockHash, txHash, txIndex, logIndex);
   }
 
   /**
@@ -94,7 +96,7 @@ export class LogId {
    * @returns A string representation of the log id.
    */
   public toString(): string {
-    return `${this.blockNumber}-${this.txIndex}-${this.logIndex}-${this.blockHash.toString()}`;
+    return `${this.blockNumber}-${this.txIndex}-${this.logIndex}-${this.blockHash.toString()}-${this.txHash.toString()}`;
   }
 
   /**
@@ -103,13 +105,14 @@ export class LogId {
    * @returns A log id.
    */
   static fromString(data: string): LogId {
-    const [rawBlockNumber, rawTxIndex, rawLogIndex, rawBlockHash] = data.split('-');
+    const [rawBlockNumber, rawTxIndex, rawLogIndex, rawBlockHash, rawTxHash] = data.split('-');
     const blockNumber = BlockNumber(Number(rawBlockNumber));
     const blockHash = BlockHash.fromString(rawBlockHash);
+    const txHash = TxHash.fromString(rawTxHash);
     const txIndex = Number(rawTxIndex);
     const logIndex = Number(rawLogIndex);
 
-    return new LogId(blockNumber, blockHash, txIndex, logIndex);
+    return new LogId(blockNumber, blockHash, txHash, txIndex, logIndex);
   }
 
   /**
@@ -117,6 +120,6 @@ export class LogId {
    * @returns A human readable representation of the log id.
    */
   public toHumanReadable(): string {
-    return `logId: (blockNumber: ${this.blockNumber}, blockHash: ${this.blockHash.toString()}, txIndex: ${this.txIndex}, logIndex: ${this.logIndex})`;
+    return `logId: (blockNumber: ${this.blockNumber}, blockHash: ${this.blockHash.toString()}, txHash: ${this.txHash.toString()}, txIndex: ${this.txIndex}, logIndex: ${this.logIndex})`;
   }
 }


### PR DESCRIPTION
As title. It is convenient to include `txHash` as an attribute of each returned public log for client use. Without this, clients need to issue a `getBlock` call to find it out. 
