### PR TITLE
refactor: migrate scheduled benchmarks to merge-train/spartan

### DIFF
--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       nightly_tag:
-        description: "Nightly tag to use (e.g., 2.3.4-nightly.20251209). Leave empty to auto-detect."
+        description: "Nightly tag to use (e.g., 2.3.4-nextnet-nightly.20251209). Leave empty to auto-detect."
         required: false
         type: string
 
@@ -20,7 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        # Note cron jobs will be on 'next' by default.
+        with:
+          ref: merge-train/spartan
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -29,7 +30,7 @@ jobs:
             nightly_tag="${{ inputs.nightly_tag }}"
           else
             current_version=$(jq -r '."."' .release-please-manifest.json)
-            nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)"
+            nightly_tag="${current_version}-nextnet-nightly.$(date -u +%Y%m%d)"
           fi
           echo "nightly_tag=$nightly_tag" >> $GITHUB_OUTPUT
           echo "Using nightly tag: $nightly_tag"
@@ -123,7 +124,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        # Note cron jobs will be on 'next' by default.
+        with:
+          ref: merge-train/spartan
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -132,7 +134,7 @@ jobs:
             nightly_tag="${{ inputs.nightly_tag }}"
           else
             current_version=$(jq -r '."."' .release-please-manifest.json)
-            nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)"
+            nightly_tag="${current_version}-nextnet-nightly.$(date -u +%Y%m%d)"
           fi
           echo "nightly_tag=$nightly_tag" >> $GITHUB_OUTPUT
           echo "Using nightly tag: $nightly_tag"

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       nightly_tag:
-        description: "Nightly tag to use (e.g., 2.3.4-nightly.20251209). Leave empty to auto-detect."
+        description: "Nightly tag to use (e.g., 2.3.4-nextnet-nightly.20251209). Leave empty to auto-detect."
         required: false
         type: string
 
@@ -20,7 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        # Note cron jobs will be on 'next' by default.
+        with:
+          ref: merge-train/spartan
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -29,7 +30,7 @@ jobs:
             nightly_tag="${{ inputs.nightly_tag }}"
           else
             current_version=$(jq -r '."."' .release-please-manifest.json)
-            nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)"
+            nightly_tag="${current_version}-nextnet-nightly.$(date -u +%Y%m%d)"
           fi
           echo "nightly_tag=$nightly_tag" >> $GITHUB_OUTPUT
           echo "Using nightly tag: $nightly_tag"


### PR DESCRIPTION
## Summary
- Migrated `nightly-spartan-bench.yml` and `weekly-proving-bench.yml` to checkout from `merge-train/spartan` instead of defaulting to `next`. By default, operate on -nextnet-nightly (confusing, nextnet implies merge-train/spartan, we'll eventually change but it requires domain changes so not at first)
- This aligns benchmark execution with the merge-train workflow, ensuring benchmarks run against the same code used for next-net deployments

---

Claude -provided checklist I went through (All 'next'-oriented CI Flows):

### ✅ Already Migrated (this PR)
- [x] `nightly-spartan-bench.yml` - Scheduled benchmarks now use merge-train/spartan
- [x] `weekly-proving-bench.yml` - Weekly proving benchmark now uses merge-train/spartan

### ✅ Already Using merge-train/spartan
- [x] `deploy-next-net.yml` - Uses `ref: merge-train/spartan` for checkout and deploy

### 📋 Workflows Triggered on Push to 'next' (Review Needed)
- [x] `fuzzing-docker-avm-build.yml` - Triggers on push to `next`
- [x] `fuzzing-docker-build.yml` - Triggers on push to `next`
- [x] `avm-circuit-inputs.yml` - Triggers on push to `next`
- [x] `filter-history.yml` - Triggers on push to `next`, pushes to `next-linear-git`
- [x] `redo-typo-pr.yml` - Triggers on push to `next`
- [x] `auto-close-issues.yml` - Triggers on push to `next`
- [x] `release-canary-pr-update.yml` - Triggers on push to `next`, creates canary branch from `next`

### 📋 Workflows with Default Ref 'next'
- [x] `fund-sepolia-accounts.yml` - Default ref is `next`
- [x] `metrics-deploy.yml` - Default ref is `next`

### ✅ Intentionally 'next'-oriented (No Migration Needed)
- [x] `merge-train-next-to-branches.yml` - Designed to sync `next` → merge trains (keep as-is)
- [x] `merge-train-create-pr.yml` - Creates PRs from merge-train → `next` (keep as-is)
- [x] `squashed-pr-check.yml` - Only for PRs targeting `next` (keep as-is)
- [x] `ci3.yml` - Main CI gatekeeping merges to `next` (keep as-is)
- [x] `ci3-external.yml` - External PRs can target `next` (keep as-is)
- [x] `create-release-branch.yml` - Takes version from `next`, updates manifest (keep as-is)
- [x] `nightly-release-tag.yml` - Creates nextnet nightly tags (keep as-is)
- [x] `nightly-docs-release.yml` - Updates docs on `next` (keep as-is)
- [x] `mirror-repos.yml` - Rebases on `next` (keep as-is)

### 📝 Network/Environment References (No Migration Needed)
- [x] `ensure-funded-environments.yml` - Funds `next-net` environment (keep as-is)
- [x] `ensure-funded-environment.yml` - Funds `next-net` environment (keep as-is)
- [x] `deploy-staging-network.yml` - Includes `devnet-next` option (keep as-is)