### PR TITLE
fix: stricter rules for static calls

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -248,6 +248,19 @@ impl PrivateCallDataValidator {
                 "static call cannot make non-static public teardown call",
             );
         }
+
+        // A static call cannot nominate itself as fee payer, because that directly results in the fee payer's FeeJuice
+        // balance being decremented by the AVM or the Private Tx Base Rollup circuit, which is technically a state
+        // change that violates the notion of "static call".
+        assert_eq(this_call.is_fee_payer, false, "static call cannot nominate itself as fee payer");
+
+        // A static call cannot set the min revertible side effect counter, which would affect whether a side effect
+        // should be retained or discarded if the tx reverts.
+        assert_eq(
+            this_call.min_revertible_side_effect_counter,
+            0,
+            "static call cannot set the min revertible side effect counter",
+        );
     }
 
     /// For Init and Inner.

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_inner/private_call_data/validate_for_static_call_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_inner/private_call_data/validate_for_static_call_tests.nr
@@ -98,3 +98,21 @@ fn with_non_static_public_teardown_call_request() {
 
     builder.execute_and_fail();
 }
+
+#[test(should_fail_with = "static call cannot nominate itself as fee payer")]
+fn with_is_fee_payer() {
+    let mut builder = TestBuilder::new_static_call();
+
+    builder.private_call.is_fee_payer = true;
+
+    builder.execute_and_fail();
+}
+
+#[test(should_fail_with = "static call cannot set the min revertible side effect counter")]
+fn with_min_revertible_side_effect_counter() {
+    let mut builder = TestBuilder::new_static_call();
+
+    builder.private_call.end_setup();
+
+    builder.execute_and_fail();
+}


### PR DESCRIPTION
Disallow a static call to make the teardown call request, nominate itself as fee payer, or set the min_revertible_side_effect_counter.