### PR TITLE
docs(aztec.js): add dependencies and package structure documentation

### DIFF
--- a/docs/docs-developers/docs/aztec-js/index.md
+++ b/docs/docs-developers/docs/aztec-js/index.md
@@ -15,6 +15,38 @@ Aztec.js is a library that provides APIs for managing accounts and interacting w
 npm install @aztec/aztec.js@#include_version_without_prefix
 ```
 
+## Common Dependencies
+
+Most applications will need additional packages alongside `@aztec/aztec.js`, e.g.:
+
+```bash
+npm install @aztec/aztec.js@#include_version_without_prefix \
+  @aztec/accounts@#include_version_without_prefix \
+  @aztec/test-wallet@#include_version_without_prefix \
+  @aztec/noir-contracts.js@#include_version_without_prefix
+```
+
+| Package                    | Description                                                   |
+| -------------------------- | ------------------------------------------------------------- |
+| `@aztec/aztec.js`          | Core SDK for contracts, transactions, and network interaction |
+| `@aztec/accounts`          | Account contract implementations (Schnorr, ECDSA)             |
+| `@aztec/test-wallet`       | Simplified wallet for local development and testing           |
+| `@aztec/noir-contracts.js` | Pre-compiled contract interfaces (Token, NFT, etc.)           |
+
+## Package Structure
+
+`@aztec/aztec.js` uses subpath exports. You must import from specific subpaths rather than the package root:
+
+```typescript
+import { createAztecNodeClient, waitForNode } from "@aztec/aztec.js/node";
+import { Fr } from "@aztec/aztec.js/fields";
+import { AztecAddress } from "@aztec/aztec.js/addresses";
+```
+
+## AI-Friendly Reference
+
+The [TypeScript API reference](./typescript_api_reference.mdx) links to markdown interface files for common packages for easy use with AI coding assistants. Copy relevant sections to give your AI tool accurate context about Aztec.js APIs.
+
 ## Guides
 
 <DocCardList />

--- a/docs/docs-words.txt
+++ b/docs/docs-words.txt
@@ -300,6 +300,8 @@ stakeˮ
 Standardisation
 subcomponents
 suboperation
+subpath
+subpaths
 substate
 Substate
 substracted


### PR DESCRIPTION
## Summary

- Add "Common Dependencies" section showing packages typically needed alongside `@aztec/aztec.js`
- Add "Package Structure" section explaining subpath exports (since barrel export was removed)
- Add "AI-Friendly Reference" section linking to TypeScript API docs
- Add "subpath" and "subpaths" to docs spellcheck dictionary

## Test plan

- [ ] Preview docs locally with `yarn start` in docs directory
- [ ] Verify all version macros resolve correctly
- [ ] Check that links work

🤖 Generated with [Claude Code](https://claude.ai/code)