### PR TITLE
fix(docs): make docs release resilient to yarn-project build failures

### DIFF
--- a/.github/workflows/nightly-docs-release.yml
+++ b/.github/workflows/nightly-docs-release.yml
@@ -149,12 +149,15 @@ jobs:
           ./bootstrap.sh build_packages
 
       - name: Build aztec CLI
+        id: build-cli
+        continue-on-error: true
         working-directory: ./yarn-project
         run: |
           ./bootstrap.sh
           echo "AZTEC_CLI_PATH=$(pwd)/aztec/dest/bin" >> $GITHUB_ENV
 
       - name: Generate TypeScript API documentation
+        if: steps.build-cli.outcome == 'success'
         working-directory: ./docs
         run: |
           # Generate TypeScript API docs for this version (requires yarn-project to be built)
@@ -162,6 +165,7 @@ jobs:
           echo "Generated TypeScript API docs for: ${{ env.NIGHTLY_TAG }}"
 
       - name: Generate CLI documentation
+        if: steps.build-cli.outcome == 'success'
         working-directory: ./docs
         continue-on-error: true
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -277,6 +277,8 @@ jobs:
 
           The release will continue, but CLI reference docs may be incomplete for this version.
 
+          cc @AztecProtocol/devrel
+
           [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           EOF
           )"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -197,12 +197,15 @@ jobs:
           ./bootstrap.sh build_packages
 
       - name: Build aztec CLI
+        id: build-cli
+        continue-on-error: true
         working-directory: ./yarn-project
         run: |
           ./bootstrap.sh
           echo "AZTEC_CLI_PATH=$(pwd)/aztec/dest/bin" >> $GITHUB_ENV
 
       - name: Generate TypeScript API documentation
+        if: steps.build-cli.outcome == 'success'
         working-directory: ./docs
         run: |
           # Generate TypeScript API docs for this version (requires yarn-project to be built)
@@ -211,6 +214,7 @@ jobs:
 
       - name: Generate Aztec CLI documentation
         id: aztec-cli-docs
+        if: steps.build-cli.outcome == 'success'
         working-directory: ./docs
         continue-on-error: true
         run: |
@@ -243,13 +247,20 @@ jobs:
           echo "Generated BB CLI documentation for: ${{ steps.version.outputs.semver }}"
 
       - name: Comment on PR if CLI docs generation failed
-        if: steps.aztec-cli-docs.outcome == 'failure' || steps.bb-cli-docs.outcome == 'failure'
+        if: steps.build-cli.outcome == 'failure' || steps.aztec-cli-docs.outcome == 'failure' || steps.bb-cli-docs.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
           FAILED_DOCS=""
+          if [[ "${{ steps.build-cli.outcome }}" == "failure" ]]; then
+            FAILED_DOCS="yarn-project build (cache miss)"
+          fi
           if [[ "${{ steps.aztec-cli-docs.outcome }}" == "failure" ]]; then
-            FAILED_DOCS="Aztec CLI"
+            if [[ -n "$FAILED_DOCS" ]]; then
+              FAILED_DOCS="$FAILED_DOCS, Aztec CLI"
+            else
+              FAILED_DOCS="Aztec CLI"
+            fi
           fi
           if [[ "${{ steps.bb-cli-docs.outcome }}" == "failure" ]]; then
             if [[ -n "$FAILED_DOCS" ]]; then


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` and `id: build-cli` to the yarn-project build step in both `nightly-docs-release.yml` and `release-please.yml`
- Gates TypeScript API doc generation and CLI doc generation on `steps.build-cli.outcome == 'success'` so they're skipped (not errored) when the build fails
- Extends the "failed docs" PR comment in `release-please.yml` to also report yarn-project build failures

This prevents the entire docs release from failing when yarn-project hits a cache miss or transient build error. The auto-generated CLI/TS API docs will be omitted from that version, but the rest of the docs release proceeds normally.

## Test plan
- [ ] Verify nightly docs workflow succeeds when yarn-project build passes (happy path unchanged)
- [ ] Verify nightly docs workflow completes (without CLI/TS docs) when yarn-project build fails
- [ ] Verify release-please workflow posts a PR comment listing all failed doc generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)