### PR TITLE
refactor: move alpha-team-centric CI to be based on merge-train

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -41,6 +41,21 @@ function main {
   local ci_mode
   if [ "${GITHUB_EVENT_NAME:-}" == "merge_group" ] || has_label "ci-merge-queue"; then
     ci_mode="merge-queue"
+    # Check if this is a merge-train/spartan PR entering the merge queue.
+    # If so, use the heavier merge-queue-heavy mode (10 grind runs).
+    if [ "${GITHUB_EVENT_NAME:-}" == "merge_group" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+      # GITHUB_REF_NAME in merge_group is like: gh-readonly-queue/next/pr-XXX-SHA
+      local pr_number
+      pr_number=$(echo "${GITHUB_REF_NAME:-}" | sed -n 's|gh-readonly-queue/.*/pr-\([0-9]*\)-.*|\1|p')
+      if [ -n "$pr_number" ]; then
+        local head_branch
+        head_branch=$(GH_TOKEN="$GITHUB_TOKEN" gh pr view "$pr_number" --json headRefName -q '.headRefName' 2>/dev/null || true)
+        if [ "$head_branch" == "merge-train/spartan" ]; then
+          echo "Merge-train/spartan PR detected, using merge-queue-heavy mode" >&2
+          ci_mode="merge-queue-heavy"
+        fi
+      fi
+    fi
   elif has_label "ci-release-pr"; then
     ci_mode="release-pr"
   elif has_label "ci-full"; then
@@ -67,7 +82,7 @@ function main {
   echo "CI mode: $ci_mode"
 
   # Determine if benchmarks should be uploaded (merge-queue, full, or full-no-test-cache modes)
-  if [[ "$ci_mode" == "merge-queue" || "$ci_mode" == "full" || "$ci_mode" == "full-no-test-cache" ]]; then
+  if [[ "$ci_mode" == "merge-queue" || "$ci_mode" == "merge-queue-heavy" || "$ci_mode" == "full" || "$ci_mode" == "full-no-test-cache" ]]; then
     echo "SHOULD_UPLOAD_BENCHMARKS=1" >> $GITHUB_ENV
   fi
 

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -58,6 +58,7 @@ jobs:
           MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./.github/ci3_labels_to_env.sh ${{ join(github.event.pull_request.labels.*.name, ' ') }}
 
       - name: Run
@@ -129,10 +130,9 @@ jobs:
       fail-fast: false
       matrix:
         test_set: ["1", "2"]
-    # We either run after a release (tag starting with v), or when the ci-network-scenario label is present in a PR.
-    # We exclude ci-release-pr test tags (v0.0.1-commit.*) which are only for testing the release process.
+    # We run after a nextnet-nightly release (from merge-train/spartan), or when the ci-network-scenario label is present in a PR.
     needs: ci
-    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-commit.')) || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
+    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && ((startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-nextnet-nightly.')) || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
     steps:
       - name: Remove label (one-time use)
         if: github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'ci-network-scenario')
@@ -179,8 +179,8 @@ jobs:
           ./.github/ci3.sh network-scenarios next-scenario "$namespace" "$docker_image" "${{ matrix.test_set }}"
 
       - name: Cleanup network resources
-        # Clean up if this is a CI label or nightly.
-        if: always() && (!startsWith(github.ref, 'refs/tags/v') || contains(github.ref_name, '-nightly.'))
+        # Clean up if this is a CI label or nextnet-nightly.
+        if: always() && (!startsWith(github.ref, 'refs/tags/v') || contains(github.ref_name, '-nextnet-nightly.'))
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -1,6 +1,6 @@
-# Deploy next-net environment
+# Deploy next-net environment from merge-train/spartan
 # This workflow deploys the next-net environment with a specified version
-# Runs nightly with the latest nightly tag, or can be manually triggered with any image
+# Runs nightly with the latest nextnet nightly tag, or can be manually triggered with any image
 name: Deploy Next Net
 
 on:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Docker image tag (e.g., 2.3.4, 3.0.0-nightly.20251004-amd64, or leave empty for latest nightly)'
+        description: 'Docker image tag (e.g., 2.3.4, 3.0.0-nextnet-nightly.20251004-amd64, or leave empty for latest nextnet nightly)'
         required: false
         type: string
 
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: merge-train/spartan
 
       - name: Determine image tag
         id: determine_tag
@@ -36,22 +38,22 @@ jobs:
             TAG="${{ inputs.image_tag }}"
             echo "Using manually specified tag: $TAG"
 
-            # Extract semver (remove -amd64 suffix if present, remove -nightly.YYYYMMDD if present)
-            SEMVER=$(echo "$TAG" | sed 's/-amd64$//' | sed 's/-nightly\.[0-9]\{8\}//')
+            # Extract semver (remove -amd64 suffix if present, remove -nextnet-nightly.YYYYMMDD if present)
+            SEMVER=$(echo "$TAG" | sed 's/-amd64$//' | sed 's/-nextnet-nightly\.[0-9]\{8\}//')
           else
-            # Scheduled nightly run - get latest nightly tag
+            # Scheduled nightly run - get latest nextnet nightly tag
             current_version=$(jq -r '."."' .release-please-manifest.json)
             echo "Current version: $current_version"
 
-            # Format the tag as: <current_version>-nightly.<YYYYMMDD>-amd64
-            nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)-amd64"
+            # Format the tag as: <current_version>-nextnet-nightly.<YYYYMMDD>-amd64
+            nightly_tag="${current_version}-nextnet-nightly.$(date -u +%Y%m%d)-amd64"
 
             # Check if the tag exists on docker hub
             TAGS=$(curl -s https://registry.hub.docker.com/v2/repositories/aztecprotocol/aztec/tags/$nightly_tag)
             if [[ "$TAGS" != *"not found"* ]]; then
               TAG="$nightly_tag"
               SEMVER="$current_version"
-              echo "Using nightly tag: $TAG"
+              echo "Using nextnet nightly tag: $TAG"
             else
               echo "Error: Tag $nightly_tag not published to docker hub"
               exit 1
@@ -68,5 +70,5 @@ jobs:
       network: next-net
       semver: ${{ needs.get-image-tag.outputs.semver }}
       docker_image_tag: ${{ needs.get-image-tag.outputs.tag }}
-      ref: ${{ github.ref }}
+      ref: merge-train/spartan
     secrets: inherit

--- a/.github/workflows/merge-train-create-pr.yml
+++ b/.github/workflows/merge-train-create-pr.yml
@@ -46,10 +46,14 @@ jobs:
               base_branch="next"
 
               # Create PR with ci-no-squash label
+              labels="ci-no-squash"
+              if [[ "$branch" == "merge-train/spartan" ]]; then
+                labels="$labels,ci-full"
+              fi
               gh pr create --base "$base_branch" --head "$branch" \
                 --title "feat: $branch" \
                 --body "$(echo -e "See [merge-train-readme.md](https://github.com/${{ github.repository }}/blob/next/.github/workflows/merge-train-readme.md).\nThis is a merge-train.")" \
-                --label "ci-no-squash"
+                --label "$labels"
 
               echo "Created PR for $branch"
             else

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -33,3 +33,23 @@ jobs:
           # Tag and push.
           git tag -a "$nightly_tag" -m "$nightly_tag"
           git push origin "$nightly_tag"
+
+  nightly-release-tag-nextnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: merge-train/spartan
+          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+
+      - name: Create Nextnet Nightly Tag
+        run: |
+          git config --global user.email "tech@aztecprotocol.com"
+          git config --global user.name "AztecBot"
+          current_version=$(jq -r '."."' .release-please-manifest.json)
+          echo "Current version: $current_version"
+          nightly_tag="v${current_version}-nextnet-nightly.$(date -u +%Y%m%d)"
+          echo "Nextnet nightly tag: $nightly_tag"
+          # Tag and push.
+          git tag -a "$nightly_tag" -m "$nightly_tag"
+          git push origin "$nightly_tag"

--- a/ci.sh
+++ b/ci.sh
@@ -115,6 +115,33 @@ case "$cmd" in
       'run x4-full amd64 ci-full-no-test-cache-makefile' \
       'run a1-fast arm64 ci-fast' | DUP=1 cache_log "Merge queue CI run" $RUN_ID
     ;;
+  merge-queue-heavy)
+    # Heavy merge queue with 10 parallel grind runs, used for merge-train/spartan PRs.
+    if [[ "$REF_NAME" =~ ^gh-readonly-queue/ ]]; then
+      export CI_DASHBOARD=${TARGET_BRANCH:-local}
+    else
+      export CI_DASHBOARD="prs"
+    fi
+    export DENOISE=1
+    export DENOISE_WIDTH=32
+    run() {
+      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+    }
+    export -f run
+
+    parallel --jobs 10 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
+      'run x1-full amd64 ci-full-no-test-cache' \
+      'run x2-full amd64 ci-full-no-test-cache' \
+      'run x3-full amd64 ci-full-no-test-cache' \
+      'run x4-full amd64 ci-full-no-test-cache' \
+      'run x5-full amd64 ci-full-no-test-cache' \
+      'run x6-full amd64 ci-full-no-test-cache' \
+      'run x7-full amd64 ci-full-no-test-cache' \
+      'run x8-full amd64 ci-full-no-test-cache' \
+      'run x9-full amd64 ci-full-no-test-cache' \
+      'run x10-full amd64 ci-full-no-test-cache' \
+      'run a1-fast arm64 ci-fast' | DUP=1 cache_log "Merge queue heavy CI run" $RUN_ID
+    ;;
   grind-test)
     full_cmd="$1"
     timeout="${2:-}"
@@ -128,7 +155,6 @@ case "$cmd" in
     export INSTANCE_POSTFIX=$JOB_ID
     bootstrap_ec2 "./bootstrap.sh ci-grind-test '$full_cmd' $timeout $commit" | DUP=1 cache_log "Grind test CI run" $RUN_ID
     ;;
-
   ##########################################
   # NETWORK DEPLOYMENTS WITH BENCHES/TESTS #
   ##########################################

--- a/scripts/merge-train/update-pr-body.sh
+++ b/scripts/merge-train/update-pr-body.sh
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
-# Function to get meaningful commits (non-merge, non-empty)
+# Function to get meaningful commits (ones with PR numbers like (#1234))
 function get_meaningful_commits {
   local base="$1"
   local head="$2"
 
-  git log --oneline --no-merges --reverse "${base}..${head}" \
-    --pretty=format:"%s" | grep -v "^\[empty\]" || true
+  git log --oneline --reverse "${base}..${head}" \
+    --pretty=format:"%s" | grep -E '\(#[0-9]+\)' || true
 }
 
 # Usage: update-pr-body.sh <branch-name>


### PR DESCRIPTION
## Summary
- We introduce another set of nightly releases from `merge-train/spartan` with `nextnet-nightly` tag format, published alongside the regular nightly from `next`
- Deploy next-net from `merge-train/spartan` nextnet-nightly images instead of regular nightlies
- Network scenarios now only run off nextnet-nightly tags (from merge-train/spartan), not regular releases/nightlies
- `merge-queue-heavy` CI mode (10 grind runs) for merge-train/spartan PRs entering the merge queue
- `ci-full` label automatically added to merge-train/spartan PR recreations
- PR body commit summarization now finds commits by `(#<pr-number>)` pattern instead of filtering merge commits
