### PR TITLE
refactor(pxe): convert positional params to object params across PXE

### DIFF
--- a/boxes/boxes/vanilla/app/embedded-wallet.ts
+++ b/boxes/boxes/vanilla/app/embedded-wallet.ts
@@ -361,14 +361,11 @@ export class EmbeddedWallet extends BaseWallet {
     const contractOverrides = {
       [opts.from.toString()]: { instance, artifact },
     };
-    return this.pxe.simulateTx(
-      txRequest,
-      true /* simulatePublic */,
-      true,
-      true,
-      {
-        contracts: contractOverrides,
-      }
-    );
+    return this.pxe.simulateTx(txRequest, {
+      simulatePublic: true,
+      skipTxValidation: true,
+      skipFeeEnforcement: true,
+      overrides: { contracts: contractOverrides },
+    });
   }
 }

--- a/playground/src/wallet/embedded_wallet.ts
+++ b/playground/src/wallet/embedded_wallet.ts
@@ -260,8 +260,11 @@ export class EmbeddedWallet extends BaseWallet {
     const contractOverrides = {
       [opts.from.toString()]: { instance, artifact },
     };
-    return this.pxe.simulateTx(txRequest, true /* simulatePublic */, true, true, {
-      contracts: contractOverrides,
+    return this.pxe.simulateTx(txRequest, {
+      simulatePublic: true,
+      skipTxValidation: true,
+      skipFeeEnforcement: true,
+      overrides: { contracts: contractOverrides },
     });
   }
 }

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -234,12 +234,11 @@ export class CLIWallet extends BaseWallet {
         chainInfo,
         executionOptions,
       );
-      simulationResults = await this.pxe.simulateTx(
-        txRequest,
-        true /* simulatePublic */,
-        opts?.skipTxValidation,
-        opts?.skipFeeEnforcement ?? true,
-      );
+      simulationResults = await this.pxe.simulateTx(txRequest, {
+        simulatePublic: true,
+        skipTxValidation: opts?.skipTxValidation,
+        skipFeeEnforcement: opts?.skipFeeEnforcement ?? true,
+      });
     } else {
       const { account: fromAccount, instance, artifact } = await this.getFakeAccountDataFor(opts.from);
       const txRequest = await fromAccount.createTxExecutionRequest(
@@ -251,8 +250,11 @@ export class CLIWallet extends BaseWallet {
       const contractOverrides = {
         [opts.from.toString()]: { instance, artifact },
       };
-      simulationResults = await this.pxe.simulateTx(txRequest, true /* simulatePublic */, true, true, {
-        contracts: contractOverrides,
+      simulationResults = await this.pxe.simulateTx(txRequest, {
+        simulatePublic: true,
+        skipTxValidation: true,
+        skipFeeEnforcement: true,
+        overrides: { contracts: contractOverrides },
       });
     }
 

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -90,52 +90,89 @@ import { executePrivateFunction } from './oracle/private_execution.js';
 import { PrivateExecutionOracle } from './oracle/private_execution_oracle.js';
 import { UtilityExecutionOracle } from './oracle/utility_execution_oracle.js';
 
+/** Options for ContractFunctionSimulator.run. */
+export type ContractSimulatorRunOpts = {
+  /** The address of the contract (should match request.origin). */
+  contractAddress: AztecAddress;
+  /** The function selector of the entry point. */
+  selector: FunctionSelector;
+  /** The address calling the function. Can be replaced to simulate a call from another contract or account. */
+  msgSender?: AztecAddress;
+  /** The block header to use as base state for this run. */
+  anchorBlockHeader: BlockHeader;
+  /** The address used as a tagging sender when emitting private logs. */
+  senderForTags?: AztecAddress;
+  /** The accounts whose notes we can access in this call. Defaults to all. */
+  scopes?: AztecAddress[];
+  /** The job ID for staged writes. */
+  jobId: string;
+};
+
+/** Args for ContractFunctionSimulator constructor. */
+export type ContractFunctionSimulatorArgs = {
+  contractStore: ContractStore;
+  noteStore: NoteStore;
+  keyStore: KeyStore;
+  addressStore: AddressStore;
+  aztecNode: AztecNode;
+  senderTaggingStore: SenderTaggingStore;
+  recipientTaggingStore: RecipientTaggingStore;
+  senderAddressBookStore: SenderAddressBookStore;
+  capsuleStore: CapsuleStore;
+  privateEventStore: PrivateEventStore;
+  simulator: CircuitSimulator;
+  contractSyncService: ContractSyncService;
+};
+
 /**
  * The contract function simulator.
  */
 export class ContractFunctionSimulator {
-  private log: Logger;
+  private readonly log: Logger;
+  private readonly contractStore: ContractStore;
+  private readonly noteStore: NoteStore;
+  private readonly keyStore: KeyStore;
+  private readonly addressStore: AddressStore;
+  private readonly aztecNode: AztecNode;
+  private readonly senderTaggingStore: SenderTaggingStore;
+  private readonly recipientTaggingStore: RecipientTaggingStore;
+  private readonly senderAddressBookStore: SenderAddressBookStore;
+  private readonly capsuleStore: CapsuleStore;
+  private readonly privateEventStore: PrivateEventStore;
+  private readonly simulator: CircuitSimulator;
+  private readonly contractSyncService: ContractSyncService;
 
-  constructor(
-    private contractStore: ContractStore,
-    private noteStore: NoteStore,
-    private keyStore: KeyStore,
-    private addressStore: AddressStore,
-    private aztecNode: AztecNode,
-    private senderTaggingStore: SenderTaggingStore,
-    private recipientTaggingStore: RecipientTaggingStore,
-    private senderAddressBookStore: SenderAddressBookStore,
-    private capsuleStore: CapsuleStore,
-    private privateEventStore: PrivateEventStore,
-    private simulator: CircuitSimulator,
-    private contractSyncService: ContractSyncService,
-  ) {
+  constructor(args: ContractFunctionSimulatorArgs) {
+    this.contractStore = args.contractStore;
+    this.noteStore = args.noteStore;
+    this.keyStore = args.keyStore;
+    this.addressStore = args.addressStore;
+    this.aztecNode = args.aztecNode;
+    this.senderTaggingStore = args.senderTaggingStore;
+    this.recipientTaggingStore = args.recipientTaggingStore;
+    this.senderAddressBookStore = args.senderAddressBookStore;
+    this.capsuleStore = args.capsuleStore;
+    this.privateEventStore = args.privateEventStore;
+    this.simulator = args.simulator;
+    this.contractSyncService = args.contractSyncService;
     this.log = createLogger('simulator');
   }
 
   /**
    * Runs a private function.
    * @param request - The transaction request.
-   * @param entryPointArtifact - The artifact of the entry point function.
-   * @param contractAddress - The address of the contract (should match request.origin)
-   * @param msgSender - The address calling the function. This can be replaced to simulate a call from another contract
-   * or a specific account.
-   * @param anchorBlockHeader - The block header to use as base state for this run.
-   * @param senderForTags - The address that is used as a tagging sender when emitting private logs. Returned from
-   * the `privateGetSenderForTags` oracle.
-   * @param scopes - The accounts whose notes we can access in this call. Currently optional and will default to all.
-   * @param jobId - The job ID for staged writes.
-   * @returns The result of the execution.
    */
   public async run(
     request: TxExecutionRequest,
-    contractAddress: AztecAddress,
-    selector: FunctionSelector,
-    msgSender = AztecAddress.fromField(Fr.MAX_FIELD_VALUE),
-    anchorBlockHeader: BlockHeader,
-    senderForTags: AztecAddress | undefined,
-    scopes: AztecAddress[] | undefined,
-    jobId: string,
+    {
+      contractAddress,
+      selector,
+      msgSender = AztecAddress.fromField(Fr.MAX_FIELD_VALUE),
+      anchorBlockHeader,
+      senderForTags,
+      scopes,
+      jobId,
+    }: ContractSimulatorRunOpts,
   ): Promise<PrivateExecutionResult> {
     const simulatorSetupTimer = new Timer();
 
@@ -165,38 +202,37 @@ export class ContractFunctionSimulator {
     const noteCache = new ExecutionNoteCache(protocolNullifier);
     const taggingIndexCache = new ExecutionTaggingIndexCache();
 
-    const privateExecutionOracle = new PrivateExecutionOracle(
-      request.firstCallArgsHash,
-      request.txContext,
+    const privateExecutionOracle = new PrivateExecutionOracle({
+      argsHash: request.firstCallArgsHash,
+      txContext: request.txContext,
       callContext,
       anchorBlockHeader,
-      async call => {
+      utilityExecutor: async call => {
         await this.runUtility(call, [], anchorBlockHeader, scopes, jobId);
       },
-      request.authWitnesses,
-      request.capsules,
-      HashedValuesCache.create(request.argsOfCalls),
+      authWitnesses: request.authWitnesses,
+      capsules: request.capsules,
+      executionCache: HashedValuesCache.create(request.argsOfCalls),
       noteCache,
       taggingIndexCache,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.aztecNode,
-      this.senderTaggingStore,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.contractSyncService,
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.aztecNode,
+      senderTaggingStore: this.senderTaggingStore,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      contractSyncService: this.contractSyncService,
       jobId,
-      0, // totalPublicArgsCount
-      startSideEffectCounter,
-      undefined, // log
+      totalPublicCalldataCount: 0,
+      sideEffectCounter: startSideEffectCounter,
       scopes,
       senderForTags,
-      this.simulator,
-    );
+      simulator: this.simulator,
+    });
 
     const setupTime = simulatorSetupTimer.ms();
 
@@ -269,24 +305,23 @@ export class ContractFunctionSimulator {
       throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);
     }
 
-    const oracle = new UtilityExecutionOracle(
-      call.to,
-      authwits,
-      [],
+    const oracle = new UtilityExecutionOracle({
+      contractAddress: call.to,
+      authWitnesses: authwits,
+      capsules: [],
       anchorBlockHeader,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.aztecNode,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.aztecNode,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
       jobId,
-      undefined,
       scopes,
-    );
+    });
 
     try {
       this.log.verbose(`Executing utility function ${entryPointArtifact.name}`, {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -90,7 +90,7 @@ describe('Oracle Version Check test suite', () => {
       return { ...artifact, debug: undefined };
     });
 
-    acirSimulator = new ContractFunctionSimulator(
+    acirSimulator = new ContractFunctionSimulator({
       contractStore,
       noteStore,
       keyStore,
@@ -103,7 +103,7 @@ describe('Oracle Version Check test suite', () => {
       privateEventStore,
       simulator,
       contractSyncService,
-    );
+    });
   });
 
   describe('private function execution', () => {
@@ -139,16 +139,14 @@ describe('Oracle Version Check test suite', () => {
       // Call the private function with arbitrary message sender and sender for tags
       const msgSender = await AztecAddress.random();
       const senderForTags = await AztecAddress.random();
-      await acirSimulator.run(
-        txRequest,
+      await acirSimulator.run(txRequest, {
         contractAddress,
         selector,
         msgSender,
         anchorBlockHeader,
         senderForTags,
-        undefined,
-        'test',
-      );
+        jobId: 'test',
+      });
 
       expect(utilityAssertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
     }, 30_000);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -215,16 +215,14 @@ describe('Private Execution test suite', () => {
       salt: Fr.random(),
     });
 
-    return acirSimulator.run(
-      txRequest,
+    return acirSimulator.run(txRequest, {
       contractAddress,
       selector,
       msgSender,
       anchorBlockHeader,
       senderForTags,
-      undefined,
-      TEST_JOB_ID,
-    );
+      jobId: TEST_JOB_ID,
+    });
   };
 
   const insertLeaves = async (leaves: Fr[], name = 'noteHash') => {
@@ -327,13 +325,7 @@ describe('Private Execution test suite', () => {
     contractSyncService = mock<ContractSyncService>();
     // Configure mock to actually perform sync_state calls (needed for nested call tests)
     contractSyncService.ensureContractSynced.mockImplementation(
-      async (
-        contractAddress: AztecAddress,
-        functionToInvokeAfterSync: FunctionSelector | null,
-        utilityExecutor: (call: FunctionCall) => Promise<unknown>,
-        header: BlockHeader,
-        jobId: string,
-      ) => {
+      async (contractAddress, functionToInvokeAfterSync, utilityExecutor, anchorBlockHeader, jobId) => {
         await syncState(
           contractAddress,
           contractStore,
@@ -341,7 +333,7 @@ describe('Private Execution test suite', () => {
           utilityExecutor,
           noteStore,
           aztecNode,
-          header,
+          anchorBlockHeader,
           jobId,
         );
       },
@@ -484,7 +476,7 @@ describe('Private Execution test suite', () => {
       },
     );
 
-    acirSimulator = new ContractFunctionSimulator(
+    acirSimulator = new ContractFunctionSimulator({
       contractStore,
       noteStore,
       keyStore,
@@ -497,7 +489,7 @@ describe('Private Execution test suite', () => {
       privateEventStore,
       simulator,
       contractSyncService,
-    );
+    });
   });
 
   describe('no constructor', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -2,7 +2,6 @@ import { MAX_FR_CALLDATA_TO_ALL_ENQUEUED_CALLS, PRIVATE_CONTEXT_INPUTS_LENGTH } 
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import type { KeyStore } from '@aztec/key-store';
 import { type CircuitSimulator, toACVMWitness } from '@aztec/simulator/client';
 import {
   type FunctionAbi,
@@ -12,18 +11,14 @@ import {
   type NoteSelector,
   countArgumentsSize,
 } from '@aztec/stdlib/abi';
-import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { siloNullifier } from '@aztec/stdlib/hash';
-import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import { PrivateContextInputs } from '@aztec/stdlib/kernel';
 import { type ContractClassLog, DirectionalAppTaggingSecret, type PreTag } from '@aztec/stdlib/logs';
 import { Tag } from '@aztec/stdlib/logs';
 import { Note, type NoteStatus } from '@aztec/stdlib/note';
 import {
-  type BlockHeader,
   CallContext,
-  Capsule,
   CountedContractClassLog,
   NoteAndSlot,
   PrivateCallExecutionResult,
@@ -32,13 +27,6 @@ import {
 
 import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import { NoteService } from '../../notes/note_service.js';
-import type { AddressStore } from '../../storage/address_store/address_store.js';
-import type { CapsuleStore } from '../../storage/capsule_store/capsule_store.js';
-import type { ContractStore } from '../../storage/contract_store/contract_store.js';
-import type { NoteStore } from '../../storage/note_store/note_store.js';
-import type { PrivateEventStore } from '../../storage/private_event_store/private_event_store.js';
-import type { RecipientTaggingStore } from '../../storage/tagging_store/recipient_tagging_store.js';
-import type { SenderAddressBookStore } from '../../storage/tagging_store/sender_address_book_store.js';
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
 import { syncSenderTaggingIndexes } from '../../tagging/index.js';
 import type { ExecutionNoteCache } from '../execution_note_cache.js';
@@ -47,7 +35,25 @@ import type { HashedValuesCache } from '../hashed_values_cache.js';
 import { pickNotes } from '../pick_notes.js';
 import type { IPrivateExecutionOracle, NoteData } from './interfaces.js';
 import { executePrivateFunction } from './private_execution.js';
-import { UtilityExecutionOracle } from './utility_execution_oracle.js';
+import { UtilityExecutionOracle, type UtilityExecutionOracleArgs } from './utility_execution_oracle.js';
+
+/** Args for PrivateExecutionOracle constructor. */
+export type PrivateExecutionOracleArgs = Omit<UtilityExecutionOracleArgs, 'contractAddress'> & {
+  argsHash: Fr;
+  txContext: TxContext;
+  callContext: CallContext;
+  /** Needed to trigger contract synchronization before nested calls */
+  utilityExecutor: (call: FunctionCall) => Promise<void>;
+  executionCache: HashedValuesCache;
+  noteCache: ExecutionNoteCache;
+  taggingIndexCache: ExecutionTaggingIndexCache;
+  senderTaggingStore: SenderTaggingStore;
+  contractSyncService: ContractSyncService;
+  totalPublicCalldataCount?: number;
+  sideEffectCounter?: number;
+  senderForTags?: AztecAddress;
+  simulator?: CircuitSimulator;
+};
 
 /**
  * The execution oracle for the private part of a transaction.
@@ -69,57 +75,39 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private offchainEffects: { data: Fr[] }[] = [];
   private nestedExecutionResults: PrivateCallExecutionResult[] = [];
 
-  constructor(
-    private readonly argsHash: Fr,
-    private readonly txContext: TxContext,
-    private readonly callContext: CallContext,
-    /** Header of a block whose state is used during private execution (not the block the transaction is included in). */
-    protected override readonly anchorBlockHeader: BlockHeader,
-    /** Needed to trigger contract synchronization before nested calls */
-    private readonly utilityExecutor: (call: FunctionCall) => Promise<void>,
-    /** List of transient auth witnesses to be used during this simulation */
-    authWitnesses: AuthWitness[],
-    capsules: Capsule[],
-    private readonly executionCache: HashedValuesCache,
-    private readonly noteCache: ExecutionNoteCache,
-    private readonly taggingIndexCache: ExecutionTaggingIndexCache,
-    contractStore: ContractStore,
-    noteStore: NoteStore,
-    keyStore: KeyStore,
-    addressStore: AddressStore,
-    aztecNode: AztecNode,
-    private readonly senderTaggingStore: SenderTaggingStore,
-    recipientTaggingStore: RecipientTaggingStore,
-    senderAddressBookStore: SenderAddressBookStore,
-    capsuleStore: CapsuleStore,
-    privateEventStore: PrivateEventStore,
-    private readonly contractSyncService: ContractSyncService,
-    jobId: string,
-    private totalPublicCalldataCount: number = 0,
-    protected sideEffectCounter: number = 0,
-    log = createLogger('simulator:client_execution_context'),
-    scopes?: AztecAddress[],
-    private senderForTags?: AztecAddress,
-    private simulator?: CircuitSimulator,
-  ) {
-    super(
-      callContext.contractAddress,
-      authWitnesses,
-      capsules,
-      anchorBlockHeader,
-      contractStore,
-      noteStore,
-      keyStore,
-      addressStore,
-      aztecNode,
-      recipientTaggingStore,
-      senderAddressBookStore,
-      capsuleStore,
-      privateEventStore,
-      jobId,
-      log,
-      scopes,
-    );
+  private readonly argsHash: Fr;
+  private readonly txContext: TxContext;
+  private readonly callContext: CallContext;
+  private readonly utilityExecutor: (call: FunctionCall) => Promise<void>;
+  private readonly executionCache: HashedValuesCache;
+  private readonly noteCache: ExecutionNoteCache;
+  private readonly taggingIndexCache: ExecutionTaggingIndexCache;
+  private readonly senderTaggingStore: SenderTaggingStore;
+  private readonly contractSyncService: ContractSyncService;
+  private totalPublicCalldataCount: number;
+  protected sideEffectCounter: number;
+  private senderForTags?: AztecAddress;
+  private readonly simulator?: CircuitSimulator;
+
+  constructor(args: PrivateExecutionOracleArgs) {
+    super({
+      ...args,
+      contractAddress: args.callContext.contractAddress,
+      log: args.log ?? createLogger('simulator:client_execution_context'),
+    });
+    this.argsHash = args.argsHash;
+    this.txContext = args.txContext;
+    this.callContext = args.callContext;
+    this.utilityExecutor = args.utilityExecutor;
+    this.executionCache = args.executionCache;
+    this.noteCache = args.noteCache;
+    this.taggingIndexCache = args.taggingIndexCache;
+    this.senderTaggingStore = args.senderTaggingStore;
+    this.contractSyncService = args.contractSyncService;
+    this.totalPublicCalldataCount = args.totalPublicCalldataCount ?? 0;
+    this.sideEffectCounter = args.sideEffectCounter ?? 0;
+    this.senderForTags = args.senderForTags;
+    this.simulator = args.simulator;
   }
 
   public getPrivateContextInputs(): PrivateContextInputs {
@@ -555,41 +543,41 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     const derivedCallContext = await this.deriveCallContext(targetContractAddress, targetArtifact, isStaticCall);
 
-    const privateExecutionOracle = new PrivateExecutionOracle(
+    const privateExecutionOracle = new PrivateExecutionOracle({
       argsHash,
-      derivedTxContext,
-      derivedCallContext,
-      this.anchorBlockHeader,
-      this.utilityExecutor,
-      this.authWitnesses,
-      this.capsules,
-      this.executionCache,
-      this.noteCache,
-      this.taggingIndexCache,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.aztecNode,
-      this.senderTaggingStore,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.contractSyncService,
-      this.jobId,
-      this.totalPublicCalldataCount,
+      txContext: derivedTxContext,
+      callContext: derivedCallContext,
+      anchorBlockHeader: this.anchorBlockHeader,
+      utilityExecutor: this.utilityExecutor,
+      authWitnesses: this.authWitnesses,
+      capsules: this.capsules,
+      executionCache: this.executionCache,
+      noteCache: this.noteCache,
+      taggingIndexCache: this.taggingIndexCache,
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.aztecNode,
+      senderTaggingStore: this.senderTaggingStore,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      contractSyncService: this.contractSyncService,
+      jobId: this.jobId,
+      totalPublicCalldataCount: this.totalPublicCalldataCount,
       sideEffectCounter,
-      this.log,
-      this.scopes,
-      this.senderForTags,
-      this.simulator,
-    );
+      log: this.log,
+      scopes: this.scopes,
+      senderForTags: this.senderForTags,
+      simulator: this.simulator!,
+    });
 
     const setupTime = simulatorSetupTimer.ms();
 
     const childExecutionResult = await executePrivateFunction(
-      this.simulator,
+      this.simulator!,
       privateExecutionOracle,
       targetArtifact,
       targetContractAddress,

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -90,7 +90,7 @@ describe('Utility Execution test suite', () => {
     capsuleStore.readCapsuleArray.mockImplementation((address, slot) => {
       return Promise.resolve(capsuleArrays.get(`${address.toString()}:${slot.toString()}`) ?? []);
     });
-    acirSimulator = new ContractFunctionSimulator(
+    acirSimulator = new ContractFunctionSimulator({
       contractStore,
       noteStore,
       keyStore,
@@ -103,7 +103,7 @@ describe('Utility Execution test suite', () => {
       privateEventStore,
       simulator,
       contractSyncService,
-    );
+    });
 
     const ownerPartialAddress = Fr.random();
     ownerCompleteAddress = await CompleteAddress.fromSecretKeyAndPartialAddress(ownerSecretKey, ownerPartialAddress);
@@ -205,10 +205,10 @@ describe('Utility Execution test suite', () => {
         globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(syncedBlockNumber) }),
       });
 
-      utilityExecutionOracle = new UtilityExecutionOracle(
+      utilityExecutionOracle = new UtilityExecutionOracle({
         contractAddress,
-        [],
-        [],
+        authWitnesses: [],
+        capsules: [],
         anchorBlockHeader,
         contractStore,
         noteStore,
@@ -219,8 +219,8 @@ describe('Utility Execution test suite', () => {
         senderAddressBookStore,
         capsuleStore,
         privateEventStore,
-        'test-job-id',
-      );
+        jobId: 'test-job-id',
+      });
     });
 
     describe('Respects synced block number', () => {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -40,6 +40,27 @@ import { pickNotes } from '../pick_notes.js';
 import type { IMiscOracle, IUtilityExecutionOracle, NoteData } from './interfaces.js';
 import { MessageLoadOracleInputs } from './message_load_oracle_inputs.js';
 
+/** Args for UtilityExecutionOracle constructor. */
+export type UtilityExecutionOracleArgs = {
+  contractAddress: AztecAddress;
+  /** List of transient auth witnesses to be used during this simulation */
+  authWitnesses: AuthWitness[];
+  capsules: Capsule[]; // TODO(#12425): Rename to transientCapsules
+  anchorBlockHeader: BlockHeader;
+  contractStore: ContractStore;
+  noteStore: NoteStore;
+  keyStore: KeyStore;
+  addressStore: AddressStore;
+  aztecNode: AztecNode;
+  recipientTaggingStore: RecipientTaggingStore;
+  senderAddressBookStore: SenderAddressBookStore;
+  capsuleStore: CapsuleStore;
+  privateEventStore: PrivateEventStore;
+  jobId: string;
+  log?: ReturnType<typeof createLogger>;
+  scopes?: AztecAddress[];
+};
+
 /**
  * The oracle for an execution of utility contract functions.
  */
@@ -49,25 +70,41 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
 
   private contractLogger: Logger | undefined;
 
-  constructor(
-    protected readonly contractAddress: AztecAddress,
-    /** List of transient auth witnesses to be used during this simulation */
-    protected readonly authWitnesses: AuthWitness[],
-    protected readonly capsules: Capsule[], // TODO(#12425): Rename to transientCapsules
-    protected readonly anchorBlockHeader: BlockHeader,
-    protected readonly contractStore: ContractStore,
-    protected readonly noteStore: NoteStore,
-    protected readonly keyStore: KeyStore,
-    protected readonly addressStore: AddressStore,
-    protected readonly aztecNode: AztecNode,
-    protected readonly recipientTaggingStore: RecipientTaggingStore,
-    protected readonly senderAddressBookStore: SenderAddressBookStore,
-    protected readonly capsuleStore: CapsuleStore,
-    protected readonly privateEventStore: PrivateEventStore,
-    protected readonly jobId: string,
-    protected log = createLogger('simulator:client_view_context'),
-    protected readonly scopes?: AztecAddress[],
-  ) {}
+  protected readonly contractAddress: AztecAddress;
+  protected readonly authWitnesses: AuthWitness[];
+  protected readonly capsules: Capsule[];
+  protected readonly anchorBlockHeader: BlockHeader;
+  protected readonly contractStore: ContractStore;
+  protected readonly noteStore: NoteStore;
+  protected readonly keyStore: KeyStore;
+  protected readonly addressStore: AddressStore;
+  protected readonly aztecNode: AztecNode;
+  protected readonly recipientTaggingStore: RecipientTaggingStore;
+  protected readonly senderAddressBookStore: SenderAddressBookStore;
+  protected readonly capsuleStore: CapsuleStore;
+  protected readonly privateEventStore: PrivateEventStore;
+  protected readonly jobId: string;
+  protected log: ReturnType<typeof createLogger>;
+  protected readonly scopes?: AztecAddress[];
+
+  constructor(args: UtilityExecutionOracleArgs) {
+    this.contractAddress = args.contractAddress;
+    this.authWitnesses = args.authWitnesses;
+    this.capsules = args.capsules;
+    this.anchorBlockHeader = args.anchorBlockHeader;
+    this.contractStore = args.contractStore;
+    this.noteStore = args.noteStore;
+    this.keyStore = args.keyStore;
+    this.addressStore = args.addressStore;
+    this.aztecNode = args.aztecNode;
+    this.recipientTaggingStore = args.recipientTaggingStore;
+    this.senderAddressBookStore = args.senderAddressBookStore;
+    this.capsuleStore = args.capsuleStore;
+    this.privateEventStore = args.privateEventStore;
+    this.jobId = args.jobId;
+    this.log = args.log ?? createLogger('simulator:client_view_context');
+    this.scopes = args.scopes;
+  }
 
   public utilityAssertCompatibleOracleVersion(version: number): void {
     if (version !== ORACLE_VERSION) {

--- a/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
@@ -52,6 +52,14 @@ export async function createPXE(
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
-  const pxe = await PXE.create(aztecNode, store, prover, simulator, protocolContractsProvider, config, pxeLogger);
+  const pxe = await PXE.create({
+    node: aztecNode,
+    store,
+    proofCreator: prover,
+    simulator,
+    protocolContractsProvider,
+    config,
+    loggerOrSuffix: pxeLogger,
+  });
   return pxe;
 }

--- a/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
@@ -52,6 +52,14 @@ export async function createPXE(
   const protocolContractsProvider = new LazyProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
-  const pxe = await PXE.create(aztecNode, store, prover, simulator, protocolContractsProvider, config, pxeLogger);
+  const pxe = await PXE.create({
+    node: aztecNode,
+    store,
+    proofCreator: prover,
+    simulator,
+    protocolContractsProvider,
+    config,
+    loggerOrSuffix: pxeLogger,
+  });
   return pxe;
 }

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -58,14 +58,14 @@ export async function createPXE(
   const protocolContractsProvider = new BundledProtocolContractsProvider();
 
   const pxeLogger = loggers.pxe ?? createLogger('pxe:service', { actor });
-  const pxe = await PXE.create(
-    aztecNode,
-    options.store,
-    prover,
+  const pxe = await PXE.create({
+    node: aztecNode,
+    store: options.store,
+    proofCreator: prover,
     simulator,
     protocolContractsProvider,
-    configWithContracts,
-    pxeLogger,
-  );
+    config: configWithContracts,
+    loggerOrSuffix: pxeLogger,
+  });
   return pxe;
 }

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -77,7 +77,14 @@ describe('PXE', () => {
       },
     });
 
-    pxe = await PXE.create(node, kvStore, kernelProver, simulator, protocolContractsProvider, config);
+    pxe = await PXE.create({
+      node,
+      store: kvStore,
+      proofCreator: kernelProver,
+      simulator,
+      protocolContractsProvider,
+      config,
+    });
   }, 120_000);
 
   it('registers an account and returns it as an account only and not as a recipient', async () => {

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -86,6 +86,54 @@ export type PackedPrivateEvent = InTx & {
   eventSelector: EventSelector;
 };
 
+/** Options for PXE.profileTx. */
+export type ProfileTxOpts = {
+  /** The profiling mode to use. */
+  profileMode: 'full' | 'execution-steps' | 'gates';
+  /** If true, proof generation is skipped during profiling. Defaults to true. */
+  skipProofGeneration?: boolean;
+};
+
+/** Options for PXE.simulateTx. */
+export type SimulateTxOpts = {
+  /** Whether to simulate the public part of the transaction. */
+  simulatePublic: boolean;
+  /** If false, this function throws if the transaction is unable to be included in a block at the current state. */
+  skipTxValidation?: boolean;
+  /** If false, fees are enforced. */
+  skipFeeEnforcement?: boolean;
+  /** State overrides for the simulation, such as contract instances and artifacts. */
+  overrides?: SimulationOverrides;
+  /** The accounts whose notes we can access in this call. Defaults to all. */
+  scopes?: AztecAddress[];
+};
+
+/** Options for PXE.simulateUtility. */
+export type SimulateUtilityOpts = {
+  /** The authentication witnesses required for the function call. */
+  authwits?: AuthWitness[];
+  /** The accounts whose notes we can access in this call. Defaults to all. */
+  scopes?: AztecAddress[];
+};
+
+/** Args for PXE.create. */
+export type PXECreateArgs = {
+  /** The Aztec node to connect to. */
+  node: AztecNode;
+  /** The key-value store for persisting PXE state. */
+  store: AztecAsyncKVStore;
+  /** The prover for generating private kernel proofs. */
+  proofCreator: PrivateKernelProver;
+  /** The circuit simulator for executing ACIR circuits. */
+  simulator: CircuitSimulator;
+  /** Provider for protocol contract artifacts and instances. */
+  protocolContractsProvider: ProtocolContractsProvider;
+  /** PXE configuration options. */
+  config: PXEConfig;
+  /** Optional logger instance or string suffix for the logger name. */
+  loggerOrSuffix?: string | Logger;
+};
+
 /**
  * Private eXecution Environment (PXE) is a library used by wallets to simulate private phase of transactions and to
  * manage private state of users.
@@ -122,15 +170,15 @@ export class PXE {
    *
    * @returns A promise that resolves PXE is ready to be used.
    */
-  public static async create(
-    node: AztecNode,
-    store: AztecAsyncKVStore,
-    proofCreator: PrivateKernelProver,
-    simulator: CircuitSimulator,
-    protocolContractsProvider: ProtocolContractsProvider,
-    config: PXEConfig,
-    loggerOrSuffix?: string | Logger,
-  ) {
+  public static async create({
+    node,
+    store,
+    proofCreator,
+    simulator,
+    protocolContractsProvider,
+    config,
+    loggerOrSuffix,
+  }: PXECreateArgs) {
     // Extract bindings from the logger, or use empty bindings if a string suffix is provided.
     const bindings: LoggerBindings | undefined =
       loggerOrSuffix && typeof loggerOrSuffix !== 'string' ? loggerOrSuffix.getBindings() : undefined;
@@ -227,20 +275,20 @@ export class PXE {
   #getSimulatorForTx(overrides?: { contracts?: ContractOverrides }) {
     const proxyContractStore = ProxiedContractStoreFactory.create(this.contractStore, overrides?.contracts);
 
-    return new ContractFunctionSimulator(
-      proxyContractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      BenchmarkedNodeFactory.create(this.node),
-      this.senderTaggingStore,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.simulator,
-      this.contractSyncService,
-    );
+    return new ContractFunctionSimulator({
+      contractStore: proxyContractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: BenchmarkedNodeFactory.create(this.node),
+      senderTaggingStore: this.senderTaggingStore,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      simulator: this.simulator,
+      contractSyncService: this.contractSyncService,
+    });
   }
 
   #contextualizeError(err: Error, ...context: string[]): Error {
@@ -322,18 +370,13 @@ export class PXE {
         jobId,
       );
 
-      const result = await contractFunctionSimulator.run(
-        txRequest,
+      const result = await contractFunctionSimulator.run(txRequest, {
         contractAddress,
-        functionSelector,
-        undefined,
+        selector: functionSelector,
         anchorBlockHeader,
-        // The sender for tags is set by contracts, typically by an account
-        // contract entrypoint
-        undefined, // senderForTags
         scopes,
         jobId,
-      );
+      });
       this.log.debug(`Private simulation completed for ${contractAddress.toString()}:${functionSelector}`);
       return result;
     } catch (err) {
@@ -736,17 +779,13 @@ export class PXE {
 
   /**
    * Profiles a transaction, reporting gate counts (unless disabled) and returns an execution trace.
-   *
-   * @param txRequest - An authenticated tx request ready for simulation
-   * @param msgSender - (Optional) The message sender to use for the simulation.
-   * @param skipTxValidation - (Optional) If false, this function throws if the transaction is unable to be included in a block at the current state.
+   * @param txRequest - An authenticated tx request ready for simulation.
    * @returns A trace of the program execution with gate counts.
    * @throws If the code for the functions executed in this transaction have not been made available via `addContracts`.
    */
   public profileTx(
     txRequest: TxExecutionRequest,
-    profileMode: 'full' | 'execution-steps' | 'gates',
-    skipProofGeneration: boolean = true,
+    { profileMode, skipProofGeneration = true }: ProfileTxOpts,
   ): Promise<TxProfileResult> {
     // We disable concurrent profiles for consistency with simulateTx.
     return this.#putInJobQueue(async jobId => {
@@ -831,12 +870,7 @@ export class PXE {
    * In that case, the transaction returned is only potentially ready to be sent to the network for execution.
    *
    *
-   * @param txRequest - An authenticated tx request ready for simulation
-   * @param simulatePublic - Whether to simulate the public part of the transaction.
-   * @param skipTxValidation - (Optional) If false, this function throws if the transaction is unable to be included in a block at the current state.
-   * @param skipFeeEnforcement - (Optional) If false, fees are enforced.
-   * @param overrides - (Optional) State overrides for the simulation, such as msgSender, contract instances and artifacts.
-   * @param scopes - (Optional) The accounts whose notes we can access in this call. Currently optional and will default to all.
+   * @param txRequest - An authenticated tx request ready for simulation.
    * @returns A simulated transaction result object that includes public and private return values.
    * @throws If the code for the functions executed in this transaction have not been made available via `addContracts`.
    * Also throws if simulatePublic is true and public simulation reverts.
@@ -845,11 +879,7 @@ export class PXE {
    */
   public simulateTx(
     txRequest: TxExecutionRequest,
-    simulatePublic: boolean,
-    skipTxValidation: boolean = false,
-    skipFeeEnforcement: boolean = false,
-    overrides?: SimulationOverrides,
-    scopes?: AztecAddress[],
+    { simulatePublic, skipTxValidation = false, skipFeeEnforcement = false, overrides, scopes }: SimulateTxOpts,
   ): Promise<TxSimulationResult> {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
@@ -980,18 +1010,12 @@ export class PXE {
   }
 
   /**
-   * Simulate the execution of a contract utility function.
-   *
+   * Simulates the execution of a contract utility function.
    * @param call - The function call containing the function details, arguments, and target contract address.
-   * @param authwits - (Optional) The authentication witnesses required for the function call.
-   * @param scopes - (Optional) The accounts whose notes we can access in this call. Currently optional and will
-   * default to all.
-   * @returns The result of the utility function call, structured based on the function ABI.
    */
   public simulateUtility(
     call: FunctionCall,
-    authwits?: AuthWitness[],
-    scopes?: AztecAddress[],
+    { authwits, scopes }: SimulateUtilityOpts = {},
   ): Promise<UtilitySimulationResult> {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to

--- a/yarn-project/test-wallet/src/wallet/test_wallet.ts
+++ b/yarn-project/test-wallet/src/wallet/test_wallet.ts
@@ -232,7 +232,12 @@ export abstract class BaseTestWallet extends BaseWallet {
       const contractOverrides = {
         [opts.from.toString()]: { instance, artifact },
       };
-      return this.pxe.simulateTx(txRequest, true /* simulatePublic */, true, true, { contracts: contractOverrides });
+      return this.pxe.simulateTx(txRequest, {
+        simulatePublic: true,
+        skipTxValidation: true,
+        skipFeeEnforcement: true,
+        overrides: { contracts: contractOverrides },
+      });
     }
   }
 

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -337,43 +337,37 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     const simulator = new WASMSimulator();
 
-    const privateExecutionOracle = new PrivateExecutionOracle(
+    const privateExecutionOracle = new PrivateExecutionOracle({
       argsHash,
       txContext,
       callContext,
-      /** Header of a block whose state is used during private execution (not the block the transaction is included in). */
-      blockHeader,
+      anchorBlockHeader: blockHeader,
       utilityExecutor,
-      /** List of transient auth witnesses to be used during this simulation */
-      Array.from(this.authwits.values()),
-      /** List of transient auth witnesses to be used during this simulation */
-      [],
-      HashedValuesCache.create([new HashedValues(args, argsHash)]),
+      authWitnesses: Array.from(this.authwits.values()),
+      capsules: [],
+      executionCache: HashedValuesCache.create([new HashedValues(args, argsHash)]),
       noteCache,
       taggingIndexCache,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.stateMachine.node,
-      this.senderTaggingStore,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.stateMachine.contractSyncService,
-      this.jobId,
-      0, // totalPublicArgsCount
-      minRevertibleSideEffectCounter, // (start) sideEffectCounter
-      undefined, // log
-      effectiveScopes, // scopes
-      /**
-       * In TXE, the typical transaction entrypoint is skipped, so we need to simulate the actions that such a
-       * contract would perform, including setting senderForTags.
-       */
-      from,
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.stateMachine.node,
+      senderTaggingStore: this.senderTaggingStore,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      contractSyncService: this.stateMachine.contractSyncService,
+      jobId: this.jobId,
+      totalPublicCalldataCount: 0,
+      sideEffectCounter: minRevertibleSideEffectCounter,
+      scopes: effectiveScopes,
+      // In TXE, the typical transaction entrypoint is skipped, so we need to simulate the actions that such a
+      // contract would perform, including setting senderForTags.
+      senderForTags: from,
       simulator,
-    );
+    });
 
     // Note: This is a slight modification of simulator.run without any of the checks. Maybe we should modify simulator.run with a boolean value to skip checks.
     let result: PrivateExecutionResult;
@@ -712,24 +706,23 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
     try {
       const anchorBlockHeader = await this.stateMachine.anchorBlockStore.getBlockHeader();
-      const oracle = new UtilityExecutionOracle(
-        call.to,
-        [],
-        [],
+      const oracle = new UtilityExecutionOracle({
+        contractAddress: call.to,
+        authWitnesses: [],
+        capsules: [],
         anchorBlockHeader,
-        this.contractStore,
-        this.noteStore,
-        this.keyStore,
-        this.addressStore,
-        this.stateMachine.node,
-        this.recipientTaggingStore,
-        this.senderAddressBookStore,
-        this.capsuleStore,
-        this.privateEventStore,
-        this.jobId,
-        undefined, // log
-        scopes, // scopes - used to filter notes by account
-      );
+        contractStore: this.contractStore,
+        noteStore: this.noteStore,
+        keyStore: this.keyStore,
+        addressStore: this.addressStore,
+        aztecNode: this.stateMachine.node,
+        recipientTaggingStore: this.recipientTaggingStore,
+        senderAddressBookStore: this.senderAddressBookStore,
+        capsuleStore: this.capsuleStore,
+        privateEventStore: this.privateEventStore,
+        jobId: this.jobId,
+        scopes,
+      });
       const acirExecutionResult = await new WASMSimulator()
         .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())
         .catch((err: Error) => {

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -339,30 +339,30 @@ export class TXESession implements TXESessionStateHandler {
     const taggingIndexCache = new ExecutionTaggingIndexCache();
 
     const utilityExecutor = this.utilityExecutorForContractSync(anchorBlock);
-    this.oracleHandler = new PrivateExecutionOracle(
-      Fr.ZERO,
-      new TxContext(this.chainId, this.version, GasSettings.empty()),
-      new CallContext(AztecAddress.ZERO, contractAddress, FunctionSelector.empty(), false),
-      anchorBlock!,
+    this.oracleHandler = new PrivateExecutionOracle({
+      argsHash: Fr.ZERO,
+      txContext: new TxContext(this.chainId, this.version, GasSettings.empty()),
+      callContext: new CallContext(AztecAddress.ZERO, contractAddress, FunctionSelector.empty(), false),
+      anchorBlockHeader: anchorBlock!,
       utilityExecutor,
-      [],
-      [],
-      new HashedValuesCache(),
+      authWitnesses: [],
+      capsules: [],
+      executionCache: new HashedValuesCache(),
       noteCache,
       taggingIndexCache,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.stateMachine.node,
-      this.senderTaggingStore,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.stateMachine.contractSyncService,
-      this.currentJobId,
-    );
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.stateMachine.node,
+      senderTaggingStore: this.senderTaggingStore,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      contractSyncService: this.stateMachine.contractSyncService,
+      jobId: this.currentJobId,
+    });
 
     // We store the note and tagging index caches fed into the PrivateExecutionOracle (along with some other auxiliary
     // data) in order to refer to it later, mimicking the way this object is used by the ContractFunctionSimulator. The
@@ -416,22 +416,22 @@ export class TXESession implements TXESessionStateHandler {
       this.currentJobId,
     ).syncNoteNullifiers(contractAddress);
 
-    this.oracleHandler = new UtilityExecutionOracle(
+    this.oracleHandler = new UtilityExecutionOracle({
       contractAddress,
-      [],
-      [],
+      authWitnesses: [],
+      capsules: [],
       anchorBlockHeader,
-      this.contractStore,
-      this.noteStore,
-      this.keyStore,
-      this.addressStore,
-      this.stateMachine.node,
-      this.recipientTaggingStore,
-      this.senderAddressBookStore,
-      this.capsuleStore,
-      this.privateEventStore,
-      this.currentJobId,
-    );
+      contractStore: this.contractStore,
+      noteStore: this.noteStore,
+      keyStore: this.keyStore,
+      addressStore: this.addressStore,
+      aztecNode: this.stateMachine.node,
+      recipientTaggingStore: this.recipientTaggingStore,
+      senderAddressBookStore: this.senderAddressBookStore,
+      capsuleStore: this.capsuleStore,
+      privateEventStore: this.privateEventStore,
+      jobId: this.currentJobId,
+    });
 
     this.state = { name: 'UTILITY' };
     this.logger.debug(`Entered state ${this.state.name}`);
@@ -506,22 +506,22 @@ export class TXESession implements TXESessionStateHandler {
       }
 
       try {
-        const oracle = new UtilityExecutionOracle(
-          call.to,
-          [],
-          [],
-          anchorBlock!,
-          this.contractStore,
-          this.noteStore,
-          this.keyStore,
-          this.addressStore,
-          this.stateMachine.node,
-          this.recipientTaggingStore,
-          this.senderAddressBookStore,
-          this.capsuleStore,
-          this.privateEventStore,
-          this.currentJobId,
-        );
+        const oracle = new UtilityExecutionOracle({
+          contractAddress: call.to,
+          authWitnesses: [],
+          capsules: [],
+          anchorBlockHeader: anchorBlock!,
+          contractStore: this.contractStore,
+          noteStore: this.noteStore,
+          keyStore: this.keyStore,
+          addressStore: this.addressStore,
+          aztecNode: this.stateMachine.node,
+          recipientTaggingStore: this.recipientTaggingStore,
+          senderAddressBookStore: this.senderAddressBookStore,
+          capsuleStore: this.capsuleStore,
+          privateEventStore: this.privateEventStore,
+          jobId: this.currentJobId,
+        });
         await new WASMSimulator()
           .executeUserCircuit(toACVMWitness(0, call.args), entryPointArtifact, new Oracle(oracle).toACIRCallback())
           .catch((err: Error) => {

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -300,7 +300,7 @@ export abstract class BaseWallet implements Wallet {
     skipFeeEnforcement?: boolean,
   ) {
     const txRequest = await this.createTxExecutionRequestFromPayloadAndFee(executionPayload, from, feeOptions);
-    return this.pxe.simulateTx(txRequest, true /* simulatePublic */, skipTxValidation, skipFeeEnforcement);
+    return this.pxe.simulateTx(txRequest, { simulatePublic: true, skipTxValidation, skipFeeEnforcement });
   }
 
   /**
@@ -350,7 +350,10 @@ export abstract class BaseWallet implements Wallet {
   async profileTx(executionPayload: ExecutionPayload, opts: ProfileOptions): Promise<TxProfileResult> {
     const feeOptions = await this.completeFeeOptions(opts.from, executionPayload.feePayer, opts.fee?.gasSettings);
     const txRequest = await this.createTxExecutionRequestFromPayloadAndFee(executionPayload, opts.from, feeOptions);
-    return this.pxe.profileTx(txRequest, opts.profileMode, opts.skipProofGeneration ?? true);
+    return this.pxe.profileTx(txRequest, {
+      profileMode: opts.profileMode,
+      skipProofGeneration: opts.skipProofGeneration ?? true,
+    });
   }
 
   public async sendTx<W extends InteractionWaitOptions = undefined>(
@@ -396,7 +399,7 @@ export abstract class BaseWallet implements Wallet {
   }
 
   simulateUtility(call: FunctionCall, authwits?: AuthWitness[]): Promise<UtilitySimulationResult> {
-    return this.pxe.simulateUtility(call, authwits);
+    return this.pxe.simulateUtility(call, { authwits });
   }
 
   async getPrivateEvents<T>(


### PR DESCRIPTION
We are now refactoring some functions in PXE to add named params to those that take a lot of parameters

The idea was:
- Convention was "absolutely mandatory and well types args" are standalone, "optional/less important/behavioral modifiers" belong in an opts object
- For constructors, we made everything an object