### PR TITLE
fix: `DelayedPublicMutable` not relying on the guarantee of increasing timestamps

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable.nr
@@ -174,24 +174,25 @@ where
         // However, since this value might change, we must constrain the maximum transaction timestamp as this proof
         // will only be valid for the time we can ensure the value will not change, which will depend on the current
         // delay and any scheduled delay changes.
-        let (value_change, delay_change, anchor_timestamp) = self.anchor_read_from_public_storage();
+        let (value_change, delay_change, anchor_block_timestamp) = self.anchor_read_from_public_storage();
 
         // We use the effective minimum delay as opposed to the current delay at the anchor block's timestamp as this
         // one also takes into consideration any scheduled delay changes. For example, consider a scenario in which at
         // timestamp `x` the current delay was 86400 seconds (1 day). We may naively think that the earliest we could
-        // change the value would be at timestamp `x + 86400` by scheduling immediately after the anchor block's
-        // timestamp, i.e. at timestamp `x + 1`. But if there was a delay change scheduled for timestamp `y` to reduce
-        // the delay to 43200 seconds (12 hours), then if a value change was scheduled at timestamp `y` it would go
-        // into effect at timestamp `y + 43200`, which is earlier than what we'd expect if we only considered the
+        // change the value would be at timestamp `x + 86400` by scheduling immediately in the block following the
+        // anchor block - since blocks within the same checkpoint can share timestamps, the earliest scheduling can
+        // happen at the anchor block's timestamp `x`.  But if there was a delay change scheduled for timestamp `y` to
+        // reduce the delay to 43200 seconds (12 hours), then if a value change was scheduled at timestamp `y` it would
+        // go into effect at timestamp `y + 43200`, which is earlier than what we'd expect if we only considered the
         // current delay.
-        let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(anchor_timestamp);
-        let time_horizon = value_change.get_time_horizon(anchor_timestamp, effective_minimum_delay);
+        let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+        let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, effective_minimum_delay);
 
         // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
         // historical public value matches the current one, since it can only change after the horizon.
         self.context.set_expiration_timestamp(time_horizon);
 
-        value_change.get_current_at(anchor_timestamp)
+        value_change.get_current_at(anchor_block_timestamp)
     }
 
     fn anchor_read_from_public_storage(self) -> (ScheduledValueChange<T>, ScheduledDelayChange<InitialDelay>, u64)
@@ -201,12 +202,12 @@ where
         let header = self.context.get_anchor_block_header();
         let address = self.context.this_address();
 
-        let anchor_timestamp = header.global_variables.timestamp;
+        let anchor_block_timestamp = header.global_variables.timestamp;
 
         let values: DelayedPublicMutableValues<T, InitialDelay> =
             WithHash::historical_public_storage_read(header, address, self.storage_slot);
 
-        (values.svc, values.sdc, anchor_timestamp)
+        (values.svc, values.sdc, anchor_block_timestamp)
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/delayed_public_mutable/test.nr
@@ -230,7 +230,7 @@ unconstrained fn get_current_value_in_private_initial() {
         assert_eq(state_var.get_current_value(), zeroed());
         assert_eq(
             context.expiration_timestamp,
-            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY,
+            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY - 1,
         );
     });
 }
@@ -305,7 +305,7 @@ unconstrained fn get_current_value_in_private_at_change() {
         assert_eq(state_var.get_current_value(), new_value);
         assert_eq(
             context.expiration_timestamp,
-            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY,
+            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY - 1,
         );
     });
 }
@@ -333,7 +333,7 @@ unconstrained fn get_current_value_in_private_after_change() {
         assert_eq(state_var.get_current_value(), new_value);
         assert_eq(
             context.expiration_timestamp,
-            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY,
+            context.get_anchor_block_header().global_variables.timestamp + TEST_INITIAL_DELAY - 1,
         );
     });
 }
@@ -351,17 +351,17 @@ unconstrained fn get_current_value_in_private_with_non_initial_delay() {
         (state_var.get_scheduled_value(), state_var.get_scheduled_delay())
     });
 
-    let historical_timestamp = std::cmp::max(value_timestamp_of_change, delay_timestamp_of_change);
-    env.mine_block_at(historical_timestamp);
+    let anchor_block_timestamp = std::cmp::max(value_timestamp_of_change, delay_timestamp_of_change);
+    env.mine_block_at(anchor_block_timestamp);
 
     env.private_context(|context| {
         // Make sure we're at a block with the expected timestamp
-        assert_eq(context.get_anchor_block_header().global_variables.timestamp, historical_timestamp);
+        assert_eq(context.get_anchor_block_header().global_variables.timestamp, anchor_block_timestamp);
 
         let state_var = in_private(context);
 
         assert_eq(state_var.get_current_value(), new_value);
-        assert_eq(context.expiration_timestamp, historical_timestamp + new_delay);
+        assert_eq(context.expiration_timestamp, anchor_block_timestamp + new_delay - 1);
     });
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_output_validator_builder/validate_aggregated_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_output_validator_builder/validate_aggregated_values.nr
@@ -132,8 +132,13 @@ fn validate_aggregated_values_expiration_timestamp_from_both_pick_larger_private
 fn validate_aggregated_values_expiration_timestamp_pick_for_contract_updates_succeeds() {
     let mut builder = PrivateKernelCircuitOutputValidatorBuilder::new();
 
-    let expiration_timestamp_for_contract_updates =
-        builder.private_call.anchor_block_header.global_variables.timestamp + DEFAULT_UPDATE_DELAY;
+    let expiration_timestamp_for_contract_updates = builder
+        .private_call
+        .anchor_block_header
+        .global_variables
+        .timestamp
+        + DEFAULT_UPDATE_DELAY
+        - 1;
 
     builder.previous_kernel.expiration_timestamp = expiration_timestamp_for_contract_updates + 1;
     builder.private_call.expiration_timestamp = expiration_timestamp_for_contract_updates + 1;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/output_composition_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_init/output_composition_tests.nr
@@ -94,8 +94,9 @@ fn expiration_timestamp_constrained_by_contract_updates() {
 
     // Set the private call's expiration_timestamp to a large value
     // that exceeds the contract update time horizon
-    let anchor_timestamp = builder.private_call.anchor_block_header.global_variables.timestamp;
-    let contract_update_horizon = anchor_timestamp + DEFAULT_UPDATE_DELAY;
+    let anchor_block_timestamp =
+        builder.private_call.anchor_block_header.global_variables.timestamp;
+    let contract_update_horizon = anchor_block_timestamp + DEFAULT_UPDATE_DELAY - 1;
 
     // Set expiration_timestamp larger than the contract update horizon
     builder.private_call.expiration_timestamp = contract_update_horizon + 1000;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/mod.nr
@@ -11,12 +11,15 @@ pub mod with_hash;
 
 pub fn compute_delayed_public_mutable_time_horizon<T, let INITIAL_DELAY: u64>(
     delayed_public_mutable_values: DelayedPublicMutableValues<T, INITIAL_DELAY>,
-    anchor_timestamp: u64,
+    anchor_block_timestamp: u64,
 ) -> u64
 where
     T: ToField + Eq + FromField,
 {
     let effective_minimum_delay =
-        delayed_public_mutable_values.sdc.get_effective_minimum_delay_at(anchor_timestamp);
-    delayed_public_mutable_values.svc.get_time_horizon(anchor_timestamp, effective_minimum_delay)
+        delayed_public_mutable_values.sdc.get_effective_minimum_delay_at(anchor_block_timestamp);
+    delayed_public_mutable_values.svc.get_time_horizon(
+        anchor_block_timestamp,
+        effective_minimum_delay,
+    )
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change.nr
@@ -3,8 +3,8 @@ use std::cmp::min;
 
 mod test;
 
-// This data structure is used by DelayedPublicMutable to store the minimum delay with which a ScheduledValueChange object can
-// schedule a change.
+// This data structure is used by DelayedPublicMutable to store the minimum delay with which a ScheduledValueChange
+// object can schedule a change.
 // This delay is initially equal to INITIAL_DELAY, and can be safely mutated to any other value over time. This mutation
 // is performed via `schedule_change` in order to satisfy ScheduleValueChange constraints: if e.g. we allowed for the
 // delay to be decreased immediately then it'd be possible for the state variable to schedule a value change with a
@@ -29,8 +29,8 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
     /// WARNING: This function only returns a meaningful value when called in public with the current timestamp - for
     /// historical private reads use `get_effective_minimum_delay_at` instead.
     pub fn get_current(self, current_timestamp: u64) -> u64 {
-        // The post value becomes the current one at the timestamp of change, so any transaction that is included at or after
-        // the timestamp of change will use the post value.
+        // The post value becomes the current one at the timestamp of change, so any transaction that is included at or
+        // after the timestamp of change will use the post value.
         if current_timestamp < self.timestamp_of_change {
             self.pre.unwrap_or(INITIAL_DELAY)
         } else {
@@ -111,23 +111,23 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
     }
 
     /// Returns the minimum delay before a value might mutate due to a scheduled change, from the perspective of some
-    /// historical timestamp. It only returns a meaningful value when called in private with historical timestamps.
+    /// anchor block timestamp. It only returns a meaningful value when called in private with anchor block timestamps.
     /// The output of this function can be passed into `ScheduledValueChange.get_time_horizon` to properly
     /// constrain the `expiration_timestamp` when reading delayed mutable state.
-    /// This value typically equals the current delay at the timestamp following the historical one (the earliest one in
-    /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is
+    /// This value typically equals the current delay at the timestamp following the anchor block one (the earliest one
+    /// in which a value change could be scheduled), but it also considers scenarios in which a delay reduction is
     /// scheduled to happen in the near future, resulting in a way to schedule a change with an overall delay lower than
     /// the current one.
     ///
-    /// Alternative explanation: returns the maximum amount of time (from the historical timestamp) that a state read
-    /// (as at the historical timestamp) will remain valid.
+    /// Alternative explanation: returns the maximum amount of time (from the anchor block timestamp) that a state read
+    /// (as at the anchor block timestamp) will remain valid.
     /// A read might end up being valid for less time in the case where a `svc.timestamp_of_change` has already been
     /// set and if it's sooner than the output of this function. In that case, the `scheduled_value_change.nr`'s
     /// `get_time_horizon` function will realize this.
     ///
-    pub fn get_effective_minimum_delay_at(self, historical_timestamp: u64) -> u64 {
+    pub fn get_effective_minimum_delay_at(self, anchor_block_timestamp: u64) -> u64 {
         // If a change is scheduled, then the effective delay might be lower than the current one (pre). At the
-        // timestamp of change the current delay will be the scheduled one, with an overall delay from the historical
+        // timestamp of change the current delay will be the scheduled one, with an overall delay from the anchor block
         // timestamp equal to the time until the change plus the new delay. If this value is lower
         // than the current delay, then that is the effective minimum delay.
 
@@ -136,26 +136,24 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
         // `delayed_mutable` _as at the very end_ of that block.
         // Therefore the `delayed_mutable` that you will read _as at the very start of the next
         // block_ will be _the very same_ `delayed_mutable` (nothing can possibly have changed).
-        // Therefore the first opportunity to schedule a value change (from the anchor timestamp)
-        // is the first tx of that next block, which takes place at least 1 second after the
-        // anchor block.
-        // So should you choose to go ahead and schedule a value change in the first tx of that
-        // next block, it will only take effect after the "current delay" (as dictated by the
+        // Therefore the first opportunity to schedule a value change (from the anchor block timestamp)
+        // is the first tx of a subsequent block. Blocks within the same checkpoint can share
+        // timestamps, so the earliest scheduling timestamp can equal the anchor block timestamp.
+        // So should you choose to go ahead and schedule a value change in a subsequent block,
+        // it will only take effect after the "current" delay (as dictated by the
         // `delayed_mutable` of that tx, which is the same as the `delayed_mutable` as at the
-        // anchor timestamp).
+        // anchor block timestamp).
         // In all, the time between the anchor block's timestamp and the earliest-possible value
-        // timestamp_of_change, is therefore: 1 second + the "current" delay (as at the time of
-        // the anchor timestamp).
+        // timestamp_of_change, is therefore: the "current" delay (as at the time of the anchor
+        // timestamp).
         // Reads must only be valid until _just before_ the earliest-possible value change --
         // i.e. 1 second before the earliest-possible value change.
         // That is, reads are only valid for the "current" delay (as at the time of the anchor
-        // timestamp) _at most_.
-        // (I.e. the read remains valid for 1 + "current delay" - 1 = "current delay", from the
-        // anchor timestamp).
+        // block timestamp) _at most_.
         //
         //  ____________                               ____________
         // |            |                             |            |
-        // |  Block     |<--At least a 1 second gap-->|  Block     |
+        // |  Block     |<-- 0 or more seconds gap -->|  Block     |
         // |____________|                             |____________|
         //              ^                              ^
         //              |                              You can schedule a value change from here.
@@ -164,69 +162,82 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
         //    The delayed_mutable (and hence the "current" delay) as at the end of this block will
         //    be the same as at the start of the next block.
         //
-        if self.timestamp_of_change <= historical_timestamp {
+        if self.timestamp_of_change <= anchor_block_timestamp {
             //
-            //              `self.timestamp_of_change` <= `historical_timestamp`
+            //              `self.timestamp_of_change` <= `anchor_block_timestamp`
             //                    v                              v
             // ===================|==============================|=========
             // ^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             // `self.pre` is      |`self.post` takes effect from here.
             // effective before.  |
             //
-            // So in this `if` case, `self.post` is in effect at the time of the `historical_timestamp`.
+            // So in this `if` case, `self.post` is in effect at the time of the `anchor_block_timestamp`.
             //
-            // If no delay changes are scheduled (as at the time of the anchor timestamp), then the
-            // "current delay" (as at the time of the historical timestamp) is `self.post` (or the
-            // INITIAL_DELAY if never set).
-            self.post.unwrap_or(INITIAL_DELAY)
+            // If no delay changes are scheduled (as at the time of the anchor timestamp), then the "current delay" (as
+            // at the time of the anchor block timestamp) is `self.post - 1` (or the `INITIAL_DELAY - 1` if never set).
+            self.post.unwrap_or(INITIAL_DELAY) - 1
         } else {
             //
-            //          `historical_timestamp` < `self.timestamp_of_change`
+            //          `anchor_block_timestamp` < `self.timestamp_of_change`
             //                                           v
             // ===================|======================|====================================
             // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             //           `self.pre` is effective         |`self.post` takes effect from here.
             //           during this period.             |
             //
-            // So in this `else` case, `self.pre` is in effect at the time of the `historical_timestamp`.
             //
-            // If a delay change _is_ already scheduled (as at the time of the historical timestamp):
+            // So in this `else` case, `self.pre` is in effect at the time of the `anchor_block_timestamp`.
+            //
+            //
+            //
+            // If a delay change _is_ already scheduled (as at the time of the anchor block timestamp):
             //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             //                   |________________
             //                                    |
             //                                    v                          Earliest possible
-            //  `historical_           Scheduled delay change:               `svc.timestamp_of_change`
+            //  `anchor_block_          Scheduled delay change:               `svc.timestamp_of_change`
             //  timestamp`      <      `self.timestamp_of_change`            (if not already set [^1])
             //     v                              v                                    v
-            //  ===||=============================|====================================|================>
-            //     .|                             .                                    .
-            //     .|                             .                                    .
-            //     .|__ Earliest possible timestamp at which a                         .
+            //  ===|==============================|====================================|================>
+            //     |                              .                                    .
+            //     |                              .                                    .
+            //     |__ Earliest possible timestamp at which a                          .
             //     .    function could call `schedule_change` for a new                .
-            //     .    _value_ change..................................................And the earliest timestamp at
-            //     .                              .                                    .which the new value would take effect.
-            //     .[---------------`self.pre` delay-----------------------------------]
+            //     .    _value_ change.................................................| And the earliest timestamp at
+            //     .                              .                                    . which the new value would take effect,
+            //     .                              .                                    . as dictated by `self.pre`.
             //     .                              .                                    .
-            //     [******************************************************************].
-            //     [                                                                  ].
-            //     [----------------`self.pre` delay----------------------------------].
-            //     [                                                                  ].
-            //     [ If reading a _value_ at that (<--) anchor timestamp, then the    ].
-            //     [ read will remain valid for this duration, unless a shorter       ].
-            //     [ delay has been scheduled (see just below in this diagram).       ].
-            //     [ If a _deferred, longer_ delay has been scheduled, it might yet   ].
-            //     [ still be cancelled, in which case this `pre` delay would         ].
-            //     [ bite (see the `min` calc below) -- meaning reads would remain    ].
-            //     [ valid for this duration.                                         ].
-            //     [                                                                  ].
-            //     [******************************************************************].
+            //     [---------------`self.pre` delay------------------------------------]
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     .                              .                                    .
+            //     ********************************************************************.
+            //     *                                                                  *.
+            //     [----------------`self.pre - 1`------------------------------------].
+            //     *                                                                  *.
+            //     * If reading a _value_ at that (<--) anchor timestamp, then the    *.
+            //     * read will remain valid for this duration, unless a shorter       *.
+            //     * delay has been scheduled (see just below in this diagram).       *.
+            //     * See the `min` calc in the code below.                            *.
+            //     *                                                                  *.
+            //     * Future enhancement, recorded here so we don't have to            *.
+            //     * re-remember it:                                                  *.
+            //     * If a _deferred, longer_ delay has been scheduled (not yet        *.
+            //     * possible), it might yet still be cancelled, in which case this   *.
+            //     * `pre - 1` delay would also bite (meaning reads would remain      *.
+            //     * valid for this duration).                                        *.
+            //     *                                                                  *.
+            //     ********************************************************************.
+            //     .                              .                                    .
+            //     .                              .                                    .
             //     .                              .                                    .
             //     .                              .                                    .
             //     [---`time_until_delay_change`--]                                    .
             //     .                              .                                    .
             //     .                              .                                    .
             //     .                              .                                    .
-            //     SCENARIO 1: scheduled delay is shorter than the `self.pre` delay:   .
+            //     SCENARIO 1: an already-scheduled delay is shorter than the `self.pre` delay:
             //     .                              .                                    .
             //     .                              .                                    .
             //     .                              [-`self.post` delay-]                .
@@ -234,59 +245,66 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
             //     .                              .  than `pre`)     ||_ new values can take effect from here.
             //     .                              .                  |
             //     .                              .                  |_ reads are only valid until here:
-            //     .                              .                  .  `historic_timestamp + time_until_delay_change + self.post - 1`
+            //     .                              .                  .  `anchor_block_timestamp + time_until_delay_change + self.post - 1`
             //     .                              .                  .                 .
-            //     [*************************************************]                 .
-            //     [                                                 ]                 .
+            //     ***************************************************                 .
+            //     *                                                 *                 .
             //     [----`time_until_delay_change + self.post - 1`----]                 .
-            //     [                                                 ]                 .
-            //     [ If reading a _value_ at that (<--) anchor       ]                 .
-            //     [ timestamp, then the read will remain valid      ]                 .
-            //     [ for this duration:                              ]                 .
-            //     [                                                 ]                 .
-            //     [*************************************************]                 .
+            //     *                                                 *                 .
+            //     * If reading a _value_ at that (<--) anchor       *                 .
+            //     * timestamp, then the read will remain valid      *                 .
+            //     * for this duration:                              *                 .
+            //     *                                                 *                 .
+            //     ***************************************************                 .
             //     .                              .                                    .
             //     .                              .                                    .
             //     .                              .                                    .
-            //     SCENARIO 2: scheduled delay is longer than the `self.pre` delay, AND is deferred:
+            //     .                              .                                    .
+            //     SCENARIO 2: an already-scheduled delay is longer than the `self.pre` delay, AND is deferred:
             //     (note: scheduling deferred delay changes is not yet possible)
+            //     .                              .                                    .
             //     .                              .                                    .
             //     .                              .                                    .
             //     .                              [-`self.post` delay (if longer than `pre` & deferred)------------------]
             //     .                              .  (scheduling deferred delay changes is not yet possible)            ^^
             //     .                              .                                                                     ||
             //     .                              .     reads would only be valid until here:___________________________||
-            //     .                              .     `historic_timestamp + time_until_delay_change + self.post - 1`   |
+            //     .                              .     `anchor_block_timestamp + time_until_delay_change + self.post - 1` |
             //     .                              .                                                                      |
             //     .                              .                        new values would take effect from here,_______|
             //     .                              .                        but only once this longer delay takes effect  .
             //     .                              .                                    .                                 .
             //     .                              .                                    .                                 .
-            //     [****************************************************************************************************].
-            //     [                                                                                                    ].
+            //     .                              .                                    .                                 .
+            //     ******************************************************************************************************.
+            //     *                                                                                                    *.
             //     [----`time_until_delay_change + self.post - 1`-------------------------------------------------------].
-            //     [                                                                                                    ].
-            //     [ Given a longer, deferred delay, then if reading a _value_ at that (<--) historical timestamp, then ].
-            //     [ you might think the read would remain valid for this duration.                                     ].
-            //     [ BUT, in this case of this deferred, longer-than-`self.pre` delay, the `pre` delay ends sooner (by  ].
-            //     [ construction) (see above in this diagram).                                                         ].
-            //     [ And since this scheduled delay (`post`) can be cancelled up until the time it takes effect,        ].
-            //     [ any reads as at that (<--) historical timestamp would cautiously only be valid until the earlier   ].
-            //     [ `pre` delay expiry.                                                                                ].
-            //     [                                                                                                    ].
-            //     [****************************************************************************************************].
+            //     *                                                                                                    *.
+            //     * Given a longer, deferred delay, then if reading a _value_ at that (<--) anchor block timestamp, then *.
+            //     * you might think the read would remain valid for this duration.                                     *.
+            //     * BUT, in this case of this deferred, longer-than-`self.pre` delay, the `pre` delay ends sooner (by  *.
+            //     * construction) (see above in this diagram).                                                         *.
+            //     * And since this scheduled delay (`post`) can be cancelled up until the time it takes effect,        *.
+            //     * any reads as at that (<--) anchor block timestamp would cautiously only be valid until the earlier   *.
+            //     * `pre` delay expiry.                                                                                *.
+            //     *                                                                                                    *.
+            //     ******************************************************************************************************.
             //
             //
             //
             // [^1] If a svc.timestamp_of_change has already been set, and if it's sooner than the
             //      output of this function, then it will bite within `scheduled_value_change.nr`'s
             //      `get_time_horizon` function.
-            let time_until_delay_change = self.timestamp_of_change - historical_timestamp;
+            let time_until_delay_change = self.timestamp_of_change - anchor_block_timestamp;
 
-            min(
+            let time_until_next_delay_change = min(
                 self.pre.unwrap_or(INITIAL_DELAY), // in case the scheduled delay (`post`) gets cancelled before it takes effect.
-                time_until_delay_change + self.post.unwrap_or(INITIAL_DELAY) - 1,
-            )
+                time_until_delay_change + self.post.unwrap_or(INITIAL_DELAY),
+            );
+
+            // The effective minimum delay equals the minimum time until a value change, minus 1, since reads are
+            // valid only up to (but not including) the moment the value can change.
+            time_until_next_delay_change - 1
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_delay_change/test.nr
@@ -163,16 +163,18 @@ unconstrained fn test_schedule_change_to_longer_delay_from_initial() {
 
 unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u64>(
     delay_change: &mut ScheduledDelayChange<INITIAL_DELAY>,
-    historical_timestamp: u64,
+    anchor_block_timestamp: u64,
     effective_minimum_delay: u64,
 ) {
     // The effective minimum delay guarantees the earliest timestamp in which a scheduled value change could be made
-    // effective. No action, even if executed immediately after the historical timestamp, should result in a scheduled
+    // effective. No action, even if executed in the block following the anchor block, should result in a scheduled
     // value change having a timestamp of change lower than this.
-    let expected_earliest_value_change_timestamp =
-        historical_timestamp + 1 + effective_minimum_delay;
+    //
+    // Note that blocks within the same checkpoint can share timestamps, so the earliest scheduling can happen at the
+    // anchor block timestamp.
+    let expected_earliest_value_change_timestamp = anchor_block_timestamp + effective_minimum_delay;
 
-    if delay_change.timestamp_of_change > historical_timestamp {
+    if delay_change.timestamp_of_change > anchor_block_timestamp {
         // If a delay change is already scheduled to happen in the future, we then must consider the scenario in
         // which a value change is scheduled to occur right as the delay changes and becomes the current one.
         let delay_change_timestamp = delay_change.timestamp_of_change;
@@ -182,16 +184,17 @@ unconstrained fn assert_effective_minimum_delay_invariants<let INITIAL_DELAY: u6
         assert(expected_earliest_value_change_timestamp <= value_change_timestamp);
     }
 
-    // Another possibility would be to schedule a value change immediately after the historical timestamp.
-    let change_schedule_timestamp = historical_timestamp + 1;
+    // Another possibility would be to schedule a value change at the earliest possible timestamp, which is the anchor
+    // block timestamp.
+    let change_schedule_timestamp = anchor_block_timestamp;
     let value_change_timestamp =
         change_schedule_timestamp + delay_change.get_current(change_schedule_timestamp);
     assert(expected_earliest_value_change_timestamp <= value_change_timestamp);
 
-    // Finally, a delay reduction could be scheduled immediately after the historical timestamp. We reduce the delay to
-    // zero, which means that at the delay timestamp of change there'll be no delay and a value change could be
-    // performed immediately then.
-    delay_change.schedule_change(0, historical_timestamp + 1);
+    // Finally, a delay reduction could be scheduled at the anchor block timestamp. We reduce the delay to zero, which
+    // means that at the delay timestamp of change there'll be no delay and a value change could be performed
+    // immediately then.
+    delay_change.schedule_change(0, anchor_block_timestamp + 0);
     assert(expected_earliest_value_change_timestamp <= delay_change.timestamp_of_change);
 }
 
@@ -201,18 +204,19 @@ unconstrained fn test_get_effective_delay_at_before_change_in_far_future() {
     let post = 25;
     let timestamp_of_change = 500;
 
-    let historical_timestamp = 200;
+    let anchor_block_timestamp = 200;
 
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
     // The scheduled delay change is far into the future (further than the current delay is), so it doesn't affect
-    // the effective delay, which is simply the current one (pre).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
-    assert_eq(effective_minimum_delay, pre);
+    // the effective delay, which is simply the current one (pre - 1).
+    let effective_minimum_delay =
+        delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+    assert_eq(effective_minimum_delay, pre - 1);
 
     assert_effective_minimum_delay_invariants(
         &mut delay_change,
-        historical_timestamp,
+        anchor_block_timestamp,
         effective_minimum_delay,
     );
 }
@@ -223,19 +227,20 @@ unconstrained fn test_get_effective_delay_at_before_change_to_long_delay() {
     let post = 25;
     let timestamp_of_change = 500;
 
-    let historical_timestamp = 495;
+    let anchor_block_timestamp = 495;
 
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
     // The scheduled delay change will be effective soon (it's fewer seconds away than the current delay), but due to
     // it being larger than the current one it doesn't affect the effective delay, which is simply the current one
-    // (pre).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
-    assert_eq(effective_minimum_delay, pre);
+    // (pre) minus 1.
+    let effective_minimum_delay =
+        delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+    assert_eq(effective_minimum_delay, pre - 1);
 
     assert_effective_minimum_delay_invariants(
         &mut delay_change,
-        historical_timestamp,
+        anchor_block_timestamp,
         effective_minimum_delay,
     );
 }
@@ -246,7 +251,7 @@ unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay()
     let post = 3;
     let timestamp_of_change = 500;
 
-    let historical_timestamp = 495;
+    let anchor_block_timestamp = 495;
 
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
@@ -255,12 +260,13 @@ unconstrained fn test_get_effective_delay_at_before_near_change_to_short_delay()
     // reduced, and a delay change would be scheduled there with an overall delay lower than the current one.
     // The effective delay therefore is the new delay plus the number of seconds that need to elapse until it becomes
     // effective (i.e. until the timestamp of change).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
-    assert_eq(effective_minimum_delay, post + timestamp_of_change - (historical_timestamp + 1));
+    let effective_minimum_delay =
+        delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+    assert_eq(effective_minimum_delay, post + timestamp_of_change - anchor_block_timestamp - 1);
 
     assert_effective_minimum_delay_invariants(
         &mut delay_change,
-        historical_timestamp,
+        anchor_block_timestamp,
         effective_minimum_delay,
     );
 }
@@ -271,17 +277,18 @@ unconstrained fn test_get_effective_delay_at_after_change() {
     let post = 25;
     let timestamp_of_change = 500;
 
-    let historical_timestamp = timestamp_of_change + 50;
+    let anchor_block_timestamp = timestamp_of_change + 50;
 
     let mut delay_change = get_non_initial_delay_change(pre, post, timestamp_of_change);
 
-    // No delay change is scheduled, so the effective delay is simply the current one (post).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
-    assert_eq(effective_minimum_delay, post);
+    // No delay change is scheduled, so the effective delay is simply the current one (post) minus 1.
+    let effective_minimum_delay =
+        delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+    assert_eq(effective_minimum_delay, post - 1);
 
     assert_effective_minimum_delay_invariants(
         &mut delay_change,
-        historical_timestamp,
+        anchor_block_timestamp,
         effective_minimum_delay,
     );
 }
@@ -290,16 +297,17 @@ unconstrained fn test_get_effective_delay_at_after_change() {
 unconstrained fn test_get_effective_delay_at_initial() {
     let mut delay_change = get_initial_delay_change();
 
-    let historical_timestamp = 200;
+    let anchor_block_timestamp = 200;
 
     // Like in the after change scenario, no delay change is scheduled, so the effective delay is simply the current
-    // one (initial).
-    let effective_minimum_delay = delay_change.get_effective_minimum_delay_at(historical_timestamp);
-    assert_eq(effective_minimum_delay, TEST_INITIAL_DELAY);
+    // one (initial) minus 1.
+    let effective_minimum_delay =
+        delay_change.get_effective_minimum_delay_at(anchor_block_timestamp);
+    assert_eq(effective_minimum_delay, TEST_INITIAL_DELAY - 1);
 
     assert_effective_minimum_delay_invariants(
         &mut delay_change,
-        historical_timestamp,
+        anchor_block_timestamp,
         effective_minimum_delay,
     );
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change.nr
@@ -61,17 +61,17 @@ impl<T> ScheduledValueChange<T> {
     /// The value returned by `get_current_at` in private when called with a anchor block's timestamp is only safe to use
     /// if the transaction's `expiration_timestamp` property is set to a value lower or equal to the time horizon
     /// computed using the same anchor timestamp.
-    pub fn get_time_horizon(self, anchor_timestamp: u64, minimum_delay: u64) -> u64 {
+    pub fn get_time_horizon(self, anchor_block_timestamp: u64, minimum_delay: u64) -> u64 {
         // The time horizon is the very last timestamp in which the current value is known. Any timestamp past the
         // horizon (i.e. with a timestamp larger than the time horizon) may have a different current value.
         // Reading the current value in private typically requires constraining the maximum valid timestamp to be equal
         // to the time horizon.
-        if anchor_timestamp >= self.timestamp_of_change {
+        if anchor_block_timestamp >= self.timestamp_of_change {
             // Once the timestamp of change has passed (block with timestamp >= timestamp_of_change was mined),
             // the current value (post) will not change unless a new value change is scheduled. This did not happen at
             // the anchor timestamp (or else it would not be greater or equal to the timestamp of change), and
             // therefore could only happen after the anchor timestamp. The earliest would be the immediate next
-            // timestamp, and so the smallest possible next timestamp of change equals `anchor_timestamp + 1 +
+            // timestamp, and so the smallest possible next timestamp of change equals `anchor_block_timestamp + 1 +
             // minimum_delay`. Our time horizon is simply the previous timestamp to that one.
             //
             //   timestamp of    anchor
@@ -80,7 +80,7 @@ impl<T> ScheduledValueChange<T> {
             //                         ^                   ^
             //                         ---------------------
             //                             minimum delay
-            anchor_timestamp + minimum_delay
+            anchor_block_timestamp + minimum_delay
         } else {
             // If the timestamp of change has not yet been reached however, then there are two possible scenarios.
             //   a) It could be so far into the future that the time horizon is actually determined by the minimum
@@ -112,11 +112,11 @@ impl<T> ScheduledValueChange<T> {
             // Note that the current implementation does not allow the caller to set the timestamp of change to an
             // arbitrary value, and therefore scenario a) is not currently possible. However implementing #5501 would
             // allow for this to happen.
-            // Because anchor_timestamp < self.timestamp_of_change, then timestamp_of_change > 0 and we can safely
+            // Because anchor_block_timestamp < self.timestamp_of_change, then timestamp_of_change > 0 and we can safely
             // subtract 1.
             min(
+                anchor_block_timestamp + minimum_delay,
                 self.timestamp_of_change - 1,
-                anchor_timestamp + minimum_delay,
             )
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/delayed_public_mutable/scheduled_value_change/test.nr
@@ -31,59 +31,60 @@ unconstrained fn test_get_scheduled() {
 
 unconstrained fn assert_time_horizon_invariants(
     value_change: &mut ScheduledValueChange<Field>,
-    historical_timestamp: u64,
+    anchor_block_timestamp: u64,
     time_horizon: u64,
 ) {
     // The current value should not change at the time horizon (but it might later).
-    let current_at_historical = value_change.get_current_at(historical_timestamp);
-    assert_eq(current_at_historical, value_change.get_current_at(time_horizon));
+    let current_at_anchor = value_change.get_current_at(anchor_block_timestamp);
+    assert_eq(current_at_anchor, value_change.get_current_at(time_horizon));
 
-    // The earliest a new change could be scheduled in would be the immediate next timestamp to the historical one. This
-    // should result in the new timestamp of change landing *after* the time horizon, and the current value still not
-    // changing at the previously determined time_horizon.
+    // The earliest a new change could be scheduled is in the beginning of the next block following the anchor block
+    // and since blocks within the same checkpoint can share timestamps, the smallest timestamp of a block following
+    // the anchor block is "anchor_block_timestamp". This should result in the new timestamp of change landing
+    // *after* the time horizon, and the current value still not changing at the previously determined time_horizon.
     let new = value_change.pre + value_change.post; // Make sure it's different to both pre and post
     value_change.schedule_change(
         new,
-        historical_timestamp + 1,
-        TEST_DELAY,
-        historical_timestamp + 1 + TEST_DELAY,
+        anchor_block_timestamp,
+        TEST_DELAY + 1,
+        anchor_block_timestamp + TEST_DELAY + 1,
     );
 
     assert(value_change.timestamp_of_change > time_horizon);
-    assert_eq(current_at_historical, value_change.get_current_at(time_horizon));
+    assert_eq(current_at_anchor, value_change.get_current_at(time_horizon));
 }
 
 #[test]
 unconstrained fn test_get_time_horizon_change_in_past() {
-    let historical_timestamp = 100;
+    let anchor_block_timestamp = 100;
     let timestamp_of_change = 50;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, anchor_block_timestamp + TEST_DELAY);
 
-    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
+    assert_time_horizon_invariants(&mut value_change, anchor_block_timestamp, time_horizon);
 }
 
 #[test]
 unconstrained fn test_get_time_horizon_change_in_immediate_past() {
-    let historical_timestamp = 100;
+    let anchor_block_timestamp = 100;
     let timestamp_of_change = 100;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, anchor_block_timestamp + TEST_DELAY);
 
-    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
+    assert_time_horizon_invariants(&mut value_change, anchor_block_timestamp, time_horizon);
 }
 
 #[test]
 unconstrained fn test_get_time_horizon_change_in_near_future() {
-    let historical_timestamp = 100;
+    let anchor_block_timestamp = 100;
     let timestamp_of_change = 120;
 
     let mut value_change: ScheduledValueChange<Field> =
@@ -92,38 +93,38 @@ unconstrained fn test_get_time_horizon_change_in_near_future() {
     // Note that this is the only scenario in which the timestamp of change informs the time horizon.
     // This may result in privacy leaks when interacting with applications that have a scheduled change
     // in the near future.
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, TEST_DELAY);
     assert_eq(time_horizon, timestamp_of_change - 1);
 
-    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
+    assert_time_horizon_invariants(&mut value_change, anchor_block_timestamp, time_horizon);
 }
 
 #[test]
 unconstrained fn test_get_time_horizon_change_in_far_future() {
-    let historical_timestamp = 100;
+    let anchor_block_timestamp = 100;
     let timestamp_of_change = 500;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, anchor_block_timestamp + TEST_DELAY);
 
-    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
+    assert_time_horizon_invariants(&mut value_change, anchor_block_timestamp, time_horizon);
 }
 
 #[test]
 unconstrained fn test_get_time_horizon_n0_delay() {
-    let historical_timestamp = 100;
+    let anchor_block_timestamp = 100;
     let timestamp_of_change = 50;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let time_horizon = value_change.get_time_horizon(historical_timestamp, 0);
-    // Since the time horizon equals the historical timestamp, it is not possible to read the current value in
+    let time_horizon = value_change.get_time_horizon(anchor_block_timestamp, 0);
+    // Since the time horizon equals the anchor block timestamp, it is not possible to read the current value in
     // private since the transaction `expiration_timestamp` property would equal an already mined timestamp.
-    assert_eq(time_horizon, historical_timestamp);
+    assert_eq(time_horizon, anchor_block_timestamp);
 }
 
 #[test]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -208,7 +208,7 @@ impl FixtureBuilder {
         builder.global_variables.timestamp = fixtures::GENESIS_TIMESTAMP + 135;
 
         builder.expiration_timestamp =
-            builder.anchor_block_header.global_variables.timestamp + MAX_TX_LIFETIME;
+            builder.anchor_block_header.global_variables.timestamp + MAX_TX_LIFETIME - 1;
 
         builder.vk_tree_root = vk_tree_root;
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -333,8 +333,11 @@ describe('e2e_state_vars', () => {
       await delay(4);
 
       // The validity of our DelayedPublicMutable read request should be limited to the new delay
+      // Note: We subtract 1 because blocks within the same checkpoint can share timestamps so the earliest scheduling
+      // can happen at the anchor timestamp itself. For this reason, the latest timestamp at which a change is
+      // guaranteed to not have happened is the anchor timestamp + the new delay - 1.
       const expectedModifiedExpirationTimestamp =
-        (await aztecNode.getBlockHeader('latest'))!.globalVariables.timestamp + newDelay;
+        (await aztecNode.getBlockHeader('latest'))!.globalVariables.timestamp + newDelay - 1n;
 
       // We now call our AuthContract to see if the change in expiration timestamp has reflected our delay change
       const tx = await proveInteraction(wallet, authContract.methods.get_authorized_in_private(), {


### PR DESCRIPTION
Block timestamps are no longer guaranteed to be increasing and instead now are just guaranteed to be non-decreasing (monotonically increasing). This is because blocks in the same checkpoint can have the same timestamp. With this change it was necessary to update `DelayedPublicMutable` as there the timestamps-are-always-increasing assumption was used to compute the effective minimum delay.

Closes https://linear.app/aztec-labs/issue/F-307/fix-bug-in-delayed-public-mutable

Tagging @iAmMichaelConnor to make him aware that this is getting tackled.

## Unrelated changes I sneaked in

I renamed the historical timestamp everywhere as anchor block timestamp. The motivation for this was that the old naming made this PR even more convoluted. We also in some places used "anchor timestamp". I renamed that as well to anchor block timestamp to maintain consistency.

## Note on docs

This all was too hard to understand. Feels like re-writing the docs here would be a good idea.