### PR TITLE
fix: follow redirects in aztec-up install script

### DIFF
--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -42,8 +42,8 @@ else
   install_url="$INSTALL_URI/aztec-install"
 fi
 
-if curl --head --silent --fail "$install_url" > /dev/null; then
-  bash <(curl -s "$install_url")
+if curl -L --head --silent --fail "$install_url" > /dev/null; then
+  bash <(curl -sL "$install_url")
 else
   echo "Error: Install script not found at $install_url"
   echo "Please check the version specified."


### PR DESCRIPTION
## Summary
- Add `-L` flag to `curl` commands in `aztec-up` so redirects from `install.aztec.network` are followed
- Without this fix, `aztec-up -v <version>` silently exits 0 without actually installing the specified version, because `curl` doesn't follow redirects by default

## Test plan
- [ ] Run `aztec-up -v 3.0.0-devnet.6-patch.1` from a clean install and verify the correct docker image is pulled
- [ ] Verify `curl -L --head --silent --fail <install_url>` correctly follows the redirect and returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)