### PR TITLE
fix: prevent gh CLI failure from crashing docs examples bootstrap

### DIFF
--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -90,7 +90,7 @@ function get_pr_number {
   local branch="${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}"
 
   if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
-    gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null
+    gh pr list --head "$branch" --json number --jq '.[0].number' 2>/dev/null || echo "Failed to query PR number from branch $branch" >&2
   fi
 }
 


### PR DESCRIPTION
## Summary

- The `get_pr_number` function in `docs/examples/bootstrap.sh` had an unguarded `gh pr list` call
- With `inherit_errexit` and `set -e` active (from `ci3/source_options`), a `gh` API failure (e.g. exit code 4) would silently kill the entire `docs/bootstrap.sh` job — even though all compile and validation steps had already passed
- Added `|| echo "..." >&2` guard so the failure is logged but doesn't propagate

## Test plan

- [ ] Verify docs bootstrap passes in CI
- [ ] If `gh pr list` fails, confirm the error message appears in logs and the job still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)