### PR TITLE
feat(token): emit Transfer event on public transfer

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -11,6 +11,7 @@ use crate::protocol::{
 };
 
 global MAX_PRIVATE_EVENTS_PER_TXE_QUERY: u32 = 5;
+global MAX_PUBLIC_EVENTS_PER_TXE_QUERY: u32 = 5;
 global MAX_EVENT_SERIALIZATION_LENGTH: u32 = 12;
 
 pub unconstrained fn deploy<let M: u32, let N: u32, let P: u32>(
@@ -103,6 +104,27 @@ unconstrained fn get_private_events_oracle(
     contract_address: AztecAddress,
     scope: AztecAddress,
     ) -> ([[Field; MAX_EVENT_SERIALIZATION_LENGTH]; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], [u32; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], u32) {}
+
+// experimental
+pub unconstrained fn get_public_events(
+    selector: EventSelector,
+    contract_address: AztecAddress,
+) -> BoundedVec<BoundedVec<Field, MAX_EVENT_SERIALIZATION_LENGTH>, MAX_PUBLIC_EVENTS_PER_TXE_QUERY> {
+    let (raw_array_storage, event_lengths, query_length) = get_public_events_oracle(selector, contract_address);
+
+    let mut events = BoundedVec::new();
+    for i in 0..query_length {
+        events.push(BoundedVec::from_parts(raw_array_storage[i], event_lengths[i]));
+    }
+
+    events
+}
+
+#[oracle(txeGetPublicEvents)]
+unconstrained fn get_public_events_oracle(
+    selector: EventSelector,
+    contract_address: AztecAddress,
+    ) -> ([[Field; MAX_EVENT_SERIALIZATION_LENGTH]; MAX_PUBLIC_EVENTS_PER_TXE_QUERY], [u32; MAX_PUBLIC_EVENTS_PER_TXE_QUERY], u32) {}
 
 #[oracle(txeAdvanceBlocksBy)]
 pub unconstrained fn advance_blocks_by(blocks: u32) {}

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -44,6 +44,9 @@ pub contract Token {
     // an overall small circuit regardless.
     global RECURSIVE_TRANSFER_CALL_MAX_NOTES: u32 = 8;
 
+    global PRIVATE_ADDRESS_MAGIC_VALUE: AztecAddress =
+        AztecAddress { inner: 0x1ea7e01501975545617c2e694d931cb576b691a4a867fed81ebd3264 };
+
     #[event]
     struct Transfer {
         from: AztecAddress,
@@ -161,6 +164,7 @@ pub contract Token {
         let supply = self.storage.total_supply.read().add(amount);
         self.storage.public_balances.at(to).write(new_balance);
         self.storage.total_supply.write(supply);
+        self.emit(Transfer { from: AztecAddress::zero(), to, amount });
     }
 
     // docs:start:transfer_in_public
@@ -176,6 +180,7 @@ pub contract Token {
         self.storage.public_balances.at(from).write(from_balance);
         let to_balance = self.storage.public_balances.at(to).read().add(amount);
         self.storage.public_balances.at(to).write(to_balance);
+        self.emit(Transfer { from, to, amount });
     }
     // docs:end:transfer_in_public
 
@@ -186,6 +191,7 @@ pub contract Token {
         self.storage.public_balances.at(from).write(from_balance);
         let new_supply = self.storage.total_supply.read().sub(amount);
         self.storage.total_supply.write(new_supply);
+        self.emit(Transfer { from, to: AztecAddress::zero(), amount });
     }
 
     #[authorize_once("from", "authwit_nonce")]
@@ -436,6 +442,7 @@ pub contract Token {
 
         // We finalize the transfer by completing the partial note.
         partial_note.complete(self.context, from_and_completer, amount);
+        self.emit(Transfer { from: from_and_completer, to: PRIVATE_ADDRESS_MAGIC_VALUE, amount });
     }
     // docs:end:finalize_transfer_to_private
 
@@ -496,6 +503,7 @@ pub contract Token {
 
         // We finalize the transfer by completing the partial note.
         partial_note.complete(self.context, completer, amount);
+        self.emit(Transfer { from: AztecAddress::zero(), to: PRIVATE_ADDRESS_MAGIC_VALUE, amount });
     }
 
     #[external("public")]
@@ -505,6 +513,7 @@ pub contract Token {
 
         let new_balance = to_balance.read().add(amount);
         to_balance.write(new_balance);
+        self.emit(Transfer { from: PRIVATE_ADDRESS_MAGIC_VALUE, to, amount });
     }
 
     #[external("public")]
@@ -513,6 +522,7 @@ pub contract Token {
         // Only to be called from burn.
         let new_supply = self.storage.total_supply.read().sub(amount);
         self.storage.total_supply.write(new_supply);
+        self.emit(Transfer { from: PRIVATE_ADDRESS_MAGIC_VALUE, to: AztecAddress::zero(), amount });
     }
 
     // docs:start:balance_of_private

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -1,6 +1,9 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{oracle::random::random, test::helpers::authwit::add_public_authwit_from_call};
+use aztec::{
+    oracle::random::random, protocol::address::AztecAddress,
+    test::helpers::authwit::add_public_authwit_from_call,
+};
 
 #[test]
 unconstrained fn burn_public_success() {
@@ -15,6 +18,14 @@ unconstrained fn burn_public_success() {
         token_contract_address,
         owner,
         mint_amount - burn_amount,
+    );
+
+    // Check Transfer event: burn emits Transfer { from: owner, to: zero, amount }
+    utils::check_transfer_event(
+        token_contract_address,
+        owner,
+        AztecAddress::zero(),
+        burn_amount,
     );
 }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -1,4 +1,5 @@
 use crate::{test::utils, Token};
+use aztec::protocol::address::AztecAddress;
 
 #[test]
 unconstrained fn mint_to_public_success() {
@@ -12,6 +13,14 @@ unconstrained fn mint_to_public_success() {
 
     let total_supply = env.view_public(Token::at(token_contract_address).total_supply());
     assert(total_supply == mint_amount);
+
+    // Check Transfer event: mint emits Transfer { from: zero, to: owner, amount }
+    utils::check_transfer_event(
+        token_contract_address,
+        AztecAddress::zero(),
+        owner,
+        mint_amount,
+    );
 }
 
 #[test(should_fail_with = "caller is not minter")]

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -22,6 +22,9 @@ unconstrained fn public_transfer() {
         mint_amount - transfer_amount,
     );
     utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
+
+    // Check Transfer event: transfer emits Transfer { from: owner, to: recipient, amount }
+    utils::check_transfer_event(token_contract_address, owner, recipient, transfer_amount);
 }
 
 #[test]

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -1,5 +1,9 @@
 use crate::Token;
-use aztec::{protocol::address::AztecAddress, test::helpers::test_environment::TestEnvironment};
+use aztec::{
+    event::EventSelector,
+    protocol::{address::AztecAddress, traits::ToField},
+    test::helpers::{test_environment::TestEnvironment, txe_oracles::get_public_events},
+};
 
 pub unconstrained fn setup(
     with_account_contracts: bool,
@@ -104,4 +108,27 @@ pub unconstrained fn setup_and_mint_to_public_with_proxy() -> (TestEnvironment, 
         setup_and_mint_to_public(/* with_account_contracts */ true);
     let proxy = env.deploy("@generic_proxy_contract/GenericProxy").without_initializer();
     (env, token_contract_address, owner, recipient, mint_amount, proxy)
+}
+
+pub unconstrained fn check_transfer_event(
+    contract_address: AztecAddress,
+    from: AztecAddress,
+    to: AztecAddress,
+    amount: u128,
+) {
+    let selector = EventSelector::from_signature("Transfer((Field),(Field),u128)");
+    let events = get_public_events(selector, contract_address);
+    assert(events.len() > 0, "Expected at least one Transfer event");
+
+    let mut found = false;
+    for i in 0..events.len() {
+        let event = events.get(i);
+        if (event.len() == 3)
+            & (event.get(0) == from.to_field())
+            & (event.get(1) == to.to_field())
+            & (event.get(2) == amount as Field) {
+            found = true;
+        }
+    }
+    assert(found, "Expected Transfer event not found");
 }

--- a/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
@@ -1,8 +1,14 @@
+import { AztecAddress } from '@aztec/aztec.js/addresses';
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
+import { getPublicEvents } from '@aztec/aztec.js/events';
 import { Fr } from '@aztec/aztec.js/fields';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 
 import { DUPLICATE_NULLIFIER_ERROR, U128_UNDERFLOW_ERROR } from '../fixtures/index.js';
 import { TokenContractTest } from './token_contract_test.js';
+
+const PRIVATE_ADDRESS = TokenContractTest.PRIVATE_ADDRESS;
 
 describe('e2e_token_contract burn', () => {
   const t = new TokenContractTest('burn');
@@ -30,6 +36,25 @@ describe('e2e_token_contract burn', () => {
       const amount = balance0 / 2n;
       expect(amount).toBeGreaterThan(0n);
       await asset.methods.burn_public(adminAddress, amount, 0).send({ from: adminAddress });
+
+      tokenSim.burnPublic(adminAddress, amount);
+    });
+
+    it('emits a Transfer event on public burn', async () => {
+      const balance0 = await asset.methods.balance_of_public(adminAddress).simulate({ from: adminAddress });
+      const amount = balance0 / 2n;
+      expect(amount).toBeGreaterThan(0n);
+      const receipt = await asset.methods.burn_public(adminAddress, amount, 0).send({ from: adminAddress });
+
+      const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+        fromBlock: BlockNumber(receipt.blockNumber!),
+        toBlock: BlockNumber(receipt.blockNumber! + 1),
+      });
+
+      expect(events.length).toBe(1);
+      expect(events[0].event.from).toEqual(adminAddress);
+      expect(events[0].event.to).toEqual(AztecAddress.ZERO);
+      expect(events[0].event.amount).toEqual(amount);
 
       tokenSim.burnPublic(adminAddress, amount);
     });
@@ -135,6 +160,25 @@ describe('e2e_token_contract burn', () => {
       const amount = balance0 / 2n;
       expect(amount).toBeGreaterThan(0n);
       await asset.methods.burn_private(adminAddress, amount, 0).send({ from: adminAddress });
+      tokenSim.burnPrivate(adminAddress, amount);
+    });
+
+    it('emits a Transfer event on private burn', async () => {
+      const balance0 = await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress });
+      const amount = balance0 / 2n;
+      expect(amount).toBeGreaterThan(0n);
+      const receipt = await asset.methods.burn_private(adminAddress, amount, 0).send({ from: adminAddress });
+
+      const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+        fromBlock: BlockNumber(receipt.blockNumber!),
+        toBlock: BlockNumber(receipt.blockNumber! + 1),
+      });
+
+      expect(events.length).toBe(1);
+      expect(events[0].event.from).toEqual(PRIVATE_ADDRESS);
+      expect(events[0].event.to).toEqual(AztecAddress.ZERO);
+      expect(events[0].event.amount).toEqual(amount);
+
       tokenSim.burnPrivate(adminAddress, amount);
     });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/minting.test.ts
@@ -1,5 +1,12 @@
+import { AztecAddress } from '@aztec/aztec.js/addresses';
+import { getPublicEvents } from '@aztec/aztec.js/events';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
+
 import { U128_OVERFLOW_ERROR } from '../fixtures/fixtures.js';
 import { TokenContractTest } from './token_contract_test.js';
+
+const PRIVATE_ADDRESS = TokenContractTest.PRIVATE_ADDRESS;
 
 describe('e2e_token_contract minting', () => {
   const t = new TokenContractTest('minting');
@@ -29,6 +36,23 @@ describe('e2e_token_contract minting', () => {
         tokenSim.balanceOfPublic(adminAddress),
       );
       expect(await asset.methods.total_supply().simulate({ from: adminAddress })).toEqual(tokenSim.totalSupply);
+    });
+
+    it('emits a Transfer event on public mint', async () => {
+      const amount = 10000n;
+      const receipt = await asset.methods.mint_to_public(adminAddress, amount).send({ from: adminAddress });
+
+      const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+        fromBlock: BlockNumber(receipt.blockNumber!),
+        toBlock: BlockNumber(receipt.blockNumber! + 1),
+      });
+
+      expect(events.length).toBe(1);
+      expect(events[0].event.from).toEqual(AztecAddress.ZERO);
+      expect(events[0].event.to).toEqual(adminAddress);
+      expect(events[0].event.amount).toEqual(amount);
+
+      tokenSim.mintPublic(adminAddress, amount);
     });
 
     describe('failure cases', () => {
@@ -65,6 +89,23 @@ describe('e2e_token_contract minting', () => {
         tokenSim.balanceOfPrivate(adminAddress),
       );
       expect(await asset.methods.total_supply().simulate({ from: adminAddress })).toEqual(tokenSim.totalSupply);
+    });
+
+    it('emits a Transfer event on private mint', async () => {
+      const amount = 10000n;
+      const receipt = await asset.methods.mint_to_private(adminAddress, amount).send({ from: adminAddress });
+
+      const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+        fromBlock: BlockNumber(receipt.blockNumber!),
+        toBlock: BlockNumber(receipt.blockNumber! + 1),
+      });
+
+      expect(events.length).toBe(1);
+      expect(events[0].event.from).toEqual(AztecAddress.ZERO);
+      expect(events[0].event.to).toEqual(PRIVATE_ADDRESS);
+      expect(events[0].event.amount).toEqual(amount);
+
+      tokenSim.mintPrivate(adminAddress, amount);
     });
 
     describe('failure cases', () => {

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -18,6 +18,7 @@ export class TokenContractTest {
   static TOKEN_NAME = 'USDC';
   static TOKEN_SYMBOL = 'USD';
   static TOKEN_DECIMALS = 18n;
+  static PRIVATE_ADDRESS = AztecAddress.fromBigInt(0x1ea7e01501975545617c2e694d931cb576b691a4a867fed81ebd3264n);
   context!: EndToEndContext;
   logger: Logger;
   metricsPort?: number;

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_public.test.ts
@@ -1,4 +1,7 @@
+import { getPublicEvents } from '@aztec/aztec.js/events';
 import { Fr } from '@aztec/aztec.js/fields';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 
 import { U128_UNDERFLOW_ERROR } from '../fixtures/fixtures.js';
 import { type AlertConfig, GrafanaClient } from '../quality_of_service/grafana_client.js';
@@ -47,6 +50,27 @@ describe('e2e_token_contract transfer public', () => {
     const amount = balance0 / 2n;
     expect(amount).toBeGreaterThan(0n);
     await asset.methods.transfer_in_public(adminAddress, account1Address, amount, 0).send({ from: adminAddress });
+
+    tokenSim.transferPublic(adminAddress, account1Address, amount);
+  });
+
+  it('emits a Transfer event on public transfer', async () => {
+    const balance0 = await asset.methods.balance_of_public(adminAddress).simulate({ from: adminAddress });
+    const amount = balance0 / 2n;
+    expect(amount).toBeGreaterThan(0n);
+    const receipt = await asset.methods
+      .transfer_in_public(adminAddress, account1Address, amount, 0)
+      .send({ from: adminAddress });
+
+    const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+      fromBlock: BlockNumber(receipt.blockNumber!),
+      toBlock: BlockNumber(receipt.blockNumber! + 1),
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event.from).toEqual(adminAddress);
+    expect(events[0].event.to).toEqual(account1Address);
+    expect(events[0].event.amount).toEqual(amount);
 
     tokenSim.transferPublic(adminAddress, account1Address, amount);
   });

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_private.test.ts
@@ -1,5 +1,11 @@
+import { getPublicEvents } from '@aztec/aztec.js/events';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
+
 import { U128_UNDERFLOW_ERROR } from '../fixtures/fixtures.js';
 import { TokenContractTest } from './token_contract_test.js';
+
+const PRIVATE_ADDRESS = TokenContractTest.PRIVATE_ADDRESS;
 
 describe('e2e_token_contract transfer_to_private', () => {
   const t = new TokenContractTest('transfer_to_private');
@@ -31,6 +37,26 @@ describe('e2e_token_contract transfer_to_private', () => {
     // Check that the result matches token sim
     tokenSim.transferToPrivate(adminAddress, adminAddress, amount);
     await tokenSim.check();
+  });
+
+  it('emits a Transfer event on transfer to private', async () => {
+    const balancePub = await asset.methods.balance_of_public(adminAddress).simulate({ from: adminAddress });
+    const amount = balancePub / 2n;
+    expect(amount).toBeGreaterThan(0n);
+
+    const receipt = await asset.methods.transfer_to_private(adminAddress, amount).send({ from: adminAddress });
+
+    const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+      fromBlock: BlockNumber(receipt.blockNumber!),
+      toBlock: BlockNumber(receipt.blockNumber! + 1),
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event.from).toEqual(adminAddress);
+    expect(events[0].event.to).toEqual(PRIVATE_ADDRESS);
+    expect(events[0].event.amount).toEqual(amount);
+
+    tokenSim.transferToPrivate(adminAddress, adminAddress, amount);
   });
 
   it('to someone else', async () => {

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
@@ -1,8 +1,13 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
+import { getPublicEvents } from '@aztec/aztec.js/events';
 import { Fr } from '@aztec/aztec.js/fields';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { TokenContract, type Transfer } from '@aztec/noir-contracts.js/Token';
 
 import { DUPLICATE_NULLIFIER_ERROR } from '../fixtures/fixtures.js';
 import { TokenContractTest } from './token_contract_test.js';
+
+const PRIVATE_ADDRESS = TokenContractTest.PRIVATE_ADDRESS;
 
 describe('e2e_token_contract transfer_to_public', () => {
   const t = new TokenContractTest('transfer_to_public');
@@ -30,6 +35,28 @@ describe('e2e_token_contract transfer_to_public', () => {
     expect(amount).toBeGreaterThan(0n);
 
     await asset.methods.transfer_to_public(adminAddress, adminAddress, amount, 0).send({ from: adminAddress });
+
+    tokenSim.transferToPublic(adminAddress, adminAddress, amount);
+  });
+
+  it('emits a Transfer event on transfer to public', async () => {
+    const balancePriv = await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress });
+    const amount = balancePriv / 2n;
+    expect(amount).toBeGreaterThan(0n);
+
+    const receipt = await asset.methods
+      .transfer_to_public(adminAddress, adminAddress, amount, 0)
+      .send({ from: adminAddress });
+
+    const events = await getPublicEvents<Transfer>(t.node, TokenContract.events.Transfer, {
+      fromBlock: BlockNumber(receipt.blockNumber!),
+      toBlock: BlockNumber(receipt.blockNumber! + 1),
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event.from).toEqual(PRIVATE_ADDRESS);
+    expect(events[0].event.to).toEqual(adminAddress);
+    expect(events[0].event.amount).toEqual(amount);
 
     tokenSim.transferToPublic(adminAddress, adminAddress, amount);
   });

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -64,6 +64,7 @@ export interface ITxeExecutionOracle {
     nullifiers: Fr[];
   }>;
   txeGetPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
+  txeGetPublicEvents(selector: EventSelector, contractAddress: AztecAddress): Promise<Fr[][]>;
   txePrivateCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress,

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -182,6 +182,28 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     ).map(e => e.packedEvent);
   }
 
+  async txeGetPublicEvents(selector: EventSelector, contractAddress: AztecAddress) {
+    const lastBlockNumber = await this.getLastBlockNumber();
+    const { logs } = await this.stateMachine.archiver.getPublicLogs({
+      contractAddress,
+      fromBlock: 0,
+      toBlock: lastBlockNumber + 1,
+    });
+
+    // Each public log's fields contain: [serialized_event_fields..., event_type_id]
+    // We filter by event selector (last field) and return only the event data fields (without event_type_id).
+    const selectorField = selector.toField();
+    return logs
+      .filter(extLog => {
+        const fields = extLog.log.fields;
+        return fields.length > 0 && fields[fields.length - 1].equals(selectorField);
+      })
+      .map(extLog => {
+        // Return all fields except the last one (event_type_id)
+        return extLog.log.fields.slice(0, extLog.log.fields.length - 1);
+      });
+  }
+
   async txeAdvanceBlocksBy(blocks: number) {
     this.logger.debug(`time traveling ${blocks} blocks`);
 

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -32,6 +32,7 @@ import {
 
 const MAX_EVENT_LEN = 12; // This is MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVENT_RESERVED_FIELDS
 const MAX_PRIVATE_EVENTS_PER_TXE_QUERY = 5;
+const MAX_PUBLIC_EVENTS_PER_TXE_QUERY = 5;
 
 export class UnavailableOracleError extends Error {
   constructor(oracleName: string) {
@@ -304,6 +305,32 @@ export class RPCTranslator {
     const eventLengths = events
       .map(e => new Fr(e.length))
       .concat(Array(MAX_PRIVATE_EVENTS_PER_TXE_QUERY - events.length).fill(new Fr(0)));
+    const queryLength = new Fr(events.length);
+
+    return toForeignCallResult([toArray(rawArrayStorage), toArray(eventLengths), toSingle(queryLength)]);
+  }
+
+  async txeGetPublicEvents(foreignSelector: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
+    const selector = EventSelector.fromField(fromSingle(foreignSelector));
+    const contractAddress = addressFromSingle(foreignContractAddress);
+
+    const events = await this.handlerAsTxe().txeGetPublicEvents(selector, contractAddress);
+
+    if (events.length > MAX_PUBLIC_EVENTS_PER_TXE_QUERY) {
+      throw new Error(`Array of length ${events.length} larger than maxLen ${MAX_PUBLIC_EVENTS_PER_TXE_QUERY}`);
+    }
+
+    if (events.some(e => e.length > MAX_EVENT_LEN)) {
+      throw new Error(`Some public event has length larger than maxLen ${MAX_EVENT_LEN}`);
+    }
+
+    const rawArrayStorage = events
+      .map(e => e.concat(Array(MAX_EVENT_LEN - e.length).fill(new Fr(0))))
+      .concat(Array(MAX_PUBLIC_EVENTS_PER_TXE_QUERY - events.length).fill(Array(MAX_EVENT_LEN).fill(new Fr(0))))
+      .flat();
+    const eventLengths = events
+      .map(e => new Fr(e.length))
+      .concat(Array(MAX_PUBLIC_EVENTS_PER_TXE_QUERY - events.length).fill(new Fr(0)));
     const queryLength = new Fr(events.length);
 
     return toForeignCallResult([toArray(rawArrayStorage), toArray(eventLengths), toSingle(queryLength)]);


### PR DESCRIPTION
## Summary

- Add `self.emit(Transfer { from, to, amount })` to all balance changes
- Uses a magic address when the from/to is private

Closes F-296
