### PR TITLE
feat(foundation): add pino format string support to Logger

### DIFF
--- a/yarn-project/foundation/src/log/log_fn.ts
+++ b/yarn-project/foundation/src/log/log_fn.ts
@@ -1,5 +1,13 @@
 /** Structured log data to include with the message. */
 export type LogData = Record<string, string | number | bigint | boolean | { toString(): string } | undefined | null>;
 
-/** A callable logger instance. */
-export type LogFn = (msg: string, data?: unknown) => void;
+/**
+ * A callable logger instance.
+ * Supports pino-style format strings with %s, %d, %o placeholders.
+ * @example
+ * log('Simple message');
+ * log('Message with %s placeholder', 'value');
+ * log('Message with data', { key: 'value' });
+ * log('Message with %s and data', 'value', { key: 'data' });
+ */
+export type LogFn = (msg: string, ...args: unknown[]) => void;

--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -73,6 +73,66 @@ describe('pino-logger', () => {
     expect(logEntry.level).toBe(30); // info level
   });
 
+  it('supports pino-style format strings with %s substitution', () => {
+    const testLogger = createLogger('format-test');
+    capturingStream.clear();
+
+    testLogger.info('Hello %s', 'world');
+
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      module: 'format-test',
+      msg: 'Hello world',
+    });
+  });
+
+  it('supports multiple format arguments', () => {
+    const testLogger = createLogger('multi-format-test');
+    capturingStream.clear();
+
+    testLogger.info('User %s logged in from %s', 'alice', '192.168.1.1');
+
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      module: 'multi-format-test',
+      msg: 'User alice logged in from 192.168.1.1',
+    });
+  });
+
+  it('supports format strings with data object', () => {
+    const testLogger = createLogger('format-data-test');
+    capturingStream.clear();
+
+    testLogger.info('Processing block %s', 42, { txCount: 10 });
+
+    const entries = capturingStream.getJsonLines() as any[];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].module).toBe('format-data-test');
+    expect(entries[0].msg).toBe('Processing block 42');
+    expect(entries[0].txCount).toBe(10);
+  });
+
+  it('handles format strings at different log levels', () => {
+    const testLogger = createLogger('level-format-test');
+    capturingStream.clear();
+
+    testLogger.debug('Debug %s', 'message');
+    testLogger.verbose('Verbose %s', 'message');
+    testLogger.trace('Trace %s', 'message');
+    testLogger.warn('Warn %s', 'message');
+
+    const entries = capturingStream.getJsonLines() as any[];
+    expect(entries).toHaveLength(4);
+    expect(entries.map(e => e.msg)).toEqual([
+      'Debug message',
+      'Verbose message',
+      'Trace message',
+      'Warn message',
+    ]);
+  });
+
   it('logs at different levels', () => {
     const testLogger = createLogger('level-test');
     capturingStream.clear();

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -46,6 +46,11 @@ function getBindingsFromHandlers(): LoggerBindings | undefined {
   return undefined;
 }
 
+/** Check if value is a plain object (not null, array, Date, etc.) - used to detect data argument. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date);
+}
+
 export function createLogger(module: string, bindings?: LoggerBindings): Logger {
   module = module.replace(/^aztec:/, '');
 
@@ -60,26 +65,40 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
-  const logFn = (level: LogLevel, msg: string, data?: unknown) =>
-    isLevelEnabled(pinoLogger, level) && pinoLogger[level](processLogData((data as LogData) ?? {}), msg);
+  // Supports pino-style format strings: logger.info('msg %s', value) or logger.info('msg %s', value, { data })
+  const logFn = (level: LogLevel, msg: string, ...args: unknown[]) => {
+    if (!isLevelEnabled(pinoLogger, level)) {
+      return;
+    }
+    // Check if the last argument is a plain object (data), not a primitive or array
+    const lastArg = args[args.length - 1];
+    const hasDataObject = args.length > 0 && isPlainObject(lastArg);
+    const data = hasDataObject ? (args.pop() as LogData) : {};
+    // Remaining args are format string arguments
+    pinoLogger[level](processLogData(data), msg, ...args);
+  };
+
+  // Helper for error/fatal which have (msg, err?, data?) signature
+  const logErrFn = (level: LogLevel, msg: string, err?: unknown, data?: unknown) =>
+    logFn(level, formatErr(msg, err), ...(data !== undefined ? [data] : []));
 
   return {
     silent: () => {},
     // TODO(palla/log): Should we move err to data instead of the text message?
     /** Log as fatal. Use when an error has brought down the system. */
-    fatal: (msg: string, err?: unknown, data?: unknown) => logFn('fatal', formatErr(msg, err), data),
+    fatal: (msg: string, err?: unknown, data?: unknown) => logErrFn('fatal', msg, err, data),
     /** Log as error. Use for errors in general. */
-    error: (msg: string, err?: unknown, data?: unknown) => logFn('error', formatErr(msg, err), data),
+    error: (msg: string, err?: unknown, data?: unknown) => logErrFn('error', msg, err, data),
     /** Log as warn. Use for when we stray from the happy path. */
-    warn: (msg: string, data?: unknown) => logFn('warn', msg, data),
+    warn: (msg: string, ...args: unknown[]) => logFn('warn', msg, ...args),
     /** Log as info. Use for providing an operator with info on what the system is doing. */
-    info: (msg: string, data?: unknown) => logFn('info', msg, data),
+    info: (msg: string, ...args: unknown[]) => logFn('info', msg, ...args),
     /** Log as verbose. Use for when we need additional insight on what a subsystem is doing. */
-    verbose: (msg: string, data?: unknown) => logFn('verbose', msg, data),
+    verbose: (msg: string, ...args: unknown[]) => logFn('verbose', msg, ...args),
     /** Log as debug. Use for when we need debugging info to troubleshoot an issue on a specific component. */
-    debug: (msg: string, data?: unknown) => logFn('debug', msg, data),
+    debug: (msg: string, ...args: unknown[]) => logFn('debug', msg, ...args),
     /** Log as trace. Use for when we want to denial-of-service any recipient of the logs. */
-    trace: (msg: string, data?: unknown) => logFn('trace', msg, data),
+    trace: (msg: string, ...args: unknown[]) => logFn('trace', msg, ...args),
     /** Level of the logger */
     level: pinoLogger.level as LogLevel,
     /** Whether the given level is enabled for this logger. */


### PR DESCRIPTION
## Summary
- Enable pino-style format string substitution (`%s`, `%d`, `%o`) in Logger methods
- Maintain backward compatibility with existing `(msg, data)` signature
- Add tests for format string functionality

## Motivation
Part of #13035 - String interpolation has performance overhead as strings are constructed even when log level is disabled. Pino format strings skip string construction when the level is not enabled.

## Changes

### `log_fn.ts`
- Updated `LogFn` type to accept variadic arguments: `(msg: string, ...args: unknown[]) => void`

### `pino-logger.ts`
- Added `isPlainObject` helper to detect data objects vs format arguments
- Updated `logFn` to:
  - Check if last argument is a plain object (data)
  - Pass remaining arguments as pino format string substitutions
- Keep `error`/`fatal` with separate `(msg, err?, data?)` signature

### `pino-logger.test.ts`
- Added tests for format string substitution
- Tests for multiple format arguments
- Tests for format strings with data objects

## Usage Examples
```typescript
// Simple format string
logger.info('Processing block %s', blockNumber);

// Multiple substitutions
logger.info('User %s logged in from %s', username, ip);

// Format string with data object (last plain object is data)
logger.info('Block %s processed', blockNumber, { txCount: 10 });

// Backward compatible - data object only
logger.info('Simple message', { key: 'value' });
```

## Test Plan
- [x] Added unit tests for format string functionality
- [ ] CI passes

Prerequisite for #20266 (blob-client logging migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)