### PR TITLE
fix(e2e): enable broadcastEquivocatedProposals in duplicate proposal slash test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -125,7 +125,12 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
 
     t.logger.warn(`Creating malicious node 1 with coinbase ${coinbase1.toString()}`);
     const maliciousNode1 = await createNode(
-      { ...t.ctx.aztecNodeConfig, validatorPrivateKey: maliciousPrivateKeyHex, coinbase: coinbase1 },
+      {
+        ...t.ctx.aztecNodeConfig,
+        validatorPrivateKey: maliciousPrivateKeyHex,
+        coinbase: coinbase1,
+        broadcastEquivocatedProposals: true,
+      },
       t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 1,
       t.bootstrapNodeEnr,
@@ -137,7 +142,12 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
 
     t.logger.warn(`Creating malicious node 2 with coinbase ${coinbase2.toString()}`);
     const maliciousNode2 = await createNode(
-      { ...t.ctx.aztecNodeConfig, validatorPrivateKey: maliciousPrivateKeyHex, coinbase: coinbase2 },
+      {
+        ...t.ctx.aztecNodeConfig,
+        validatorPrivateKey: maliciousPrivateKeyHex,
+        coinbase: coinbase2,
+        broadcastEquivocatedProposals: true,
+      },
       t.ctx.dateProvider,
       BOOT_NODE_UDP_PORT + 2,
       t.bootstrapNodeEnr,


### PR DESCRIPTION
## Summary
- The `e2e_p2p_duplicate_proposal_slash` test was flaking because malicious nodes were not actually broadcasting duplicate proposals to the network.
- The `P2PClient.broadcastProposal()` method throws when it detects a duplicate block proposal for the same slot, unless `broadcastEquivocatedProposals` is set to `true`.
- Added `broadcastEquivocatedProposals: true` to both malicious node configs, matching what the `duplicate_attestation_slash` test already does.

## Test plan
- The existing `e2e_p2p_duplicate_proposal_slash` test should now pass reliably since the duplicate proposals will actually reach the network and be detected by the slasher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)