### PR TITLE
refactor: fast divmod when the divisor is small

### DIFF
--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
@@ -216,6 +216,7 @@ class alignas(32) uint256_t {
     uint64_t data[4]; // NOLINT
 
     [[nodiscard]] constexpr std::pair<uint256_t, uint256_t> divmod(const uint256_t& b) const;
+    [[nodiscard]] constexpr std::pair<uint256_t, uint64_t> fast_divmod(uint64_t b) const;
 
     size_t hash() const noexcept { return utils::hash_as_tuple(data[0], data[1], data[2], data[3]); }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -8,6 +8,7 @@
 #include "../bitop/get_msb.hpp"
 #include "./uint256.hpp"
 #include "barretenberg/common/assert.hpp"
+#include "barretenberg/numeric/uint128/uint128.hpp"
 namespace bb::numeric {
 
 constexpr std::pair<uint64_t, uint64_t> uint256_t::mul_wide(const uint64_t a, const uint64_t b)
@@ -171,6 +172,38 @@ constexpr std::pair<uint256_t, uint256_t> uint256_t::divmod(const uint256_t& b) 
     }
 
     return { quotient, remainder };
+}
+
+/**
+ * @brief Optimized divmod for a single-limb divisor using schoolbook long division in base 2^64.
+ * For smaller divisors this is significantly faster than the general divmod.
+ * Each iteration divides a 128-bit intermediate (remainder << 64 | limb) by b, which is safe
+ * because the invariant remainder < b guarantees the quotient limb fits in 64 bits.
+ * Falls back to the uint256_t overload for wasm.
+ */
+constexpr std::pair<uint256_t, uint64_t> uint256_t::fast_divmod(uint64_t b) const
+{
+    if (*this == 0 || b == 0) {
+        return { 0, 0 };
+    }
+    if (b == 1) {
+        return { *this, 0 };
+    }
+
+#if !defined(__wasm__)
+    uint256_t quotient;
+    uint64_t remainder = 0;
+    for (int i = 3; i >= 0; --i) {
+        uint128_t cur = (static_cast<uint128_t>(remainder) << 64) | data[i];
+        quotient.data[i] = static_cast<uint64_t>(cur / b);
+        remainder = static_cast<uint64_t>(cur % b);
+    }
+    return { quotient, remainder };
+#else
+    // Fallback to the general divmod since wasm doesn't have native support for 128-bit instructions.
+    auto [q, r] = divmod(uint256_t(b));
+    return { q, static_cast<uint64_t>(r.data[0]) };
+#endif
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_to_radix.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_to_radix.cpp
@@ -17,13 +17,12 @@ std::pair<std::vector<uint8_t>, /* truncated */ bool> PureToRadix::to_le_radix(c
 {
     BB_BENCH_NAME("PureToRadix::to_le_radix");
 
-    uint256_t radix_integer = static_cast<uint256_t>(radix);
     uint256_t value_integer = static_cast<uint256_t>(value);
     std::vector<uint8_t> limbs;
     limbs.reserve(num_limbs);
 
     for (uint32_t i = 0; i < num_limbs; i++) {
-        auto [quotient, remainder] = value_integer.divmod(radix_integer);
+        auto [quotient, remainder] = value_integer.fast_divmod(static_cast<uint64_t>(radix));
         limbs.push_back(static_cast<uint8_t>(remainder));
         value_integer = quotient;
     }


### PR DESCRIPTION
Adds an overload to `divmod` in `uint256` when the divisor is small (< 64 bits). This change allows us to do 4x long division + carry between the limbs instead of ~3000 multi-limb operations.

The difference is most significant when the divisor is small and the dividend is large. In our benchmarks it's about 10x 