### PR TITLE
chore(barretenberg): remove generated empty testoutput.log

### DIFF
--- a/barretenberg/sol/.gitignore
+++ b/barretenberg/sol/.gitignore
@@ -15,3 +15,6 @@ out/
 **/build*/*
 
 src/honk/keys
+
+# Generated test output
+/testoutput.log


### PR DESCRIPTION
### What changed
This PR removes `testoutput.log`, an empty generated file that was accidentally committed to the repository.

### Why
The file is a generated test artifact with no functional purpose.
Keeping it in version control adds noise and increases the risk of accidentally committing local or CI output.

### Additional notes
A scoped ignore rule was added under `barretenberg/sol/.gitignore` to prevent the file from being reintroduced.