### PR TITLE
fix(p2p): wrap attestation pool operations in transactions for atomicity

### DIFF
--- a/yarn-project/.claude/rules/typescript-style.md
+++ b/yarn-project/.claude/rules/typescript-style.md
@@ -198,6 +198,38 @@ try {
 - Use `await using` for `AsyncDisposable` resources (implements `[Symbol.asyncDispose](): Promise<void>`)
 - When the resource is obtained asynchronously but disposed synchronously, use `using x = await getResource()`
 
+## KV Store Transactions
+
+When working with `AztecAsyncKVStore`, wrap related reads and writes in `store.transactionAsync()` to ensure atomicity:
+
+```typescript
+// Good: All reads and writes in a single transaction
+public async tryAdd(item: Item): Promise<boolean> {
+  return await this.store.transactionAsync(async () => {
+    const exists = await this.items.hasAsync(item.id);
+    if (exists) {
+      return false;
+    }
+    await this.items.set(item.id, item.toBuffer());
+    return true;
+  });
+}
+
+// Bad: Race condition - reads outside transaction, write inside
+public async tryAdd(item: Item): Promise<boolean> {
+  const exists = await this.items.hasAsync(item.id);  // Read outside transaction
+  if (exists) {
+    return false;
+  }
+  await this.store.transactionAsync(async () => {
+    await this.items.set(item.id, item.toBuffer());  // Write inside transaction
+  });
+  return true;
+}
+```
+
+Without transactions, concurrent operations can see inconsistent state (e.g., two callers both pass the `exists` check and both write).
+
 ## General Style
 
 - Prefer `const` over `let`

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -365,8 +365,8 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       : this.attestationPool.getCheckpointAttestationsForSlot(slot));
   }
 
-  public addCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void> {
-    return this.attestationPool.addCheckpointAttestations(attestations);
+  public addOwnCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void> {
+    return this.attestationPool.addOwnCheckpointAttestations(attestations);
   }
 
   // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -34,7 +34,7 @@ export type AttestationPoolApi = Pick<
   | 'getBlockProposal'
   | 'tryAddCheckpointProposal'
   | 'getCheckpointProposal'
-  | 'addCheckpointAttestations'
+  | 'addOwnCheckpointAttestations'
   | 'tryAddCheckpointAttestation'
   | 'deleteOlderThan'
   | 'getCheckpointAttestationsForSlot'
@@ -160,32 +160,43 @@ export class AttestationPool {
    * @returns Result indicating whether the proposal was added and duplicate detection info
    */
   public async tryAddBlockProposal(blockProposal: BlockProposal): Promise<TryAddResult> {
-    const proposalId = blockProposal.archive.toString();
+    return await this.store.transactionAsync(async () => {
+      const proposalId = blockProposal.archive.toString();
 
-    // Check if already exists
-    const alreadyExists = await this.blockProposals.hasAsync(proposalId);
-    if (alreadyExists) {
+      // Check if already exists
+      const alreadyExists = await this.blockProposals.hasAsync(proposalId);
+      if (alreadyExists) {
+        const totalForPosition = await this.getBlockProposalCountForPosition(
+          blockProposal.slotNumber,
+          blockProposal.indexWithinCheckpoint,
+        );
+        return { added: false, alreadyExists: true, totalForPosition };
+      }
+
+      // Get current count for position and check cap, do not add if exceeded
       const totalForPosition = await this.getBlockProposalCountForPosition(
         blockProposal.slotNumber,
         blockProposal.indexWithinCheckpoint,
       );
-      return { added: false, alreadyExists: true, totalForPosition };
-    }
 
-    // Get current count for position and check cap, do not add if exceeded
-    const totalForPosition = await this.getBlockProposalCountForPosition(
-      blockProposal.slotNumber,
-      blockProposal.indexWithinCheckpoint,
-    );
+      if (totalForPosition >= MAX_PROPOSALS_PER_POSITION) {
+        return { added: false, alreadyExists: false, totalForPosition };
+      }
 
-    if (totalForPosition >= MAX_PROPOSALS_PER_POSITION) {
-      return { added: false, alreadyExists: false, totalForPosition };
-    }
+      // Add the proposal
+      await this.addBlockProposal(blockProposal);
 
-    // Add the proposal
-    await this.addBlockProposal(blockProposal);
+      this.log.debug(
+        `Added block proposal for slot ${blockProposal.slotNumber} and index ${blockProposal.indexWithinCheckpoint}`,
+        {
+          proposalId,
+          slotNumber: blockProposal.slotNumber,
+          indexWithinCheckpoint: blockProposal.indexWithinCheckpoint,
+        },
+      );
 
-    return { added: true, alreadyExists: false, totalForPosition: totalForPosition + 1 };
+      return { added: true, alreadyExists: false, totalForPosition: totalForPosition + 1 };
+    });
   }
 
   /** Gets the count of block proposals for a given position (slot, indexWithinCheckpoint). */
@@ -197,16 +208,15 @@ export class AttestationPool {
     return this.blockProposalsForSlotAndIndex.getValueCountAsync(positionKey);
   }
 
+  /** Internal method - must be called within a transaction. */
   private async addBlockProposal(blockProposal: BlockProposal): Promise<void> {
-    await this.store.transactionAsync(async () => {
-      const proposalId = blockProposal.archive.toString();
-      // Strip signedTxs before storing to avoid persisting full tx data
-      await this.blockProposals.set(proposalId, blockProposal.withoutSignedTxs().toBuffer());
+    const proposalId = blockProposal.archive.toString();
+    // Strip signedTxs before storing to avoid persisting full tx data
+    await this.blockProposals.set(proposalId, blockProposal.withoutSignedTxs().toBuffer());
 
-      // Index by slot and position for duplicate detection
-      const positionKey = this.getBlockPositionKey(blockProposal.slotNumber, blockProposal.indexWithinCheckpoint);
-      await this.blockProposalsForSlotAndIndex.set(positionKey, proposalId);
-    });
+    // Index by slot and position for duplicate detection
+    const positionKey = this.getBlockPositionKey(blockProposal.slotNumber, blockProposal.indexWithinCheckpoint);
+    await this.blockProposalsForSlotAndIndex.set(positionKey, proposalId);
   }
 
   /**
@@ -245,35 +255,41 @@ export class AttestationPool {
    * @returns Result indicating whether the proposal was added and duplicate detection info
    */
   public async tryAddCheckpointProposal(proposal: CheckpointProposalCore): Promise<TryAddResult> {
-    const proposalId = proposal.archive.toString();
-
-    // Check if already exists
-    const alreadyExists = await this.checkpointProposals.hasAsync(proposalId);
-    if (alreadyExists) {
-      const totalForPosition = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
-      return { added: false, alreadyExists: true, totalForPosition };
-    }
-
-    // Get current count for slot and check cap
-    const totalForPosition = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
-    if (totalForPosition >= MAX_PROPOSALS_PER_SLOT) {
-      return { added: false, alreadyExists: false, totalForPosition };
-    }
-
-    // Add the proposal if cap not exceeded
-    await this.addCheckpointProposal(proposal);
-
-    return { added: true, alreadyExists: false, totalForPosition: totalForPosition + 1 };
-  }
-
-  private async addCheckpointProposal(proposal: CheckpointProposalCore): Promise<void> {
-    await this.store.transactionAsync(async () => {
-      const slotKey = proposal.slotNumber;
+    return await this.store.transactionAsync(async () => {
       const proposalId = proposal.archive.toString();
 
-      await this.checkpointProposalsForSlot.set(slotKey, proposalId);
-      await this.checkpointProposals.set(proposalId, proposal.toBuffer());
+      // Check if already exists
+      const alreadyExists = await this.checkpointProposals.hasAsync(proposalId);
+      if (alreadyExists) {
+        const totalForPosition = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
+        return { added: false, alreadyExists: true, totalForPosition };
+      }
+
+      // Get current count for slot and check cap
+      const totalForPosition = await this.checkpointProposalsForSlot.getValueCountAsync(proposal.slotNumber);
+      if (totalForPosition >= MAX_PROPOSALS_PER_SLOT) {
+        return { added: false, alreadyExists: false, totalForPosition };
+      }
+
+      // Add the proposal if cap not exceeded
+      await this.addCheckpointProposal(proposal);
+
+      this.log.debug(`Added checkpoint proposal for slot ${proposal.slotNumber}`, {
+        proposalId,
+        slotNumber: proposal.slotNumber,
+      });
+
+      return { added: true, alreadyExists: false, totalForPosition: totalForPosition + 1 };
     });
+  }
+
+  /** Internal method - must be called within a transaction. */
+  private async addCheckpointProposal(proposal: CheckpointProposalCore): Promise<void> {
+    const slotKey = proposal.slotNumber;
+    const proposalId = proposal.archive.toString();
+
+    await this.checkpointProposalsForSlot.set(slotKey, proposalId);
+    await this.checkpointProposals.set(proposalId, proposal.toBuffer());
   }
 
   /**
@@ -299,11 +315,10 @@ export class AttestationPool {
   }
 
   /**
-   * Add checkpoint attestations to the pool.
-   *
-   * @param attestations - Checkpoint attestations to add into the pool
+   * Adds own checkpoint attestations to the pool.
+   * Skips validations on number of checkpoint attestations stored for the given slot.
    */
-  public async addCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void> {
+  public async addOwnCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void> {
     await this.store.transactionAsync(async () => {
       for (const attestation of attestations) {
         const slotNumber = attestation.payload.header.slotNumber;
@@ -312,7 +327,7 @@ export class AttestationPool {
 
         // Skip attestations with invalid signatures
         if (!sender) {
-          this.log.warn(`Skipping checkpoint attestation with invalid signature for slot ${slotNumber}`, {
+          this.log.warn(`Skipping own checkpoint attestation with invalid signature for slot ${slotNumber}`, {
             signature: attestation.signature.toString(),
             slotNumber,
             proposalId,
@@ -327,7 +342,7 @@ export class AttestationPool {
           attestation.toBuffer(),
         );
 
-        this.log.verbose(`Added checkpoint attestation for slot ${slotNumber} from ${address}`, {
+        this.log.debug(`Added own checkpoint attestation for slot ${slotNumber} from ${address}`, {
           signature: attestation.signature.toString(),
           slotNumber,
           address,
@@ -383,7 +398,7 @@ export class AttestationPool {
   public async deleteOlderThan(oldestSlot: SlotNumber): Promise<void> {
     let numberOfAttestations = 0;
     let numberOfCheckpointProposals = 0;
-    let numberOfBlockPositions = 0;
+    let numberOfBlockProposals = 0;
 
     await this.store.transactionAsync(async () => {
       // Delete checkpoint attestations with slot < oldestSlot
@@ -404,12 +419,16 @@ export class AttestationPool {
         await this.checkpointProposalsForSlot.delete(slot);
       }
 
-      // Delete block proposal position index for slots < oldestSlot
+      // Delete block proposals for slots < oldestSlot, using blockProposalsForSlotAndIndex as index
       // Key format: (slot << INDEX_BITS) | indexWithinCheckpoint
       const blockPositionEndKey = oldestSlot << AttestationPool.INDEX_BITS;
       for await (const positionKey of this.blockProposalsForSlotAndIndex.keysAsync({ end: blockPositionEndKey })) {
+        const proposalIds = await toArray(this.blockProposalsForSlotAndIndex.getValuesAsync(positionKey));
+        for (const proposalId of proposalIds) {
+          await this.blockProposals.delete(proposalId);
+          numberOfBlockProposals++;
+        }
         await this.blockProposalsForSlotAndIndex.delete(positionKey);
-        numberOfBlockPositions++;
       }
     });
 
@@ -417,7 +436,7 @@ export class AttestationPool {
       oldestSlot,
       numberOfAttestations,
       numberOfCheckpointProposals,
-      numberOfBlockPositions,
+      numberOfBlockProposals,
     });
   }
 
@@ -445,31 +464,32 @@ export class AttestationPool {
       return { added: false, alreadyExists: false, totalForPosition: 0 };
     }
 
-    const key = this.getAttestationKey(slotNumber, proposalId, sender.toString());
-    const alreadyExists = await this.checkpointAttestations.hasAsync(key);
+    return await this.store.transactionAsync(async () => {
+      const key = this.getAttestationKey(slotNumber, proposalId, sender.toString());
+      const alreadyExists = await this.checkpointAttestations.hasAsync(key);
 
-    if (alreadyExists) {
-      const total = await this.getAttestationCount(slotNumber, proposalId);
-      return { added: false, alreadyExists: true, totalForPosition: total };
-    }
+      if (alreadyExists) {
+        const total = await this.getAttestationCount(slotNumber, proposalId);
+        return { added: false, alreadyExists: true, totalForPosition: total };
+      }
 
-    const limit = committeeSize + ATTESTATION_CAP_BUFFER;
-    const currentCount = await this.getAttestationCount(slotNumber, proposalId);
+      const limit = committeeSize + ATTESTATION_CAP_BUFFER;
+      const currentCount = await this.getAttestationCount(slotNumber, proposalId);
 
-    if (currentCount >= limit) {
-      return { added: false, alreadyExists: false, totalForPosition: currentCount };
-    }
+      if (currentCount >= limit) {
+        return { added: false, alreadyExists: false, totalForPosition: currentCount };
+      }
 
-    await this.checkpointAttestations.set(key, attestation.toBuffer());
+      await this.checkpointAttestations.set(key, attestation.toBuffer());
 
-    this.log.verbose(`Added checkpoint attestation for slot ${slotNumber} from ${sender.toString()}`, {
-      signature: attestation.signature.toString(),
-      slotNumber,
-      address: sender.toString(),
-      proposalId,
+      this.log.debug(`Added checkpoint attestation for slot ${slotNumber} from ${sender.toString()}`, {
+        signature: attestation.signature.toString(),
+        slotNumber,
+        address: sender.toString(),
+        proposalId,
+      });
+      return { added: true, alreadyExists: false, totalForPosition: currentCount + 1 };
     });
-
-    return { added: true, alreadyExists: false, totalForPosition: currentCount + 1 };
   }
 
   /** Gets the count of attestations for a given (slot, proposalId). */

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -57,7 +57,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const archive = Fr.random();
       const attestations = signers.slice(0, -1).map(signer => mockCheckpointAttestation(signer, slotNumber, archive));
 
-      await ap.addCheckpointAttestations(attestations);
+      await ap.addOwnCheckpointAttestations(attestations);
 
       const retrievedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
@@ -72,7 +72,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
       // Add another one
       const newAttestation = mockCheckpointAttestation(signers[NUMBER_OF_SIGNERS_PER_TEST - 1], slotNumber, archive);
-      await ap.addCheckpointAttestations([newAttestation]);
+      await ap.addOwnCheckpointAttestations([newAttestation]);
       const retrievedAttestationsAfterAdd = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
         archive.toString(),
@@ -106,7 +106,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       }
 
       // Add them to store and check we end up with only one
-      await ap.addCheckpointAttestations(attestations);
+      await ap.addOwnCheckpointAttestations(attestations);
 
       const retreivedAttestations = await ap.getCheckpointAttestationsForSlotAndProposal(
         SlotNumber(slotNumber),
@@ -117,7 +117,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       expect(retreivedAttestations[0].getSender()?.toString()).toEqual(signer.address.toString());
 
       // Try adding them on another operation and check they are still not duplicated
-      await ap.addCheckpointAttestations([attestations[0]]);
+      await ap.addOwnCheckpointAttestations([attestations[0]]);
       expect(
         await ap.getCheckpointAttestationsForSlotAndProposal(SlotNumber(slotNumber), archive.toString()),
       ).toHaveLength(1);
@@ -127,7 +127,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const slotNumbers = [1, 2, 3, 4];
       const attestations = signers.map((signer, i) => mockCheckpointAttestation(signer, slotNumbers[i]));
 
-      await ap.addCheckpointAttestations(attestations);
+      await ap.addOwnCheckpointAttestations(attestations);
 
       for (const attestation of attestations) {
         const slot = attestation.payload.header.slotNumber;
@@ -145,7 +145,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       const archives = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
       const attestations = signers.map((signer, i) => mockCheckpointAttestation(signer, slotNumbers[i], archives[i]));
 
-      await ap.addCheckpointAttestations(attestations);
+      await ap.addOwnCheckpointAttestations(attestations);
 
       for (const attestation of attestations) {
         const slot = attestation.payload.header.slotNumber;
@@ -165,7 +165,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       ).flat();
       const proposalId = attestations[0].archive.toString();
 
-      await ap.addCheckpointAttestations(attestations);
+      await ap.addOwnCheckpointAttestations(attestations);
 
       const attestationsForSlot1 = await ap.getCheckpointAttestationsForSlotAndProposal(SlotNumber(1), proposalId);
       expect(attestationsForSlot1.length).toBe(signers.length);
@@ -554,6 +554,31 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         const result2 = await ap.tryAddBlockProposal(newProposal2);
         expect(result2.totalForPosition).toBe(1);
       });
+
+      it('should delete block proposals from storage when deleting old data', async () => {
+        const oldSlot = 50;
+        const newSlot = 100;
+
+        // Add proposals at old and new slots
+        const oldProposal = await mockBlockProposalWithIndex(signers[0], oldSlot, 0);
+        const newProposal = await mockBlockProposalWithIndex(signers[1], newSlot, 0);
+
+        await ap.tryAddBlockProposal(oldProposal);
+        await ap.tryAddBlockProposal(newProposal);
+
+        // Verify both proposals exist
+        expect(await ap.getBlockProposal(oldProposal.archive.toString())).toBeDefined();
+        expect(await ap.getBlockProposal(newProposal.archive.toString())).toBeDefined();
+
+        // Delete slots older than newSlot (should delete oldSlot)
+        await ap.deleteOlderThan(SlotNumber(newSlot));
+
+        // Old proposal should be deleted from storage
+        expect(await ap.getBlockProposal(oldProposal.archive.toString())).toBeUndefined();
+
+        // New proposal should still exist
+        expect(await ap.getBlockProposal(newProposal.archive.toString())).toBeDefined();
+      });
     });
 
     describe('tryAddCheckpointProposal duplicate detection', () => {
@@ -651,7 +676,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
 
         // Attestation arrives BEFORE the checkpoint proposal (race condition in p2p)
         const attestation = mockCheckpointAttestation(signers[0], slotNumber, archive);
-        await ap.addCheckpointAttestations([attestation]);
+        await ap.addOwnCheckpointAttestations([attestation]);
 
         // Now the checkpoint proposal arrives - this should NOT be detected as a duplicate
         const proposal = await mockCheckpointProposalCoreForPool(signers[1], slotNumber, archive);
@@ -671,7 +696,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
         // Add attestations for two different proposals in the same slot
         const attestation1 = mockCheckpointAttestation(signers[0], slotNumber, archive1);
         const attestation2 = mockCheckpointAttestation(signers[1], slotNumber, archive2);
-        await ap.addCheckpointAttestations([attestation1, attestation2]);
+        await ap.addOwnCheckpointAttestations([attestation1, attestation2]);
 
         // Add the first checkpoint proposal - should not be affected by attestations
         const proposal1 = await mockCheckpointProposalCoreForPool(signers[2], slotNumber, archive1);

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -956,8 +956,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       return;
     }
 
-    this.logger.debug(
-      `Received checkpoint attestation for slot ${attestation.slotNumber} from external peer ${source.toString()}`,
+    this.logger.verbose(
+      `Received valid checkpoint attestation for slot ${attestation.slotNumber} from external peer ${source.toString()}`,
       {
         p2pMessageIdentifier: await attestation.p2pMessageLoggingIdentifier(),
         slot: attestation.slotNumber,
@@ -1295,7 +1295,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const attestations = await this.checkpointReceivedCallback(checkpoint, sender);
     if (attestations && attestations.length > 0) {
       // If the callback returned attestations, add them to the pool and propagate them
-      await this.mempools.attestationPool.addCheckpointAttestations(attestations);
+      await this.mempools.attestationPool.addOwnCheckpointAttestations(attestations);
       for (const attestation of attestations) {
         await this.propagate(attestation);
       }

--- a/yarn-project/p2p/src/test-helpers/testbench-utils.ts
+++ b/yarn-project/p2p/src/test-helpers/testbench-utils.ts
@@ -173,7 +173,7 @@ export class InMemoryAttestationPool {
     return Promise.resolve(undefined);
   }
 
-  async addCheckpointAttestations(_attestations: CheckpointAttestation[]): Promise<void> {}
+  async addOwnCheckpointAttestations(_attestations: CheckpointAttestation[]): Promise<void> {}
 
   async deleteOlderThan(_slot: SlotNumber): Promise<void> {}
 

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -63,7 +63,7 @@ export interface P2PApiWithAttestations extends P2PApiWithoutAttestations {
 
 export interface P2PClient extends P2PApiWithAttestations {
   /** Manually adds checkpoint attestations to the p2p client attestation pool. */
-  addCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void>;
+  addOwnCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void>;
 }
 
 export type P2PApi<T extends P2PClientType = P2PClientType.Full> = T extends P2PClientType.Full

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -134,8 +134,8 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "getCheckpointAttestationsForSlot"');
   }
 
-  public addCheckpointAttestations(_attestations: CheckpointAttestation[]): Promise<void> {
-    throw new Error('DummyP2P does not implement "addCheckpointAttestations"');
+  public addOwnCheckpointAttestations(_attestations: CheckpointAttestation[]): Promise<void> {
+    throw new Error('DummyP2P does not implement "addOwnCheckpointAttestations"');
   }
 
   public getL2BlockHash(_number: number): Promise<string | undefined> {

--- a/yarn-project/validator-client/src/validator.ha.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.ha.integration.test.ts
@@ -81,7 +81,7 @@ describe('ValidatorClient HA Integration', () => {
     // Set up mocks
     p2pClient = mock<P2P>();
     p2pClient.getCheckpointAttestationsForSlot.mockImplementation(() => Promise.resolve([]));
-    p2pClient.addCheckpointAttestations.mockResolvedValue();
+    p2pClient.addOwnCheckpointAttestations.mockResolvedValue();
     p2pClient.broadcastCheckpointAttestations.mockResolvedValue();
     checkpointsBuilder = mock<FullNodeCheckpointsBuilder>();
     checkpointsBuilder.getConfig.mockReturnValue({

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -231,7 +231,7 @@ describe('ValidatorClient', () => {
       epochCache.filterInCommittee.mockResolvedValueOnce(
         validatorAccounts.map(account => EthAddress.fromString(account.address)),
       );
-      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addOwnCheckpointAttestations');
       const proposal = await makeCheckpointProposal({ lastBlock: {} });
       // collectAttestations still throws as we don't have a real p2pClient
       await expect(
@@ -388,7 +388,7 @@ describe('ValidatorClient', () => {
     });
 
     it('should not attest to a checkpoint proposal if we did not validate a block for that slot', async () => {
-      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addOwnCheckpointAttestations');
 
       const checkpointProposal = await makeCheckpointProposal({
         archiveRoot: proposal.archive,
@@ -406,7 +406,7 @@ describe('ValidatorClient', () => {
     });
 
     it('should attest to a checkpoint proposal after validating a block for that slot', async () => {
-      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addOwnCheckpointAttestations');
 
       const didValidate = await validatorClient.validateBlockProposal(proposal, sender);
       expect(didValidate).toBe(true);
@@ -705,8 +705,8 @@ describe('ValidatorClient', () => {
       // Set up so validator is NOT in the committee
       epochCache.filterInCommittee.mockResolvedValueOnce([]);
 
-      // Spy on addCheckpointAttestations to verify attestations are NOT added to the pool
-      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addCheckpointAttestations');
+      // Spy on addOwnCheckpointAttestations to verify attestations are NOT added to the pool
+      const addCheckpointAttestationsSpy = jest.spyOn(p2pClient, 'addOwnCheckpointAttestations');
 
       // In the new model, validateBlockProposal returns a boolean
       // Fisherman mode re-executes to validate but doesn't attest (that's for checkpoint proposals)

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -523,7 +523,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     attestors: EthAddress[] = [],
   ): Promise<CheckpointAttestation[]> {
     const attestations = await this.validationService.attestToCheckpointProposal(proposal, attestors);
-    await this.p2pClient.addCheckpointAttestations(attestations);
+    await this.p2pClient.addOwnCheckpointAttestations(attestations);
     return attestations;
   }
 


### PR DESCRIPTION
## Summary

- Fix `tryAddBlockProposal` to wrap all reads and writes in a single transaction (was reading outside transaction, then writing inside separate transaction)
- Fix `tryAddCheckpointProposal` to wrap all reads and writes in a single transaction (same issue)
- Fix `tryAddCheckpointAttestation` to wrap all reads and writes in a single transaction (write was not in a transaction at all)
- Fix `deleteOlderThan` to delete block proposals from main storage, not just the index (was causing storage leak)
- Rename `addCheckpointAttestations` to `addOwnCheckpointAttestations` for clarity

## Test plan

- All existing attestation pool tests pass
- Added new test `should delete block proposals from storage when deleting old data` to verify the deleteOlderThan fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)