### PR TITLE
chore: rename fast_divmod

### DIFF
--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256.hpp
@@ -216,7 +216,7 @@ class alignas(32) uint256_t {
     uint64_t data[4]; // NOLINT
 
     [[nodiscard]] constexpr std::pair<uint256_t, uint256_t> divmod(const uint256_t& b) const;
-    [[nodiscard]] constexpr std::pair<uint256_t, uint64_t> fast_divmod(uint64_t b) const;
+    [[nodiscard]] constexpr std::pair<uint256_t, uint64_t> divmod(uint64_t b) const;
 
     size_t hash() const noexcept { return utils::hash_as_tuple(data[0], data[1], data[2], data[3]); }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/uint256/uint256_impl.hpp
@@ -181,7 +181,7 @@ constexpr std::pair<uint256_t, uint256_t> uint256_t::divmod(const uint256_t& b) 
  * because the invariant remainder < b guarantees the quotient limb fits in 64 bits.
  * Falls back to the uint256_t overload for wasm.
  */
-constexpr std::pair<uint256_t, uint64_t> uint256_t::fast_divmod(uint64_t b) const
+constexpr std::pair<uint256_t, uint64_t> uint256_t::divmod(uint64_t b) const
 {
     if (*this == 0 || b == 0) {
         return { 0, 0 };

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_to_radix.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/standalone/pure_to_radix.cpp
@@ -22,7 +22,7 @@ std::pair<std::vector<uint8_t>, /* truncated */ bool> PureToRadix::to_le_radix(c
     limbs.reserve(num_limbs);
 
     for (uint32_t i = 0; i < num_limbs; i++) {
-        auto [quotient, remainder] = value_integer.fast_divmod(static_cast<uint64_t>(radix));
+        auto [quotient, remainder] = value_integer.divmod(static_cast<uint64_t>(radix));
         limbs.push_back(static_cast<uint8_t>(remainder));
         value_integer = quotient;
     }


### PR DESCRIPTION
Assuming the semantic is the same, a caller doesn't need to differentiate these.
