### PR TITLE
refactor: verifier contracts

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_optimized_contract.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/honk_optimized_contract.hpp
@@ -83,9 +83,10 @@ inline std::string generate_memory_offsets(int log_n)
                                                 "PROOF_NUM_PUBLIC_INPUTS",
                                                 "PROOF_PUB_INPUTS_OFFSET" };
 
-    const std::vector<std::string> pairing_points = { "PAIRING_POINT_0", "PAIRING_POINT_1", "PAIRING_POINT_2",
-                                                      "PAIRING_POINT_3", "PAIRING_POINT_4", "PAIRING_POINT_5",
-                                                      "PAIRING_POINT_6", "PAIRING_POINT_7" };
+    const std::vector<std::string> pairing_points = { "PAIRING_POINT_0_X_0_LOC", "PAIRING_POINT_0_X_1_LOC",
+                                                      "PAIRING_POINT_0_Y_0_LOC", "PAIRING_POINT_0_Y_1_LOC",
+                                                      "PAIRING_POINT_1_X_0_LOC", "PAIRING_POINT_1_X_1_LOC",
+                                                      "PAIRING_POINT_1_Y_0_LOC", "PAIRING_POINT_1_Y_1_LOC" };
 
     const std::vector<std::string> proof_g1 = {
         "W_L", "W_R", "W_O", "LOOKUP_READ_COUNTS", "LOOKUP_READ_TAGS", "W_4", "LOOKUP_INVERSES", "Z_PERM"
@@ -416,12 +417,6 @@ uint256 constant PUBLIC_INPUTS_OFFSET = 1;
 // LOG_N * 8
 uint256 constant NUMBER_OF_BARYCENTRIC_INVERSES = {{ NUMBER_OF_BARYCENTRIC_INVERSES }};
 
-error PUBLIC_INPUT_TOO_LARGE();
-error SUMCHECK_FAILED();
-error PAIRING_FAILED();
-error BATCH_ACCUMULATION_FAILED();
-error MODEXP_FAILED();
-
 contract HonkVerifier is IVerifier {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                    SLAB ALLOCATION                         */
@@ -525,17 +520,24 @@ contract HonkVerifier is IVerifier {
         0x00000000000000000000000000000000000000000000000000000000000013b0;
 
     // Constants for computing public input delta
-    uint256 constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
+    uint256 internal constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         ERRORS                             */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-    uint256 internal constant PUBLIC_INPUT_TOO_LARGE_SELECTOR = 0x803bff7c;
-    uint256 internal constant SUMCHECK_FAILED_SELECTOR = 0x7d06dd7fa;
-    uint256 internal constant PAIRING_FAILED_SELECTOR = 0xd71fd2634;
-    uint256 internal constant BATCH_ACCUMULATION_FAILED_SELECTOR = 0xfef01a9a4;
-    uint256 internal constant MODEXP_FAILED_SELECTOR = 0xf442f1632;
-    uint256 internal constant PROOF_POINT_NOT_ON_CURVE_SELECTOR = 0x661e012dec;
+    // The errors match Errors.sol
+
+    bytes4 internal constant VALUE_GE_LIMB_MAX_SELECTOR = 0xeb73e0bd;
+    bytes4 internal constant VALUE_GE_GROUP_ORDER_SELECTOR = 0x607be13e;
+    bytes4 internal constant VALUE_GE_FIELD_ORDER_SELECTOR = 0x20a33589;
+    bytes4 internal constant SUMCHECK_FAILED_SELECTOR = 0x9fc3a218;
+    bytes4 internal constant SHPLEMINI_FAILED_SELECTOR = 0xa5d82e8a;
+    bytes4 internal constant POINT_AT_INFINITY_SELECTOR = 0x4ddaa5e5;
+
+    bytes4 internal constant PROOF_LENGTH_WRONG_WITH_LOG_N_SELECTOR = 0x59895a53;
+    bytes4 internal constant PUBLIC_INPUTS_LENGTH_WRONG_SELECTOR = 0xfa066593;
+
+    bytes4 internal constant MODEXP_FAILED_SELECTOR = 0xf442f163;
 
     constructor() {}
 
@@ -623,6 +625,41 @@ contract HonkVerifier is IVerifier {
                 let proof_ptr := add(calldataload(0x04), 0x24)
 
                 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+                /*              VALIDATE INPUT LENGTHS                      */
+                /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+                // Validate proof byte length matches expected size for this circuit's LOG_N.
+                // Expected = (8*2 + LOG_N*BATCHED_RELATION_PARTIAL_LENGTH + NUMBER_OF_ENTITIES
+                //             + (LOG_N-1)*2 + LOG_N + 2*2 + PAIRING_POINTS_SIZE) * 32
+                {
+                    let expected_proof_size := mul(
+                        add(
+                            add(
+                                add(16, mul(LOG_N, BATCHED_RELATION_PARTIAL_LENGTH)),
+                                add(NUMBER_OF_ENTITIES, mul(sub(LOG_N, 1), 2))
+                            ),
+                            add(add(LOG_N, 4), PAIRING_POINTS_SIZE)
+                        ),
+                        32
+                    )
+                    let proof_length := calldataload(add(calldataload(0x04), 0x04))
+                    if iszero(eq(proof_length, expected_proof_size)) {
+                        mstore(0x00, PROOF_LENGTH_WRONG_WITH_LOG_N_SELECTOR)
+                        mstore(0x04, LOG_N)
+                        mstore(0x24, proof_length)
+                        mstore(0x44, expected_proof_size)
+                        revert(0x00, 0x64)
+                    }
+                }
+                // Validate public inputs array length matches expected count.
+                {
+                    let pi_count := calldataload(add(calldataload(0x24), 0x04))
+                    if iszero(eq(pi_count, REAL_NUMBER_PUBLIC_INPUTS)) {
+                        mstore(0x00, PUBLIC_INPUTS_LENGTH_WRONG_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
+                }
+
+                /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
                 /*                    GENERATE CHALLENGES                     */
                 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
                 /*
@@ -687,9 +724,87 @@ contract HonkVerifier is IVerifier {
                 // We copy the entire proof into memory as we must hash each proof section for challenge
                 // evaluation
                 // The last item in the proof, and the first item in the proof (pairing point 0)
-                let proof_size := sub(ETA_CHALLENGE, PAIRING_POINT_0)
+                let proof_size := sub(ETA_CHALLENGE, PAIRING_POINT_0_X_0_LOC)
 
-                calldatacopy(PAIRING_POINT_0, proof_ptr, proof_size)
+                calldatacopy(PAIRING_POINT_0_X_0_LOC, proof_ptr, proof_size)
+
+                /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+                /*               VALIDATE PROOF INPUTS                      */
+                /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+                // Validate all proof elements are within their expected ranges.
+                // Pairing limbs: lo < 2^136, hi < 2^120. G1 coordinates < Q. Fr elements < P.
+                {
+                    let valid := true
+                    let lo_limb_max := shl(136, 1)
+                    let hi_limb_max := shl(120, 1)
+                    let q_mod := Q
+
+                    // 1. Pairing limbs: lo < 2^136, hi < 2^120 (4 pairs, stride 0x40)
+                    let ptr := PAIRING_POINT_0_X_0_LOC
+                    for {} lt(ptr, W_L_X_LOC) { ptr := add(ptr, 0x40) } {
+                        valid := and(valid, lt(mload(ptr), lo_limb_max))
+                        valid := and(valid, lt(mload(add(ptr, 0x20)), hi_limb_max))
+                    }
+                    if iszero(valid) {
+                        mstore(0x00, VALUE_GE_LIMB_MAX_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
+
+                    // 2. G1 coordinates: each < Q
+                    //    - Witness commitments: W_L through Z_PERM (16 slots)
+                    for { ptr := W_L_X_LOC } lt(ptr, SUMCHECK_UNIVARIATE_0_0_LOC) { ptr := add(ptr, 0x20) } {
+                        valid := and(valid, lt(mload(ptr), q_mod))
+                    }
+                    //    - Gemini fold commitments (28 slots)
+                    for { ptr := GEMINI_FOLD_UNIVARIATE_0_X_LOC } lt(ptr, GEMINI_A_EVAL_0) { ptr := add(ptr, 0x20) } {
+                        valid := and(valid, lt(mload(ptr), q_mod))
+                    }
+                    //    - Shplonk Q + KZG quotient (4 slots)
+                    for { ptr := SHPLONK_Q_X_LOC } lt(ptr, ETA_CHALLENGE) { ptr := add(ptr, 0x20) } {
+                        valid := and(valid, lt(mload(ptr), q_mod))
+                    }
+                    if iszero(valid) {
+                        mstore(0x00, VALUE_GE_GROUP_ORDER_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
+
+                    // 2b. G1 points: reject point at infinity (0,0).
+                    //     EVM precompiles silently treat (0,0) as the identity element,
+                    //     which could zero out commitments. On-curve validation (y² = x³ + 3)
+                    //     is handled by the ecAdd/ecMul precompiles per EIP-196.
+                    //    - Witness commitments (8 points, stride 0x40)
+                    for { ptr := W_L_X_LOC } lt(ptr, SUMCHECK_UNIVARIATE_0_0_LOC) { ptr := add(ptr, 0x40) } {
+                        valid := and(valid, iszero(iszero(or(mload(ptr), mload(add(ptr, 0x20))))))
+                    }
+                    //    - Gemini fold commitments (14 points, stride 0x40)
+                    for { ptr := GEMINI_FOLD_UNIVARIATE_0_X_LOC } lt(ptr, GEMINI_A_EVAL_0) { ptr := add(ptr, 0x40) } {
+                        valid := and(valid, iszero(iszero(or(mload(ptr), mload(add(ptr, 0x20))))))
+                    }
+                    //    - Shplonk Q + KZG quotient (2 points, stride 0x40)
+                    for { ptr := SHPLONK_Q_X_LOC } lt(ptr, ETA_CHALLENGE) { ptr := add(ptr, 0x40) } {
+                        valid := and(valid, iszero(iszero(or(mload(ptr), mload(add(ptr, 0x20))))))
+                    }
+                    if iszero(valid) {
+                        mstore(0x00, POINT_AT_INFINITY_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
+
+                    // 3. Fr elements: each < P
+                    //    - Sumcheck univariates + evaluations (161 slots)
+                    for { ptr := SUMCHECK_UNIVARIATE_0_0_LOC } lt(ptr, GEMINI_FOLD_UNIVARIATE_0_X_LOC) {
+                        ptr := add(ptr, 0x20)
+                    } {
+                        valid := and(valid, lt(mload(ptr), p))
+                    }
+                    //    - Gemini evaluations (15 slots)
+                    for { ptr := GEMINI_A_EVAL_0 } lt(ptr, SHPLONK_Q_X_LOC) { ptr := add(ptr, 0x20) } {
+                        valid := and(valid, lt(mload(ptr), p))
+                    }
+                    if iszero(valid) {
+                        mstore(0x00, VALUE_GE_FIELD_ORDER_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
+                }
 
                 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
                 /*             GENERATE BETA and GAMMAA  CHALLENGE            */
@@ -959,11 +1074,17 @@ contract HonkVerifier is IVerifier {
                     denominator_acc := addmod(denominator_acc, sub(p_clone, beta), p_clone)
                 }
 
+                // Revert if not all public inputs are field elements (i.e. < p)
+                if iszero(valid_inputs) {
+                    mstore(0x00, VALUE_GE_FIELD_ORDER_SELECTOR)
+                    revert(0x00, 0x04)
+                }
+
                 /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
                 /*           PUBLIC INPUT DELTA - Pairing points accum        */
                 /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
                 // Pairing points contribution to public inputs delta
-                let pairing_points_ptr := PAIRING_POINT_0
+                let pairing_points_ptr := PAIRING_POINT_0_X_0_LOC
                 for {} lt(pairing_points_ptr, W_L_X_LOC) { pairing_points_ptr := add(pairing_points_ptr, 0x20) } {
                     let input := mload(pairing_points_ptr)
 
@@ -972,12 +1093,6 @@ contract HonkVerifier is IVerifier {
 
                     numerator_acc := addmod(numerator_acc, beta, p_clone)
                     denominator_acc := addmod(denominator_acc, sub(p_clone, beta), p_clone)
-                }
-
-                // Revert if not all public inputs are field elements (i.e. < p)
-                if iszero(valid_inputs) {
-                    mstore(0x00, PUBLIC_INPUT_TOO_LARGE_SELECTOR)
-                    revert(0x00, 0x04)
                 }
 
                 mstore(PUBLIC_INPUTS_DELTA_NUMERATOR_CHALLENGE, numerator_value)
@@ -2360,7 +2475,7 @@ contract HonkVerifier is IVerifier {
 
                 if iszero(sumcheck_valid) {
                     mstore(0x00, SUMCHECK_FAILED_SELECTOR)
-                    return(0x00, 0x20)
+                    revert(0x00, 0x04)
                 }
             }
 
@@ -2472,8 +2587,6 @@ contract HonkVerifier is IVerifier {
 
             /// {{ UNROLL_SECTION_START COLLECT_INVERSES }}
             /// {{ UNROLL_SECTION_END COLLECT_INVERSES }}
-
-            let inverted_gemini_r := accumulator
 
             let unshifted_scalar := 0
             let shifted_scalar := 0
@@ -2850,7 +2963,6 @@ contract HonkVerifier is IVerifier {
                 mstore(SS_GEMINI_EVALS_LOC, GEMINI_A_EVAL_1)
                 let fold_pos_evals_loc := FOLD_POS_EVALUATIONS_1_LOC
 
-                let shplonk_z := mload(SHPLONK_Z_CHALLENGE)
                 let scalars_loc := BATCH_SCALAR_37_LOC
 
                 for { let i := 0 } lt(i, sub(LOG_N, 1)) { i := add(i, 1) } {
@@ -2886,16 +2998,6 @@ contract HonkVerifier is IVerifier {
                 // WORKTODO(md): we can ignore this accumulation as we are multiplying by 1,
                 // Just set the accumulator instead.
                 mstore(SCALAR_LOCATION, 0x1)
-                {
-                    let x := mload(SHPLONK_Q_X_LOC)
-                    let y := mload(SHPLONK_Q_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 mcopy(G1_LOCATION, SHPLONK_Q_X_LOC, 0x40)
                 precomp_success_flag := staticcall(gas(), 7, G1_LOCATION, 0x60, ACCUMULATOR, 0x40)
             }
@@ -3239,17 +3341,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(W_L_X_LOC)
-                    let y := mload(W_L_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
-
                 // Accumulate proof points
                 // Accumulator = accumulator + scalar[29] * w_l
                 mcopy(G1_LOCATION, W_L_X_LOC, 0x40)
@@ -3263,17 +3354,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(W_R_X_LOC)
-                    let y := mload(W_R_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
-
                 // Accumulator = accumulator + scalar[30] * w_r
                 mcopy(G1_LOCATION, W_R_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_30_LOC))
@@ -3285,17 +3365,6 @@ contract HonkVerifier is IVerifier {
                     precomp_success_flag,
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
-
-                {
-                    let x := mload(W_O_X_LOC)
-                    let y := mload(W_O_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
 
                 // Accumulator = accumulator + scalar[31] * w_o
                 mcopy(G1_LOCATION, W_O_X_LOC, 0x40)
@@ -3310,16 +3379,6 @@ contract HonkVerifier is IVerifier {
                 )
 
                 // Accumulator = accumulator + scalar[32] * w_4
-                {
-                    let x := mload(W_4_X_LOC)
-                    let y := mload(W_4_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 mcopy(G1_LOCATION, W_4_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_32_LOC))
                 precomp_success_flag := and(
@@ -3331,16 +3390,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(Z_PERM_X_LOC)
-                    let y := mload(Z_PERM_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 // Accumulator = accumulator + scalar[33] * z_perm
                 mcopy(G1_LOCATION, Z_PERM_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_33_LOC))
@@ -3353,16 +3402,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(LOOKUP_INVERSES_X_LOC)
-                    let y := mload(LOOKUP_INVERSES_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 // Accumulator = accumulator + scalar[34] * lookup_inverses
                 mcopy(G1_LOCATION, LOOKUP_INVERSES_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_34_LOC))
@@ -3375,16 +3414,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(LOOKUP_READ_COUNTS_X_LOC)
-                    let y := mload(LOOKUP_READ_COUNTS_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 // Accumulator = accumulator + scalar[35] * lookup_read_counts
                 mcopy(G1_LOCATION, LOOKUP_READ_COUNTS_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_35_LOC))
@@ -3397,16 +3426,6 @@ contract HonkVerifier is IVerifier {
                     staticcall(gas(), 6, ACCUMULATOR, 0x80, ACCUMULATOR, 0x40)
                 )
 
-                {
-                    let x := mload(LOOKUP_READ_TAGS_X_LOC)
-                    let y := mload(LOOKUP_READ_TAGS_Y_LOC)
-                    let xx := mulmod(x, x, q)
-                    // validate on curve
-                    precomp_success_flag := and(
-                        eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                        precomp_success_flag
-                    )
-                }
                 // Accumulator = accumulator + scalar[36] * lookup_read_tags
                 mcopy(G1_LOCATION, LOOKUP_READ_TAGS_X_LOC, 0x40)
                 mstore(SCALAR_LOCATION, mload(BATCH_SCALAR_36_LOC))
@@ -3444,16 +3463,6 @@ contract HonkVerifier is IVerifier {
 
                     // Accumlate final quotient commitment into shplonk check
                     // Accumulator = accumulator + shplonkZ * quotient commitment
-                    {
-                        let x := mload(KZG_QUOTIENT_X_LOC)
-                        let y := mload(KZG_QUOTIENT_Y_LOC)
-                        let xx := mulmod(x, x, q)
-                        // validate on curve
-                        precomp_success_flag := and(
-                            eq(mulmod(y, y, q), addmod(mulmod(x, xx, q), 3, q)),
-                            precomp_success_flag
-                        )
-                    }
                     mcopy(G1_LOCATION, KZG_QUOTIENT_X_LOC, 0x40)
 
                     mstore(SCALAR_LOCATION, mload(SHPLONK_Z_CHALLENGE))
@@ -3467,8 +3476,10 @@ contract HonkVerifier is IVerifier {
                     )
                 }
 
+                // All G1 points were validated on-curve during input validation.
+                // precomp_success_flag now only tracks ecAdd/ecMul precompile success.
                 if iszero(precomp_success_flag) {
-                    mstore(0x00, BATCH_ACCUMULATION_FAILED_SELECTOR)
+                    mstore(0x00, SHPLEMINI_FAILED_SELECTOR)
                     revert(0x00, 0x04)
                 }
 
@@ -3493,31 +3504,31 @@ contract HonkVerifier is IVerifier {
                     /*                   PAIRING AGGREGATION                      */
                     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
                     // Read the pairing encoded in the first 8 field elements of the proof (2 limbs per coordinate)
-                    let p0_other_x := mload(PAIRING_POINT_0)
-                    p0_other_x := or(shl(136, mload(PAIRING_POINT_1)), p0_other_x)
+                    let p0_other_x := mload(PAIRING_POINT_0_X_0_LOC)
+                    p0_other_x := or(shl(136, mload(PAIRING_POINT_0_X_1_LOC)), p0_other_x)
 
-                    let p0_other_y := mload(PAIRING_POINT_2)
-                    p0_other_y := or(shl(136, mload(PAIRING_POINT_3)), p0_other_y)
+                    let p0_other_y := mload(PAIRING_POINT_0_Y_0_LOC)
+                    p0_other_y := or(shl(136, mload(PAIRING_POINT_0_Y_1_LOC)), p0_other_y)
 
-                    let p1_other_x := mload(PAIRING_POINT_4)
-                    p1_other_x := or(shl(136, mload(PAIRING_POINT_5)), p1_other_x)
+                    let p1_other_x := mload(PAIRING_POINT_1_X_0_LOC)
+                    p1_other_x := or(shl(136, mload(PAIRING_POINT_1_X_1_LOC)), p1_other_x)
 
-                    let p1_other_y := mload(PAIRING_POINT_6)
-                    p1_other_y := or(shl(136, mload(PAIRING_POINT_7)), p1_other_y)
+                    let p1_other_y := mload(PAIRING_POINT_1_Y_0_LOC)
+                    p1_other_y := or(shl(136, mload(PAIRING_POINT_1_Y_1_LOC)), p1_other_y)
 
-                    // Validate p_0_other on curve
-                    let xx := mulmod(p0_other_x, p0_other_x, q)
-                    let xxx := mulmod(xx, p0_other_x, q)
-                    let yy := mulmod(p0_other_y, p0_other_y, q)
+                    // Reconstructed coordinates must be < Q to prevent malleability
+                    if iszero(and(
+                        and(lt(p0_other_x, q), lt(p0_other_y, q)),
+                        and(lt(p1_other_x, q), lt(p1_other_y, q))
+                    )) {
+                        mstore(0x00, VALUE_GE_GROUP_ORDER_SELECTOR)
+                        revert(0x00, 0x04)
+                    }
 
-                    let success := eq(yy, addmod(xxx, 3, q))
-
-                    // Validate p_1_other on curve
-                    xx := mulmod(p1_other_x, p1_other_x, q)
-                    xxx := mulmod(xx, p1_other_x, q)
-                    yy := mulmod(p1_other_y, p1_other_y, q)
-
-                    success := and(success, eq(yy, addmod(xxx, 3, q)))
+                    // Validate p_0_other not point of infinity
+                    let success := iszero(iszero(or(p0_other_x, p0_other_y)))
+                    // Validate p_1_other not point of infinity
+                    success := and(success, iszero(iszero(or(p1_other_x, p1_other_y))))
 
                     // p_0
                     mstore(0x00, p0_other_x)
@@ -3569,7 +3580,7 @@ contract HonkVerifier is IVerifier {
 
                     let pairing_success := and(success, staticcall(gas(), 8, 0x00, 0x180, 0x00, 0x20))
                     if iszero(and(pairing_success, mload(0x00))) {
-                        mstore(0x00, PAIRING_FAILED_SELECTOR)
+                        mstore(0x00, SHPLEMINI_FAILED_SELECTOR)
                         revert(0x00, 0x04)
                     }
 

--- a/barretenberg/sol/.solhint.json
+++ b/barretenberg/sol/.solhint.json
@@ -1,0 +1,44 @@
+{
+    "extends": "solhint:recommended",
+    "rules": {
+        "one-contract-per-file": "off",
+        "no-inline-assembly": "off",
+        "import-path-check": "off",
+        "not-rely-on-time": "off",
+        "private-vars-no-leading-underscore": "error",
+        "func-param-name-leading-underscore": "error",
+        "no-global-import": "error",
+        "interface-starts-with-i": "error",
+        "immutable-vars-naming": [
+            "warn",
+            {
+                "immutablesAsConstants": true
+            }
+        ],
+        "compiler-version": [
+            "error",
+            ">=0.8.27"
+        ],
+        "func-visibility": [
+            "error",
+            {
+                "ignoreConstructors": true
+            }
+        ],
+        "no-unused-vars": "error",
+        "state-visibility": "error",
+        "var-name-mixedcase": "warn",
+        "func-param-name-mixedcase": "warn",
+        "ordering": "error",
+        "comprehensive-interface": "error",
+        "no-unused-import": "error",
+        "imports-order": "error",
+        "check-send-result": "error",
+        "duplicated-imports": "warn",
+        "gas-custom-errors": "warn",
+        "named-parameters-mapping": "warn",
+        "gas-struct-packing": "warn",
+        "no-empty-blocks": "warn",
+        "private-func-leading-underscore": "warn"
+    }
+}

--- a/barretenberg/sol/bootstrap.sh
+++ b/barretenberg/sol/bootstrap.sh
@@ -70,7 +70,7 @@ function bench {
   # Run forge test with gas report using JSON flag
   echo "Running gas report for verifier contracts..."
   # Do not include foundry std err messages in the output
-  FORGE_GAS_REPORT=true forge test --no-match-contract Base --json 2>&1 | grep -v "non-empty stderr" > gas_report.json
+  FORGE_GAS_REPORT=true forge test --no-match-contract Base --mt "(testValidProof|test_ValidProof)" --json 2>&1 | grep -v "non-empty stderr" > gas_report.json
 
   # Check if we got any output
   if [ ! -s gas_report.json ]; then

--- a/barretenberg/sol/foundry.toml
+++ b/barretenberg/sol/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 src = 'src'
 out = 'out'
+test = 'test'
 libs = ['lib']
 ffi = true
 optimizer_runs = 1

--- a/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
+++ b/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
@@ -25,7 +25,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Define paths relative to the barretenberg directory
 BARRETENBERG_DIR="$REPO_ROOT/barretenberg"
-SOL_SRC_FILE="$BARRETENBERG_DIR/sol/src/honk/optimised/honk-optimized.sol"
+SOL_SRC_FILE="$BARRETENBERG_DIR/sol/src/honk/instance/BlakeHonkOpt.sol"
 CPP_FILE="$BARRETENBERG_DIR/cpp/src/barretenberg/dsl/acir_proofs/honk_optimized_contract.hpp"
 
 # Check if source file exists

--- a/barretenberg/sol/scripts/sync_blake_opt_vk.sh
+++ b/barretenberg/sol/scripts/sync_blake_opt_vk.sh
@@ -8,7 +8,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VK_FILE="$SCRIPT_DIR/../src/honk/keys/BlakeHonkVerificationKey.sol"
-OPT_FILE="$SCRIPT_DIR/../src/honk/optimised/honk-optimized.sol"
+OPT_FILE="$SCRIPT_DIR/../src/honk/instance/BlakeHonkOpt.sol"
 TEMPLATE_FILE="$SCRIPT_DIR/../src/honk/optimised/honk-optimized.sol.template"
 
 if [ ! -f "$VK_FILE" ]; then

--- a/barretenberg/sol/src/honk/BaseHonkVerifier.sol
+++ b/barretenberg/sol/src/honk/BaseHonkVerifier.sol
@@ -1,39 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../interfaces/IVerifier.sol";
+import {IVerifier} from "./../interfaces/IVerifier.sol";
+import {CommitmentSchemeLib} from "./CommitmentScheme.sol";
+import {ONE, ZERO, Fr, FrLib} from "./Fr.sol";
 import {
     Honk,
-    WIRE,
     NUMBER_OF_ENTITIES,
-    NUMBER_OF_SUBRELATIONS,
-    NUMBER_OF_ALPHAS,
     NUMBER_UNSHIFTED,
     NUMBER_TO_BE_SHIFTED,
     BATCHED_RELATION_PARTIAL_LENGTH,
     PAIRING_POINTS_SIZE
 } from "./HonkTypes.sol";
-
-import {negateInplace, pairing, validateOnCurve} from "./utils.sol";
-
-// Field arithmetic libraries - prevent littering the code with modmul / addmul
-import {ONE, ZERO, Fr, FrLib} from "./Fr.sol";
-
-import {Transcript, TranscriptLib} from "./Transcript.sol";
-
 import {RelationsLib} from "./Relations.sol";
-
-import {CommitmentSchemeLib} from "./CommitmentScheme.sol";
+import {Transcript, TranscriptLib} from "./Transcript.sol";
+import {negateInplace, pairing, rejectPointAtInfinity} from "./utils.sol";
 import {generateRecursionSeparator, convertPairingPointsToG1, mulWithSeperator} from "./utils.sol";
+import {Errors} from "./Errors.sol";
 
 abstract contract BaseHonkVerifier is IVerifier {
     using FrLib for Fr;
 
-    uint256 immutable $N;
-    uint256 immutable $LOG_N;
-    uint256 immutable $VK_HASH;
-    uint256 immutable $NUM_PUBLIC_INPUTS;
+    // Constants for proof length calculation (matching UltraKeccakFlavor)
+    uint256 internal constant NUM_WITNESS_ENTITIES = 8;
+    uint256 internal constant NUM_ELEMENTS_COMM = 2; // uint256 elements for curve points
+    uint256 internal constant NUM_ELEMENTS_FR = 1; // uint256 elements for field elements
+
+    // Number of field elements in a ultra keccak honk proof for log_n = 25, including pairing point object.
+    uint256 internal constant PROOF_SIZE = 350; // Legacy constant - will be replaced by calculateProofSize($LOG_N)
+    uint256 internal constant SHIFTED_COMMITMENTS_START = 29;
+
+    uint256 internal constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
+
+    uint256 internal immutable $N;
+    uint256 internal immutable $LOG_N;
+    uint256 internal immutable $VK_HASH;
+    uint256 internal immutable $NUM_PUBLIC_INPUTS;
 
     constructor(uint256 _N, uint256 _logN, uint256 _vkHash, uint256 _numPublicInputs) {
         $N = _N;
@@ -42,59 +45,19 @@ abstract contract BaseHonkVerifier is IVerifier {
         $NUM_PUBLIC_INPUTS = _numPublicInputs;
     }
 
-    // Errors
-    error ProofLengthWrong();
-    error ProofLengthWrongWithLogN(uint256 logN, uint256 actualLength, uint256 expectedLength);
-    error PublicInputsLengthWrong();
-    error SumcheckFailed();
-    error ShpleminiFailed();
-
-    // Constants for proof length calculation (matching UltraKeccakFlavor)
-    uint256 constant NUM_WITNESS_ENTITIES = 8;
-    uint256 constant NUM_ELEMENTS_COMM = 2; // uint256 elements for curve points
-    uint256 constant NUM_ELEMENTS_FR = 1; // uint256 elements for field elements
-
-    // Calculate proof size based on log_n (matching UltraKeccakFlavor formula)
-    function calculateProofSize(uint256 logN) internal pure returns (uint256) {
-        // Witness commitments
-        uint256 proofLength = NUM_WITNESS_ENTITIES * NUM_ELEMENTS_COMM; // witness commitments
-
-        // Sumcheck
-        proofLength += logN * BATCHED_RELATION_PARTIAL_LENGTH * NUM_ELEMENTS_FR; // sumcheck univariates
-        proofLength += NUMBER_OF_ENTITIES * NUM_ELEMENTS_FR; // sumcheck evaluations
-
-        // Gemini
-        proofLength += (logN - 1) * NUM_ELEMENTS_COMM; // Gemini Fold commitments
-        proofLength += logN * NUM_ELEMENTS_FR; // Gemini evaluations
-
-        // Shplonk and KZG commitments
-        proofLength += NUM_ELEMENTS_COMM * 2; // Shplonk Q and KZG W commitments
-
-        // Pairing points
-        proofLength += PAIRING_POINTS_SIZE; // pairing inputs carried on public inputs
-
-        return proofLength;
-    }
-
-    // Number of field elements in a ultra keccak honk proof for log_n = 25, including pairing point object.
-    uint256 constant PROOF_SIZE = 350; // Legacy constant - will be replaced by calculateProofSize($LOG_N)
-    uint256 constant SHIFTED_COMMITMENTS_START = 29;
-
-    function loadVerificationKey() internal pure virtual returns (Honk.VerificationKey memory);
-
     function verify(bytes calldata proof, bytes32[] calldata publicInputs) public view override returns (bool) {
         // Calculate expected proof size based on $LOG_N
         uint256 expectedProofSize = calculateProofSize($LOG_N);
 
         // Check the received proof is the expected size where each field element is 32 bytes
         if (proof.length != expectedProofSize * 32) {
-            revert ProofLengthWrongWithLogN($LOG_N, proof.length, expectedProofSize * 32);
+            revert Errors.ProofLengthWrongWithLogN($LOG_N, proof.length, expectedProofSize * 32);
         }
 
         Honk.VerificationKey memory vk = loadVerificationKey();
         Honk.Proof memory p = TranscriptLib.loadProof(proof, $LOG_N);
         if (publicInputs.length != vk.publicInputsSize - PAIRING_POINTS_SIZE) {
-            revert PublicInputsLengthWrong();
+            revert Errors.PublicInputsLengthWrong();
         }
 
         // Generate the fiat shamir challenges for the whole protocol
@@ -113,15 +76,13 @@ abstract contract BaseHonkVerifier is IVerifier {
 
         // Sumcheck
         bool sumcheckVerified = verifySumcheck(p, t);
-        if (!sumcheckVerified) revert SumcheckFailed();
+        if (!sumcheckVerified) revert Errors.SumcheckFailed();
 
         bool shpleminiVerified = verifyShplemini(p, vk, t);
-        if (!shpleminiVerified) revert ShpleminiFailed();
+        if (!shpleminiVerified) revert Errors.ShpleminiFailed();
 
         return sumcheckVerified && shpleminiVerified; // Boolean condition not required - nice for vanity :)
     }
-
-    uint256 constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
 
     function computePublicInputDelta(
         bytes32[] memory publicInputs,
@@ -170,7 +131,7 @@ abstract contract BaseHonkVerifier is IVerifier {
         for (uint256 round = 0; round < $LOG_N; ++round) {
             Fr[BATCHED_RELATION_PARTIAL_LENGTH] memory roundUnivariate = proof.sumcheckUnivariates[round];
             bool valid = checkSum(roundUnivariate, roundTarget);
-            if (!valid) revert SumcheckFailed();
+            if (!valid) revert Errors.SumcheckFailed();
 
             Fr roundChallenge = tp.sumCheckUChallenges[round];
 
@@ -184,15 +145,6 @@ abstract contract BaseHonkVerifier is IVerifier {
             proof.sumcheckEvaluations, tp.relationParameters, tp.alphas, powPartialEvaluation
         );
         verified = (grandHonkRelationSum == roundTarget);
-    }
-
-    function checkSum(Fr[BATCHED_RELATION_PARTIAL_LENGTH] memory roundUnivariate, Fr roundTarget)
-        internal
-        pure
-        returns (bool checked)
-    {
-        Fr totalSum = roundUnivariate[0] + roundUnivariate[1];
-        checked = totalSum == roundTarget;
     }
 
     // Return the new target sum for the next sumcheck round
@@ -239,16 +191,6 @@ abstract contract BaseHonkVerifier is IVerifier {
 
         // Scale the sum by the value of B(x)
         targetSum = targetSum * numeratorValue;
-    }
-
-    // Univariate evaluation of the monomial ((1-X_l) + X_l.B_l) at the challenge point X_l=u_l
-    function partiallyEvaluatePOW(Fr gateChallenge, Fr currentEvaluation, Fr roundChallenge)
-        internal
-        pure
-        returns (Fr newEvaluation)
-    {
-        Fr univariateEval = ONE + (roundChallenge * (gateChallenge - ONE));
-        newEvaluation = currentEvaluation * univariateEval;
     }
 
     function verifyShplemini(Honk.Proof memory proof, Honk.VerificationKey memory vk, Transcript memory tp)
@@ -449,8 +391,8 @@ abstract contract BaseHonkVerifier is IVerifier {
             convertPairingPointsToG1(proof.pairingPointObject);
 
         // Validate the points from the proof are on the curve
-        validateOnCurve(P_0_other);
-        validateOnCurve(P_1_other);
+        rejectPointAtInfinity(P_0_other);
+        rejectPointAtInfinity(P_1_other);
 
         // accumulate with aggregate points in proof
         P_0_agg = mulWithSeperator(P_0_agg, P_0_other, recursionSeparator);
@@ -468,7 +410,7 @@ abstract contract BaseHonkVerifier is IVerifier {
 
         // Validate all points are on the curve
         for (uint256 i = 0; i < limit; ++i) {
-            validateOnCurve(base[i]);
+            rejectPointAtInfinity(base[i]);
         }
 
         bool success = true;
@@ -496,6 +438,49 @@ abstract contract BaseHonkVerifier is IVerifier {
             mstore(add(result, 0x20), mload(add(free, 0x20)))
         }
 
-        require(success, ShpleminiFailed());
+        require(success, Errors.ShpleminiFailed());
     }
+
+    // Calculate proof size based on log_n (matching UltraKeccakFlavor formula)
+    function calculateProofSize(uint256 logN) internal pure returns (uint256) {
+        // Witness commitments
+        uint256 proofLength = NUM_WITNESS_ENTITIES * NUM_ELEMENTS_COMM; // witness commitments
+
+        // Sumcheck
+        proofLength += logN * BATCHED_RELATION_PARTIAL_LENGTH * NUM_ELEMENTS_FR; // sumcheck univariates
+        proofLength += NUMBER_OF_ENTITIES * NUM_ELEMENTS_FR; // sumcheck evaluations
+
+        // Gemini
+        proofLength += (logN - 1) * NUM_ELEMENTS_COMM; // Gemini Fold commitments
+        proofLength += logN * NUM_ELEMENTS_FR; // Gemini evaluations
+
+        // Shplonk and KZG commitments
+        proofLength += NUM_ELEMENTS_COMM * 2; // Shplonk Q and KZG W commitments
+
+        // Pairing points
+        proofLength += PAIRING_POINTS_SIZE; // pairing inputs carried on public inputs
+
+        return proofLength;
+    }
+
+    function checkSum(Fr[BATCHED_RELATION_PARTIAL_LENGTH] memory roundUnivariate, Fr roundTarget)
+        internal
+        pure
+        returns (bool checked)
+    {
+        Fr totalSum = roundUnivariate[0] + roundUnivariate[1];
+        checked = totalSum == roundTarget;
+    }
+
+    // Univariate evaluation of the monomial ((1-X_l) + X_l.B_l) at the challenge point X_l=u_l
+    function partiallyEvaluatePOW(Fr gateChallenge, Fr currentEvaluation, Fr roundChallenge)
+        internal
+        pure
+        returns (Fr newEvaluation)
+    {
+        Fr univariateEval = ONE + (roundChallenge * (gateChallenge - ONE));
+        newEvaluation = currentEvaluation * univariateEval;
+    }
+
+    function loadVerificationKey() internal pure virtual returns (Honk.VerificationKey memory);
 }

--- a/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
+++ b/barretenberg/sol/src/honk/BaseZKHonkVerifier.sol
@@ -1,44 +1,68 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../interfaces/IVerifier.sol";
+import {IVerifier} from "./../interfaces/IVerifier.sol";
+import {CommitmentSchemeLib} from "./CommitmentScheme.sol";
+import {SUBGROUP_GENERATOR, SUBGROUP_GENERATOR_INVERSE, SUBGROUP_SIZE, Fr, FrLib} from "./Fr.sol";
 import {
     Honk,
-    WIRE,
     NUMBER_OF_ENTITIES,
     NUMBER_OF_ENTITIES_ZK,
     NUM_MASKING_POLYNOMIALS,
-    NUMBER_OF_SUBRELATIONS,
-    NUMBER_OF_ALPHAS,
-    NUMBER_UNSHIFTED,
     NUMBER_UNSHIFTED_ZK,
     NUMBER_TO_BE_SHIFTED,
     ZK_BATCHED_RELATION_PARTIAL_LENGTH,
     CONST_PROOF_SIZE_LOG_N,
     PAIRING_POINTS_SIZE
 } from "./HonkTypes.sol";
-
-import {negateInplace, pairing} from "./utils.sol";
-
-// Field arithmetic libraries - prevent littering the code with modmul / addmul
-import {SUBGROUP_GENERATOR, SUBGROUP_GENERATOR_INVERSE, SUBGROUP_SIZE, Fr, FrLib} from "./Fr.sol";
-
-import {ZKTranscript, ZKTranscriptLib} from "./ZKTranscript.sol";
-
 import {RelationsLib} from "./Relations.sol";
-
-import {CommitmentSchemeLib} from "./CommitmentScheme.sol";
-import {generateRecursionSeparator, convertPairingPointsToG1, mulWithSeperator, validateOnCurve} from "./utils.sol";
+import {negateInplace, pairing} from "./utils.sol";
+import {
+    generateRecursionSeparator,
+    convertPairingPointsToG1,
+    mulWithSeperator,
+    rejectPointAtInfinity
+} from "./utils.sol";
+import {ZKTranscript, ZKTranscriptLib} from "./ZKTranscript.sol";
+import {Errors} from "./Errors.sol";
 
 abstract contract BaseZKHonkVerifier is IVerifier {
     using FrLib for Fr;
 
-    uint256 immutable $N;
-    uint256 immutable $LOG_N;
-    uint256 immutable $VK_HASH;
-    uint256 immutable $NUM_PUBLIC_INPUTS;
-    uint256 immutable $MSMSize;
+    struct PairingInputs {
+        Honk.G1Point P_0;
+        Honk.G1Point P_1;
+    }
+
+    struct SmallSubgroupIpaIntermediates {
+        Fr[SUBGROUP_SIZE] challengePolyLagrange;
+        Fr challengePolyEval;
+        Fr lagrangeFirst;
+        Fr lagrangeLast;
+        Fr rootPower;
+        Fr[SUBGROUP_SIZE] denominators; // this has to disappear
+        Fr diff;
+    }
+
+    // Constants for proof length calculation (matching UltraKeccakZKFlavor)
+    uint256 internal constant NUM_WITNESS_ENTITIES = 8 + NUM_MASKING_POLYNOMIALS;
+    uint256 internal constant NUM_ELEMENTS_COMM = 2; // uint256 elements for curve points
+    uint256 internal constant NUM_ELEMENTS_FR = 1; // uint256 elements for field elements
+    uint256 internal constant NUM_LIBRA_EVALUATIONS = 4; // libra evaluations
+
+    uint256 internal constant LIBRA_COMMITMENTS = 3;
+    uint256 internal constant LIBRA_EVALUATIONS = 4;
+    uint256 internal constant LIBRA_UNIVARIATES_LENGTH = 9;
+
+    uint256 internal constant SHIFTED_COMMITMENTS_START = 30;
+    uint256 internal constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
+
+    uint256 internal immutable $N;
+    uint256 internal immutable $LOG_N;
+    uint256 internal immutable $VK_HASH;
+    uint256 internal immutable $NUM_PUBLIC_INPUTS;
+    uint256 internal immutable $MSMSize;
 
     constructor(uint256 _N, uint256 _logN, uint256 _vkHash, uint256 _numPublicInputs) {
         $N = _N;
@@ -47,50 +71,6 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         $NUM_PUBLIC_INPUTS = _numPublicInputs;
         $MSMSize = NUMBER_UNSHIFTED_ZK + _logN + LIBRA_COMMITMENTS + 2;
     }
-
-    // Errors
-    error ProofLengthWrong();
-    error ProofLengthWrongWithLogN(uint256 logN, uint256 actualLength, uint256 expectedLength);
-    error PublicInputsLengthWrong();
-    error SumcheckFailed();
-    error ShpleminiFailed();
-    error GeminiChallengeInSubgroup();
-    error ConsistencyCheckFailed();
-
-    // Constants for proof length calculation (matching UltraKeccakZKFlavor)
-    uint256 constant NUM_WITNESS_ENTITIES = 8 + NUM_MASKING_POLYNOMIALS;
-    uint256 constant NUM_ELEMENTS_COMM = 2; // uint256 elements for curve points
-    uint256 constant NUM_ELEMENTS_FR = 1; // uint256 elements for field elements
-    uint256 constant NUM_LIBRA_EVALUATIONS = 4; // libra evaluations
-
-    // Calculate proof size based on log_n (matching UltraKeccakZKFlavor formula)
-    function calculateProofSize(uint256 logN) internal pure returns (uint256) {
-        // Witness and Libra commitments
-        uint256 proofLength = NUM_WITNESS_ENTITIES * NUM_ELEMENTS_COMM; // witness commitments
-        proofLength += NUM_ELEMENTS_COMM * 3; // Libra concat, grand sum, quotient comms + Gemini masking
-
-        // Sumcheck
-        proofLength += logN * ZK_BATCHED_RELATION_PARTIAL_LENGTH * NUM_ELEMENTS_FR; // sumcheck univariates
-        proofLength += NUMBER_OF_ENTITIES_ZK * NUM_ELEMENTS_FR; // sumcheck evaluations
-
-        // Libra and Gemini
-        proofLength += NUM_ELEMENTS_FR * 2; // Libra sum, claimed eval
-        proofLength += logN * NUM_ELEMENTS_FR; // Gemini a evaluations
-        proofLength += NUM_LIBRA_EVALUATIONS * NUM_ELEMENTS_FR; // libra evaluations
-
-        // PCS commitments
-        proofLength += (logN - 1) * NUM_ELEMENTS_COMM; // Gemini Fold commitments
-        proofLength += NUM_ELEMENTS_COMM * 2; // Shplonk Q and KZG W commitments
-
-        // Pairing points
-        proofLength += PAIRING_POINTS_SIZE; // pairing inputs carried on public inputs
-
-        return proofLength;
-    }
-
-    uint256 constant SHIFTED_COMMITMENTS_START = 30;
-
-    function loadVerificationKey() internal pure virtual returns (Honk.VerificationKey memory);
 
     function verify(bytes calldata proof, bytes32[] calldata publicInputs)
         public
@@ -102,16 +82,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         uint256 expectedProofSize = calculateProofSize($LOG_N);
 
         // Check the received proof is the expected size where each field element is 32 bytes
-        if (proof.length != expectedProofSize * 32) {
-            revert ProofLengthWrongWithLogN($LOG_N, proof.length, expectedProofSize * 32);
-        }
+        require(
+            proof.length == expectedProofSize, Errors.ProofLengthWrongWithLogN($LOG_N, proof.length, expectedProofSize)
+        );
 
         Honk.VerificationKey memory vk = loadVerificationKey();
         Honk.ZKProof memory p = ZKTranscriptLib.loadProof(proof, $LOG_N);
 
-        if (publicInputs.length != vk.publicInputsSize - PAIRING_POINTS_SIZE) {
-            revert PublicInputsLengthWrong();
-        }
+        require(publicInputs.length == vk.publicInputsSize - PAIRING_POINTS_SIZE, Errors.PublicInputsLengthWrong());
 
         // Generate the fiat shamir challenges for the whole protocol
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1281): Add pubInputsOffset to VK or remove entirely.
@@ -129,14 +107,11 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         );
 
         // Sumcheck
-        if (!verifySumcheck(p, t)) revert SumcheckFailed();
-
-        if (!verifyShplemini(p, vk, t)) revert ShpleminiFailed();
+        require(verifySumcheck(p, t), Errors.SumcheckFailed());
+        require(verifyShplemini(p, vk, t), Errors.ShpleminiFailed());
 
         verified = true;
     }
-
-    uint256 constant PERMUTATION_ARGUMENT_VALUE_SEPARATOR = 1 << 28;
 
     function computePublicInputDelta(
         bytes32[] memory publicInputs,
@@ -185,7 +160,7 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         for (uint256 round; round < $LOG_N; ++round) {
             Fr[ZK_BATCHED_RELATION_PARTIAL_LENGTH] memory roundUnivariate = proof.sumcheckUnivariates[round];
             Fr totalSum = roundUnivariate[0] + roundUnivariate[1];
-            if (totalSum != roundTargetSum) revert SumcheckFailed();
+            require(totalSum == roundTargetSum, Errors.SumcheckFailed());
 
             Fr roundChallenge = tp.sumCheckUChallenges[round];
 
@@ -257,15 +232,6 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         // Scale the sum by the value of B(x)
         targetSum = targetSum * numeratorValue;
-    }
-
-    uint256 constant LIBRA_COMMITMENTS = 3;
-    uint256 constant LIBRA_EVALUATIONS = 4;
-    uint256 constant LIBRA_UNIVARIATES_LENGTH = 9;
-
-    struct PairingInputs {
-        Honk.G1Point P_0;
-        Honk.G1Point P_1;
     }
 
     function verifyShplemini(Honk.ZKProof memory proof, Honk.VerificationKey memory vk, ZKTranscript memory tp)
@@ -484,9 +450,10 @@ abstract contract BaseZKHonkVerifier is IVerifier {
         commitments[boundary] = Honk.G1Point({x: 1, y: 2});
         scalars[boundary++] = mem.constantTermAccumulator;
 
-        if (!checkEvalsConsistency(proof.libraPolyEvals, tp.geminiR, tp.sumCheckUChallenges, proof.libraEvaluation)) {
-            revert ConsistencyCheckFailed();
-        }
+        require(
+            checkEvalsConsistency(proof.libraPolyEvals, tp.geminiR, tp.sumCheckUChallenges, proof.libraEvaluation),
+            Errors.ConsistencyCheckFailed()
+        );
 
         Honk.G1Point memory quotient_commitment = proof.kzgQuotient;
 
@@ -503,24 +470,14 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             convertPairingPointsToG1(proof.pairingPointObject);
 
         // Validate the points from the proof are on the curve
-        validateOnCurve(P_0_other);
-        validateOnCurve(P_1_other);
+        rejectPointAtInfinity(P_0_other);
+        rejectPointAtInfinity(P_1_other);
 
         // accumulate with aggregate points in proof
         pair.P_0 = mulWithSeperator(pair.P_0, P_0_other, recursionSeparator);
         pair.P_1 = mulWithSeperator(pair.P_1, P_1_other, recursionSeparator);
 
         return pairing(pair.P_0, pair.P_1);
-    }
-
-    struct SmallSubgroupIpaIntermediates {
-        Fr[SUBGROUP_SIZE] challengePolyLagrange;
-        Fr challengePolyEval;
-        Fr lagrangeFirst;
-        Fr lagrangeLast;
-        Fr rootPower;
-        Fr[SUBGROUP_SIZE] denominators; // this has to disappear
-        Fr diff;
     }
 
     function checkEvalsConsistency(
@@ -531,9 +488,7 @@ abstract contract BaseZKHonkVerifier is IVerifier {
     ) internal view returns (bool check) {
         Fr one = Fr.wrap(1);
         Fr vanishingPolyEval = geminiR.pow(SUBGROUP_SIZE) - one;
-        if (vanishingPolyEval == Fr.wrap(0)) {
-            revert GeminiChallengeInSubgroup();
-        }
+        require(vanishingPolyEval != Fr.wrap(0), Errors.GeminiChallengeInSubgroup());
 
         SmallSubgroupIpaIntermediates memory mem;
         mem.challengePolyLagrange[0] = one;
@@ -578,7 +533,7 @@ abstract contract BaseZKHonkVerifier is IVerifier {
 
         // Validate all points are on the curve
         for (uint256 i = 0; i < limit; ++i) {
-            validateOnCurve(base[i]);
+            rejectPointAtInfinity(base[i]);
         }
 
         bool success = true;
@@ -606,6 +561,33 @@ abstract contract BaseZKHonkVerifier is IVerifier {
             mstore(add(result, 0x20), mload(add(free, 0x20)))
         }
 
-        require(success, ShpleminiFailed());
+        require(success, Errors.ShpleminiFailed());
     }
+
+    // Calculate proof size based on log_n (matching UltraKeccakZKFlavor formula)
+    function calculateProofSize(uint256 logN) internal pure returns (uint256) {
+        // Witness and Libra commitments
+        uint256 proofLength = NUM_WITNESS_ENTITIES * NUM_ELEMENTS_COMM; // witness commitments
+        proofLength += NUM_ELEMENTS_COMM * 3; // Libra concat, grand sum, quotient comms + Gemini masking
+
+        // Sumcheck
+        proofLength += logN * ZK_BATCHED_RELATION_PARTIAL_LENGTH * NUM_ELEMENTS_FR; // sumcheck univariates
+        proofLength += NUMBER_OF_ENTITIES_ZK * NUM_ELEMENTS_FR; // sumcheck evaluations
+
+        // Libra and Gemini
+        proofLength += NUM_ELEMENTS_FR * 2; // Libra sum, claimed eval
+        proofLength += logN * NUM_ELEMENTS_FR; // Gemini a evaluations
+        proofLength += NUM_LIBRA_EVALUATIONS * NUM_ELEMENTS_FR; // libra evaluations
+
+        // PCS commitments
+        proofLength += (logN - 1) * NUM_ELEMENTS_COMM; // Gemini Fold commitments
+        proofLength += NUM_ELEMENTS_COMM * 2; // Shplonk Q and KZG W commitments
+
+        // Pairing points
+        proofLength += PAIRING_POINTS_SIZE; // pairing inputs carried on public inputs
+
+        return proofLength * 32;
+    }
+
+    function loadVerificationKey() internal pure virtual returns (Honk.VerificationKey memory);
 }

--- a/barretenberg/sol/src/honk/CommitmentScheme.sol
+++ b/barretenberg/sol/src/honk/CommitmentScheme.sol
@@ -1,21 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../interfaces/IVerifier.sol";
-import {
-    Honk,
-    WIRE,
-    NUMBER_OF_ENTITIES,
-    NUMBER_OF_SUBRELATIONS,
-    NUMBER_OF_ALPHAS,
-    NUMBER_UNSHIFTED,
-    BATCHED_RELATION_PARTIAL_LENGTH,
-    CONST_PROOF_SIZE_LOG_N
-} from "./HonkTypes.sol";
-
-// Field arithmetic libraries - prevent littering the code with modmul / addmul
-import {MODULUS as P, MINUS_ONE, ONE, ZERO, Fr, FrLib} from "./Fr.sol";
+import {ONE, Fr, FrLib} from "./Fr.sol";
+import {CONST_PROOF_SIZE_LOG_N} from "./HonkTypes.sol";
 
 library CommitmentSchemeLib {
     using FrLib for Fr;
@@ -46,16 +34,7 @@ library CommitmentSchemeLib {
         Fr[] foldPosEvaluations;
     }
 
-    function computeSquares(Fr r, uint256 logN) internal pure returns (Fr[] memory) {
-        Fr[] memory squares = new Fr[](logN);
-        squares[0] = r;
-        for (uint256 i = 1; i < logN; ++i) {
-            squares[i] = squares[i - 1].sqr();
-        }
-        return squares;
-    }
     // Compute the evaluations Aₗ(r^{2ˡ}) for l = 0, ..., m-1
-
     function computeFoldPosEvaluations(
         Fr[CONST_PROOF_SIZE_LOG_N] memory sumcheckUChallenges,
         Fr batchedEvalAccumulator,
@@ -77,5 +56,14 @@ library CommitmentSchemeLib {
             foldPosEvaluations[i - 1] = batchedEvalRoundAcc;
         }
         return foldPosEvaluations;
+    }
+
+    function computeSquares(Fr r, uint256 logN) internal pure returns (Fr[] memory) {
+        Fr[] memory squares = new Fr[](logN);
+        squares[0] = r;
+        for (uint256 i = 1; i < logN; ++i) {
+            squares[i] = squares[i - 1].sqr();
+        }
+        return squares;
     }
 }

--- a/barretenberg/sol/src/honk/Errors.sol
+++ b/barretenberg/sol/src/honk/Errors.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+/**
+ * @notice  Library of error codes
+ * @dev     You can run `forge inspect Errors errors` to get the selectors for the optimised verifier
+ */
+library Errors {
+    error ValueGeLimbMax();
+    error ValueGeGroupOrder();
+    error ValueGeFieldOrder();
+
+    error InvertOfZero();
+    error NotPowerOfTwo();
+    error ModExpFailed();
+
+    error ProofLengthWrong();
+    error ProofLengthWrongWithLogN(uint256 logN, uint256 actualLength, uint256 expectedLength);
+    error PublicInputsLengthWrong();
+    error SumcheckFailed();
+    error ShpleminiFailed();
+
+    error PointAtInfinity();
+
+    error ConsistencyCheckFailed();
+    error GeminiChallengeInSubgroup();
+}

--- a/barretenberg/sol/src/honk/Fr.sol
+++ b/barretenberg/sol/src/honk/Fr.sol
@@ -1,5 +1,8 @@
-// TODO: doc
-pragma solidity ^0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Errors} from "./Errors.sol";
 
 type Fr is uint256;
 
@@ -7,8 +10,6 @@ using {add as +} for Fr global;
 using {sub as -} for Fr global;
 using {mul as *} for Fr global;
 
-// Yuck using ^ for exp  - todo maybe make it manual
-using {exp as ^} for Fr global;
 using {notEqual as !=} for Fr global;
 using {equal as ==} for Fr global;
 
@@ -23,26 +24,12 @@ Fr constant ZERO = Fr.wrap(0);
 // Instantiation
 
 library FrLib {
-    function from(uint256 value) internal pure returns (Fr) {
-        unchecked {
-            return Fr.wrap(value % MODULUS);
-        }
-    }
-
-    function fromBytes32(bytes32 value) internal pure returns (Fr) {
-        unchecked {
-            return Fr.wrap(uint256(value) % MODULUS);
-        }
-    }
-
-    function toBytes32(Fr value) internal pure returns (bytes32) {
-        unchecked {
-            return bytes32(Fr.unwrap(value));
-        }
-    }
+    bytes4 internal constant FRLIB_MODEXP_FAILED_SELECTOR = 0xf8d61709;
 
     function invert(Fr value) internal view returns (Fr) {
         uint256 v = Fr.unwrap(value);
+        require(v != 0, Errors.InvertOfZero());
+
         uint256 result;
 
         // Call the modexp precompile to invert in the field
@@ -56,19 +43,20 @@ library FrLib {
             mstore(add(free, 0xa0), MODULUS)
             let success := staticcall(gas(), 0x05, free, 0xc0, 0x00, 0x20)
             if iszero(success) {
-                // TODO: meaningful error
-                revert(0, 0)
+                mstore(0x00, FRLIB_MODEXP_FAILED_SELECTOR)
+                revert(0, 0x04)
             }
             result := mload(0x00)
-            mstore(0x40, add(free, 0x80))
+            mstore(0x40, add(free, 0xc0))
         }
 
         return Fr.wrap(result);
     }
 
-    // TODO: edit other pow, it only works for powers of two
     function pow(Fr base, uint256 v) internal view returns (Fr) {
         uint256 b = Fr.unwrap(base);
+        // Only works for power of 2
+        require(v > 0 && (v & (v - 1)) == 0, Errors.NotPowerOfTwo());
         uint256 result;
 
         // Call the modexp precompile to invert in the field
@@ -82,11 +70,11 @@ library FrLib {
             mstore(add(free, 0xa0), MODULUS)
             let success := staticcall(gas(), 0x05, free, 0xc0, 0x00, 0x20)
             if iszero(success) {
-                // TODO: meaningful error
-                revert(0, 0)
+                mstore(0x00, FRLIB_MODEXP_FAILED_SELECTOR)
+                revert(0, 0x04)
             }
             result := mload(0x00)
-            mstore(0x40, add(free, 0x80))
+            mstore(0x40, add(free, 0xc0))
         }
 
         return Fr.wrap(result);
@@ -116,6 +104,27 @@ library FrLib {
             return Fr.wrap(MODULUS - Fr.unwrap(value));
         }
     }
+
+    function from(uint256 value) internal pure returns (Fr) {
+        unchecked {
+            require(value < MODULUS, Errors.ValueGeFieldOrder());
+            return Fr.wrap(value);
+        }
+    }
+
+    function fromBytes32(bytes32 value) internal pure returns (Fr) {
+        unchecked {
+            uint256 v = uint256(value);
+            require(v < MODULUS, Errors.ValueGeFieldOrder());
+            return Fr.wrap(v);
+        }
+    }
+
+    function toBytes32(Fr value) internal pure returns (bytes32) {
+        unchecked {
+            return bytes32(Fr.unwrap(value));
+        }
+    }
 }
 
 // Free functions
@@ -135,15 +144,6 @@ function sub(Fr a, Fr b) pure returns (Fr) {
     unchecked {
         return Fr.wrap(addmod(Fr.unwrap(a), MODULUS - Fr.unwrap(b), MODULUS));
     }
-}
-
-function exp(Fr base, Fr exponent) pure returns (Fr) {
-    if (Fr.unwrap(exponent) == 0) return Fr.wrap(1);
-    // Implement exponent with a loop as we will overflow otherwise
-    for (uint256 i = 1; i < Fr.unwrap(exponent); i += i) {
-        base = base * base;
-    }
-    return base;
 }
 
 function notEqual(Fr a, Fr b) pure returns (bool) {

--- a/barretenberg/sol/src/honk/HonkTypes.sol
+++ b/barretenberg/sol/src/honk/HonkTypes.sol
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
 import {Fr} from "./Fr.sol";
 

--- a/barretenberg/sol/src/honk/Relations.sol
+++ b/barretenberg/sol/src/honk/Relations.sol
@@ -1,22 +1,96 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {
-    Honk,
-    WIRE,
-    NUMBER_OF_ENTITIES,
-    NUMBER_OF_SUBRELATIONS,
-    NUMBER_OF_ALPHAS,
-    NUMBER_UNSHIFTED,
-    CONST_PROOF_SIZE_LOG_N
-} from "./HonkTypes.sol";
-
-// Field arithmetic libraries
-import {MINUS_ONE, ONE, ZERO, MODULUS as P, Fr, FrLib} from "./Fr.sol";
+import {MINUS_ONE, ONE, ZERO, Fr, FrLib} from "./Fr.sol";
+import {Honk, WIRE, NUMBER_OF_ENTITIES, NUMBER_OF_SUBRELATIONS, NUMBER_OF_ALPHAS} from "./HonkTypes.sol";
 
 library RelationsLib {
+    struct EllipticParams {
+        // Points
+        Fr x_1;
+        Fr y_1;
+        Fr x_2;
+        Fr y_2;
+        Fr y_3;
+        Fr x_3;
+        // push accumulators into memory
+        Fr x_double_identity;
+    }
+
+    // Parameters used within the Memory Relation
+    // A struct is used to work around stack too deep. This relation has alot of variables
+    struct MemParams {
+        Fr memory_record_check;
+        Fr partial_record_check;
+        Fr next_gate_access_type;
+        Fr record_delta;
+        Fr index_delta;
+        Fr adjacent_values_match_if_adjacent_indices_match;
+        Fr adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation;
+        Fr access_check;
+        Fr next_gate_access_type_is_boolean;
+        Fr ROM_consistency_check_identity;
+        Fr RAM_consistency_check_identity;
+        Fr timestamp_delta;
+        Fr RAM_timestamp_check_identity;
+        Fr memory_identity;
+        Fr index_is_monotonically_increasing;
+    }
+
+    // Parameters used within the Non-Native Field Relation
+    // A struct is used to work around stack too deep. This relation has alot of variables
+    struct NnfParams {
+        Fr limb_subproduct;
+        Fr non_native_field_gate_1;
+        Fr non_native_field_gate_2;
+        Fr non_native_field_gate_3;
+        Fr limb_accumulator_1;
+        Fr limb_accumulator_2;
+        Fr nnf_identity;
+    }
+
+    // Big todo for poseidon params, reduce them
+    struct PoseidonExternalParams {
+        Fr s1;
+        Fr s2;
+        Fr s3;
+        Fr s4;
+        Fr u1;
+        Fr u2;
+        Fr u3;
+        Fr u4;
+        Fr t0;
+        Fr t1;
+        Fr t2;
+        Fr t3;
+        Fr v1;
+        Fr v2;
+        Fr v3;
+        Fr v4;
+        Fr q_pos_by_scaling;
+    }
+
+    struct PoseidonInternalParams {
+        Fr u1;
+        Fr u2;
+        Fr u3;
+        Fr u4;
+        Fr u_sum;
+        Fr v1;
+        Fr v2;
+        Fr v3;
+        Fr v4;
+        Fr s1;
+        Fr q_pos_by_scaling;
+    }
+
     Fr internal constant GRUMPKIN_CURVE_B_PARAMETER_NEGATED = Fr.wrap(17); // -(-17)
+    uint256 internal constant NEG_HALF_MODULO_P = 0x183227397098d014dc2822db40c0ac2e9419f4243cdcb848a1f0fac9f8000000;
+
+    // Constants for the Non-native Field relation
+    Fr internal constant LIMB_SIZE = Fr.wrap(uint256(1) << 68);
+    Fr internal constant SUBLIMB_SHIFT = Fr.wrap(uint256(1) << 14);
 
     function accumulateRelationEvaluations(
         Fr[NUMBER_OF_ENTITIES] memory purportedEvaluations,
@@ -50,12 +124,10 @@ library RelationsLib {
         return p[uint256(_wire)];
     }
 
-    uint256 internal constant NEG_HALF_MODULO_P = 0x183227397098d014dc2822db40c0ac2e9419f4243cdcb848a1f0fac9f8000000;
     /**
      * Ultra Arithmetic Relation
      *
      */
-
     function accumulateArithmeticRelation(
         Fr[NUMBER_OF_ENTITIES] memory p,
         Fr[NUMBER_OF_SUBRELATIONS] memory evals,
@@ -242,18 +314,6 @@ library RelationsLib {
         }
     }
 
-    struct EllipticParams {
-        // Points
-        Fr x_1;
-        Fr y_1;
-        Fr x_2;
-        Fr y_2;
-        Fr y_3;
-        Fr x_3;
-        // push accumulators into memory
-        Fr x_double_identity;
-    }
-
     function accumulateEllipticRelation(
         Fr[NUMBER_OF_ENTITIES] memory p,
         Fr[NUMBER_OF_SUBRELATIONS] memory evals,
@@ -320,26 +380,6 @@ library RelationsLib {
             Fr y_double_identity = x1_sqr_mul_3 * (ep.x_1 - ep.x_3) - (ep.y_1 + ep.y_1) * (ep.y_1 + ep.y_3);
             evals[12] = evals[12] + y_double_identity * domainSep * wire(p, WIRE.Q_ELLIPTIC) * q_is_double;
         }
-    }
-
-    // Parameters used within the Memory Relation
-    // A struct is used to work around stack too deep. This relation has alot of variables
-    struct MemParams {
-        Fr memory_record_check;
-        Fr partial_record_check;
-        Fr next_gate_access_type;
-        Fr record_delta;
-        Fr index_delta;
-        Fr adjacent_values_match_if_adjacent_indices_match;
-        Fr adjacent_values_match_if_adjacent_indices_match_and_next_access_is_a_read_operation;
-        Fr access_check;
-        Fr next_gate_access_type_is_boolean;
-        Fr ROM_consistency_check_identity;
-        Fr RAM_consistency_check_identity;
-        Fr timestamp_delta;
-        Fr RAM_timestamp_check_identity;
-        Fr memory_identity;
-        Fr index_is_monotonically_increasing;
     }
 
     function accumulateMemoryRelation(
@@ -512,22 +552,6 @@ library RelationsLib {
         evals[13] = ap.memory_identity;
     }
 
-    // Constants for the Non-native Field relation
-    Fr constant LIMB_SIZE = Fr.wrap(uint256(1) << 68);
-    Fr constant SUBLIMB_SHIFT = Fr.wrap(uint256(1) << 14);
-
-    // Parameters used within the Non-Native Field Relation
-    // A struct is used to work around stack too deep. This relation has alot of variables
-    struct NnfParams {
-        Fr limb_subproduct;
-        Fr non_native_field_gate_1;
-        Fr non_native_field_gate_2;
-        Fr non_native_field_gate_3;
-        Fr limb_accumulator_1;
-        Fr limb_accumulator_2;
-        Fr nnf_identity;
-    }
-
     function accumulateNnfRelation(
         Fr[NUMBER_OF_ENTITIES] memory p,
         Fr[NUMBER_OF_SUBRELATIONS] memory evals,
@@ -604,27 +628,6 @@ library RelationsLib {
         evals[19] = ap.nnf_identity;
     }
 
-    // Big todo for poseidon params, reduce them
-    struct PoseidonExternalParams {
-        Fr s1;
-        Fr s2;
-        Fr s3;
-        Fr s4;
-        Fr u1;
-        Fr u2;
-        Fr u3;
-        Fr u4;
-        Fr t0;
-        Fr t1;
-        Fr t2;
-        Fr t3;
-        Fr v1;
-        Fr v2;
-        Fr v3;
-        Fr v4;
-        Fr q_pos_by_scaling;
-    }
-
     function accumulatePoseidonExternalRelation(
         Fr[NUMBER_OF_ENTITIES] memory p,
         Fr[NUMBER_OF_SUBRELATIONS] memory evals,
@@ -665,20 +668,6 @@ library RelationsLib {
         evals[22] = evals[22] + ep.q_pos_by_scaling * (ep.v3 - wire(p, WIRE.W_O_SHIFT));
 
         evals[23] = evals[23] + ep.q_pos_by_scaling * (ep.v4 - wire(p, WIRE.W_4_SHIFT));
-    }
-
-    struct PoseidonInternalParams {
-        Fr u1;
-        Fr u2;
-        Fr u3;
-        Fr u4;
-        Fr u_sum;
-        Fr v1;
-        Fr v2;
-        Fr v3;
-        Fr v4;
-        Fr s1;
-        Fr q_pos_by_scaling;
     }
 
     function accumulatePoseidonInternalRelation(

--- a/barretenberg/sol/src/honk/Transcript.sol
+++ b/barretenberg/sol/src/honk/Transcript.sol
@@ -1,5 +1,9 @@
-pragma solidity >=0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
+import {Errors} from "./Errors.sol";
+import {Fr, FrLib, P} from "./Fr.sol";
 import {
     Honk,
     NUMBER_OF_ALPHAS,
@@ -10,7 +14,6 @@ import {
     FIELD_ELEMENT_SIZE,
     GROUP_ELEMENT_SIZE
 } from "./HonkTypes.sol";
-import {Fr, FrLib} from "./Fr.sol";
 import {bytesToG1Point, bytesToFr} from "./utils.sol";
 
 // Transcript library to generate fiat shamir challenges
@@ -36,7 +39,7 @@ library TranscriptLib {
         uint256 vkHash,
         uint256 publicInputsSize,
         uint256 logN
-    ) internal view returns (Transcript memory t) {
+    ) internal pure returns (Transcript memory t) {
         Fr previousChallenge;
         (t.relationParameters, previousChallenge) =
             generateRelationParametersChallenges(proof, publicInputs, vkHash, publicInputsSize, previousChallenge);
@@ -63,8 +66,8 @@ library TranscriptLib {
         // Split into two equal 127-bit chunks (254/2)
         uint256 lo = challengeU256 & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 127 bits
         uint256 hi = challengeU256 >> 127;
-        first = FrLib.fromBytes32(bytes32(lo));
-        second = FrLib.fromBytes32(bytes32(hi));
+        first = FrLib.from(lo);
+        second = FrLib.from(hi);
     }
 
     function generateRelationParametersChallenges(
@@ -89,7 +92,8 @@ library TranscriptLib {
         round0[0] = bytes32(vkHash);
 
         for (uint256 i = 0; i < publicInputsSize - PAIRING_POINTS_SIZE; i++) {
-            round0[1 + i] = bytes32(publicInputs[i]);
+            require(uint256(publicInputs[i]) < P, Errors.ValueGeFieldOrder());
+            round0[1 + i] = publicInputs[i];
         }
         for (uint256 i = 0; i < PAIRING_POINTS_SIZE; i++) {
             round0[1 + publicInputsSize - PAIRING_POINTS_SIZE + i] = FrLib.toBytes32(proof.pairingPointObject[i]);
@@ -104,7 +108,7 @@ library TranscriptLib {
         round0[1 + publicInputsSize + 4] = bytes32(proof.w3.x);
         round0[1 + publicInputsSize + 5] = bytes32(proof.w3.y);
 
-        previousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(round0)));
+        previousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(round0))) % P);
         (eta,) = splitChallenge(previousChallenge);
     }
 
@@ -122,7 +126,7 @@ library TranscriptLib {
         round1[5] = bytes32(proof.w4.x);
         round1[6] = bytes32(proof.w4.y);
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(round1)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(round1))) % P);
         (beta, gamma) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -140,7 +144,7 @@ library TranscriptLib {
         alpha0[3] = proof.zPerm.x;
         alpha0[4] = proof.zPerm.y;
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(alpha0)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(alpha0))) % P);
         Fr alpha;
         (alpha,) = splitChallenge(nextPreviousChallenge);
 
@@ -156,7 +160,7 @@ library TranscriptLib {
         pure
         returns (Fr[CONST_PROOF_SIZE_LOG_N] memory gateChallenges, Fr nextPreviousChallenge)
     {
-        previousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(Fr.unwrap(previousChallenge))));
+        previousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(Fr.unwrap(previousChallenge)))) % P);
         (gateChallenges[0],) = splitChallenge(previousChallenge);
         for (uint256 i = 1; i < logN; i++) {
             gateChallenges[i] = gateChallenges[i - 1] * gateChallenges[i - 1];
@@ -177,7 +181,7 @@ library TranscriptLib {
             for (uint256 j = 0; j < BATCHED_RELATION_PARTIAL_LENGTH; j++) {
                 univariateChal[j + 1] = proof.sumcheckUnivariates[i][j];
             }
-            prevChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(univariateChal)));
+            prevChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(univariateChal))) % P);
             Fr unused;
             (sumcheckChallenges[i], unused) = splitChallenge(prevChallenge);
         }
@@ -197,7 +201,7 @@ library TranscriptLib {
             rhoChallengeElements[i + 1] = proof.sumcheckEvaluations[i];
         }
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(rhoChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(rhoChallengeElements))) % P);
         Fr unused;
         (rho, unused) = splitChallenge(nextPreviousChallenge);
     }
@@ -215,7 +219,7 @@ library TranscriptLib {
             gR[2 + i * 2] = proof.geminiFoldComms[i].y;
         }
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(gR)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(gR))) % P);
         Fr unused;
         (geminiR, unused) = splitChallenge(nextPreviousChallenge);
     }
@@ -232,14 +236,14 @@ library TranscriptLib {
             shplonkNuChallengeElements[i + 1] = Fr.unwrap(proof.geminiAEvaluations[i]);
         }
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(shplonkNuChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(shplonkNuChallengeElements))) % P);
         Fr unused;
         (shplonkNu, unused) = splitChallenge(nextPreviousChallenge);
     }
 
     function generateShplonkZChallenge(Honk.Proof memory proof, Fr prevChallenge)
         internal
-        view
+        pure
         returns (Fr shplonkZ, Fr nextPreviousChallenge)
     {
         uint256[3] memory shplonkZChallengeElements;
@@ -248,21 +252,20 @@ library TranscriptLib {
         shplonkZChallengeElements[1] = proof.shplonkQ.x;
         shplonkZChallengeElements[2] = proof.shplonkQ.y;
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(shplonkZChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(shplonkZChallengeElements))) % P);
         Fr unused;
         (shplonkZ, unused) = splitChallenge(nextPreviousChallenge);
     }
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1234)
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1235)
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1236)
     function loadProof(bytes calldata proof, uint256 logN) internal pure returns (Honk.Proof memory p) {
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1332): Optimize this away when we finalize.
         uint256 boundary = 0x00;
 
         // Pairing point object
         for (uint256 i = 0; i < PAIRING_POINTS_SIZE; i++) {
-            p.pairingPointObject[i] = bytesToFr(proof[boundary:boundary + FIELD_ELEMENT_SIZE]);
+            uint256 limb = uint256(bytes32(proof[boundary:boundary + FIELD_ELEMENT_SIZE]));
+            // lo limbs (even index) < 2^136, hi limbs (odd index) < 2^120
+            require(limb < 2 ** (i % 2 == 0 ? 136 : 120), Errors.ValueGeLimbMax());
+            p.pairingPointObject[i] = FrLib.from(limb);
             boundary += FIELD_ELEMENT_SIZE;
         }
         // Commitments

--- a/barretenberg/sol/src/honk/ZKTranscript.sol
+++ b/barretenberg/sol/src/honk/ZKTranscript.sol
@@ -1,9 +1,12 @@
-pragma solidity >=0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
+import {Errors} from "./Errors.sol";
+import {Fr, FrLib, P} from "./Fr.sol";
 import {
     Honk,
     NUMBER_OF_ALPHAS,
-    NUMBER_OF_ENTITIES,
     NUMBER_OF_ENTITIES_ZK,
     ZK_BATCHED_RELATION_PARTIAL_LENGTH,
     CONST_PROOF_SIZE_LOG_N,
@@ -11,9 +14,7 @@ import {
     GROUP_ELEMENT_SIZE,
     FIELD_ELEMENT_SIZE
 } from "./HonkTypes.sol";
-import {Fr, FrLib} from "./Fr.sol";
 import {bytesToG1Point, bytesToFr} from "./utils.sol";
-import {logFr} from "./Debug.sol";
 
 // ZKTranscript library to generate fiat shamir challenges, the ZK transcript only differest
 /// forge-lint: disable-next-item(pascal-case-struct)
@@ -67,8 +68,8 @@ library ZKTranscriptLib {
         // Split into two equal 127-bit chunks (254/2)
         uint256 lo = challengeU256 & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF; // 127 bits
         uint256 hi = challengeU256 >> 127;
-        first = FrLib.fromBytes32(bytes32(lo));
-        second = FrLib.fromBytes32(bytes32(hi));
+        first = FrLib.from(lo);
+        second = FrLib.from(hi);
     }
 
     function generateRelationParametersChallenges(
@@ -94,7 +95,8 @@ library ZKTranscriptLib {
         round0[0] = bytes32(vkHash);
 
         for (uint256 i = 0; i < publicInputsSize - PAIRING_POINTS_SIZE; i++) {
-            round0[1 + i] = bytes32(publicInputs[i]);
+            require(uint256(publicInputs[i]) < P, Errors.ValueGeFieldOrder());
+            round0[1 + i] = publicInputs[i];
         }
         for (uint256 i = 0; i < PAIRING_POINTS_SIZE; i++) {
             round0[1 + publicInputsSize - PAIRING_POINTS_SIZE + i] = FrLib.toBytes32(proof.pairingPointObject[i]);
@@ -113,7 +115,7 @@ library ZKTranscriptLib {
         round0[1 + publicInputsSize + 6] = bytes32(proof.w3.x);
         round0[1 + publicInputsSize + 7] = bytes32(proof.w3.y);
 
-        previousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(round0)));
+        previousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(round0))) % P);
         (eta,) = splitChallenge(previousChallenge);
     }
 
@@ -131,7 +133,7 @@ library ZKTranscriptLib {
         round1[5] = bytes32(proof.w4.x);
         round1[6] = bytes32(proof.w4.y);
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(round1)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(round1))) % P);
         (beta, gamma) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -149,7 +151,7 @@ library ZKTranscriptLib {
         alpha0[3] = proof.zPerm.x;
         alpha0[4] = proof.zPerm.y;
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(alpha0)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(alpha0))) % P);
         Fr alpha;
         (alpha,) = splitChallenge(nextPreviousChallenge);
 
@@ -165,7 +167,7 @@ library ZKTranscriptLib {
         pure
         returns (Fr[CONST_PROOF_SIZE_LOG_N] memory gateChallenges, Fr nextPreviousChallenge)
     {
-        previousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(Fr.unwrap(previousChallenge))));
+        previousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(Fr.unwrap(previousChallenge)))) % P);
         (gateChallenges[0],) = splitChallenge(previousChallenge);
         for (uint256 i = 1; i < logN; i++) {
             gateChallenges[i] = gateChallenges[i - 1] * gateChallenges[i - 1];
@@ -184,7 +186,7 @@ library ZKTranscriptLib {
         challengeData[1] = proof.libraCommitments[0].x;
         challengeData[2] = proof.libraCommitments[0].y;
         challengeData[3] = Fr.unwrap(proof.libraSum);
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(challengeData)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(challengeData))) % P);
         (libraChallenge,) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -201,7 +203,7 @@ library ZKTranscriptLib {
             for (uint256 j = 0; j < ZK_BATCHED_RELATION_PARTIAL_LENGTH; j++) {
                 univariateChal[j + 1] = proof.sumcheckUnivariates[i][j];
             }
-            prevChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(univariateChal)));
+            prevChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(univariateChal))) % P);
 
             (sumcheckChallenges[i],) = splitChallenge(prevChallenge);
         }
@@ -229,7 +231,7 @@ library ZKTranscriptLib {
         rhoChallengeElements[i] = proof.libraCommitments[2].x;
         rhoChallengeElements[i + 1] = proof.libraCommitments[2].y;
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(rhoChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(rhoChallengeElements))) % P);
         (rho,) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -246,7 +248,7 @@ library ZKTranscriptLib {
             gR[2 + i * 2] = proof.geminiFoldComms[i].y;
         }
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(gR)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(gR))) % P);
 
         (geminiR,) = splitChallenge(nextPreviousChallenge);
     }
@@ -269,7 +271,7 @@ library ZKTranscriptLib {
             libraIdx++;
         }
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(shplonkNuChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(shplonkNuChallengeElements))) % P);
         (shplonkNu,) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -284,7 +286,7 @@ library ZKTranscriptLib {
         shplonkZChallengeElements[1] = proof.shplonkQ.x;
         shplonkZChallengeElements[2] = proof.shplonkQ.y;
 
-        nextPreviousChallenge = FrLib.fromBytes32(keccak256(abi.encodePacked(shplonkZChallengeElements)));
+        nextPreviousChallenge = FrLib.from(uint256(keccak256(abi.encodePacked(shplonkZChallengeElements))) % P);
         (shplonkZ,) = splitChallenge(nextPreviousChallenge);
     }
 
@@ -294,7 +296,10 @@ library ZKTranscriptLib {
 
         // Pairing point object
         for (uint256 i = 0; i < PAIRING_POINTS_SIZE; i++) {
-            p.pairingPointObject[i] = bytesToFr(proof[boundary:boundary + FIELD_ELEMENT_SIZE]);
+            uint256 limb = uint256(bytes32(proof[boundary:boundary + FIELD_ELEMENT_SIZE]));
+            // lo limbs (even index) < 2^136, hi limbs (odd index) < 2^120
+            require(limb < 2 ** (i % 2 == 0 ? 136 : 120), Errors.ValueGeLimbMax());
+            p.pairingPointObject[i] = FrLib.from(limb);
             boundary += FIELD_ELEMENT_SIZE;
         }
 

--- a/barretenberg/sol/src/honk/instance/.gitignore
+++ b/barretenberg/sol/src/honk/instance/.gitignore
@@ -1,0 +1,1 @@
+BlakeHonkOpt.sol.bak

--- a/barretenberg/sol/src/honk/instance/Add2Honk.sol
+++ b/barretenberg/sol/src/honk/instance/Add2Honk.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseHonkVerifier as BASE} from "./../BaseHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     Add2HonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/Add2HonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-import {BaseHonkVerifier as BASE} from "../BaseHonkVerifier.sol";
+} from "./../keys/Add2HonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract Add2HonkVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/Add2HonkZK.sol
+++ b/barretenberg/sol/src/honk/instance/Add2HonkZK.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseZKHonkVerifier as BASE} from "./../BaseZKHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     Add2HonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/Add2HonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-import {BaseZKHonkVerifier as BASE} from "../BaseZKHonkVerifier.sol";
+} from "./../keys/Add2HonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract Add2HonkZKVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/BlakeHonk.sol
+++ b/barretenberg/sol/src/honk/instance/BlakeHonk.sol
@@ -1,19 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseHonkVerifier as BASE} from "./../BaseHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     BlakeHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/BlakeHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-
-import {BaseHonkVerifier as BASE} from "../BaseHonkVerifier.sol";
+} from "./../keys/BlakeHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract BlakeHonkVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/BlakeHonkOpt.sol
+++ b/barretenberg/sol/src/honk/instance/BlakeHonkOpt.sol
@@ -11,7 +11,7 @@ uint256 constant NUMBER_UNSHIFTED = 36;
 uint256 constant NUMBER_TO_BE_SHIFTED = 5;
 uint256 constant PAIRING_POINTS_SIZE = 8;
 
-uint256 constant VK_HASH = 0x157796adb620b78d78cfed721afc48567d797a60027858aa28920832a9ea8c96;
+uint256 constant VK_HASH = 0x0abf6255375df552d73b53ed1363199a766849a567a16de07a9e0b27ace176af;
 uint256 constant CIRCUIT_SIZE = 32768;
 uint256 constant LOG_N = 15;
 uint256 constant NUMBER_PUBLIC_INPUTS = 12;
@@ -1032,62 +1032,62 @@ contract BlakeOptHonkVerifier is IVerifier {
             //
             // Although defined at the top of the file, it is used towards the end of the algorithm when batching in the commitment scheme.
             function loadVk() {
-                mstore(Q_L_X_LOC, 0x09e23733855a5c921f5cfb83d6f934cff1356dc146662bc8e9187b1acb8fe6a6)
-                mstore(Q_L_Y_LOC, 0x1aa0ad3788d48e1f0f339b73c90e687385a6b7c2440652840056ea177b58f59a)
-                mstore(Q_R_X_LOC, 0x045214b975bd93bffe90aceffaaeee76e1c69da84e47fe39601e1b3f6cba7a7d)
-                mstore(Q_R_Y_LOC, 0x1bdabba1b6d1915e2d3206c6eadc8e5e44e230d9d86c09108096359e3d5aba01)
-                mstore(Q_O_X_LOC, 0x1d8c7e2a42321955e3f104775468bc373978634236fec7df32c991bf89a81bdc)
-                mstore(Q_O_Y_LOC, 0x218ecf963782e0216bfe0f3bbff044d968ad56a7ea2bdde0c4d3af52fa534365)
-                mstore(Q_4_X_LOC, 0x02765903971f82d88b486222033f711cd67bcd6149d7fb4e8126c862430d65fc)
-                mstore(Q_4_Y_LOC, 0x2d359819a8d5a50d6c68df088a27649efb842ee42fab7a7f6665cb6728459d6a)
-                mstore(Q_M_X_LOC, 0x1cddc50a02fc4e43aa9c52a4eb2c04be259337b7dd6e22b1fb973c21cb072e19)
-                mstore(Q_M_Y_LOC, 0x2e6e1f27fd59333d32ca1e6e9b6be035bc81290a6a3e327f2c825f8aca244488)
-                mstore(Q_C_X_LOC, 0x1156486c940c2f0e85e763a490294a47fac4acca9d01c6dba24af114a21efe79)
-                mstore(Q_C_Y_LOC, 0x0f585118d3c7fe771ae4e0598ebdd46d8fcf1b5c06a8e098311e190f5d6ba811)
-                mstore(Q_LOOKUP_X_LOC, 0x2f52fd71248e5fb7fcda49e0778edcf84065f4c837dc259c99350f66d2756526)
-                mstore(Q_LOOKUP_Y_LOC, 0x07f7f722d2341b84f37e028a0993f9ba6eb0539524e258a6666f2149f7edba7e)
-                mstore(Q_ARITH_X_LOC, 0x0ee854e8ccc8f2e31101569da4887b52ce453b84147eb55a287ec361b6096c3b)
-                mstore(Q_ARITH_Y_LOC, 0x25e611d6105a52ab7441e481a5dfcbca641f631e9faa1c3569a869adcd1eb332)
-                mstore(Q_DELTA_RANGE_X_LOC, 0x29cc35a6626981b21979854b2893fedc8c58874e2e76dc37e280ec95960b6cd0)
-                mstore(Q_DELTA_RANGE_Y_LOC, 0x10828237d302d369a783d1428bddc33ca0985cc731f1ec1fb21aba36901dd588)
-                mstore(Q_ELLIPTIC_X_LOC, 0x1ce363830feceb6a88e3c0b243761ac90e5305d22189f61b2cc3306874d66be1)
-                mstore(Q_ELLIPTIC_Y_LOC, 0x0e31169cf2ef5ed3a842e39c541e6dbd332b241f2c6745bd247346de0abfc04b)
-                mstore(Q_MEMORY_X_LOC, 0x1f3f147ebab4234562531ac5a88acd0fa19856f233f08dccaf08323be841ebf2)
-                mstore(Q_MEMORY_Y_LOC, 0x2796d440d563f33cf86ce45396894be9f72940b607f5b736a23865a383139a1e)
-                mstore(Q_NNF_X_LOC, 0x13dda68222b5fc74faaffbb474e83983bb48e76d9fce38dab0f73c9cc93a383a)
-                mstore(Q_NNF_Y_LOC, 0x16772f40eba04c6df1ac038ab36f08710bb62b1bf30e7eef48c79aebedf8aeb2)
-                mstore(Q_POSEIDON_2_EXTERNAL_X_LOC, 0x0e072393a94d366c7e949259eb295b21c0a1a6571fb0cb5c3a52bfa501f8c9c9)
-                mstore(Q_POSEIDON_2_EXTERNAL_Y_LOC, 0x12e831816a4f7b5d50c7886feedee3b93d18a3916d0fd1f7d1206193cf6c0984)
-                mstore(Q_POSEIDON_2_INTERNAL_X_LOC, 0x1d58934c5e5a89462366591d58dc1e54653135c12b94b6eaf65379d74d2654bd)
-                mstore(Q_POSEIDON_2_INTERNAL_Y_LOC, 0x2489cff8c34b7cbb6173002f247b272ea8b10f0835239e5b113adea6f5f1a1c1)
-                mstore(SIGMA_1_X_LOC, 0x1fbcd7f900d4f2f28c7aac5fe88b306ef7073c86566220a54c95e651235a9d50)
-                mstore(SIGMA_1_Y_LOC, 0x2a7701c77bcebafa6a95a8dbf47a27d12e6a07edeb073259fadb75fd746fae60)
-                mstore(SIGMA_2_X_LOC, 0x126a1f1815f97fe661d214087eedd221feee3d6c06b25213a4b23911a7223cd0)
-                mstore(SIGMA_2_Y_LOC, 0x1024c7ad64775ffd88bee89718ce974a3741e96cbb86c813fd6212cadbd3c620)
-                mstore(SIGMA_3_X_LOC, 0x0f8487ff805fdb357768156ffdffaece1a019bbb477bdc1ba3548f9f12f0eed9)
-                mstore(SIGMA_3_Y_LOC, 0x178ff23f1aebb7eaad97cfa6e5e98eac07c82545f5d06a56ad75d2056c2f0581)
-                mstore(SIGMA_4_X_LOC, 0x084d17dfd50cccee96eabaef71682d20b5f7361909bc58ecbdeb3b1e5dd0fe20)
-                mstore(SIGMA_4_Y_LOC, 0x04552efbddbcebb689d94f9416abb9ff95ae8e96eaf92ad4cc6e33280db3f760)
+                mstore(Q_L_X_LOC, 0x1fa81a7d3c0b8ee4f968c954bffbedb166526292fc6c6704fceb23d712ad5f6b)
+                mstore(Q_L_Y_LOC, 0x152afe5849e9761e74aafeb3c11424ed9e07997edc5ccc735b2b77c1022d1fb1)
+                mstore(Q_R_X_LOC, 0x13c7b9b320294e251342c5de9cf747be2c0cd59508ecc42276894dd180c20131)
+                mstore(Q_R_Y_LOC, 0x00090da459dee153c5eb5cc58c5f62f4b88fda9bc4210af64c6a517e17574523)
+                mstore(Q_O_X_LOC, 0x0bdc1fac7a43a0aea97b16b560a9f487c4254ae867deed29262271bd23c2dbfd)
+                mstore(Q_O_Y_LOC, 0x013834be0a88b4d4cab15069c2a1c46e7196a764927698db14316a751b620392)
+                mstore(Q_4_X_LOC, 0x189d72328100c0c3beac15d1832316da53352eb7311b3a8883c6327194552de4)
+                mstore(Q_4_Y_LOC, 0x05029e1cbb73b42f764a557b960f420e9731452c5b1053df675e190e43d42e8c)
+                mstore(Q_M_X_LOC, 0x1dfc2538e61928080085243037ba40ae9a514918987bb79e5bc5712273e334f1)
+                mstore(Q_M_Y_LOC, 0x203c451afe6ea90794fa0e293f8b0aaa515e3523a28eff7b024f6981027cc428)
+                mstore(Q_C_X_LOC, 0x2edd2ce3f0f3027aba62ca6d457fe34d98ec4edfece11e3c9862c97bfab294d6)
+                mstore(Q_C_Y_LOC, 0x024fa6e64ae6c1e501fd9485e2de1710fcc1ba81bde77723d5f4bb80c9524c7f)
+                mstore(Q_LOOKUP_X_LOC, 0x0b3dcd453ea78838fcdb3f76bf6ed33e9f5a367dda25de9a8c3d47d4d73b9e2b)
+                mstore(Q_LOOKUP_Y_LOC, 0x16eb7cd3cf6b2adf2d940f21fd2bbd6f36226061ab47847f48c6a928c23c6b6e)
+                mstore(Q_ARITH_X_LOC, 0x157a018bfd0c2cef0180376310280007cb3f4674214596d81d16a3f9fb3180c8)
+                mstore(Q_ARITH_Y_LOC, 0x203331eb7909c48101bb02418b2057024eaf8328e64a5ba0defe68676acbbe08)
+                mstore(Q_DELTA_RANGE_X_LOC, 0x03b3c157d6b50acef890ad151beb551f5a5176325ff93ebc40e5d91201d315af)
+                mstore(Q_DELTA_RANGE_Y_LOC, 0x0db8b381a1b8cad0d6f2c99786671ded32bbfecf738e111ce29b0228a5ef8e59)
+                mstore(Q_ELLIPTIC_X_LOC, 0x2881e4da043e5db2ef3a1645d071224a9e1471395dce4364b0f2db4d78d0c079)
+                mstore(Q_ELLIPTIC_Y_LOC, 0x2bb158658b17a7800cd175784c68bada881487ef1ba1f5a91567204bb6fd5d66)
+                mstore(Q_MEMORY_X_LOC, 0x2b42c3cff1aef53ec336eb0768fd69a0f2a42ee43cd41768fa41bc435b49e176)
+                mstore(Q_MEMORY_Y_LOC, 0x1992a385cba9ed9a8b09c842e2c0741948fc13d4061bcc37eaefcc65bc7daa52)
+                mstore(Q_NNF_X_LOC, 0x0d0f35f2d5ac5c001264e203f204aab41206b55240bfe2c371cde5c658ebb685)
+                mstore(Q_NNF_Y_LOC, 0x12162bfe330e9f7207c0b1e20012d4106f5d5bd34106de5df4804ee71903fdfa)
+                mstore(Q_POSEIDON_2_EXTERNAL_X_LOC, 0x20c607e1de94fe57ca6f2c513628880a828bfe6c1dafe23d61729a6622f118b8)
+                mstore(Q_POSEIDON_2_EXTERNAL_Y_LOC, 0x14d20b63eca57db9c2ab0a723db6620e14c71481f76e349ab4a281ba880744ca)
+                mstore(Q_POSEIDON_2_INTERNAL_X_LOC, 0x0b2806708a43eda2e2990743e8b2859b3ed1dcf0e66eab01c647e5f2ca55ff9e)
+                mstore(Q_POSEIDON_2_INTERNAL_Y_LOC, 0x232db7a81297a24e6eb82d65310341a0c60c87a93d378b8b1136e83c4a965240)
+                mstore(SIGMA_1_X_LOC, 0x0ce8d8e8dcffae5efbcad28ede7d7a595a41ce1fc1c7b650f5f04f10167fac03)
+                mstore(SIGMA_1_Y_LOC, 0x0d24579a2342f6e23f52aa536351a60d804880ac0c18844f12071bde70408f32)
+                mstore(SIGMA_2_X_LOC, 0x20338755144893885c9da047e848f92b0a8a0b66bcd9b476ae68b57c1c23ff43)
+                mstore(SIGMA_2_Y_LOC, 0x094c227441bfe3b19f215e5798f86247f957f863fe13b32bcf5951fe94429cd9)
+                mstore(SIGMA_3_X_LOC, 0x0f632bd67f8342836f9ffff346bd3b4e81a80be77f63e5b2a965f14131960272)
+                mstore(SIGMA_3_Y_LOC, 0x1496fe156cbe31651dcbbdf3562cb3ca2d322721b706d11c5b4aa8cb8994f8b1)
+                mstore(SIGMA_4_X_LOC, 0x1c838998d3f8d3ca6f0d0f163d1df56a277226b8e775376139d588f1b27d0f0b)
+                mstore(SIGMA_4_Y_LOC, 0x109ba035a2f985dcfa96b13e4f466746a6871b218dbe7024e1503f09c8405ed1)
                 mstore(TABLE_1_X_LOC, 0x092adcffc07888d1ea53fdaa87e51d00614435ae5beeda41222f1300beb209f1)
                 mstore(TABLE_1_Y_LOC, 0x17d3b0c8f579f153a87a831b7e4f4d5af79cb1cbee232a3590ea68445d8e8885)
                 mstore(TABLE_2_X_LOC, 0x288bca978add237e513115827263877d2879d70853ae1dc3bccc228f9297fdec)
                 mstore(TABLE_2_Y_LOC, 0x2091a8aa28ad5de84ea48d048d3472599a4a25b4001c9dc6488651ced23c4a8b)
-                mstore(TABLE_3_X_LOC, 0x1ca90fbf226a8241f127b4456105dbf74cd9dcd196b550033d50ae98808c5b27)
-                mstore(TABLE_3_Y_LOC, 0x077ced98ba89ffb9e959eafe7cf3ec685d3fda8833c346ad73702504e2159b8b)
+                mstore(TABLE_3_X_LOC, 0x2cedbf0e3de59b60e7bd5910443d61fd9a3eb046d72903c7c5d46865b217923b)
+                mstore(TABLE_3_Y_LOC, 0x169e6cd2bab5a9ba4f567be33e113a74f297ad53b33823be9a84ca750d9457e9)
                 mstore(TABLE_4_X_LOC, 0x2987794caaa7e3277da9e0fa04644cff19433f7e62178e98a18badf4ece924c4)
                 mstore(TABLE_4_Y_LOC, 0x0f2ebe1caa931ad968c79d2ad8713df60eae316d0b5f0dc0603e65adb8d79d5b)
-                mstore(ID_1_X_LOC, 0x0680b6a756618fe4d79036856d8e8992d4d8744f0f75656863c3fcd8f69ee9d4)
-                mstore(ID_1_Y_LOC, 0x2a0a59d20546e84c48280dcc7395cca07a674465639a8ee58d729f2bbf8a438e)
-                mstore(ID_2_X_LOC, 0x1da75009c0ec98ebdd33fe5e28ad36fca53cbfc4e2d415a296fcd2cdeb51c97e)
-                mstore(ID_2_Y_LOC, 0x135a05d485d0eb13c8d528b312ad24819459b3979c3a025622bfbf1f26c569f9)
-                mstore(ID_3_X_LOC, 0x11a422a11902b64ac3acfd23c4ebf246955dbae6cc4b40c4b5ccb9727beecf13)
-                mstore(ID_3_Y_LOC, 0x23150ce8d59b596241a80a865f856ba0ec3ab0b9dcef1ccd8a638a3fc138fb9d)
-                mstore(ID_4_X_LOC, 0x148447c4222a74f296bd44ed71d4a53d3f0af52dd0b847c7c01ddb0ecb01f7d5)
-                mstore(ID_4_Y_LOC, 0x040f5d6a143f653198fb65709bec7f6fa4c88013ce4ace45815b3fa8298f00a2)
+                mstore(ID_1_X_LOC, 0x1fb35d6a15d12d54c204042ee7e02c468fe45e05237e422eba5d08c91a338c18)
+                mstore(ID_1_Y_LOC, 0x0f6e701a5e59163dd158c7c3fff1cc779d937792fb79c5cad59aa74eb3bde6a8)
+                mstore(ID_2_X_LOC, 0x1470f9d21916e1e96faed37fb942ff3764c8f943b763d2ee950c888e38ec9f20)
+                mstore(ID_2_Y_LOC, 0x236121664bdaf33e294fac3faba09d185029521333edee2654ac390966bad911)
+                mstore(ID_3_X_LOC, 0x1ada91205aecc74692e722356789fe885678789485f035e9607fa99cebcf695c)
+                mstore(ID_3_Y_LOC, 0x11cd679786230bef9d3a87c333d56ac5774c4b7a21dbb9dcfe88a56ee35c496c)
+                mstore(ID_4_X_LOC, 0x23fec04bb425778c699e0276d14924bce4e52dc6cc7bded6ea5d4e1d673177f8)
+                mstore(ID_4_Y_LOC, 0x1b2613b28bd60b2b4d1100626a934ed40640420f940d804868b4160f7fde0dda)
                 mstore(LAGRANGE_FIRST_X_LOC, 0x0000000000000000000000000000000000000000000000000000000000000001)
                 mstore(LAGRANGE_FIRST_Y_LOC, 0x0000000000000000000000000000000000000000000000000000000000000002)
-                mstore(LAGRANGE_LAST_X_LOC, 0x0e1dce18d44d62c3b8db97bb10e3e782d865c6cf454d0e3282bbe0c196301c34)
-                mstore(LAGRANGE_LAST_Y_LOC, 0x2f6cb343158e34f22cedf2078bc9f2f1f9a20f955fb0003afc0e91628d60abb5)
+                mstore(LAGRANGE_LAST_X_LOC, 0x2f29cfec402b2b1cf2035ef5f7d770aa159e67f3544720efa8541c406f0975c3)
+                mstore(LAGRANGE_LAST_Y_LOC, 0x096756bb4c74f38ff57928f104419d0d0007f55eedb7f9570b49a665ad09934b)
             }
 
             // Prime field order - placing on the stack
@@ -1103,16 +1103,17 @@ contract BlakeOptHonkVerifier is IVerifier {
                 // Expected = (8*2 + LOG_N*BATCHED_RELATION_PARTIAL_LENGTH + NUMBER_OF_ENTITIES
                 //             + (LOG_N-1)*2 + LOG_N + 2*2 + PAIRING_POINTS_SIZE) * 32
                 {
-                    let expected_proof_size := mul(
-                        add(
+                    let expected_proof_size :=
+                        mul(
                             add(
-                                add(16, mul(LOG_N, BATCHED_RELATION_PARTIAL_LENGTH)),
-                                add(NUMBER_OF_ENTITIES, mul(sub(LOG_N, 1), 2))
+                                add(
+                                    add(16, mul(LOG_N, BATCHED_RELATION_PARTIAL_LENGTH)),
+                                    add(NUMBER_OF_ENTITIES, mul(sub(LOG_N, 1), 2))
+                                ),
+                                add(add(LOG_N, 4), PAIRING_POINTS_SIZE)
                             ),
-                            add(add(LOG_N, 4), PAIRING_POINTS_SIZE)
-                        ),
-                        32
-                    )
+                            32
+                        )
                     let proof_length := calldataload(add(calldataload(0x04), 0x04))
                     if iszero(eq(proof_length, expected_proof_size)) {
                         mstore(0x00, PROOF_LENGTH_WRONG_WITH_LOG_N_SELECTOR)
@@ -4574,10 +4575,9 @@ contract BlakeOptHonkVerifier is IVerifier {
                     p1_other_y := or(shl(136, mload(PAIRING_POINT_1_Y_1_LOC)), p1_other_y)
 
                     // Reconstructed coordinates must be < Q to prevent malleability
-                    if iszero(and(
-                        and(lt(p0_other_x, q), lt(p0_other_y, q)),
-                        and(lt(p1_other_x, q), lt(p1_other_y, q))
-                    )) {
+                    if iszero(
+                        and(and(lt(p0_other_x, q), lt(p0_other_y, q)), and(lt(p1_other_x, q), lt(p1_other_y, q)))
+                    ) {
                         mstore(0x00, VALUE_GE_GROUP_ORDER_SELECTOR)
                         revert(0x00, 0x04)
                     }

--- a/barretenberg/sol/src/honk/instance/BlakeHonkZK.sol
+++ b/barretenberg/sol/src/honk/instance/BlakeHonkZK.sol
@@ -1,19 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseZKHonkVerifier as BASE} from "./../BaseZKHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     BlakeHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/BlakeHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-
-import {BaseZKHonkVerifier as BASE} from "../BaseZKHonkVerifier.sol";
+} from "./../keys/BlakeHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract BlakeHonkZKVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/EcdsaHonk.sol
+++ b/barretenberg/sol/src/honk/instance/EcdsaHonk.sol
@@ -1,19 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseHonkVerifier as BASE} from "./../BaseHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     EcdsaHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/EcdsaHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-
-import {BaseHonkVerifier as BASE} from "../BaseHonkVerifier.sol";
+} from "./../keys/EcdsaHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract EcdsaHonkVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/EcdsaHonkZK.sol
+++ b/barretenberg/sol/src/honk/instance/EcdsaHonkZK.sol
@@ -1,19 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseZKHonkVerifier as BASE} from "./../BaseZKHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     EcdsaHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/EcdsaHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-
-import {BaseZKHonkVerifier as BASE} from "../BaseZKHonkVerifier.sol";
+} from "./../keys/EcdsaHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract EcdsaHonkZKVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/RecursiveHonk.sol
+++ b/barretenberg/sol/src/honk/instance/RecursiveHonk.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseHonkVerifier as BASE} from "./../BaseHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     RecursiveHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/RecursiveHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-import {BaseHonkVerifier as BASE} from "../BaseHonkVerifier.sol";
+} from "./../keys/RecursiveHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract RecursiveHonkVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/instance/RecursiveHonkZK.sol
+++ b/barretenberg/sol/src/honk/instance/RecursiveHonkZK.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Aztec Labs
-pragma solidity >=0.8.21;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {IVerifier} from "../../interfaces/IVerifier.sol";
+import {BaseZKHonkVerifier as BASE} from "./../BaseZKHonkVerifier.sol";
+import {Honk} from "./../HonkTypes.sol";
 import {
     RecursiveHonkVerificationKey as VK,
     N,
     LOG_N,
     NUMBER_OF_PUBLIC_INPUTS,
     VK_HASH
-} from "../keys/RecursiveHonkVerificationKey.sol";
-
-import {Honk} from "../HonkTypes.sol";
-import {BaseZKHonkVerifier as BASE} from "../BaseZKHonkVerifier.sol";
+} from "./../keys/RecursiveHonkVerificationKey.sol";
 
 /// Smart contract verifier of honk proofs
 contract RecursiveHonkZKVerifier is BASE(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {

--- a/barretenberg/sol/src/honk/optimised/.gitignore
+++ b/barretenberg/sol/src/honk/optimised/.gitignore
@@ -1,2 +1,0 @@
-honk-optimized.sol
-honk-optimized.sol.bak

--- a/barretenberg/sol/src/honk/optimised/generate_offsets.py
+++ b/barretenberg/sol/src/honk/optimised/generate_offsets.py
@@ -46,14 +46,14 @@ proof_fr = [
 ]
 
 pairing_points = [
-    "PAIRING_POINT_0",
-    "PAIRING_POINT_1",
-    "PAIRING_POINT_2",
-    "PAIRING_POINT_3",
-    "PAIRING_POINT_4",
-    "PAIRING_POINT_5",
-    "PAIRING_POINT_6",
-    "PAIRING_POINT_7",
+    "PAIRING_POINT_0_X_0_LOC",
+    "PAIRING_POINT_0_X_1_LOC",
+    "PAIRING_POINT_0_Y_0_LOC",
+    "PAIRING_POINT_0_Y_1_LOC",
+    "PAIRING_POINT_1_X_0_LOC",
+    "PAIRING_POINT_1_X_1_LOC",
+    "PAIRING_POINT_1_Y_0_LOC",
+    "PAIRING_POINT_1_Y_1_LOC",
 ]
 
 proof_g1 = [

--- a/barretenberg/sol/src/honk/utils.sol
+++ b/barretenberg/sol/src/honk/utils.sol
@@ -1,29 +1,12 @@
-pragma solidity >=0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
+import {Fr, FrLib, P} from "./Fr.sol";
 import {Honk, PAIRING_POINTS_SIZE} from "./HonkTypes.sol";
-import {Fr, FrLib} from "./Fr.sol";
-import {
-    Honk,
-    NUMBER_OF_ALPHAS,
-    NUMBER_OF_ENTITIES,
-    BATCHED_RELATION_PARTIAL_LENGTH,
-    CONST_PROOF_SIZE_LOG_N
-} from "./HonkTypes.sol";
+import {Errors} from "./Errors.sol";
 
 uint256 constant Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583; // EC group order. F_q
-
-function bytes32ToString(bytes32 value) pure returns (string memory result) {
-    bytes memory alphabet = "0123456789abcdef";
-
-    bytes memory str = new bytes(66);
-    str[0] = "0";
-    str[1] = "x";
-    for (uint256 i = 0; i < 32; i++) {
-        str[2 + i * 2] = alphabet[uint8(value[i] >> 4)];
-        str[3 + i * 2] = alphabet[uint8(value[i] & 0x0f)];
-    }
-    result = string(str);
-}
 
 // Fr utility
 
@@ -33,13 +16,24 @@ function bytesToFr(bytes calldata proofSection) pure returns (Fr scalar) {
 
 // EC Point utilities
 function bytesToG1Point(bytes calldata proofSection) pure returns (Honk.G1Point memory point) {
-    point = Honk.G1Point({
-        x: uint256(bytes32(proofSection[0x00:0x20])) % Q, y: uint256(bytes32(proofSection[0x20:0x40])) % Q
-    });
+    uint256 x = uint256(bytes32(proofSection[0x00:0x20]));
+    uint256 y = uint256(bytes32(proofSection[0x20:0x40]));
+    require(x < Q && y < Q, Errors.ValueGeGroupOrder());
+
+    // Reject the point at infinity (0,0). EVM precompiles silently treat (0,0)
+    // as the identity element, which could zero out commitments.
+    // On-curve validation (y² = x³ + 3) is handled by the ecAdd/ecMul precompiles
+    // per EIP-196, so we only need to catch this special case here.
+    require((x | y) != 0, Errors.PointAtInfinity());
+
+    point = Honk.G1Point({x: x, y: y});
 }
 
 function negateInplace(Honk.G1Point memory point) pure returns (Honk.G1Point memory) {
-    point.y = (Q - point.y) % Q;
+    // When y == 0 (order-2 point), negation is the same point. Q - 0 = Q which is >= Q.
+    if (point.y != 0) {
+        point.y = Q - point.y;
+    }
     return point;
 }
 
@@ -60,22 +54,28 @@ function convertPairingPointsToG1(Fr[PAIRING_POINTS_SIZE] memory pairingPoints)
     pure
     returns (Honk.G1Point memory lhs, Honk.G1Point memory rhs)
 {
-    // P0 (lhs): x = lo + hi << 136
+    // P0 (lhs): x = lo | (hi << 136)
     uint256 lhsX = Fr.unwrap(pairingPoints[0]);
     lhsX |= Fr.unwrap(pairingPoints[1]) << 136;
-    lhs.x = lhsX;
 
     uint256 lhsY = Fr.unwrap(pairingPoints[2]);
     lhsY |= Fr.unwrap(pairingPoints[3]) << 136;
-    lhs.y = lhsY;
 
-    // P1 (rhs): x = lo + hi << 136
+    // P1 (rhs): x = lo | (hi << 136)
     uint256 rhsX = Fr.unwrap(pairingPoints[4]);
     rhsX |= Fr.unwrap(pairingPoints[5]) << 136;
-    rhs.x = rhsX;
 
     uint256 rhsY = Fr.unwrap(pairingPoints[6]);
     rhsY |= Fr.unwrap(pairingPoints[7]) << 136;
+
+    // Reconstructed coordinates must be < Q to prevent malleability.
+    // Without this, two different limb encodings could map to the same curve point
+    // (via mulmod reduction in on-curve checks) but produce different transcript hashes.
+    require(lhsX < Q && lhsY < Q && rhsX < Q && rhsY < Q, Errors.ValueGeGroupOrder());
+
+    lhs.x = lhsX;
+    lhs.y = lhsY;
+    rhs.x = rhsX;
     rhs.y = rhsY;
 }
 
@@ -113,7 +113,7 @@ function generateRecursionSeparator(
     recursionSeparatorElements[6] = accRhs.x;
     recursionSeparatorElements[7] = accRhs.y;
 
-    recursionSeparator = FrLib.fromBytes32(keccak256(abi.encodePacked(recursionSeparatorElements)));
+    recursionSeparator = FrLib.from(uint256(keccak256(abi.encodePacked(recursionSeparatorElements))) % P);
 }
 
 /**
@@ -232,17 +232,8 @@ function ecAdd(Honk.G1Point memory lhs, Honk.G1Point memory rhs) view returns (H
     return result;
 }
 
-function validateOnCurve(Honk.G1Point memory point) pure {
-    uint256 x = point.x;
-    uint256 y = point.y;
-
-    bool success = false;
-    assembly {
-        let xx := mulmod(x, x, Q)
-        success := eq(mulmod(y, y, Q), addmod(mulmod(x, xx, Q), 3, Q))
-    }
-
-    require(success, "point is not on the curve");
+function rejectPointAtInfinity(Honk.G1Point memory point) pure {
+    require((point.x | point.y) != 0, Errors.PointAtInfinity());
 }
 
 function pairing(Honk.G1Point memory rhs, Honk.G1Point memory lhs) view returns (bool decodedResult) {

--- a/barretenberg/sol/src/interfaces/IVerifier.sol
+++ b/barretenberg/sol/src/interfaces/IVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 Aztec
-pragma solidity >=0.8.4;
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
 interface IVerifier {
     function verify(bytes calldata _proof, bytes32[] calldata _publicInputs) external view returns (bool);

--- a/barretenberg/sol/test/FrLib.t.sol
+++ b/barretenberg/sol/test/FrLib.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {TestBase} from "test/base/TestBase.sol";
+import {Fr, FrLib, P} from "src/honk/Fr.sol";
+import {Errors} from "src/honk/Errors.sol";
+
+contract FrLibWrapper {
+    function pow(Fr a, uint256 b) public view returns (Fr) {
+        return FrLib.pow(a, b);
+    }
+
+    function invert(Fr a) public view returns (Fr) {
+        return FrLib.invert(a);
+    }
+
+    function from(uint256 value) public view returns (Fr) {
+        return FrLib.from(value);
+    }
+
+    function fromBytes32(bytes32 value) public view returns (Fr) {
+        return FrLib.fromBytes32(value);
+    }
+}
+
+contract FrLibTest is TestBase {
+    FrLibWrapper public lib;
+
+    function setUp() public {
+        lib = new FrLibWrapper();
+    }
+
+    function test_fr_pow() public {
+        Fr a = Fr.wrap(1);
+
+        vm.expectRevert(Errors.NotPowerOfTwo.selector);
+        lib.pow(a, 0);
+
+        vm.expectRevert(Errors.NotPowerOfTwo.selector);
+        lib.pow(a, 3);
+    }
+
+    function test_fr_invert() public {
+        Fr a = Fr.wrap(0);
+
+        vm.expectRevert(Errors.InvertOfZero.selector);
+        lib.invert(a);
+    }
+
+    function test_fr_value_out_of_range() public {
+        // Beware the danger of using wrap directly.
+        Fr a = Fr.wrap(P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        lib.from(P + 1);
+    }
+
+    function test_fr_from_bytes32() public {
+        bytes32 a = bytes32(uint256(P + 1));
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        lib.fromBytes32(a);
+    }
+}

--- a/barretenberg/sol/test/honk/blakeOpt.t.sol
+++ b/barretenberg/sol/test/honk/blakeOpt.t.sol
@@ -1,5 +1,5 @@
 import {BlakeHonkVerifier} from "../../src/honk/instance/BlakeHonk.sol";
-import {BlakeOptHonkVerifier} from "../../src/honk/optimised/honk-optimized.sol";
+import {BlakeOptHonkVerifier} from "../../src/honk/instance/BlakeHonkOpt.sol";
 import {DifferentialFuzzer} from "../base/DifferentialFuzzer.sol";
 import {TestBaseHonk} from "./TestBaseHonk.sol";
 import {IVerifier} from "../../src/interfaces/IVerifier.sol";

--- a/barretenberg/sol/test/honk/negative/NegativeTestBase.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestBase.sol
@@ -1,0 +1,803 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {TestBase} from "test/base/TestBase.sol";
+import {DifferentialFuzzer} from "test/base/DifferentialFuzzer.sol";
+import {IVerifier} from "src/interfaces/IVerifier.sol";
+
+import {Errors} from "src/honk/Errors.sol";
+
+/**
+ * @title NegativeTestBase
+ * @notice Abstract base class for negative tests on non-ZK Honk verifiers
+ *
+ * @dev Provides common test infrastructure and attack vectors for:
+ * - Standard Blake Honk verifier (BaseHonkVerifier)
+ * - Optimized Blake Honk verifier (BlakeOptHonkVerifier)
+ *
+ * SECURITY OBSERVATION:
+ * Both verifiers reject the point at infinity (0,0) at the input boundary:
+ * - Standard: bytesToG1Point checks (x | y) != 0 during deserialization
+ * - Optimized: inline point-at-infinity check after calldatacopy
+ *
+ * On-curve validation (y² = x³ + 3) is delegated to the ecAdd/ecMul precompiles
+ * per EIP-196. Off-curve points that pass the (0,0) check are caught when
+ * precompile operations fail, or indirectly via transcript corruption → SumcheckFailed.
+ *
+ * Test categories:
+ * 1. Basic validation (proof length, public inputs length)
+ * 2. Sumcheck failures (round check, final check)
+ * 3. Point validation (point-at-infinity + off-curve via precompiles)
+ * 4. Shplemini/pairing failures
+ * 5. Q+1 attacks (field modulus aliasing)
+ * 6. Pairing point limb overflow
+ * 7. Field element >= P attacks
+ *
+ *
+ * Note on gas:
+ * We pass "only" 15M gas, since the pre-compile failure will consume remaining gas for the call
+ * and with "infinite" gas available that makes it possible to reach the following error (for example
+ * failing shplimini that is directly dependent on the pre-compile [so also correct] but the potential for
+ * multiple different errors here is painful for test).
+ */
+abstract contract NegativeTestBase is TestBase {
+    IVerifier public verifier;
+    DifferentialFuzzer public fuzzer;
+    uint256 public PUBLIC_INPUT_COUNT;
+
+    bytes internal cachedProof;
+    bytes32[] internal cachedPublicInputs;
+
+    // BN254 curve field modulus (for EC points)
+    uint256 constant Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    // BN254 scalar field modulus (for Fr elements)
+    uint256 constant P = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+    // Blake circuit has LOG_N = 15
+    uint256 constant LOG_N = 15;
+
+    // Non-ZK proof structure offsets (from proof start)
+    // Pairing points: 8 limbs × 32 bytes = 256 bytes at offset 0
+    uint256 constant PAIRING_POINTS_OFFSET = 0;
+    uint256 constant PAIRING_POINTS_SIZE = 256;
+
+    // Witness commitments start after pairing points (8 commitments × 64 bytes each)
+    // Serialization order: w1, w2, w3, lookupReadCounts, lookupReadTags, w4, lookupInverses, zPerm
+    uint256 constant W_L_OFFSET = 256;
+    uint256 constant W_R_OFFSET = 320;
+    uint256 constant W_O_OFFSET = 384;
+
+    // Each G1 point is 64 bytes (x, y)
+    uint256 constant G1_POINT_SIZE = 64;
+
+    /*//////////////////////////////////////////////////////////////
+                        VIRTUAL FUNCTIONS - OVERRIDE THESE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Create the verifier instance
+    function _createVerifier() internal virtual returns (IVerifier);
+
+    /*//////////////////////////////////////////////////////////////
+                              SETUP
+    //////////////////////////////////////////////////////////////*/
+
+    function setUp() public virtual {
+        fuzzer = new DifferentialFuzzer().with_flavor(DifferentialFuzzer.Flavor.Honk);
+        fuzzer = fuzzer.with_circuit_type(DifferentialFuzzer.CircuitType.Blake);
+
+        verifier = _createVerifier();
+
+        PUBLIC_INPUT_COUNT = 4;
+
+        uint256[] memory defaultInputs = new uint256[](4);
+        defaultInputs[0] = 0x0000000000000000000000000000000000000000000000000000000000000001;
+        defaultInputs[1] = 0x0000000000000000000000000000000000000000000000000000000000000002;
+        defaultInputs[2] = 0x0000000000000000000000000000000000000000000000000000000000000003;
+        defaultInputs[3] = 0x0000000000000000000000000000000000000000000000000000000000000004;
+
+        fuzzer = fuzzer.with_inputs(defaultInputs);
+
+        bytes memory proofData = fuzzer.generate_proof();
+        (cachedPublicInputs, cachedProof) = splitProofHonk(proofData, PUBLIC_INPUT_COUNT);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Helper to modify a G1 point in the proof
+    function setG1Point(bytes memory proof, uint256 offset, uint256 x, uint256 y) internal pure {
+        assembly {
+            mstore(add(add(proof, 0x20), offset), x)
+            mstore(add(add(proof, 0x20), add(offset, 32)), y)
+        }
+    }
+
+    /// @notice Helper to modify a single 32-byte value in the proof
+    function setValue(bytes memory proof, uint256 offset, uint256 value) internal pure {
+        assembly {
+            mstore(add(add(proof, 0x20), offset), value)
+        }
+    }
+
+    /// @notice Helper to read a 32-byte value from the proof
+    function getValue(bytes memory proof, uint256 offset) internal pure returns (uint256 value) {
+        assembly {
+            value := mload(add(add(proof, 0x20), offset))
+        }
+    }
+
+    /// @notice Copy cached proof to avoid mutation across tests
+    function copyProof() internal view returns (bytes memory) {
+        return cachedProof;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           SANITY CHECK
+    //////////////////////////////////////////////////////////////*/
+
+    function test_ValidProof() public {
+        assertTrue(verifier.verify{gas: 15_000_000}(cachedProof, cachedPublicInputs), "Valid proof should verify");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        BASIC VALIDATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_InvalidProofLength(uint256 _size) public virtual {
+        uint256 expectedLength = cachedProof.length;
+        uint256 size = bound(_size, 0, expectedLength * 2);
+        vm.assume(size != expectedLength);
+
+        bytes memory proof = new bytes(size);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.ProofLengthWrongWithLogN.selector, LOG_N, size, cachedProof.length)
+        );
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_InvalidPublicInputsLength(uint256 _size) public virtual {
+        uint256 size = bound(_size, 0, cachedPublicInputs.length * 2);
+        vm.assume(size != cachedPublicInputs.length);
+
+        bytes32[] memory publicInputs = new bytes32[](size);
+
+        vm.expectRevert(Errors.PublicInputsLengthWrong.selector);
+        verifier.verify{gas: 15_000_000}(cachedProof, publicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          SUMCHECK FAILURES
+    //////////////////////////////////////////////////////////////*/
+
+    // Sumcheck verifies that polynomial evaluations are consistent.
+    // Two failure modes: round check (univariate consistency) and final check (evaluation match).
+
+    /// @notice Corrupt sumcheck univariate - triggers round check failure
+    /// @dev Each round, the verifier checks: univariate(0) + univariate(1) = previous_sum
+    ///      Corrupting a univariate coefficient breaks this invariant.
+    function testRevertSumcheckFailedRoundCheck() public virtual {
+        bytes memory proof = copyProof();
+
+        // sumcheckUnivariates start after witness commitments (8 * 64 = 512 bytes after pairing points)
+        uint256 univariateOffset = PAIRING_POINTS_SIZE + (8 * G1_POINT_SIZE);
+
+        assembly {
+            let loc := add(add(proof, 0x20), univariateOffset)
+            mstore(loc, add(mload(loc), 1))
+        }
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupt sumcheck evaluation - triggers final check failure
+    /// @dev After all rounds, verifier checks evaluations match claimed polynomial values.
+    ///      Corrupting an evaluation breaks the final consistency check.
+    function testRevertSumcheckFailedFinalCheck() public virtual {
+        bytes memory proof = copyProof();
+
+        // Work backwards: kzg_w(64) + shplonk_q(64) + gemini_evals(LOG_N*32) + gemini_comms((LOG_N-1)*64)
+        uint256 evalsEndOffset = proof.length - 64 - 64 - LOG_N * 32 - (LOG_N - 1) * 64;
+        uint256 lastEvalOffset = evalsEndOffset - 32;
+
+        assembly {
+            let loc := add(add(proof, 0x20), lastEvalOffset)
+            mstore(loc, add(mload(loc), 1))
+        }
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    POINT VALIDATION - OFF-CURVE REJECTION
+    //////////////////////////////////////////////////////////////*/
+
+    // Off-curve points (with coordinates < Q and not (0,0)) pass input validation.
+    // They are caught downstream by EVM precompile rejection (ecAdd/ecMul per EIP-196)
+    // or indirectly via transcript corruption causing SumcheckFailed.
+    //
+    // - Transcript points (W_L, etc.): wrong challenges → SumcheckFailed
+    // - Non-transcript points (kzgQuotient, shplonkQ, geminiFoldComm):
+    //   precompile rejects off-curve input → empty revert
+
+    /// @notice Off-curve kzgQuotient - precompile rejects during Shplemini
+    /// @dev kzgQuotient is NOT in the Fiat-Shamir transcript, so sumcheck
+    ///      passes with correct challenges. The ecMul precompile rejects the
+    ///      off-curve point during Shplemini verification.
+    function test_OffCurve_KzgQuotient() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 64;
+        uint256 y = getValue(proof, xOffset + 32);
+        // +7 breaks the curve equation while staying < Q
+        setValue(proof, xOffset + 32, y + 7);
+
+        // Precompile rejection, but because there is gas leftover and this value is used
+        // right after the revert, the 1/64 of gas left is sufficient to give us that error
+        // instead...
+        vm.expectRevert(Errors.ShpleminiFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Off-curve W_L - caught via transcript corruption
+    /// @dev W_L is hashed into the transcript to derive the eta challenge.
+    ///      Corrupting its y-coordinate changes all downstream challenges,
+    ///      causing sumcheck to fail before any EC operation touches W_L.
+    function test_OffCurve_WL() public virtual {
+        bytes memory proof = copyProof();
+        uint256 y = getValue(proof, W_L_OFFSET + 32);
+        // +7 breaks the curve equation while staying < Q
+        setValue(proof, W_L_OFFSET + 32, y + 7);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Off-curve shplonkQ - precompile rejects during Shplemini
+    /// @dev shplonkQ is NOT in the transcript. The ecMul precompile rejects it.
+    function test_OffCurve_ShplonkQ() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 128;
+        uint256 y = getValue(proof, xOffset + 32);
+        setValue(proof, xOffset + 32, y + 7);
+
+        // Precompile rejection: revert(0, 0) → empty revert data
+        vm.expectRevert(bytes(""));
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Off-curve gemini fold commitment - precompile rejects during Shplemini
+    /// @dev Gemini fold commitments are hashed for gemini_r AFTER sumcheck passes.
+    ///      The keccak256 hash works fine on raw bytes, but the subsequent ecMul
+    ///      precompile rejects the off-curve point.
+    function test_OffCurve_GeminiFoldComm() public virtual {
+        bytes memory proof = copyProof();
+        // Last gemini fold comm y offset
+        uint256 geminiFoldYOffset = proof.length - 64 - 64 - LOG_N * 32 - 32;
+        uint256 y = getValue(proof, geminiFoldYOffset);
+        setValue(proof, geminiFoldYOffset, y + 7);
+
+        // Precompile rejection: revert(0, 0) → empty revert data
+        vm.expectRevert(bytes(""));
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    SHPLEMINI / PAIRING FAILURES
+    //////////////////////////////////////////////////////////////*/
+
+    // Shplemini is the polynomial commitment verification step.
+    // Different proof elements cause different failure modes depending on
+    // whether they affect the transcript (challenges) or not.
+
+    /// @notice Corrupt witness commitment - fails at SUMCHECK, not Shplemini
+    /// @dev KEY INSIGHT: Witness commitments are hashed into transcript.
+    ///      Corrupting them changes challenges, failing sumcheck BEFORE pairing.
+    ///      This documents the verification order dependency.
+    function testRevertSumcheckFailedWitnessCommitment() public virtual {
+        bytes memory proof = copyProof();
+
+        // Negate W_L's y-coordinate (point negation is still on curve but wrong)
+        uint256 y = getValue(proof, W_L_OFFSET + 32);
+        setValue(proof, W_L_OFFSET + 32, Q - y);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupt gemini fold commitment - fails at Shplemini
+    /// @dev Gemini commitments are NOT in transcript, so challenges unaffected.
+    ///      The pairing check fails because commitment doesn't match.
+    function testRevertShpleminiFailedGeminiFoldComm() public virtual {
+        bytes memory proof = copyProof();
+
+        // Last gemini fold comm y offset
+        uint256 geminiFoldYOffset = proof.length - 64 - 64 - LOG_N * 32 - 32;
+
+        uint256 y = getValue(proof, geminiFoldYOffset);
+        setValue(proof, geminiFoldYOffset, Q - y);
+
+        vm.expectRevert(Errors.ShpleminiFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Replace kzgQuotient with valid but wrong point - fails at pairing
+    /// @dev Adds generator G=(1,2) to the original kzgQuotient.
+    ///      Result is still on-curve (passes on-curve check) but wrong value.
+    ///      This tests the actual pairing equation: e(P, Q) = e(R, S) fails.
+    function testRevertShpleminiFailedPairing() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 xOffset = proof.length - 64;
+        uint256 yOffset = proof.length - 32;
+
+        uint256 px = getValue(proof, xOffset);
+        uint256 py = getValue(proof, yOffset);
+
+        // Add generator G = (1, 2) using ecAdd precompile
+        uint256 rx;
+        uint256 ry;
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, px)
+            mstore(add(ptr, 0x20), py)
+            mstore(add(ptr, 0x40), 1)
+            mstore(add(ptr, 0x60), 2)
+            if iszero(staticcall(gas(), 0x06, ptr, 0x80, ptr, 0x40)) { revert(0, 0) }
+            rx := mload(ptr)
+            ry := mload(add(ptr, 0x20))
+        }
+
+        setG1Point(proof, xOffset, rx, ry);
+
+        vm.expectRevert(Errors.ShpleminiFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    POINT OF INFINITY (0,0) INJECTION
+    //////////////////////////////////////////////////////////////*/
+
+    // ATTACK VECTOR: Point of Infinity Injection
+    //
+    // EVM precompiles silently treat (0,0) as the identity element instead of reverting.
+    // This could zero out commitments and allow a forged proof to pass.
+    //
+    // Both verifiers explicitly reject (0,0) at the input boundary:
+    // - Standard: bytesToG1Point checks (x | y) != 0
+    // - Optimized: inline point-at-infinity check after calldatacopy
+    // This catches (0,0) with PointAtInfinity before any computation begins.
+
+    /// @notice (0,0) in W_L - caught by point-at-infinity check at deserialization
+    function test_PointOfInfinity_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in W_R - caught by point-at-infinity check at deserialization
+    function test_PointOfInfinity_WR() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_R_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in W_O - caught by point-at-infinity check at deserialization
+    function test_PointOfInfinity_WO() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_O_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in kzgQuotient - caught by point-at-infinity check
+    function test_PointOfInfinity_KzgQuotient() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 64;
+        setG1Point(proof, xOffset, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in shplonkQ - caught by point-at-infinity check
+    function test_PointOfInfinity_ShplonkQ() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 128;
+        setG1Point(proof, xOffset, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in pairing points - no explicit check, caught via computation
+    function test_PointOfInfinity_PairingPoint() public virtual {
+        bytes memory proof = copyProof();
+
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, 0);
+        }
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    Q+1 ATTACKS (FIELD MODULUS ALIASING)
+    //////////////////////////////////////////////////////////////*/
+
+    // ATTACK VECTOR: Field modulus aliasing
+    //
+    // Without validation, the BN254 curve field modulus Q would cause values >= Q
+    // to reduce via % Q. E.g., (Q+1, 2) would become (1, 2) - the generator point.
+    // This is a valid curve point, so it would pass on-curve checks.
+    //
+    // Security property tested: The verifier explicitly checks all point coordinates
+    // are < Q and rejects with ValueGeGroupOrder BEFORE any reduction or EC operation.
+    // This prevents attackers from using non-canonical representations.
+    //
+    // We test multiple witness wires (W_L, W_R, W_O) to ensure all commitment
+    // positions are properly validated at the input boundary.
+
+    /// @notice Q+1 attack on W_L - tests left wire commitment validation
+    /// @dev (Q+1, 2) would reduce to (1, 2) - the generator point - but the verifier
+    ///      rejects with ValueGeGroupOrder before any reduction occurs.
+    function test_QPlusOne_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Q+1 attack on W_R - tests right wire commitment validation
+    function test_QPlusOne_WR() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_R_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Q+1 attack on W_O - tests output wire commitment validation
+    function test_QPlusOne_WO() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_O_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Q+1 in kzgQuotient - tests non-transcript commitment validation
+    /// @dev kzgQuotient is NOT hashed into the transcript, but the explicit >= Q check
+    ///      catches it at the input boundary just like transcript commitments.
+    function test_QPlusOne_KzgQuotient() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 64;
+        setG1Point(proof, xOffset, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice 2Q attack - tests values well beyond modulus boundary
+    function test_TwoQ_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, 2 * Q, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Exact Q attack - tests boundary case
+    /// @dev (Q, 2) would reduce to (0, 2) but is caught by ValueGeGroupOrder at exact boundary.
+    function test_ExactQ_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, Q, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Y-coordinate aliasing - tests both x and y are checked against Q
+    function test_YCoordinateExactQ() public virtual {
+        bytes memory proof = copyProof();
+        uint256 originalX = getValue(proof, W_L_OFFSET);
+        setG1Point(proof, W_L_OFFSET, originalX, Q);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Maximum uint256 attack - tests extreme value handling
+    function test_MaxUint256Coordinate() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, type(uint256).max, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PAIRING POINT LIMB OVERFLOW
+    //////////////////////////////////////////////////////////////*/
+
+    // SECURITY OBSERVATION: Pairing Point Representation
+    //
+    // Pairing points use 136-bit limb encoding: 2 limbs per field element (lo, hi).
+    // Reconstruction: value = lo | (hi << 136)
+    // 4 coordinates (P0.x, P0.y, P1.x, P1.y) = 8 meaningful limbs (indices 0-7).
+    //
+    // Differentiated validation: lo limbs (even indices) < 2^136, hi limbs (odd indices) < 2^120.
+    // This ensures reconstructed coordinates cannot exceed ~2^256 and stay within valid range.
+    // Values exceeding their respective bounds are rejected with ValueGeLimbMax error.
+    // Valid but corrupted limbs flow through and are caught via sumcheck failure.
+
+    /// @notice Bit 136 overflow - first invalid bit position
+    /// @dev Valid limbs use bits 0-135. Bit 136 overflows the limb boundary.
+    function test_PairingLimbOverflow_Limb0Bit136() public virtual {
+        bytes memory proof = copyProof();
+        uint256 malformedLimb = 1 << 136;
+        setValue(proof, PAIRING_POINTS_OFFSET, malformedLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Maximum uint256 - extreme overflow across all bit positions
+    function test_PairingLimbOverflow_MaxUint256() public virtual {
+        bytes memory proof = copyProof();
+        setValue(proof, PAIRING_POINTS_OFFSET, type(uint256).max);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb corruption - tests second limb of first coordinate (P0.x_hi)
+    /// @dev With 2-limb encoding, offset 32 is the hi limb of P0.x.
+    ///      A corrupted value < 2^136 passes limb validation but produces wrong reconstruction.
+    function test_PairingLimbTruncation_HiLimb() public virtual {
+        bytes memory proof = copyProof();
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 32;
+        uint256 truncatingValue = 1 << 52;
+        setValue(proof, hiLimbOffset, truncatingValue);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Cross-limb bit collision - set bit 136 in lo limb to overflow into hi limb's space
+    /// @dev With 136-bit limbs, bit 136 in the lo limb (index 0) overlaps with bit 0 of
+    ///      the hi limb (index 1). This creates the same reconstructed value as adding 1
+    ///      to the hi limb, but with a non-canonical representation.
+    ///      Now caught by explicit limb validation (>= 2^136).
+    function test_PairingLimbOverlap() public virtual {
+        bytes memory proof = copyProof();
+
+        // Read original lo limb and set bit 136 (overflows into hi limb's space)
+        uint256 limb0 = getValue(proof, PAIRING_POINTS_OFFSET);
+        uint256 newLimb0 = limb0 | (1 << 136);
+
+        setValue(proof, PAIRING_POINTS_OFFSET, newLimb0);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice All 8 meaningful limbs overflowing - comprehensive corruption
+    /// @dev Sets all limbs used by convertPairingPointsToG1 to >= 2^136
+    function test_PairingLimbs_AllOverflowing() public virtual {
+        bytes memory proof = copyProof();
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, 1 << 136);
+        }
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb >= 2^120 but < 2^136 - tests differentiated limb bounds
+    /// @dev Hi limbs (odd indices: 1,3,5,7) are the upper 120 bits of each coordinate.
+    ///      A value >= 2^120 would pass the old uniform 2^136 check but is now rejected.
+    ///      This validates that lo limbs use 136-bit bound and hi limbs use 120-bit bound.
+    function test_PairingHiLimbOverflow_Bit120() public virtual {
+        bytes memory proof = copyProof();
+
+        // Hi limb of P0.x is at index 1 (offset 32)
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 32;
+        uint256 malformedHiLimb = 1 << 120; // exactly 2^120, valid under old 2^136 check
+        setValue(proof, hiLimbOffset, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb just below 2^136 - tests that the tighter bound catches it
+    /// @dev 2^136 - 1 is valid under old check but >> 2^120 so caught by new check
+    function test_PairingHiLimbOverflow_Max136() public virtual {
+        bytes memory proof = copyProof();
+
+        // Hi limb of P0.y is at index 3 (offset 96)
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 96;
+        uint256 malformedHiLimb = (1 << 136) - 1; // max valid under old check
+        setValue(proof, hiLimbOffset, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Lo limb just below 2^136 - should still be accepted (caught later by sumcheck)
+    /// @dev Validates that lo limbs retain the full 136-bit range
+    function test_PairingLoLimbMaxValid() public virtual {
+        bytes memory proof = copyProof();
+
+        // Lo limb of P0.x is at index 0 (offset 0)
+        uint256 loLimbOffset = PAIRING_POINTS_OFFSET;
+        uint256 maxLoLimb = (1 << 136) - 1; // max valid lo limb
+        setValue(proof, loLimbOffset, maxLoLimb);
+
+        // Should pass limb validation but fail somewhere in sumcheck (not ValueGeLimbMax)
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice All hi limbs at 2^120 - comprehensive check of all 4 hi limb positions
+    function test_PairingHiLimbOverflow_AllHiLimbs() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 malformedHiLimb = 1 << 120;
+        // Hi limbs are at odd indices: 1, 3, 5, 7 (offsets 32, 96, 160, 224)
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 96, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 160, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 224, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Field aliasing + limb attack combined
+    /// @dev Q ≈ 2^254 >> 2^136, so all limbs fail the limb validation check
+    function test_PairingLimbs_AllQPlusOne() public virtual {
+        bytes memory proof = copyProof();
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, Q + 1);
+        }
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+            PAIRING POINT RECONSTRUCTED COORDINATE >= Q
+    //////////////////////////////////////////////////////////////*/
+
+    // ATTACK VECTOR: Limb-level aliasing
+    //
+    // Individual limbs can pass their bounds (lo < 2^136, hi < 2^120) while
+    // the reconstructed coordinate lo | (hi << 136) >= Q.
+    //
+    // An explicit < Q check exists in convertPairingPointsToG1 (defense-in-depth against
+    // a malicious prover using non-canonical coordinates). However, since the pairing point
+    // limbs are hashed into the eta challenge BEFORE sumcheck, mutating limbs in an existing
+    // proof always corrupts the transcript first - causing SumcheckFailed before we reach
+    // the reconstruction check. These tests document that rejection path.
+    //
+    // Q >> 136 ≈ 2^118 which is well under 2^120, so a hi limb of (Q >> 136) + 1
+    // passes the hi limb check but pushes the reconstructed coordinate above Q.
+
+    /// @notice Reconstructed P0.x >= Q - caught by sumcheck (transcript corruption)
+    /// @dev hi = (Q >> 136) + 1 is ~118 bits (passes < 2^120 check), lo = 0.
+    ///      Reconstructed value = ((Q >> 136) + 1) << 136 > Q.
+    ///      The modified limb changes the eta challenge, so sumcheck fails before
+    ///      the explicit < Q check in convertPairingPointsToG1 is reached.
+    function test_PairingReconstructedCoordGeQ() public virtual {
+        bytes memory proof = copyProof();
+
+        // Set P0.x: lo = 0 (index 0), hi = (Q >> 136) + 1 (index 1)
+        uint256 hiLimb = (Q >> 136) + 1;
+        setValue(proof, PAIRING_POINTS_OFFSET, 0); // lo
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, hiLimb); // hi
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Reconstructed P0.x just above Q - minimal overflow
+    /// @dev Uses exact Q >> 136 as hi limb with lo chosen to push total just past Q.
+    ///      Same transcript corruption path as above - sumcheck fails first.
+    function test_PairingReconstructedCoordJustAboveQ() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 hiLimb = Q >> 136;
+        // Remainder: Q - (hiLimb << 136). Adding 1 to lo pushes total to Q + 1.
+        uint256 loLimb = Q - (hiLimb << 136) + 1;
+
+        setValue(proof, PAIRING_POINTS_OFFSET, loLimb); // lo
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, hiLimb); // hi
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    FIELD ELEMENT >= P ATTACKS
+    //////////////////////////////////////////////////////////////*/
+
+    // ATTACK VECTOR: Scalar Field Modulus Aliasing
+    //
+    // Field elements (Fr) use scalar field modulus P (different from curve field Q).
+    // Values >= P get reduced via % P. Like Q+1 attacks on curve points,
+    // these are sanitized but still cause proof rejection.
+
+    /// @notice Public input value >= P - tests input validation
+    /// @dev Sets first public input to P+1. Behavior differs by verifier:
+    ///      - Standard: FrLib.fromBytes32 reduces P+1 → 1, but transcript hashes
+    ///        the raw value P+1, causing challenge mismatch → sumcheck failure.
+    ///      - Optimized: Explicit check (input < p) → PUBLIC_INPUT_TOO_LARGE.
+    function test_PublicInputGreaterThanP() public virtual {
+        bytes32[] memory publicInputs = new bytes32[](cachedPublicInputs.length);
+        for (uint256 i = 0; i < cachedPublicInputs.length; i++) {
+            publicInputs[i] = cachedPublicInputs[i];
+        }
+        // Set first public input to P + 1 (valid uint256, but >= scalar field modulus)
+        publicInputs[0] = bytes32(P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        verifier.verify{gas: 15_000_000}(cachedProof, publicInputs);
+    }
+
+    /// @notice P+1 in sumcheck evaluation - tests Fr sanitization
+    /// @dev Targets QM polynomial evaluation. P+1 % P = 1.
+    function test_EvaluationGreaterThanP() public virtual {
+        bytes memory proof = copyProof();
+        uint256 qmEvalOffset = PAIRING_POINTS_SIZE + 8 * G1_POINT_SIZE + (LOG_N * 8 * 32);
+        setValue(proof, qmEvalOffset, P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice P+1 in sumcheck univariate - tests round check with aliased value
+    function test_SumcheckUnivariateGreaterThanP() public virtual {
+        bytes memory proof = copyProof();
+        uint256 univariateOffset = PAIRING_POINTS_SIZE + 8 * G1_POINT_SIZE;
+        setValue(proof, univariateOffset, P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    DEBUG HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function testDebugProofStructure() public {
+        bytes memory proof = cachedProof;
+
+        emit log_named_uint("Proof length", proof.length);
+        emit log_named_uint("LOG_N", LOG_N);
+
+        uint256 kzgX = getValue(proof, proof.length - 64);
+        uint256 kzgY = getValue(proof, proof.length - 32);
+
+        emit log_named_uint("kzgQuotient.x", kzgX);
+        emit log_named_uint("kzgQuotient.y", kzgY);
+
+        uint256 lhs = mulmod(kzgY, kzgY, Q);
+        uint256 xx = mulmod(kzgX, kzgX, Q);
+        uint256 rhs = addmod(mulmod(kzgX, xx, Q), 3, Q);
+
+        emit log_named_uint("y^2 mod Q", lhs);
+        emit log_named_uint("x^3+3 mod Q", rhs);
+        emit log_named_string("On curve", lhs == rhs ? "YES" : "NO");
+    }
+}

--- a/barretenberg/sol/test/honk/negative/NegativeTestBaseZK.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestBaseZK.sol
@@ -1,0 +1,773 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {TestBase} from "test/base/TestBase.sol";
+import {DifferentialFuzzer} from "test/base/DifferentialFuzzer.sol";
+import {IVerifier} from "src/interfaces/IVerifier.sol";
+import {BaseZKHonkVerifier} from "src/honk/BaseZKHonkVerifier.sol";
+import {Errors} from "src/honk/Errors.sol";
+
+/**
+ * @title NegativeTestBaseZK
+ * @notice Base contract for ZK verifier negative tests
+ *
+ * @dev Uses Blake circuit so the same proof can be tested against both:
+ * - BlakeHonkZKVerifier (standard ZK)
+ * - BlakeOptHonkVerifier (optimized ZK)
+ *
+ * Error selectors are virtual so optimized verifier can override them.
+ * The optimized verifier uses different error types (SUMCHECK_FAILED vs BaseZKHonkVerifier.SumcheckFailed).
+ *
+ * SECURITY OBSERVATION:
+ * The ZK verifier rejects the point at infinity (0,0) at the deserialization boundary
+ * via bytesToG1Point's (x | y) != 0 check. On-curve validation (y² = x³ + 3) is
+ * delegated to the ecAdd/ecMul precompiles per EIP-196.
+ *
+ * Pairing points (136-bit limb encoded) have their limbs validated for bounds
+ * and reconstructed coordinates checked < Q. Corrupted limbs that produce
+ * valid-looking but wrong points are caught indirectly via sumcheck failure.
+ *
+ * Test categories:
+ * 1. Basic validation (proof length, public inputs length)
+ * 2. Sumcheck failures (round check, final check, libra eval)
+ * 3. Point validation (on-curve check - only kzgQuotient/shplonkQ)
+ * 4. Shplemini/pairing failures
+ * 5. Consistency check failures (ZK-specific)
+ * 6. Q+1 attacks (field modulus aliasing)
+ * 7. Pairing point limb overflow
+ * 8. Field element >= P attacks
+ * 9. ZK-specific commitment corruption (geminiMaskingPoly, libraCommitments)
+ *
+ * Note on gas:
+ * We pass "only" 15M gas, since the pre-compile failure will consume remaining gas for the call
+ * and with "infinite" gas available that makes it possible to reach the following error (for example
+ * failing shplimini that is directly dependent on the pre-compile [so also correct] but the potential for
+ * multiple different errors here is painful for test).
+ */
+abstract contract NegativeTestBaseZK is TestBase {
+    IVerifier public verifier;
+    DifferentialFuzzer public fuzzer;
+    uint256 public PUBLIC_INPUT_COUNT;
+
+    bytes internal cachedProof;
+    bytes32[] internal cachedPublicInputs;
+
+    // BN254 curve field modulus (for EC points)
+    uint256 constant Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    // BN254 scalar field modulus (for Fr elements)
+    uint256 constant P = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+    // Blake circuit has LOG_N = 15
+    uint256 constant LOG_N = 15;
+
+    // ZK proof structure offsets (from proof start)
+    // Based on ZKTranscript.loadProof serialization order:
+    //
+    // Layout:
+    //   pairingPointObject(256) + geminiMaskingPoly(64) +
+    //   w1(64) + w2(64) + w3(64) +
+    //   lookupReadCounts(64) + lookupReadTags(64) + w4(64) + lookupInverses(64) + zPerm(64) +
+    //   libraCommitments[0](64) + libraSum(32) + sumcheckUnivariates...
+    //
+    // NOTE: libraCommitments[1] and [2] are serialized LATE (after sumcheck evals + libraEval),
+    //       so they cannot be expressed as static offset constants.
+
+    // Pairing points: 8 limbs × 32 bytes = 256 bytes at offset 0
+    uint256 constant PAIRING_POINTS_OFFSET = 0;
+    uint256 constant PAIRING_POINTS_SIZE = 256;
+
+    // ZK-specific: geminiMaskingPoly commitment after pairing points
+    uint256 constant GEMINI_MASKING_POLY_OFFSET = 256;
+
+    // Witness commitments start after geminiMaskingPoly
+    // NOTE: serialization order differs from struct layout (w4 comes after lookupReadTags)
+    uint256 constant W_L_OFFSET = 320; // 256 + 64 (w1)
+    uint256 constant W_R_OFFSET = 384; // 320 + 64 (w2)
+    uint256 constant W_O_OFFSET = 448; // 384 + 64 (w3)
+    uint256 constant LOOKUP_READ_COUNTS_OFFSET = 512; // 448 + 64
+    uint256 constant LOOKUP_READ_TAGS_OFFSET = 576; // 512 + 64
+    uint256 constant W_4_OFFSET = 640; // 576 + 64
+    uint256 constant LOOKUP_INVERSES_OFFSET = 704; // 640 + 64
+    uint256 constant Z_PERM_OFFSET = 768; // 704 + 64
+
+    // ZK-specific: only libraCommitments[0] is serialized here
+    uint256 constant LIBRA_COMM_0_OFFSET = 832; // 768 + 64
+
+    // libraSum (Fr element) after libraCommitments[0]
+    uint256 constant LIBRA_SUM_OFFSET = 896; // 832 + 64
+
+    // sumcheckUnivariates start after libraSum
+    uint256 constant SUMCHECK_UNIVARIATES_OFFSET = 928; // 896 + 32
+
+    // Each G1 point is 64 bytes (x, y)
+    uint256 constant G1_POINT_SIZE = 64;
+
+    // ZK-specific constants
+    uint256 constant NUMBER_OF_ENTITIES_ZK = 44;
+    uint256 constant ZK_BATCHED_RELATION_PARTIAL_LENGTH = 9; // 9 coefficients per round for ZK
+
+    /// @notice Override in concrete test to return the verifier instance
+    function _createVerifier() internal virtual returns (IVerifier);
+
+    /// @notice Override to return expected proof length for this circuit
+    function _expectedProofLength() internal view virtual returns (uint256) {
+        return cachedProof.length;
+    }
+
+    function setUp() public virtual {
+        fuzzer = new DifferentialFuzzer().with_flavor(DifferentialFuzzer.Flavor.HonkZK);
+        fuzzer = fuzzer.with_circuit_type(DifferentialFuzzer.CircuitType.Blake);
+
+        verifier = _createVerifier();
+
+        PUBLIC_INPUT_COUNT = 4;
+
+        // Add default inputs to the fuzzer
+        uint256[] memory defaultInputs = new uint256[](4);
+        defaultInputs[0] = 0x0000000000000000000000000000000000000000000000000000000000000001;
+        defaultInputs[1] = 0x0000000000000000000000000000000000000000000000000000000000000002;
+        defaultInputs[2] = 0x0000000000000000000000000000000000000000000000000000000000000003;
+        defaultInputs[3] = 0x0000000000000000000000000000000000000000000000000000000000000004;
+
+        fuzzer = fuzzer.with_inputs(defaultInputs);
+
+        bytes memory proofData = fuzzer.generate_proof();
+        (cachedPublicInputs, cachedProof) = splitProofHonk(proofData, PUBLIC_INPUT_COUNT);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Helper to modify a G1 point in the proof
+    function setG1Point(bytes memory proof, uint256 offset, uint256 x, uint256 y) internal pure {
+        assembly {
+            mstore(add(add(proof, 0x20), offset), x)
+            mstore(add(add(proof, 0x20), add(offset, 32)), y)
+        }
+    }
+
+    /// @notice Helper to modify a single 32-byte value in the proof
+    function setValue(bytes memory proof, uint256 offset, uint256 value) internal pure {
+        assembly {
+            mstore(add(add(proof, 0x20), offset), value)
+        }
+    }
+
+    /// @notice Helper to read a 32-byte value from the proof
+    function getValue(bytes memory proof, uint256 offset) internal pure returns (uint256 value) {
+        assembly {
+            value := mload(add(add(proof, 0x20), offset))
+        }
+    }
+
+    /// @notice Copy cached proof to avoid mutation across tests
+    function copyProof() internal view returns (bytes memory) {
+        return cachedProof;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           SANITY CHECK
+    //////////////////////////////////////////////////////////////*/
+
+    function test_ValidProof() public {
+        assertTrue(verifier.verify{gas: 15_000_000}(cachedProof, cachedPublicInputs), "Valid proof should verify");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        BASIC VALIDATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_InvalidProofLength(uint256 _size) public virtual {
+        uint256 expectedLength = _expectedProofLength();
+        uint256 size = bound(_size, 0, expectedLength * 2);
+        vm.assume(size != expectedLength);
+
+        bytes memory proof = new bytes(size);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.ProofLengthWrongWithLogN.selector, LOG_N, size, expectedLength));
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_InvalidPublicInputsLength(uint256 _size) public virtual {
+        uint256 size = bound(_size, 0, cachedPublicInputs.length * 2);
+        vm.assume(size != cachedPublicInputs.length);
+
+        bytes32[] memory publicInputs = new bytes32[](size);
+
+        vm.expectRevert(Errors.PublicInputsLengthWrong.selector);
+        verifier.verify{gas: 15_000_000}(cachedProof, publicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          SUMCHECK FAILURES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Calculate offset to sumcheck univariates for ZK proof
+    /// @dev ZK layout: pairingPoints(256) + geminiMaskingPoly(64) + witnesses(8*64) +
+    ///                 libraCommitments[0](64) + libraSum(32) = 928
+    function _sumcheckUnivariateOffset() internal pure virtual returns (uint256) {
+        return SUMCHECK_UNIVARIATES_OFFSET;
+    }
+
+    function testRevertSumcheckFailedRoundCheck() public virtual {
+        bytes memory proof = copyProof();
+        uint256 univariateOffset = _sumcheckUnivariateOffset();
+
+        assembly {
+            let loc := add(add(proof, 0x20), univariateOffset)
+            mstore(loc, add(mload(loc), 1))
+        }
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupting a libraPolyEval triggers ConsistencyCheckFailed
+    /// @dev The ZK verifier runs: verifySumcheck → verifyShplemini (which includes consistency check).
+    ///      libraPolyEvals are NOT used by sumcheck, so sumcheck passes.
+    ///      The consistency check (checkEvalsConsistency) validates that libraPolyEvals are
+    ///      consistent with libraEvaluation - corrupting one breaks this invariant.
+    ///
+    ///      Proof layout (from end): kzgQuotient(64) + shplonkQ(64) + libraPolyEvals(4×32=128)
+    function testRevertConsistencyCheckFailedFinalCheck() public virtual {
+        bytes memory proof = copyProof();
+
+        // First libraPolyEval is at proof.length - 256 (after kzg(64) + shplonk(64) + 4 evals(128))
+        uint256 libraPolyEvalOffset = proof.length - 256;
+
+        assembly {
+            let loc := add(add(proof, 0x20), libraPolyEvalOffset)
+            mstore(loc, add(mload(loc), 1))
+        }
+
+        vm.expectRevert(Errors.ConsistencyCheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupting witness commitment causes SumcheckFailed
+    /// @dev Witness commitments are hashed into transcript challenges.
+    ///      The corrupted point changes the challenges, causing sumcheck to fail.
+    function testRevertSumcheckFailedWitnessCommitment() public virtual {
+        bytes memory proof = copyProof();
+
+        // Negate W_L's y-coordinate (point negation is still on curve but wrong)
+        uint256 y = getValue(proof, W_L_OFFSET + 32);
+        setValue(proof, W_L_OFFSET + 32, Q - y);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    POINT VALIDATION - COORDINATE >= Q
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Corrupting kzgQuotient's y MSB with 0xff pushes it >= Q
+    /// @dev XORing the most significant byte with 0xff creates a value exceeding the
+    ///      curve field modulus Q, caught by bytesToG1Point's x < Q && y < Q check.
+    function test_failedCoordinateGeQ() public virtual {
+        bytes memory proof = copyProof();
+
+        // Corrupt kzgQuotient's y-coordinate MSB - pushes value >= Q
+        proof[proof.length - 32] ^= 0xff;
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    SHPLEMINI / PAIRING FAILURES
+    //////////////////////////////////////////////////////////////*/
+
+    function testRevertShpleminiFailedPairing() public virtual {
+        bytes memory proof = copyProof();
+
+        // kzgQuotient is last 64 bytes
+        uint256 xOffset = proof.length - 64;
+        uint256 yOffset = proof.length - 32;
+
+        uint256 px = getValue(proof, xOffset);
+        uint256 py = getValue(proof, yOffset);
+
+        // Add generator G = (1, 2)
+        uint256 rx;
+        uint256 ry;
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, px)
+            mstore(add(ptr, 0x20), py)
+            mstore(add(ptr, 0x40), 1)
+            mstore(add(ptr, 0x60), 2)
+            if iszero(staticcall(gas(), 0x06, ptr, 0x80, ptr, 0x40)) { revert(0, 0) }
+            rx := mload(ptr)
+            ry := mload(add(ptr, 0x20))
+        }
+
+        setG1Point(proof, xOffset, rx, ry);
+
+        vm.expectRevert(Errors.ShpleminiFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupting gemini fold commitment causes ConsistencyCheckFailed in ZK verifier
+    /// @dev Gemini fold comms are used in consistency check validation
+    function testRevertConsistencyCheckFailedGeminiFoldComm() public virtual {
+        bytes memory proof = copyProof();
+
+        // Last gemini fold comm y offset
+        // Work backwards for ZK: kzg(64) + shplonk(64) + libraPolyEvals(128) + gemini_evals(LOG_N*32) + last_gemini_fold_y
+        uint256 geminiFoldYOffset = proof.length - 64 - 64 - 128 - LOG_N * 32 - 32;
+
+        uint256 y = getValue(proof, geminiFoldYOffset);
+        setValue(proof, geminiFoldYOffset, Q - y);
+
+        vm.expectRevert(Errors.ConsistencyCheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    POINT OF INFINITY (0,0) INJECTION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice (0,0) in witness commitments - caught by point-at-infinity check
+    /// @dev bytesToG1Point validates (x | y) != 0. (0,0) is rejected with
+    ///      PointAtInfinity before any computation begins.
+    function test_PointOfInfinity_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_PointOfInfinity_WR() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_R_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_PointOfInfinity_WO() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_O_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in kzgQuotient - caught by point-at-infinity check
+    function test_PointOfInfinity_KzgQuotient() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 64;
+        setG1Point(proof, xOffset, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in shplonkQ - caught by point-at-infinity check
+    function test_PointOfInfinity_ShplonkQ() public virtual {
+        bytes memory proof = copyProof();
+        // shplonkQ is right before kzgQuotient (last 64 bytes)
+        uint256 xOffset = proof.length - 128;
+        setG1Point(proof, xOffset, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in pairing points causes SumcheckFailed
+    /// @dev No explicit on-curve check for pairing points.
+    ///      Corrupted pairing points affect computation → SumcheckFailed
+    function test_PointOfInfinity_PairingPoint() public virtual {
+        bytes memory proof = copyProof();
+
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, 0);
+        }
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    ZK-SPECIFIC COMMITMENT CORRUPTION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice (0,0) in geminiMaskingPoly - caught by point-at-infinity check
+    /// @dev bytesToG1Point validates (x | y) != 0. (0,0) is rejected with PointAtInfinity.
+    function test_PointOfInfinity_GeminiMaskingPoly() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, GEMINI_MASKING_POLY_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice (0,0) in libraCommitments[0] - caught by point-at-infinity check
+    /// @dev bytesToG1Point validates (x | y) != 0. (0,0) is rejected with PointAtInfinity.
+    function test_PointOfInfinity_LibraComm0() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, LIBRA_COMM_0_OFFSET, 0, 0);
+
+        vm.expectRevert(Errors.PointAtInfinity.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Corrupting geminiMaskingPoly causes SumcheckFailed
+    function test_GeminiMaskingPoly_Negated() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 y = getValue(proof, GEMINI_MASKING_POLY_OFFSET + 32);
+        setValue(proof, GEMINI_MASKING_POLY_OFFSET + 32, Q - y);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Q+1 in geminiMaskingPoly - caught by bytesToG1Point coordinate validation
+    function test_QPlusOne_GeminiMaskingPoly() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, GEMINI_MASKING_POLY_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    Q+1 ATTACKS (FIELD MODULUS ALIASING)
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Q+1 >= Q, caught by bytesToG1Point coordinate validation
+    function test_QPlusOne_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_QPlusOne_WR() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_R_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    function test_QPlusOne_WO() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_O_OFFSET, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Q+1 in kzgQuotient - caught by bytesToG1Point coordinate validation
+    /// @dev Caught during loadProof before any verification logic runs.
+    function test_QPlusOne_KzgQuotient() public virtual {
+        bytes memory proof = copyProof();
+        uint256 xOffset = proof.length - 64;
+        setG1Point(proof, xOffset, Q + 1, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @dev 2Q >= Q, caught by bytesToG1Point coordinate validation
+    function test_TwoQ_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, 2 * Q, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @dev Q >= Q, caught by bytesToG1Point coordinate validation
+    function test_ExactQ_WL() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, Q, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @dev y = Q >= Q, caught by bytesToG1Point coordinate validation
+    function test_YCoordinateExactQ() public virtual {
+        bytes memory proof = copyProof();
+        uint256 originalX = getValue(proof, W_L_OFFSET);
+        setG1Point(proof, W_L_OFFSET, originalX, Q);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @dev max uint256 >= Q, caught by bytesToG1Point coordinate validation
+    function test_MaxUint256Coordinate() public virtual {
+        bytes memory proof = copyProof();
+        setG1Point(proof, W_L_OFFSET, type(uint256).max, 2);
+
+        vm.expectRevert(Errors.ValueGeGroupOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PAIRING POINT LIMB OVERFLOW
+    //////////////////////////////////////////////////////////////*/
+
+    // SECURITY OBSERVATION: Pairing Point Representation
+    //
+    // Pairing points use 136-bit limb encoding: 2 limbs per field element (lo, hi).
+    // Reconstruction: value = lo | (hi << 136)
+    // 4 coordinates (P0.x, P0.y, P1.x, P1.y) = 8 meaningful limbs (indices 0-7).
+    //
+    // Differentiated validation: lo limbs (even indices) < 2^136, hi limbs (odd indices) < 2^120.
+    // This ensures reconstructed coordinates cannot exceed ~2^256 and stay within valid range.
+    // Values exceeding their respective bounds are rejected with ValueGeLimbMax error.
+    // Valid but corrupted limbs flow through and are caught via sumcheck failure.
+
+    /// @notice Bit 136 overflow - first invalid bit position
+    /// @dev Valid limbs use bits 0-135. Bit 136 overflows the limb boundary.
+    function test_PairingLimbOverflow_Limb0Bit136() public virtual {
+        bytes memory proof = copyProof();
+        uint256 malformedLimb = 1 << 136;
+        setValue(proof, PAIRING_POINTS_OFFSET, malformedLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Maximum uint256 - exceeds both limb boundary and field modulus
+    /// @dev type(uint256).max > MODULUS, caught by FrLib.fromBytes32 during bytesToFr
+    function test_PairingLimbOverflow_MaxUint256() public virtual {
+        bytes memory proof = copyProof();
+        setValue(proof, PAIRING_POINTS_OFFSET, type(uint256).max);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb corruption - tests second limb of first coordinate (P0.x_hi)
+    /// @dev With 2-limb encoding, offset 32 is the hi limb of P0.x.
+    ///      A corrupted value < 2^136 passes limb validation but produces wrong reconstruction.
+    function test_PairingLimbTruncation_HiLimb() public virtual {
+        bytes memory proof = copyProof();
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 32;
+        uint256 truncatingValue = 1 << 52;
+        setValue(proof, hiLimbOffset, truncatingValue);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Cross-limb bit collision - set bit 136 in lo limb to overflow into hi limb's space
+    /// @dev With 136-bit limbs, bit 136 in the lo limb (index 0) overlaps with bit 0 of
+    ///      the hi limb (index 1). Caught by explicit limb validation (>= 2^136).
+    function test_PairingLimbOverlap() public virtual {
+        bytes memory proof = copyProof();
+        uint256 limb0 = getValue(proof, PAIRING_POINTS_OFFSET);
+        uint256 newLimb0 = limb0 | (1 << 136);
+
+        setValue(proof, PAIRING_POINTS_OFFSET, newLimb0);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice All 8 meaningful limbs overflowing - comprehensive corruption
+    /// @dev Sets all limbs used by convertPairingPointsToG1 to >= 2^136
+    function test_PairingLimbs_AllOverflowing() public virtual {
+        bytes memory proof = copyProof();
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, 1 << 136);
+        }
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb >= 2^120 but < 2^136 - tests differentiated limb bounds
+    /// @dev Hi limbs (odd indices: 1,3,5,7) are the upper 120 bits of each coordinate.
+    ///      A value >= 2^120 would pass the old uniform 2^136 check but is now rejected.
+    function test_PairingHiLimbOverflow_Bit120() public virtual {
+        bytes memory proof = copyProof();
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 32; // P0.x hi limb
+        uint256 malformedHiLimb = 1 << 120;
+        setValue(proof, hiLimbOffset, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Hi limb just below 2^136 - tests that the tighter bound catches it
+    /// @dev 2^136 - 1 is valid under old check but >> 2^120 so caught by new check
+    function test_PairingHiLimbOverflow_Max136() public virtual {
+        bytes memory proof = copyProof();
+        uint256 hiLimbOffset = PAIRING_POINTS_OFFSET + 96; // P0.y hi limb
+        uint256 malformedHiLimb = (1 << 136) - 1;
+        setValue(proof, hiLimbOffset, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Lo limb just below 2^136 - should still be accepted (caught later by sumcheck)
+    /// @dev Validates that lo limbs retain the full 136-bit range
+    function test_PairingLoLimbMaxValid() public virtual {
+        bytes memory proof = copyProof();
+        uint256 loLimbOffset = PAIRING_POINTS_OFFSET; // P0.x lo limb
+        uint256 maxLoLimb = (1 << 136) - 1;
+        setValue(proof, loLimbOffset, maxLoLimb);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice All hi limbs at 2^120 - comprehensive check of all 4 hi limb positions
+    function test_PairingHiLimbOverflow_AllHiLimbs() public virtual {
+        bytes memory proof = copyProof();
+        uint256 malformedHiLimb = 1 << 120;
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 96, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 160, malformedHiLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 224, malformedHiLimb);
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Field aliasing + limb attack combined
+    /// @dev Q+1 > MODULUS (P), caught by FrLib.fromBytes32 during bytesToFr
+    function test_PairingLimbs_AllQPlusOne() public virtual {
+        bytes memory proof = copyProof();
+        for (uint256 i = 0; i < 8; i++) {
+            setValue(proof, PAIRING_POINTS_OFFSET + i * 32, Q + 1);
+        }
+
+        vm.expectRevert(Errors.ValueGeLimbMax.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+            PAIRING POINT RECONSTRUCTED COORDINATE >= Q
+    //////////////////////////////////////////////////////////////*/
+
+    // ATTACK VECTOR: Limb-level aliasing
+    //
+    // Individual limbs can pass their bounds (lo < 2^136, hi < 2^120) while
+    // the reconstructed coordinate lo | (hi << 136) >= Q.
+    //
+    // An explicit < Q check exists in convertPairingPointsToG1 (defense-in-depth against
+    // a malicious prover using non-canonical coordinates). However, since the pairing point
+    // limbs are hashed into the eta challenge BEFORE sumcheck, mutating limbs in an existing
+    // proof always corrupts the transcript first - causing SumcheckFailed before we reach
+    // the reconstruction check. These tests document that rejection path.
+
+    /// @notice Reconstructed P0.x >= Q - caught by sumcheck (transcript corruption)
+    /// @dev hi = (Q >> 136) + 1 is ~118 bits (passes < 2^120 check), lo = 0.
+    ///      The modified limb changes the eta challenge, so sumcheck fails before
+    ///      the explicit < Q check in convertPairingPointsToG1 is reached.
+    function test_PairingReconstructedCoordGeQ() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 hiLimb = (Q >> 136) + 1;
+        setValue(proof, PAIRING_POINTS_OFFSET, 0);
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, hiLimb);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice Reconstructed P0.x just above Q - minimal overflow
+    /// @dev Same transcript corruption path - sumcheck fails first.
+    function test_PairingReconstructedCoordJustAboveQ() public virtual {
+        bytes memory proof = copyProof();
+
+        uint256 hiLimb = Q >> 136;
+        uint256 loLimb = Q - (hiLimb << 136) + 1;
+
+        setValue(proof, PAIRING_POINTS_OFFSET, loLimb);
+        setValue(proof, PAIRING_POINTS_OFFSET + 32, hiLimb);
+
+        vm.expectRevert(Errors.SumcheckFailed.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    FIELD ELEMENT >= P ATTACKS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Evaluation >= P caught by FrLib.fromBytes32 during loadProof
+    /// @dev P+1 >= MODULUS, so bytesToFr rejects it with ValueGeFieldOrder
+    function test_EvaluationGreaterThanP() public virtual {
+        bytes memory proof = copyProof();
+
+        // Work backwards to find first sumcheck evaluation
+        // End structure: kzgQuotient(64) + shplonkQ(64) + libraPolyEvals(128) = 256 bytes
+        // Before that: geminiAEvaluations(LOG_N * 32) = 480 bytes
+        // Before that: geminiFoldComms((LOG_N-1) * 64) = 896 bytes
+        // Before that: libraComm2(64) + libraComm1(64) + libraEvaluation(32) = 160 bytes
+        // Before that: sumcheckEvaluations(NUMBER_OF_ENTITIES_ZK * 32)
+        uint256 evalsEndOffset = proof.length - 256 - LOG_N * 32 - (LOG_N - 1) * 64 - 160;
+        uint256 firstEvalOffset = evalsEndOffset - NUMBER_OF_ENTITIES_ZK * 32;
+
+        setValue(proof, firstEvalOffset, P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /// @notice P+1 in sumcheck univariate - caught by FrLib.fromBytes32 validation
+    function test_SumcheckUnivariateGreaterThanP() public virtual {
+        bytes memory proof = copyProof();
+        uint256 univariateOffset = _sumcheckUnivariateOffset();
+        setValue(proof, univariateOffset, P + 1);
+
+        vm.expectRevert(Errors.ValueGeFieldOrder.selector);
+        verifier.verify{gas: 15_000_000}(proof, cachedPublicInputs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    DEBUG HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function testDebugProofStructure() public {
+        bytes memory proof = cachedProof;
+
+        emit log_named_uint("Proof length", proof.length);
+        emit log_named_uint("LOG_N", LOG_N);
+
+        // Offsets from start
+        emit log_named_uint("PAIRING_POINTS_OFFSET", PAIRING_POINTS_OFFSET);
+        emit log_named_uint("GEMINI_MASKING_POLY_OFFSET", GEMINI_MASKING_POLY_OFFSET);
+        emit log_named_uint("W_L_OFFSET", W_L_OFFSET);
+        emit log_named_uint("W_4_OFFSET", W_4_OFFSET);
+        emit log_named_uint("Z_PERM_OFFSET", Z_PERM_OFFSET);
+        emit log_named_uint("LIBRA_COMM_0_OFFSET", LIBRA_COMM_0_OFFSET);
+        emit log_named_uint("LIBRA_SUM_OFFSET", LIBRA_SUM_OFFSET);
+        emit log_named_uint("SUMCHECK_UNIVARIATES_OFFSET", SUMCHECK_UNIVARIATES_OFFSET);
+
+        // Calculated offsets (work backwards from end)
+        uint256 evalsEndOffset = proof.length - 256 - LOG_N * 32 - (LOG_N - 1) * 64;
+        emit log_named_uint("Calculated sumcheckEvals end offset", evalsEndOffset);
+        emit log_named_uint("Calculated sumcheckEvals start offset", evalsEndOffset - NUMBER_OF_ENTITIES_ZK * 32);
+
+        // kzgQuotient validation
+        uint256 kzgX = getValue(proof, proof.length - 64);
+        uint256 kzgY = getValue(proof, proof.length - 32);
+
+        emit log_named_uint("kzgQuotient.x", kzgX);
+        emit log_named_uint("kzgQuotient.y", kzgY);
+
+        uint256 lhs = mulmod(kzgY, kzgY, Q);
+        uint256 xx = mulmod(kzgX, kzgX, Q);
+        uint256 rhs = addmod(mulmod(kzgX, xx, Q), 3, Q);
+
+        emit log_named_uint("y^2 mod Q", lhs);
+        emit log_named_uint("x^3+3 mod Q", rhs);
+        emit log_named_string("On curve", lhs == rhs ? "YES" : "NO");
+    }
+}

--- a/barretenberg/sol/test/honk/negative/NegativeTestHonk.t.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestHonk.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {NegativeTestBase} from "./NegativeTestBase.sol";
+import {IVerifier} from "src/interfaces/IVerifier.sol";
+import {BlakeHonkVerifier} from "src/honk/instance/BlakeHonk.sol";
+import {BaseHonkVerifier} from "src/honk/BaseHonkVerifier.sol";
+
+/**
+ * @title NegativeTestHonk
+ * @notice Negative tests for the standard (non-ZK) Blake Honk verifier
+ *
+ * @dev Inherits all tests from NegativeTestBase and provides error selectors
+ * for BaseHonkVerifier:
+ * - BaseHonkVerifier.SumcheckFailed for sumcheck failures
+ * - BaseHonkVerifier.ShpleminiFailed for pairing failures
+ * - "point is not on the curve" for on-curve validation
+ * - BaseHonkVerifier.ProofLengthWrongWithLogN for proof length
+ * - BaseHonkVerifier.PublicInputsLengthWrong for public inputs length
+ */
+contract NegativeTestHonk is NegativeTestBase {
+    /*//////////////////////////////////////////////////////////////
+                        VIRTUAL FUNCTION OVERRIDES
+    //////////////////////////////////////////////////////////////*/
+
+    function _createVerifier() internal override returns (IVerifier) {
+        return IVerifier(address(new BlakeHonkVerifier()));
+    }
+}

--- a/barretenberg/sol/test/honk/negative/NegativeTestHonkOpt.t.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestHonkOpt.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {NegativeTestBase} from "./NegativeTestBase.sol";
+import {IVerifier} from "src/interfaces/IVerifier.sol";
+import {BlakeOptHonkVerifier} from "src/honk/instance/BlakeHonkOpt.sol";
+
+/**
+ * @title NegativeTestBlakeOptHonk
+ * @notice Negative tests for the OPTIMIZED Blake Honk verifier (non-ZK variant)
+ *
+ * @dev Inherits all tests from NegativeTestBase. The optimized verifier uses
+ * the same error selectors as the standard verifier (from Errors.sol), and performs
+ * inline input validation including proof/public input length checks.
+ * No test overrides are needed.
+ */
+contract NegativeTestBlakeOptHonk is NegativeTestBase {
+    /*//////////////////////////////////////////////////////////////
+                        VIRTUAL FUNCTION OVERRIDES
+    //////////////////////////////////////////////////////////////*/
+
+    function _createVerifier() internal override returns (IVerifier) {
+        return IVerifier(address(new BlakeOptHonkVerifier()));
+    }
+}

--- a/barretenberg/sol/test/honk/negative/NegativeTestZKHonk.t.sol
+++ b/barretenberg/sol/test/honk/negative/NegativeTestZKHonk.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.21;
+
+import {NegativeTestBaseZK} from "./NegativeTestBaseZK.sol";
+import {BlakeHonkZKVerifier} from "src/honk/instance/BlakeHonkZK.sol";
+import {IVerifier} from "src/interfaces/IVerifier.sol";
+
+/**
+ * @title NegativeTestBlakeZKHonk
+ * @notice Negative tests for the standard Blake ZK Honk verifier
+ *
+ * @dev Inherits all tests from NegativeTestBaseZK.
+ * The base class error selectors are already configured for BaseZKHonkVerifier,
+ * so no overrides are needed.
+ *
+ * This contract pairs with NegativeTestBlakeOptHonk.t.sol to provide:
+ * - BlakeHonkZKVerifier (standard ZK) - this file
+ */
+contract NegativeTestBlakeZKHonk is NegativeTestBaseZK {
+    function _createVerifier() internal override returns (IVerifier) {
+        return IVerifier(address(new BlakeHonkZKVerifier()));
+    }
+}

--- a/barretenberg/sol/test/utils/Debug.sol
+++ b/barretenberg/sol/test/utils/Debug.sol
@@ -1,5 +1,9 @@
-pragma solidity >=0.8.21;
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
+import "forge-std/console2.sol";
+import {Fr} from "src/honk/Fr.sol";
 import {
     Honk,
     NUMBER_OF_ALPHAS,
@@ -7,40 +11,43 @@ import {
     BATCHED_RELATION_PARTIAL_LENGTH,
     CONST_PROOF_SIZE_LOG_N,
     PAIRING_POINTS_SIZE
-} from "./HonkTypes.sol";
+} from "src/honk/HonkTypes.sol";
+import {Transcript} from "src/honk/Transcript.sol";
 
-import {bytes32ToString} from "./utils.sol";
-import {Fr} from "./Fr.sol";
-import {Transcript} from "./Transcript.sol";
+function bytes32ToString(bytes32 value) pure returns (string memory result) {
+    bytes memory alphabet = "0123456789abcdef";
 
-import "forge-std/console2.sol";
+    bytes memory str = new bytes(66);
+    str[0] = "0";
+    str[1] = "x";
+    for (uint256 i = 0; i < 32; i++) {
+        str[2 + i * 2] = alphabet[uint8(value[i] >> 4)];
+        str[3 + i * 2] = alphabet[uint8(value[i] & 0x0f)];
+    }
+    result = string(str);
+}
 
 function logG(string memory name, uint256 i, Honk.G1Point memory point) pure {
     string memory x = bytes32ToString(bytes32(point.x));
     string memory y = bytes32ToString(bytes32(point.y));
 
     string memory message = string(abi.encodePacked(" x: ", x, " y: ", y));
-    console2.log(name, i, message);
 }
 
 function logUint(string memory name, uint256 value) pure {
     string memory as_hex = bytes32ToString(bytes32(value));
-    console2.log(name, as_hex);
 }
 
 function logUint(string memory name, uint256 i, uint256 value) pure {
     string memory as_hex = bytes32ToString(bytes32(value));
-    console2.log(name, i, as_hex);
 }
 
 function logFr(string memory name, Fr value) pure {
     string memory as_hex = bytes32ToString(bytes32(Fr.unwrap(value)));
-    console2.log(name, as_hex);
 }
 
 function logFr(string memory name, uint256 i, Fr value) pure {
     string memory as_hex = bytes32ToString(bytes32(Fr.unwrap(value)));
-    console2.log(name, i, as_hex);
 }
 
 function print_transcript(Transcript memory t) pure {


### PR DESCRIPTION
I added a whole bunch of negative test and been fixing minor findings.

What did I do:
- Handled linting issues such as; unused variables, missing visibility, wrong order etc.
- Revert if trying to invert `0`
- Revert if `pow` for non-powers of zero
- Rename `PAIRING_POINT` to convey same points but limbs 
- Update `FrLib` such that `from` and `fromBytes` revert if larger than field order
- Update challenges to explicitly be `% P`, reverts with `ValueGeFieldOrder` if above
- Bound values in `bytesToG1Point` by `Q`, reverts with `ValueGeGroupOrder` if above 
- Bound limb size to 136 bits, reverts with `ValueGeLimbMax`
- Move errors to shared file to ensure that same errors for optimised and unoptimised making testing simpler. 
- More consistent checks of untrusted input, e.g., proof and public inputs are within bounds generally. This is done early when possible to make code more legible.
- Check the proof size and number of public inputs
- Stop doing the partial is on curve checks since the pre-compile checks them more fully, with the exception of checking against point of infinity (0, 0). So we just check that instead.


The diff looks large here as I added one of the variants to git, such that it is a bit more clear when it changes as well. Not sure if this is a massive pain in the ass for you guys, but seems like a good thing with audits and such.

--- 

The gas cost of the optimised rose by ~16K, from ~583K to ~600K for the blake circuit. Part of the increase due to timing of the checks, but seemed like a way to make it simpler to reason about.