### PR TITLE
feat(avm): use only witness rows in check-circuit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -38,11 +38,11 @@ AvmProvingHelper::Proof AvmProvingHelper::prove(tracegen::TraceContainer&& trace
 bool AvmProvingHelper::check_circuit(tracegen::TraceContainer&& trace)
 {
     // The proof is done over the whole circuit (2^21 rows).
-    // However, for check-circuit purposes we run only over the trace rows
+    // However, for check-circuit purposes we run only over the witness rows
     // PLUS one extra row to catch any possible errors in the empty remainder
     // of the circuit.
-    const size_t num_rows = trace.get_num_rows_without_clk() + 1;
     const bool skippable_enabled = (getenv("AVM_DISABLE_SKIPPABLE") == nullptr);
+    const size_t num_rows = skippable_enabled ? trace.get_num_witness_rows() + 1 : trace.get_num_rows();
     vinfo("Running check ",
           skippable_enabled ? "(with skippable)" : "(without skippable)",
           " circuit over ",

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -13,7 +13,6 @@ namespace {
 
 // We need a zero value to return (a reference to) when a value is not found.
 static const FF zero = FF::zero();
-constexpr auto clk_column = Column::precomputed_idx;
 
 } // namespace
 
@@ -83,20 +82,22 @@ uint32_t TraceContainer::get_column_rows(Column col) const
     return static_cast<uint32_t>(column_data.max_row_number + 1);
 }
 
-uint32_t TraceContainer::get_num_rows_without_clk() const
+uint32_t TraceContainer::get_num_witness_rows() const
 {
     uint32_t max_rows = 0;
-    for (size_t col = 0; col < num_columns(); ++col) {
-        if (static_cast<Column>(col) != clk_column) {
-            max_rows = std::max(max_rows, get_column_rows(static_cast<Column>(col)));
-        }
+    for (size_t col = WITNESS_START_IDX; col < WITNESS_END_IDX; ++col) {
+        max_rows = std::max(max_rows, get_column_rows(static_cast<Column>(col)));
     }
     return max_rows;
 }
 
 uint32_t TraceContainer::get_num_rows() const
 {
-    return std::max(get_column_rows(clk_column), get_num_rows_without_clk());
+    uint32_t max_rows = 0;
+    for (size_t col = 0; col < num_columns(); ++col) {
+        max_rows = std::max(max_rows, get_column_rows(static_cast<Column>(col)));
+    }
+    return max_rows;
 }
 
 void TraceContainer::visit_column(Column col, const std::function<void(uint32_t, const FF&)>& visitor) const

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
@@ -48,8 +48,8 @@ class TraceContainer {
     uint32_t get_column_rows(Column col) const;
     // Maximum number of rows in any column.
     uint32_t get_num_rows() const;
-    // Maximum number of rows in any column (ignoring clk which is always 2^21).
-    uint32_t get_num_rows_without_clk() const;
+    // Maximum number of rows in any witness column (no precomputed columns).
+    uint32_t get_num_witness_rows() const;
     // Number of columns (without shifts).
     static constexpr size_t num_columns() { return NUM_COLUMNS_WITHOUT_SHIFTS; }
 


### PR DESCRIPTION
I was inspired by [this sumcheck code](https://github.com/AztecProtocol/aztec-packages/blob/next/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp#L114), which computes the round size as the size of the maximum _witness_ polynomial. This ignores the precomputed polynomials for sumcheck. We can do the same for check circuit.

Note that **lookups** to precomputed WILL be checked, because the inverse will be set in a witness column.

----

BEFORE (bulk)
```
proving/check_circuit_ms: 1757
```
AFTER (bulk)
```
proving/check_circuit_ms: 1602
```
The difference should be bigger for shorter traces.