### PR TITLE
fix: notes and events leaking between modules in macros

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -5,7 +5,7 @@ use crate::macros::{
     },
     dispatch::generate_public_dispatch,
     internals_functions_generation::{create_fn_abi_exports, process_functions},
-    notes::NOTES,
+    notes::get_notes,
     storage::STORAGE_LAYOUT_NAME,
     utils::{
         get_trait_impl_method, is_fn_contract_library_method, is_fn_external, is_fn_internal, is_fn_test,
@@ -38,7 +38,7 @@ pub comptime fn aztec(m: Module) -> Quoted {
     let contract_library_method_compute_note_hash_and_nullifier = if !m.functions().any(|f| {
         f.name() == quote { _compute_note_hash_and_nullifier }
     }) {
-        generate_contract_library_method_compute_note_hash_and_nullifier()
+        generate_contract_library_method_compute_note_hash_and_nullifier(m)
     } else {
         quote {}
     };
@@ -135,16 +135,17 @@ comptime fn generate_contract_interface(m: Module) -> Quoted {
 /// Generates a contract library method called `_compute_note_hash_and_nullifier` which is used for note discovery (to
 /// create the `aztec::messages::discovery::ComputeNoteHashAndNullifier` function) and to implement the
 /// `compute_note_hash_and_nullifier` unconstrained contract function.
-comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -> Quoted {
-    if NOTES.len() > 0 {
+comptime fn generate_contract_library_method_compute_note_hash_and_nullifier(m: Module) -> Quoted {
+    let module_notes = get_notes(m);
+    if module_notes.len() > 0 {
         // Contracts that do define notes produce an if-else chain where `note_type_id` is matched against the
         // `get_note_type_id()` function of each note type that we know of, in order to identify the note type. Once we
         // know it we call we correct `unpack` method from the `Packable` trait to obtain the underlying note type, and
         // compute the note hash (non-siloed) and inner nullifier (also non-siloed).
 
         let mut if_note_type_id_match_statements_list = @[];
-        for i in 0..NOTES.len() {
-            let typ = NOTES.get(i);
+        for i in 0..module_notes.len() {
+            let typ = module_notes.get(i);
 
             let get_note_type_id = get_trait_impl_method(
                 typ,

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -4,14 +4,16 @@ use crate::macros::{
         internal_functions::generate_call_internal_struct,
     },
     dispatch::generate_public_dispatch,
+    events::get_event_selectors,
     internals_functions_generation::{create_fn_abi_exports, process_functions},
-    notes::get_notes,
+    notes::{get_notes, MAX_NOTE_TYPES},
     storage::STORAGE_LAYOUT_NAME,
     utils::{
         get_trait_impl_method, is_fn_contract_library_method, is_fn_external, is_fn_internal, is_fn_test,
         module_has_storage,
     },
 };
+use std::collections::bounded_vec::BoundedVec;
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
 /// the `sync_state` utility function.
@@ -33,26 +35,49 @@ pub comptime fn aztec(m: Module) -> Quoted {
     // We generate ABI exports for all the external functions in the contract.
     let fn_abi_exports = create_fn_abi_exports(m);
 
-    // We generate `_compute_note_hash_and_nullifier`, `sync_state` and `process_message` functions only if they are
-    // not already implemented. If they are implemented we just insert empty quotes.
+    // We generate `_compute_note_hash_and_nullifier`, `sync_state` and `process_message` functions only if the
+    // contract has notes or events and the functions are not already implemented.
+    let module_notes = get_notes(m);
+    let module_events = get_event_selectors(m);
+
+    let has_notes = module_notes.len() > 0;
+    let has_events = !module_events.is_empty();
+
+    let has_notes_or_events = has_notes | has_events;
+
+    // Generate _compute_note_hash_and_nullifier:
+    // - Full version if has_notes
+    // - Panic version if has_events but no notes
     let contract_library_method_compute_note_hash_and_nullifier = if !m.functions().any(|f| {
         f.name() == quote { _compute_note_hash_and_nullifier }
     }) {
-        generate_contract_library_method_compute_note_hash_and_nullifier(m)
+        if has_notes {
+            generate_contract_library_method_compute_note_hash_and_nullifier(module_notes)
+        } else if has_events {
+            generate_compute_note_hash_and_nullifier_panic()
+        } else {
+            quote {}
+        }
     } else {
         quote {}
     };
-    let sync_state_fn_and_abi_export = if !m.functions().any(|f| f.name() == quote { sync_state }) {
+
+    // Generate sync_state and process_message if has notes OR events
+
+    let has_sync_state = m.functions().any(|f| f.name() == quote { sync_state });
+    let sync_state_fn_and_abi_export = if has_notes_or_events & !has_sync_state {
         generate_sync_state()
     } else {
         quote {}
     };
 
-    let process_message_fn_and_abi_export = if !m.functions().any(|f| f.name() == quote { process_message }) {
+    let has_process_message = m.functions().any(|f| f.name() == quote { process_message });
+    let process_message_fn_and_abi_export = if has_notes_or_events & !has_process_message {
         generate_process_message()
     } else {
         quote {}
     };
+
     let public_dispatch = generate_public_dispatch(m);
 
     quote {
@@ -135,131 +160,133 @@ comptime fn generate_contract_interface(m: Module) -> Quoted {
 /// Generates a contract library method called `_compute_note_hash_and_nullifier` which is used for note discovery (to
 /// create the `aztec::messages::discovery::ComputeNoteHashAndNullifier` function) and to implement the
 /// `compute_note_hash_and_nullifier` unconstrained contract function.
-comptime fn generate_contract_library_method_compute_note_hash_and_nullifier(m: Module) -> Quoted {
-    let module_notes = get_notes(m);
-    if module_notes.len() > 0 {
-        // Contracts that do define notes produce an if-else chain where `note_type_id` is matched against the
-        // `get_note_type_id()` function of each note type that we know of, in order to identify the note type. Once we
-        // know it we call we correct `unpack` method from the `Packable` trait to obtain the underlying note type, and
-        // compute the note hash (non-siloed) and inner nullifier (also non-siloed).
+///
+/// This function is only called when the contract has notes (module_notes.len() > 0).
+comptime fn generate_contract_library_method_compute_note_hash_and_nullifier(
+    module_notes: BoundedVec<Type, MAX_NOTE_TYPES>,
+) -> Quoted {
+    // Contracts that do define notes produce an if-else chain where `note_type_id` is matched against the
+    // `get_note_type_id()` function of each note type that we know of, in order to identify the note type. Once we
+    // know it we call we correct `unpack` method from the `Packable` trait to obtain the underlying note type, and
+    // compute the note hash (non-siloed) and inner nullifier (also non-siloed).
 
-        let mut if_note_type_id_match_statements_list = @[];
-        for i in 0..module_notes.len() {
-            let typ = module_notes.get(i);
+    let mut if_note_type_id_match_statements_list = @[];
+    for i in 0..module_notes.len() {
+        let typ = module_notes.get(i);
 
-            let get_note_type_id = get_trait_impl_method(
-                typ,
-                quote { crate::note::note_interface::NoteType },
-                quote { get_id },
-            );
-            let unpack = get_trait_impl_method(
-                typ,
-                quote { crate::protocol::traits::Packable },
-                quote { unpack },
-            );
+        let get_note_type_id = get_trait_impl_method(
+            typ,
+            quote { crate::note::note_interface::NoteType },
+            quote { get_id },
+        );
+        let unpack = get_trait_impl_method(
+            typ,
+            quote { crate::protocol::traits::Packable },
+            quote { unpack },
+        );
 
-            let compute_note_hash = get_trait_impl_method(
-                typ,
-                quote { crate::note::note_interface::NoteHash },
-                quote { compute_note_hash },
-            );
+        let compute_note_hash = get_trait_impl_method(
+            typ,
+            quote { crate::note::note_interface::NoteHash },
+            quote { compute_note_hash },
+        );
 
-            let compute_nullifier_unconstrained = get_trait_impl_method(
-                typ,
-                quote { crate::note::note_interface::NoteHash },
-                quote { compute_nullifier_unconstrained },
-            );
+        let compute_nullifier_unconstrained = get_trait_impl_method(
+            typ,
+            quote { crate::note::note_interface::NoteHash },
+            quote { compute_nullifier_unconstrained },
+        );
 
-            let if_or_else_if = if i == 0 {
-                quote { if }
-            } else {
-                quote { else if }
-            };
+        let if_or_else_if = if i == 0 {
+            quote { if }
+        } else {
+            quote { else if }
+        };
 
-            if_note_type_id_match_statements_list = if_note_type_id_match_statements_list.push_back(
-                quote {
-                    $if_or_else_if note_type_id == $get_note_type_id() {
-                        // As an extra safety check we make sure that the packed_note BoundedVec has the expected
-                        // length, since we're about to interpret its raw storage as a fixed-size array by calling the
-                        // unpack function on it.
-                        let expected_len = <$typ as $crate::protocol::traits::Packable>::N;
-                        let actual_len = packed_note.len();
-                        assert(
-                            actual_len == expected_len,
-                            f"Expected packed note of length {expected_len} but got {actual_len} for note type id {note_type_id}"
-                        );
+        if_note_type_id_match_statements_list = if_note_type_id_match_statements_list.push_back(
+            quote {
+                $if_or_else_if note_type_id == $get_note_type_id() {
+                    // As an extra safety check we make sure that the packed_note BoundedVec has the expected
+                    // length, since we're about to interpret its raw storage as a fixed-size array by calling the
+                    // unpack function on it.
+                    let expected_len = <$typ as $crate::protocol::traits::Packable>::N;
+                    let actual_len = packed_note.len();
+                    assert(
+                        actual_len == expected_len,
+                        f"Expected packed note of length {expected_len} but got {actual_len} for note type id {note_type_id}"
+                    );
 
-                        let note = $unpack(aztec::utils::array::subarray(packed_note.storage(), 0));
+                    let note = $unpack(aztec::utils::array::subarray(packed_note.storage(), 0));
 
-                        let note_hash = $compute_note_hash(note, owner, storage_slot, randomness);
-    
-                        // The message discovery process finds settled notes, that is, notes that were created in prior transactions and are therefore already part of the note hash tree. We therefore compute the nullification note hash by treating the note as a settled note with the provided note nonce.
-                        let note_hash_for_nullification = aztec::note::utils::compute_note_hash_for_nullification(
-                            aztec::note::HintedNote{
-                                note,
-                                contract_address,
-                                owner,
-                                randomness,
-                                storage_slot,
-                                metadata: aztec::note::note_metadata::SettledNoteMetadata::new(note_nonce).into()
-                            }
-                        );
+                    let note_hash = $compute_note_hash(note, owner, storage_slot, randomness);
 
-                        let inner_nullifier = $compute_nullifier_unconstrained(note, owner, note_hash_for_nullification);
+                    // The message discovery process finds settled notes, that is, notes that were created in prior transactions and are therefore already part of the note hash tree. We therefore compute the nullification note hash by treating the note as a settled note with the provided note nonce.
+                    let note_hash_for_nullification = aztec::note::utils::compute_note_hash_for_nullification(
+                        aztec::note::HintedNote{
+                            note,
+                            contract_address,
+                            owner,
+                            randomness,
+                            storage_slot,
+                            metadata: aztec::note::note_metadata::SettledNoteMetadata::new(note_nonce).into()
+                        }
+                    );
 
-                        Option::some(
-                            aztec::messages::discovery::NoteHashAndNullifier {
-                                note_hash, inner_nullifier
-                            }
-                        )
-                    }
-                },
-            );
-        }
+                    let inner_nullifier = $compute_nullifier_unconstrained(note, owner, note_hash_for_nullification);
 
-        let if_note_type_id_match_statements = if_note_type_id_match_statements_list.join(quote {});
-
-        quote {
-            /// Unpacks an array into a note corresponding to `note_type_id` and then computes its note hash (non-siloed) and inner nullifier (non-siloed) assuming the note has been inserted into the note hash tree with `note_nonce`.
-            ///
-            /// The signature of this function notably matches the `aztec::messages::discovery::ComputeNoteHashAndNullifier` type, and so it can be used to call functions from that module such as `do_sync_state` and `attempt_note_discovery`.
-            ///
-            /// This function is automatically injected by the `#[aztec]` macro.
-            #[contract_library_method]
-            unconstrained fn _compute_note_hash_and_nullifier(
-                packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
-                owner: aztec::protocol::address::AztecAddress,
-                storage_slot: Field,
-                note_type_id: Field,
-                contract_address: aztec::protocol::address::AztecAddress,
-                randomness: Field,
-                note_nonce: Field,
-            ) -> Option<aztec::messages::discovery::NoteHashAndNullifier> {
-                $if_note_type_id_match_statements
-                else {
-                    Option::none()
+                    Option::some(
+                        aztec::messages::discovery::NoteHashAndNullifier {
+                            note_hash, inner_nullifier
+                        }
+                    )
                 }
+            },
+        );
+    }
+
+    let if_note_type_id_match_statements = if_note_type_id_match_statements_list.join(quote {});
+
+    quote {
+        /// Unpacks an array into a note corresponding to `note_type_id` and then computes its note hash (non-siloed) and inner nullifier (non-siloed) assuming the note has been inserted into the note hash tree with `note_nonce`.
+        ///
+        /// The signature of this function notably matches the `aztec::messages::discovery::ComputeNoteHashAndNullifier` type, and so it can be used to call functions from that module such as `do_sync_state` and `attempt_note_discovery`.
+        ///
+        /// This function is automatically injected by the `#[aztec]` macro.
+        #[contract_library_method]
+        unconstrained fn _compute_note_hash_and_nullifier(
+            packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
+            owner: aztec::protocol::address::AztecAddress,
+            storage_slot: Field,
+            note_type_id: Field,
+            contract_address: aztec::protocol::address::AztecAddress,
+            randomness: Field,
+            note_nonce: Field,
+        ) -> Option<aztec::messages::discovery::NoteHashAndNullifier> {
+            $if_note_type_id_match_statements
+            else {
+                Option::none()
             }
         }
-    } else {
-        // Contracts with no notes still implement this function to avoid having special-casing, the implementation
-        // simply throws immediately.
-        quote {
-            /// This contract does not use private notes, so this function should never be called as it will unconditionally fail.
-            ///
-            /// This function is automatically injected by the `#[aztec]` macro.
-            #[contract_library_method]
-            unconstrained fn _compute_note_hash_and_nullifier(
-                _packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
-                _owner: aztec::protocol::address::AztecAddress,
-                _storage_slot: Field,
-                _note_type_id: Field,
-                _contract_address: aztec::protocol::address::AztecAddress,
-                _randomness: Field,
-                _nonce: Field,
-            ) -> Option<aztec::messages::discovery::NoteHashAndNullifier> {
-                panic(f"This contract does not use private notes")
-            }
+    }
+}
+
+/// Generates a panic version of _compute_note_hash_and_nullifier for contracts with events but no notes.
+comptime fn generate_compute_note_hash_and_nullifier_panic() -> Quoted {
+    quote {
+        /// This contract does not use private notes, so this function should never be called.
+        ///
+        /// This function is automatically injected by the `#[aztec]` macro.
+        #[contract_library_method]
+        unconstrained fn _compute_note_hash_and_nullifier(
+            _packed_note: BoundedVec<Field, aztec::messages::logs::note::MAX_NOTE_PACKED_LEN>,
+            _owner: aztec::protocol::address::AztecAddress,
+            _storage_slot: Field,
+            _note_type_id: Field,
+            _contract_address: aztec::protocol::address::AztecAddress,
+            _randomness: Field,
+            _nonce: Field,
+        ) -> Option<aztec::messages::discovery::NoteHashAndNullifier> {
+            panic(f"This contract does not use private notes")
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -4,9 +4,14 @@ use crate::{
 };
 use std::panic;
 
-/// A map from event selector to event name indicating whether the event selector has already been seen during the
-/// contract compilation - prevents event selector collisions.
-pub comptime mut global EVENT_SELECTORS: CHashMap<Field, Quoted> = CHashMap::new();
+/// A map from module to a map from event selector to event name indicating whether the event selector has already been
+/// seen during that module's contract compilation - prevents event selector collisions within a contract.
+comptime mut global EVENT_SELECTORS: CHashMap<Module, CHashMap<Field, Quoted>> = CHashMap::new();
+
+/// Returns the event selectors registered for a specific module.
+pub comptime fn get_event_selectors(m: Module) -> CHashMap<Field, Quoted> {
+    EVENT_SELECTORS.get(m).unwrap_or(CHashMap::new())
+}
 
 comptime fn generate_event_interface_and_get_selector(s: TypeDefinition) -> (Quoted, Field) {
     let name = s.name();
@@ -31,20 +36,24 @@ comptime fn generate_event_interface_and_get_selector(s: TypeDefinition) -> (Quo
     )
 }
 
-comptime fn register_event_selector(event_selector: Field, event_name: Quoted) {
-    let existing_event = EVENT_SELECTORS.get(event_selector);
+comptime fn register_event_selector(m: Module, event_selector: Field, event_name: Quoted) {
+    let mut module_events = get_event_selectors(m);
+
+    let existing_event = module_events.get(event_selector);
     if existing_event.is_some() {
         let existing_event = existing_event.unwrap();
         panic(
             f"Event selector collision detected between events '{event_name}' and '{existing_event}'",
         );
     }
-    EVENT_SELECTORS.insert(event_selector, event_name);
+
+    module_events.insert(event_selector, event_name);
+    EVENT_SELECTORS.insert(m, module_events);
 }
 
 pub comptime fn event(s: TypeDefinition) -> Quoted {
     let (event_interface_impl, event_selector) = generate_event_interface_and_get_selector(s);
-    register_event_selector(event_selector, s.name());
+    register_event_selector(s.module(), event_selector, s.name());
 
     let serialize_impl = derive_serialize_if_not_implemented(s);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -1,5 +1,7 @@
 use crate::{
-    macros::utils::{compute_struct_selector, derive_serialize_if_not_implemented, get_trait_impl_method},
+    macros::utils::{
+        compute_struct_selector, derive_serialize_if_not_implemented, find_aztec_contract_module, get_trait_impl_method,
+    },
     utils::cmap::CHashMap,
 };
 use std::panic;
@@ -53,7 +55,11 @@ comptime fn register_event_selector(m: Module, event_selector: Field, event_name
 
 pub comptime fn event(s: TypeDefinition) -> Quoted {
     let (event_interface_impl, event_selector) = generate_event_interface_and_get_selector(s);
-    register_event_selector(s.module(), event_selector, s.name());
+
+    let m = find_aztec_contract_module(s.module());
+    if m.is_some() {
+        register_event_selector(m.unwrap(), event_selector, s.name());
+    }
 
     let serialize_impl = derive_serialize_if_not_implemented(s);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -1,9 +1,10 @@
+use crate::macros::utils::find_aztec_contract_module;
 use crate::note::note_getter_options::PropertySelector;
 use crate::utils::cmap::CHashMap;
 use std::{collections::bounded_vec::BoundedVec, meta::type_of};
 
 /// Maximum number of note types within 1 contract.
-comptime global MAX_NOTE_TYPES: u32 = 128;
+pub comptime global MAX_NOTE_TYPES: u32 = 128;
 
 /// A map from module to a BoundedVec containing all the note types within that module's contract.
 comptime mut global NOTES: CHashMap<Module, BoundedVec<Type, MAX_NOTE_TYPES>> = CHashMap::new();
@@ -221,7 +222,7 @@ pub comptime fn note(s: TypeDefinition) -> Quoted {
 
     // We register the note in the module-specific `NOTES` map because we need that information inside the #[aztec]
     // macro to generate note processing functionality.
-    let m = s.module();
+    let m = find_aztec_contract_module(s.module());
     register_note(m, s.as_type());
 
     let note_properties = generate_note_properties(s);
@@ -282,7 +283,7 @@ pub comptime fn custom_note(s: TypeDefinition) -> Quoted {
 
     // We register the note in the module-specific `NOTES` map because we need that information inside the #[aztec]
     // macro to generate note processing functionality.
-    let m = s.module();
+    let m = find_aztec_contract_module(s.module());
     register_note(m, s.as_type());
 
     let note_type_id = get_next_note_type_id(m);

--- a/noir-projects/aztec-nr/aztec/src/macros/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes.nr
@@ -1,24 +1,37 @@
 use crate::note::note_getter_options::PropertySelector;
+use crate::utils::cmap::CHashMap;
 use std::{collections::bounded_vec::BoundedVec, meta::type_of};
 
 /// Maximum number of note types within 1 contract.
 comptime global MAX_NOTE_TYPES: u32 = 128;
 
-/// A BoundedVec containing all the note types within this contract.
-pub comptime mut global NOTES: BoundedVec<Type, MAX_NOTE_TYPES> = BoundedVec::new();
+/// A map from module to a BoundedVec containing all the note types within that module's contract.
+comptime mut global NOTES: CHashMap<Module, BoundedVec<Type, MAX_NOTE_TYPES>> = CHashMap::new();
 
-comptime mut global NOTE_TYPE_ID_COUNTER: u32 = 0;
+/// A map from module to the note type id counter for that module.
+comptime mut global NOTE_TYPE_ID_COUNTER: CHashMap<Module, u32> = CHashMap::new();
 
-/// The note type id is set by enumerating the note types.
-comptime fn get_next_note_type_id() -> Field {
+/// Returns the notes registered for a specific module.
+pub comptime fn get_notes(m: Module) -> BoundedVec<Type, MAX_NOTE_TYPES> {
+    NOTES.get(m).unwrap_or(BoundedVec::new())
+}
+
+/// Registers a note type for a specific module.
+comptime fn register_note(m: Module, note_type: Type) {
+    let mut module_notes = NOTES.get(m).unwrap_or(BoundedVec::new());
+    module_notes.push(note_type);
+    NOTES.insert(m, module_notes);
+}
+
+/// The note type id is set by enumerating the note types within a module.
+comptime fn get_next_note_type_id(m: Module) -> Field {
+    let current_counter = NOTE_TYPE_ID_COUNTER.get(m).unwrap_or(0);
+
     // We assert that the note type id fits within 7 bits
-    assert(
-        NOTE_TYPE_ID_COUNTER < MAX_NOTE_TYPES,
-        f"A contract can contain at most {MAX_NOTE_TYPES} different note types",
-    );
+    assert(current_counter < MAX_NOTE_TYPES, f"A contract can contain at most {MAX_NOTE_TYPES} different note types");
 
-    let note_type_id = NOTE_TYPE_ID_COUNTER as Field;
-    NOTE_TYPE_ID_COUNTER += 1;
+    let note_type_id = current_counter as Field;
+    NOTE_TYPE_ID_COUNTER.insert(m, current_counter + 1);
     note_type_id
 }
 
@@ -206,12 +219,13 @@ comptime fn generate_note_properties(s: TypeDefinition) -> Quoted {
 pub comptime fn note(s: TypeDefinition) -> Quoted {
     assert_has_packable(s);
 
-    // We register the note in the global `NOTES` BoundedVec because we need that information inside the #[aztec] macro
-    // to generate note processing functionality.
-    NOTES.push(s.as_type());
+    // We register the note in the module-specific `NOTES` map because we need that information inside the #[aztec]
+    // macro to generate note processing functionality.
+    let m = s.module();
+    register_note(m, s.as_type());
 
     let note_properties = generate_note_properties(s);
-    let note_type_id = get_next_note_type_id();
+    let note_type_id = get_next_note_type_id(m);
     let note_type_impl = generate_note_type_impl(s, note_type_id);
     let note_hash_impl = generate_note_hash_trait_impl(s);
 
@@ -266,11 +280,12 @@ pub comptime fn note(s: TypeDefinition) -> Quoted {
 pub comptime fn custom_note(s: TypeDefinition) -> Quoted {
     assert_has_packable(s);
 
-    // We register the note in the global `NOTES` BoundedVec because we need that information inside the #[aztec] macro
-    // to generate note processing functionality.
-    NOTES.push(s.as_type());
+    // We register the note in the module-specific `NOTES` map because we need that information inside the #[aztec]
+    // macro to generate note processing functionality.
+    let m = s.module();
+    register_note(m, s.as_type());
 
-    let note_type_id = get_next_note_type_id();
+    let note_type_id = get_next_note_type_id(m);
     let note_properties = generate_note_properties(s);
     let note_type_impl = generate_note_type_impl(s, note_type_id);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -164,3 +164,24 @@ pub comptime fn derive_serialize_if_not_implemented(s: TypeDefinition) -> Quoted
         derive_serialize(s)
     }
 }
+
+/// Finds the nearest parent module (or self) that has the #[aztec] attribute.
+/// If no #[aztec] module is found, returns the crate root module.
+/// This ensures notes and events in sibling modules of a contract get registered
+/// under the same key that the contract will look up.
+pub comptime fn find_aztec_contract_module(m: Module) -> Option<Module> {
+    // Check if current module has #[aztec] attribute
+    std::println(m.name());
+    if m.has_named_attribute("aztec") {
+        Option::some(m)
+    } else {
+        // Try to get parent module
+        let maybe_parent_module = m.parent();
+
+        if maybe_parent_module.is_some() {
+            find_aztec_contract_module(maybe_parent_module.unwrap())
+        } else {
+            Option::none()
+        }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/utils/cmap.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/cmap.nr
@@ -47,6 +47,11 @@ impl<K, V> CHashMap<K, V> {
             self.entries = self.entries.push_back((key, value));
         }
     }
+
+    /// Returns true if the map contains no entries.
+    pub comptime fn is_empty(self) -> bool {
+        self.entries.len() == 0
+    }
 }
 
 impl<K, V> Default for CHashMap<K, V> {


### PR DESCRIPTION
We had a bug in the macros. We used a global `NOTES` and `EVENT_SELECTORS` variables instead of having them be a per-module map. This resulted in us considering a contract A to have notes if the contract imported contract B and that the contract B contained notes.

**Note**: This still doesn't allow us to not generate `sync_state` function in the `AMM` because there we import `PartialUintNote` type from `uint_note` even though we don't emit any note there 😔

Related issue https://linear.app/aztec-labs/issue/F-301/avoid-generating-and-calling-sync-state-function-when-there-is-no