### PR TITLE
fix: e2e HA flake

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -165,11 +165,6 @@ tests:
     error_regex: "Anvil failed to stop in time|Cannot read properties of undefined"
     owners:
       - *palla
-  # http://ci.aztec-labs.com/f2007345762c50a8
-  - regex: "src/e2e_multi_validator_node.test.ts"
-    error_regex: "✕ should attest ONLY with the correct validator keys"
-    owners:
-      - *spyros
 
   # yarn-project tests
   - regex: "yarn-project/kv-store"

--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -616,31 +616,51 @@ describe('HA Full Setup', () => {
     expect(l1VoteCount).toBeGreaterThan(0);
     logger.info(`Verified ${l1VoteCount} governance vote(s) successfully sent to L1`);
 
-    // Also verify HA database coordination
+    // Get L1 round info to determine which slots have actually landed on L1.
+    // We anchor the comparison on L1's lastSignalSlot since:
+    // - The DB may have duties for future slots that haven't been published to L1 yet
+    // - L1 may have signals from earlier slots in the round before the governance payload was set in the DB
+    const roundInfo = await governanceProposer.getRoundInfo(
+      deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
+      round,
+    );
+    const lastSignalSlot = Number(roundInfo.lastSignalSlot);
+    logger.info(
+      `L1 round ${round} info: lastSignalSlot=${lastSignalSlot}, l1VoteCount=${l1VoteCount}, payloadWithMostSignals=${roundInfo.payloadWithMostSignals}`,
+    );
+
+    // Query governance vote duties only for slots that have actually landed on L1 (up to lastSignalSlot)
     const dbResult = await mainPool.query<DutyRow>(
-      `SELECT * FROM validator_duties WHERE slot = $1 AND duty_type = 'GOVERNANCE_VOTE' ORDER BY started_at`,
-      [blockSlot.toString()],
+      `SELECT * FROM validator_duties WHERE slot::numeric <= $1 AND duty_type = 'GOVERNANCE_VOTE' ORDER BY slot, started_at`,
+      [lastSignalSlot.toString()],
     );
     const governanceVoteDuties = dbResult.rows;
-    logger.info(`HA database shows ${governanceVoteDuties.length} governance vote duty(ies)`);
+    logger.info(
+      `HA database shows ${governanceVoteDuties.length} governance vote duty(ies) up to slot ${lastSignalSlot}`,
+    );
 
     if (governanceVoteDuties.length > 0) {
-      // Verify HA coordination: Only one duty per validator address should exist
-      const uniqueValidators = new Set(governanceVoteDuties.map(row => row.validator_address));
-      expect(uniqueValidators.size).toBe(governanceVoteDuties.length); // No duplicate validators
+      // Verify HA coordination: Only one duty per (slot, validator) should exist
+      const dutyKeys = governanceVoteDuties.map(row => `${row.slot}-${row.validator_address}`);
+      const uniqueDutyKeys = new Set(dutyKeys);
+      expect(uniqueDutyKeys.size).toBe(governanceVoteDuties.length); // No duplicate (slot, validator) pairs
 
       // All duties should be completed
       for (const duty of governanceVoteDuties) {
         logger.info(
-          `  Governance vote duty: validator ${duty.validator_address}, node ${duty.node_id}, status ${duty.status}`,
+          `  Governance vote duty: slot ${duty.slot}, validator ${duty.validator_address}, node ${duty.node_id}, status ${duty.status}`,
         );
         expect(duty.status).toBe(DutyStatus.SIGNED);
         expect(duty.completed_at).toBeDefined();
       }
 
-      // L1 votes should match exactly one vote per unique validator (no double-voting)
-      expect(l1VoteCount).toBe(uniqueValidators.size);
-      logger.info(`Verified L1 votes (${l1VoteCount}) === unique validators (${uniqueValidators.size})`);
+      // L1 votes should match the number of unique slots in the DB that have landed on L1
+      const uniqueSlots = new Set(governanceVoteDuties.map(row => row.slot));
+      logger.info(
+        `L1 vote count: ${l1VoteCount}, unique slots in DB with governance votes up to L1 lastSignalSlot: ${uniqueSlots.size} (slots: ${[...uniqueSlots].join(', ')})`,
+      );
+      expect(l1VoteCount).toBe(uniqueSlots.size);
+      logger.info(`Verified L1 votes (${l1VoteCount}) === unique slots with votes (${uniqueSlots.size})`);
     }
 
     logger.info('Governance voting with HA coordination and L1 verification complete');


### PR DESCRIPTION
The check was failing because we were getting all round votes from L1 but only a single slot from the DB.
Updated to check that votes are unique from all validators for the whole round