### PR TITLE
chore: enable iOS CI builds

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -266,11 +266,9 @@ jobs:
   # Only produces static libraries — Zig cannot link iOS executables (no TBD/dylib support).
   # Requires iOS SDK headers for C stdlib types; downloaded via scripts/download-ios-sdk.sh.
   # Non-blocking (continue-on-error) to avoid rugging releases - alerts #honk-team on failure.
-  # TEMPORARILY DISABLED: Migrating from Xcode toolchain to Zig cross-compilation
   build-bb-ios:
     name: Build iOS static libraries
     runs-on: ubuntu-latest
-    if: false  # Disabled during migration to Zig-based iOS builds
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Enable the `build-bb-ios` CI job to validate Zig cross-compilation on real CI infrastructure
- Targets the presets branch so CI runs against the new iOS presets

## Test plan

- [ ] `build-bb-ios` job runs successfully for both `zig-arm64-ios` and `zig-arm64-ios-sim` presets
- [ ] `libbb-external.a` is produced for each target