### PR TITLE
feat: pass real circuit names to bb.js, reorganize CLAUDE.md

### DIFF
--- a/barretenberg/CLAUDE.md
+++ b/barretenberg/CLAUDE.md
@@ -1,0 +1,57 @@
+THE PROJECT ROOT IS AT ONE LEVEL ABOVE THIS FOLDER. Typically, the repository is at ~/aztec-packages. All advice is from the root.
+
+# Git workflow for barretenberg
+
+**IMPORTANT**: When comparing branches or looking at diffs for barretenberg work, use `origin/merge-train/barretenberg` as the base branch, NOT `master` or `next`. Create new branches off `origin/merge-train/barretenberg` and target PRs to `merge-train/barretenberg`.
+
+Examples:
+- `git checkout -b my-branch origin/merge-train/barretenberg` (create a new branch)
+- `git diff origin/merge-train/barretenberg...HEAD` (not `git diff master...HEAD`)
+- `git log origin/merge-train/barretenberg..HEAD` (not `git log master..HEAD`)
+- `gh pr create --base merge-train/barretenberg` (target PRs to merge-train)
+
+**Do NOT include `Co-Authored-By: Claude` lines in commit messages or `Generated with Claude Code` in PR descriptions.**
+
+Barretenberg issues are tracked at `AztecProtocol/barretenberg` (separate repo), not `AztecProtocol/aztec-packages`. PRs go to `AztecProtocol/aztec-packages` but should reference issues from `AztecProtocol/barretenberg`.
+
+Run ./bootstrap.sh at the top-level to be sure the repo fully builds.
+Bootstrap scripts can be called with relative paths e.g. ../barretenberg/bootstrap.sh
+
+# Modules
+
+## ts/ => typescript code for bb.js
+
+Bootstrap modes:
+
+- `./bootstrap.sh` => generate TypeScript bindings and build. See package.json for more fine-grained commands.
+  Other commands:
+- `yarn build:esm` => the quickest way to rebuild, if only changes inside ts/ folder, and only testing yarn-project.
+- `BUILD_CPP=1 scripts/copy_native.sh` => Ensures required cpp code is build (bb and nodejs_module) and copies into expected location.
+
+## Integration testing
+
+The focus is on barretenberg/cpp development. Other components need to work with barretenberg changes:
+
+### yarn-project/end-to-end - E2E tests that verify the full stack
+
+Run end-to-end tests from the root directory:
+
+````bash
+# Run specific e2e tests
+yarn-project/end-to-end/scripts/run_test.sh simple e2e_block_building
+# To run this you CANNOT USE DISABLE_AVM=1. Only run this if the user asks (e.g. 'run the prover full test') You first need to confirm with the user that they want to build without AVM.
+yarn-project/end-to-end/scripts/run_test.sh simple e2e_prover/full
+
+### yarn-project IVC integration tests
+Run IVC (Incremental Verifiable Computation) integration tests from the root:
+```bash
+# Run specific IVC tests
+yarn-project/scripts/run_test.sh ivc-integration/src/native_chonk_integration.test.ts
+yarn-project/scripts/run_test.sh ivc-integration/src/wasm_chonk_integration.test.ts
+yarn-project/scripts/run_test.sh ivc-integration/src/browser_chonk_integration.test.ts
+
+# Run rollup IVC tests (with verbose logging)
+BB_VERBOSE=1 yarn-project/scripts/run_test.sh ivc-integration/src/rollup_ivc_integration.test.ts
+````
+
+When making barretenberg changes, ensure these tests still pass.

--- a/barretenberg/acir_tests/browser-test-app/src/index.ts
+++ b/barretenberg/acir_tests/browser-test-app/src/index.ts
@@ -69,18 +69,20 @@ function installChonkGlobal() {
 
   async function processChonkInputs(
     ivcInputsBuf: Uint8Array
-  ): Promise<[Uint8Array[], Uint8Array[], Uint8Array[]]> {
+  ): Promise<[Uint8Array[], Uint8Array[], Uint8Array[], string[]]> {
     const acirBufs: Uint8Array[] = [];
     const vkBufs: Uint8Array[] = [];
     const witnessBufs: Uint8Array[] = [];
+    const names: string[] = [];
     // Unpack the msgpack data into the format AztecClientBackend expects
     const steps: PrivateExecutionStepRaw[] = unpack(ivcInputsBuf);
     for (const step of steps) {
       acirBufs.push(ungzip(step.bytecode));
       vkBufs.push(step.vk);
       witnessBufs.push(ungzip(step.witness));
+      names.push(step.functionName);
     }
-    return [acirBufs, witnessBufs, vkBufs];
+    return [acirBufs, witnessBufs, vkBufs, names];
   }
 
   async function proveChonk(
@@ -89,12 +91,12 @@ function installChonkGlobal() {
   ): Promise<{ proof: Uint8Array; verificationKey: Uint8Array }> {
     const { AztecClientBackend } = await import("@aztec/bb.js");
 
-    const [acirBufs, witnessBufs, vkBufs] = await processChonkInputs(
+    const [acirBufs, witnessBufs, vkBufs, circuitNames] = await processChonkInputs(
       ivcInputsBuf
     );
     logger.debug("starting test...");
     const bb = await Barretenberg.new({ threads, logger: bbLogger });
-    const backend = new AztecClientBackend(acirBufs, bb);
+    const backend = new AztecClientBackend(acirBufs, bb, circuitNames);
     const [_, proof, verificationKey] = await backend.prove(
       witnessBufs,
       vkBufs

--- a/barretenberg/cpp/CLAUDE.md
+++ b/barretenberg/cpp/CLAUDE.md
@@ -1,25 +1,6 @@
-succint aztec-packages cheat sheet.
+# barretenberg/cpp
 
-THE PROJECT ROOT IS AT TWO LEVELS ABOVE THIS FOLDER. Typically, the repository is at ~/aztec-packages. all advice is from the root.
-
-# Git workflow for barretenberg
-
-**IMPORTANT**: When comparing branches or looking at diffs for barretenberg work, use `merge-train/barretenberg` as the base branch, NOT `master`. The master branch is often outdated for barretenberg development.
-
-Examples:
-- `git diff merge-train/barretenberg...HEAD` (not `git diff master...HEAD`)
-- `git log merge-train/barretenberg..HEAD` (not `git log master..HEAD`)
-
-Run ./bootstrap.sh at the top-level to be sure the repo fully builds.
-Bootstrap scripts can be called with relative paths e.g. ../barretenberg/bootstrap.sh
-
-# Working on modules:
-
-## barretenberg/
-
-The core proving system library. Focus development is in barretenberg/cpp.
-
-### cpp/ => cpp code for prover library
+The core proving system library.
 
 Bootstrap modes:
 
@@ -75,58 +56,6 @@ Note: Once you enable AVM, subsequent `ninja` calls will include AVM targets unt
 - **bbapi/** - BB API for external interaction. If changing here, we will also want to update the ts/ folder because bb.js consumes this. (first build ninja bb in build/)
 - **dsl/** - ACIR definition in C++. This is dictated by the serialization in noir/, so refactor should generally not change the structure without confirming that the user is changing noir.
 - **vm2/** - AVM implementation (not enabled, but might need to be fixed for compilation issues in root ./bootstrap.sh). If working in vm2, use barretenberg/cpp/src/barretenberg/vm2/CLAUDE.md
-
-### ts/ => typescript code for bb.js
-
-Bootstrap modes:
-
-- `./bootstrap.sh` => generate TypeScript bindings and build. See package.json for more fine-grained commands.
-  Other commands:
-- `yarn build:esm` => the quickest way to rebuild, if only changes inside ts/ folder, and only testing yarn-project.
-- `BUILD_CPP=1 scripts/copy_native.sh` => Ensures required cpp code is build (bb and nodejs_module) and copies into expected location.
-
-## noir/
-
-### noir-repo/ => clone of noir programming language git repo
-
-Bootstrap modes:
-
-- `./bootstrap.sh` => standard build
-
-## avm-transpiler:
-
-Transpiles Noir to AVM bytecode
-Bootstrap modes:
-
-- `./bootstrap.sh` => standard build
-
-## Integration testing:
-
-The focus is on barretenberg/cpp development. Other components need to work with barretenberg changes:
-
-### yarn-project/end-to-end - E2E tests that verify the full stack
-
-Run end-to-end tests from the root directory:
-
-````bash
-# Run specific e2e tests
-yarn-project/end-to-end/scripts/run_test.sh simple e2e_block_building
-# To run this you CANNOT USE DISABLE_AVM=1. Only run this if the user asks (e.g. 'run the prover full test') You first need to confirm with the user that they want to build without AVM.
-yarn-project/end-to-end/scripts/run_test.sh simple e2e_prover/full
-
-### yarn-project IVC integration tests
-Run IVC (Incremental Verifiable Computation) integration tests from the root:
-```bash
-# Run specific IVC tests
-yarn-project/scripts/run_test.sh ivc-integration/src/native_chonk_integration.test.ts
-yarn-project/scripts/run_test.sh ivc-integration/src/wasm_chonk_integration.test.ts
-yarn-project/scripts/run_test.sh ivc-integration/src/browser_chonk_integration.test.ts
-
-# Run rollup IVC tests (with verbose logging)
-BB_VERBOSE=1 yarn-project/scripts/run_test.sh ivc-integration/src/rollup_ivc_integration.test.ts
-````
-
-When making barretenberg changes, ensure these tests still pass.
 
 ## Benchmarking:
 

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -285,6 +285,7 @@ export class AztecClientBackend {
   constructor(
     private acirBuf: Uint8Array[],
     private api: Barretenberg,
+    private circuitNames: string[] = [],
   ) {}
 
   async prove(witnessBuf: Uint8Array[], vksBuf: Uint8Array[] = []): Promise<[Uint8Array[], Uint8Array, Uint8Array]> {
@@ -304,7 +305,7 @@ export class AztecClientBackend {
       const bytecode = this.acirBuf[i];
       const witness = witnessBuf[i] || new Uint8Array(0);
       const vk = vksBuf[i] || new Uint8Array(0);
-      const functionName = `unknown_wasm_${i}`;
+      const functionName = this.circuitNames[i] || `circuit_${i}`;
 
       // Load the circuit
       this.api.chonkLoad({
@@ -326,10 +327,11 @@ export class AztecClientBackend {
     // The API currently expects a msgpack-encoded API.
     const proof = new Encoder({ useRecords: false }).encode(fromChonkProof(proveResult.proof));
     // Generate the VK
+    const lastIdx = this.acirBuf.length - 1;
     const vkResult = await this.api.chonkComputeVk({
       circuit: {
-        name: 'hiding',
-        bytecode: this.acirBuf[this.acirBuf.length - 1],
+        name: this.circuitNames[lastIdx] || 'circuit',
+        bytecode: this.acirBuf[lastIdx],
       },
     });
 
@@ -370,11 +372,11 @@ export class AztecClientBackend {
 
   async gates(): Promise<number[]> {
     const circuitSizes: number[] = [];
-    for (const buf of this.acirBuf) {
+    for (let i = 0; i < this.acirBuf.length; i++) {
       const gates = await this.api.chonkStats({
         circuit: {
-          name: 'circuit',
-          bytecode: buf,
+          name: this.circuitNames[i] || `circuit_${i}`,
+          bytecode: this.acirBuf[i],
         },
         includeGatesPerOpcode: false,
       });

--- a/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
@@ -283,6 +283,7 @@ export abstract class BBPrivateKernelProver implements PrivateKernelProver {
     const backend = new AztecClientBackend(
       executionSteps.map(step => ungzip(step.bytecode)),
       barretenberg,
+      executionSteps.map(step => step.functionName),
     );
 
     const [proof] = await backend.prove(
@@ -303,7 +304,7 @@ export abstract class BBPrivateKernelProver implements PrivateKernelProver {
       ...this.options,
       logger: this.options.logger?.[(process.env.LOG_LEVEL as LogLevel) || 'verbose'],
     });
-    const backend = new AztecClientBackend([ungzip(_bytecode)], barretenberg);
+    const backend = new AztecClientBackend([ungzip(_bytecode)], barretenberg, [_circuitName]);
     const gateCount = await backend.gates();
     return gateCount[0];
   }


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/barretenberg/issues/1621

## Summary
- `AztecClientBackend` now accepts an optional `circuitNames` array in its constructor
- Replaces misleading `unknown_wasm_${i}` placeholders with real function names in C++ logs (`ChonkLoad`, `ChonkAccumulate`, `ChonkStats`)
- Production caller (`BBPrivateKernelProver`) passes `PrivateExecutionStep.functionName`
- Browser test app passes `functionName` from msgpack-decoded steps
- Backward compatible: callers that don't pass names get `circuit_${i}` fallback
- Reorganized `barretenberg/CLAUDE.md` files: cross-cutting concerns (git workflow, commit conventions, issue tracker) moved to `barretenberg/CLAUDE.md`, cpp-specific content stays in `barretenberg/cpp/CLAUDE.md`

## Test plan
- [x] `yarn-project/ivc-integration` chonk_integration tests pass (6/6)
- [x] TypeScript compiles across bb.js, bb-prover, and browser-test-app
- [x] Verified logs show real names when passed (e.g. `mock_app_creator`, `private_kernel_init`)
- [x] No remaining `unknown_wasm` references in codebase