### PR TITLE
fix(cache_download): CACHE_SSH_HOST no longer requires aws creds

### DIFF
--- a/ci3/cache_download
+++ b/ci3/cache_download
@@ -38,7 +38,7 @@ if [[ -n "${S3_BUILD_CACHE_AWS_PARAMS:-}" ]]; then
   aws $S3_BUILD_CACHE_AWS_PARAMS s3 cp "$s3_uri" "-" | extract_tar
 elif [[ -n "${CACHE_SSH_HOST:-}" ]]; then
   # Run S3 download on remote host via SSH jump and pipe back
-  if ! ssh "$CACHE_SSH_HOST" "aws s3 cp '$s3_uri' -" | extract_tar; then
+  if ! ssh "$CACHE_SSH_HOST" "curl -s -f \"$S3_ENDPOINT/build-cache/$tar_file\"" | extract_tar; then
     echo_stderr "SSH cache download of $tar_file via $CACHE_SSH_HOST failed."
     exit 1
   fi

--- a/ci3/cache_download
+++ b/ci3/cache_download
@@ -30,6 +30,7 @@ function extract_tar {
 
 mkdir -p "$out_dir"
 
+S3_ENDPOINT="http://aztec-ci-artifacts.s3.amazonaws.com"
 s3_uri="s3://aztec-ci-artifacts/build-cache/$tar_file"
 
 if [[ -n "${S3_BUILD_CACHE_AWS_PARAMS:-}" ]]; then
@@ -44,7 +45,6 @@ elif [[ -n "${CACHE_SSH_HOST:-}" ]]; then
   fi
 else
   # Default to AWS S3 URL via curl
-  S3_ENDPOINT="http://aztec-ci-artifacts.s3.amazonaws.com"
   # Attempt to download and extract the cache file
   if ! curl -s -f "$S3_ENDPOINT/build-cache/$tar_file" | extract_tar; then
     echo_stderr "Cache download of $tar_file failed."


### PR DESCRIPTION
This prevents needing AWS creds on the mainframe box at all.