### PR TITLE
fix: AI audit based protocol contract fixes

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/auth.nr
@@ -413,7 +413,7 @@ pub unconstrained fn set_reject_all(context: PublicContext, reject: bool) {
     let res = context.call_public_function(
         CANONICAL_AUTH_REGISTRY_ADDRESS,
         comptime { FunctionSelector::from_signature("set_reject_all(bool)") },
-        [context.this_address().to_field(), reject as Field],
+        [reject as Field],
         GasOpts::default(),
     );
     assert(res.len() == 0);

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/auth.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/authwit/auth.nr
@@ -144,7 +144,7 @@ pub unconstrained fn set_reject_all(context: PublicContext, reject: bool) {
     let res = context.call_public_function(
         CANONICAL_AUTH_REGISTRY_ADDRESS,
         comptime { FunctionSelector::from_signature("set_reject_all(bool)") },
-        [context.this_address().to_field(), reject as Field],
+        [reject as Field],
         GasOpts::default(),
     );
     assert(res.len() == 0);


### PR DESCRIPTION
In this PR I address AI audit findings @Rumata888 sent me. I needed to do changes only based on finding 1) (as described below) but I would need to do changes based on findings 3) and 4) as well if we were not already dropping the relevant functions in https://github.com/AztecProtocol/aztec-packages/pull/20248. So overall I would say the AI review was quite valuable.

## Summary of the AI audit findings

1. **Medium**
   - **Contract:** AuthRegistry helper (`aztec-nr/aztec/src/authwit/auth.nr`)
   - **Issue:** `set_reject_all` helper passes wrong args; cannot disable reject_all
2. **Low-Medium**
   - **Contract:** ContractInstanceRegistry
   - **Issue:** 10-minute minimum upgrade delay may be insufficient
3. **Low**
   - **Contract:** ContractClassRegistry
   - **Issue:** Broadcast functions don't verify class existence
4. **Low**
   - **Contract:** ContractClassRegistry
   - **Issue:** Broadcast functions don't verify bytecode
5. **Info**
   - **Contract:** AuthRegistry
   - **Issue:** No expiry on public authwits
6. **Info**
   - **Contract:** ContractClassRegistry
   - **Issue:** No revocation mechanism
7. **Info**
   - **Contract:** FeeJuice
   - **Issue:** Tight coupling with protocol circuit storage layout

## My fixes

1. This one was real and was not caught as the helper was unused. **Fixed** in https://github.com/AztecProtocol/aztec-packages/pull/20328/commits/aa7193091ef0d3fceafcb8d9056228b34cf12e56
2. As the floor value that seems fine - decided to not do any changes here.
3. Now irrelevant as the functions are getting dropped in https://github.com/AztecProtocol/aztec-packages/pull/20248
4. Now irrelevant as the functions are getting dropped in https://github.com/AztecProtocol/aztec-packages/pull/20248
5. Spoke with Lasse [here](https://aztecprotocol.slack.com/archives/C04PUD9AA4W/p1770716213613729) and doesen't make sense to add expiry directly to `AuthRegistry` as we can always add an expiry to the signed payload and check that it the contract we are authorizing actions for. That is ultimately a better design as it doesn't add cost to all the pub authwits (if this was implemented directly in the `AuthRegistry` we would add AVM opcodes to all the flows as we would need to pack "boolean" and "expiry" into 1 storage slot).
6. It being impossible to "un-publish" a contract class is a conscious design decision.
7. This is considered fine as we are the maintainers of protocol contracts and there is no practical way around it.
