### PR TITLE
fix(p2p): fix flaky file store tx collection tests

### DIFF
--- a/yarn-project/p2p/src/services/tx_collection/file_store_tx_collection.test.ts
+++ b/yarn-project/p2p/src/services/tx_collection/file_store_tx_collection.test.ts
@@ -3,6 +3,7 @@ import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
+import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
 import type { TxPool } from '../../mem_pools/index.js';
@@ -54,6 +55,8 @@ describe('FileStoreTxCollection', () => {
   };
 
   beforeEach(async () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
     txPool = mock<TxPool>();
     txPool.addTxs.mockImplementation(txs => Promise.resolve(txs.length));
 
@@ -70,6 +73,7 @@ describe('FileStoreTxCollection', () => {
 
   afterEach(async () => {
     await fileStoreCollection.stop();
+    jest.restoreAllMocks();
   });
 
   it('downloads txs immediately when startCollecting is called', async () => {


### PR DESCRIPTION
## Summary
- Mock `Math.random` in `FileStoreTxCollection` tests to ensure deterministic file store iteration order
- The `downloadTx` method picks a random starting index for round-robin across file stores, which caused two tests to intermittently fail depending on which store was tried first

## Test plan
- [x] All 6 tests in `file_store_tx_collection.test.ts` pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)