### PR TITLE
fix(aztec-up): add -L flag to curl commands to follow redirects

### DIFF
--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -3,7 +3,7 @@
 TYPE=$1
 NAME=$2
 
-curl -s https://install.aztec.network | NON_INTERACTIVE=1 bash -s
+curl -sL https://install.aztec.network | NON_INTERACTIVE=1 bash -s
 docker compose -f $HOME/.aztec/docker-compose.local-network.yml pull
 
 if ! grep -q "PXE_URL" ~/.bashrc; then

--- a/aztec-up/README.md
+++ b/aztec-up/README.md
@@ -1,7 +1,7 @@
 # The Aztec Installation Script
 
 ```
-bash -i <(curl -s https://install.aztec.network)
+bash -i <(curl -sL https://install.aztec.network)
 ```
 
 That is all.

--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Root bootstrap script for Aztec toolchain
 # This script installs aztec-up and then delegates to it for version installation.
-# Usage: bash -i <(curl -s https://install.aztec.network)
-#    or: VERSION=0.85.0 bash -i <(curl -s https://install.aztec.network)
+# Usage: bash -i <(curl -sL https://install.aztec.network)
+#    or: VERSION=0.85.0 bash -i <(curl -sL https://install.aztec.network)
 set -euo pipefail
 
 # Colors

--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -128,8 +128,8 @@ function cmd_install {
 
   local install_url="$INSTALL_URI/$resolved_version/install"
 
-  # Check if install script exists
-  if ! curl --head --silent --fail "$install_url" > /dev/null; then
+  # Check if install script exists (use -L to follow redirects)
+  if ! curl -L --head --silent --fail "$install_url" > /dev/null; then
     echo "Error: Version installer not found at $install_url"
     echo "Please check the version specified."
     exit 1

--- a/aztec-up/scripts/run_isolated_test.sh
+++ b/aztec-up/scripts/run_isolated_test.sh
@@ -93,7 +93,7 @@ EOF
   else
     export NON_INTERACTIVE=1
   fi
-  bash ${bash_args:-} <(curl -s $INSTALL_URI/aztec-install)
+  bash ${bash_args:-} <(curl -sL $INSTALL_URI/aztec-install)
 
   echo "Version information:"
 

--- a/yarn-project/cli/README.md
+++ b/yarn-project/cli/README.md
@@ -7,7 +7,7 @@ The Aztec CLI `aztec-cli` is a command-line interface (CLI) tool for interacting
 1. In your terminal, download the local network by running
 
 ```
-bash -i <(curl -s https://install.aztec.network)
+bash -i <(curl -sL https://install.aztec.network)
 ```
 
 2. Verify the installation: After the installation is complete, run the following command to verify that `aztec-cli` is installed correctly:


### PR DESCRIPTION
## Summary
- The `install.aztec.network` URL now redirects, causing `curl` without `-L` to silently fail
- This caused `aztec-up` to report success (exit code 0) but not actually install the requested version
- Added `-L` flag to all curl commands to follow redirects

## Changes
- **Core fix**: Add `-L` to the HEAD check in `aztec-up/bin/aztec-up` that verifies the install script exists
- **Documentation**: Update all installation examples in READMEs to use `curl -sL`
- **Scripts**: Update test scripts and devcontainer setup to use `curl -sL`

## Test plan
- Run `bash -i <(curl -sL https://install.aztec.network)` to verify installation works
- Verify `aztec-up -v <version>` properly installs the specified version

Fixes A-517