### PR TITLE
fix(aztec.nr): remove Context from AccountActions init definition

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -7,11 +7,11 @@ use crate::authwit::entrypoint::app::AppPayload;
 
 pub struct AccountActions<Context> {
     context: Context,
-    is_valid_impl: fn(&mut PrivateContext, Field) -> bool,
+    is_valid_impl: fn(Context, Field) -> bool,
 }
 
 impl<Context> AccountActions<Context> {
-    pub fn init(context: Context, is_valid_impl: fn(&mut PrivateContext, Field) -> bool) -> Self {
+    pub fn init(context: Context, is_valid_impl: fn(Context, Field) -> bool) -> Self {
         AccountActions { context, is_valid_impl }
     }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `&mut PrivateContext` with generic `Context` type in the `is_valid_impl` function signature within `AccountActions` struct and its `init` method
- This makes the struct properly generic over the Context type parameter as intended

Closes #19872

## Test plan

- [x] Existing account contracts (schnorr, ecdsa_k, ecdsa_r, etc.) should continue to work unchanged since when `Context = &mut PrivateContext`, the function signature `fn(Context, Field) -> bool` resolves to `fn(&mut PrivateContext, Field) -> bool`
- [ ] CI should validate that all account-related tests pass

Generated with Claude Code