### PR TITLE
fix: private state sync from pxe.debug.getNotes

### DIFF
--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -1,10 +1,12 @@
-import { randomBytes } from '@aztec/foundation/crypto/random';
+import type { FunctionCall } from '@aztec/stdlib/abi';
+import type { AuthWitness } from '@aztec/stdlib/auth-witness';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { NoteDao, NotesFilter } from '@aztec/stdlib/note';
-import type { BlockHeader } from '@aztec/stdlib/tx';
+import type { BlockHeader, ContractOverrides } from '@aztec/stdlib/tx';
 
 import type { BlockSynchronizer } from '../block_synchronizer/block_synchronizer.js';
-import type { PXE } from '../pxe.js';
-import type { ContractStore } from '../storage/contract_store/contract_store.js';
+import type { ContractFunctionSimulator } from '../contract_function_simulator/contract_function_simulator.js';
+import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
 import type { AnchorBlockStore } from '../storage/index.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
@@ -13,20 +15,38 @@ import type { NoteStore } from '../storage/note_store/note_store.js';
  * No backwards compatibility or API stability should be expected. Use at your own risk.
  */
 export class PXEDebugUtils {
-  #pxe!: PXE;
   #putJobInQueue!: <T>(job: (jobId: string) => Promise<T>) => Promise<T>;
+  #getSimulatorForTx!: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator;
+  #simulateUtility!: (
+    contractFunctionSimulator: ContractFunctionSimulator,
+    call: FunctionCall,
+    authWitnesses: AuthWitness[] | undefined,
+    scopes: AztecAddress[] | undefined,
+    jobId: string,
+  ) => Promise<any>;
 
   constructor(
-    private contractStore: ContractStore,
+    private contractSyncService: ContractSyncService,
     private noteStore: NoteStore,
     private blockStateSynchronizer: BlockSynchronizer,
     private anchorBlockStore: AnchorBlockStore,
   ) {}
 
   /** Not injected through constructor since they're are co-dependant */
-  public setPXE(pxe: PXE, putJobInQueue: <T>(job: (jobId: string) => Promise<T>) => Promise<T>) {
-    this.#pxe = pxe;
+  public setPXEHelpers(
+    putJobInQueue: <T>(job: (jobId: string) => Promise<T>) => Promise<T>,
+    getSimulatorForTx: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator,
+    simulateUtility: (
+      contractFunctionSimulator: ContractFunctionSimulator,
+      call: FunctionCall,
+      authWitnesses: AuthWitness[] | undefined,
+      scopes: AztecAddress[] | undefined,
+      jobId: string,
+    ) => Promise<any>,
+  ) {
     this.#putJobInQueue = putJobInQueue;
+    this.#getSimulatorForTx = getSimulatorForTx;
+    this.#simulateUtility = simulateUtility;
   }
 
   /**
@@ -40,12 +60,25 @@ export class PXEDebugUtils {
    * @param filter - The filter to apply to the notes.
    * @returns The requested notes.
    */
-  public async getNotes(filter: NotesFilter): Promise<NoteDao[]> {
-    // We need to manually trigger private state sync to have a guarantee that all the notes are available.
-    const call = await this.contractStore.getFunctionCall('sync_state', [], filter.contractAddress);
-    await this.#pxe.simulateUtility(call);
+  public getNotes(filter: NotesFilter): Promise<NoteDao[]> {
+    return this.#putJobInQueue(async (jobId: string) => {
+      await this.blockStateSynchronizer.sync();
 
-    return this.noteStore.getNotes(filter, randomBytes(8).toString('hex'));
+      const anchorBlockHeader = await this.anchorBlockStore.getBlockHeader();
+
+      const contractFunctionSimulator = this.#getSimulatorForTx();
+
+      await this.contractSyncService.ensureContractSynced(
+        filter.contractAddress,
+        null,
+        async privateSyncCall =>
+          await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], undefined, jobId),
+        anchorBlockHeader,
+        jobId,
+      );
+
+      return this.noteStore.getNotes(filter, jobId);
+    });
   }
 
   /** Returns the block header up to which the PXE has synced. */

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -179,7 +179,7 @@ export class PXE {
       contractSyncService,
     ]);
 
-    const debugUtils = new PXEDebugUtils(contractStore, noteStore, synchronizer, anchorBlockStore);
+    const debugUtils = new PXEDebugUtils(contractSyncService, noteStore, synchronizer, anchorBlockStore);
 
     const jobQueue = new SerialQueue();
 
@@ -207,7 +207,11 @@ export class PXE {
       debugUtils,
     );
 
-    debugUtils.setPXE(pxe, pxe.#putInJobQueue.bind(pxe));
+    debugUtils.setPXEHelpers(
+      pxe.#putInJobQueue.bind(pxe),
+      pxe.#getSimulatorForTx.bind(pxe),
+      pxe.#simulateUtility.bind(pxe),
+    );
 
     pxe.jobQueue.start();
 


### PR DESCRIPTION
This debugging utility needs to trigger a contract sync, but it was doing so in a deprecated way, triggering a "Forbidden invocation". This PR brings that code up to date.

The code is a bit ugly because we need some private methods from PXE, which we don't want to make protected or public because we want to keep PXE's public interface minimal. I don't think it makes sense to make this cuter given calling `pxe.debug.getNotes` is a hack