### PR TITLE
fix: out hash hint out of bounds

### DIFF
--- a/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
+++ b/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
@@ -254,9 +254,11 @@ export class EpochProvingState {
       }
       outHashes.push(outHash);
 
-      // Get or create hints for the next checkpoint.
-      hint = checkpoint.getOutHashHintForNextCheckpoint() ?? (await computeOutHashHint(outHashes));
-      checkpoint.setOutHashHintForNextCheckpoint(hint);
+      // If this is NOT the last checkpoint, get or create the hint for the next checkpoint.
+      if (i !== this.totalNumCheckpoints - 1) {
+        hint = checkpoint.getOutHashHintForNextCheckpoint() ?? (await computeOutHashHint(outHashes));
+        checkpoint.setOutHashHintForNextCheckpoint(hint);
+      }
     }
   }
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_checkpoints.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_checkpoints.test.ts
@@ -23,7 +23,7 @@ describe('prover/orchestrator/multi-checkpoints', () => {
   });
 
   describe('multiple checkpoints ', () => {
-    it.each([4, 5])(
+    it.each([4, 5, MAX_CHECKPOINTS_PER_EPOCH])(
       'builds an epoch with %s checkpoints in sequence',
       async (numCheckpoints: number) => {
         const numBlocksPerCheckpoint = 1;


### PR DESCRIPTION
Skip creating hint of the out hash tree for the next checkpoint if it's the last checkpoint, otherwise `tree.getSiblingPath(nextAvailableLeafIndex)` would throw: Invalid leaf index: got 32 but leaves count is 32