### PR TITLE
chore(test): fix p2p integration test

### DIFF
--- a/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_message_propagation.test.ts
@@ -71,6 +71,7 @@ describe('p2p client integration message propagation', () => {
     });
 
     attestationPool.isEmpty.mockResolvedValue(true);
+    attestationPool.tryAddBlockProposal.mockResolvedValue({ added: true, alreadyExists: false, totalForPosition: 1 });
 
     worldState.status.mockResolvedValue({
       state: mock(),


### PR DESCRIPTION
It was broken with the latest changes to the attestation pool.
