### PR TITLE
fix(validator): do not process proposals from self

### DIFF
--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -352,6 +352,15 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       return false;
     }
 
+    // Ignore proposals from ourselves (may happen in HA setups)
+    if (this.getValidatorAddresses().some(addr => addr.equals(proposer))) {
+      this.log.warn(`Ignoring block proposal from self for slot ${slotNumber}`, {
+        proposer: proposer.toString(),
+        slotNumber,
+      });
+      return false;
+    }
+
     // Check if we're in the committee (for metrics purposes)
     const inCommittee = await this.epochCache.filterInCommittee(slotNumber, this.getValidatorAddresses());
     const partOfCommittee = inCommittee.length > 0;
@@ -450,6 +459,15 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     // Reject proposals with invalid signatures
     if (!proposer) {
       this.log.warn(`Received checkpoint proposal with invalid signature for slot ${slotNumber}`);
+      return undefined;
+    }
+
+    // Ignore proposals from ourselves (may happen in HA setups)
+    if (this.getValidatorAddresses().some(addr => addr.equals(proposer))) {
+      this.log.warn(`Ignoring block proposal from self for slot ${slotNumber}`, {
+        proposer: proposer.toString(),
+        slotNumber,
+      });
       return undefined;
     }
 


### PR DESCRIPTION
In a HA setup, if we receive a block or checkpoint proposal from an address we control, there's no point in processing it. We should just add it to the attestation pool to track equivocations (which is handled by the libp2p service), and that's it.
