### PR TITLE
refactor: renamed nophasecheck as allowphasechange

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -233,6 +233,7 @@
     "noinitcheck",
     "noirc",
     "noirup",
+    "allow_phase_change",
     "nophasecheck",
     "nullifer",
     "Nullifiable",

--- a/docs/docs-developers/docs/aztec-nr/framework-description/functions/attributes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/functions/attributes.md
@@ -20,7 +20,7 @@ This page documents the attributes (macros) available in Aztec.nr for defining c
 | `#[view]` | functions | Prevents state modification |
 | `#[initializer]` | functions | Contract constructor |
 | `#[noinitcheck]` | functions | Callable before contract initialization |
-| `#[nophasecheck]` | functions | Skips transaction phase validation |
+| `#[allow_phase_change]` | functions | Allows for phase change to happen during the function's execution |
 | `#[only_self]` | functions | Only callable by the same contract |
 | `#[authorize_once]` | functions | Requires authwit authorization with replay protection |
 | `#[note]` | structs | Defines a private note type |
@@ -129,15 +129,15 @@ This macro inserts a check at the beginning of the function to ensure that the c
 assert(self.msg_sender().unwrap() == self.address, "Function can only be called internally");
 ```
 
-## #[nophasecheck]
+## #[allow_phase_change]
 
-Private functions normally include a check to validate the current transaction phase. The `#[nophasecheck]` attribute skips this validation, allowing the function to handle phase transitions internally.
+Private functions normally include a check to validate the current transaction phase. The `#[allow_phase_change]` attribute skips this validation, allowing the function to handle phase transitions internally.
 
 This is primarily used in account contract entrypoints that need to handle fee payment methods spanning multiple phases:
 
 ```rust
 #[external("private")]
-#[nophasecheck]
+#[allow_phase_change]
 fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
     // Handle different fee payment methods that may span phases
 }

--- a/docs/docs-developers/docs/aztec-nr/framework-description/macros.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/macros.md
@@ -27,7 +27,7 @@ Aztec.nr provides macros (attributes) that transform your code during compilatio
 | `#[view]` | Prevents state modification |
 | `#[initializer]` | Contract constructor |
 | `#[noinitcheck]` | Callable before contract initialization |
-| `#[nophasecheck]` | Skips transaction phase validation |
+| `#[allow_phase_change]` | Allows for phase change to happen during the function's execution |
 | `#[only_self]` | Only callable by the same contract |
 | `#[authorize_once]` | Requires authwit authorization with replay protection |
 

--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -29,14 +29,14 @@ The `getDecodedPublicEvents` function has been renamed to `getPublicEvents` and 
 The new function returns richer metadata including `contractAddress`, `txHash`, `l2BlockNumber`, and `l2BlockHash` for each event:
 
 ```typescript
-import { getPublicEvents } from '@aztec/aztec.js/events';
-import { MyContract } from './artifacts/MyContract.js';
+import { getPublicEvents } from "@aztec/aztec.js/events";
+import { MyContract } from "./artifacts/MyContract.js";
 
 // Query events from a contract
 const events = await getPublicEvents<{ amount: bigint; sender: AztecAddress }>(
   aztecNode,
   MyContract.events.Transfer,
-  { contractAddress: myContractAddress, fromBlock: BlockNumber(1) }
+  { contractAddress: myContractAddress, fromBlock: BlockNumber(1) },
 );
 
 // Each event includes decoded data and metadata
@@ -46,6 +46,8 @@ for (const { event, metadata } of events) {
   console.log(`  Contract: ${metadata.contractAddress}`);
 }
 ```
+
+### [Aztec.nr] `nophasecheck` renamed as `allow_phase_change`
 
 ### [AztecNode] Removed sibling path RPC methods
 
@@ -58,12 +60,12 @@ The following methods have been removed from the `AztecNode` interface:
 
 These methods were not used by PXE and returned a subset of the information already available through the corresponding membership witness methods:
 
-| Removed Method | Use Instead |
-|----------------|-------------|
-| `getNullifierSiblingPath` | `getNullifierMembershipWitness` |
-| `getNoteHashSiblingPath` | `getNoteHashMembershipWitness` |
-| `getArchiveSiblingPath` | `getBlockHashMembershipWitness` |
-| `getPublicDataSiblingPath` | `getPublicDataWitness` |
+| Removed Method             | Use Instead                     |
+| -------------------------- | ------------------------------- |
+| `getNullifierSiblingPath`  | `getNullifierMembershipWitness` |
+| `getNoteHashSiblingPath`   | `getNoteHashMembershipWitness`  |
+| `getArchiveSiblingPath`    | `getBlockHashMembershipWitness` |
+| `getPublicDataSiblingPath` | `getPublicDataWitness`          |
 
 The membership witness methods return both the sibling path and additional context (leaf index, preimage data) needed for proofs.
 
@@ -72,6 +74,7 @@ The membership witness methods return both the sibling path and additional conte
 The nullifier secret key (`nsk_m` / `nsk_app`) has been renamed to nullifier hiding key (`nhk_m` / `nhk_app`). This is a protocol-breaking change: the domain separator string changes from `"az_nsk_m"` to `"az_nhk_m"`, producing a different constant value.
 
 **Noir changes:**
+
 ```diff
 - context.request_nsk_app(npk_m_hash)
 + context.request_nhk_app(npk_m_hash)
@@ -81,6 +84,7 @@ The nullifier secret key (`nsk_m` / `nsk_app`) has been renamed to nullifier hid
 ```
 
 **TypeScript changes:**
+
 ```diff
 - import { computeAppNullifierSecretKey, deriveMasterNullifierSecretKey } from '@aztec/stdlib/keys';
 + import { computeAppNullifierHidingKey, deriveMasterNullifierHidingKey } from '@aztec/stdlib/keys';

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -7,7 +7,7 @@ use crate::macros::{
     internals_functions_generation::{external_functions_registry, internal_functions_registry},
     utils::{is_fn_external, module_has_initializer},
 };
-use super::utils::{fn_has_noinitcheck, fn_has_nophasecheck, is_fn_initializer, is_fn_only_self, is_fn_view};
+use super::utils::{fn_has_allow_phase_change, fn_has_noinitcheck, is_fn_initializer, is_fn_only_self, is_fn_view};
 use auth_registry::AUTHORIZE_ONCE_REGISTRY;
 
 // Functions can have multiple attributes applied to them, e.g. a single function can have #[external("public")],
@@ -122,12 +122,12 @@ pub comptime fn noinitcheck(f: FunctionDefinition) {
     }
 }
 
-/// A no-phase-check function will allow transitioning from the non-revertible to the revertible phase during its
+/// An allow_phase_change function will allow transitioning from the non-revertible to the revertible phase during its
 /// execution.
 ///
 /// This is an advanced feature that is typically only required for account contract entrypoints that handle
 /// transaction fee payment.
-pub comptime fn nophasecheck(f: FunctionDefinition) {
+pub comptime fn allow_phase_change(f: FunctionDefinition) {
     // Marker attribute - see the comment at the top of this file
     if !is_fn_external(f) {
         // Unfortunately we cannot check if we are dealing with a utility or public function here as Noir does not
@@ -135,7 +135,7 @@ pub comptime fn nophasecheck(f: FunctionDefinition) {
         // public macro functions are run.
         let name = f.name();
         panic(
-            f"The #[nophasecheck] attribute can only be applied to #[external(\"private\")] functions - {name} is not",
+            f"The #[allow_phase_change] attribute can only be applied to #[external(\"private\")] functions - {name} is not",
         );
     }
 }
@@ -373,10 +373,10 @@ comptime fn assert_valid_public(f: FunctionDefinition) {
         );
     }
 
-    if fn_has_nophasecheck(f) {
+    if fn_has_allow_phase_change(f) {
         let name = f.name();
         panic(
-            f"The #[nophasecheck] attribute cannot be applied to #[external(\"public\")] functions - {name}",
+            f"The #[allow_phase_change] attribute cannot be applied to #[external(\"public\")] functions - {name}",
         );
     }
 }
@@ -398,9 +398,9 @@ comptime fn assert_valid_utility(f: FunctionDefinition) {
     }
 
     // Utility functions cannot be used with the following modifiers: #[authorize_once], #[only_self], #[view],
-    // #[initializer], #[nophasecheck], and #[noinitcheck]. Since we cannot enforce a specific ordering between these
-    // modifiers and #[external(...)], and we cannot access the #[external(...)] argument from within these modifiers'
-    // implementations (as accessing EXTERNAL_REGISTRY would require enforcing ordering), we perform these
+    // #[initializer], #[allow_phase_change], and #[noinitcheck]. Since we cannot enforce a specific ordering between
+    // these modifiers and #[external(...)], and we cannot access the #[external(...)] argument from within these
+    // modifiers' implementations (as accessing EXTERNAL_REGISTRY would require enforcing ordering), we perform these
     // compatibility checks here in the utility macro.
     if AUTHORIZE_ONCE_REGISTRY.get(f).is_some() {
         let name = f.name();
@@ -437,10 +437,10 @@ comptime fn assert_valid_utility(f: FunctionDefinition) {
         );
     }
 
-    if fn_has_nophasecheck(f) {
+    if fn_has_allow_phase_change(f) {
         let name = f.name();
         panic(
-            f"The #[nophasecheck] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
+            f"The #[allow_phase_change] attribute cannot be applied to #[external(\"utility\")] functions - {name}",
         );
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -1,8 +1,8 @@
 use crate::macros::{
     internals_functions_generation::external::helpers::{create_authorize_once_check, get_abi_relevant_attributes},
     utils::{
-        fn_has_authorize_once, fn_has_noinitcheck, fn_has_nophasecheck, is_fn_initializer, is_fn_only_self, is_fn_view,
-        module_has_initializer, module_has_storage,
+        fn_has_allow_phase_change, fn_has_authorize_once, fn_has_noinitcheck, is_fn_initializer, is_fn_only_self,
+        is_fn_view, module_has_initializer, module_has_storage,
     },
 };
 use crate::protocol::meta::utils::derive_serialization_quotes;
@@ -93,20 +93,20 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
     };
 
     // Phase checks are skipped in functions that request to manually handle phases
-    let initial_phase_store = if fn_has_nophasecheck(f) {
+    let initial_phase_store = if fn_has_allow_phase_change(f) {
         quote {}
     } else {
         quote { let within_revertible_phase: bool = self.context.in_revertible_phase(); }
     };
 
-    let no_phase_change_check = if fn_has_nophasecheck(f) {
+    let no_phase_change_check = if fn_has_allow_phase_change(f) {
         quote {}
     } else {
         quote {   
             assert_eq(
                 within_revertible_phase,
                 self.context.in_revertible_phase(),
-                f"Phase change detected on function with phase check. If this is expected, use #[nophasecheck]",
+                f"Phase change detected on function with phase check. If this is expected, use #[allow_phase_change]",
             ); 
         }
     };

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -33,8 +33,8 @@ pub(crate) comptime fn fn_has_noinitcheck(f: FunctionDefinition) -> bool {
     f.has_named_attribute("noinitcheck")
 }
 
-pub(crate) comptime fn fn_has_nophasecheck(f: FunctionDefinition) -> bool {
-    f.has_named_attribute("nophasecheck")
+pub(crate) comptime fn fn_has_allow_phase_change(f: FunctionDefinition) -> bool {
+    f.has_named_attribute("allow_phase_change")
 }
 
 pub(crate) comptime fn fn_has_authorize_once(f: FunctionDefinition) -> bool {

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -8,7 +8,7 @@ pub contract EcdsaKAccount {
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
         macros::{
-            functions::{external, initializer, noinitcheck, nophasecheck, view},
+            functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -55,7 +55,7 @@ pub contract EcdsaKAccount {
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
     #[external("private")]
     #[noinitcheck]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -7,7 +7,7 @@ pub contract EcdsaRAccount {
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
         macros::{
-            functions::{external, initializer, noinitcheck, nophasecheck, view},
+            functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -54,7 +54,7 @@ pub contract EcdsaRAccount {
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
     #[external("private")]
     #[noinitcheck]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -15,7 +15,7 @@ pub contract SchnorrAccount {
         context::PrivateContext,
         hash::compute_siloed_nullifier,
         macros::{
-            functions::{external, initializer, noinitcheck, nophasecheck, view},
+            functions::{allow_phase_change, external, initializer, noinitcheck, view},
             storage::storage,
         },
         messages::message_delivery::MessageDelivery,
@@ -69,7 +69,7 @@ pub contract SchnorrAccount {
     // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
     #[external("private")]
     #[noinitcheck]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_hardcoded_account_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract SchnorrHardcodedAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::functions::{external, nophasecheck, view},
+        macros::functions::{allow_phase_change, external, view},
         oracle::{auth_witness::get_auth_witness, notes::set_sender_for_tags},
     };
     use std::embedded_curve_ops::EmbeddedCurvePoint;
@@ -19,7 +19,7 @@ pub contract SchnorrHardcodedAccount {
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_single_key_account_contract/src/main.nr
@@ -13,11 +13,11 @@ pub contract SchnorrSingleKeyAccount {
 
     use crate::{auth_oracle::get_auth_witness, util::recover_address};
 
-    use dep::aztec::macros::functions::{external, nophasecheck, view};
+    use dep::aztec::macros::functions::{allow_phase_change, external, view};
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/simulated_account_contract/src/main.nr
@@ -11,13 +11,13 @@ pub contract SimulatedAccount {
     use dep::aztec::{
         authwit::{account::AccountActions, auth::IS_VALID_SELECTOR, entrypoint::app::AppPayload},
         context::PrivateContext,
-        macros::functions::{external, nophasecheck, view},
+        macros::functions::{allow_phase_change, external, view},
         oracle::notes::set_sender_for_tags,
     };
 
     // @dev: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts (specifically `getEntrypointAbi()`)
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload, fee_payment_method: u8, cancellable: bool) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -44,7 +44,7 @@ pub contract AppSubscription {
 
     use aztec::{
         authwit::auth::assert_current_call_valid_authwit,
-        macros::{functions::{external, initializer, nophasecheck}, storage::storage},
+        macros::{functions::{allow_phase_change, external, initializer}, storage::storage},
         messages::message_delivery::MessageDelivery,
         oracle::notes::set_sender_for_tags,
         protocol::address::AztecAddress,
@@ -66,7 +66,7 @@ pub contract AppSubscription {
     global SUBSCRIPTION_TXS: u32 = 5;
 
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(payload: DAppPayload, user_address: AztecAddress) {
         // Safety: The sender for tags is only used to compute unconstrained shared secrets for emitting logs.
         // Since this value is only used for unconstrained tagging and not for any constrained logic,

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -14,7 +14,10 @@ pub contract FPC {
     use crate::{config::Config, utils::safe_cast_to_u128};
     use dep::uint_note::PartialUintNote;
     use aztec::{
-        macros::{functions::{external, initializer, nophasecheck, only_self}, storage::storage},
+        macros::{
+            functions::{allow_phase_change, external, initializer, only_self},
+            storage::storage,
+        },
         protocol::address::AztecAddress,
         state_vars::PublicImmutable,
     };
@@ -77,7 +80,7 @@ pub contract FPC {
     /// - the asset which was used to make the payment.
     // docs:start:fee_entrypoint_private
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn fee_entrypoint_private(max_fee: u128, authwit_nonce: Field) {
         let accepted_asset = self.storage.config.read().accepted_asset;
 
@@ -154,7 +157,7 @@ pub contract FPC {
     /// Protocol-enshrined fee-payment phase:
     /// 4. The protocol deducts the actual fee denominated in fee juice from the FPC's balance.
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn fee_entrypoint_public(max_fee: u128, authwit_nonce: Field) {
         let config = self.storage.config.read();
 

--- a/noir-projects/noir-contracts/contracts/fees/sponsored_fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/sponsored_fpc_contract/src/main.nr
@@ -5,11 +5,11 @@ use dep::aztec::macros::aztec;
 /// This contract covers transaction fees for users unconditionally.
 #[aztec]
 pub contract SponsoredFPC {
-    use dep::aztec::macros::functions::{external, nophasecheck};
+    use dep::aztec::macros::functions::{allow_phase_change, external};
 
     /// Sponsors the transaction unconditionally.
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn sponsor_unconditionally() {
         // Set the FPC as the fee payer of the tx.
         self.context.set_as_fee_payer();

--- a/noir-projects/noir-contracts/contracts/protocol/multi_call_entrypoint_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/multi_call_entrypoint_contract/src/main.nr
@@ -12,10 +12,13 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract MultiCallEntrypoint {
-    use aztec::{authwit::entrypoint::app::AppPayload, macros::functions::{external, nophasecheck}};
+    use aztec::{
+        authwit::entrypoint::app::AppPayload,
+        macros::functions::{allow_phase_change, external},
+    };
 
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn entrypoint(app_payload: AppPayload) {
         app_payload.execute_calls(self.context);
     }

--- a/noir-projects/noir-contracts/contracts/protocol_interface/fee_juice_interface/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol_interface/fee_juice_interface/src/main.nr
@@ -15,7 +15,7 @@ use aztec::macros::aztec;
 #[aztec]
 pub contract FeeJuice {
     use aztec::{
-        macros::functions::{external, nophasecheck, only_self, view},
+        macros::functions::{allow_phase_change, external, only_self, view},
         protocol::address::AztecAddress,
     };
 
@@ -23,7 +23,7 @@ pub contract FeeJuice {
     fn claim(to: AztecAddress, amount: u128, secret: Field, message_leaf_index: Field) {}
 
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn claim_and_end_setup(
         to: AztecAddress,
         amount: u128,

--- a/noir-projects/noir-contracts/contracts/test/sponsored_fpc_no_end_setup_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/sponsored_fpc_no_end_setup_contract/src/main.nr
@@ -5,11 +5,11 @@ use dep::aztec::macros::aztec;
 /// Useful for e2e testing of phase checking only.
 #[aztec]
 pub contract SponsoredFPCNoEndSetup {
-    use dep::aztec::macros::functions::{external, nophasecheck};
+    use dep::aztec::macros::functions::{allow_phase_change, external};
 
     /// Sponsors the transaction unconditionally. Doesn't end the setup phase.
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn sponsor_unconditionally() {
         // Set the FPC as the fee payer of the tx.
         self.context.set_as_fee_payer();

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -43,7 +43,7 @@ pub contract Test {
         // Macros
         macros::{
             events::event,
-            functions::{initializer, only_self, noinitcheck, external, nophasecheck},
+            functions::{initializer, only_self, noinitcheck, external, allow_phase_change},
             storage::storage,
         },
         // Contract instance management
@@ -282,7 +282,7 @@ pub contract Test {
     }
 
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn end_setup_checking_phases() {
         assert(!self.context.in_revertible_phase());
         self.context.end_setup();
@@ -296,7 +296,7 @@ pub contract Test {
     }
 
     #[external("private")]
-    #[nophasecheck]
+    #[allow_phase_change]
     fn call_function_that_ends_setup_without_phase_check() {
         self.call_self.end_setup_checking_phases();
     }

--- a/yarn-project/end-to-end/src/e2e_phase_check.test.ts
+++ b/yarn-project/end-to-end/src/e2e_phase_check.test.ts
@@ -13,7 +13,7 @@ import { defaultInitialAccountFeeJuice } from '@aztec/world-state/testing';
 import { setup } from './fixtures/utils.js';
 
 // Private functions should receive automatically a phase check that avoids any nested call changing the phase.
-// Functions that opt out of this phase check can be marked with #[nophasecheck].
+// Functions that opt out of this phase check can be marked with #[allow_phase_change].
 describe('Phase check', () => {
   let wallet: TestWallet;
   let defaultAccountAddress: AztecAddress;
@@ -62,7 +62,7 @@ describe('Phase check', () => {
     ).rejects.toThrow('Phase change detected on function with phase check.');
   });
 
-  it('should not fail when a nested call changes the phase if #[nophasecheck] is used', async () => {
+  it('should not fail when a nested call changes the phase if #[allow_phase_change] is used', async () => {
     await contract.methods.call_function_that_ends_setup_without_phase_check().simulate({
       from: defaultAccountAddress,
       fee: {


### PR DESCRIPTION
because it's nicer

https://aztecprotocol.slack.com/archives/C04PUD9AA4W/p1770123569757129

Closes https://linear.app/aztec-labs/issue/F-298/rename-suggestion-from-live-in-a-meeting-nophasecheck-allowphasechange