### PR TITLE
chore(bb): git ignore honk-optimized.sol

### DIFF
--- a/barretenberg/.gitignore
+++ b/barretenberg/.gitignore
@@ -9,6 +9,8 @@ cmake-build-debug
 *_opt.pil
 bench-out
 
+/sol/src/honk/optimised/honk-optimized.*
+
 # Generated code from msgpack schema (run `yarn generate` in ts/)
 rust/barretenberg-rs/src/generated_types.rs
 rust/barretenberg-rs/src/api.rs


### PR DESCRIPTION
This was consistently showing up as modified after bootstrapping.
