### PR TITLE
fix: use `self` instead of `window` for iOS detection in WASM

### DIFF
--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -82,9 +82,10 @@ export class Barretenberg extends AsyncApi {
   }
 
   getDefaultSrsSize(): number {
-    // iOS browser is very aggressive with memory. Check if running in browser and on iOS
+    // iOS browser is very aggressive with memory. Check if running in browser and on iOS.
     // We expect the mobile iOS browser to kill us >=1GB, so no real use in using a larger SRS.
-    if (typeof window !== 'undefined' && /iPad|iPhone/.test(navigator.userAgent)) {
+    // Use `self` instead of `window` so this check also works inside Web Workers.
+    if (typeof self !== 'undefined' && typeof self.navigator !== 'undefined' && /iPad|iPhone/.test(self.navigator.userAgent)) {
       return 2 ** 18;
     }
     return 2 ** 20;

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
@@ -85,9 +85,10 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
   }
 
   private getDefaultMaximumMemoryPages(): number {
-    // iOS browser is very aggressive with memory. Check if running in browser and on iOS
+    // iOS browser is very aggressive with memory. Check if running in browser and on iOS.
     // We at any rate expect the mobile iOS browser to kill us >=1GB, so we don't set a maximum higher than that.
-    if (typeof window !== 'undefined' && /iPad|iPhone/.test(navigator.userAgent)) {
+    // Use `self` instead of `window` so this check also works inside Web Workers.
+    if (typeof self !== 'undefined' && typeof self.navigator !== 'undefined' && /iPad|iPhone/.test(self.navigator.userAgent)) {
       return 2 ** 14;
     }
     return 2 ** 16;


### PR DESCRIPTION
Fix iOS detection in `getDefaultMaximumMemoryPages()` and `getDefaultSrsSize()` to work inside Web Workers