### PR TITLE
refactor: use all caps for generics

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -5,13 +5,13 @@ use crate::protocol::{constants::DOM_SEP__TX_NULLIFIER, hash::poseidon2_hash_wit
 use crate::authwit::auth::{compute_authwit_message_hash, IS_VALID_SELECTOR};
 use crate::authwit::entrypoint::app::AppPayload;
 
-pub struct AccountActions<Context> {
-    context: Context,
+pub struct AccountActions<CONTEXT> {
+    context: CONTEXT,
     is_valid_impl: fn(&mut PrivateContext, Field) -> bool,
 }
 
-impl<Context> AccountActions<Context> {
-    pub fn init(context: Context, is_valid_impl: fn(&mut PrivateContext, Field) -> bool) -> Self {
+impl<CONTEXT> AccountActions<CONTEXT> {
+    pub fn init(context: CONTEXT, is_valid_impl: fn(&mut PrivateContext, Field) -> bool) -> Self {
         AccountActions { context, is_valid_impl }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/contract_self.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self.nr
@@ -49,14 +49,14 @@ use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
 ///
 /// ## Type Parameters
 ///
-/// - `Context`: The execution context type - either `&mut PrivateContext`, `PublicContext`, or `UtilityContext`
-/// - `Storage`: The contract's storage struct (defined with [`storage`](crate::macros::storage::storage), or `()` if
+/// - `CONTEXT`: The execution context type - either `&mut PrivateContext`, `PublicContext`, or `UtilityContext`
+/// - `STORAGE`: The contract's storage struct (defined with [`storage`](crate::macros::storage::storage), or `()` if
 /// the contract has no storage
-/// - `CallSelf`: Macro-generated type for calling contract's own non-view functions
-/// - `EnqueueSelf`: Macro-generated type for enqueuing calls to the contract's own non-view functions
-/// - `CallSelfStatic`: Macro-generated type for calling contract's own view functions
-/// - `EnqueueSelfStatic`: Macro-generated type for enqueuing calls to the contract's own view functions
-pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
+/// - `CALL_SELF`: Macro-generated type for calling contract's own non-view functions
+/// - `ENQUEUE_SELF`: Macro-generated type for enqueuing calls to the contract's own non-view functions
+/// - `CALL_SELF_STATIC`: Macro-generated type for calling contract's own view functions
+/// - `ENQUEUE_SELF_STATIC`: Macro-generated type for enqueuing calls to the contract's own view functions
+pub struct ContractSelf<CONTEXT, STORAGE, CALL_SELF, ENQUEUE_SELF, CALL_SELF_STATIC, ENQUEUE_SELF_STATIC, CALL_INTERNAL> {
     /// The address of this contract
     pub address: AztecAddress,
 
@@ -71,16 +71,16 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     ///
     /// ## Developer Note
     ///
-    /// If you've arrived here while trying to access your contract's storage while the `Storage` generic type is set
+    /// If you've arrived here while trying to access your contract's storage while the `STORAGE` generic type is set
     /// to unit type `()`, it means you haven't yet defined a Storage struct using the
     /// [`storage`](crate::macros::storage::storage) macro in your contract. For guidance on setting this up, please
     /// refer to our docs: https://docs.aztec.network/developers/docs/guides/smart_contracts/storage
 
-    pub storage: Storage,
+    pub storage: STORAGE,
 
     /// The execution context whose type is determined by the [`external`](crate::macros::functions::external)
     /// attribute of the contract function based on the external function type (private, public, or utility).
-    pub context: Context,
+    pub context: CONTEXT,
 
     /// Provides type-safe methods for calling this contract's own non-view functions.
     ///
@@ -91,7 +91,7 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// ```noir
     /// self.call_self.some_private_function(args)
     /// ```
-    pub call_self: CallSelf,
+    pub call_self: CALL_SELF,
 
     /// Provides type-safe methods for enqueuing calls to this contract's own non-view functions.
     ///
@@ -102,7 +102,7 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// ```noir
     /// self.enqueue_self.some_public_function(args)
     /// ```
-    pub enqueue_self: EnqueueSelf,
+    pub enqueue_self: ENQUEUE_SELF,
 
     /// Provides type-safe methods for calling this contract's own view functions.
     ///
@@ -113,7 +113,7 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// ```noir
     /// self.call_self_static.some_view_function(args)
     /// ```
-    pub call_self_static: CallSelfStatic,
+    pub call_self_static: CALL_SELF_STATIC,
 
     /// Provides type-safe methods for enqueuing calls to this contract's own view functions.
     ///
@@ -124,7 +124,7 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// ```noir
     /// self.enqueue_self_static.some_public_view_function(args)
     /// ```
-    pub enqueue_self_static: EnqueueSelfStatic,
+    pub enqueue_self_static: ENQUEUE_SELF_STATIC,
 
     /// Provides type-safe methods for calling internal functions.
     ///
@@ -135,24 +135,24 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// ```noir
     /// self.internal.some_internal_function(args)
     /// ```
-    pub internal: CallInternal,
+    pub internal: CALL_INTERNAL,
 }
 
 // Implementation for `ContractSelf` in private execution contexts.
 //
 // This implementation is used when an external or internal contract function is marked with "private".
-impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> ContractSelf<&mut PrivateContext, Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
+impl<STORAGE, CALL_SELF, ENQUEUE_SELF, CALL_SELF_STATIC, ENQUEUE_SELF_STATIC, CALL_INTERNAL> ContractSelf<&mut PrivateContext, STORAGE, CALL_SELF, ENQUEUE_SELF, CALL_SELF_STATIC, ENQUEUE_SELF_STATIC, CALL_INTERNAL> {
     /// Creates a new `ContractSelf` instance for a private function.
     ///
     /// This constructor is called automatically by the macro system and should not be called directly.
     pub fn new_private(
         context: &mut PrivateContext,
-        storage: Storage,
-        call_self: CallSelf,
-        enqueue_self: EnqueueSelf,
-        call_self_static: CallSelfStatic,
-        enqueue_self_static: EnqueueSelfStatic,
-        internal: CallInternal,
+        storage: STORAGE,
+        call_self: CALL_SELF,
+        enqueue_self: ENQUEUE_SELF,
+        call_self_static: CALL_SELF_STATIC,
+        enqueue_self_static: ENQUEUE_SELF_STATIC,
+        internal: CALL_INTERNAL,
     ) -> Self {
         Self {
             context,
@@ -214,9 +214,9 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     /// The nullifier created when emitting a private event leaks nothing about the content of the event - it's a
     /// commitment that includes a random value, so even with full knowledge of the event preimage determining if an
     /// event was emitted or not requires brute-forcing the entire `Field` space.
-    pub fn emit<Event>(&mut self, event: Event) -> EventMessage<Event>
+    pub fn emit<EVENT>(&mut self, event: EVENT) -> EventMessage<EVENT>
     where
-        Event: EventInterface + Serialize,
+        EVENT: EventInterface + Serialize,
     {
         emit_event_in_private(self.context, event)
     }
@@ -430,16 +430,16 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
 // Implementation for `ContractSelf` in public execution contexts.
 //
 // This implementation is used when an external or internal contract function is marked with "public".
-impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext, Storage, CallSelf, (), CallSelfStatic, (), CallInternal> {
+impl<STORAGE, CALL_SELF, CALL_SELF_STATIC, CALL_INTERNAL> ContractSelf<PublicContext, STORAGE, CALL_SELF, (), CALL_SELF_STATIC, (), CALL_INTERNAL> {
     /// Creates a new `ContractSelf` instance for a public function.
     ///
     /// This constructor is called automatically by the macro system and should not be called directly.
     pub fn new_public(
         context: PublicContext,
-        storage: Storage,
-        call_self: CallSelf,
-        call_self_static: CallSelfStatic,
-        internal: CallInternal,
+        storage: STORAGE,
+        call_self: CALL_SELF,
+        call_self_static: CALL_SELF_STATIC,
+        internal: CALL_INTERNAL,
     ) -> Self {
         Self {
             context,
@@ -489,9 +489,9 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
     ///
     /// Public event emission is achieved by emitting public transaction logs. A total of `N+1` fields are emitted,
     /// where `N` is the serialization length of the event.
-    pub fn emit<Event>(&mut self, event: Event)
+    pub fn emit<EVENT>(&mut self, event: EVENT)
     where
-        Event: EventInterface + Serialize,
+        EVENT: EventInterface + Serialize,
     {
         emit_event_in_public(self.context, event);
     }
@@ -547,11 +547,11 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext
 // Implementation for `ContractSelf` in utility execution contexts.
 //
 // This implementation is used when an external or internal contract function is marked with "utility".
-impl<Storage> ContractSelf<UtilityContext, Storage, (), (), (), (), ()> {
+impl<STORAGE> ContractSelf<UtilityContext, STORAGE, (), (), (), (), ()> {
     /// Creates a new `ContractSelf` instance for a utility function.
     ///
     /// This constructor is called automatically by the macro system and should not be called directly.
-    pub fn new_utility(context: UtilityContext, storage: Storage) -> Self {
+    pub fn new_utility(context: UtilityContext, storage: STORAGE) -> Self {
         Self {
             context,
             storage,

--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -6,15 +6,15 @@ use crate::{
 use crate::protocol::traits::{Serialize, ToField};
 
 /// An event that was emitted in the current contract call.
-pub struct NewEvent<Event> {
-    pub(crate) event: Event,
+pub struct NewEvent<EVENT> {
+    pub(crate) event: EVENT,
     pub(crate) randomness: Field,
 }
 
 /// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelf::emit`].
-pub fn emit_event_in_private<Event>(context: &mut PrivateContext, event: Event) -> EventMessage<Event>
+pub fn emit_event_in_private<EVENT>(context: &mut PrivateContext, event: EVENT) -> EventMessage<EVENT>
 where
-    Event: EventInterface + Serialize,
+    EVENT: EventInterface + Serialize,
 {
     // In private events, we automatically inject randomness to prevent event commitment preimage attacks and event
     // commitment collisions (the commitments are included in the nullifier tree and duplicate nullifiers are by
@@ -35,11 +35,11 @@ where
 }
 
 /// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelf::emit`].
-pub fn emit_event_in_public<Event>(context: PublicContext, event: Event)
+pub fn emit_event_in_public<EVENT>(context: PublicContext, event: EVENT)
 where
-    Event: EventInterface + Serialize,
+    EVENT: EventInterface + Serialize,
 {
-    let mut log_content = [0; <Event as Serialize>::N + 1];
+    let mut log_content = [0; <EVENT as Serialize>::N + 1];
 
     let serialized_event = event.serialize();
     for i in 0..serialized_event.len() {
@@ -49,7 +49,7 @@ where
     // We put the selector in the "last" place, to avoid reading or assigning to an expression in an index
     //
     // TODO(F-224): change this order.
-    log_content[serialized_event.len()] = Event::get_event_type_id().to_field();
+    log_content[serialized_event.len()] = EVENT::get_event_type_id().to_field();
 
     context.emit_public_log(log_content);
 }

--- a/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
@@ -15,12 +15,12 @@ pub trait EventInterface {
 /// This random value prevents attacks in which someone guesses plausible events (e.g. 'Alice transfers to Bob an
 /// amount of 10'), since they will not be able to test for existence of their guessed events without brute-forcing the
 /// entire `Field` space by guessing `randomness` values.
-pub fn compute_private_event_commitment<Event>(event: Event, randomness: Field) -> Field
+pub fn compute_private_event_commitment<EVENT>(event: EVENT, randomness: Field) -> Field
 where
-    Event: EventInterface + Serialize,
+    EVENT: EventInterface + Serialize,
 {
     poseidon2_hash_with_separator(
-        [randomness, Event::get_event_type_id().to_field()].concat(event.serialize()),
+        [randomness, EVENT::get_event_type_id().to_field()].concat(event.serialize()),
         DOM_SEP__EVENT_COMMITMENT,
     )
 }

--- a/noir-projects/aztec-nr/aztec/src/event/event_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_message.nr
@@ -10,8 +10,8 @@ use crate::protocol::{address::AztecAddress, traits::Serialize};
 ///
 /// Use [`EventMessage::deliver_to`] to select a delivery mechanism.
 #[must_use = "Unused EventMessage result - use the `deliver_to` function to prevent the event information from being lost forever"]
-pub struct EventMessage<Event> {
-    pub(crate) new_event: NewEvent<Event>,
+pub struct EventMessage<EVENT> {
+    pub(crate) new_event: NewEvent<EVENT>,
 
     // EventMessage is constructed when an event is emitted, which means that the `context` object will be in scope. By
     // storing a reference to it inside this object we remove the need for its methods to receive it, resulting in a
@@ -19,11 +19,11 @@ pub struct EventMessage<Event> {
     context: &mut PrivateContext,
 }
 
-impl<Event> EventMessage<Event>
+impl<EVENT> EventMessage<EVENT>
 where
-    Event: EventInterface + Serialize,
+    EVENT: EventInterface + Serialize,
 {
-    pub(crate) fn new(new_event: NewEvent<Event>, context: &mut PrivateContext) -> Self {
+    pub(crate) fn new(new_event: NewEvent<EVENT>, context: &mut PrivateContext) -> Self {
         Self { new_event, context }
     }
 

--- a/noir-projects/aztec-nr/aztec/src/history/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note.nr
@@ -15,9 +15,9 @@ use crate::{
 
 mod test;
 
-pub fn assert_note_existed_by<Note>(block_header: BlockHeader, hinted_note: HintedNote<Note>) -> ConfirmedNote<Note>
+pub fn assert_note_existed_by<NOTE>(block_header: BlockHeader, hinted_note: HintedNote<NOTE>) -> ConfirmedNote<NOTE>
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let note_hash =
         hinted_note.note.compute_note_hash(hinted_note.owner, hinted_note.storage_slot, hinted_note.randomness);
@@ -43,25 +43,25 @@ where
     ConfirmedNote::new(hinted_note, unique_note_hash)
 }
 
-pub fn assert_note_was_valid_by<Note>(
+pub fn assert_note_was_valid_by<NOTE>(
     block_header: BlockHeader,
-    hinted_note: HintedNote<Note>,
+    hinted_note: HintedNote<NOTE>,
     context: &mut PrivateContext,
 )
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let confirmed_note = assert_note_existed_by(block_header, hinted_note);
     assert_note_was_not_nullified_by(block_header, confirmed_note, context);
 }
 
-pub fn assert_note_was_nullified_by<Note>(
+pub fn assert_note_was_nullified_by<NOTE>(
     block_header: BlockHeader,
-    confirmed_note: ConfirmedNote<Note>,
+    confirmed_note: ConfirmedNote<NOTE>,
     context: &mut PrivateContext,
 )
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let note_hash_for_nullification = compute_confirmed_note_hash_for_nullification(confirmed_note);
     let inner_nullifier =
@@ -72,13 +72,13 @@ where
     assert_nullifier_existed_by(block_header, siloed_nullifier);
 }
 
-pub fn assert_note_was_not_nullified_by<Note>(
+pub fn assert_note_was_not_nullified_by<NOTE>(
     block_header: BlockHeader,
-    confirmed_note: ConfirmedNote<Note>,
+    confirmed_note: ConfirmedNote<NOTE>,
     context: &mut PrivateContext,
 )
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let note_hash_for_nullification = compute_confirmed_note_hash_for_nullification(confirmed_note);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/calls_generation/external_functions.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/calls_generation/external_functions.nr
@@ -119,9 +119,9 @@ pub(crate) comptime fn generate_external_function_self_calls_structs(m: Module) 
         .join(quote {});
 
     quote {
-        pub struct CallSelf<Context> {
+        pub struct CallSelf<CONTEXT> {
             pub address: aztec::protocol::address::AztecAddress,
-            pub context: Context,
+            pub context: CONTEXT,
         }
 
         impl CallSelf<&mut aztec::context::PrivateContext> {
@@ -132,9 +132,9 @@ pub(crate) comptime fn generate_external_function_self_calls_structs(m: Module) 
             $call_self_public_methods
         }
 
-        pub struct CallSelfStatic<Context> {
+        pub struct CallSelfStatic<CONTEXT> {
             pub address: aztec::protocol::address::AztecAddress,
-            pub context: Context,
+            pub context: CONTEXT,
         }
 
         impl CallSelfStatic<&mut aztec::context::PrivateContext> {
@@ -145,18 +145,18 @@ pub(crate) comptime fn generate_external_function_self_calls_structs(m: Module) 
             $call_self_public_static_methods
         }
 
-        pub struct EnqueueSelf<Context> {
+        pub struct EnqueueSelf<CONTEXT> {
             pub address: aztec::protocol::address::AztecAddress,
-            pub context: Context,
+            pub context: CONTEXT,
         }
 
         impl EnqueueSelf<&mut aztec::context::PrivateContext> {
             $enqueue_self_methods
         }
 
-        pub struct EnqueueSelfStatic<Context> {
+        pub struct EnqueueSelfStatic<CONTEXT> {
             pub address: aztec::protocol::address::AztecAddress,
-            pub context: Context,
+            pub context: CONTEXT,
         }
 
         impl EnqueueSelfStatic<&mut aztec::context::PrivateContext> {

--- a/noir-projects/aztec-nr/aztec/src/macros/calls_generation/internal_functions.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/calls_generation/internal_functions.nr
@@ -62,8 +62,8 @@ pub(crate) comptime fn generate_call_internal_struct(m: Module) -> Quoted {
         public_internal_functions.map(|function| generate_public_internal_function_call(function)).join(quote {});
 
     quote {
-        pub struct CallInternal<Context> {
-            pub context: Context,
+        pub struct CallInternal<CONTEXT> {
+            pub context: CONTEXT,
         }
 
         impl CallInternal<&mut aztec::context::PrivateContext> {

--- a/noir-projects/aztec-nr/aztec/src/macros/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/storage.nr
@@ -45,7 +45,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
             if typ.implements(quote { crate::state_vars::OwnedStateVariable<$_maybe_owned_context> }
                 .as_trait_constraint()) {
                 panic(
-                    f"Type {typ} implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<{typ}<..., Context>>, Context>.",
+                    f"Type {typ} implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<{typ}<..., CONTEXT>>, CONTEXT>.",
                 )
             }
 
@@ -58,7 +58,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
         let slot_as_field = slot as Field;
 
         storage_vars_constructors = storage_vars_constructors.push_back(
-            quote { $name: aztec::state_vars::StateVariable::<$storage_size, Context>::new(context, $slot_as_field) },
+            quote { $name: aztec::state_vars::StateVariable::<$storage_size, CONTEXT>::new(context, $slot_as_field) },
         );
 
         // We have `Storable` in a separate `.nr` file instead of defining it in the last quote of this function
@@ -85,8 +85,8 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
     STORAGE_LAYOUT_NAME.insert(module, storage_layout_name);
 
     quote {
-        impl<Context> Storage<Context> {
-            fn init(context: Context) -> Self {
+        impl<CONTEXT> Storage<CONTEXT> {
+            fn init(context: CONTEXT) -> Self {
                 Self {
                     $storage_vars_constructors
                 }
@@ -111,7 +111,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
 }
 
 /// Same as `storage`, except the user is in charge of providing an implementation of the `init` constructor function
-/// with signature `fn init<Context>(context: Context) -> Self`, which allows for manual control of storage slot
+/// with signature `fn init<CONTEXT>(context: CONTEXT) -> Self`, which allows for manual control of storage slot
 /// allocation. Similarly, no `StorageLayout` struct will be created.
 ///
 /// The contract's storage is accessed via the `storage` variable, which will will automatically be made available in

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -60,7 +60,7 @@ pub struct NoteHashAndNullifier {
 ///     };
 /// }
 /// ```
-pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /*
+pub type ComputeNoteHashAndNullifier<ENV> = unconstrained fn[ENV](/* packed_note */BoundedVec<Field, MAX_NOTE_PACKED_LEN>, /*
  owner */ AztecAddress, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /*
 randomness */ Field, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 
@@ -74,9 +74,9 @@ randomness */ Field, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 ///
 /// Receives the address of the contract on which discovery is performed along with its
 /// `compute_note_hash_and_nullifier` function.
-pub unconstrained fn do_sync_state<Env>(
+pub unconstrained fn do_sync_state<ENV>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
 ) {
     debug_log("Performing state synchronization");
 

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
@@ -23,10 +23,10 @@ pub struct DiscoveredNoteInfo {
 ///
 /// Due to how nonces are computed, this function requires knowledge of the transaction in which the note was created,
 /// more specifically the list of all unique note hashes in it plus the value of its first nullifier.
-pub unconstrained fn attempt_note_nonce_discovery<Env>(
+pub unconstrained fn attempt_note_nonce_discovery<ENV>(
     unique_note_hashes_in_tx: BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>,
     first_nullifier_in_tx: Field,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     contract_address: AztecAddress,
     owner: AztecAddress,
     storage_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -67,9 +67,9 @@ pub unconstrained fn process_partial_note_private_msg(
 
 /// Searches for logs that would result in the completion of pending partial notes, ultimately resulting in the notes
 /// being delivered to PXE if completed.
-pub unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
+pub unconstrained fn fetch_and_process_partial_note_completion_logs<ENV>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
 ) {
     let pending_partial_notes = CapsuleArray::at(
         contract_address,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
@@ -6,13 +6,13 @@ use crate::messages::{
 };
 use crate::protocol::{address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX, debug_log::debug_log_format};
 
-pub unconstrained fn process_private_note_msg<Env>(
+pub unconstrained fn process_private_note_msg<ENV>(
     contract_address: AztecAddress,
     tx_hash: Field,
     unique_note_hashes_in_tx: BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>,
     first_nullifier_in_tx: Field,
     recipient: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     msg_metadata: u64,
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
 ) {
@@ -36,13 +36,13 @@ pub unconstrained fn process_private_note_msg<Env>(
 
 /// Attempts discovery of a note given information about its contents and the transaction in which it is suspected the
 /// note was created.
-pub unconstrained fn attempt_note_discovery<Env>(
+pub unconstrained fn attempt_note_discovery<ENV>(
     contract_address: AztecAddress,
     tx_hash: Field,
     unique_note_hashes_in_tx: BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>,
     first_nullifier_in_tx: Field,
     recipient: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     owner: AztecAddress,
     storage_slot: Field,
     randomness: Field,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -23,9 +23,9 @@ use crate::protocol::{address::AztecAddress, debug_log::{debug_log, debug_log_fo
 ///
 /// Events are processed by computing an event commitment from the serialized event data and its randomness field, then
 /// enqueueing the event data and commitment for validation.
-pub unconstrained fn process_message_ciphertext<Env>(
+pub unconstrained fn process_message_ciphertext<ENV>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
@@ -46,9 +46,9 @@ pub unconstrained fn process_message_ciphertext<Env>(
     }
 }
 
-pub unconstrained fn process_message_plaintext<Env>(
+pub unconstrained fn process_message_plaintext<ENV>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
     message_context: MessageContext,
 ) {

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -20,12 +20,12 @@ pub global MAX_EVENT_SERIALIZED_LEN: u32 = MAX_MESSAGE_CONTENT_LEN - PRIVATE_EVE
 /// Creates the plaintext for a private event message (i.e. one of type [`PRIVATE_EVENT_MSG_TYPE_ID`]).
 ///
 /// This plaintext is meant to be decoded via [`decode_private_event_message`].
-pub fn encode_private_event_message<Event>(
-    event: Event,
+pub fn encode_private_event_message<EVENT>(
+    event: EVENT,
     randomness: Field,
-) -> [Field; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Event as Serialize>::N + MESSAGE_EXPANDED_METADATA_LEN]
+) -> [Field; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <EVENT as Serialize>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
-    Event: EventInterface + Serialize,
+    EVENT: EventInterface + Serialize,
 {
     // We use `Serialize` because we want for events to be processable by off-chain actors, e.g. block explorers,
     // wallets and apps, without having to rely on contract invocation. If we used `Packable` we'd need to call utility
@@ -40,7 +40,7 @@ where
         "unexpected value for PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
     );
 
-    let mut msg_plaintext = [0; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Event as Serialize>::N];
+    let mut msg_plaintext = [0; PRIVATE_EVENT_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <EVENT as Serialize>::N];
     msg_plaintext[PRIVATE_EVENT_MSG_PLAINTEXT_RANDOMNESS_INDEX] = randomness;
 
     for i in 0..serialized_event.len() {
@@ -50,7 +50,7 @@ where
     // The event type id is stored in the message metadata
     encode_message(
         PRIVATE_EVENT_MSG_TYPE_ID,
-        Event::get_event_type_id().to_field() as u64,
+        EVENT::get_event_type_id().to_field() as u64,
         msg_plaintext,
     )
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/note.nr
@@ -22,14 +22,14 @@ pub global MAX_NOTE_PACKED_LEN: u32 = MAX_MESSAGE_CONTENT_LEN - PRIVATE_NOTE_MSG
 /// Creates the plaintext for a private note message (i.e. one of type [`PRIVATE_NOTE_MSG_TYPE_ID`]).
 ///
 /// This plaintext is meant to be decoded via [`decode_private_note_message`].
-pub fn encode_private_note_message<Note>(
-    note: Note,
+pub fn encode_private_note_message<NOTE>(
+    note: NOTE,
     owner: AztecAddress,
     storage_slot: Field,
     randomness: Field,
-) -> [Field; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Note as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
+) -> [Field; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <NOTE as Packable>::N + MESSAGE_EXPANDED_METADATA_LEN]
 where
-    Note: NoteType + Packable,
+    NOTE: NoteType + Packable,
 {
     let packed_note = note.pack();
 
@@ -40,7 +40,7 @@ where
         "unexpected value for PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN",
     );
 
-    let mut msg_content = [0; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <Note as Packable>::N];
+    let mut msg_content = [0; PRIVATE_NOTE_MSG_PLAINTEXT_RESERVED_FIELDS_LEN + <NOTE as Packable>::N];
     msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_OWNER_INDEX] = owner.to_field();
     msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_STORAGE_SLOT_INDEX] = storage_slot;
     msg_content[PRIVATE_NOTE_MSG_PLAINTEXT_RANDOMNESS_INDEX] = randomness;
@@ -49,7 +49,7 @@ where
     }
 
     // Notes use the note type id for metadata
-    encode_message(PRIVATE_NOTE_MSG_TYPE_ID, Note::get_id() as u64, msg_content)
+    encode_message(PRIVATE_NOTE_MSG_TYPE_ID, NOTE::get_id() as u64, msg_content)
 }
 
 /// Decodes the plaintext from a private note message (i.e. one of type [`PRIVATE_NOTE_MSG_TYPE_ID`]).

--- a/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
@@ -192,9 +192,9 @@ pub global MessageDelivery: MessageDeliveryEnum =
 /// be created, there is no point in delivering the message.
 ///
 /// `delivery_mode` must be one of [`MessageDeliveryEnum`].
-pub(crate) fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
+pub(crate) fn do_private_message_delivery<ENV, let MESSAGE_PLAINTEXT_LEN: u32>(
     context: &mut PrivateContext,
-    encode_into_message_plaintext: fn[Env]() -> [Field; MESSAGE_PLAINTEXT_LEN],
+    encode_into_message_plaintext: fn[ENV]() -> [Field; MESSAGE_PLAINTEXT_LEN],
     maybe_note_hash_counter: Option<u32>,
     recipient: AztecAddress,
     delivery_mode: u8,

--- a/noir-projects/aztec-nr/aztec/src/note/confirmed_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/confirmed_note.nr
@@ -20,8 +20,8 @@ use crate::protocol::address::AztecAddress;
 /// the
 /// note hash tree: if it is nullified in the same transaction, both note hash and nullifier will be squashed (deleted)
 /// by the kernel, resulting in a _transient note_.
-pub struct ConfirmedNote<Note> {
-    pub note: Note,
+pub struct ConfirmedNote<NOTE> {
+    pub note: NOTE,
 
     pub contract_address: AztecAddress,
     pub owner: AztecAddress,
@@ -36,8 +36,8 @@ pub struct ConfirmedNote<Note> {
     pub(crate) proven_note_hash: Field,
 }
 
-impl<Note> ConfirmedNote<Note> {
-    pub(crate) fn new(hinted_note: HintedNote<Note>, proven_note_hash: Field) -> Self {
+impl<NOTE> ConfirmedNote<NOTE> {
+    pub(crate) fn new(hinted_note: HintedNote<NOTE>, proven_note_hash: Field) -> Self {
         Self {
             note: hinted_note.note,
             contract_address: hinted_note.contract_address,

--- a/noir-projects/aztec-nr/aztec/src/note/hinted_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/hinted_note.nr
@@ -10,8 +10,8 @@ use crate::protocol::{address::AztecAddress, traits::{Deserialize, Packable, Ser
 /// converted into a [`crate::note::confirmed_note::ConfirmedNote`] via
 /// [`crate::history::note::assert_note_existed_by`].
 #[derive(Deserialize, Eq, Serialize, Packable)]
-pub struct HintedNote<Note> {
-    pub note: Note,
+pub struct HintedNote<NOTE> {
+    pub note: NOTE,
     pub contract_address: AztecAddress,
     pub owner: AztecAddress,
     pub randomness: Field,

--- a/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/lifecycle.nr
@@ -11,8 +11,8 @@ use crate::{
 use crate::protocol::{address::AztecAddress, traits::Packable};
 
 /// A note that was created in the current contract call.
-pub struct NewNote<Note> {
-    pub(crate) note: Note,
+pub struct NewNote<NOTE> {
+    pub(crate) note: NOTE,
     pub(crate) owner: AztecAddress,
     pub(crate) storage_slot: Field,
     pub(crate) randomness: Field,
@@ -20,22 +20,22 @@ pub struct NewNote<Note> {
     pub(crate) note_hash_counter: u32,
 }
 
-impl<Note> NewNote<Note> {
-    fn new(note: Note, owner: AztecAddress, storage_slot: Field, randomness: Field, note_hash_counter: u32) -> Self {
+impl<NOTE> NewNote<NOTE> {
+    fn new(note: NOTE, owner: AztecAddress, storage_slot: Field, randomness: Field, note_hash_counter: u32) -> Self {
         // A counter of value zero indicates a settled note, which a NewNote by definition cannot be.
         assert(note_hash_counter != 0, "A NewNote cannot have a zero note hash counter");
         Self { note, owner, storage_slot, randomness, note_hash_counter }
     }
 }
 
-pub fn create_note<Note>(
+pub fn create_note<NOTE>(
     context: &mut PrivateContext,
     owner: AztecAddress,
     storage_slot: Field,
-    note: Note,
-) -> NoteMessage<Note>
+    note: NOTE,
+) -> NoteMessage<NOTE>
 where
-    Note: NoteType + NoteHash + Packable,
+    NOTE: NoteType + NoteHash + Packable,
 {
     let note_hash_counter = context.side_effect_counter;
 
@@ -51,7 +51,7 @@ where
         owner,
         storage_slot,
         randomness,
-        Note::get_id(),
+        NOTE::get_id(),
         note.pack(),
         note_hash,
         note_hash_counter,
@@ -65,9 +65,9 @@ where
     )
 }
 
-pub fn destroy_note<Note>(context: &mut PrivateContext, confirmed_note: ConfirmedNote<Note>)
+pub fn destroy_note<NOTE>(context: &mut PrivateContext, confirmed_note: ConfirmedNote<NOTE>)
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let note_hash_for_nullification = compute_confirmed_note_hash_for_nullification(confirmed_note);
     let nullifier = confirmed_note.note.compute_nullifier(context, confirmed_note.owner, note_hash_for_nullification);

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -64,29 +64,29 @@ fn check_notes_order<let N: u32>(fields_0: [Field; N], fields_1: [Field; N], sor
     }
 }
 
-pub fn get_note<Note>(
+pub fn get_note<NOTE>(
     context: &mut PrivateContext,
     owner: Option<AztecAddress>,
     storage_slot: Field,
-) -> ConfirmedNote<Note>
+) -> ConfirmedNote<NOTE>
 where
-    Note: NoteType + NoteHash + Packable,
+    NOTE: NoteType + NoteHash + Packable,
 {
     // Safety: Constraining that we got a valid note from the oracle is fairly straightforward: all we need to do is
     // check that the metadata is correct, and that the note exists.
-    let hinted_note = unsafe { view_note::<Note>(owner, storage_slot) };
+    let hinted_note = unsafe { view_note::<NOTE>(owner, storage_slot) };
 
     confirm_hinted_note(context, hinted_note, owner, storage_slot)
 }
 
-fn confirm_hinted_note<Note>(
+fn confirm_hinted_note<NOTE>(
     context: &mut PrivateContext,
-    hinted_note: HintedNote<Note>,
+    hinted_note: HintedNote<NOTE>,
     owner: Option<AztecAddress>,
     storage_slot: Field,
-) -> ConfirmedNote<Note>
+) -> ConfirmedNote<NOTE>
 where
-    Note: NoteType + NoteHash + Packable,
+    NOTE: NoteType + NoteHash + Packable,
 {
     // For settled notes, the contract address is implicitly checked since the hash returned from
     // `compute_note_existence_request` is siloed and kernels verify the siloing during note read request validation.
@@ -122,13 +122,13 @@ where
 /// or _valid_ - this typically requires also emitting the note's nullifier to prove that it had not been emitted
 /// before. Because of this, calling this function directly from end-user applications should be discouraged, and safe
 /// abstractions such as aztec-nr's state variables should be used instead.
-pub fn get_notes<Note, let M: u32, PreprocessorArgs, FilterArgs>(
+pub fn get_notes<NOTE, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
     context: &mut PrivateContext,
     storage_slot: Field,
-    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
-) -> BoundedVec<ConfirmedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+    options: NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+) -> BoundedVec<ConfirmedNote<NOTE>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
 where
-    Note: NoteType + NoteHash + Eq + Packable<N = M>,
+    NOTE: NoteType + NoteHash + Eq + Packable<N = M>,
 {
     // Safety: The notes are constrained below.
     let maybe_hinted_notes = unsafe { get_notes_internal(storage_slot, options) };
@@ -138,22 +138,22 @@ where
     confirm_hinted_notes(context, storage_slot, maybe_hinted_notes, options)
 }
 
-unconstrained fn apply_preprocessor<Note, PreprocessorArgs>(
-    notes: [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    preprocessor: fn([Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    preprocessor_args: PreprocessorArgs,
-) -> [Option<Note>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
+unconstrained fn apply_preprocessor<NOTE, PREPROCESSOR_ARGS>(
+    notes: [Option<NOTE>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    preprocessor: fn([Option<NOTE>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<NOTE>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    preprocessor_args: PREPROCESSOR_ARGS,
+) -> [Option<NOTE>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
     preprocessor(notes, preprocessor_args)
 }
 
-fn confirm_hinted_notes<Note, let M: u32, PreprocessorArgs, FilterArgs>(
+fn confirm_hinted_notes<NOTE, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
     context: &mut PrivateContext,
     storage_slot: Field,
-    maybe_hinted_notes: [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
-) -> BoundedVec<ConfirmedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+    maybe_hinted_notes: [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    options: NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+) -> BoundedVec<ConfirmedNote<NOTE>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
 where
-    Note: NoteType + NoteHash + Eq + Packable<N = M>,
+    NOTE: NoteType + NoteHash + Eq + Packable<N = M>,
 {
     // The filter is applied first to avoid pushing note read requests for notes we're not interested in. Note that
     // while the filter function can technically mutate the notes (as opposed to simply removing some), the private
@@ -211,9 +211,9 @@ where
     confirmed_notes
 }
 
-pub unconstrained fn view_note<Note>(owner: Option<AztecAddress>, storage_slot: Field) -> HintedNote<Note>
+pub unconstrained fn view_note<NOTE>(owner: Option<AztecAddress>, storage_slot: Field) -> HintedNote<NOTE>
 where
-    Note: NoteType + Packable,
+    NOTE: NoteType + Packable,
 {
     let maybe_hinted_notes: [_; 1] = oracle::notes::get_notes(
         owner,
@@ -236,12 +236,12 @@ where
     maybe_hinted_notes[0].expect(f"Failed to get a note")
 }
 
-unconstrained fn get_notes_internal<Note, let M: u32, PreprocessorArgs, FilterArgs>(
+unconstrained fn get_notes_internal<NOTE, let M: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
     storage_slot: Field,
-    options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
-) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL]
+    options: NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL]
 where
-    Note: NoteType + Packable<N = M>,
+    NOTE: NoteType + Packable<N = M>,
 {
     // This function simply performs some transformations from NoteGetterOptions into the types required by the oracle.
     let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) =
@@ -275,12 +275,12 @@ where
 /// Unconstrained variant of `get_notes`, meant to be used in unconstrained execution contexts. Notably only the note
 /// content is returned, and not any of the information used when proving its existence (e.g. note nonce, note hash,
 /// etc.).
-pub unconstrained fn view_notes<Note, let M: u32>(
+pub unconstrained fn view_notes<NOTE, let M: u32>(
     storage_slot: Field,
-    options: NoteViewerOptions<Note, M>,
-) -> BoundedVec<Note, MAX_NOTES_PER_PAGE>
+    options: NoteViewerOptions<NOTE, M>,
+) -> BoundedVec<NOTE, MAX_NOTES_PER_PAGE>
 where
-    Note: NoteType + Packable<N = M> + Eq,
+    NOTE: NoteType + Packable<N = M> + Eq,
 {
     let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) =
         flatten_options(options.selects, options.sorts);

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -35,7 +35,7 @@ where
     assert_eq(count, vec.len());
 }
 
-unconstrained fn confirmed_to_hinted<Note>(confirmed: ConfirmedNote<Note>) -> HintedNote<Note> {
+unconstrained fn confirmed_to_hinted<NOTE>(confirmed: ConfirmedNote<NOTE>) -> HintedNote<NOTE> {
     HintedNote {
         note: confirmed.note,
         contract_address: confirmed.contract_address,

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter_options.nr
@@ -56,14 +56,14 @@ pub global NoteStatus: NoteStatusEnum = NoteStatusEnum {
 };
 
 // This is the default filter and preprocessor, which does nothing
-fn return_all_notes<Note>(
-    notes: [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+fn return_all_notes<NOTE>(
+    notes: [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
     _p: Field,
-) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
+) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL] {
     notes
 }
 
-pub struct NoteGetterOptions<Note, let N: u32, PreprocessorArgs, FilterArgs> {
+pub struct NoteGetterOptions<NOTE, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS> {
     pub selects: BoundedVec<Option<Select>, N>,
     pub sorts: BoundedVec<Option<Sort>, N>,
     pub limit: u32,
@@ -71,10 +71,10 @@ pub struct NoteGetterOptions<Note, let N: u32, PreprocessorArgs, FilterArgs> {
     pub owner: Option<AztecAddress>,
     // Preprocessor and filter functions are used to filter notes. The preprocessor is applied before the filter and
     // unlike filter it is applied in an unconstrained context.
-    pub preprocessor: fn([Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    pub preprocessor_args: PreprocessorArgs,
-    pub filter: fn([Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FilterArgs) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-    pub filter_args: FilterArgs,
+    pub preprocessor: fn([Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    pub preprocessor_args: PREPROCESSOR_ARGS,
+    pub filter: fn([Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+    pub filter_args: FILTER_ARGS,
     pub status: u8,
 }
 
@@ -82,7 +82,7 @@ pub struct NoteGetterOptions<Note, let N: u32, PreprocessorArgs, FilterArgs> {
 // precise and controlled data retrieval. The database-level configurations are applied first: `selects` to specify
 // fields, `sorts` to establish sorting criteria, `offset` to skip items, and `limit` to cap the result size. And
 // finally, a custom preprocessor and filter to refine the outcome further.
-impl<Note, let N: u32, PreprocessorArgs, FilterArgs> NoteGetterOptions<Note, N, PreprocessorArgs, FilterArgs> {
+impl<NOTE, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS> NoteGetterOptions<NOTE, N, PREPROCESSOR_ARGS, FILTER_ARGS> {
     // This method adds a `Select` criterion to the options. It takes a property_selector indicating which field to
     // select, a value representing the specific value to match in that field, and a comparator (For possible values of
     // comparators, please see the Comparator enum from `utils::comparison`)
@@ -134,15 +134,15 @@ impl<Note, let N: u32, PreprocessorArgs, FilterArgs> NoteGetterOptions<Note, N, 
     }
 }
 
-impl<Note, let M: u32> NoteGetterOptions<Note, M, Field, Field>
+impl<NOTE, let M: u32> NoteGetterOptions<NOTE, M, Field, Field>
 where
-    Note: NoteType + Packable<N = M>,
+    NOTE: NoteType + Packable<N = M>,
 {
     // This function initializes a NoteGetterOptions that simply returns the maximum number of notes allowed in a call.
     pub fn new() -> Self {
         Self {
-            selects: BoundedVec::<_, <Note as Packable>::N>::new(),
-            sorts: BoundedVec::<_, <Note as Packable>::N>::new(),
+            selects: BoundedVec::<_, <NOTE as Packable>::N>::new(),
+            sorts: BoundedVec::<_, <NOTE as Packable>::N>::new(),
             limit: MAX_NOTE_HASH_READ_REQUESTS_PER_CALL as u32,
             offset: 0,
             owner: Option::none(),
@@ -155,16 +155,16 @@ where
     }
 }
 
-impl<Note, let M: u32, PreprocessorArgs> NoteGetterOptions<Note, M, PreprocessorArgs, Field>
+impl<NOTE, let M: u32, PREPROCESSOR_ARGS> NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, Field>
 where
-    Note: NoteType + Packable<N = M>,
+    NOTE: NoteType + Packable<N = M>,
 {
     // This function initializes a NoteGetterOptions with a preprocessor, which takes the notes returned from the
     // database and preprocessor_args as its parameters. `preprocessor_args` allows you to provide additional data or
     // context to the custom preprocessor.
     pub fn with_preprocessor(
-        preprocessor: fn([Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PreprocessorArgs) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        preprocessor_args: PreprocessorArgs,
+        preprocessor: fn([Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], PREPROCESSOR_ARGS) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        preprocessor_args: PREPROCESSOR_ARGS,
     ) -> Self {
         Self {
             selects: BoundedVec::new(),
@@ -181,16 +181,16 @@ where
     }
 }
 
-impl<Note, let M: u32, FilterArgs> NoteGetterOptions<Note, M, Field, FilterArgs>
+impl<NOTE, let M: u32, FILTER_ARGS> NoteGetterOptions<NOTE, M, Field, FILTER_ARGS>
 where
-    Note: NoteType + Packable<N = M>,
+    NOTE: NoteType + Packable<N = M>,
 {
     // This function initializes a NoteGetterOptions with a filter, which takes the notes returned from the database
     // and filter_args as its parameters. `filter_args` allows you to provide additional data or context to the custom
     // filter.
     pub fn with_filter(
-        filter: fn([Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FilterArgs) -> [Option<HintedNote<Note>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
-        filter_args: FilterArgs,
+        filter: fn([Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL], FILTER_ARGS) -> [Option<HintedNote<NOTE>>; MAX_NOTE_HASH_READ_REQUESTS_PER_CALL],
+        filter_args: FILTER_ARGS,
     ) -> Self {
         Self {
             selects: BoundedVec::new(),

--- a/noir-projects/aztec-nr/aztec/src/note/note_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_message.nr
@@ -11,8 +11,8 @@ use crate::protocol::{address::AztecAddress, traits::Packable};
 /// Use [`NoteMessage::deliver`] to select a delivery mechanism. The same message can be delivered to multiple
 /// recipients.
 #[must_use = "Unused NoteMessage result - use the `deliver` function to prevent the note information from being lost forever"]
-pub struct NoteMessage<Note> {
-    pub(crate) new_note: NewNote<Note>,
+pub struct NoteMessage<NOTE> {
+    pub(crate) new_note: NewNote<NOTE>,
 
     // NoteMessage is constructed when a note is created, which means that the `context` object will be in scope. By
     // storing a reference to it inside this object we remove the need for its methods to receive it, resulting in a
@@ -20,11 +20,11 @@ pub struct NoteMessage<Note> {
     context: &mut PrivateContext,
 }
 
-impl<Note> NoteMessage<Note>
+impl<NOTE> NoteMessage<NOTE>
 where
-    Note: NoteType + Packable,
+    NOTE: NoteType + Packable,
 {
-    pub fn new(new_note: NewNote<Note>, context: &mut PrivateContext) -> Self {
+    pub fn new(new_note: NewNote<NOTE>, context: &mut PrivateContext) -> Self {
         Self { new_note, context }
     }
 
@@ -85,7 +85,7 @@ where
     }
 
     /// Returns the note contained in the message.
-    pub fn get_note(self) -> Note {
+    pub fn get_note(self) -> NOTE {
         self.new_note.note
     }
 
@@ -93,7 +93,7 @@ where
     ///
     /// This is an advanced function, typically needed only when creating new kinds of state variables that need to
     /// create [`MaybeNoteMessage`] values.
-    pub fn get_new_note(self) -> NewNote<Note> {
+    pub fn get_new_note(self) -> NewNote<NOTE> {
         self.new_note
     }
 }
@@ -103,12 +103,12 @@ where
 ///
 /// Other than that, it and [`MaybeNoteMessage::deliver`] behave the exact same way as [`NoteMessage`].
 #[must_use = "Unused NoteMessage result - use the `deliver` function to prevent the note information from being lost forever"]
-pub struct MaybeNoteMessage<Note> {
+pub struct MaybeNoteMessage<NOTE> {
     // We can't simply create an `Option` of `NoteMessage` because that type includes a mutable reference to the
     // `context`. All `Option` methods (map, or, etc.) have if-else expressions in which they might return the
     // contents, and conditionally returning mutable references is disallowed by Noir. Hence, we create this type which
     // only holds `NewNote` in the `Option`, keeping the `context` out.
-    maybe_new_note: Option<NewNote<Note>>,
+    maybe_new_note: Option<NewNote<NOTE>>,
 
     // MaybeNoteMessage is expected to be constructed when a note is created, which means that the `context` object
     // will be in scope. By storing a reference to it inside this object we remove the need for its methods to receive
@@ -116,11 +116,11 @@ pub struct MaybeNoteMessage<Note> {
     context: &mut PrivateContext,
 }
 
-impl<Note> MaybeNoteMessage<Note>
+impl<NOTE> MaybeNoteMessage<NOTE>
 where
-    Note: NoteType + Packable,
+    NOTE: NoteType + Packable,
 {
-    pub fn new(maybe_new_note: Option<NewNote<Note>>, context: &mut PrivateContext) -> Self {
+    pub fn new(maybe_new_note: Option<NewNote<NOTE>>, context: &mut PrivateContext) -> Self {
         Self { maybe_new_note, context }
     }
 
@@ -147,7 +147,7 @@ where
     }
 
     /// Returns the note contained in the message.
-    pub fn get_note(self) -> Option<Note> {
+    pub fn get_note(self) -> Option<NOTE> {
         self.maybe_new_note.map(|new_note| new_note.note)
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/note_viewer_options.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_viewer_options.nr
@@ -4,7 +4,7 @@ use crate::note::note_interface::NoteType;
 use crate::protocol::{address::AztecAddress, traits::{Packable, ToField}};
 use std::option::Option;
 
-pub struct NoteViewerOptions<Note, let M: u32> {
+pub struct NoteViewerOptions<NOTE, let M: u32> {
     pub selects: BoundedVec<Option<Select>, M>,
     pub sorts: BoundedVec<Option<Sort>, M>,
     pub limit: u32,
@@ -13,10 +13,10 @@ pub struct NoteViewerOptions<Note, let M: u32> {
     pub status: u8,
 }
 
-impl<Note, let M: u32> NoteViewerOptions<Note, M> {
-    pub fn new() -> NoteViewerOptions<Note, M>
+impl<NOTE, let M: u32> NoteViewerOptions<NOTE, M> {
+    pub fn new() -> NoteViewerOptions<NOTE, M>
     where
-        Note: NoteType + Packable<N = M>,
+        NOTE: NoteType + Packable<N = M>,
     {
         NoteViewerOptions {
             selects: BoundedVec::new(),

--- a/noir-projects/aztec-nr/aztec/src/note/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/utils.nr
@@ -3,9 +3,9 @@ use crate::{context::NoteExistenceRequest, note::{ConfirmedNote, HintedNote, not
 use crate::protocol::hash::{compute_siloed_note_hash, compute_unique_note_hash};
 
 /// Returns the [`NoteExistenceRequest`] used to prove a note exists.
-pub fn compute_note_existence_request<Note>(hinted_note: HintedNote<Note>) -> NoteExistenceRequest
+pub fn compute_note_existence_request<NOTE>(hinted_note: HintedNote<NOTE>) -> NoteExistenceRequest
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     let note_hash =
         hinted_note.note.compute_note_hash(hinted_note.owner, hinted_note.storage_slot, hinted_note.randomness);
@@ -28,9 +28,9 @@ where
 
 /// Returns the note hash that must be used to compute a note's nullifier when calling `NoteHash::compute_nullifier` or
 /// `NoteHash::compute_nullifier_unconstrained`.
-pub fn compute_note_hash_for_nullification<Note>(hinted_note: HintedNote<Note>) -> Field
+pub fn compute_note_hash_for_nullification<NOTE>(hinted_note: HintedNote<NOTE>) -> Field
 where
-    Note: NoteHash,
+    NOTE: NoteHash,
 {
     compute_confirmed_note_hash_for_nullification(ConfirmedNote::new(
         hinted_note,
@@ -41,7 +41,7 @@ where
 /// Same as `compute_note_hash_for_nullification`, except it takes the note hash used in a read request (i.e. what
 /// `compute_note_existence_request` would return). This is useful in scenarios where that hash has already been
 /// computed to reduce constraints by reusing this value.
-pub fn compute_confirmed_note_hash_for_nullification<Note>(confirmed_note: ConfirmedNote<Note>) -> Field {
+pub fn compute_confirmed_note_hash_for_nullification<NOTE>(confirmed_note: ConfirmedNote<NOTE>) -> Field {
     // There is just one instance in which the note hash for nullification does not match the note hash used for a read
     // request, which is when dealing with pending previous phase notes. These had their existence proven using their
     // non-siloed note hash along with the note hash counter (like all pending notes), but since they will be

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -76,7 +76,7 @@ unconstrained fn notify_nullified_note_oracle_wrapper(nullifier: Field, note_has
 unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) {}
 
 #[oracle(utilityGetNotes)]
-unconstrained fn get_notes_oracle<Note, let M: u32, let MaxNotes: u32>(
+unconstrained fn get_notes_oracle<NOTE, let M: u32, let MaxNotes: u32>(
     _owner: Option<AztecAddress>,
     _storage_slot: Field,
     _num_selects: u8,
@@ -94,16 +94,16 @@ unconstrained fn get_notes_oracle<Note, let M: u32, let MaxNotes: u32>(
     _status: u8,
     // This is always set to MAX_NOTES. We need to pass it to TS in order to correctly construct the BoundedVec
     _max_notes: u32,
-    // This is always set to <HintedNote<Note> as Packable>::N. We need to pass it to TS in order to be able to
+    // This is always set to <HintedNote<NOTE> as Packable>::N. We need to pass it to TS in order to be able to
     // correctly construct the BoundedVec there.
     _packed_hinted_note_length: u32,
-) -> BoundedVec<[Field; <HintedNote<Note> as Packable>::N], MaxNotes>
+) -> BoundedVec<[Field; <HintedNote<NOTE> as Packable>::N], MaxNotes>
 where
-    // TODO(https://github.com/noir-lang/noir/issues/9399): `Note: Packable` should work here.
-    HintedNote<Note>: Packable,
+    // TODO(https://github.com/noir-lang/noir/issues/9399): `NOTE: Packable` should work here.
+    HintedNote<NOTE>: Packable,
 {}
 
-pub unconstrained fn get_notes<Note, let M: u32, let MaxNotes: u32>(
+pub unconstrained fn get_notes<NOTE, let M: u32, let MaxNotes: u32>(
     owner: Option<AztecAddress>,
     storage_slot: Field,
     num_selects: u8,
@@ -119,11 +119,11 @@ pub unconstrained fn get_notes<Note, let M: u32, let MaxNotes: u32>(
     limit: u32,
     offset: u32,
     status: u8,
-) -> [Option<HintedNote<Note>>; MaxNotes]
+) -> [Option<HintedNote<NOTE>>; MaxNotes]
 where
-    Note: NoteType + Packable,
+    NOTE: NoteType + Packable,
 {
-    let packed_hinted_notes: BoundedVec<[Field; <HintedNote<Note> as Packable>::N], MaxNotes> = get_notes_oracle::<Note, M, MaxNotes>(
+    let packed_hinted_notes: BoundedVec<[Field; <HintedNote<NOTE> as Packable>::N], MaxNotes> = get_notes_oracle::<NOTE, M, MaxNotes>(
         owner,
         storage_slot,
         num_selects,
@@ -140,7 +140,7 @@ where
         offset,
         status,
         MaxNotes,
-        <HintedNote<Note> as Packable>::N,
+        <HintedNote<NOTE> as Packable>::N,
     );
 
     let mut notes = BoundedVec::<_, MaxNotes>::new();

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -13,8 +13,8 @@ use crate::{context::{PrivateContext, PublicContext, UtilityContext}, state_vars
 mod test;
 
 /// Public mutable values with private read access.
-pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
-    context: Context,
+pub struct DelayedPublicMutable<T, let InitialDelay: u64, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
@@ -32,11 +32,11 @@ pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
 //
 // This implementation requires that T implements the Packable and Eq traits, and allocates `M + 1` storage slots to
 // this state variable.
-impl<T, let InitialDelay: u64, Context, let M: u32> StateVariable<M + 1, Context> for DelayedPublicMutable<T, InitialDelay, Context>
+impl<T, let InitialDelay: u64, CONTEXT, let M: u32> StateVariable<M + 1, CONTEXT> for DelayedPublicMutable<T, InitialDelay, CONTEXT>
 where
     DelayedPublicMutableValues<T, InitialDelay>: Packable<N = M>,
 {
-    fn new(context: Context, storage_slot: Field) -> Self {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/map.nr
@@ -12,10 +12,10 @@ use crate::state_vars::StateVariable;
 /// You can declare a state variable contained within a Map in your contract's
 /// [`storage`](crate::macros::storage::storage) struct.
 ///
-/// For example, you might use `Map<AztecAddress, PublicMutable<FieldNote, Context>, Context>` to track token balances
+/// For example, you might use `Map<AztecAddress, PublicMutable<FieldNote, CONTEXT>, CONTEXT>` to track token balances
 /// for different users, similar to how you'd use `mapping(address => uint256)` in Solidity.
 ///
-/// > Aside: the verbose `Context` in the declaration is a consequence of > leveraging Noir's regular syntax for
+/// > Aside: the verbose `CONTEXT` in the declaration is a consequence of > leveraging Noir's regular syntax for
 /// generics to ensure that certain > state variable methods can only be called in some contexts (private, > public,
 /// utility).
 ///
@@ -30,7 +30,7 @@ use crate::state_vars::StateVariable;
 /// - `PublicImmutable`
 /// - `DelayedPublicMutable`
 /// - `Map`
-/// - `Context`: The execution context (handles private/public function contexts)
+/// - `CONTEXT`: The execution context (handles private/public function contexts)
 ///
 /// ## Usage Maps are typically declared in your contract's [`storage`](crate::macros::storage::storage) struct and accessed using the `at(key)` method to get the state variable for a specific key. The resulting state variable can then be read from or written to using its own methods.
 ///
@@ -47,16 +47,16 @@ use crate::state_vars::StateVariable;
 /// `poseidon2_hash([base_slot, key.to_field()])`, ensuring cryptographically secure slot separation.
 ///
 /// docs:start:map
-pub struct Map<K, V, Context> {
-    pub context: Context,
+pub struct Map<K, V, CONTEXT> {
+    pub context: CONTEXT,
     storage_slot: Field,
 }
 
 // Map reserves a single storage slot regardless of what it stores because nothing is stored at said slot: it is only
 // used to derive the storage slots of nested state variables, which is expected to never result in collisions or slots
 // being close to one another due to these being hashes. This mirrors the strategy adopted by Solidity mappings.
-impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<K, V, CONTEXT> StateVariable<1, CONTEXT> for Map<K, V, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Map { context, storage_slot }
     }
@@ -66,7 +66,7 @@ impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
     }
 }
 
-impl<K, V, Context> Map<K, V, Context> {
+impl<K, V, CONTEXT> Map<K, V, CONTEXT> {
     /// Returns the state variable associated with the given key.
     ///
     /// This is equivalent to accessing `mapping[`key`]` in Solidity. It returns the state variable instance for the
@@ -99,7 +99,7 @@ impl<K, V, Context> Map<K, V, Context> {
     pub fn at<let N: u32>(self, key: K) -> V
     where
         K: ToField,
-        V: StateVariable<N, Context>,
+        V: StateVariable<N, CONTEXT>,
     {
         V::new(
             self.context,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/owned.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/owned.nr
@@ -10,7 +10,7 @@ use crate::state_vars::{OwnedStateVariable, StateVariable};
 /// ```noir
 /// #[storage]
 /// struct Storage {
-///     balance: Owned<PrivateSet<UintNote, Context>, Context>,
+///     balance: Owned<PrivateSet<UintNote, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -24,17 +24,17 @@ use crate::state_vars::{OwnedStateVariable, StateVariable};
 ///
 /// # Type Parameters
 ///
-/// * `V` - The underlying type that implements `OwnedStateVariable<Context>` (e.g., `PrivateSet`, `PrivateMutable`).
-/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+/// * `V` - The underlying type that implements `OwnedStateVariable<CONTEXT>` (e.g., `PrivateSet`, `PrivateMutable`).
+/// * `CONTEXT` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
 /// determines which methods of the state variable are available.
 ///
-pub struct Owned<V, Context> {
-    pub context: Context,
+pub struct Owned<V, CONTEXT> {
+    pub context: CONTEXT,
     storage_slot: Field,
 }
 
-impl<V, Context> StateVariable<1, Context> for Owned<V, Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<V, CONTEXT> StateVariable<1, CONTEXT> for Owned<V, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Owned { context, storage_slot }
     }
@@ -44,11 +44,11 @@ impl<V, Context> StateVariable<1, Context> for Owned<V, Context> {
     }
 }
 
-impl<V, Context> Owned<V, Context> {
+impl<V, CONTEXT> Owned<V, CONTEXT> {
     /// Returns an instance of the underlying owned state variable for a given owner.
     pub fn at(self, owner: AztecAddress) -> V
     where
-        V: OwnedStateVariable<Context>,
+        V: OwnedStateVariable<CONTEXT>,
     {
         V::new(self.context, self.storage_slot, owner)
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/owned_state_variable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/owned_state_variable.nr
@@ -6,7 +6,7 @@ use crate::protocol::address::AztecAddress;
 /// ```noir
 /// #[storage]
 /// struct Storage {
-///     balance: Owned<PrivateSet<UintNote, Context>, Context>,
+///     balance: Owned<PrivateSet<UintNote, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -26,13 +26,13 @@ use crate::protocol::address::AztecAddress;
 ///
 /// # Type Parameters
 ///
-/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+/// * `CONTEXT` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
 /// determines which methods of the state variable are available and controls whether the variable can be accessed in
 /// public, private or utility functions.
 ///
-pub trait OwnedStateVariable<Context> {
+pub trait OwnedStateVariable<CONTEXT> {
     /// Initializes a new owned state variable with a given storage slot and owner. The storage slot is inherited from
     /// the `Owned` state variable unchanged. The `Owned` state variable calls this function when its `at` method is
     /// invoked.
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self;
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self;
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -26,8 +26,8 @@ use crate::protocol::{
 ///
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     your_variable: Owned<PrivateImmutable<YourNote, Context>, Context>,
+/// struct Storage<CONTEXT> {
+///     your_variable: Owned<PrivateImmutable<YourNote, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -48,22 +48,22 @@ use crate::protocol::{
 ///
 /// # Generic Parameters:
 ///
-/// * `Note` - A single note of this type will represent the PrivateImmutable's value at the given storage_slot.
-/// * `Context` - The execution context (PrivateContext or UtilityContext).
+/// * `NOTE` - A single note of this type will represent the PrivateImmutable's value at the given storage_slot.
+/// * `CONTEXT` - The execution context (PrivateContext or UtilityContext).
 ///
-pub struct PrivateImmutable<Note, Context> {
-    context: Context,
+pub struct PrivateImmutable<NOTE, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
     owner: AztecAddress,
 }
 
-impl<Note, Context> OwnedStateVariable<Context> for PrivateImmutable<Note, Context> {
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+impl<NOTE, CONTEXT> OwnedStateVariable<CONTEXT> for PrivateImmutable<NOTE, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self {
         Self { context, storage_slot, owner }
     }
 }
 
-impl<Note, Context> PrivateImmutable<Note, Context> {
+impl<NOTE, CONTEXT> PrivateImmutable<NOTE, CONTEXT> {
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -73,7 +73,7 @@ impl<Note, Context> PrivateImmutable<Note, Context> {
     }
 }
 
-impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
+impl<NOTE> PrivateImmutable<NOTE, &mut PrivateContext> {
     /// Computes the nullifier that will be created when this PrivateImmutable is first initialized.
     ///
     /// This function is primarily used internally by the `initialize` method, but may also be useful for contracts
@@ -95,9 +95,9 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     ///
     /// Unlike PrivateMutable, this note will never be nullified or replaced through the state variable interface
     /// - it persists for the lifetime of the state variable.
-    pub fn initialize(self, note: Note) -> NoteMessage<Note>
+    pub fn initialize(self, note: NOTE) -> NoteMessage<NOTE>
     where
-        Note: NoteType + NoteHash + Packable,
+        NOTE: NoteType + NoteHash + Packable,
     {
         // We emit an initialization nullifier to indicate that the struct is initialized. This also prevents the value
         // from being initialized again as a nullifier can be included only once.
@@ -115,9 +115,9 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     /// Since the note is immutable, there's no risk of reading stale data or race conditions - the note never changes
     /// after initialization.
     ///
-    pub fn get_note(self) -> Note
+    pub fn get_note(self) -> NOTE
     where
-        Note: NoteType + NoteHash + Packable,
+        NOTE: NoteType + NoteHash + Packable,
     {
         let storage_slot = self.storage_slot;
         let confirmed_note = get_note(self.context, Option::some(self.owner), storage_slot);
@@ -129,9 +129,9 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     }
 }
 
-impl<Note> PrivateImmutable<Note, UtilityContext>
+impl<NOTE> PrivateImmutable<NOTE, UtilityContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Computes the nullifier that will be created when this PrivateImmutable is first initialized.
     unconstrained fn get_initialization_nullifier(self) -> Field {
@@ -154,9 +154,9 @@ where
     ///
     /// Unlike the constrained `get_note()`, this function does not push read requests or perform validation. It simply
     /// reads the note from the PXE's database.
-    pub unconstrained fn view_note(self) -> Note
+    pub unconstrained fn view_note(self) -> NOTE
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         view_note(Option::some(self.owner), self.storage_slot).note
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -28,8 +28,8 @@ mod test;
 /// E.g.:
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     your_variable: Owned<PrivateMutable<YourNote, Context>, Context>,
+/// struct Storage<CONTEXT> {
+///     your_variable: Owned<PrivateMutable<YourNote, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -69,22 +69,22 @@ mod test;
 ///
 /// # Generic Parameters:
 ///
-/// * `Note` - A single note of this type will represent the PrivateMutable's current value at the given storage_slot.
-/// * `Context` - The execution context (PrivateContext or UtilityContext).
+/// * `NOTE` - A single note of this type will represent the PrivateMutable's current value at the given storage_slot.
+/// * `CONTEXT` - The execution context (PrivateContext or UtilityContext).
 ///
-pub struct PrivateMutable<Note, Context> {
-    context: Context,
+pub struct PrivateMutable<NOTE, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
     owner: AztecAddress,
 }
 
-impl<Note, Context> OwnedStateVariable<Context> for PrivateMutable<Note, Context> {
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+impl<NOTE, CONTEXT> OwnedStateVariable<CONTEXT> for PrivateMutable<NOTE, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self {
         Self { context, storage_slot, owner }
     }
 }
 
-impl<Note, Context> PrivateMutable<Note, Context> {
+impl<NOTE, CONTEXT> PrivateMutable<NOTE, CONTEXT> {
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -94,9 +94,9 @@ impl<Note, Context> PrivateMutable<Note, Context> {
     }
 }
 
-impl<Note> PrivateMutable<Note, &mut PrivateContext>
+impl<NOTE> PrivateMutable<NOTE, &mut PrivateContext>
 where
-    Note: NoteType + NoteHash,
+    NOTE: NoteType + NoteHash,
 {
     /// Computes the nullifier that will be created when this PrivateMutable is first initialized.
     ///
@@ -125,7 +125,7 @@ where
     ///
     /// ## Returns
     ///
-    /// * `NoteMessage<Note>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
+    /// * `NoteMessage<NOTE>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
     /// someone. You can call `.deliver()` on it to encrypt and deliver the note. See NoteMessage for more details.
     ///
     /// ## Advanced
@@ -139,9 +139,9 @@ where
     ///
     /// The initialization nullifier is deterministically computed from the storage slot and can leak privacy
     /// information (see `compute_initialization_nullifier` documentation).
-    pub fn initialize(self, note: Note) -> NoteMessage<Note>
+    pub fn initialize(self, note: NOTE) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // Nullify the storage slot.
         let nullifier = self.get_initialization_nullifier();
@@ -163,12 +163,12 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `f` - A function that takes the current `Note` and returns a new `Note` that will replace it and become the
+    /// * `f` - A function that takes the current `NOTE` and returns a new `NOTE` that will replace it and become the
     /// "current value".
     ///
     /// ## Returns
     ///
-    /// * `NoteMessage<Note>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
+    /// * `NoteMessage<NOTE>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
     /// someone. You can call `.deliver()` on it to encrypt and log the note. See NoteMessage documentation for more
     /// details.
     ///
@@ -186,9 +186,9 @@ where
     /// The nullification of the previous note ensures that it cannot be used again, maintaining the invariant that a
     /// PrivateMutable has exactly one current note.
     ///
-    pub fn replace<Env>(self, f: fn[Env](Note) -> Note) -> NoteMessage<Note>
+    pub fn replace<ENV>(self, f: fn[ENV](NOTE) -> NOTE) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         let prev_confirmed_note = get_note(self.context, Option::some(self.owner), self.storage_slot);
 
@@ -208,20 +208,20 @@ where
     ///
     /// ## Arguments
     ///
-    /// * `f` - A function that takes an `Option` with the current `Note` and returns the `Note` to insert. This allows
+    /// * `f` - A function that takes an `Option` with the current `NOTE` and returns the `NOTE` to insert. This allows
     /// you to transform the current note before it is reinserted. The `Option` is `none` if the state variable was not
     /// initialized.
     ///
     ///
     /// ## Returns
     ///
-    /// * `NoteMessage<Note>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
+    /// * `NoteMessage<NOTE>` - A type-safe wrapper that requires you to decide whether to encrypt and send the note to
     /// someone. You can call `.deliver()` on it to encrypt and log the note. See NoteMessage documentation for more
     /// details.
     ///
-    pub fn initialize_or_replace<Env>(self, f: fn[Env](Option<Note>) -> Note) -> NoteMessage<Note>
+    pub fn initialize_or_replace<ENV>(self, f: fn[ENV](Option<NOTE>) -> NOTE) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // Safety: `check_nullifier_exists` is an unconstrained function - we can constrain a true value by providing
         // an inclusion proof of the nullifier, but cannot constrain a false value since a non-inclusion proof would
@@ -264,7 +264,7 @@ where
     ///
     /// ## Returns
     ///
-    /// * `NoteMessage<Note>` - A type-safe wrapper containing the newly-created note. You still need to decide whether
+    /// * `NoteMessage<NOTE>` - A type-safe wrapper containing the newly-created note. You still need to decide whether
     /// to encrypt and send the note to someone. You can call `.deliver()` on it to encrypt and log the note. See
     /// NoteMessage documentation for more details.
     ///
@@ -286,9 +286,9 @@ where
     /// different nullifier, allowing it to be consumed in the future.
     ///
     /// docs:start:get_note
-    pub fn get_note(self) -> NoteMessage<Note>
+    pub fn get_note(self) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         let confirmed_note = get_note(self.context, Option::some(self.owner), self.storage_slot);
 
@@ -306,9 +306,9 @@ where
     }
 }
 
-impl<Note> PrivateMutable<Note, UtilityContext>
+impl<NOTE> PrivateMutable<NOTE, UtilityContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Computes the nullifier that will be created when this PrivateMutable is first initialized.
     unconstrained fn get_initialization_nullifier(self) -> Field {
@@ -343,12 +343,12 @@ where
     ///
     /// ## Returns
     ///
-    /// * `Note` - The current note stored in this PrivateMutable.
+    /// * `NOTE` - The current note stored in this PrivateMutable.
     ///
     /// docs:start:view_note
-    pub unconstrained fn view_note(self) -> Note
+    pub unconstrained fn view_note(self) -> NOTE
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         view_note(Option::some(self.owner), self.storage_slot).note
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -24,8 +24,8 @@ mod test;
 /// E.g.:
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     your_variable: Owned<PrivateSet<YourNote, Context>, Context>,
+/// struct Storage<CONTEXT> {
+///     your_variable: Owned<PrivateSet<YourNote, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -91,24 +91,24 @@ mod test;
 ///
 /// # Generic Parameters:
 ///
-/// * `Note` - Many notes of this type will collectively form the PrivateSet at the given storage_slot.
-/// * `Context` - The execution context (PrivateContext or UtilityContext).
+/// * `NOTE` - Many notes of this type will collectively form the PrivateSet at the given storage_slot.
+/// * `CONTEXT` - The execution context (PrivateContext or UtilityContext).
 ///
-pub struct PrivateSet<Note, Context> {
-    pub context: Context,
+pub struct PrivateSet<NOTE, CONTEXT> {
+    pub context: CONTEXT,
     pub storage_slot: Field,
     pub owner: AztecAddress,
 }
 
-impl<Note, Context> OwnedStateVariable<Context> for PrivateSet<Note, Context> {
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+impl<NOTE, CONTEXT> OwnedStateVariable<CONTEXT> for PrivateSet<NOTE, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self {
         Self { context, storage_slot, owner }
     }
 }
 
-impl<Note> PrivateSet<Note, &mut PrivateContext>
+impl<NOTE> PrivateSet<NOTE, &mut PrivateContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Inserts a new `note` into the PrivateSet.
     ///
@@ -118,7 +118,7 @@ where
     ///
     /// # Returns
     ///
-    /// - NoteMessage<Note> - A type-safe wrapper which makes it clear to the smart contract dev that they now have a
+    /// - NoteMessage<NOTE> - A type-safe wrapper which makes it clear to the smart contract dev that they now have a
     /// choice: they need to decide whether they would like to send the contents of the newly- created note to someone,
     /// or not. If they would like to, they have some further choices:
     /// - What kind of log to use? (Private log, or offchain log).
@@ -152,9 +152,9 @@ where
     /// - Ensure uniqueness of the `siloed_note_hash`, to prevent Faerie-Gold attacks, by hashing the
     /// `siloed_note_hash` with a unique value, to yield a `unique_siloed_note_hash` (see the protocol spec for more).
     ///
-    pub fn insert(self, note: Note) -> NoteMessage<Note>
+    pub fn insert(self, note: NOTE) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         create_note(self.context, self.owner, self.storage_slot, note)
     }
@@ -189,8 +189,8 @@ where
     ///
     /// # Generic Parameters
     ///
-    /// * `PreprocessorArgs` - See `NoteGetterOptions`.
-    /// * `FilterArgs` - See `NoteGetterOptions`.
+    /// * `PREPROCESSOR_ARGS` - See `NoteGetterOptions`.
+    /// * `FILTER_ARGS` - See `NoteGetterOptions`.
     /// * `M` - The length of the note (in Fields), when packed by the Packable trait.
     ///
     /// # Advanced:
@@ -222,12 +222,12 @@ where
     /// - Ensure that each `siloed_nullifier` does not already exist in the nullifier tree. The nullifier tree is an
     /// indexed merkle tree, which supports efficient non-membership proofs.
     ///
-    pub fn pop_notes<PreprocessorArgs, FilterArgs, let M: u32>(
+    pub fn pop_notes<PREPROCESSOR_ARGS, FILTER_ARGS, let M: u32>(
         self,
-        mut options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
-    ) -> BoundedVec<Note, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+        mut options: NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+    ) -> BoundedVec<NOTE, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
     where
-        Note: Packable<N = M>,
+        NOTE: Packable<N = M>,
     {
         std::static_assert(options.owner.is_none(), "Owner cannot be set in pop_notes");
 
@@ -262,7 +262,7 @@ where
     ///
     /// # Returns
     ///
-    /// - NoteMessage<Note> - A type-safe wrapper which makes it clear to the smart contract dev that they now have a
+    /// - NoteMessage<NOTE> - A type-safe wrapper which makes it clear to the smart contract dev that they now have a
     /// choice: they need to decide whether they would like to send the contents of the newly- created note to someone,
     /// or not. If they would like to, they have some further choices:
     /// - What kind of log to use? (Private log, or offchain log).
@@ -272,7 +272,7 @@ where
     /// syntax of how to encrypt and deliver notes much clearer, and to make the default options much clearer to
     /// developers. We will also be enabling easier ways to customize your own note encryption options.
     ///
-    pub fn remove(self, confirmed_note: ConfirmedNote<Note>) {
+    pub fn remove(self, confirmed_note: ConfirmedNote<NOTE>) {
         destroy_note(self.context, confirmed_note);
     }
 
@@ -305,8 +305,8 @@ where
     ///
     /// # Generic Parameters
     ///
-    /// * `PreprocessorArgs` - See `NoteGetterOptions`.
-    /// * `FilterArgs` - See `NoteGetterOptions`.
+    /// * `PREPROCESSOR_ARGS` - See `NoteGetterOptions`.
+    /// * `FILTER_ARGS` - See `NoteGetterOptions`.
     /// * `M` - The length of the note (in Fields), when packed by the Packable trait.
     ///
     /// # Advanced:
@@ -326,12 +326,12 @@ where
     /// - For transient notes: makes a request to the kernel to ensure that the note was indeed emitted by some earlier
     /// execution frame of this tx.
     ///
-    pub fn get_notes<PreprocessorArgs, FilterArgs, let M: u32>(
+    pub fn get_notes<PREPROCESSOR_ARGS, FILTER_ARGS, let M: u32>(
         self,
-        mut options: NoteGetterOptions<Note, M, PreprocessorArgs, FilterArgs>,
-    ) -> BoundedVec<ConfirmedNote<Note>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
+        mut options: NoteGetterOptions<NOTE, M, PREPROCESSOR_ARGS, FILTER_ARGS>,
+    ) -> BoundedVec<ConfirmedNote<NOTE>, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL>
     where
-        Note: Packable<N = M>,
+        NOTE: Packable<N = M>,
     {
         std::static_assert(options.owner.is_none(), "Owner cannot be set in get_notes");
 
@@ -340,9 +340,9 @@ where
     }
 }
 
-impl<Note> PrivateSet<Note, UtilityContext>
+impl<NOTE> PrivateSet<NOTE, UtilityContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Returns a collection of notes which belong to this PrivateSet, according to the given selection `options`.
     ///
@@ -356,10 +356,10 @@ where
     ///
     pub unconstrained fn view_notes(
         self,
-        mut options: NoteViewerOptions<Note, <Note as Packable>::N>,
-    ) -> BoundedVec<Note, MAX_NOTES_PER_PAGE>
+        mut options: NoteViewerOptions<NOTE, <NOTE as Packable>::N>,
+    ) -> BoundedVec<NOTE, MAX_NOTES_PER_PAGE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         std::static_assert(options.owner.is_none(), "Owner cannot be set in view_notes");
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -64,10 +64,10 @@ mod test;
 ///
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     decimals: PublicImmutable<u8, Context>,
+/// struct Storage<CONTEXT> {
+///     decimals: PublicImmutable<u8, CONTEXT>,
 ///
-///     account_types: Map<AztecAddress, PublicImmutable<AccountType, Context>, Context>,
+///     account_types: Map<AztecAddress, PublicImmutable<AccountType, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -89,18 +89,18 @@ mod test;
 /// do not have access to the current network state, only the _past_ state at the anchor block. They _can_ perform
 /// historical non-inclusion proofs of the initialization nullifier at past times, but they have no way to guarantee
 /// that it has not been emitted since then.
-pub struct PublicImmutable<T, Context> {
-    context: Context,
+pub struct PublicImmutable<T, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
 // `PublicImmutable` stores both the packed value (using M fields) and its hash (1 field), requiring M + 1 total
 // fields.
-impl<T, Context, let M: u32> StateVariable<M + 1, Context> for PublicImmutable<T, Context>
+impl<T, CONTEXT, let M: u32> StateVariable<M + 1, CONTEXT> for PublicImmutable<T, CONTEXT>
 where
     T: Packable<N = M>,
 {
-    fn new(context: Context, storage_slot: Field) -> Self {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         PublicImmutable { context, storage_slot }
     }
@@ -110,7 +110,7 @@ where
     }
 }
 
-impl<T, Context> PublicImmutable<T, Context> {
+impl<T, CONTEXT> PublicImmutable<T, CONTEXT> {
     /// Returns the inner nullifier emitted during initialization.
     pub fn compute_initialization_inner_nullifier(self) -> Field {
         poseidon2_hash_with_separator([self.storage_slot], DOM_SEP__INITIALIZATION_NULLIFIER)
@@ -299,9 +299,9 @@ impl<T> PublicImmutable<T, &mut PrivateContext> {
     /// ```noir
     /// // Bad: reading both `decimals` and `symbol` will require two historical public storage reads
     /// #[storage]
-    /// struct Storage<Context> {
-    ///     decimals: PublicImmutable<u8, Context>,
-    ///     symbol: PubicImmutable<FieldCompressedString, Context>,
+    /// struct Storage<CONTEXT> {
+    ///     decimals: PublicImmutable<u8, CONTEXT>,
+    ///     symbol: PubicImmutable<FieldCompressedString, CONTEXT>,
     /// }
     ///
     /// // Good: both `decimals` and `symbol` are retrieved in a single historical public storage read
@@ -312,8 +312,8 @@ impl<T> PublicImmutable<T, &mut PrivateContext> {
     /// }
     ///
     /// #[storage]
-    /// struct Storage<Context> {
-    ///     config: PublicImmutable<Config, Context>,
+    /// struct Storage<CONTEXT> {
+    ///     config: PublicImmutable<Config, CONTEXT>,
     /// }
     /// ```
     pub fn read(self) -> T

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -54,11 +54,11 @@ use crate::state_vars::StateVariable;
 ///
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     total_supply: PublicMutable<u128, Context>,
-///     public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
+/// struct Storage<CONTEXT> {
+///     total_supply: PublicMutable<u128, CONTEXT>,
+///     public_balances: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
 ///
-///     vote_tallies: Map<ElectionId, PublicMutable<u128, Context>, Context>,
+///     vote_tallies: Map<ElectionId, PublicMutable<u128, CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -77,16 +77,16 @@ use crate::state_vars::StateVariable;
 /// [`PublicImmutable`](crate::state_vars::PublicImmutable) and
 /// [`DelayedPublicMutable`](crate::state_vars::DelayedPublicMutable) are examples of public state variables that _can_
 /// be read privately by restricting mutation.
-pub struct PublicMutable<T, Context> {
-    context: Context,
+pub struct PublicMutable<T, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
-impl<T, Context, let M: u32> StateVariable<M, Context> for PublicMutable<T, Context>
+impl<T, CONTEXT, let M: u32> StateVariable<M, CONTEXT> for PublicMutable<T, CONTEXT>
 where
     T: Packable<N = M>,
 {
-    fn new(context: Context, storage_slot: Field) -> Self {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         PublicMutable { context, storage_slot }
     }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_immutable.nr
@@ -35,8 +35,8 @@ mod test;
 ///
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     your_variable: SinglePrivateImmutable<YourNote, Context>,
+/// struct Storage<CONTEXT> {
+///     your_variable: SinglePrivateImmutable<YourNote, CONTEXT>,
 /// }
 /// ```
 ///
@@ -54,13 +54,13 @@ mod test;
 /// nullifier includes the contract's nullifier hiding key (nhk) in its preimage and because the contract is set as
 /// the owner of the underlying note. This is expected to not ever be a problem because the contracts that use
 /// SinglePrivateImmutable generally have keys associated with them (account contracts or escrow contracts).
-pub struct SinglePrivateImmutable<Note, Context> {
-    context: Context,
+pub struct SinglePrivateImmutable<NOTE, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
-impl<Note, Context> StateVariable<1, Context> for SinglePrivateImmutable<Note, Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<NOTE, CONTEXT> StateVariable<1, CONTEXT> for SinglePrivateImmutable<NOTE, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }
@@ -70,7 +70,7 @@ impl<Note, Context> StateVariable<1, Context> for SinglePrivateImmutable<Note, C
     }
 }
 
-impl<Note, Context> SinglePrivateImmutable<Note, Context> {
+impl<NOTE, CONTEXT> SinglePrivateImmutable<NOTE, CONTEXT> {
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -80,7 +80,7 @@ impl<Note, Context> SinglePrivateImmutable<Note, Context> {
     }
 }
 
-impl<Note> SinglePrivateImmutable<Note, &mut PrivateContext> {
+impl<NOTE> SinglePrivateImmutable<NOTE, &mut PrivateContext> {
     /// Computes the nullifier that will be created when this SinglePrivateImmutable is first initialized.
     ///
     /// This function is primarily used internally by the `initialize` method, but may also be useful for contracts
@@ -98,9 +98,9 @@ impl<Note> SinglePrivateImmutable<Note, &mut PrivateContext> {
     ///
     /// This function inserts the single, permanent note for this state variable. It can only be called once per
     /// SinglePrivateImmutable. Subsequent calls will fail because the initialization nullifier will already exist.
-    pub fn initialize(self, note: Note) -> NoteMessage<Note>
+    pub fn initialize(self, note: NOTE) -> NoteMessage<NOTE>
     where
-        Note: NoteType + NoteHash + Packable,
+        NOTE: NoteType + NoteHash + Packable,
     {
         let nullifier = self.get_initialization_nullifier();
         self.context.push_nullifier(nullifier);
@@ -130,9 +130,9 @@ impl<Note> SinglePrivateImmutable<Note, &mut PrivateContext> {
     /// Since the note is immutable, there's no risk of reading stale data or race conditions - the note never changes
     /// after initialization.
     ///
-    pub fn get_note(self) -> Note
+    pub fn get_note(self) -> NOTE
     where
-        Note: NoteType + NoteHash + Packable,
+        NOTE: NoteType + NoteHash + Packable,
     {
         // The note owner is set to none rather than msg_sender(), which means that anyone with access to this note in
         // the PXE can read it.
@@ -145,9 +145,9 @@ impl<Note> SinglePrivateImmutable<Note, &mut PrivateContext> {
     }
 }
 
-impl<Note> SinglePrivateImmutable<Note, UtilityContext>
+impl<NOTE> SinglePrivateImmutable<NOTE, UtilityContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Computes the nullifier that will be created when this SinglePrivateImmutable is first initialized.
     unconstrained fn get_initialization_nullifier(self) -> Field {
@@ -165,9 +165,9 @@ where
     }
 
     /// Returns the permanent note in this SinglePrivateImmutable state variable instance.
-    pub unconstrained fn view_note(self) -> Note
+    pub unconstrained fn view_note(self) -> NOTE
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // The note owner is set to none rather than msg_sender(), which means that anyone with access to this note in
         // the PXE can read it.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_private_mutable.nr
@@ -37,8 +37,8 @@ mod test;
 ///
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     your_variable: SinglePrivateMutable<YourNote, Context>,
+/// struct Storage<CONTEXT> {
+///     your_variable: SinglePrivateMutable<YourNote, CONTEXT>,
 /// }
 /// ```
 ///
@@ -60,10 +60,10 @@ mod test;
 /// A private token's admin and total supply can be stored in two single private mutable state variables:
 /// ```noir
 /// #[storage]
-/// struct Storage<Context> {
-///     admin: SinglePrivateMutable<AddressNote, Context>,
-///     total_supply: SinglePrivateMutable<UintNote, Context>,
-///     balances: Owned<BalanceSet<Context>, Context>,
+/// struct Storage<CONTEXT> {
+///     admin: SinglePrivateMutable<AddressNote, CONTEXT>,
+///     total_supply: SinglePrivateMutable<UintNote, CONTEXT>,
+///     balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
 /// }
 /// ```
 ///
@@ -86,13 +86,13 @@ mod test;
 /// decide what method of note message delivery to use. Keep in mind that unless the caller of the relevant function is
 /// incentivized to deliver the note you should use constrained delivery or you are at a risk of a malicious actor
 /// bricking the contract.
-pub struct SinglePrivateMutable<Note, Context> {
-    context: Context,
+pub struct SinglePrivateMutable<NOTE, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
-impl<Note, Context> StateVariable<1, Context> for SinglePrivateMutable<Note, Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<NOTE, CONTEXT> StateVariable<1, CONTEXT> for SinglePrivateMutable<NOTE, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }
@@ -102,7 +102,7 @@ impl<Note, Context> StateVariable<1, Context> for SinglePrivateMutable<Note, Con
     }
 }
 
-impl<Note, Context> SinglePrivateMutable<Note, Context> {
+impl<NOTE, CONTEXT> SinglePrivateMutable<NOTE, CONTEXT> {
     /// Computes the initialization nullifier using the provided secret.
     fn compute_initialization_nullifier(self, secret: Field) -> Field {
         poseidon2_hash_with_separator(
@@ -112,9 +112,9 @@ impl<Note, Context> SinglePrivateMutable<Note, Context> {
     }
 }
 
-impl<Note> SinglePrivateMutable<Note, &mut PrivateContext>
+impl<NOTE> SinglePrivateMutable<NOTE, &mut PrivateContext>
 where
-    Note: NoteType + NoteHash,
+    NOTE: NoteType + NoteHash,
 {
     /// Computes the nullifier that will be created when this SinglePrivateMutable is first initialized.
     ///
@@ -133,9 +133,9 @@ where
     ///
     /// This function can only be called once per SinglePrivateMutable. Subsequent calls will fail because the
     /// initialization nullifier will already exist.
-    pub fn initialize(self, note: Note, owner: AztecAddress) -> NoteMessage<Note>
+    pub fn initialize(self, note: NOTE, owner: AztecAddress) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // Nullify the storage slot.
         let nullifier = self.get_initialization_nullifier();
@@ -162,9 +162,9 @@ where
     ///
     /// The nullification of the previous note ensures that it cannot be used again, maintaining the invariant that a
     /// SinglePrivateMutable has exactly one current note.
-    pub fn replace<Env>(self, f: fn[Env](Note) -> Note, new_owner: AztecAddress) -> NoteMessage<Note>
+    pub fn replace<ENV>(self, f: fn[ENV](NOTE) -> NOTE, new_owner: AztecAddress) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         let prev_confirmed_note = get_note(self.context, Option::none(), self.storage_slot);
 
@@ -179,18 +179,18 @@ where
 
     /// Initializes the SinglePrivateMutable if it's uninitialized, or replaces the current note using a transform
     /// function `f` while the new note is owned by `new_owner`. The function `f` takes an `Option` with the current
-    /// `Note` and returns the `Note` to insert. The `Option` is `none` if the state variable was not initialized.
+    /// `NOTE` and returns the `NOTE` to insert. The `Option` is `none` if the state variable was not initialized.
     ///
     /// This function returns a [`NoteMessage`] that allows you to decide what method of note message delivery to use
     /// for
     /// the new note.
-    pub fn initialize_or_replace<Env>(
+    pub fn initialize_or_replace<ENV>(
         self,
-        f: fn[Env](Option<Note>) -> Note,
+        f: fn[ENV](Option<NOTE>) -> NOTE,
         new_owner: AztecAddress,
-    ) -> NoteMessage<Note>
+    ) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // Safety: `check_nullifier_exists` is an unconstrained function - we can constrain a true value by providing
         // an inclusion proof of the nullifier, but cannot constrain a false value since a non-inclusion proof would
@@ -219,9 +219,9 @@ where
     /// This function returns a [`NoteMessage`] that allows you to decide what method of note message delivery to use
     /// for
     /// the new note.
-    pub fn get_note(self) -> NoteMessage<Note>
+    pub fn get_note(self) -> NoteMessage<NOTE>
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         let confirmed_note = get_note(self.context, Option::none(), self.storage_slot);
 
@@ -236,9 +236,9 @@ where
     }
 }
 
-impl<Note> SinglePrivateMutable<Note, UtilityContext>
+impl<NOTE> SinglePrivateMutable<NOTE, UtilityContext>
 where
-    Note: NoteType + NoteHash + Eq,
+    NOTE: NoteType + NoteHash + Eq,
 {
     /// Computes the nullifier that will be created when this SinglePrivateMutable is first initialized.
     unconstrained fn get_initialization_nullifier(self) -> Field {
@@ -256,9 +256,9 @@ where
     }
 
     /// Returns the current note in this SinglePrivateMutable.
-    pub unconstrained fn view_note(self) -> Note
+    pub unconstrained fn view_note(self) -> NOTE
     where
-        Note: Packable,
+        NOTE: Packable,
     {
         // The note owner is set to none rather than msg_sender(), which means that anyone with access to this note in
         // the PXE can read it.

--- a/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/single_use_claim.nr
@@ -29,11 +29,11 @@ mod test;
 /// struct ElectionId { id: Field }
 ///
 /// #[storage]
-/// struct Storage<Context> {
+/// struct Storage<CONTEXT> {
 ///     // election => candidate => number of votes
-///     tally: Map<ElectionId, Map<Field, PublicMutable<Field, Context>, Context>, Context>,
+///     tally: Map<ElectionId, Map<Field, PublicMutable<Field, CONTEXT>, CONTEXT>, CONTEXT>,
 ///     // track right to vote at most once per election
-///     vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
+///     vote_claims: Map<ElectionId, Owned<SingleUseClaim<CONTEXT>, CONTEXT>, CONTEXT>,
 /// }
 ///
 /// #[external("private")]
@@ -63,19 +63,19 @@ mod test;
 /// Public effects you emit alongside a claim (e.g. a  public function call to update a tally) may still let observers
 /// infer who likely exercised the claim, so consider that when designing flows.
 /// ```
-pub struct SingleUseClaim<Context> {
-    context: Context,
+pub struct SingleUseClaim<CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
     owner: AztecAddress,
 }
 
-impl<Context> OwnedStateVariable<Context> for SingleUseClaim<Context> {
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+impl<CONTEXT> OwnedStateVariable<CONTEXT> for SingleUseClaim<CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self {
         Self { context, storage_slot, owner }
     }
 }
 
-impl<Context> SingleUseClaim<Context> {
+impl<CONTEXT> SingleUseClaim<CONTEXT> {
     /// Computes the nullifier that will be created when the single use claim is claimed by the owner (denoted by the
     /// app-siloed nullifier hiding key `owner_nhk_app`).
     ///

--- a/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/state_variable.nr
@@ -5,18 +5,18 @@
 /// # Type Parameters
 ///
 /// * `N` - A compile-time constant that determines how many storage slots need to be reserved for this state variable.
-/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+/// * `CONTEXT` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
 /// determines which methods of the state variable are available and controls whether the variable can be accessed in
 /// public, private or utility functions.
 ///
-pub trait StateVariable<let N: u32, Context> {
+pub trait StateVariable<let N: u32, CONTEXT> {
     /// Initializes a new state variable at a given storage slot.
     ///
     /// This function is automatically called within the [`storage`](crate::macros::storage::storage) macro and needs
     /// to
     /// be manually called only when [`storage_no_init`](crate::macros::storage::storage_no_init) is used.
     ///
-    fn new(context: Context, storage_slot: Field) -> Self;
+    fn new(context: CONTEXT, storage_slot: Field) -> Self;
 
     /// Returns the storage slot at which the state variable is placed. Typically used only when testing the contract
     /// or when using a lower-level API like `get_notes` function.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -187,24 +187,24 @@ impl TestEnvironment {
     ///   state_var.read()
     /// });
     /// ```
-    pub unconstrained fn public_context<Env, T>(self: Self, f: unconstrained fn[Env](PublicContext) -> T) -> T {
+    pub unconstrained fn public_context<ENV, T>(self: Self, f: unconstrained fn[ENV](PublicContext) -> T) -> T {
         self.public_context_opts(PublicContextOptions { contract_address: Option::none() }, f)
     }
 
     /// Variant of `public_context` which allows specifying the contract address in which the public context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
-    pub unconstrained fn public_context_at<Env, T>(
+    pub unconstrained fn public_context_at<ENV, T>(
         self: Self,
         addr: AztecAddress,
-        f: unconstrained fn[Env](PublicContext) -> T,
+        f: unconstrained fn[ENV](PublicContext) -> T,
     ) -> T {
         self.public_context_opts(PublicContextOptions { contract_address: Option::some(addr) }, f)
     }
 
-    unconstrained fn public_context_opts<Env, T>(
+    unconstrained fn public_context_opts<ENV, T>(
         _self: Self,
         opts: PublicContextOptions,
-        f: unconstrained fn[Env](PublicContext) -> T,
+        f: unconstrained fn[ENV](PublicContext) -> T,
     ) -> T {
         txe_oracles::set_public_txe_context(opts.contract_address);
 
@@ -249,7 +249,7 @@ impl TestEnvironment {
     ///   state_var.get_note()
     /// });
     /// ```
-    pub unconstrained fn private_context<Env, T>(self: Self, f: unconstrained fn[Env](&mut PrivateContext) -> T) -> T {
+    pub unconstrained fn private_context<ENV, T>(self: Self, f: unconstrained fn[ENV](&mut PrivateContext) -> T) -> T {
         self.private_context_opts(
             PrivateContextOptions { contract_address: Option::none(), anchor_block_number: Option::none() },
             f,
@@ -258,10 +258,10 @@ impl TestEnvironment {
 
     /// Variant of `private_context` which allows specifying the contract address in which the private context will
     /// execute, which will affect note and nullifier siloing, storage access, etc.
-    pub unconstrained fn private_context_at<Env, T>(
+    pub unconstrained fn private_context_at<ENV, T>(
         self: Self,
         addr: AztecAddress,
-        f: unconstrained fn[Env](&mut PrivateContext) -> T,
+        f: unconstrained fn[ENV](&mut PrivateContext) -> T,
     ) -> T {
         self.private_context_opts(
             PrivateContextOptions { contract_address: Option::some(addr), anchor_block_number: Option::none() },
@@ -270,10 +270,10 @@ impl TestEnvironment {
     }
 
     /// Variant of `private_context` which allows specifying multiple configuration values via `PrivateContextOptions`.
-    pub unconstrained fn private_context_opts<Env, T>(
+    pub unconstrained fn private_context_opts<ENV, T>(
         _self: Self,
         opts: PrivateContextOptions,
-        f: unconstrained fn[Env](&mut PrivateContext) -> T,
+        f: unconstrained fn[ENV](&mut PrivateContext) -> T,
     ) -> T {
         let mut context = PrivateContext::new(
             txe_oracles::set_private_txe_context(opts.contract_address, opts.anchor_block_number),
@@ -313,24 +313,24 @@ impl TestEnvironment {
     ///   state_var.view_note()
     /// });
     /// ```
-    pub unconstrained fn utility_context<Env, T>(self: Self, f: unconstrained fn[Env](UtilityContext) -> T) -> T {
+    pub unconstrained fn utility_context<ENV, T>(self: Self, f: unconstrained fn[ENV](UtilityContext) -> T) -> T {
         self.utility_context_opts(UtilityContextOptions { contract_address: Option::none() }, f)
     }
 
     /// Variant of `utility_context` which allows specifying the contract address in which the utility context will
     /// execute, which will affect note and storage access.
-    pub unconstrained fn utility_context_at<Env, T>(
+    pub unconstrained fn utility_context_at<ENV, T>(
         self: Self,
         addr: AztecAddress,
-        f: unconstrained fn[Env](UtilityContext) -> T,
+        f: unconstrained fn[ENV](UtilityContext) -> T,
     ) -> T {
         self.utility_context_opts(UtilityContextOptions { contract_address: Option::some(addr) }, f)
     }
 
-    unconstrained fn utility_context_opts<Env, T>(
+    unconstrained fn utility_context_opts<ENV, T>(
         _self: Self,
         opts: UtilityContextOptions,
-        f: unconstrained fn[Env](UtilityContext) -> T,
+        f: unconstrained fn[ENV](UtilityContext) -> T,
     ) -> T {
         txe_oracles::set_utility_txe_context(opts.contract_address);
         let context = UtilityContext::new();
@@ -685,9 +685,9 @@ impl TestEnvironment {
     ///
     /// env.private_context(|context| { let (hinted_note, _) = get_note::<MockNote>(context, storage_slot); });
     /// ```
-    pub unconstrained fn discover_note<Note>(self: Self, note_message: NoteMessage<Note>)
+    pub unconstrained fn discover_note<NOTE>(self: Self, note_message: NoteMessage<NOTE>)
     where
-        Note: Packable + NoteType + NoteHash,
+        NOTE: Packable + NoteType + NoteHash,
     {
         self.discover_note_opts(NoteDiscoveryOptions { contract_address: Option::none() }, note_message);
     }
@@ -707,16 +707,16 @@ impl TestEnvironment {
     ///     let (hinted_note, _) = get_note::<MockNote>(context, storage_slot);
     /// });
     /// ```
-    pub unconstrained fn discover_note_at<Note>(self: Self, addr: AztecAddress, note_message: NoteMessage<Note>)
+    pub unconstrained fn discover_note_at<NOTE>(self: Self, addr: AztecAddress, note_message: NoteMessage<NOTE>)
     where
-        Note: Packable + NoteType + NoteHash,
+        NOTE: Packable + NoteType + NoteHash,
     {
         self.discover_note_opts(NoteDiscoveryOptions { contract_address: Option::some(addr) }, note_message);
     }
 
-    unconstrained fn discover_note_opts<Note>(self: Self, opts: NoteDiscoveryOptions, note_message: NoteMessage<Note>)
+    unconstrained fn discover_note_opts<NOTE>(self: Self, opts: NoteDiscoveryOptions, note_message: NoteMessage<NOTE>)
     where
-        Note: Packable + NoteType + NoteHash,
+        NOTE: Packable + NoteType + NoteHash,
     {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message created from the received note message.
@@ -734,12 +734,12 @@ impl TestEnvironment {
 
         // We also need to provide an implementation for the `compute_note_hash_and_nullifier` function, which would
         // typically be created by the macros for the different notes in a given contract. Here we build one
-        // specialized for `Note`.
+        // specialized for `NOTE`.
         let compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<_> = |packed_note, owner, storage_slot, note_type_id, contract_address, randomness, note_nonce| {
-            assert_eq(note_type_id, Note::get_id());
-            assert_eq(packed_note.len(), <Note as Packable>::N);
+            assert_eq(note_type_id, NOTE::get_id());
+            assert_eq(packed_note.len(), <NOTE as Packable>::N);
 
-            let note = Note::unpack(subarray(packed_note.storage(), 0));
+            let note = NOTE::unpack(subarray(packed_note.storage(), 0));
 
             let note_hash = note.compute_note_hash(owner, storage_slot, randomness);
             let note_hash_for_nullification = compute_note_hash_for_nullification(
@@ -793,13 +793,13 @@ impl TestEnvironment {
     ///
     /// env.discover_event(event_message, recipient);
     /// ```
-    pub(crate) unconstrained fn discover_event<Event>(
+    pub(crate) unconstrained fn discover_event<EVENT>(
         self: Self,
-        event_message: EventMessage<Event>,
+        event_message: EventMessage<EVENT>,
         recipient: AztecAddress,
     )
     where
-        Event: Serialize + EventInterface,
+        EVENT: Serialize + EventInterface,
     {
         self.discover_event_opts(EventDiscoveryOptions { contract_address: Option::none() }, event_message, recipient);
     }
@@ -817,14 +817,14 @@ impl TestEnvironment {
     ///
     /// env.discover_event_at(contract_address, event_message);
     /// ```
-    pub(crate) unconstrained fn discover_event_at<Event>(
+    pub(crate) unconstrained fn discover_event_at<EVENT>(
         self: Self,
         addr: AztecAddress,
-        event_message: EventMessage<Event>,
+        event_message: EventMessage<EVENT>,
         recipient: AztecAddress,
     )
     where
-        Event: Serialize + EventInterface,
+        EVENT: Serialize + EventInterface,
     {
         self.discover_event_opts(
             EventDiscoveryOptions { contract_address: Option::some(addr) },
@@ -833,14 +833,14 @@ impl TestEnvironment {
         );
     }
 
-    unconstrained fn discover_event_opts<Event>(
+    unconstrained fn discover_event_opts<EVENT>(
         self: Self,
         opts: EventDiscoveryOptions,
-        event_message: EventMessage<Event>,
+        event_message: EventMessage<EVENT>,
         recipient: AztecAddress,
     )
     where
-        Event: Serialize + EventInterface,
+        EVENT: Serialize + EventInterface,
     {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message created from the received event message.
@@ -871,12 +871,12 @@ impl TestEnvironment {
         );
     }
 
-    unconstrained fn discover_data_in_message_plaintext<Env>(
+    unconstrained fn discover_data_in_message_plaintext<ENV>(
         self,
         message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
         contract_address: Option<AztecAddress>,
         recipient: Option<AztecAddress>,
-        compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+        compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ENV>,
     ) {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message plaintext.

--- a/noir-projects/aztec-nr/aztec/src/utils/remove_constraints.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/remove_constraints.nr
@@ -1,6 +1,6 @@
 /// Calls a function and returns its return value, but removes any constraints associated with calling the function,
 /// behaving as if the function was unconstrained.
-pub unconstrained fn remove_constraints<Env, T>(f: fn[Env]() -> T) -> T {
+pub unconstrained fn remove_constraints<ENV, T>(f: fn[ENV]() -> T) -> T {
     f()
 }
 
@@ -8,7 +8,7 @@ pub unconstrained fn remove_constraints<Env, T>(f: fn[Env]() -> T) -> T {
 /// `condition` is true, behaving as if the function was unconstrained.
 ///
 /// Requires `condition` to be a compile time constant.
-pub fn remove_constraints_if<Env, T>(condition: bool, f: fn[Env]() -> T) -> T {
+pub fn remove_constraints_if<ENV, T>(condition: bool, f: fn[ENV]() -> T) -> T {
     // If `condition` is not a compile-time constant, then the compiler won't optimize away the branch not taken in the
     // if statement below, and we may end up with constraints for `f` regardless of the runtime value of `condition`.
     assert_constant(condition);

--- a/noir-projects/aztec-nr/balance-set/src/balance_set.nr
+++ b/noir-projects/aztec-nr/balance-set/src/balance_set.nr
@@ -13,13 +13,13 @@ use aztec::{
 use std::ops::Add;
 use uint_note::UintNote;
 
-pub struct BalanceSet<Context> {
-    set: PrivateSet<UintNote, Context>,
+pub struct BalanceSet<CONTEXT> {
+    set: PrivateSet<UintNote, CONTEXT>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> OwnedStateVariable<Context> for BalanceSet<Context> {
-    fn new(context: Context, storage_slot: Field, owner: AztecAddress) -> Self {
+impl<CONTEXT> OwnedStateVariable<CONTEXT> for BalanceSet<CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field, owner: AztecAddress) -> Self {
         Self { set: PrivateSet::new(context, storage_slot, owner) }
     }
 }

--- a/noir-projects/noir-contracts-comp-failures/contracts/duplicate_storage/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/duplicate_storage/src/main.nr
@@ -5,8 +5,8 @@ pub contract DuplicateStorage {
     use aztec::macros::storage::storage;
 
     #[storage]
-    struct Storage<Context> {}
+    struct Storage<CONTEXT> {}
 
     #[storage]
-    struct Storage2<Context> {}
+    struct Storage2<CONTEXT> {}
 }

--- a/noir-projects/noir-contracts-comp-failures/contracts/incorrect_storage_struct_name/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/incorrect_storage_struct_name/src/main.nr
@@ -6,5 +6,5 @@ pub contract IncorrectStorageStructName {
 
     // The following struct name is incorrect because it is not `Storage`
     #[storage]
-    struct Storage2<Context> {}
+    struct Storage2<CONTEXT> {}
 }

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_non_state_var_in_storage/src/main.nr
@@ -10,7 +10,7 @@ pub contract PanicOnNonStateVarInStorage {
     }
 
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         non_state_var: NonStateVar,
     }
 

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/expected_error
@@ -1,1 +1,1 @@
-Type PrivateImmutable<Field, Context> implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<PrivateImmutable<Field, Context><..., Context>>, Context>.
+Type PrivateImmutable<Field, CONTEXT> implements OwnedStateVariable and hence cannot be placed in Storage struct without being wrapped in Owned. Define the type in storage as Owned<PrivateImmutable<Field, CONTEXT><..., CONTEXT>>, CONTEXT>.

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_owned_state_var_in_storage/src/main.nr
@@ -6,8 +6,8 @@ pub contract PanicOnOwnedStateVarInStorage {
     use aztec::{macros::{functions::external, storage::storage}, state_vars::PrivateImmutable};
 
     #[storage]
-    struct Storage<Context> {
-        owned_state_var: PrivateImmutable<Field, Context>,
+    struct Storage<CONTEXT> {
+        owned_state_var: PrivateImmutable<Field, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_k_account_contract/src/main.nr
@@ -19,8 +19,8 @@ pub contract EcdsaKAccount {
     use dep::ecdsa_public_key_note::EcdsaPublicKeyNote;
 
     #[storage]
-    struct Storage<Context> {
-        signing_public_key: SinglePrivateImmutable<EcdsaPublicKeyNote, Context>,
+    struct Storage<CONTEXT> {
+        signing_public_key: SinglePrivateImmutable<EcdsaPublicKeyNote, CONTEXT>,
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification

--- a/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/ecdsa_r_account_contract/src/main.nr
@@ -18,8 +18,8 @@ pub contract EcdsaRAccount {
     use dep::ecdsa_public_key_note::EcdsaPublicKeyNote;
 
     #[storage]
-    struct Storage<Context> {
-        signing_public_key: SinglePrivateImmutable<EcdsaPublicKeyNote, Context>,
+    struct Storage<CONTEXT> {
+        signing_public_key: SinglePrivateImmutable<EcdsaPublicKeyNote, CONTEXT>,
     }
 
     // Creates a new account out of an ECDSA public key to use for signature verification

--- a/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/account/schnorr_account_contract/src/main.nr
@@ -31,9 +31,9 @@ pub contract SchnorrAccount {
     use crate::public_key_note::PublicKeyNote;
 
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // docs:start:public_key
-        signing_public_key: SinglePrivateImmutable<PublicKeyNote, Context>,
+        signing_public_key: SinglePrivateImmutable<PublicKeyNote, CONTEXT>,
         // docs:end:public_key
     }
 

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -49,8 +49,8 @@ pub contract AMM {
     use dep::uint_note::PartialUintNote;
 
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
     }
 
     /// Amount of liquidity which gets locked when liquidity is provided for the first time. Its purpose is to prevent

--- a/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/app_subscription_contract/src/main.nr
@@ -55,10 +55,10 @@ pub contract AppSubscription {
     use token::Token;
 
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
         // docs:start:owned_private_mutable
-        subscriptions: Owned<PrivateMutable<SubscriptionNote, Context>, Context>,
+        subscriptions: Owned<PrivateMutable<SubscriptionNote, CONTEXT>, CONTEXT>,
         // docs:end:owned_private_mutable
     }
 

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -17,10 +17,10 @@ pub contract Auth {
     pub(crate) global CHANGE_AUTHORIZED_DELAY: u64 = 180;
 
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // Admin can change the value of the authorized address via set_authorized()
-        admin: PublicImmutable<AztecAddress, Context>,
-        authorized: DelayedPublicMutable<AztecAddress, CHANGE_AUTHORIZED_DELAY, Context>,
+        admin: PublicImmutable<AztecAddress, CONTEXT>,
+        authorized: DelayedPublicMutable<AztecAddress, CHANGE_AUTHORIZED_DELAY, CONTEXT>,
     }
     // docs:end:delayed_public_mutable_storage
 

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/cards.nr
@@ -65,13 +65,13 @@ impl CardNote {
     }
 }
 
-pub struct Deck<Context> {
-    owned_set: Owned<PrivateSet<FieldNote, Context>, Context>,
+pub struct Deck<CONTEXT> {
+    owned_set: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
 }
 
 // TODO(#13824): remove this impl once we allow structs to hold state variables.
-impl<Context> StateVariable<1, Context> for Deck<Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<CONTEXT> StateVariable<1, CONTEXT> for Deck<CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         Deck { owned_set: Owned::new(context, storage_slot) }
     }
 
@@ -106,8 +106,8 @@ pub fn filter_cards<let N: u32>(
     selected
 }
 
-impl<Context> Deck<Context> {
-    pub fn new(context: Context, storage_slot: Field) -> Self {
+impl<CONTEXT> Deck<CONTEXT> {
+    pub fn new(context: CONTEXT, storage_slot: Field) -> Self {
         let owned_set = Owned::new(context, storage_slot);
         Deck { owned_set }
     }

--- a/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/card_game_contract/src/main.nr
@@ -18,10 +18,10 @@ pub contract CardGame {
     use dep::aztec::protocol::traits::{FromField, ToField};
 
     #[storage]
-    struct Storage<Context> {
-        collections: Deck<Context>,
-        game_decks: Map<Field, Deck<Context>, Context>,
-        games: Map<Field, PublicMutable<Game, Context>, Context>,
+    struct Storage<CONTEXT> {
+        collections: Deck<CONTEXT>,
+        game_decks: Map<Field, Deck<CONTEXT>, CONTEXT>,
+        games: Map<Field, PublicMutable<Game, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/claim_contract/src/main.nr
@@ -16,11 +16,11 @@ pub contract Claim {
 
     // TODO: This can be optimized by storing the addresses in Config struct in 1 PublicImmutable (less merkle proofs).
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // Address of a contract based on whose notes we distribute the rewards
-        target_contract: PublicImmutable<AztecAddress, Context>,
+        target_contract: PublicImmutable<AztecAddress, CONTEXT>,
         // Token to be distributed as a reward when claiming
-        reward_token: PublicImmutable<AztecAddress, Context>,
+        reward_token: PublicImmutable<AztecAddress, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -24,10 +24,10 @@ pub contract Crowdfunding {
     }
     // docs:start:storage
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
         // Notes emitted to donors when they donate (can be used as proof to obtain rewards, eg in Claim contracts)
-        donation_receipts: Owned<PrivateSet<UintNote, Context>, Context>,
+        donation_receipts: Owned<PrivateSet<UintNote, CONTEXT>, CONTEXT>,
     }
     // docs:end:storage
 

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/main.nr
@@ -15,8 +15,8 @@ pub contract Escrow {
 
     // docs:start:single_private_immutable_storage
     #[storage]
-    struct Storage<Context> {
-        owner: SinglePrivateImmutable<AddressNote, Context>,
+    struct Storage<CONTEXT> {
+        owner: SinglePrivateImmutable<AddressNote, CONTEXT>,
     }
     // docs:end:single_private_immutable_storage
 

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
@@ -30,14 +30,14 @@ pub contract Lending {
     // docs:start:custom_struct_storage_map
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // docs:start:public_mutable
-        collateral_asset: PublicMutable<AztecAddress, Context>,
+        collateral_asset: PublicMutable<AztecAddress, CONTEXT>,
         // docs:end:public_mutable
-        stable_coin: PublicMutable<AztecAddress, Context>,
-        assets: Map<Field, PublicMutable<Asset, Context>, Context>,
-        collateral: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
-        static_debt: Map<AztecAddress, PublicMutable<u128, Context>, Context>, // abusing keys very heavily
+        stable_coin: PublicMutable<AztecAddress, CONTEXT>,
+        assets: Map<Field, PublicMutable<Asset, CONTEXT>, CONTEXT>,
+        collateral: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
+        static_debt: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>, // abusing keys very heavily
     }
     // docs:end:custom_struct_storage_map
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -39,21 +39,21 @@ pub contract NFT {
 
     // docs:start:storage_struct
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // The symbol of the NFT
-        symbol: PublicImmutable<FieldCompressedString, Context>,
+        symbol: PublicImmutable<FieldCompressedString, CONTEXT>,
         // The name of the NFT
-        name: PublicImmutable<FieldCompressedString, Context>,
+        name: PublicImmutable<FieldCompressedString, CONTEXT>,
         // The admin of the contract
-        admin: PublicMutable<AztecAddress, Context>,
+        admin: PublicMutable<AztecAddress, CONTEXT>,
         // Addresses that can mint
-        minters: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
+        minters: Map<AztecAddress, PublicMutable<bool, CONTEXT>, CONTEXT>,
         // Contains the NFTs owned by each address in private.
-        private_nfts: Owned<PrivateSet<NFTNote, Context>, Context>,
+        private_nfts: Owned<PrivateSet<NFTNote, CONTEXT>, CONTEXT>,
         // A map from token ID to a boolean indicating if the NFT exists.
-        nft_exists: Map<Field, PublicMutable<bool, Context>, Context>,
+        nft_exists: Map<Field, PublicMutable<bool, CONTEXT>, CONTEXT>,
         // A map from token ID to the public owner of the NFT.
-        public_owners: Map<Field, PublicMutable<AztecAddress, Context>, Context>,
+        public_owners: Map<Field, PublicMutable<AztecAddress, CONTEXT>, CONTEXT>,
     }
     // docs:end:storage_struct
 

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -55,9 +55,9 @@ pub contract Orderbook {
     }
 
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
-        orders: Map<Field, PublicImmutable<Order, Context>, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
+        orders: Map<Field, PublicImmutable<Order, CONTEXT>, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/price_feed_contract/src/main.nr
@@ -11,8 +11,8 @@ pub contract PriceFeed {
 
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
-    struct Storage<Context> {
-        assets: Map<Field, PublicMutable<Asset, Context>, Context>,
+    struct Storage<CONTEXT> {
+        assets: Map<Field, PublicMutable<Asset, CONTEXT>, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_token_contract/src/main.nr
@@ -16,14 +16,14 @@ pub contract PrivateToken {
 
     // docs:start_single_private_mutable
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<BalanceSet<Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
         // This contract has only a single admin whose identity we don't want to leak to the public so we store it in
         // a single private mutable.
-        admin: SinglePrivateMutable<AddressNote, Context>,
+        admin: SinglePrivateMutable<AddressNote, CONTEXT>,
         // We don't want this contract to leak information about its total supply so we store it in a single private
         // mutable.
-        total_supply: SinglePrivateMutable<UintNote, Context>,
+        total_supply: SinglePrivateMutable<UintNote, CONTEXT>,
     }
     // docs:end_single_private_mutable
 

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/main.nr
@@ -28,17 +28,17 @@ pub contract PrivateVoting {
     // docs:end:imports
     // docs:start:storage_struct
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // admin can start and end elections
-        admin: PublicMutable<AztecAddress, Context>,
+        admin: PublicMutable<AztecAddress, CONTEXT>,
         // election => candidate => number of votes
-        tally: Map<ElectionId, Map<Field, PublicMutable<Field, Context>, Context>, Context>,
+        tally: Map<ElectionId, Map<Field, PublicMutable<Field, CONTEXT>, CONTEXT>, CONTEXT>,
         // election => election ended
-        vote_ended: Map<ElectionId, PublicMutable<bool, Context>, Context>,
+        vote_ended: Map<ElectionId, PublicMutable<bool, CONTEXT>, CONTEXT>,
         // election => election started at
-        active_at_block: Map<ElectionId, PublicImmutable<u32, Context>, Context>,
+        active_at_block: Map<ElectionId, PublicImmutable<u32, CONTEXT>, CONTEXT>,
         // election => voter => single use claim that ensures voter can at most vote once per election
-        vote_claims: Map<ElectionId, Owned<SingleUseClaim<Context>, Context>, Context>,
+        vote_claims: Map<ElectionId, Owned<SingleUseClaim<CONTEXT>, CONTEXT>, CONTEXT>,
     }
     // docs:end:storage_struct
 

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -38,14 +38,14 @@ pub contract SimpleToken {
     }
 
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<BalanceSet<Context>, Context>,
-        total_supply: PublicMutable<u128, Context>,
-        public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
+        total_supply: PublicMutable<u128, CONTEXT>,
+        public_balances: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
         // docs:start:public_immutable
-        symbol: PublicImmutable<FieldCompressedString, Context>,
-        name: PublicImmutable<FieldCompressedString, Context>,
-        decimals: PublicImmutable<u8, Context>,
+        symbol: PublicImmutable<FieldCompressedString, CONTEXT>,
+        name: PublicImmutable<FieldCompressedString, CONTEXT>,
+        decimals: PublicImmutable<u8, CONTEXT>,
         // docs:end:public_immutable
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -53,12 +53,12 @@ pub contract TokenBlacklist {
     global TRANSPARENT_NOTE_RANDOMNESS: Field = 0;
 
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<BalanceSet<Context>, Context>,
-        total_supply: PublicMutable<u128, Context>,
-        pending_shields: Owned<PrivateSet<TransparentNote, Context>, Context>,
-        public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
-        roles: Map<AztecAddress, DelayedPublicMutable<UserFlags, CHANGE_ROLES_DELAY, Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
+        total_supply: PublicMutable<u128, CONTEXT>,
+        pending_shields: Owned<PrivateSet<TransparentNote, CONTEXT>, CONTEXT>,
+        public_balances: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
+        roles: Map<AztecAddress, DelayedPublicMutable<UserFlags, CHANGE_ROLES_DELAY, CONTEXT>, CONTEXT>,
     }
 
     // docs:start:constructor

--- a/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_bridge_contract/src/main.nr
@@ -24,8 +24,8 @@ pub contract TokenBridge {
 
     // Storage structure, containing all storage, and specifying what slots they use.
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
     }
 
     // Constructs the contract.

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -53,15 +53,15 @@ pub contract Token {
 
     // docs:start:storage_struct
     #[storage]
-    struct Storage<Context> {
-        admin: PublicMutable<AztecAddress, Context>,
-        minters: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
-        balances: Owned<BalanceSet<Context>, Context>,
-        total_supply: PublicMutable<u128, Context>,
-        public_balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
-        symbol: PublicImmutable<FieldCompressedString, Context>,
-        name: PublicImmutable<FieldCompressedString, Context>,
-        decimals: PublicImmutable<u8, Context>,
+    struct Storage<CONTEXT> {
+        admin: PublicMutable<AztecAddress, CONTEXT>,
+        minters: Map<AztecAddress, PublicMutable<bool, CONTEXT>, CONTEXT>,
+        balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
+        total_supply: PublicMutable<u128, CONTEXT>,
+        public_balances: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
+        symbol: PublicImmutable<FieldCompressedString, CONTEXT>,
+        name: PublicImmutable<FieldCompressedString, CONTEXT>,
+        decimals: PublicImmutable<u8, CONTEXT>,
     }
     // docs:end:storage_struct
 

--- a/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/uniswap_contract/src/main.nr
@@ -27,8 +27,8 @@ pub contract Uniswap {
     use dep::token_bridge::TokenBridge;
 
     #[storage]
-    struct Storage<Context> {
-        portal_address: PublicImmutable<EthAddress, Context>,
+    struct Storage<CONTEXT> {
+        portal_address: PublicImmutable<EthAddress, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -21,8 +21,8 @@ pub contract FPC {
     use token::Token;
 
     #[storage]
-    struct Storage<Context> {
-        config: PublicImmutable<Config, Context>,
+    struct Storage<CONTEXT> {
+        config: PublicImmutable<Config, CONTEXT>,
     }
 
     /// Initializes the contract with an accepted asset (AA) and an admin (address that can pull accumulated AA funds

--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
@@ -21,12 +21,12 @@ pub contract AuthRegistry {
         state_vars::{Map, PublicMutable, StateVariable},
     };
 
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         /// Map of addresses that have rejected all actions
-        reject_all: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
+        reject_all: Map<AztecAddress, PublicMutable<bool, CONTEXT>, CONTEXT>,
         /// Nested map of approvers to their authorized message hashes
         /// First key is the approver address, second key is the message hash, value is authorization status
-        approved_actions: Map<AztecAddress, Map<Field, PublicMutable<bool, Context>, Context>, Context>,
+        approved_actions: Map<AztecAddress, Map<Field, PublicMutable<bool, CONTEXT>, CONTEXT>, CONTEXT>,
     }
 
     /**
@@ -350,14 +350,14 @@ pub contract AuthRegistry {
         panic(f"Unknown selector {selector}")
     }
 
-    impl<Context> Storage<Context> {
-        fn init(context: Context) -> Self {
+    impl<CONTEXT> Storage<CONTEXT> {
+        fn init(context: CONTEXT) -> Self {
             Self {
-                reject_all: <Map<AztecAddress, PublicMutable<bool, Context>, Context> as StateVariable<1, Context>>::new(
+                reject_all: <Map<AztecAddress, PublicMutable<bool, CONTEXT>, CONTEXT> as StateVariable<1, CONTEXT>>::new(
                     context,
                     1,
                 ),
-                approved_actions: <Map<AztecAddress, Map<Field, PublicMutable<bool, Context>, Context>, Context> as StateVariable<1, Context>>::new(
+                approved_actions: <Map<AztecAddress, Map<Field, PublicMutable<bool, CONTEXT>, CONTEXT>, CONTEXT> as StateVariable<1, CONTEXT>>::new(
                     context,
                     2,
                 ),

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/delayed_public_mutable.nr
@@ -15,8 +15,8 @@ use crate::{
 };
 
 /// Public mutable values with private read access.
-pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
-    context: Context,
+pub struct DelayedPublicMutable<T, let InitialDelay: u64, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
@@ -24,11 +24,11 @@ pub struct DelayedPublicMutable<T, let InitialDelay: u64, Context> {
 //  - publicly known (i.e. unencrypted)
 //  - mutable in public
 //  - readable in private with no contention
-impl<T, let InitialDelay: u64, Context, let M: u32> StateVariable<M + 1, Context> for DelayedPublicMutable<T, InitialDelay, Context>
+impl<T, let InitialDelay: u64, CONTEXT, let M: u32> StateVariable<M + 1, CONTEXT> for DelayedPublicMutable<T, InitialDelay, CONTEXT>
 where
     DelayedPublicMutableValues<T, InitialDelay>: Packable<N = M>,
 {
-    fn new(context: Context, storage_slot: Field) -> Self {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Self { context, storage_slot }
     }

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/map.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/map.nr
@@ -4,15 +4,15 @@ use crate::state_vars::StateVariable;
 /// A key-value container for state variables.
 ///
 /// A key-value storage container that maps keys to state variables, similar to Solidity mappings.
-pub struct Map<K, V, Context> {
-    pub context: Context,
+pub struct Map<K, V, CONTEXT> {
+    pub context: CONTEXT,
     storage_slot: Field,
 }
 
 // Map reserves a single storage slot regardless of what it stores because nothing is stored at said slot: it is only
 // used to derive the storage slots of nested state variables.
-impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
-    fn new(context: Context, storage_slot: Field) -> Self {
+impl<K, V, CONTEXT> StateVariable<1, CONTEXT> for Map<K, V, CONTEXT> {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         Map { context, storage_slot }
     }
@@ -22,14 +22,14 @@ impl<K, V, Context> StateVariable<1, Context> for Map<K, V, Context> {
     }
 }
 
-impl<K, V, Context> Map<K, V, Context> {
+impl<K, V, CONTEXT> Map<K, V, CONTEXT> {
     /// Returns the state variable associated with the given key.
     ///
     /// This is equivalent to accessing `mapping[key]` in Solidity.
     pub fn at<let N: u32>(self, key: K) -> V
     where
         K: ToField,
-        V: StateVariable<N, Context>,
+        V: StateVariable<N, CONTEXT>,
     {
         V::new(
             self.context,

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/public_mutable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/public_mutable.nr
@@ -6,16 +6,16 @@ use crate::state_vars::StateVariable;
 ///
 /// This is one of the most basic public state variables. It is equivalent to a non-`immutable` non-`constant` Solidity
 /// state variable.
-pub struct PublicMutable<T, Context> {
-    context: Context,
+pub struct PublicMutable<T, CONTEXT> {
+    context: CONTEXT,
     storage_slot: Field,
 }
 
-impl<T, Context, let M: u32> StateVariable<M, Context> for PublicMutable<T, Context>
+impl<T, CONTEXT, let M: u32> StateVariable<M, CONTEXT> for PublicMutable<T, CONTEXT>
 where
     T: Packable<N = M>,
 {
-    fn new(context: Context, storage_slot: Field) -> Self {
+    fn new(context: CONTEXT, storage_slot: Field) -> Self {
         assert(storage_slot != 0, "Storage slot 0 not allowed. Storage slots must start from 1.");
         PublicMutable { context, storage_slot }
     }

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/state_variable.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/state_vars/state_variable.nr
@@ -4,13 +4,13 @@
 /// # Type Parameters
 ///
 /// * `N` - A compile-time constant that determines how many storage slots need to be reserved for this state variable.
-/// * `Context` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
+/// * `CONTEXT` - The execution context type (e.g., `PublicContext`, `PrivateContext`, `UtilityContext`). The context
 /// determines which methods of the state variable are available and controls whether the variable can be accessed in
 /// public, private or utility functions.
 ///
-pub trait StateVariable<let N: u32, Context> {
+pub trait StateVariable<let N: u32, CONTEXT> {
     /// Initializes a new state variable at a given storage slot.
-    fn new(context: Context, storage_slot: Field) -> Self;
+    fn new(context: CONTEXT, storage_slot: Field) -> Self;
 
     /// Returns the storage slot at which the state variable is placed.
     fn get_storage_slot(self) -> Field;

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
@@ -98,8 +98,8 @@ pub contract ContractInstanceRegistry {
         timestamp_of_change: u64,
     }
 
-    struct Storage<Context> {
-        updated_class_ids: Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context>,
+    struct Storage<CONTEXT> {
+        updated_class_ids: Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, CONTEXT>, CONTEXT>,
     }
 
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
@@ -315,10 +315,10 @@ pub contract ContractInstanceRegistry {
 
     // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
 
-    impl<Context> Storage<Context> {
-        fn init(context: Context) -> Self {
+    impl<CONTEXT> Storage<CONTEXT> {
+        fn init(context: CONTEXT) -> Self {
             Self {
-                updated_class_ids: <Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context> as StateVariable<1, Context>>::new(
+                updated_class_ids: <Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, CONTEXT>, CONTEXT> as StateVariable<1, CONTEXT>>::new(
                     context,
                     1,
                 ),

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
@@ -13,10 +13,10 @@ pub contract FeeJuice {
     };
     use std::ops::Add;
 
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // This map is accessed directly by protocol circuits to check balances for fee payment.
         // Do not change this storage layout unless you also update the base rollup circuits.
-        balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
+        balances: Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT>,
     }
 
     global INCREASE_PUBLIC_BALANCE_SELECTOR: Field = comptime {
@@ -250,10 +250,10 @@ pub contract FeeJuice {
         fields: StorageLayoutFields { balances: aztec::state_vars::Storable { slot: 1 } },
     };
 
-    impl<Context> Storage<Context> {
-        fn init(context: Context) -> Self {
+    impl<CONTEXT> Storage<CONTEXT> {
+        fn init(context: CONTEXT) -> Self {
             Self {
-                balances: <Map<AztecAddress, PublicMutable<u128, Context>, Context> as aztec::state_vars::StateVariable<1, Context>>::new(
+                balances: <Map<AztecAddress, PublicMutable<u128, CONTEXT>, CONTEXT> as aztec::state_vars::StateVariable<1, CONTEXT>>::new(
                     context,
                     1,
                 ),

--- a/noir-projects/noir-contracts/contracts/test/avm_initializer_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_initializer_test_contract/src/main.nr
@@ -9,8 +9,8 @@ pub contract AvmInitializerTest {
     };
 
     #[storage]
-    struct Storage<Context> {
-        immutable: PublicImmutable<Field, Context>,
+    struct Storage<CONTEXT> {
+        immutable: PublicImmutable<Field, CONTEXT>,
     }
 
     /************************************************************************

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr
@@ -47,10 +47,10 @@ pub contract AvmTest {
     use std::ops::Add;
 
     #[storage]
-    struct Storage<Context> {
-        single: PublicMutable<Field, Context>,
-        list: PublicMutable<Note, Context>,
-        map: Map<AztecAddress, PublicMutable<u32, Context>, Context>,
+    struct Storage<CONTEXT> {
+        single: PublicMutable<Field, CONTEXT>,
+        list: PublicMutable<Note, CONTEXT>,
+        map: Map<AztecAddress, PublicMutable<u32, CONTEXT>, CONTEXT>,
     }
 
     /************************************************************************

--- a/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/benchmarking_contract/src/main.nr
@@ -17,9 +17,9 @@ pub contract Benchmarking {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        notes: Owned<PrivateSet<FieldNote, Context>, Context>,
-        balances: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
+    struct Storage<CONTEXT> {
+        notes: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
+        balances: Map<AztecAddress, PublicMutable<Field, CONTEXT>, CONTEXT>,
     }
 
     // Creates a new value note for the target owner. Use this method to seed an initial set of notes.

--- a/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/child_contract/src/main.nr
@@ -15,9 +15,9 @@ pub contract Child {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        current_value: PublicMutable<Field, Context>,
-        private_values: Owned<PrivateSet<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        current_value: PublicMutable<Field, CONTEXT>,
+        private_values: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     // Returns a sum of the input and the chain id and version of the contract in private circuit public input's return_values.

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -17,8 +17,8 @@ pub contract Counter {
 
     // docs:start:storage_struct
     #[storage]
-    struct Storage<Context> {
-        counters: Owned<BalanceSet<Context>, Context>,
+    struct Storage<CONTEXT> {
+        counters: Owned<BalanceSet<CONTEXT>, CONTEXT>,
     }
     // docs:end:storage_struct
 

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -14,8 +14,8 @@ pub contract NoConstructor {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        private_mutable: Owned<PrivateMutable<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        private_mutable: Owned<PrivateMutable<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     /// Arbitrary public method used to test that publishing for public execution works for a contract with no constructor.

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -17,8 +17,8 @@ pub contract NoteGetter {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        set: Owned<PrivateSet<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        set: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_effect_contract/src/main.nr
@@ -27,8 +27,8 @@ contract OffchainEffect {
     }
 
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<PrivateSet<UintNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<PrivateSet<UintNote, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/pending_note_hashes_contract/src/main.nr
@@ -26,8 +26,8 @@ pub contract PendingNoteHashes {
 
     // docs:start:private_set
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<PrivateSet<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
     }
     // docs:end:private_set
 

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -6,8 +6,8 @@ contract PublicImmutableContract {
     use aztec::{macros::{functions::external, storage::storage}, state_vars::PublicImmutable};
 
     #[storage]
-    struct Storage<Context> {
-        immutable_value: PublicImmutable<Field, Context>,
+    struct Storage<CONTEXT> {
+        immutable_value: PublicImmutable<Field, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/scope_test_contract/src/main.nr
@@ -15,8 +15,8 @@ pub contract ScopeTest {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        note: Owned<PrivateImmutable<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        note: Owned<PrivateImmutable<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     #[initializer]

--- a/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/spam_contract/src/main.nr
@@ -19,9 +19,9 @@ pub contract Spam {
     use balance_set::BalanceSet;
 
     #[storage]
-    struct Storage<Context> {
-        balances: Owned<BalanceSet<Context>, Context>,
-        public_balances: Map<Field, PublicMutable<u128, Context>, Context>,
+    struct Storage<CONTEXT> {
+        balances: Owned<BalanceSet<CONTEXT>, CONTEXT>,
+        public_balances: Map<Field, PublicMutable<u128, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -21,15 +21,15 @@ pub contract StateVars {
     }
 
     #[storage_no_init]
-    struct Storage<Context> {
-        mock_struct: PublicMutable<MockStruct, Context>,
-        private_mutable: Owned<PrivateMutable<FieldNote, Context>, Context>,
-        private_immutable: Owned<PrivateImmutable<FieldNote, Context>, Context>,
-        public_immutable: PublicImmutable<MockStruct, Context>,
+    struct Storage<CONTEXT> {
+        mock_struct: PublicMutable<MockStruct, CONTEXT>,
+        private_mutable: Owned<PrivateMutable<FieldNote, CONTEXT>, CONTEXT>,
+        private_immutable: Owned<PrivateImmutable<FieldNote, CONTEXT>, CONTEXT>,
+        public_immutable: PublicImmutable<MockStruct, CONTEXT>,
     }
 
-    impl<Context> Storage<Context> {
-        fn init(context: Context) -> Self {
+    impl<CONTEXT> Storage<CONTEXT> {
+        fn init(context: CONTEXT) -> Self {
             Storage {
                 mock_struct: PublicMutable::new(context, 1),
                 private_mutable: Owned::new(context, 3),

--- a/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/stateful_test_contract/src/main.nr
@@ -19,9 +19,9 @@ pub contract StatefulTest {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        notes: Owned<PrivateSet<FieldNote, Context>, Context>,
-        public_values: Map<AztecAddress, PublicMutable<Field, Context>, Context>,
+    struct Storage<CONTEXT> {
+        notes: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
+        public_values: Map<AztecAddress, PublicMutable<Field, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/static_child_contract/src/main.nr
@@ -15,9 +15,9 @@ pub contract StaticChild {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        current_value: PublicMutable<Field, Context>,
-        a_private_value: Owned<PrivateSet<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        current_value: PublicMutable<Field, CONTEXT>,
+        a_private_value: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     // Returns base_value + chain_id + version + block_number + timestamp statically

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -81,20 +81,20 @@ pub contract Test {
     // This struct is used to test the storage slot allocation mechanism - if modified the test_storage_slot_allocation
     // test function must also be updated accordingly.
     #[storage]
-    struct Storage<Context> {
+    struct Storage<CONTEXT> {
         // docs:start:private_immutable
-        note_in_private_immutable: Owned<PrivateImmutable<TestNote, Context>, Context>,
+        note_in_private_immutable: Owned<PrivateImmutable<TestNote, CONTEXT>, CONTEXT>,
         // docs:end:private_immutable
-        struct_in_private_immutable: Owned<PrivateImmutable<ExampleStruct, Context>, Context>,
-        note_in_private_mutable: Owned<PrivateMutable<TestNote, Context>, Context>,
-        struct_in_private_mutable: Owned<PrivateMutable<ExampleStruct, Context>, Context>,
-        note_in_private_set: Owned<PrivateSet<AddressNote, Context>, Context>,
-        struct_in_private_set: Owned<PrivateSet<ExampleStruct, Context>, Context>,
-        note_in_public_immutable: PublicImmutable<TestNote, Context>,
-        struct_in_public_immutable: PublicImmutable<ExampleStruct, Context>,
-        struct_in_map: Map<AztecAddress, PublicImmutable<ExampleStruct, Context>, Context>,
-        struct_in_delayed_public_mutable: DelayedPublicMutable<ExampleStruct, DELAYED_PUBLIC_MUTABLE_INITIAL_DELAY, Context>,
-        dummy_variable: Owned<PrivateImmutable<TestNote, Context>, Context>,
+        struct_in_private_immutable: Owned<PrivateImmutable<ExampleStruct, CONTEXT>, CONTEXT>,
+        note_in_private_mutable: Owned<PrivateMutable<TestNote, CONTEXT>, CONTEXT>,
+        struct_in_private_mutable: Owned<PrivateMutable<ExampleStruct, CONTEXT>, CONTEXT>,
+        note_in_private_set: Owned<PrivateSet<AddressNote, CONTEXT>, CONTEXT>,
+        struct_in_private_set: Owned<PrivateSet<ExampleStruct, CONTEXT>, CONTEXT>,
+        note_in_public_immutable: PublicImmutable<TestNote, CONTEXT>,
+        struct_in_public_immutable: PublicImmutable<ExampleStruct, CONTEXT>,
+        struct_in_map: Map<AztecAddress, PublicImmutable<ExampleStruct, CONTEXT>, CONTEXT>,
+        struct_in_delayed_public_mutable: DelayedPublicMutable<ExampleStruct, DELAYED_PUBLIC_MUTABLE_INITIAL_DELAY, CONTEXT>,
+        dummy_variable: Owned<PrivateImmutable<TestNote, CONTEXT>, CONTEXT>,
     }
 
     #[initializer]

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -24,8 +24,8 @@ pub contract TestLog {
     }
 
     #[storage]
-    struct Storage<Context> {
-        example_set: Owned<PrivateSet<FieldNote, Context>, Context>,
+    struct Storage<CONTEXT> {
+        example_set: Owned<PrivateSet<FieldNote, CONTEXT>, CONTEXT>,
     }
 
     #[external("private")]

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -16,9 +16,9 @@ contract Updatable {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        private_value: Owned<PrivateMutable<FieldNote, Context>, Context>,
-        public_value: PublicMutable<Field, Context>,
+    struct Storage<CONTEXT> {
+        private_value: Owned<PrivateMutable<FieldNote, CONTEXT>, CONTEXT>,
+        public_value: PublicMutable<Field, CONTEXT>,
     }
 
     #[initializer]

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -13,9 +13,9 @@ contract Updated {
     use field_note::FieldNote;
 
     #[storage]
-    struct Storage<Context> {
-        private_value: Owned<PrivateMutable<FieldNote, Context>, Context>,
-        public_value: PublicMutable<Field, Context>,
+    struct Storage<CONTEXT> {
+        private_value: Owned<PrivateMutable<FieldNote, CONTEXT>, CONTEXT>,
+        public_value: PublicMutable<Field, CONTEXT>,
     }
 
     #[external("public")]

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_padded_transformed_array.nr
@@ -57,16 +57,16 @@ use types::{
 ///                                         CappedSize
 /// output:         [v, v, v, v | p, p, p, p, p | 0, 0, 0]
 ///
-pub fn assert_sorted_padded_transformed_array_capped_size<Value, TransformedValue, let N: u32, Env, let CappedSize: u32>(
-    original_array: ClaimedLengthArray<Value, N>, // "kept" values (after squashing)
-    padded_items: [Value; N],
-    output_array: ClaimedLengthArray<TransformedValue, N>,
+pub fn assert_sorted_padded_transformed_array_capped_size<VALUE, TRANSFORMED_VALUE, let N: u32, ENV, let CappedSize: u32>(
+    original_array: ClaimedLengthArray<VALUE, N>, // "kept" values (after squashing)
+    padded_items: [VALUE; N],
+    output_array: ClaimedLengthArray<TRANSFORMED_VALUE, N>,
     // "Transformed" here means: "assert siloed" or "assert siloed & unique-ified".
-    assert_transformed: fn[Env](Value, TransformedValue) -> (),
+    assert_transformed: fn[ENV](VALUE, TRANSFORMED_VALUE) -> (),
 )
 where
-    Value: Ordered + Empty,
-    TransformedValue: Ordered + Empty,
+    VALUE: Ordered + Empty,
+    TRANSFORMED_VALUE: Ordered + Empty,
 {
     assert_sorted_padded_transformed_i_array_capped_size::<_, _, _, _, CappedSize>(
         original_array,
@@ -76,13 +76,13 @@ where
     );
 }
 
-unconstrained fn get_num_padded_items<Value, let N: u32>(
-    padded_items: [Value; N],
+unconstrained fn get_num_padded_items<VALUE, let N: u32>(
+    padded_items: [VALUE; N],
     original_array_length: u32,
     CappedSize: u32,
 ) -> u32
 where
-    Value: Ordered,
+    VALUE: Ordered,
 {
     let mut num_padded_items = 0;
     for i in original_array_length..CappedSize {
@@ -97,15 +97,15 @@ where
 /// Same as `assert_sorted_padded_transformed_array_capped_size` (see that fn for more details), but this callback
 /// `assert_transformed_i` has an additional index (`i`) argument.
 /// Used for note hashes to compute the unique note hash value with the index.
-pub fn assert_sorted_padded_transformed_i_array_capped_size<Value, TransformedValue, let N: u32, Env, let CappedSize: u32>(
-    original_array: ClaimedLengthArray<Value, N>,
-    padded_items: [Value; N],
-    output_array: ClaimedLengthArray<TransformedValue, N>,
-    assert_transformed_i: fn[Env](Value, TransformedValue, u32) -> (),
+pub fn assert_sorted_padded_transformed_i_array_capped_size<VALUE, TRANSFORMED_VALUE, let N: u32, ENV, let CappedSize: u32>(
+    original_array: ClaimedLengthArray<VALUE, N>,
+    padded_items: [VALUE; N],
+    output_array: ClaimedLengthArray<TRANSFORMED_VALUE, N>,
+    assert_transformed_i: fn[ENV](VALUE, TRANSFORMED_VALUE, u32) -> (),
 )
 where
-    Value: Ordered + Empty,
-    TransformedValue: Ordered + Empty,
+    VALUE: Ordered + Empty,
+    TRANSFORMED_VALUE: Ordered + Empty,
 {
     // Safety: The hints are constrained by `assert_sorted_padded_transformed_i_array_capped_size_with_hints`.
     let (sorted_index_hints, num_padded_items_hint) = unsafe {
@@ -128,17 +128,17 @@ where
 /// @param original_array - is technically the so-called `kept_` array that's already been through squashing; it's "original" from
 /// the perspective of this function and the transformations it will apply.
 /// @param CappedSize - is a comptime constant for the number of siloing iterations this variant of the circuit supports.
-fn assert_sorted_padded_transformed_i_array_capped_size_with_hints<Value, TransformedValue, let N: u32, Env, let CappedSize: u32>(
-    original_array: ClaimedLengthArray<Value, N>,
-    padded_items: [Value; N],
-    output_array: ClaimedLengthArray<TransformedValue, N>, // after sorting, siloing, padding, etc.
-    assert_transformed_i: fn[Env](Value, TransformedValue, u32) -> (),
+fn assert_sorted_padded_transformed_i_array_capped_size_with_hints<VALUE, TRANSFORMED_VALUE, let N: u32, ENV, let CappedSize: u32>(
+    original_array: ClaimedLengthArray<VALUE, N>,
+    padded_items: [VALUE; N],
+    output_array: ClaimedLengthArray<TRANSFORMED_VALUE, N>, // after sorting, siloing, padding, etc.
+    assert_transformed_i: fn[ENV](VALUE, TRANSFORMED_VALUE, u32) -> (),
     sorted_index_hints: [u32; N],
     num_padded_items_hint: u32,
 )
 where
-    Value: Ordered + Empty,
-    TransformedValue: Ordered + Empty,
+    VALUE: Ordered + Empty,
+    TRANSFORMED_VALUE: Ordered + Empty,
 {
     let original_array_length = original_array.length;
     assert(

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_sorted_transformed_array.nr
@@ -26,10 +26,10 @@ use types::{side_effect::Ordered, traits::Empty, utils::arrays::ClaimedLengthArr
 /// - Transformed values may not contain counters; the hints are built in this function to associate each transformed
 ///   item with its original counter.
 /// - This function does not mutate the input arrays; it only validates correctness.
-pub fn assert_sorted_transformed_array<T, S, let N: u32, Env>(
+pub fn assert_sorted_transformed_array<T, S, let N: u32, ENV>(
     original_array: ClaimedLengthArray<T, N>,
     sorted_transformed_array: [S; N],
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
 )
 where
     T: Ordered + Empty,
@@ -47,10 +47,10 @@ where
     );
 }
 
-fn assert_sorted_transformed_array_with_hints<T, S, let N: u32, Env>(
+fn assert_sorted_transformed_array_with_hints<T, S, let N: u32, ENV>(
     original_array: ClaimedLengthArray<T, N>,
     sorted_transformed_array: [S; N],
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
     hints: OrderHints<N>,
 )
 where

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_sorted_transformed_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_sorted_transformed_arrays.nr
@@ -32,12 +32,12 @@ use types::{side_effect::Ordered, traits::Empty, utils::arrays::ClaimedLengthArr
 /// - Transformed values may not contain counters; the hints are used to associate each transformed item with its
 ///   original counter.
 /// - This function does not mutate the input arrays; it only validates correctness.
-pub fn assert_split_sorted_transformed_arrays<T, S, let N: u32, Env>(
+pub fn assert_split_sorted_transformed_arrays<T, S, let N: u32, ENV>(
     original_array: ClaimedLengthArray<T, N>,
     sorted_transformed_array_lt: [S; N],
     sorted_transformed_array_gte: [S; N],
     split_counter: u32,
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
 )
 where
     T: Ordered + Empty,
@@ -57,12 +57,12 @@ where
     );
 }
 
-pub fn assert_split_sorted_transformed_arrays_with_hints<T, S, let N: u32, Env>(
+pub fn assert_split_sorted_transformed_arrays_with_hints<T, S, let N: u32, ENV>(
     original_array: ClaimedLengthArray<T, N>,
     sorted_transformed_array_lt: [S; N],
     sorted_transformed_array_gte: [S; N],
     split_counter: u32,
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
     hints: SplitOrderHints<N>,
 )
 where

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_transformed_arrays_from_sorted_padded_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_split_transformed_arrays_from_sorted_padded_array.nr
@@ -35,12 +35,12 @@ use types::{
 /// - A padded (dummy) item is an item with a counter equal to `MAX_U32_VALUE`. They are added by the protocol in the
 ///   reset circuit to hide the actual number of side effects emitted in the tx.
 /// - This function does not mutate the input arrays; it only validates correctness.
-pub fn assert_split_transformed_arrays_from_sorted_padded_array<T, S, let N: u32, Env>(
+pub fn assert_split_transformed_arrays_from_sorted_padded_array<T, S, let N: u32, ENV>(
     sorted_padded_array: ClaimedLengthArray<T, N>,
     transformed_array_lt: [S; N],
     transformed_array_gte: [S; N],
     split_counter: u32,
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
     num_padded_lt: u32,
 )
 where
@@ -72,12 +72,12 @@ where
     );
 }
 
-fn assert_split_transformed_arrays_from_sorted_padded_array_with_hint<T, S, let N: u32, Env>(
+fn assert_split_transformed_arrays_from_sorted_padded_array_with_hint<T, S, let N: u32, ENV>(
     sorted_padded_array: ClaimedLengthArray<T, N>,
     transformed_array_lt: [S; N],
     transformed_array_gte: [S; N],
     split_counter: u32,
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
     num_padded_lt: u32,
     first_after_split_index: u32,
     first_padded_index: u32,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/accumulated_data/assert_transformed_array.nr
@@ -17,10 +17,10 @@ use types::{traits::Empty, utils::arrays::ClaimedLengthArray};
 /// - This function also checks the transformation of the items beyond `original_array.length`. The caller should ensure
 ///   that the array is dense trimmed if this is desired.
 /// - This function does not mutate the input arrays; it only validates correctness.
-pub fn assert_transformed_array<T, S, let N: u32, Env>(
+pub fn assert_transformed_array<T, S, let N: u32, ENV>(
     original_array: ClaimedLengthArray<T, N>,
     transformed_array: [S; N],
-    assert_transformed: fn[Env](T, S) -> (),
+    assert_transformed: fn[ENV](T, S) -> (),
 )
 where
     S: Empty,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_composer.nr
@@ -39,9 +39,9 @@ use dep::types::{
     utils::arrays::ClaimedLengthArray,
 };
 
-unconstrained fn transform_array<T, let N: u32, Env>(
+unconstrained fn transform_array<T, let N: u32, ENV>(
     array: ClaimedLengthArray<T, N>,
-    f: unconstrained fn[Env]([T; N]) -> [T; N],
+    f: unconstrained fn[ENV]([T; N]) -> [T; N],
 ) -> ClaimedLengthArray<T, N>
 where
     T: Ordered + Empty,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_hints.nr
@@ -3,12 +3,12 @@ use super::{
     validate_settled_read_requests::SettledReadHint,
 };
 
-pub struct ReadRequestHints<let ReadRequestLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> {
+pub struct ReadRequestHints<let ReadRequestLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> {
     // Each item in this array of actions corresponds to an item in the previous kernel's note_hashes (or nullifiers) read_requests array.
     // Each item hints at whether the corresponding read request should be skipped (ignored by this circuit and propagated to a later one);
     // or processed as a "pending" read (a read of a note/nullifier that was emitted by another fn of this same tx); or processed as a
     // "settled" read (a read from a state tree of a note/nullifier from some earlier tx).
     pub read_request_actions: [ReadRequestAction; ReadRequestLen],
     pub pending_read_hints: [PendingReadHint; PendingReadHintsLen],
-    pub settled_read_hints: [SettledReadHint<TreeHeight, SettledReadLeafPreimage>; SettledReadHintsLen],
+    pub settled_read_hints: [SettledReadHint<TreeHeight, SETTLED_READ_LEAF_PREIMAGE>; SettledReadHintsLen],
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/read_request_validator.nr
@@ -11,18 +11,18 @@ use dep::types::{
     utils::arrays::ClaimedLengthArray,
 };
 
-pub struct ReadRequestValidator<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> {
+pub struct ReadRequestValidator<let ReadRequestLen: u32, VALUE, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> {
     pub read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    pub pending_values: ClaimedLengthArray<Scoped<Counted<Value>>, PendingValueLen>,
+    pub pending_values: ClaimedLengthArray<Scoped<Counted<VALUE>>, PendingValueLen>,
     pub tree_root: Field,
     pub propagated_read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    pub hints: ReadRequestHints<ReadRequestLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SettledReadLeafPreimage>,
+    pub hints: ReadRequestHints<ReadRequestLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SETTLED_READ_LEAF_PREIMAGE>,
 }
 
-impl<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> ReadRequestValidator<ReadRequestLen, Value, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SettledReadLeafPreimage>
+impl<let ReadRequestLen: u32, VALUE, let PendingValueLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> ReadRequestValidator<ReadRequestLen, VALUE, PendingValueLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SETTLED_READ_LEAF_PREIMAGE>
 where
-    Value: Readable,
-    SettledReadLeafPreimage: LeafPreimage + Readable,
+    VALUE: Readable,
+    SETTLED_READ_LEAF_PREIMAGE: LeafPreimage + Readable,
 {
     // The `...Len` generic names passed through this circuit (see main.nr) are used to dictate array lengths.
     // But sometimes we want to compile variants of the reset circuit with some of these arrays having zero

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/read_request_hints_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/tests/read_request_hints_builder.nr
@@ -5,15 +5,15 @@ use crate::reset::read_request::{
 };
 use dep::types::{merkle_tree::MembershipWitness, traits::Empty};
 
-pub struct ReadRequestHintsBuilder<let ReadRequestLen: u32, let PendingHintsLen: u32, let SettledHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> {
+pub struct ReadRequestHintsBuilder<let ReadRequestLen: u32, let PendingHintsLen: u32, let SettledHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> {
     pub read_request_actions: [ReadRequestAction; ReadRequestLen],
     pub pending_read_hints: BoundedVec<PendingReadHint, PendingHintsLen>,
-    pub settled_read_hints: BoundedVec<SettledReadHint<TreeHeight, SettledReadLeafPreimage>, SettledHintsLen>,
+    pub settled_read_hints: BoundedVec<SettledReadHint<TreeHeight, SETTLED_READ_LEAF_PREIMAGE>, SettledHintsLen>,
 }
 
-impl<let ReadRequestLen: u32, let PendingHintsLen: u32, let SettledHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage> ReadRequestHintsBuilder<ReadRequestLen, PendingHintsLen, SettledHintsLen, TreeHeight, SettledReadLeafPreimage>
+impl<let ReadRequestLen: u32, let PendingHintsLen: u32, let SettledHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> ReadRequestHintsBuilder<ReadRequestLen, PendingHintsLen, SettledHintsLen, TreeHeight, SETTLED_READ_LEAF_PREIMAGE>
 where
-    SettledReadLeafPreimage: Empty,
+    SETTLED_READ_LEAF_PREIMAGE: Empty,
 {
     pub fn new() -> Self {
         ReadRequestHintsBuilder {
@@ -40,7 +40,7 @@ where
         &mut self,
         read_request_index: u32,
         membership_witness: MembershipWitness<TreeHeight>,
-        leaf_preimage: SettledReadLeafPreimage,
+        leaf_preimage: SETTLED_READ_LEAF_PREIMAGE,
     ) {
         let hint_index = self.settled_read_hints.len();
         let hint = SettledReadHint { read_request_index, membership_witness, leaf_preimage };
@@ -50,7 +50,7 @@ where
 
     pub fn to_hints(
         self,
-    ) -> ReadRequestHints<ReadRequestLen, PendingHintsLen, SettledHintsLen, TreeHeight, SettledReadLeafPreimage> {
+    ) -> ReadRequestHints<ReadRequestLen, PendingHintsLen, SettledHintsLen, TreeHeight, SETTLED_READ_LEAF_PREIMAGE> {
         ReadRequestHints {
             read_request_actions: self.read_request_actions,
             pending_read_hints: self.pending_read_hints.storage(),

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_pending_read_requests.nr
@@ -34,13 +34,13 @@ impl PendingReadHint {
 /// More info here:
 /// - https://discourse.aztec.network/t/to-read-or-not-to-read/178
 /// - https://discourse.aztec.network/t/spending-notes-which-havent-yet-been-inserted/180
-pub fn validate_pending_read_requests<let ReadRequestLen: u32, Value, let PendingValueLen: u32, let PendingReadHintsLen: u32>(
+pub fn validate_pending_read_requests<let ReadRequestLen: u32, VALUE, let PendingValueLen: u32, let PendingReadHintsLen: u32>(
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    pending_values: ClaimedLengthArray<Scoped<Counted<Value>>, PendingValueLen>, // previous_kernel.end.[note_hashes|nullifiers]
+    pending_values: ClaimedLengthArray<Scoped<Counted<VALUE>>, PendingValueLen>, // previous_kernel.end.[note_hashes|nullifiers]
     pending_read_hints: [PendingReadHint; PendingReadHintsLen],
 )
 where
-    Value: Readable,
+    VALUE: Readable,
 {
     for hint in pending_read_hints {
         let read_request_index = hint.read_request_index;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_propagated_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_propagated_read_requests.nr
@@ -1,10 +1,10 @@
 use super::{read_request_action::ReadRequestActions, read_request_hints::ReadRequestHints};
 use dep::types::{side_effect::{Counted, Scoped}, utils::arrays::ClaimedLengthArray};
 
-pub fn validate_propagated_read_requests<let ReadRequestLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage>(
+pub fn validate_propagated_read_requests<let ReadRequestLen: u32, let PendingReadHintsLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE>(
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
     propagated_read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    hints: ReadRequestHints<ReadRequestLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SettledReadLeafPreimage>,
+    hints: ReadRequestHints<ReadRequestLen, PendingReadHintsLen, SettledReadHintsLen, TreeHeight, SETTLED_READ_LEAF_PREIMAGE>,
 ) {
     let mut num_propagated = 0;
     let mut within_length = true;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/read_request/validate_settled_read_requests.nr
@@ -5,21 +5,21 @@ use dep::types::{
     utils::arrays::ClaimedLengthArray,
 };
 
-pub struct SettledReadHint<let TreeHeight: u32, SettledReadLeafPreimage> {
+pub struct SettledReadHint<let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> {
     pub read_request_index: u32,
     pub membership_witness: MembershipWitness<TreeHeight>,
-    pub leaf_preimage: SettledReadLeafPreimage,
+    pub leaf_preimage: SETTLED_READ_LEAF_PREIMAGE,
 }
 
-impl<let TreeHeight: u32, SettledReadLeafPreimage> SettledReadHint<TreeHeight, SettledReadLeafPreimage>
+impl<let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE> SettledReadHint<TreeHeight, SETTLED_READ_LEAF_PREIMAGE>
 where
-    SettledReadLeafPreimage: Empty,
+    SETTLED_READ_LEAF_PREIMAGE: Empty,
 {
     pub fn skip(read_request_len: u32) -> Self {
         Self {
             read_request_index: read_request_len,
             membership_witness: MembershipWitness::empty(),
-            leaf_preimage: SettledReadLeafPreimage::empty(),
+            leaf_preimage: SETTLED_READ_LEAF_PREIMAGE::empty(),
         }
     }
 }
@@ -37,13 +37,13 @@ where
 ///    - The membership witness must prove that the leaf exists in the tree with the given root.
 /// 2. If a hint is inactive (its `read_request_index` is ` ReadRequestLen`):
 ///    - It is ignored (no validation performed).
-pub fn validate_settled_read_requests<let ReadRequestLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SettledReadLeafPreimage>(
+pub fn validate_settled_read_requests<let ReadRequestLen: u32, let SettledReadHintsLen: u32, let TreeHeight: u32, SETTLED_READ_LEAF_PREIMAGE>(
     read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, ReadRequestLen>,
-    settled_read_hints: [SettledReadHint<TreeHeight, SettledReadLeafPreimage>; SettledReadHintsLen],
+    settled_read_hints: [SettledReadHint<TreeHeight, SETTLED_READ_LEAF_PREIMAGE>; SettledReadHintsLen],
     tree_root: Field,
 )
 where
-    SettledReadLeafPreimage: LeafPreimage + Readable,
+    SETTLED_READ_LEAF_PREIMAGE: LeafPreimage + Readable,
 {
     for hint in settled_read_hints {
         let read_request_index = hint.read_request_index;

--- a/noir-projects/noir-protocol-circuits/crates/serde/src/type_impls.nr
+++ b/noir-projects/noir-protocol-circuits/crates/serde/src/type_impls.nr
@@ -648,7 +648,7 @@ where
 }
 
 // Create a slice of the given length with each element made from `f(i)` where `i` is the current index
-comptime fn make_slice<Env, T>(length: u32, f: fn[Env](u32) -> T) -> [T] {
+comptime fn make_slice<ENV, T>(length: u32, f: fn[ENV](u32) -> T) -> [T] {
     let mut slice = @[];
     for i in 0..length {
         slice = slice.push_back(f(i));

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
@@ -16,18 +16,18 @@ pub use low_leaf::is_valid_low_leaf;
 
 /// Batch insert values into the indexed tree by creating a subtree of the values and inserting the subtree root.
 /// This function does not allow updating the values of existing leaves.
-pub fn batch_insert_no_update<Value, Leaf, let TreeHeight: u32, let SubtreeWidth: u32, let SubtreeHeight: u32>(
+pub fn batch_insert_no_update<VALUE, LEAF, let TreeHeight: u32, let SubtreeWidth: u32, let SubtreeHeight: u32>(
     start_snapshot: AppendOnlyTreeSnapshot,
-    values_to_insert: [Value; SubtreeWidth],
-    sorted_values: [Value; SubtreeWidth],
+    values_to_insert: [VALUE; SubtreeWidth],
+    sorted_values: [VALUE; SubtreeWidth],
     sorted_values_indexes: [u32; SubtreeWidth],
-    low_leaf_preimages: [Leaf; SubtreeWidth],
+    low_leaf_preimages: [LEAF; SubtreeWidth],
     low_leaf_membership_witnesses: [MembershipWitness<TreeHeight>; SubtreeWidth],
     new_subtree_sibling_path: [Field; TreeHeight - SubtreeHeight],
 ) -> AppendOnlyTreeSnapshot
 where
-    Value: IndexedTreeLeafValue,
-    Leaf: IndexedTreeLeafPreimage<Value>,
+    VALUE: IndexedTreeLeafValue,
+    LEAF: IndexedTreeLeafPreimage<VALUE>,
 {
     // Sanity check: ensure this function is called with correct generics.
     std::static_assert(
@@ -75,7 +75,7 @@ where
             let value_index = sorted_values_indexes[i];
 
             // Point the value to the low leaf's next leaf and stage it for appending later.
-            leaves_to_append[value_index] = Leaf::build_insertion_leaf(value, low_leaf_preimage);
+            leaves_to_append[value_index] = LEAF::build_insertion_leaf(value, low_leaf_preimage);
 
             // Point the low leaf to the new leaf and update it in the tree.
             let new_leaf_insertion_index = start_insertion_index + value_index as Field;
@@ -90,7 +90,7 @@ where
     }
 
     // Compute the root of the subtree form by the new leaves to be appended.
-    let subtree_root = compute_tree_root(leaves_to_append.map(|leaf: Leaf| leaf.as_leaf()));
+    let subtree_root = compute_tree_root(leaves_to_append.map(|leaf: LEAF| leaf.as_leaf()));
     // Since low leaves were updated, the tree root has changed.
     // Insert the new subtree root against the updated tree root.
     let current_snapshot = AppendOnlyTreeSnapshot {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree/low_leaf.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree/low_leaf.nr
@@ -6,12 +6,12 @@ use crate::merkle_tree::leaf_preimage::IndexedTreeLeafPreimage;
 /// - is_valid: `true` if the key is in range of the low leaf, `false` otherwise.
 /// - is_greater_than_low: `true` if the key is greater than the low leaf's key, `false` otherwise.
 /// - is_less_than_next: `true` if the key is less than the low leaf's next key, `false` otherwise.
-pub fn is_valid_low_leaf<LeafPreimage, Value>(
+pub fn is_valid_low_leaf<LEAF_PREIMAGE, VALUE>(
     key: Field,
-    low_leaf_preimage: LeafPreimage,
+    low_leaf_preimage: LEAF_PREIMAGE,
 ) -> (bool, bool, bool)
 where
-    LeafPreimage: IndexedTreeLeafPreimage<Value>,
+    LEAF_PREIMAGE: IndexedTreeLeafPreimage<VALUE>,
 {
     let low_key = low_leaf_preimage.get_key();
     let next_key = low_leaf_preimage.get_next_key();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/leaf_preimage.nr
@@ -5,16 +5,16 @@ pub trait LeafPreimage {
     fn as_leaf(self) -> Field;
 }
 
-pub trait IndexedTreeLeafPreimage<Value>: Empty + LeafPreimage {
+pub trait IndexedTreeLeafPreimage<VALUE>: Empty + LeafPreimage {
     fn get_next_key(self) -> Field;
 
     fn points_to_infinity(self) -> bool;
 
     fn update_pointers(self, next_key: Field, next_index: Field) -> Self;
 
-    fn update_value(self, value: Value) -> Self;
+    fn update_value(self, value: VALUE) -> Self;
 
-    fn build_insertion_leaf(value: Value, low_leaf: Self) -> Self;
+    fn build_insertion_leaf(value: VALUE, low_leaf: Self) -> Self;
 }
 
 pub trait IndexedTreeLeafValue: Empty {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -82,7 +82,7 @@ where
 
 // Returns the number of consecutive elements at the start of the array for which the predicate returns false.
 // This function ensures that any element after the first matching element (predicate returns true) also matches the predicate.
-pub fn array_length_until<T, let N: u32, Env>(array: [T; N], predicate: fn[Env](T) -> bool) -> u32 {
+pub fn array_length_until<T, let N: u32, ENV>(array: [T; N], predicate: fn[ENV](T) -> bool) -> u32 {
     let mut length = 0;
     let mut stop = false;
     for i in 0..N {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/claimed_length_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/claimed_length_array.nr
@@ -63,7 +63,7 @@ where
         popped_item
     }
 
-    pub fn for_each<Env>(self, f: fn[Env](T) -> ()) {
+    pub fn for_each<ENV>(self, f: fn[ENV](T) -> ()) {
         let mut within_range = true;
         for i in 0..N {
             within_range &= i != self.length;
@@ -76,7 +76,7 @@ where
 
     // E.g.
     // dest.for_each_i(|source_item, i| { assert_eq(dest.array[i], source_item, "bad copy"); })
-    pub fn for_each_i<Env>(self, f: fn[Env](T, u32) -> ()) {
+    pub fn for_each_i<ENV>(self, f: fn[ENV](T, u32) -> ()) {
         let mut within_range = true;
         for i in 0..N {
             within_range &= i != self.length;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/find_index.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/find_index.nr
@@ -1,8 +1,8 @@
 /// Helper function to find the index of the first element in an array that satisfies a given predicate.
 /// If the element is not found, the function returns the length of the array `N`
-pub unconstrained fn find_first_index<T, let N: u32, Env>(
+pub unconstrained fn find_first_index<T, let N: u32, ENV>(
     array: [T; N],
-    find: fn[Env](T) -> bool,
+    find: fn[ENV](T) -> bool,
 ) -> u32 {
     let mut index = N;
     for i in 0..N {
@@ -16,9 +16,9 @@ pub unconstrained fn find_first_index<T, let N: u32, Env>(
 
 /// Helper function to find the index of the last element in an array that satisfies a given predicate.
 /// If the element is not found, the function returns the length of the array `N`
-pub unconstrained fn find_last_index<T, let N: u32, Env>(
+pub unconstrained fn find_last_index<T, let N: u32, ENV>(
     array: [T; N],
-    find: fn[Env](T) -> bool,
+    find: fn[ENV](T) -> bool,
 ) -> u32 {
     let mut index = N;
     for i in 0..N {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuples.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuples.nr
@@ -14,9 +14,9 @@ where
 
 /// Sorts the input `array`, but also outputs an `original_index` field for each sorted
 /// item, so that you know where it came from.
-pub unconstrained fn get_sorted_tuples<T, let N: u32, Env>(
+pub unconstrained fn get_sorted_tuples<T, let N: u32, ENV>(
     array: [T; N],
-    ordering: fn[Env](T, T) -> bool,
+    ordering: fn[ENV](T, T) -> bool,
 ) -> [SortedTuple<T>; N]
 where
     T: Eq,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/for_loop.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/for_loop.nr
@@ -28,11 +28,11 @@ pub global for_loop_no_op: fn(u32) -> () = |_i: u32| ();
  * Lambda functions of the form `|i| { my_array[i].assert_empty() }` (for example) can be specified.
  * 
  */
-pub fn for_i_in_0_<Env1, Env2>(
+pub fn for_i_in_0_<ENV1, ENV2>(
     max: u32,
     MAX: u32,
-    f_within: fn[Env1](u32) -> (),
-    f_after_max: fn[Env2](u32) -> (),
+    f_within: fn[ENV1](u32) -> (),
+    f_after_max: fn[ENV2](u32) -> (),
     // If the dev knows what they're doing, they can choose to set the below bool
     // to `false` for a small constraint reduction.
     assert_max_lte_MAX: bool,
@@ -75,10 +75,10 @@ pub fn for_i_in_0_<Env1, Env2>(
  * Strangely, this sometimes results in many more constraints than `for_i_in_0_` with
  * the `for_loop_no_op` function. But other times, this one wins. I am confused.
  */
-pub fn for_i_only_in_0_<Env>(
+pub fn for_i_only_in_0_<ENV>(
     max: u32,
     MAX: u32,
-    f_within: fn[Env](u32) -> (),
+    f_within: fn[ENV](u32) -> (),
     // If the dev knows what they're doing, they can choose to set the below bool
     // to `false` for a small constraint reduction.
     assert_max_lte_MAX: bool,
@@ -125,14 +125,14 @@ pub fn for_i_only_in_0_<Env>(
  * Lambda functions of the form `|i| { my_array[i].assert_empty() }` (for example) can be specified.
  * 
  */
-pub fn for_i_in_<Env1, Env2, Env3>(
+pub fn for_i_in_<ENV1, ENV2, ENV3>(
     min: u32,
     max: u32,
     MIN: u32,
     MAX: u32,
-    f_before_min: fn[Env1](u32) -> (),
-    f_within: fn[Env2](u32) -> (),
-    f_after_max: fn[Env3](u32) -> (),
+    f_before_min: fn[ENV1](u32) -> (),
+    f_within: fn[ENV2](u32) -> (),
+    f_after_max: fn[ENV3](u32) -> (),
     // If the dev knows what they're doing, they can choose to set either or both of the below bools
     // to `false` for a small constraint reduction.
     assert_min_lte_max: bool,
@@ -188,12 +188,12 @@ pub fn for_i_in_<Env1, Env2, Env3>(
  * @param f_within: Lambda functions of the form `|i| { my_array[i].assert_empty() }` (for example) can be specified.
  * 
  */
-pub fn for_i_only_in_<Env>(
+pub fn for_i_only_in_<ENV>(
     min: u32,
     max: u32,
     MIN: u32,
     MAX: u32,
-    f_within: fn[Env](u32) -> (),
+    f_within: fn[ENV](u32) -> (),
     // If the dev knows what they're doing, they can choose to set either or both of the below bools
     // to `false` for a small constraint reduction.
     assert_min_lte_max: bool,


### PR DESCRIPTION
We are now making a big refactor to aztec.nr code. We will be using ALL_CAPS for generics so that it's easier to tell generic types from concrete types apart