### PR TITLE
chore(claude): minor changes to claude md and rules

### DIFF
--- a/yarn-project/.claude/rules/typescript-style.md
+++ b/yarn-project/.claude/rules/typescript-style.md
@@ -1,3 +1,7 @@
+---
+globs: "*.ts,*.tsx,*.mts,*.cts"
+---
+
 # TypeScript Code Style
 
 ## Type Safety

--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -75,7 +75,7 @@ For long-running tests or verbose output, redirect to a temp file and use native
 yarn workspace @aztec/<package-name> test src/file.test.ts > /tmp/test-output.log 2>&1
 ```
 
-Then use **Read** or **Grep** to examine `/tmp/test-output.log`. Never use `| tail` or `| head` to limit output—use native tools instead.
+Then use **Read** or **Grep** to examine `/tmp/test-output.log`. Never use `| tail` or `| head` to limit output—use native tools instead. Never append `; echo "EXIT: $?"` or similar—the Bash tool already reports exit codes directly.
 
 ### End-to-End Tests
 


### PR DESCRIPTION
- add glob to typescript style rule so it's only loaded on ts files
- enforce claude not to add the `echo` bash for loading exit codes, which breaks permissions
