### PR TITLE
chore(e2e): remove setup with remote env in e2e tests

### DIFF
--- a/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
@@ -138,10 +138,10 @@ export class ClientFlowsBenchmark {
     });
     await this.applyBaseSetup();
 
-    await this.context.aztecNodeService!.setConfig({ feeRecipient: this.sequencerAddress, coinbase: this.coinbase });
+    await this.context.aztecNodeService.setConfig({ feeRecipient: this.sequencerAddress, coinbase: this.coinbase });
 
     const rollupContract = RollupContract.getFromConfig(this.context.config);
-    this.chainMonitor = new ChainMonitor(rollupContract, this.context.dateProvider!, this.logger, 200).start();
+    this.chainMonitor = new ChainMonitor(rollupContract, this.context.dateProvider, this.logger, 200).start();
 
     return this;
   }
@@ -207,7 +207,7 @@ export class ClientFlowsBenchmark {
     const [{ address: adminAddress }, { address: sequencerAddress }] = deployedAccounts;
 
     this.adminWallet = this.context.wallet;
-    this.aztecNode = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
     this.cheatCodes = this.context.cheatCodes;
 
     this.adminAddress = adminAddress;
@@ -235,8 +235,8 @@ export class ClientFlowsBenchmark {
     this.feeJuiceContract = FeeJuiceContract.at(ProtocolContractAddress.FeeJuice, this.adminWallet);
 
     this.feeJuiceBridgeTestHarness = await FeeJuicePortalTestingHarnessFactory.create({
-      aztecNode: this.context.aztecNodeService!,
-      aztecNodeAdmin: this.context.aztecNodeService!,
+      aztecNode: this.context.aztecNodeService,
+      aztecNodeAdmin: this.context.aztecNodeService,
       l1Client: this.context.deployL1ContractsValues.l1Client,
       wallet: this.adminWallet,
       logger: this.logger,

--- a/yarn-project/end-to-end/src/bench/utils.ts
+++ b/yarn-project/end-to-end/src/bench/utils.ts
@@ -28,7 +28,7 @@ export async function benchmarkSetup(
   const contract = await BenchmarkingContract.deploy(context.wallet).send({ from: defaultAccountAddress });
   context.logger.info(`Deployed benchmarking contract at ${contract.address}`);
   const sequencer = (context.aztecNode as AztecNodeService).getSequencer()!;
-  const telemetry = context.telemetryClient! as BenchmarkTelemetryClient;
+  const telemetry = context.telemetryClient as BenchmarkTelemetryClient;
   context.logger.warn(`Cleared benchmark data points from setup`);
   telemetry.clear();
   const origTeardown = context.teardown.bind(context);

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -92,7 +92,7 @@ export class BlacklistTokenContractTest {
     });
 
     this.cheatCodes = this.context.cheatCodes;
-    this.aztecNode = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
     this.sequencer = this.context.sequencer!;
     this.wallet = this.context.wallet;
     this.adminAddress = deployedAccounts[0].address;

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -38,9 +38,9 @@ describe('e2e_block_building', () => {
   let minterAddress: AztecAddress;
 
   let aztecNode: AztecNode;
-  let aztecNodeAdmin: AztecNodeAdmin | undefined;
+  let aztecNodeAdmin: AztecNodeAdmin;
   let sequencer: TestSequencerClient;
-  let watcher: AnvilTestWatcher | undefined;
+  let watcher: AnvilTestWatcher;
   let teardown: () => Promise<void>;
 
   afterEach(() => {
@@ -68,11 +68,11 @@ describe('e2e_block_building', () => {
     });
 
     beforeEach(async () => {
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 1 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 1 });
     });
 
     afterEach(async () => {
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 1 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 1 });
       // Clean up any mocks
       jest.restoreAllMocks();
     });
@@ -90,7 +90,7 @@ describe('e2e_block_building', () => {
 
       // We add a delay to every public tx processing
       logger.info(`Updating aztec node config`);
-      await aztecNodeAdmin!.setConfig({
+      await aztecNodeAdmin.setConfig({
         fakeProcessingDelayPerTxMs: 300,
         minTxsPerBlock: 1,
         maxTxsPerBlock: TX_COUNT,
@@ -126,7 +126,7 @@ describe('e2e_block_building', () => {
       // Assemble N contract deployment txs
       // We need to create them sequentially since we cannot have parallel calls to a circuit
       const TX_COUNT = 8;
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: TX_COUNT });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: TX_COUNT });
 
       // Need to have value > 0, so adding + 1
       // We need to do so, because noir currently will fail if the multiscalarmul is in an `if`
@@ -171,7 +171,7 @@ describe('e2e_block_building', () => {
       // Assemble N contract deployment txs
       // We need to create them sequentially since we cannot have parallel calls to a circuit
       const TX_COUNT = 4;
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: TX_COUNT });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: TX_COUNT });
 
       const methods = times(TX_COUNT, i => contract.methods.increment_public_value(ownerAddress, i));
       const provenTxs = [];
@@ -198,7 +198,7 @@ describe('e2e_block_building', () => {
       const contract = await StatefulTestContract.deploy(wallet, ownerAddress, 1).send({ from: ownerAddress });
       const another = await TestContract.deploy(wallet).send({ from: ownerAddress });
 
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 16, maxTxsPerBlock: 16 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 16, maxTxsPerBlock: 16 });
 
       // Flood nullifiers to grow the size of the nullifier tree.
       // Can probably do this more efficiently by batching multiple emit_nullifier calls
@@ -211,7 +211,7 @@ describe('e2e_block_building', () => {
       await Promise.all(sentNullifierTxs);
       logger.info(`Nullifier txs sent`);
 
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 4 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 4 });
 
       // Now send public functions
       const TX_COUNT = 128;
@@ -228,7 +228,7 @@ describe('e2e_block_building', () => {
 
     it.skip('can call public function from different tx in same block as deployed', async () => {
       // Ensure both txs will land on the same block
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 2 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 2 });
 
       // Deploy a contract in the first transaction
       // In the same block, call a public method on the contract
@@ -501,7 +501,7 @@ describe('e2e_block_building', () => {
       });
 
       logger.info('Updating txs per block to 4');
-      await aztecNodeAdmin!.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 4 });
+      await aztecNodeAdmin.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 4 });
 
       logger.info('Spamming the network with public txs');
       const txs = [];
@@ -593,7 +593,7 @@ describe('e2e_block_building', () => {
         await sleep(1000);
       }
 
-      watcher!.setIsMarkingAsProven(false);
+      watcher.setIsMarkingAsProven(false);
     });
 
     afterEach(() => teardown());

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -109,16 +109,16 @@ export class CrossChainMessagingTest {
 
   async applyBaseSetup() {
     // Set up base context fields
-    this.aztecNode = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
     this.wallet = this.context.wallet;
     this.aztecNodeConfig = this.context.config;
     this.cheatCodes = this.context.cheatCodes;
     this.deployL1ContractsValues = this.context.deployL1ContractsValues;
-    this.aztecNodeAdmin = this.context.aztecNodeService!;
+    this.aztecNodeAdmin = this.context.aztecNodeService;
 
     if (this.requireEpochProven) {
       // Turn off the watcher to prevent it from keep marking blocks as proven.
-      this.context.watcher!.setIsMarkingAsProven(false);
+      this.context.watcher.setIsMarkingAsProven(false);
     }
 
     // Deploy 3 accounts

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l1_to_l2.test.ts
@@ -172,7 +172,7 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
       // Stop proving
       const lastProven = await aztecNode.getBlockNumber();
       log.warn(`Stopping proof submission at block ${lastProven} to allow drift`);
-      t.context.watcher!.setIsMarkingAsProven(false);
+      t.context.watcher.setIsMarkingAsProven(false);
 
       // Mine several blocks to ensure drift
       log.warn(`Mining blocks to allow drift`);
@@ -214,14 +214,14 @@ describe('e2e_cross_chain_messaging l1_to_l2', () => {
           // On private, we simulate the tx locally and check that we get a missing message error, then we advance to the next block
           await expect(() => consume().simulate({ from: user1Address })).rejects.toThrow(/No L1 to L2 message found/);
           await tryAdvanceBlock();
-          await t.context.watcher!.markAsProven();
+          await t.context.watcher.markAsProven();
         } else {
           // On public, we actually send the tx and check that it reverts due to the missing message.
           // This advances the block too as a side-effect. Note that we do not rely on a simulation since the cross chain messages
           // do not get added at the beginning of the block during node_simulatePublicCalls (maybe they should?).
           const receipt = await consume().send({ from: user1Address, wait: { dontThrowOnRevert: true } });
           expect(receipt.executionResult).toEqual(TxExecutionResult.APP_LOGIC_REVERTED);
-          await t.context.watcher!.markAsProven();
+          await t.context.watcher.markAsProven();
         }
       });
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
@@ -30,9 +30,9 @@ export class DeployTest {
       fundSponsoredFPC: true,
       skipAccountDeployment: true,
     });
-    this.aztecNode = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
     this.wallet = this.context.wallet;
-    this.aztecNodeAdmin = this.context.aztecNodeService!;
+    this.aztecNodeAdmin = this.context.aztecNodeService;
     await this.applyInitialAccount();
     return this;
   }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -172,7 +172,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     logger.warn(`Transaction included in block ${receipt.blockNumber}`);
 
     // Check that we have tagged an offense for that
-    const offenses = await context.aztecNodeAdmin!.getSlashOffenses('all');
+    const offenses = await context.aztecNodeAdmin.getSlashOffenses('all');
     expect(offenses.length).toBeGreaterThan(0);
     const invalidBlockOffense = offenses.find(o => o.offenseType === OffenseType.PROPOSED_INSUFFICIENT_ATTESTATIONS);
     expect(invalidBlockOffense).toBeDefined();

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -220,7 +220,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       await retryUntil(() => getCheckpointNumber(node).then(b => b === CHECKPOINT_NUMBER), 'node sync', 10, 0.1);
 
       logger.warn(`Reached checkpoint ${CHECKPOINT_NUMBER}. Stopping block production.`);
-      await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
+      await context.aztecNodeAdmin.setConfig({ minTxsPerBlock: 100 });
 
       // Remove the L2 block from L1
       const l1BlocksToReorg = monitor.l1BlockNumber - l1BlockNumber + 1;
@@ -248,7 +248,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       sequencerDelayer.cancelNextTx();
       await retryUntil(() => sequencerDelayer.getCancelledTxs().length, 'next block', L2_SLOT_DURATION_IN_S * 2, 0.1);
       const [l2BlockTx] = sequencerDelayer.getCancelledTxs();
-      await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
+      await context.aztecNodeAdmin.setConfig({ minTxsPerBlock: 100 });
 
       // Save the L1 block number when the L2 block would have been mined
       const l1BlockNumber = monitor.l1BlockNumber;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_manual_rollback.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_manual_rollback.test.ts
@@ -43,7 +43,7 @@ describe('e2e_epochs/manual_rollback', () => {
       await retryUntil(async () => await node.getBlockNumber().then(b => b >= 4), 'sync to 4', 10, 0.1);
 
       logger.info(`Synced to checkpoint 4. Pausing syncing and rolling back the chain.`);
-      await context.aztecNodeAdmin!.pauseSync();
+      await context.aztecNodeAdmin.pauseSync();
       context.sequencer?.updateConfig({ minTxsPerBlock: 100 }); // Ensure no new blocks are produced
       await context.cheatCodes.eth.reorg(2);
       const checkpointAfterReorg = await rollup.getCheckpointNumber();
@@ -52,7 +52,7 @@ describe('e2e_epochs/manual_rollback', () => {
 
       logger.info(`Manually rolling back node to ${checkpointAfterReorg - 1}.`);
       const blockAfterReorg = Number(checkpointAfterReorg - 1);
-      await context.aztecNodeAdmin!.rollbackTo(blockAfterReorg);
+      await context.aztecNodeAdmin.rollbackTo(blockAfterReorg);
       expect(await node.getBlockNumber()).toEqual(blockAfterReorg);
 
       logger.info(`Waiting for node to re-sync to ${blockAfterReorg}.`);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_public_cross_chain.test.ts
@@ -40,7 +40,7 @@ describe('e2e_epochs/epochs_proof_public_cross_chain', () => {
 
   it('submits proof with a tx with public l1-to-l2 message claim', async () => {
     // Deploy a contract that consumes L1 to L2 messages
-    await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 0 });
+    await context.aztecNodeAdmin.setConfig({ minTxsPerBlock: 0 });
     logger.warn(`Deploying test contract`);
     const testContract = await TestContract.deploy(context.wallet).send({ from: context.accounts[0] });
     logger.warn(`Test contract deployed at ${testContract.address}`);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -404,7 +404,7 @@ export class EpochsTestContext {
         privateKeyToAccount(this.getNextPrivateKey()),
         this.l1Client.chain,
       ),
-      this.context.dateProvider!,
+      this.context.dateProvider,
       { ethereumSlotDuration: this.L1_BLOCK_TIME_IN_S },
     );
     expect(await client.getBalance({ address: client.account.address })).toBeGreaterThan(0n);

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -34,7 +34,7 @@ describe('e2e_fees failures', () => {
 
     // Prove up until the current state by just marking it as proven.
     // Then turn off the watcher to prevent it from keep proving
-    await t.context.watcher!.trigger();
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
     t.setIsMarkingAsProven(false);
@@ -78,7 +78,7 @@ describe('e2e_fees failures', () => {
     await expectMapping(t.getGasBalanceFn, [aliceAddress, bananaFPC.address], [initialAliceGas, initialFPCGas]);
 
     // We wait until the proven chain is caught up so all previous fees are paid out.
-    await t.context.watcher!.trigger();
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
 
@@ -100,7 +100,7 @@ describe('e2e_fees failures', () => {
 
     // @note There is a potential race condition here if other tests send transactions that get into the same
     // epoch and thereby pays out fees at the same time (when proven).
-    await t.context.watcher!.trigger();
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
 

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -113,7 +113,7 @@ export class FeesTest {
     });
 
     this.rollupContract = RollupContract.getFromConfig(this.context.config);
-    this.chainMonitor = new ChainMonitor(this.rollupContract, this.context.dateProvider!, this.logger, 200).start();
+    this.chainMonitor = new ChainMonitor(this.rollupContract, this.context.dateProvider, this.logger, 200).start();
 
     await this.applyBaseSetup();
 
@@ -126,7 +126,7 @@ export class FeesTest {
   }
 
   setIsMarkingAsProven(b: boolean) {
-    this.context.watcher!.setIsMarkingAsProven(b);
+    this.context.watcher.setIsMarkingAsProven(b);
   }
 
   async catchUpProvenChain() {
@@ -188,8 +188,8 @@ export class FeesTest {
     });
 
     this.wallet = this.context.wallet;
-    this.aztecNode = this.context.aztecNodeService!;
-    this.aztecNodeAdmin = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
+    this.aztecNodeAdmin = this.context.aztecNodeService;
     this.gasSettings = GasSettings.default({ maxFeesPerGas: (await this.aztecNode.getCurrentMinFees()).mul(2) });
     this.cheatCodes = this.context.cheatCodes;
     this.accounts = deployedAccounts.map(a => a.address);
@@ -221,8 +221,8 @@ export class FeesTest {
     );
 
     this.feeJuiceBridgeTestHarness = await FeeJuicePortalTestingHarnessFactory.create({
-      aztecNode: this.context.aztecNodeService!,
-      aztecNodeAdmin: this.context.aztecNodeService!,
+      aztecNode: this.context.aztecNodeService,
+      aztecNodeAdmin: this.context.aztecNodeService,
       l1Client: this.context.deployL1ContractsValues.l1Client,
       wallet: this.wallet,
       logger: this.logger,

--- a/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
@@ -44,7 +44,7 @@ export class NestedContractTest {
     });
     this.wallet = this.context.wallet;
     [{ address: this.defaultAccountAddress }] = deployedAccounts;
-    this.aztecNode = this.context.aztecNodeService!;
+    this.aztecNode = this.context.aztecNodeService;
 
     this.logger.info('Public deploy accounts');
     await publicDeployAccounts(this.wallet, [this.defaultAccountAddress]);

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -90,7 +90,7 @@ describe('e2e_p2p_add_rollup', () => {
 
     l1TxUtils = createL1TxUtilsFromViemWallet(t.ctx.deployL1ContractsValues.l1Client);
 
-    t.ctx.watcher!.setIsMarkingAsProven(false);
+    t.ctx.watcher.setIsMarkingAsProven(false);
   });
 
   afterAll(async () => {
@@ -235,7 +235,7 @@ describe('e2e_p2p_add_rollup', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       { ...t.ctx.aztecNodeConfig, governanceProposerPayload: newPayloadAddress },
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,
@@ -251,7 +251,7 @@ describe('e2e_p2p_add_rollup', () => {
       BOOT_NODE_UDP_PORT + NUM_VALIDATORS + 1,
       t.bootstrapNodeEnr,
       ATTESTER_PRIVATE_KEYS_START_INDEX + NUM_VALIDATORS + 1,
-      { dateProvider: t.ctx.dateProvider! },
+      { dateProvider: t.ctx.dateProvider },
       t.prefilledPublicData,
       `${DATA_DIR}-prover`,
       shouldCollectMetrics(),
@@ -357,7 +357,7 @@ describe('e2e_p2p_add_rollup', () => {
         const leafId = getL2ToL1MessageLeafId(l2ToL1MessageResult);
 
         // We need to advance to the next epoch so that the out hash will be set to outbox when the epoch is proven.
-        const cheatcodes = RollupCheatCodes.create(l1RpcUrls, l1ContractAddresses, t.ctx.dateProvider!);
+        const cheatcodes = RollupCheatCodes.create(l1RpcUrls, l1ContractAddresses, t.ctx.dateProvider);
         await cheatcodes.advanceToEpoch(EpochNumber(epoch + 1));
         await waitForProven(node, l2OutgoingReceipt, { provenTimeout: 300 });
 
@@ -551,7 +551,7 @@ describe('e2e_p2p_add_rollup', () => {
 
     nodes = await createNodes(
       newConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,
@@ -566,7 +566,7 @@ describe('e2e_p2p_add_rollup', () => {
       BOOT_NODE_UDP_PORT + NUM_VALIDATORS + 1,
       t.bootstrapNodeEnr,
       ATTESTER_PRIVATE_KEYS_START_INDEX + NUM_VALIDATORS + 1,
-      { dateProvider: t.ctx.dateProvider! },
+      { dateProvider: t.ctx.dateProvider },
       prefilledPublicData,
       `${DATA_DIR_NEW}-prover`,
       shouldCollectMetrics(),

--- a/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/broadcasted_invalid_block_proposal_slash.test.ts
@@ -118,7 +118,7 @@ describe('e2e_p2p_broadcasted_invalid_block_proposal_slash', () => {
     };
     const invalidProposerNodes = await createNodes(
       invalidProposerConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       1,
       BOOT_NODE_UDP_PORT,
@@ -134,7 +134,7 @@ describe('e2e_p2p_broadcasted_invalid_block_proposal_slash', () => {
     // Create remaining honest nodes
     const honestNodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS - 1,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -120,7 +120,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
     t.logger.warn('Creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,
@@ -165,7 +165,7 @@ describe('e2e_p2p_data_withholding_slash', () => {
     t.logger.warn('Re-creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -126,7 +126,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     t.logger.warn(`Creating malicious node 1 with coinbase ${coinbase1.toString()}`);
     const maliciousNode1 = await createNode(
       { ...t.ctx.aztecNodeConfig, validatorPrivateKey: maliciousPrivateKeyHex, coinbase: coinbase1 },
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 1,
       t.bootstrapNodeEnr,
       maliciousValidatorIndex,
@@ -138,7 +138,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     t.logger.warn(`Creating malicious node 2 with coinbase ${coinbase2.toString()}`);
     const maliciousNode2 = await createNode(
       { ...t.ctx.aztecNodeConfig, validatorPrivateKey: maliciousPrivateKeyHex, coinbase: coinbase2 },
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 2,
       t.bootstrapNodeEnr,
       maliciousValidatorIndex,
@@ -151,7 +151,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     t.logger.warn('Creating honest nodes');
     const honestNode1 = await createNode(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 3,
       t.bootstrapNodeEnr,
       1,
@@ -161,7 +161,7 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     );
     const honestNode2 = await createNode(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 4,
       t.bootstrapNodeEnr,
       2,

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -107,7 +107,7 @@ describe('e2e_p2p_network', () => {
     t.logger.info('Creating validator nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,
@@ -124,7 +124,7 @@ describe('e2e_p2p_network', () => {
       BOOT_NODE_UDP_PORT + NUM_VALIDATORS + 1,
       t.bootstrapNodeEnr,
       ATTESTER_PRIVATE_KEYS_START_INDEX + NUM_VALIDATORS + 1,
-      { dateProvider: t.ctx.dateProvider! },
+      { dateProvider: t.ctx.dateProvider },
       t.prefilledPublicData,
       `${DATA_DIR}-prover`,
       shouldCollectMetrics(),
@@ -135,7 +135,7 @@ describe('e2e_p2p_network', () => {
     const monitoringNodeConfig: AztecNodeConfig = { ...t.ctx.aztecNodeConfig, alwaysReexecuteBlockProposals: true };
     monitoringNode = await createNonValidatorNode(
       monitoringNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + NUM_VALIDATORS + 2,
       t.bootstrapNodeEnr,
       t.prefilledPublicData,

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -175,7 +175,7 @@ describe('e2e_p2p_network', () => {
 
     // Set the system time in the node, only after we have warped the time and waited for a block
     // Time is only set in the NEXT block
-    t.ctx.dateProvider!.setTime(Number(timestamp) * 1000);
+    t.ctx.dateProvider.setTime(Number(timestamp) * 1000);
 
     // create our network of nodes and submit txs into each of them
     // the number of txs per node and the number of txs per rollup
@@ -185,7 +185,7 @@ describe('e2e_p2p_network', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/inactivity_slash_test.ts
@@ -98,13 +98,13 @@ export class P2PInactivityTest {
     this.rollup = rollup;
 
     if (!this.keepInitialNode) {
-      await this.test.ctx.aztecNodeService!.stop();
+      await this.test.ctx.aztecNodeService.stop();
     }
 
     // Create all active nodes
     this.activeNodes = await createNodes(
       this.test.ctx.aztecNodeConfig,
-      this.test.ctx.dateProvider!,
+      this.test.ctx.dateProvider,
       this.test.bootstrapNodeEnr,
       NUM_NODES - this.inactiveNodeCount - Number(this.keepInitialNode),
       BOOT_NODE_UDP_PORT,
@@ -118,7 +118,7 @@ export class P2PInactivityTest {
     const inactiveConfig = { ...this.test.ctx.aztecNodeConfig, dontStartSequencer: true };
     this.inactiveNodes = await createNodes(
       inactiveConfig,
-      this.test.ctx.dateProvider!,
+      this.test.ctx.dateProvider,
       this.test.bootstrapNodeEnr,
       this.inactiveNodeCount,
       BOOT_NODE_UDP_PORT,
@@ -129,7 +129,7 @@ export class P2PInactivityTest {
     );
 
     this.nodes = [
-      ...(this.keepInitialNode ? [this.test.ctx.aztecNodeService!] : []),
+      ...(this.keepInitialNode ? [this.test.ctx.aztecNodeService] : []),
       ...this.activeNodes,
       ...this.inactiveNodes,
     ];

--- a/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/multiple_validators_sentinel.parallel.test.ts
@@ -64,7 +64,7 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
 
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,
@@ -77,7 +77,7 @@ describe('e2e_p2p_multiple_validators_sentinel', () => {
 
     sentinel = await createNonValidatorNode(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 1 + NUM_NODES,
       t.bootstrapNodeEnr,
       t.prefilledPublicData,

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -333,9 +333,9 @@ export class P2PNetworkTest {
     const block = await this.context.deployL1ContractsValues.l1Client.getBlock({
       blockNumber: receipt.blockNumber,
     });
-    this.context.dateProvider!.setTime(Number(block.timestamp) * 1000);
+    this.context.dateProvider.setTime(Number(block.timestamp) * 1000);
 
-    await this.context.aztecNodeService!.stop();
+    await this.context.aztecNodeService.stop();
   }
 
   async sendDummyTx() {
@@ -374,8 +374,8 @@ export class P2PNetworkTest {
     this.prefilledPublicData = prefilledPublicData;
 
     const rollupContract = RollupContract.getFromL1ContractsValues(this.context.deployL1ContractsValues);
-    this.monitor = new ChainMonitor(rollupContract, this.context.dateProvider!).start();
-    this.monitor.on('l1-block', ({ timestamp }) => this.context.dateProvider!.setTime(Number(timestamp) * 1000));
+    this.monitor = new ChainMonitor(rollupContract, this.context.dateProvider).start();
+    this.monitor.on('l1-block', ({ timestamp }) => this.context.dateProvider.setTime(Number(timestamp) * 1000));
   }
 
   async stopNodes(nodes: AztecNodeService[]) {

--- a/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/preferred_gossip_network.test.ts
@@ -149,7 +149,7 @@ describe('e2e_p2p_preferred_network', () => {
   });
 
   afterEach(async () => {
-    await t.stopNodes([t.ctx.aztecNodeService!].concat(nodes).concat(validators).concat(preferredNodes));
+    await t.stopNodes([t.ctx.aztecNodeService].concat(nodes).concat(validators).concat(preferredNodes));
     await t.teardown();
     for (let i = 0; i < NUM_NODES + NUM_VALIDATORS + NUM_PREFERRED_NODES; i++) {
       fs.rmSync(`${DATA_DIR}-${i}`, { recursive: true, force: true, maxRetries: 3 });
@@ -190,7 +190,7 @@ describe('e2e_p2p_preferred_network', () => {
 
     preferredNodes = await createNodes(
       preferredNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_PREFERRED_NODES,
       BOOT_NODE_UDP_PORT,
@@ -224,7 +224,7 @@ describe('e2e_p2p_preferred_network', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       nodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,
@@ -247,7 +247,7 @@ describe('e2e_p2p_preferred_network', () => {
 
     validators = await createNodes(
       validatorConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS - 1,
       BOOT_NODE_UDP_PORT,
@@ -271,7 +271,7 @@ describe('e2e_p2p_preferred_network', () => {
 
     const noDiscoveryValidators = await createNodes(
       lastValidatorConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       1,
       BOOT_NODE_UDP_PORT,
@@ -282,7 +282,7 @@ describe('e2e_p2p_preferred_network', () => {
       indexOffset,
     );
 
-    const allNodes = [...nodes, ...preferredNodes, ...validators, ...noDiscoveryValidators, t.ctx.aztecNodeService!];
+    const allNodes = [...nodes, ...preferredNodes, ...validators, ...noDiscoveryValidators, t.ctx.aztecNodeService];
     const identifiers = nodes
       .map((_, i) => `Node ${i + 1}`)
       .concat(preferredNodes.map((_, i) => `Preferred Node ${i + 1}`))

--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -54,7 +54,7 @@ describe('e2e_p2p_rediscovery', () => {
     const txsSentViaDifferentNodes: TxHash[][] = [];
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,
@@ -87,7 +87,7 @@ describe('e2e_p2p_rediscovery', () => {
 
       const newNode = await createNode(
         t.ctx.aztecNodeConfig,
-        t.ctx.dateProvider!,
+        t.ctx.dateProvider,
         i + 1 + BOOT_NODE_UDP_PORT,
         undefined,
         i,

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -56,7 +56,7 @@ describe('e2e_p2p_reex', () => {
     await t.applyBaseSetup();
 
     t.logger.info('Stopping main node sequencer');
-    await t.ctx.aztecNodeService!.getSequencer()?.stop();
+    await t.ctx.aztecNodeService.getSequencer()?.stop();
 
     if (!t.bootstrapNodeEnr) {
       throw new Error('Bootstrap node ENR is not available');
@@ -70,7 +70,7 @@ describe('e2e_p2p_reex', () => {
         minTxsPerBlock: 1,
         maxTxsPerBlock: NUM_TXS_PER_NODE,
       },
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BASE_BOOT_NODE_UDP_PORT,
@@ -230,7 +230,7 @@ describe('e2e_p2p_reex', () => {
 
         // Start a fresh slot and resume proposals
         const [ts] = await t.ctx.cheatCodes.rollup.advanceToNextSlot();
-        t.ctx.dateProvider!.setTime(Number(ts) * 1000);
+        t.ctx.dateProvider.setTime(Number(ts) * 1000);
 
         await resumeProposals();
 

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp/utils.ts
@@ -81,7 +81,7 @@ export async function runReqrespTxTest(params: {
 
   const nodes = await createNodes(
     aztecNodeConfig,
-    t.ctx.dateProvider!,
+    t.ctx.dateProvider,
     t.bootstrapNodeEnr,
     NUM_VALIDATORS,
     BOOT_NODE_UDP_PORT,
@@ -95,7 +95,7 @@ export async function runReqrespTxTest(params: {
 
   await t.setupAccount();
 
-  const targetBlockNumber = await t.ctx.aztecNodeService!.getBlockNumber();
+  const targetBlockNumber = await t.ctx.aztecNodeService.getBlockNumber();
   await retryUntil(
     async () => {
       const blockNumbers = await Promise.all(nodes.map(node => node.getBlockNumber()));
@@ -108,7 +108,7 @@ export async function runReqrespTxTest(params: {
 
   t.logger.info('Preparing transactions to send');
   const txBatches = await timesAsync(2, () =>
-    prepareTransactions(t.logger, t.ctx.aztecNodeService!, NUM_TXS_PER_NODE, t.fundedAccount),
+    prepareTransactions(t.logger, t.ctx.aztecNodeService, NUM_TXS_PER_NODE, t.fundedAccount),
   );
 
   t.logger.info('Removing initial node');
@@ -116,7 +116,7 @@ export async function runReqrespTxTest(params: {
 
   t.logger.info('Starting fresh slot');
   const [timestamp] = await t.ctx.cheatCodes.rollup.advanceToNextSlot();
-  t.ctx.dateProvider!.setTime(Number(timestamp) * 1000);
+  t.ctx.dateProvider.setTime(Number(timestamp) * 1000);
   const startSlotTimestamp = BigInt(timestamp);
 
   const { proposerIndexes, nodesToTurnOffTxGossip } = await getProposerIndexes(t, startSlotTimestamp);

--- a/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slash_veto_demo.test.ts
@@ -102,7 +102,7 @@ describe('veto slash', () => {
 
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES, // Note we do not create the last validator yet, so it shows as offline
       BOOT_NODE_UDP_PORT,
@@ -117,7 +117,7 @@ describe('veto slash', () => {
     );
     vetoerL1TxUtils = createL1TxUtilsFromViemWallet(vetoerL1Client, {
       logger: t.logger,
-      dateProvider: t.ctx.dateProvider!,
+      dateProvider: t.ctx.dateProvider,
     });
 
     ({ rollup } = await t.getContracts());
@@ -201,7 +201,7 @@ describe('veto slash', () => {
     debugLogger.info(`\n\ninitializing slasher with proposer: ${proposer}\n\n`);
     const txUtils = createL1TxUtilsFromViemWallet(deployerClient, {
       logger: t.logger,
-      dateProvider: t.ctx.dateProvider!,
+      dateProvider: t.ctx.dateProvider,
     });
     await txUtils.sendAndMonitorTransaction({
       to: slasher.toString(),

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -148,7 +148,7 @@ describe('e2e_p2p_governance_proposer', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       { ...t.ctx.aztecNodeConfig, governanceProposerPayload: newPayloadAddress },
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned_slash.test.ts
@@ -113,7 +113,7 @@ describe('e2e_p2p_valid_epoch_pruned_slash', () => {
     t.logger.warn(`Creating ${NUM_VALIDATORS} new nodes`);
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_VALIDATORS,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -58,7 +58,7 @@ describe('e2e_p2p_validators_sentinel', () => {
 
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
-      t.ctx.dateProvider!,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES, // Note we do not create the last validator yet, so it shows as offline
       BOOT_NODE_UDP_PORT,
@@ -158,7 +158,7 @@ describe('e2e_p2p_validators_sentinel', () => {
       const nodeIndex = NUM_NODES + 1;
       const newNode = await createNode(
         t.ctx.aztecNodeConfig,
-        t.ctx.dateProvider!,
+        t.ctx.dateProvider,
         BOOT_NODE_UDP_PORT + nodeIndex + 1,
         t.bootstrapNodeEnr!,
         nodeIndex,

--- a/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
@@ -95,7 +95,7 @@ describe('e2e_snapshot_sync', () => {
 
   it('creates a snapshot', async () => {
     log.warn(`Creating snapshot`);
-    await context.aztecNodeAdmin!.startSnapshotUpload(snapshotLocation);
+    await context.aztecNodeAdmin.startSnapshotUpload(snapshotLocation);
     await retryUntil(() => readdir(snapshotDir).then(files => files.length > 0), 'snapshot-created', 90, 1);
     log.warn(`Snapshot created`);
   });

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -403,7 +403,7 @@ describe('e2e_synching', () => {
 
     await (aztecNode as any).stop();
     await (sequencer as any).stop();
-    await watcher?.stop();
+    await watcher.stop();
 
     const blobClient = await createBlobClientWithFileStores(config, createLogger('test:blob-client:client'));
 
@@ -411,7 +411,7 @@ describe('e2e_synching', () => {
 
     const l1TxUtils = createL1TxUtilsWithBlobsFromViemWallet(
       deployL1ContractsValues.l1Client,
-      { logger, dateProvider: dateProvider! },
+      { logger, dateProvider },
       config,
     );
     const rollupAddress = deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString();
@@ -450,7 +450,7 @@ describe('e2e_synching', () => {
         slashingProposerContract,
         slashFactoryContract,
         epochCache,
-        dateProvider: dateProvider!,
+        dateProvider,
         metrics: sequencerPublisherMetrics,
         lastActions: {},
       },

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -70,7 +70,7 @@ export class TokenContractTest {
       initialFundedAccounts: this.context.initialFundedAccounts,
     });
 
-    this.node = this.context.aztecNodeService!;
+    this.node = this.context.aztecNodeService;
     this.wallet = this.context.wallet;
     [this.adminAddress, this.account1Address, this.account2Address] = deployedAccounts.map(acc => acc.address);
 

--- a/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/e2e_prover_test.ts
@@ -144,7 +144,7 @@ export class FullProverTest {
     this.logger.info(`Enabling proving`, { realProofs: this.realProofs });
 
     // We don't wish to mark as proven automatically, so we set the flag to false
-    this.context.watcher!.setIsMarkingAsProven(false);
+    this.context.watcher.setIsMarkingAsProven(false);
 
     this.simulatedProverNode = this.context.proverNode!;
     ({
@@ -152,7 +152,7 @@ export class FullProverTest {
       deployL1ContractsValues: this.l1Contracts,
       cheatCodes: this.cheatCodes,
     } = this.context);
-    this.aztecNodeAdmin = this.context.aztecNodeService!;
+    this.aztecNodeAdmin = this.context.aztecNodeService;
 
     const config = this.context.aztecNodeConfig;
     const blobClient = await createBlobClientWithFileStores(config, this.logger);
@@ -225,7 +225,7 @@ export class FullProverTest {
     this.logger.verbose('Starting archiver for new prover node');
     const archiver = await createArchiver(
       { ...this.context.aztecNodeConfig, dataDirectory: undefined },
-      { blobClient, dateProvider: this.context.dateProvider! },
+      { blobClient, dateProvider: this.context.dateProvider },
       { blockUntilSync: true },
     );
 

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -1,5 +1,5 @@
 import { SchnorrAccountContractArtifact } from '@aztec/accounts/schnorr';
-import { type InitialAccountData, generateSchnorrAccounts, getInitialTestAccountsData } from '@aztec/accounts/testing';
+import { type InitialAccountData, generateSchnorrAccounts } from '@aztec/accounts/testing';
 import { type Archiver, createArchiver } from '@aztec/archiver';
 import { type AztecNodeConfig, AztecNodeService, getConfigEnvVars } from '@aztec/aztec-node';
 import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
@@ -13,7 +13,7 @@ import {
 import { publishContractClass, publishInstance } from '@aztec/aztec.js/deployment';
 import { Fr } from '@aztec/aztec.js/fields';
 import { type Logger, createLogger } from '@aztec/aztec.js/log';
-import { type AztecNode, createAztecNodeClient, waitForNode } from '@aztec/aztec.js/node';
+import type { AztecNode } from '@aztec/aztec.js/node';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { AnvilTestWatcher, CheatCodes } from '@aztec/aztec/testing';
 import { createBlobClientWithFileStores } from '@aztec/blob-client/client';
@@ -91,9 +91,6 @@ import { isMetricsLoggingRequested, setupMetricsLogger } from './logging.js';
 import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 
 export { startAnvil };
-
-const { AZTEC_NODE_URL = '' } = process.env;
-const getAztecUrl = () => AZTEC_NODE_URL;
 
 let telemetry: TelemetryClient | undefined = undefined;
 async function getTelemetryClient(partialConfig: Partial<TelemetryClientConfig> & { benchmark?: boolean } = {}) {
@@ -217,13 +214,13 @@ export type EndToEndContext = {
   anvil: Anvil | undefined;
   /** The Aztec Node service or client a connected to it. */
   aztecNode: AztecNode;
-  /** The Aztec Node as a service (only set if running locally). */
-  aztecNodeService: AztecNodeService | undefined;
-  /** Client to the Aztec Node admin interface (undefined if connected to remote environment) */
-  aztecNodeAdmin: AztecNodeAdmin | undefined;
+  /** The Aztec Node as a service. */
+  aztecNodeService: AztecNodeService;
+  /** Client to the Aztec Node admin interface. */
+  aztecNodeAdmin: AztecNodeAdmin;
   /** The prover node service (only set if startProverNode is true) */
   proverNode: ProverNode | undefined;
-  /** A client to the sequencer service (undefined if connected to remote environment) */
+  /** A client to the sequencer service. */
   sequencer: SequencerClient | undefined;
   /** Return values from deployAztecL1Contracts function. */
   deployL1ContractsValues: DeployAztecL1ContractsReturnType;
@@ -243,12 +240,12 @@ export type EndToEndContext = {
   cheatCodes: CheatCodes;
   /** The cheat codes for L1 */
   ethCheatCodes: EthCheatCodes;
-  /** The anvil test watcher (undefined if connected to remote environment) */
-  watcher: AnvilTestWatcher | undefined;
-  /** Allows tweaking current system time, used by the epoch cache only (undefined if connected to remote environment) */
-  dateProvider: TestDateProvider | undefined;
+  /** The anvil test watcher. */
+  watcher: AnvilTestWatcher;
+  /** Allows tweaking current system time, used by the epoch cache only. */
+  dateProvider: TestDateProvider;
   /** Telemetry client */
-  telemetryClient: TelemetryClient | undefined;
+  telemetryClient: TelemetryClient;
   /** Mock gossip sub network used for gossipping messages (only if mockGossipSubNetwork was set to true in opts) */
   mockGossipSubNetwork: MockGossipSubNetwork | undefined;
   /** Prefilled public data used for setting up nodes. */
@@ -258,86 +255,10 @@ export type EndToEndContext = {
   /** BB config (only set if running locally). */
   bbConfig: Awaited<ReturnType<typeof getBBConfig>>;
   /** Directory to cleanup on teardown. */
-  directoryToCleanup: string | undefined;
+  directoryToCleanup: string;
   /** Function to stop the started services. */
   teardown: () => Promise<void>;
 };
-
-/**
- * Function to setup the test against a remote deployment. It is assumed that L1 contract are already deployed
- */
-async function setupWithRemoteEnvironment(
-  account: HDAccount | PrivateKeyAccount,
-  config: AztecNodeConfig & SetupOptions,
-  logger: Logger,
-  numberOfAccounts: number,
-): Promise<EndToEndContext> {
-  const aztecNodeUrl = getAztecUrl();
-  logger.verbose(`Creating Aztec Node client to remote host ${aztecNodeUrl}`);
-  const aztecNode = createAztecNodeClient(aztecNodeUrl);
-  await waitForNode(aztecNode, logger);
-  logger.verbose('JSON RPC client connected to Aztec Node');
-  logger.verbose(`Retrieving contract addresses from ${aztecNodeUrl}`);
-  const { l1ContractAddresses, rollupVersion } = await aztecNode.getNodeInfo();
-
-  const l1Client = createExtendedL1Client(config.l1RpcUrls, account, foundry);
-
-  const deployL1ContractsValues: DeployAztecL1ContractsReturnType = {
-    l1ContractAddresses,
-    l1Client,
-    rollupVersion,
-  };
-  const ethCheatCodes = new EthCheatCodes(config.l1RpcUrls, new DateProvider());
-  const wallet = await TestWallet.create(aztecNode);
-
-  if (config.walletMinFeePadding !== undefined) {
-    wallet.setMinFeePadding(config.walletMinFeePadding);
-  }
-
-  const cheatCodes = await CheatCodes.create(config.l1RpcUrls, aztecNode, new DateProvider());
-  const teardown = () => Promise.resolve();
-
-  logger.verbose('Populating wallet from already registered accounts...');
-  const initialFundedAccounts = await getInitialTestAccountsData();
-
-  if (initialFundedAccounts.length < numberOfAccounts) {
-    throw new Error(`Required ${numberOfAccounts} accounts. Found ${initialFundedAccounts.length}.`);
-  }
-
-  const testAccounts = await Promise.all(
-    initialFundedAccounts.slice(0, numberOfAccounts).map(async account => {
-      const accountManager = await wallet.createSchnorrAccount(account.secret, account.salt, account.signingKey);
-      return accountManager.address;
-    }),
-  );
-
-  return {
-    anvil: undefined,
-    aztecNode,
-    aztecNodeService: undefined,
-    aztecNodeAdmin: undefined,
-    sequencer: undefined,
-    proverNode: undefined,
-    deployL1ContractsValues,
-    config,
-    aztecNodeConfig: config,
-    initialFundedAccounts,
-    wallet,
-    accounts: testAccounts,
-    logger,
-    cheatCodes,
-    ethCheatCodes,
-    prefilledPublicData: undefined,
-    mockGossipSubNetwork: undefined,
-    watcher: undefined,
-    dateProvider: undefined,
-    telemetryClient: undefined,
-    acvmConfig: undefined,
-    bbConfig: undefined,
-    directoryToCleanup: undefined,
-    teardown,
-  };
-}
 
 /**
  * Sets up the environment for the end-to-end tests.
@@ -381,12 +302,6 @@ export async function setup(
       if (!isAnvilTestChain(chain.id)) {
         throw new Error(`No ETHEREUM_HOSTS set but non anvil chain requested`);
       }
-      if (AZTEC_NODE_URL) {
-        throw new Error(
-          `AZTEC_NODE_URL provided but no ETHEREUM_HOSTS set. Refusing to run, please set both variables so tests can deploy L1 contracts to the same Anvil instance`,
-        );
-      }
-
       const res = await startAnvil({
         l1BlockTime: opts.ethereumSlotDuration,
         accounts: opts.anvilAccounts,
@@ -439,11 +354,6 @@ export async function setup(
 
     if (config.coinbase === undefined) {
       config.coinbase = EthAddress.fromString(publisherHdAccount.address);
-    }
-
-    if (AZTEC_NODE_URL) {
-      // we are setting up against a remote environment, l1 contracts are assumed to already be deployed
-      return await setupWithRemoteEnvironment(publisherHdAccount!, config, logger, numberOfAccounts);
     }
 
     // Determine which addresses to fund in genesis
@@ -683,7 +593,7 @@ export async function setup(
         logger.error(`Error during e2e test teardown`, err);
       } finally {
         try {
-          await telemetryClient?.stop();
+          await telemetryClient.stop();
         } catch (err) {
           logger.error(`Error during telemetry client stop`, err);
         }

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -84,7 +84,7 @@ export const uniswapL1L2TestSuite = (
 
       l1Client = deployL1ContractsValues.l1Client;
 
-      t.watcher?.setIsMarkingAsProven(false);
+      t.watcher.setIsMarkingAsProven(false);
 
       if (Number(await l1Client.getBlockNumber()) < expectedForkBlockNumber) {
         throw new Error('This test must be run on a fork of mainnet with the expected fork block');


### PR DESCRIPTION
This was not being used. Also removes all the conditional access to undefined components in the e2e context that we now know to be defined.
