### PR TITLE
fix: things

### DIFF
--- a/ci3/dashboard/Dockerfile
+++ b/ci3/dashboard/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12
+
+# Install aws cli.
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
+    rm -rf aws awscliv2.zip
+
+# Install redis cli.
+RUN apt update && apt install -y \
+      jq \
+      netcat-openbsd \
+      redis-tools \
+      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+RUN git config --global --add safe.directory /aztec-packages
+COPY . .
+EXPOSE 8080
+CMD ["gunicorn", "-w", "100", "-b", "0.0.0.0:8080", "rk:app"]

--- a/ci3/run_compose_test
+++ b/ci3/run_compose_test
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+set -x
+set +e
 
 name=$1
 exit_container=$2
@@ -15,7 +17,6 @@ cd "$compose_file_path"
 docker compose $name_arg down --timeout 0 &> /dev/null
 
 function cleanup {
-  set +e
   # echo compose cleanup: $name_arg >/dev/tty
   # If the container hasn't completed, wait up to 15 seconds for it to start.
   # Bit of kludge, but otherwise the "down" could happen before the "up" has started.

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -7,6 +7,7 @@ default_avm_inputs_dump_dir=dumped-avm-circuit-inputs
 
 function build {
   cache_load_image consensys/web3signer:25.11.0
+  cache_load_image postgres:16-alpine
 }
 
 # Helper function to extract test names from a test file

--- a/yarn-project/end-to-end/scripts/ha/docker-compose.yml
+++ b/yarn-project/end-to-end/scripts/ha/docker-compose.yml
@@ -9,10 +9,8 @@ services:
       POSTGRES_DB: aztec_ha_test
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aztec -d aztec_ha_test"]
+      test: ['CMD-SHELL', 'pg_isready -U aztec -d aztec_ha_test']
       interval: 5s
       timeout: 5s
       retries: 5
@@ -30,16 +28,12 @@ services:
       - --chain-id=31337
     volumes:
       - web3signer_keys:/keys
-    ports:
-      - "9000:9000"
 
   anvil:
     image: aztecprotocol/build:3.0
     cpus: 1
     mem_limit: 2G
-    entrypoint: "anvil --silent -p 8545 --host 0.0.0.0 --chain-id 31337"
-    ports:
-      - "8545:8545"
+    entrypoint: 'anvil --silent -p 8545 --host 0.0.0.0 --chain-id 31337'
 
   end-to-end:
     image: aztecprotocol/build:3.0


### PR DESCRIPTION
* commit the dashboard dockerfile to repo.
* ha compose test was exposing ports on the host for some reason. breaks isolation.
* run_compose_test never set `code` due to set -e. might explain oddities.