### PR TITLE
chore: attempt to fix kv-store browser tests flakes by disabling browser gpu initialization

### DIFF
--- a/yarn-project/kv-store/vitest.config.ts
+++ b/yarn-project/kv-store/vitest.config.ts
@@ -58,7 +58,14 @@ export default defineConfig({
         {
           browser: 'chromium',
           launch: {
-            args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+            args: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
+              '--disable-dev-shm-usage',
+              '--disable-gpu',
+              '--disable-software-rasterizer',
+            ],
+            timeout: 30_000,
           },
           context: {
             actionTimeout: 10_000,


### PR DESCRIPTION
as title