### PR TITLE
fix(aztec-up): add redirect support and installation verification

### DIFF
--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -128,15 +128,26 @@ function cmd_install {
 
   local install_url="$INSTALL_URI/$resolved_version/install"
 
-  # Check if install script exists
-  if ! curl --head --silent --fail "$install_url" > /dev/null; then
+  # Check if install script exists (use -L to follow redirects)
+  if ! curl -L --head --silent --fail "$install_url" > /dev/null; then
     echo "Error: Version installer not found at $install_url"
     echo "Please check the version specified."
     exit 1
   fi
 
   # Download and run the version-specific installer
-  curl -fsSL "$install_url" | VERSION="$resolved_version" bash
+  if ! curl -fsSL "$install_url" | VERSION="$resolved_version" bash; then
+    echo "Error: Failed to install version $resolved_version"
+    exit 1
+  fi
+
+  # Verify installation succeeded
+  if [ ! -d "$AZTEC_HOME/versions/$resolved_version" ]; then
+    echo "Error: Installation of version $resolved_version failed - version directory not created"
+    exit 1
+  fi
+
+  echo "Successfully installed aztec version $resolved_version"
 
   # Update the current symlink
   ln -sfn "$AZTEC_HOME/versions/$resolved_version" "$AZTEC_HOME/current"


### PR DESCRIPTION
## Summary
- Fix silent installation failure when version-specific installer redirects
- Add proper error handling and verification for installations

## Motivation
Fixes #20141 - `aztec-up -v 3.0.0-devnet.6-patch.1` reports success but doesn't actually install the version.

## Root Cause
1. `curl --head` without `-L` flag doesn't follow HTTP redirects
2. No error handling when `curl | bash` pipeline fails
3. No verification that the version directory was actually created

## Changes

```bash
# Before (broken):
curl --head --silent --fail "$install_url"
curl -fsSL "$install_url" | VERSION="$resolved_version" bash

# After (fixed):
curl -L --head --silent --fail "$install_url"  # -L follows redirects
if ! curl -fsSL "$install_url" | VERSION="$resolved_version" bash; then
  echo "Error: Failed to install version $resolved_version"
  exit 1
fi
# + verification that versions/$version dir exists
# + success message
```

## Test Plan
- [ ] Test `aztec-up install 3.0.0-devnet.6-patch.1` 
- [ ] Test with non-existent version (should error clearly)
- [ ] Test `aztec-up install latest`

---
🤖 Generated with [Claude Code](https://claude.ai/code)