### PR TITLE
feat: (blob audit) not recomputing barycentric inverses per blob

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,6 +5,6 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9" }
-bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.0" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.13.0" }
 types = { path = "../types" }

--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,6 +5,6 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9" }
 bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
 types = { path = "../types" }

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/abis/final_blob_batching_challenges.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/abis/final_blob_batching_challenges.nr
@@ -6,8 +6,8 @@ use types::{
 };
 
 /**
-* Final values z and gamma are injected into each block root circuit. We ensure they are correct by:
-* - Checking equality in each block merge circuit and propagating up
+* Final values z and gamma are injected into each checkpoint root circuit. We ensure they are correct by:
+* - Checking equality in each checkpoint merge circuit and propagating up
 * - Checking final z_acc == z in root circuit
 * - Checking final h(gamma_acc, z) == gamma in root circuit
 *

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
@@ -36,9 +36,8 @@ pub(crate) fn barycentric_evaluate_blob_at_z(
     //   /____       \  z - w^i  /
     //    i=0
     //
-    // perhaps because all the w^i terms are constant witnesses?
-    // (AUDITTODO) Potential optimization: The denominator is constant for all ys, since z is the same for all blobs. We could potentially just do this once in an epoch-wide precomputation.
-    // Compute the sum y_i .
+    // Note: fracs are precomputed once upstream (in the checkpoint root rollup) and shared
+    // across all blob evaluations, since they only depend on the roots and the shared challenge z.
 
     let sum = if !std::runtime::is_unconstrained() {
         // OK so...we can add multiple product terms into a sum...but I am not sure how many!
@@ -204,7 +203,7 @@ unconstrained fn __compute_fracs(z: BLS12_381_Fr) -> [BLS12_381_Fr; FIELDS_PER_B
     }
     let inv_denoms: [BLS12_381_Fr; FIELDS_PER_BLOB] = bignum::bignum::batch_invert(denoms); // 1 / (z - w^i), for all i
     // We're now done with `denoms` so we can reuse the allocated array to build `fracs`.
-    let mut fracs = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB]; // aiming for: y_i / (z - w^i), for all i
+    let mut fracs = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB]; // aiming for: w^i / (z - w^i), for all i
     for i in 0..FIELDS_PER_BLOB {
         let inv_denom = inv_denoms[i]; // 1 / (z - w^i)
         fracs[i] = ROOTS[i].__mul(inv_denom); // w^i * (1 / (z - w^i))
@@ -219,15 +218,11 @@ pub fn validate_fracs(z: BLS12_381_Fr, fracs: [BLS12_381_Fr; FIELDS_PER_BLOB]) {
         // frac <-- ROOTS[i] / (z + ROOTS[i].neg())
         // frac * (z + ROOTS[i].neg()) - ROOTS[i] == 0
         //
-        // Note: technically, if z is equal to any of the negated roots of unity, then this circuit is under-constrained,
-        // because:
-        // - The constraint becomes fracs[i] * 0 - ROOTS[i] = 0
-        // - If y_i != 0: unsatisfiable (safe)
-        // - If y_i = 0: the constraint is 0 = 0, satisfied for any value of fracs[i], meaning fracs[i] is completely
-        //   unconstrained, allowing the prover to inject arbitrary values into the sum.
-        // We _could_ spend 4096 constraints asserting that z is _not_ equal to a root of unity, but...
-        // the challenge z is derived from poseidon2_hash([blob_fields_hash, kzg_commitment[0], kzg_commitment[1]]).
-        // Finding a blob where this hash equals a specific root of unity requires a preimage attack on Poseidon2, which
+        // Note: if z equals a root of unity w^i, the constraint becomes:
+        //   fracs[i] * 0 - ROOTS[i] = 0  =>  -ROOTS[i] = 0
+        // Since ROOTS[i] != 0 for all i, this is unsatisfiable -- no valid proof can be created.
+        // Moreover, the challenge z is derived from poseidon2_hash([blob_fields_hash, kzg_commitment[0], kzg_commitment[1]]),
+        // so finding a blob where z equals a specific root of unity requires a preimage attack on Poseidon2, which
         // is assumed to be computationally infeasible.
         bignum::bignum::evaluate_quadratic_expression(
             [[fracs[i]]],
@@ -546,7 +541,7 @@ mod tests {
 
     #[test]
     unconstrained fn test_compute_fracs_direct() {
-        // Directly test __compute_fracs: verify fracs[i] * (z - w^i) = y_i
+        // Directly test __compute_fracs: verify fracs[i] * (z - w^i) = w^i
         let z = BLS12_381_Fr::from_limbs([42, 0, 0]);
         let mut ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
         ys[0] = BLS12_381_Fr::from_limbs([100, 0, 0]);
@@ -620,8 +615,8 @@ mod tests {
 
         // When z = 0:
         // - z^d = 0, so factor = (0 - 1) / d = -1/d = -D_INV
-        // - fracs[i] = y_i / (0 - w^i) = -y_i / w^i
-        // - sum = SUM( w^i * (-y_i / w^i) ) = -SUM(y_i)
+        // - fracs[i] = w^i / (0 - w^i) = -1
+        // - sum = SUM( y_i * (-1) ) = -SUM(y_i)
         // - result = factor * sum = (-D_INV) * (-SUM(y_i)) = D_INV * SUM(y_i)
         //
         // For ys = [1, 2, 0, 0, ...]: SUM(y_i) = 3

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
@@ -11,34 +11,24 @@ use types::constants::FIELDS_PER_BLOB;
  *            d      /____       z - w^i
  *                    i=0
  *
- * p(z) = factor . sum( y_i . num / denom )
- *
+ * p(z) = factor . sum( y_i . fracs_i )
  *
  * where d = 4096
  *
- * Precompute:
- * - The d roots of unity w^i (plus maybe their negatives for z - w^i computations).
- * - (1 / d)
+ * Note: `fracs` (w^i / (z - w^i) for all i) and `factor` ((z^d - 1) / d) are computed once
+ * upstream in the checkpoint root rollup and shared across all blob evaluations.
  *
- * @param z
  * @param ys - ("ys" being the plural of "y") - the many y_i's of the blob.
+ * @param fracs - precomputed w^i / (z - w^i) for all i.
+ * @param factor - precomputed (z^d - 1) / d.
  *
  * @return y = p(z)
  */
 pub(crate) fn barycentric_evaluate_blob_at_z(
-    z: BLS12_381_Fr,
     ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    factor: BLS12_381_Fr,
 ) -> BLS12_381_Fr {
-    // Note: it's more efficient (saving 30k constraints) to compute:
-    //    ___d-1
-    //    \     /    y_i    \
-    //    /    |  ---------  | . w^i
-    //   /____  \  z - w^i  /
-    //    i=0
-    //            ^^^^^^^^^
-    //              frac
-    //
-    // ... than to compute:
     //
     //    ___d-1
     //    \          /    w^i    \
@@ -47,7 +37,8 @@ pub(crate) fn barycentric_evaluate_blob_at_z(
     //    i=0
     //
     // perhaps because all the w^i terms are constant witnesses?
-    let fracs = compute_fracs(z, ys);
+    // (AUDITTODO) Potential optimization: The denominator is constant for all ys, since z is the same for all blobs. We could potentially just do this once in an epoch-wide precomputation.
+    // Compute the sum y_i .
 
     let sum = if !std::runtime::is_unconstrained() {
         // OK so...we can add multiple product terms into a sum...but I am not sure how many!
@@ -68,16 +59,13 @@ pub(crate) fn barycentric_evaluate_blob_at_z(
         let NUM_PARTIAL_SUMS = FIELDS_PER_BLOB / 8;
         // Safety: This sum is checked by the following `evaluate_quadratic_expression` calls.
         let partial_sums: [BLS12_381_Fr; FIELDS_PER_BLOB / 8] =
-            unsafe { __compute_partial_sums(fracs) };
+            unsafe { __compute_partial_sums(fracs, ys) };
 
         // We split off the first term to check the initial sum
 
         //    partial_sums[0] <- (lhs[0] * rhs[0] + ... + lhs[7] * rhs[7])
         // => (lhs[0] * rhs[0] + ... + lhs[7] * rhs[7]) - partial_sums[0] == 0
-        let lhs = [
-            [ROOTS[0]], [ROOTS[1]], [ROOTS[2]], [ROOTS[3]], [ROOTS[4]], [ROOTS[5]], [ROOTS[6]],
-            [ROOTS[7]],
-        ];
+        let lhs = [[ys[0]], [ys[1]], [ys[2]], [ys[3]], [ys[4]], [ys[5]], [ys[6]], [ys[7]]];
         let rhs = [
             [fracs[0]], [fracs[1]], [fracs[2]], [fracs[3]], [fracs[4]], [fracs[5]], [fracs[6]],
             [fracs[7]],
@@ -117,14 +105,14 @@ pub(crate) fn barycentric_evaluate_blob_at_z(
 
             bignum::bignum::evaluate_quadratic_expression(
                 /* lhs */ [
-                    [ROOTS[i * 8 + 0]],
-                    [ROOTS[i * 8 + 1]],
-                    [ROOTS[i * 8 + 2]],
-                    [ROOTS[i * 8 + 3]],
-                    [ROOTS[i * 8 + 4]],
-                    [ROOTS[i * 8 + 5]],
-                    [ROOTS[i * 8 + 6]],
-                    [ROOTS[i * 8 + 7]],
+                    [ys[i * 8 + 0]],
+                    [ys[i * 8 + 1]],
+                    [ys[i * 8 + 2]],
+                    [ys[i * 8 + 3]],
+                    [ys[i * 8 + 4]],
+                    [ys[i * 8 + 5]],
+                    [ys[i * 8 + 6]],
+                    [ys[i * 8 + 7]],
                 ],
                 [[false], [false], [false], [false], [false], [false], [false], [false]],
                 /* rhs */
@@ -152,15 +140,14 @@ pub(crate) fn barycentric_evaluate_blob_at_z(
 
         // Safety: We're running under the condition that `std::runtime::is_unconstrained()` is true.
         unsafe {
-            __compute_sum(fracs)
+            __compute_sum(fracs, ys)
         }
     };
 
-    let factor = compute_factor(z);
     factor.mul(sum)
 }
 
-fn z_pow_d(z: BLS12_381_Fr) -> BLS12_381_Fr {
+pub fn z_pow_d(z: BLS12_381_Fr) -> BLS12_381_Fr {
     // z ^ d:
     // z ^ 4096 = z ^ (2 ^ 12)
 
@@ -178,7 +165,7 @@ unconstrained fn __compute_factor_helper(z_pow_d: BLS12_381_Fr) -> BLS12_381_Fr 
     z_pow_d.__sub(one).__mul(D_INV)
 }
 
-fn validate_factor(z_pow_d: BLS12_381_Fr, factor: BLS12_381_Fr) {
+pub fn validate_factor(z_pow_d: BLS12_381_Fr, factor: BLS12_381_Fr) {
     // (z_pow_d - one) * (D_INV) - factor = 0
     // z_pow_d * D_INV - D_INV - factor = 0
     bignum::bignum::evaluate_quadratic_expression(
@@ -196,7 +183,7 @@ fn validate_factor(z_pow_d: BLS12_381_Fr, factor: BLS12_381_Fr) {
 ///  z^d - 1
 /// ---------
 ///     d
-fn compute_factor(z: BLS12_381_Fr) -> BLS12_381_Fr {
+pub fn compute_factor(z: BLS12_381_Fr) -> BLS12_381_Fr {
     let z_pow_d = z_pow_d(z);
 
     // Safety: We immediately check that this result is correct in the following `evaluate_quadratic_expression` call.
@@ -209,10 +196,8 @@ fn compute_factor(z: BLS12_381_Fr) -> BLS12_381_Fr {
     factor
 }
 
-unconstrained fn __compute_fracs(
-    z: BLS12_381_Fr,
-    ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
-) -> [BLS12_381_Fr; FIELDS_PER_BLOB] {
+// Compute the fracs: w^i / (z - w^i) for all i
+unconstrained fn __compute_fracs(z: BLS12_381_Fr) -> [BLS12_381_Fr; FIELDS_PER_BLOB] {
     let mut denoms = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
     for i in 0..FIELDS_PER_BLOB {
         denoms[i] = z.__sub(ROOTS[i]); // (z - w^i)
@@ -221,27 +206,22 @@ unconstrained fn __compute_fracs(
     // We're now done with `denoms` so we can reuse the allocated array to build `fracs`.
     let mut fracs = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB]; // aiming for: y_i / (z - w^i), for all i
     for i in 0..FIELDS_PER_BLOB {
-        let num = ys[i];
         let inv_denom = inv_denoms[i]; // 1 / (z - w^i)
-        fracs[i] = num.__mul(inv_denom); // y_i * (1 / (z - w^i))
+        fracs[i] = ROOTS[i].__mul(inv_denom); // w^i * (1 / (z - w^i))
     }
 
     fracs
 }
 
 // Extracted into a standalone fn to enable testing of invalid fracs.
-fn validate_fracs(
-    z: BLS12_381_Fr,
-    ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
-    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
-) {
+pub fn validate_fracs(z: BLS12_381_Fr, fracs: [BLS12_381_Fr; FIELDS_PER_BLOB]) {
     for i in 0..FIELDS_PER_BLOB {
-        // frac <-- ys[i] / (z + ROOTS[i].neg())
-        // frac * (z + ROOTS[i].neg()) - ys[i] == 0
+        // frac <-- ROOTS[i] / (z + ROOTS[i].neg())
+        // frac * (z + ROOTS[i].neg()) - ROOTS[i] == 0
         //
         // Note: technically, if z is equal to any of the negated roots of unity, then this circuit is under-constrained,
         // because:
-        // - The constraint becomes fracs[i] * 0 - y_i = 0
+        // - The constraint becomes fracs[i] * 0 - ROOTS[i] = 0
         // - If y_i != 0: unsatisfiable (safe)
         // - If y_i = 0: the constraint is 0 = 0, satisfied for any value of fracs[i], meaning fracs[i] is completely
         //   unconstrained, allowing the prover to inject arbitrary values into the sum.
@@ -254,7 +234,7 @@ fn validate_fracs(
             [[false]],
             [[z, ROOTS[i].neg()]],
             [[false, false]],
-            [ys[i]],
+            [ROOTS[i]],
             [true],
         );
     }
@@ -263,21 +243,18 @@ fn validate_fracs(
 /// Compute an array of the d `frac` items which contribute to this sum:
 ///
 ///    ___d-1
-///    \     /    y_i    \
-///    /    |  ---------  | . w^i
+///    \     /    w^i    \
+///    /    |  ---------  | . y_i
 ///   /____  \  z - w^i  /
 ///    i=0
 ///            ^^^^^^^^^
 ///              frac
-fn compute_fracs(
-    z: BLS12_381_Fr,
-    ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
-) -> [BLS12_381_Fr; FIELDS_PER_BLOB] {
+pub fn compute_fracs(z: BLS12_381_Fr) -> [BLS12_381_Fr; FIELDS_PER_BLOB] {
     // Safety: We immediately constrain these `fracs` to be correct in the following call to `evaluate_quadratic_expression`.
-    let fracs: [BLS12_381_Fr; FIELDS_PER_BLOB] = unsafe { __compute_fracs(z, ys) };
+    let fracs: [BLS12_381_Fr; FIELDS_PER_BLOB] = unsafe { __compute_fracs(z) };
 
     if !std::runtime::is_unconstrained() {
-        validate_fracs(z, ys, fracs);
+        validate_fracs(z, fracs);
     }
 
     fracs
@@ -285,6 +262,7 @@ fn compute_fracs(
 
 unconstrained fn __compute_partial_sums(
     fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
 ) -> [BLS12_381_Fr; FIELDS_PER_BLOB / 8] {
     let mut partial_sums: [BLS12_381_Fr; FIELDS_PER_BLOB / 8] = std::mem::zeroed();
 
@@ -299,7 +277,7 @@ unconstrained fn __compute_partial_sums(
     let mut partial_sum = BLS12_381_Fr::zero();
     for i in 0..8 {
         // y_k * ( w^k / (z - w^k) )
-        let summand = ROOTS[i].__mul(fracs[i]);
+        let summand = ys[i].__mul(fracs[i]);
 
         // partial_sum + ( y_k * ( w^k / (z - w^k) ) -> partial_sum
         partial_sum = partial_sum.__add(summand);
@@ -318,7 +296,7 @@ unconstrained fn __compute_partial_sums(
         for j in 0..8 {
             let k = i * 8 + j;
             // y_k * ( w^k / (z - w^k) )
-            let summand = ROOTS[k].__mul(fracs[k]);
+            let summand = ys[k].__mul(fracs[k]);
             // partial_sum + ( y_k * ( w^k / (z - w^k) ) -> partial_sum
             partial_sum = partial_sum.__add(summand);
         }
@@ -328,7 +306,10 @@ unconstrained fn __compute_partial_sums(
     partial_sums
 }
 
-unconstrained fn __compute_sum(fracs: [BLS12_381_Fr; FIELDS_PER_BLOB]) -> BLS12_381_Fr {
+unconstrained fn __compute_sum(
+    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    ys: [BLS12_381_Fr; FIELDS_PER_BLOB],
+) -> BLS12_381_Fr {
     // Seeking:
     //                    ___d-1
     //                    \            w^i
@@ -339,7 +320,7 @@ unconstrained fn __compute_sum(fracs: [BLS12_381_Fr; FIELDS_PER_BLOB]) -> BLS12_
     let mut sum = BLS12_381_Fr::zero();
     for i in 0..FIELDS_PER_BLOB {
         // y_k * ( w^k / (z - w^k) )
-        let summand = ROOTS[i].__mul(fracs[i]);
+        let summand = ys[i].__mul(fracs[i]);
 
         // partial_sum + ( y_k * ( w^k / (z - w^k) ) -> partial_sum
         sum = sum.__add(summand);
@@ -353,8 +334,8 @@ mod tests {
         config::{D, D_INV, LOG_FIELDS_PER_BLOB, ROOTS},
     };
     use super::{
-        __compute_fracs, __compute_partial_sums, __compute_sum, compute_factor, validate_factor,
-        validate_fracs, z_pow_d,
+        __compute_fracs, __compute_partial_sums, __compute_sum, compute_factor, compute_fracs,
+        validate_factor, validate_fracs, z_pow_d,
     };
     use bignum::{BigNum, BLS12_381_Fr};
     use std::ops::Neg;
@@ -378,8 +359,10 @@ mod tests {
         let challenge_z = poseidon2_hash([blob_fields_hash, kzg_commitment[0], kzg_commitment[1]]);
         let challenge_z_as_bignum = BLS12_381_Fr::from(challenge_z);
         let blob = blob_as_fields.map(|b| BLS12_381_Fr::from(b));
+        let fracs = compute_fracs(challenge_z_as_bignum);
+        let factor = compute_factor(challenge_z_as_bignum);
 
-        let y = barycentric_evaluate_blob_at_z(challenge_z_as_bignum, blob);
+        let y = barycentric_evaluate_blob_at_z(blob, fracs, factor);
 
         (challenge_z, y)
     }
@@ -471,9 +454,11 @@ mod tests {
         ys[0] = BLS12_381_Fr::from_limbs([0x1234, 0, 0]);
         ys[1] = BLS12_381_Fr::from_limbs([0xabcd, 0, 0]);
         ys[2] = BLS12_381_Fr::from_limbs([0x69, 0, 0]);
+        let fracs = __compute_fracs(z);
+        let factor = compute_factor(z);
 
         // evaluate the blob at z = 2 to yield y:
-        let y = barycentric_evaluate_blob_at_z(z, ys);
+        let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
         let mut expected_y: [u128; 3] = [0; 3];
         if (FIELDS_PER_BLOB == 4096) {
@@ -521,13 +506,15 @@ mod tests {
     #[test]
     fn compute_sum_and_compute_partial_sums_agree() {
         let mut fields = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
+        let mut ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
         for i in 0..FIELDS_PER_BLOB {
             fields[i] = BLS12_381_Fr::from(i as Field);
+            ys[i] = BLS12_381_Fr::from(2 * i as Field);
         }
         // Safety: this is a test
         unsafe {
-            let partial_sums = __compute_partial_sums(fields);
-            let sum = __compute_sum(fields);
+            let partial_sums = __compute_partial_sums(fields, ys);
+            let sum = __compute_sum(fields, ys);
 
             assert_eq(partial_sums[FIELDS_PER_BLOB / 8 - 1], sum);
         }
@@ -566,7 +553,7 @@ mod tests {
         ys[1] = BLS12_381_Fr::from_limbs([200, 0, 0]);
         ys[100] = BLS12_381_Fr::from_limbs([300, 0, 0]);
 
-        let fracs = __compute_fracs(z, ys);
+        let fracs = __compute_fracs(z);
 
         // Verify the division relationship for non-zero entries
         let indices_to_check = [0, 1, 100];
@@ -574,7 +561,7 @@ mod tests {
             let i = indices_to_check[j];
             let denom = z.__sub(ROOTS[i]); // z - w^i
             let product = fracs[i].__mul(denom); // fracs[i] * (z - w^i)
-            assert_eq(product, ys[i]);
+            assert_eq(product, ROOTS[i]);
         }
     }
 
@@ -583,8 +570,9 @@ mod tests {
         // Test that evaluating an all-zeros blob returns zero
         let z = BLS12_381_Fr::from_limbs([42, 0, 0]);
         let ys = [BLS12_381_Fr::zero(); FIELDS_PER_BLOB];
-
-        let y = barycentric_evaluate_blob_at_z(z, ys);
+        let fracs = __compute_fracs(z);
+        let factor = compute_factor(z);
+        let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
         assert_eq(y, BLS12_381_Fr::zero());
     }
@@ -599,7 +587,9 @@ mod tests {
         let position: u32 = 1000;
         ys[position] = BLS12_381_Fr::one();
 
-        let y = barycentric_evaluate_blob_at_z(z, ys);
+        let fracs = __compute_fracs(z);
+        let factor = compute_factor(z);
+        let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
         // For a single element y_k = 1 at position k, the formula becomes:
         // p(z) = factor * (w^k / (z - w^k))
@@ -624,7 +614,9 @@ mod tests {
         ys[0] = BLS12_381_Fr::from_limbs([1, 0, 0]);
         ys[1] = BLS12_381_Fr::from_limbs([2, 0, 0]);
 
-        let y = barycentric_evaluate_blob_at_z(z, ys);
+        let fracs = __compute_fracs(z);
+        let factor = compute_factor(z);
+        let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
         // When z = 0:
         // - z^d = 0, so factor = (0 - 1) / d = -1/d = -D_INV
@@ -654,7 +646,9 @@ mod tests {
             BLS12_381_Fr::from_limbs([0xffffffffffffff00000000, 0xffffffffffffff00000000, 0x73ed]);
 
         // Just verify it doesn't panic and produces a result
-        let _y = barycentric_evaluate_blob_at_z(z, ys);
+        let fracs = __compute_fracs(z);
+        let factor = compute_factor(z);
+        let _y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
         // If we got here without panicking, the test passes
     }
 
@@ -670,7 +664,9 @@ mod tests {
         ys[2] = BLS12_381_Fr::from_limbs([0x69, 0, 0]);
 
         // This call will exercise all the evaluate_quadratic_expression constraints
-        let y = barycentric_evaluate_blob_at_z(z, ys);
+        let fracs = compute_fracs(z);
+        let factor = compute_factor(z);
+        let y = barycentric_evaluate_blob_at_z(ys, fracs, factor);
 
         // Verify against known value (same as test_barycentric)
         let expected_y: [u128; 3] =
@@ -702,20 +698,13 @@ mod tests {
             ys[i] = BLS12_381_Fr::from_limbs([(i + 1) as u128 * 111, 0, 0]);
         }
 
-        let fracs = __compute_fracs(z, ys);
+        let fracs = compute_fracs(z);
 
-        // For each non-zero y, verify: frac * (z - w^i) = y
+        // For each non-zero y, verify: frac * (z - w^i) = w^i
         for i in 0..10 {
             let z_minus_root = z.__sub(ROOTS[i]);
-            let computed_y = fracs[i].__mul(z_minus_root);
-            assert_eq(computed_y, ys[i]);
-        }
-
-        // Also verify that for zero y values, frac * (z - w^i) = 0
-        for i in 10..20 {
-            let z_minus_root = z.__sub(ROOTS[i]);
-            let computed_y = fracs[i].__mul(z_minus_root);
-            assert_eq(computed_y, BLS12_381_Fr::zero());
+            let computed_root = fracs[i].__mul(z_minus_root);
+            assert_eq(computed_root, ROOTS[i]);
         }
     }
 
@@ -784,13 +773,13 @@ mod tests {
 
         // Compute correct fracs, then corrupt one
         // Safety: computing correct values first
-        let mut fracs = unsafe { __compute_fracs(z, ys) };
+        let mut fracs = unsafe { __compute_fracs(z) };
 
         // Corrupt fracs[0] by adding 1
         fracs[0] = unsafe { fracs[0].__add(BLS12_381_Fr::one()) };
 
         // This should fail because fracs[0] * (z - w^0) != ys[0]
-        validate_fracs(z, ys, fracs);
+        validate_fracs(z, fracs);
     }
 
     #[test(should_fail)]
@@ -803,7 +792,7 @@ mod tests {
 
         // Compute correct fracs
         // Safety: computing correct values first
-        let mut fracs = unsafe { __compute_fracs(z, ys) };
+        let mut fracs = unsafe { __compute_fracs(z) };
 
         // Swap fracs[0] and fracs[1]
         let temp = fracs[0];
@@ -811,7 +800,7 @@ mod tests {
         fracs[1] = temp;
 
         // This should fail because the constraints check each position independently
-        validate_fracs(z, ys, fracs);
+        validate_fracs(z, fracs);
     }
 
     #[test(should_fail)]
@@ -823,7 +812,7 @@ mod tests {
 
         // Compute correct fracs (should all be zero)
         // Safety: computing correct values first
-        let mut fracs = unsafe { __compute_fracs(z, ys) };
+        let mut fracs = unsafe { __compute_fracs(z) };
 
         // Set fracs[0] to a non-zero value
         // Since y[0] = 0, the constraint is fracs[0] * (z - w^0) = 0
@@ -831,6 +820,6 @@ mod tests {
         // But z = 42, so this should fail
         fracs[0] = BLS12_381_Fr::from_limbs([999, 0, 0]);
 
-        validate_fracs(z, ys, fracs);
+        validate_fracs(z, fracs);
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
@@ -4,6 +4,8 @@ use crate::{
         FinalBlobBatchingChallenges,
     },
     blob::barycentric_evaluate_blob_at_z,
+    compute_factor,
+    compute_fracs,
     utils::{compress_to_blob_commitment, validate_canonical_representation_if_infinity},
 };
 use bigcurve::BigCurve;
@@ -61,8 +63,7 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     kzg_commitments_points: [BLSPoint; NumBlobs],
     final_blob_challenges: FinalBlobBatchingChallenges,
     start_accumulator: BlobAccumulator,
-    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
-    factor: BLS12_381_Fr,
+    challenge_z: BLS12_381_Fr,
 ) -> BlobAccumulator {
     // The rationale behind this line is that the start accumulator is hinted, and in merge we just assert that left.end.eq(right.start)
     // And on root we check that left.start.eq(empty()).
@@ -72,6 +73,8 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     // but as good measure we'll validate that it's canonical here.
     // Also, the Root Rollup circuit technically validates that the start accumulator of the checkpoint is Empty,
     // and the Empty impl uses the canonical representation of infinity.
+    let fracs = compute_fracs(challenge_z);
+    let factor = compute_factor(challenge_z);
     validate_canonical_representation_if_infinity(start_accumulator.c_acc);
 
     let mut end_accumulator = start_accumulator;
@@ -130,8 +133,6 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
 mod tests {
     use crate::{
         abis::{BatchingBlobCommitment, BlobAccumulator, FinalBlobBatchingChallenges},
-        compute_factor,
-        compute_fracs,
         utils::{compress_to_blob_commitment, validate_final_blob_batching_challenges},
     };
     use super::evaluate_blobs_and_batch;
@@ -189,10 +190,7 @@ mod tests {
             gamma: BLS12_381_Fr::from_limbs(gamma_limbs_blob_400_from_ts),
         };
 
-        // Compute fracs and factor once from the shared challenge z.
         let challenge_z = BLS12_381_Fr::from(final_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         // Evaluation: Can evaluate up to 3 blobs, but only 1 is needed and will be accumulated.
         let res = evaluate_blobs_and_batch::<3>(
@@ -202,8 +200,7 @@ mod tests {
             pad_end_with([kzg_commitment], BLSPoint::point_at_infinity()),
             final_challenges,
             BlobAccumulator::empty(),
-            fracs,
-            factor,
+            challenge_z,
         );
 
         validate_final_blob_batching_challenges(res, final_challenges);
@@ -323,10 +320,7 @@ mod tests {
             gamma: BLS12_381_Fr::from_limbs(gamma_limbs_3_blobs_from_ts),
         };
 
-        // Compute fracs and factor once from the shared challenge z.
         let challenge_z = BLS12_381_Fr::from(final_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         // Init. the accumulator
         let start_acc = BlobAccumulator::empty();
@@ -338,8 +332,7 @@ mod tests {
             kzg_commitments_in,
             final_challenges,
             start_acc,
-            fracs,
-            factor,
+            challenge_z,
         );
 
         validate_final_blob_batching_challenges(output, final_challenges);
@@ -371,10 +364,7 @@ mod tests {
         let blob = [0; FIELDS_PER_BLOB];
         let final_challenges = FinalBlobBatchingChallenges::empty();
 
-        // Compute fracs and factor (even though they won't be used for empty blob).
         let challenge_z = BLS12_381_Fr::from(final_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         // The below should not throw
         let _ = evaluate_blobs_and_batch(
@@ -384,8 +374,7 @@ mod tests {
             [BLSPoint::point_at_infinity()],
             final_challenges,
             BlobAccumulator::empty(),
-            fracs,
-            factor,
+            challenge_z,
         );
     }
 
@@ -395,10 +384,7 @@ mod tests {
         let point = BLSPoint { x: BLS12_381_Fq::one(), y: BLS12_381_Fq::zero(), is_infinity: true };
         let final_challenges = FinalBlobBatchingChallenges::empty();
 
-        // Compute fracs and factor.
         let challenge_z = BLS12_381_Fr::from(final_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         let _ = evaluate_blobs_and_batch(
             blob,
@@ -407,8 +393,7 @@ mod tests {
             [point],
             final_challenges,
             BlobAccumulator::empty(),
-            fracs,
-            factor,
+            challenge_z,
         );
     }
 
@@ -422,10 +407,7 @@ mod tests {
         };
         let final_challenges = FinalBlobBatchingChallenges::empty();
 
-        // Compute fracs and factor.
         let challenge_z = BLS12_381_Fr::from(final_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         let _ = evaluate_blobs_and_batch(
             blob,
@@ -434,8 +416,7 @@ mod tests {
             [point],
             final_challenges,
             BlobAccumulator::empty(),
-            fracs,
-            factor,
+            challenge_z,
         );
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob_batching.nr
@@ -12,6 +12,8 @@ use types::{
     constants::FIELDS_PER_BLOB, hash::poseidon2_hash, traits::Empty, utils::arrays::subarray,
 };
 
+// Note: fracs and factor are computed once in the checkpoint root rollup and shared across all blobs.
+
 // Evaluates a single blob:
 // - Evaluates the blob at shared challenge z and returns result y_i
 // - Calculates this blob's challenge z_i (= H(H(blob_i), C_i)), where C_i = kzg_commitment, and blob_i = blob_as_fields[i].
@@ -19,15 +21,15 @@ fn evaluate_blob_for_batching(
     blob_as_fields: [Field; FIELDS_PER_BLOB],
     kzg_commitment: BatchingBlobCommitment,
     blob_fields_hash: Field,
-    challenge_z: Field,
+    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    factor: BLS12_381_Fr,
 ) -> (Field, BLS12_381_Fr) {
-    let challenge_z_as_bignum = BLS12_381_Fr::from(challenge_z);
-
     // Note: this conversion is lossless: the size of a native BN Fr `Field` is 254 bits, whereas
     // the BLS_12_381_Fr scalar field is 255 bits.
+    // (AUDITTODO) Potential optimization: can we batch the conversion of the blob fields to BLS12_381_Fr?
     let blob = blob_as_fields.map(|b| BLS12_381_Fr::from(b));
 
-    let y_i = barycentric_evaluate_blob_at_z(challenge_z_as_bignum, blob);
+    let y_i = barycentric_evaluate_blob_at_z(blob, fracs, factor);
     let z_i = compute_blob_challenge(blob_fields_hash, kzg_commitment);
 
     (z_i, y_i)
@@ -49,6 +51,9 @@ fn compute_blob_challenge(
 /// - Compresses each of the blob's injected commitments.
 /// - Evaluates each blob individually to find its challenge `z_i` and evaluation `y_i`.
 /// - Updates the batched blob accumulator.
+///
+/// Note: `fracs` and `factor` are computed once in the checkpoint root rollup from the shared
+/// challenge `z` and are reused for all blob evaluations.
 pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     blobs_as_fields: [Field; FIELDS_PER_BLOB * NumBlobs],
     num_fields: u32,
@@ -56,6 +61,8 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     kzg_commitments_points: [BLSPoint; NumBlobs],
     final_blob_challenges: FinalBlobBatchingChallenges,
     start_accumulator: BlobAccumulator,
+    fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    factor: BLS12_381_Fr,
 ) -> BlobAccumulator {
     // The rationale behind this line is that the start accumulator is hinted, and in merge we just assert that left.end.eq(right.start)
     // And on root we check that left.start.eq(empty()).
@@ -80,12 +87,8 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
         // Note that with multiple blobs per block, each blob uses the same blob_fields_hash in z_i.
         // This is ok, because each commitment is unique to the blob, and we need `blob_fields_hash` to encompass all
         // fields in the blob, which it does.
-        let (z_i, y_i) = evaluate_blob_for_batching(
-            single_blob_fields,
-            c_i,
-            blob_fields_hash,
-            final_blob_challenges.z,
-        );
+        let (z_i, y_i) =
+            evaluate_blob_for_batching(single_blob_fields, c_i, blob_fields_hash, fracs, factor);
 
         // Accumulate ceil(num_fields / FIELDS_PER_BLOB) blobs.
         //
@@ -127,6 +130,8 @@ pub fn evaluate_blobs_and_batch<let NumBlobs: u32>(
 mod tests {
     use crate::{
         abis::{BatchingBlobCommitment, BlobAccumulator, FinalBlobBatchingChallenges},
+        compute_factor,
+        compute_fracs,
         utils::{compress_to_blob_commitment, validate_final_blob_batching_challenges},
     };
     use super::evaluate_blobs_and_batch;
@@ -184,6 +189,11 @@ mod tests {
             gamma: BLS12_381_Fr::from_limbs(gamma_limbs_blob_400_from_ts),
         };
 
+        // Compute fracs and factor once from the shared challenge z.
+        let challenge_z = BLS12_381_Fr::from(final_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
+
         // Evaluation: Can evaluate up to 3 blobs, but only 1 is needed and will be accumulated.
         let res = evaluate_blobs_and_batch::<3>(
             pad_end(blob_fields),
@@ -192,6 +202,8 @@ mod tests {
             pad_end_with([kzg_commitment], BLSPoint::point_at_infinity()),
             final_challenges,
             BlobAccumulator::empty(),
+            fracs,
+            factor,
         );
 
         validate_final_blob_batching_challenges(res, final_challenges);
@@ -310,6 +322,12 @@ mod tests {
             // - The final gamma value is injected and checked for correctness in root (see below final_acc)
             gamma: BLS12_381_Fr::from_limbs(gamma_limbs_3_blobs_from_ts),
         };
+
+        // Compute fracs and factor once from the shared challenge z.
+        let challenge_z = BLS12_381_Fr::from(final_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
+
         // Init. the accumulator
         let start_acc = BlobAccumulator::empty();
         // Evaluate all blobs and iteratively accumulate the results
@@ -320,6 +338,8 @@ mod tests {
             kzg_commitments_in,
             final_challenges,
             start_acc,
+            fracs,
+            factor,
         );
 
         validate_final_blob_batching_challenges(output, final_challenges);
@@ -349,48 +369,73 @@ mod tests {
     #[test]
     unconstrained fn test_empty_blob() {
         let blob = [0; FIELDS_PER_BLOB];
+        let final_challenges = FinalBlobBatchingChallenges::empty();
+
+        // Compute fracs and factor (even though they won't be used for empty blob).
+        let challenge_z = BLS12_381_Fr::from(final_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
+
         // The below should not throw
         let _ = evaluate_blobs_and_batch(
             blob,
             0, // num_fields
             123, // Arbitrary blob fields hash.
             [BLSPoint::point_at_infinity()],
-            FinalBlobBatchingChallenges::empty(),
+            final_challenges,
             BlobAccumulator::empty(),
+            fracs,
+            factor,
         );
     }
 
     #[test(should_fail_with = "Non canonical x coordinate at infinity")]
     unconstrained fn test_non_canonical_point_at_infinity_fails() {
-        let mut blob = [0; FIELDS_PER_BLOB];
+        let blob = [0; FIELDS_PER_BLOB];
         let point = BLSPoint { x: BLS12_381_Fq::one(), y: BLS12_381_Fq::zero(), is_infinity: true };
+        let final_challenges = FinalBlobBatchingChallenges::empty();
+
+        // Compute fracs and factor.
+        let challenge_z = BLS12_381_Fr::from(final_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
 
         let _ = evaluate_blobs_and_batch(
             blob,
             FIELDS_PER_BLOB,
             123, // Arbitrary blob fields hash.
             [point],
-            FinalBlobBatchingChallenges::empty(),
+            final_challenges,
             BlobAccumulator::empty(),
+            fracs,
+            factor,
         );
     }
 
     #[test(should_fail)]
     unconstrained fn test_point_not_on_curve_fails() {
-        let mut blob = [0; FIELDS_PER_BLOB];
+        let blob = [0; FIELDS_PER_BLOB];
         let point = BLSPoint {
             x: BLS12_381_Fq::from_limbs([0, 0, 0, 42]),
             y: BLS12_381_Fq::from_limbs([0, 0, 0, 27]),
             is_infinity: false,
         };
+        let final_challenges = FinalBlobBatchingChallenges::empty();
+
+        // Compute fracs and factor.
+        let challenge_z = BLS12_381_Fr::from(final_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
 
         let _ = evaluate_blobs_and_batch(
             blob,
             FIELDS_PER_BLOB,
             123, // Arbitrary blob fields hash.
             [point],
-            FinalBlobBatchingChallenges::empty(),
+            final_challenges,
             BlobAccumulator::empty(),
+            fracs,
+            factor,
         );
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/lib.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/lib.nr
@@ -4,3 +4,6 @@ pub mod abis;
 mod blob;
 pub mod blob_batching;
 pub mod mock_blob_oracle;
+
+// Re-export blob evaluation functions for use in checkpoint root rollup
+pub use blob::{compute_factor, compute_fracs, validate_factor, validate_fracs, z_pow_d};

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
@@ -9,8 +9,8 @@ use types::{
 // The use of bignum adds a lot of unconstrained code which overloads limits when simulating.
 // If/when simulation times of unconstrained are improved, remove this.
 //
-// Note: `fracs` and `factor` are computed once in the checkpoint root rollup from the shared
-// challenge `z` and are passed through for consistency, but are not used by the oracle.
+// Note: `fracs` and `factor` are computed from `challenge_z` inside `evaluate_blobs_and_batch`.
+// The oracle does not use them; it receives `challenge_z` for interface consistency.
 pub unconstrained fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     blobs_as_fields: [Field; FIELDS_PER_BLOB * NumBlobs],
     num_blob_fields: u32,
@@ -18,8 +18,7 @@ pub unconstrained fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     kzg_commitments: [BLSPoint; NumBlobs],
     final_blob_challenges: FinalBlobBatchingChallenges,
     start_accumulator: BlobAccumulator,
-    _fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
-    _factor: BLS12_381_Fr,
+    challenge_z: BLS12_381_Fr,
 ) -> BlobAccumulator {
     let fields = evaluate_blobs_oracle(
         NumBlobs,

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/mock_blob_oracle.nr
@@ -1,4 +1,5 @@
 use crate::abis::{BlobAccumulator, BLSPoint, FinalBlobBatchingChallenges};
+use bignum::BLS12_381_Fr;
 use types::{
     constants::{BLOB_ACCUMULATOR_LENGTH, FIELDS_PER_BLOB},
     traits::{Deserialize, Serialize},
@@ -7,6 +8,9 @@ use types::{
 // TODO(#10323): this was added to save simulation time (~1min in ACVM, ~3mins in wasm -> 500ms).
 // The use of bignum adds a lot of unconstrained code which overloads limits when simulating.
 // If/when simulation times of unconstrained are improved, remove this.
+//
+// Note: `fracs` and `factor` are computed once in the checkpoint root rollup from the shared
+// challenge `z` and are passed through for consistency, but are not used by the oracle.
 pub unconstrained fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     blobs_as_fields: [Field; FIELDS_PER_BLOB * NumBlobs],
     num_blob_fields: u32,
@@ -14,6 +18,8 @@ pub unconstrained fn evaluate_blobs_and_batch<let NumBlobs: u32>(
     kzg_commitments: [BLSPoint; NumBlobs],
     final_blob_challenges: FinalBlobBatchingChallenges,
     start_accumulator: BlobAccumulator,
+    _fracs: [BLS12_381_Fr; FIELDS_PER_BLOB],
+    _factor: BLS12_381_Fr,
 ) -> BlobAccumulator {
     let fields = evaluate_blobs_oracle(
         NumBlobs,

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/utils/compress_to_blob_commitment.nr
@@ -68,8 +68,8 @@ mod tests {
         assert_eq(flags[0], true);
         // is_infinity = false
         assert_eq(flags[1], false);
-        // is_greater = false (point.y < -point.y for G)
-        assert_eq(flags[2], false);
+        // is_greater = false (point.y > -point.y for G)
+        assert_eq(flags[2], true);
         // Decompress back to the same point:
         let mut bytes = compress_to_blob_commitment(point).compressed;
         // Same as &= 0b0001_1111 - clear first three bits of our flags
@@ -80,13 +80,8 @@ mod tests {
         // y^2 = x^3 + ax + b
         let reconstructed_y_squared =
             reconstructed_x.__pow(BLS12_381_Fq::from(3)).add(a.mul(reconstructed_x)).add(b);
-        let mut reconstructed_y = reconstructed_y_squared.__tonelli_shanks_sqrt().unwrap();
-        // If the sqrt returned is the 'greater' one, negate it (since here is_greater = false):
-        reconstructed_y = if reconstructed_y > -reconstructed_y {
-            -reconstructed_y
-        } else {
-            reconstructed_y
-        };
+        let mut reconstructed_y = -(reconstructed_y_squared.__sqrt().unwrap());
+
         assert_eq(reconstructed_y, point.y);
     }
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
@@ -5,7 +5,7 @@ authors = [""]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
-bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.0" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.13.0" }
 types = { path = "../types" }
 blob = { path = "../blob" }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
@@ -6,8 +6,6 @@ use bignum::BLS12_381_Fr;
 use blob::{
     abis::{BlobAccumulator, BLSPoint, FinalBlobBatchingChallenges},
     blob_batching::evaluate_blobs_and_batch,
-    compute_factor,
-    compute_fracs,
 };
 use types::{
     abis::{
@@ -169,8 +167,6 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
         // Compute fracs and factor once from the shared challenge z.
         // These are reused for all blob evaluations in this checkpoint.
         let challenge_z = BLS12_381_Fr::from(self.final_blob_challenges.z);
-        let fracs = compute_fracs(challenge_z);
-        let factor = compute_factor(challenge_z);
 
         if !dep::std::runtime::is_unconstrained() {
             let end_blob_accumulator = evaluate_blobs_and_batch(
@@ -180,8 +176,7 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
                 self.blob_commitments,
                 self.final_blob_challenges,
                 self.start_blob_accumulator,
-                fracs,
-                factor,
+                challenge_z,
             );
 
             end_blob_accumulator
@@ -197,8 +192,7 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
                     self.blob_commitments,
                     self.final_blob_challenges,
                     self.start_blob_accumulator,
-                    fracs,
-                    factor,
+                    challenge_z,
                 )
             }
         }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/checkpoint_root/components/checkpoint_rollup_public_inputs_composer.nr
@@ -2,9 +2,12 @@ use crate::{
     abis::{BlockRollupPublicInputs, CheckpointRollupPublicInputs},
     block_merge::merge_block_rollups,
 };
+use bignum::BLS12_381_Fr;
 use blob::{
     abis::{BlobAccumulator, BLSPoint, FinalBlobBatchingChallenges},
     blob_batching::evaluate_blobs_and_batch,
+    compute_factor,
+    compute_fracs,
 };
 use types::{
     abis::{
@@ -163,6 +166,12 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
 
         let sponge_blob_hash = end_sponge_blob.squeeze();
 
+        // Compute fracs and factor once from the shared challenge z.
+        // These are reused for all blob evaluations in this checkpoint.
+        let challenge_z = BLS12_381_Fr::from(self.final_blob_challenges.z);
+        let fracs = compute_fracs(challenge_z);
+        let factor = compute_factor(challenge_z);
+
         if !dep::std::runtime::is_unconstrained() {
             let end_blob_accumulator = evaluate_blobs_and_batch(
                 self.blobs_fields,
@@ -171,6 +180,8 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
                 self.blob_commitments,
                 self.final_blob_challenges,
                 self.start_blob_accumulator,
+                fracs,
+                factor,
             );
 
             end_blob_accumulator
@@ -186,6 +197,8 @@ impl<let NumBlobs: u32> CheckpointRollupPublicInputsComposer<NumBlobs> {
                     self.blob_commitments,
                     self.final_blob_challenges,
                     self.start_blob_accumulator,
+                    fracs,
+                    factor,
                 )
             }
         }


### PR DESCRIPTION
currently, the `RollupCheckpointRoot` was computing the inverses required for the barycentric evaluation once per blob. However, these inverses are the same across the whole epoch. This PR changes the inverse computation to be done once per checkpoint. 