### PR TITLE
chore: deflake NoteService

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -361,11 +361,6 @@ tests:
     owners:
       - *lasse
 
-  - regex: "yarn-project/scripts/run_test.sh pxe/src/notes/note_service.test.ts"
-    error_regex: "should remove notes that have been nullified"
-    owners:
-      - *martin
-
   - regex: "yarn-project/end-to-end/scripts/run_test.sh simple src/e2e_fees/gas_estimation.test.ts"
     error_regex: "timeout: sending signal TERM to command 'bash'"
     owners:

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -400,6 +400,18 @@ describe('NoteStore', () => {
       expect(nullifierSet(notes)).toEqual(nullifierSet([note2]));
     });
 
+    it('throws when nullifier has block number 0', async () => {
+      const nullifierAtBlock0 = {
+        data: note1.siloedNullifier,
+        l2BlockNumber: BlockNumber(0),
+        l2BlockHash: BlockHash.random(),
+      };
+
+      await expect(noteStore.applyNullifiers([nullifierAtBlock0], 'test')).rejects.toThrow(
+        'applyNullifiers: nullifiers cannot have been emitted at block 0',
+      );
+    });
+
     it('throws error when nullifier is not found', async () => {
       const fakeNullifier = {
         data: Fr.random(),

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -220,6 +220,10 @@ export class NoteStore implements StagedStore {
       return Promise.resolve([]);
     }
 
+    if (nullifiers.some(n => n.l2BlockNumber === 0)) {
+      return Promise.reject(new Error('applyNullifiers: nullifiers cannot have been emitted at block 0'));
+    }
+
     return this.#withJobLock(jobId, () =>
       this.#store.transactionAsync(async () => {
         const notesToNullify = await Promise.all(

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -17,7 +17,7 @@ export type DataInBlock<T> = {
 
 export function randomInBlock(): InBlock {
   return {
-    l2BlockNumber: BlockNumber(Math.floor(Math.random() * 1000)),
+    l2BlockNumber: BlockNumber(Math.floor(Math.random() * 1000) + 1),
     l2BlockHash: BlockHash.random(),
   };
 }


### PR DESCRIPTION
Claude can explain the diagnostics much more succinctly than myself:

> 1. `randomDataInBlock(123n)` generates a random `l2BlockNumber` via `Math.floor(Math.random() * 1000)` - which can be 0
> 2. When `markAsNullified(0)` is called, `_nullifiedAt = 0`
> 3. In-memory, `isNullified()` returns true `(since 0 !== undefined)` - so the first assertion passes
> 4. During commit, toBuffer() serializes `_nullifiedAt ?? 0` which is 0
> 5. After commit, `fromBuffer` reads 0 and treats it as `undefined` (not nullified) because of this line:
>   `const nullifiedAt = nullifiedAtRaw === 0 ? undefined : (nullifiedAtRaw as BlockNumber);`
> 6. The note is now active again in the fresh-job context - assertion fails
> 
> The root cause is in `StoredNote`: block number 0 is used as a sentinel for "not nullified", so nullification at block 0 is silently
> dropped during serialization round-trip. The probability is ~1/1000 per test run (`Math.floor(Math.random() * 1000) ` producing 0).

Fixed by:
1. Adding a defensive check on `applyNullifiers` (it cannot be called with Block=0)
2. Patching the `randomDataInBlock` function so it can't return Block=0 (there's no point for it to return 0, if you want that case in a test you should explicitly write it).