### PR TITLE
chore: bump bignum and bigcurve versions

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,6 +5,6 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
-bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.0" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.13.0" }
 types = { path = "../types" }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/Nargo.toml
@@ -5,7 +5,7 @@ authors = [""]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.2" }
-bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.12.0" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.0" }
+bigcurve = { git = "https://github.com/noir-lang/noir_bigcurve", tag = "v0.13.0" }
 types = { path = "../types" }
 blob = { path = "../blob" }


### PR DESCRIPTION
bumps the library versions