### PR TITLE
fix: move nightly versions to bottom of versions JSON

### DIFF
--- a/barretenberg/docs/scripts/update_versions.sh
+++ b/barretenberg/docs/scripts/update_versions.sh
@@ -25,25 +25,11 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
         NIGHTLY_VERSIONS=$(echo "$ALL_VERSIONS" | grep "nightly" | sort -Vr)
         NON_NIGHTLY_VERSIONS=$(echo "$ALL_VERSIONS" | grep -v "nightly" | sort -Vr)
 
-        # Build versions array with nightly versions first, then stable versions
+        # Build versions array with stable versions first, then nightly last
         NEW_VERSIONS="["
         FIRST=true
 
-        # Add nightly versions first (newest first)
-        if [ -n "$NIGHTLY_VERSIONS" ]; then
-            while IFS= read -r version; do
-                if [ -n "$version" ]; then
-                    if [ "$FIRST" = true ]; then
-                        NEW_VERSIONS="$NEW_VERSIONS\"$version\""
-                        FIRST=false
-                    else
-                        NEW_VERSIONS="$NEW_VERSIONS, \"$version\""
-                    fi
-                fi
-            done <<< "$NIGHTLY_VERSIONS"
-        fi
-
-        # Add non-nightly versions (newest first)
+        # Add non-nightly versions first (newest first)
         if [ -n "$NON_NIGHTLY_VERSIONS" ]; then
             while IFS= read -r version; do
                 if [ -n "$version" ]; then
@@ -55,6 +41,20 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
                     fi
                 fi
             done <<< "$NON_NIGHTLY_VERSIONS"
+        fi
+
+        # Add nightly versions last (newest first)
+        if [ -n "$NIGHTLY_VERSIONS" ]; then
+            while IFS= read -r version; do
+                if [ -n "$version" ]; then
+                    if [ "$FIRST" = true ]; then
+                        NEW_VERSIONS="$NEW_VERSIONS\"$version\""
+                        FIRST=false
+                    else
+                        NEW_VERSIONS="$NEW_VERSIONS, \"$version\""
+                    fi
+                fi
+            done <<< "$NIGHTLY_VERSIONS"
         fi
 
         NEW_VERSIONS="$NEW_VERSIONS]"

--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/tutorials/contract_tutorials/recursive_verification.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/docs/tutorials/contract_tutorials/recursive_verification.md
@@ -23,7 +23,6 @@ Before starting, ensure you have the following installed and configured:
 - yarn package manager
 - Aztec CLI (version 3.0.0-devnet.6-patch.1)
 - Nargo (version 1.0.0-beta.15)
-- 8GB+ RAM (required for proof generation)
 - Familiarity with [Noir syntax](https://noir-lang.org/docs) and [Aztec contract basics](../../aztec-nr/index.md)
 
 Install the required tools:

--- a/docs/developer_versions.json
+++ b/docs/developer_versions.json
@@ -1,4 +1,4 @@
 [
-  "v4.0.0-nightly.20260205",
-  "v3.0.0-devnet.6-patch.1"
+  "v3.0.0-devnet.6-patch.1",
+  "v4.0.0-nightly.20260205"
 ]

--- a/docs/docs-developers/docs/tutorials/contract_tutorials/recursive_verification.md
+++ b/docs/docs-developers/docs/tutorials/contract_tutorials/recursive_verification.md
@@ -23,7 +23,6 @@ Before starting, ensure you have the following installed and configured:
 - yarn package manager
 - Aztec CLI (version 3.0.0-devnet.6-patch.1)
 - Nargo (version 1.0.0-beta.15)
-- 8GB+ RAM (required for proof generation)
 - Familiarity with [Noir syntax](https://noir-lang.org/docs) and [Aztec contract basics](../../aztec-nr/index.md)
 
 Install the required tools:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -453,6 +453,14 @@ const config = {
                 label: "Awesome Aztec",
                 to: "https://github.com/AztecProtocol/awesome-aztec",
               },
+              {
+                label: "Technical Whitepaper",
+                href: "https://aztec.network/technical-whitepaper",
+              },
+              {
+                label: "Economic Whitepaper",
+                href: "https://aztec.network/economic-whitepaper",
+              },
             ],
           },
         ],

--- a/docs/scripts/update_docs_versions.sh
+++ b/docs/scripts/update_docs_versions.sh
@@ -44,25 +44,11 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
         NIGHTLY_VERSIONS=$(echo "$ALL_VERSIONS" | grep "nightly" | sort -Vr)
         NON_NIGHTLY_VERSIONS=$(echo "$ALL_VERSIONS" | grep -v "nightly")
 
-        # Build versions array with nightly versions first, then preserve existing order
+        # Build versions array with non-nightly versions first, then nightly last
         NEW_VERSIONS="["
         FIRST=true
 
-        # Add nightly versions first (newest first)
-        if [ -n "$NIGHTLY_VERSIONS" ]; then
-            while IFS= read -r version; do
-                if [ -n "$version" ]; then
-                    if [ "$FIRST" = true ]; then
-                        NEW_VERSIONS="$NEW_VERSIONS\"$version\""
-                        FIRST=false
-                    else
-                        NEW_VERSIONS="$NEW_VERSIONS, \"$version\""
-                    fi
-                fi
-            done <<< "$NIGHTLY_VERSIONS"
-        fi
-
-        # Add non-nightly versions preserving existing order, then new ones
+        # Add non-nightly versions first, preserving existing order, then new ones
         if [ -n "$NON_NIGHTLY_VERSIONS" ]; then
             # First add existing non-nightly versions in their current order
             if [ -n "$EXISTING_VERSIONS" ]; then
@@ -95,6 +81,20 @@ if [ -d "$VERSIONED_DOCS_DIR" ]; then
                     fi
                 fi
             done <<< "$(echo "$NON_NIGHTLY_VERSIONS" | sort -Vr)"
+        fi
+
+        # Add nightly versions last (newest first)
+        if [ -n "$NIGHTLY_VERSIONS" ]; then
+            while IFS= read -r version; do
+                if [ -n "$version" ]; then
+                    if [ "$FIRST" = true ]; then
+                        NEW_VERSIONS="$NEW_VERSIONS\"$version\""
+                        FIRST=false
+                    else
+                        NEW_VERSIONS="$NEW_VERSIONS, \"$version\""
+                    fi
+                fi
+            done <<< "$NIGHTLY_VERSIONS"
         fi
 
         NEW_VERSIONS="$NEW_VERSIONS]"


### PR DESCRIPTION
## Summary

- Swaps the ordering logic in `update_docs_versions.sh` and `update_versions.sh` so non-nightly (stable) versions are listed first and nightly versions are appended at the end
- Fixes fallback lookups (`versions[0]`) in `docusaurus.config.js` and `UnifiedVersionDropdown` that were returning nightly instead of stable

## Test plan

- [x] Ran `./docs/scripts/update_docs_versions.sh developer` — confirmed output is `["v3.0.0-devnet.6-patch.1", "v4.0.0-nightly.20260205"]` (nightly last)
- [ ] Verify docs site loads correctly with version dropdowns working

🤖 Generated with [Claude Code](https://claude.com/claude-code)