### PR TITLE
fix(docs): replace deprecated dep::aztec in docs example contracts

### DIFF
--- a/docs/examples/contracts/counter_contract/src/main.nr
+++ b/docs/examples/contracts/counter_contract/src/main.nr
@@ -1,5 +1,5 @@
 // docs:start:setup
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract Counter {

--- a/docs/examples/contracts/nft/src/main.nr
+++ b/docs/examples/contracts/nft/src/main.nr
@@ -5,12 +5,12 @@ pub mod nft;
 #[aztec]
 pub contract NFTPunk {
     use crate::nft::NFTNote;
-    use dep::aztec::{
+    use aztec::{
         macros::{functions::{external, initializer, only_self}, storage::storage},
         protocol::address::AztecAddress,
         state_vars::{DelayedPublicMutable, Map, Owned, PrivateSet, PublicImmutable},
     };
-    use dep::aztec::messages::message_delivery::MessageDelivery;
+    use aztec::messages::message_delivery::MessageDelivery;
     use aztec::note::{
         note_getter_options::NoteGetterOptions, note_interface::NoteProperties,
         note_viewer_options::NoteViewerOptions,

--- a/docs/examples/contracts/nft/src/nft.nr
+++ b/docs/examples/contracts/nft/src/nft.nr
@@ -1,5 +1,5 @@
 // docs:start:nft_note_struct
-use dep::aztec::{macros::notes::note, protocol::traits::Packable};
+use aztec::{macros::notes::note, protocol::traits::Packable};
 
 #[derive(Eq, Packable)]
 #[note]

--- a/docs/examples/contracts/nft_bridge/src/main.nr
+++ b/docs/examples/contracts/nft_bridge/src/main.nr
@@ -3,12 +3,12 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract NFTBridge {
-    use dep::aztec::{
+    use aztec::{
         macros::{functions::{external, initializer}, storage::storage},
         protocol::{address::{AztecAddress, EthAddress}, hash::sha256_to_field},
         state_vars::PublicImmutable,
     };
-    use dep::NFTPunk::NFTPunk;
+    use NFTPunk::NFTPunk;
 
     #[storage]
     struct Storage<Context> {


### PR DESCRIPTION
## Summary
- Replaces deprecated `dep::aztec` path with `::aztec` in 4 docs example contract files (`nft`, `nft_bridge`, `counter_contract`)
- Also replaces `dep::NFTPunk` with `NFTPunk` in `nft_bridge`
- Fixes the docs examples validation failures reported in https://github.com/AztecProtocol/aztec-packages/pull/20278#issuecomment-3874628385
- The `bob_token_contract` TS validation failure was a cascading issue from the compile failures

## Test plan
- [ ] CI docs examples validation passes (Noir compile + TS validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)