### PR TITLE
fix: getting rid of noir compiler warnings

### DIFF
--- a/boxes/boxes/vanilla/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/contracts/src/main.nr
@@ -1,4 +1,4 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 /**
  * WARNING: this is no-longer considered a good example of an Aztec contract,
@@ -10,13 +10,13 @@ use dep::aztec::macros::aztec;
  
 #[aztec]
 pub contract PrivateVoting {
-    use dep::aztec::keys::getters::get_public_keys;
-    use dep::aztec::macros::{
+    use aztec::keys::getters::get_public_keys;
+    use aztec::macros::{
         functions::{external, initializer, only_self},
         storage::storage,
     };
-    use dep::aztec::state_vars::{Map, PublicImmutable, PublicMutable};
-    use dep::aztec::protocol::{address::AztecAddress, hash::poseidon2_hash, traits::{Hash, ToField}};
+    use aztec::state_vars::{Map, PublicImmutable, PublicMutable};
+    use aztec::protocol::{address::AztecAddress, hash::poseidon2_hash, traits::{Hash, ToField}};
 
     #[storage]
     struct Storage<Context> {

--- a/boxes/init/src/main.nr
+++ b/boxes/init/src/main.nr
@@ -1,5 +1,5 @@
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 contract Main {

--- a/noir-projects/noir-contracts/contracts/libs/token_portal_content_hash_lib/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/libs/token_portal_content_hash_lib/src/lib.nr
@@ -1,4 +1,4 @@
-use dep::aztec::protocol::{address::{AztecAddress, EthAddress}, hash::sha256_to_field, traits::ToField};
+use aztec::protocol::{address::{AztecAddress, EthAddress}, hash::sha256_to_field, traits::ToField};
 
 // Computes a content hash of a deposit/mint_to_public message.
 // Refer TokenPortal.sol for reference on L1.

--- a/noir-projects/noir-protocol-circuits/crates/types/src/validate.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/validate.nr
@@ -1,5 +1,5 @@
 // Returns whether to validate the output of the circuit. Eventually we'll want to change this
-// to `!dep::std::runtime::is_unconstrained`, so we skip unneeded validations when we
+// to `!std::runtime::is_unconstrained`, so we skip unneeded validations when we
 // do not need to generate a proof. But for now, we always validate to make sure we catch
 // errors earlier, as most of our tests run with real proofs disabled, which means validation
 // checks get skipped.


### PR DESCRIPTION
Having "dep::" in imports is now [throwing Noir compiler warnings](https://github.com/AztecProtocol/aztec-packages/pull/20328#issuecomment-3876588142) so I am dropping the remaining occurrences