### PR TITLE
fix: escape hatch snapshots

### DIFF
--- a/l1-contracts/src/core/EscapeHatch.sol
+++ b/l1-contracts/src/core/EscapeHatch.sol
@@ -163,13 +163,23 @@ contract EscapeHatch is IEscapeHatch {
   /**
    * @notice Initiate exit from the candidate set
    *
-   * @dev The exit may be immediate or delayed depending on timing relative to next hatch
+   * @dev The exit may be immediate or delayed depending on timing relative to next hatch.
+   *
+   *      Calls selectCandidates() first, which may select the caller as the designated
+   *      proposer for an upcoming hatch. If the caller is selected, their status transitions
+   *      to PROPOSING and they are removed from $activeCandidates, causing the subsequent
+   *      checks to revert. This is intentional - a designated proposer cannot exit and must
+   *      instead follow the PROPOSING -> validateProofSubmission -> EXITING -> leaveCandidateSet
+   *      flow.
    *
    * @custom:reverts EscapeHatch__NotInCandidateSet if caller is not in the candidate set
+   *                 (including when caller was just selected as proposer by selectCandidates)
    * @custom:reverts EscapeHatch__InvalidStatus if caller's status is not ACTIVE
    */
   function initiateExit() external override(IEscapeHatchCore) {
-    // Ensure current hatch is prepared (may select the caller). Makes our later checks much simpler.
+    // Prepare the current hatch. If this selects the caller as designated proposer, their
+    // status becomes PROPOSING and they are removed from $activeCandidates. The requires
+    // below will then revert, preventing a designated proposer from exiting.
     selectCandidates();
 
     address candidate = msg.sender;
@@ -275,28 +285,49 @@ contract EscapeHatch is IEscapeHatch {
 
     require(block.timestamp >= data.exitableAt, Errors.EscapeHatch__NotExitableYet(data.exitableAt, block.timestamp));
 
+    // Check if this contract was the active escape hatch for the entire active period.
+    // If not, the proposer may have been unable to fulfill duties due to governance change.
+    Epoch firstActiveEpoch = _getFirstEpoch(_hatch);
+    bool wasActiveEntirePeriod = true;
+    for (uint256 i = 0; i < ACTIVE_DURATION; i++) {
+      Epoch epoch = firstActiveEpoch + Epoch.wrap(i);
+      if (address(ROLLUP.getEscapeHatchForEpoch(epoch)) != address(this)) {
+        wasActiveEntirePeriod = false;
+        break;
+      }
+    }
+
     bool success = true;
     uint256 punishment = 0;
 
-    // Check success conditions:
-    // 1. Something must have been proposed
-    if (data.lastCheckpointNumber == 0) {
-      success = false;
-    }
+    if (!wasActiveEntirePeriod && data.lastCheckpointNumber == 0) {
+      // Escape hatch was deactivated during the active window and proposer did nothing.
+      // This is acceptable - they couldn't (or chose not to) propose during disruption.
+      // Skip punishment, transition to EXITING.
+    } else {
+      // Normal validation: either was active the entire time, or proposer proposed something
+      // (if they proposed, they're on the hook regardless of escape hatch changes,
+      // since proofs go to the rollup directly and are unaffected by escape hatch changes).
 
-    // 2. Proofs must have been submitted at least up to this checkpoint
-    if (success && ROLLUP.getProvenCheckpointNumber() < data.lastCheckpointNumber) {
-      success = false;
-    }
+      // 1. Something must have been proposed
+      if (data.lastCheckpointNumber == 0) {
+        success = false;
+      }
 
-    // 3. The checkpoint archive must still be in the chain (not pruned)
-    if (success && ROLLUP.archiveAt(data.lastCheckpointNumber) != data.lastSubmittedArchive) {
-      success = false;
-    }
+      // 2. Proofs must have been submitted at least up to this checkpoint
+      if (success && ROLLUP.getProvenCheckpointNumber() < data.lastCheckpointNumber) {
+        success = false;
+      }
 
-    if (!success) {
-      punishment = FAILED_HATCH_PUNISHMENT;
-      data.amount -= FAILED_HATCH_PUNISHMENT;
+      // 3. The checkpoint archive must still be in the chain (not pruned)
+      if (success && ROLLUP.archiveAt(data.lastCheckpointNumber) != data.lastSubmittedArchive) {
+        success = false;
+      }
+
+      if (!success) {
+        punishment = FAILED_HATCH_PUNISHMENT;
+        data.amount -= FAILED_HATCH_PUNISHMENT;
+      }
     }
 
     data.status = Status.EXITING;
@@ -547,6 +578,14 @@ contract EscapeHatch is IEscapeHatch {
    * @custom:reverts EscapeHatch__SetUnstable if called before the freeze timestamp (defense in depth)
    */
   function selectCandidates() public override(IEscapeHatchCore) {
+    // Don't select new candidates if this contract is no longer the active escape hatch.
+    // We check the latest value rather than the epoch-stable one since we sample for the future,
+    // so if the current differs, the future will as well.
+    // Early return (not revert) is important because initiateExit() calls selectCandidates() internally.
+    if (address(ROLLUP.getEscapeHatch()) != address(this)) {
+      return;
+    }
+
     Hatch currentHatch = getCurrentHatch();
     Hatch targetHatch = currentHatch + Hatch.wrap(LAG_IN_HATCHES);
 

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -412,6 +412,15 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
   }
 
   /**
+   * @notice  Get the escape hatch contract that was active at the start of a given epoch
+   * @param _epoch The epoch to look up the escape hatch for
+   * @return The escape hatch contract interface that was active at the epoch start
+   */
+  function getEscapeHatchForEpoch(Epoch _epoch) external view override(IValidatorSelection) returns (IEscapeHatch) {
+    return ValidatorOperationsExtLib.getEscapeHatchForEpoch(_epoch);
+  }
+
+  /**
    * @notice  Get the sample seed for the current epoch
    *
    * @return The sample seed for the current epoch

--- a/l1-contracts/src/core/interfaces/IValidatorSelection.sol
+++ b/l1-contracts/src/core/interfaces/IValidatorSelection.sol
@@ -12,11 +12,12 @@ struct ValidatorSelectionStorage {
   mapping(Epoch => bytes32 committeeCommitment) committeeCommitments;
   // Checkpointed map of epoch -> randao value
   Checkpoints.Trace224 randaos;
-  // The following 3 uint32s + address pack into a single slot (12 + 20 = 32 bytes)
+  // The following 3 uint32s pack into a single slot (12 bytes)
   uint32 targetCommitteeSize;
   uint32 lagInEpochsForValidatorSet;
   uint32 lagInEpochsForRandao;
-  IEscapeHatch escapeHatch;
+  // Checkpointed escape hatch addresses (key = timestamp, value = address as uint160)
+  Checkpoints.Trace160 escapeHatchCheckpoints;
 }
 
 interface IValidatorSelectionCore {
@@ -60,4 +61,5 @@ interface IValidatorSelection is IValidatorSelectionCore, IEmperor {
   function getTargetCommitteeSize() external view returns (uint256);
 
   function getEscapeHatch() external view returns (IEscapeHatch);
+  function getEscapeHatchForEpoch(Epoch _epoch) external view returns (IEscapeHatch);
 }

--- a/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/EpochProofLib.sol
@@ -308,9 +308,11 @@ library EpochProofLib {
     Epoch epoch = STFLib.getEpochForCheckpoint(_endCheckpointNumber);
 
     // Check if this is an escape hatch epoch - skip attestation verification if so
-    // since escape hatch blocks are proposed without committee attestations
+    // since escape hatch blocks are proposed without committee attestations.
+    // Uses epoch-stable lookup so proof verification uses the escape hatch that was
+    // active when the epoch started, not whatever is currently configured.
     {
-      IEscapeHatch escapeHatch = ValidatorSelectionLib.getEscapeHatch();
+      IEscapeHatch escapeHatch = ValidatorSelectionLib.getEscapeHatchForEpoch(epoch);
       if (address(escapeHatch) != address(0)) {
         (bool isOpen,) = escapeHatch.isHatchOpen(epoch);
         if (isOpen) {

--- a/l1-contracts/src/core/libraries/rollup/InvalidateLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/InvalidateLib.sol
@@ -215,9 +215,11 @@ library InvalidateLib {
     Epoch epoch = checkpointLog.slotNumber.decompress().epochFromSlot();
 
     // Check if this is an escape hatch epoch - escape hatch checkpoints cannot be invalidated
-    // since they have no committee attestations by design
+    // since they have no committee attestations by design.
+    // Uses epoch-stable lookup so invalidation rules use the escape hatch that was
+    // active when the epoch started, not whatever is currently configured.
     {
-      IEscapeHatch escapeHatch = ValidatorSelectionLib.getEscapeHatch();
+      IEscapeHatch escapeHatch = ValidatorSelectionLib.getEscapeHatchForEpoch(epoch);
       if (address(escapeHatch) != address(0)) {
         (bool isOpen,) = escapeHatch.isHatchOpen(epoch);
         require(!isOpen, Errors.Rollup__CannotInvalidateEscapeHatch());

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -199,8 +199,9 @@ library ProposeLib {
     v.headerHash = ProposedHeaderLib.hash(v.header);
 
     // Compute current epoch and check escape hatch BEFORE setupEpoch.
+    // Uses epoch-stable lookup so mid-epoch governance changes don't affect current epoch proposals.
     v.currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    v.escapeHatch = ValidatorSelectionLib.getEscapeHatch();
+    v.escapeHatch = ValidatorSelectionLib.getEscapeHatchForEpoch(v.currentEpoch);
     if (address(v.escapeHatch) != address(0)) {
       (v.isEscapeHatch, v.escapeHatchProposer) = v.escapeHatch.isHatchOpen(v.currentEpoch);
     }

--- a/l1-contracts/src/core/libraries/rollup/ValidatorOperationsExtLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorOperationsExtLib.sol
@@ -152,6 +152,10 @@ library ValidatorOperationsExtLib {
     return ValidatorSelectionLib.getEscapeHatch();
   }
 
+  function getEscapeHatchForEpoch(Epoch _epoch) external view returns (IEscapeHatch) {
+    return ValidatorSelectionLib.getEscapeHatchForEpoch(_epoch);
+  }
+
   function getTargetCommitteeSize() external view returns (uint256) {
     return ValidatorSelectionLib.getStorage().targetCommitteeSize;
   }

--- a/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ValidatorSelectionLib.sol
@@ -100,6 +100,7 @@ library ValidatorSelectionLib {
   using TimeLib for Epoch;
   using TimeLib for Slot;
   using Checkpoints for Checkpoints.Trace224;
+  using Checkpoints for Checkpoints.Trace160;
   using SafeCast for *;
   using TransientSlot for *;
   using SlotDerivation for string;
@@ -157,7 +158,12 @@ library ValidatorSelectionLib {
    * @param _escapeHatch The address of the EscapeHatch contract, or address(0) to disable
    */
   function updateEscapeHatch(address _escapeHatch) internal {
-    getStorage().escapeHatch = IEscapeHatch(_escapeHatch);
+    // Key the checkpoint to the START of the next epoch so the change never affects
+    // the current epoch. This prevents a same-block governance action from retroactively
+    // altering the escape hatch for an epoch where proposals may have already been made.
+    Epoch nextEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp() + Epoch.wrap(1);
+    uint96 nextEpochTs = uint96(Timestamp.unwrap(nextEpoch.toTimestamp()));
+    getStorage().escapeHatchCheckpoints.push(nextEpochTs, uint160(_escapeHatch));
   }
 
   /**
@@ -589,12 +595,26 @@ library ValidatorSelectionLib {
   }
 
   /**
-   * @notice Gets the escape hatch contract
-   * @dev Returns the configured escape hatch, or a zero-address IEscapeHatch if disabled
+   * @notice Gets the current escape hatch contract (latest checkpoint)
+   * @dev Returns the most recently configured escape hatch, or a zero-address IEscapeHatch if none set
    * @return The escape hatch contract interface
    */
   function getEscapeHatch() internal view returns (IEscapeHatch) {
-    return getStorage().escapeHatch;
+    return IEscapeHatch(address(getStorage().escapeHatchCheckpoints.latest()));
+  }
+
+  /**
+   * @notice Gets the escape hatch contract that was active at the start of a given epoch
+   * @dev Uses `upperLookupRecent` to find the most recent checkpoint with key <= epoch start timestamp.
+   *      Changes pushed with `block.timestamp` during epoch N take effect for epoch N+1 (since epoch
+   *      N+1's start timestamp > the push timestamp > epoch N's start timestamp), providing implicit
+   *      epoch-boundary activation.
+   * @param _epoch The epoch to look up the escape hatch for
+   * @return The escape hatch contract interface that was active at the start of the epoch
+   */
+  function getEscapeHatchForEpoch(Epoch _epoch) internal view returns (IEscapeHatch) {
+    uint96 ts = uint96(Timestamp.unwrap(TimeLib.toTimestamp(_epoch)));
+    return IEscapeHatch(address(getStorage().escapeHatchCheckpoints.upperLookupRecent(ts)));
   }
 
   /**

--- a/l1-contracts/src/core/slashing/TallySlashingProposer.sol
+++ b/l1-contracts/src/core/slashing/TallySlashingProposer.sol
@@ -1020,15 +1020,13 @@ contract TallySlashingProposer is EIP712 {
   function _getEscapeHatchEpochFlags(SlashRound _round) internal view returns (bool[] memory escapeHatchEpochs) {
     escapeHatchEpochs = new bool[](ROUND_SIZE_IN_EPOCHS);
 
-    IEscapeHatch escapeHatch = IValidatorSelection(INSTANCE).getEscapeHatch();
-
-    // If no escape hatch is configured, return all-false quickly
-    if (address(escapeHatch) == address(0)) {
-      return escapeHatchEpochs;
-    }
-
     for (uint256 epochIndex; epochIndex < ROUND_SIZE_IN_EPOCHS; epochIndex++) {
-      (bool isOpen,) = escapeHatch.isHatchOpen(getSlashTargetEpoch(_round, epochIndex));
+      Epoch epoch = getSlashTargetEpoch(_round, epochIndex);
+      IEscapeHatch escapeHatch = IValidatorSelection(INSTANCE).getEscapeHatchForEpoch(epoch);
+      if (address(escapeHatch) == address(0)) {
+        continue;
+      }
+      (bool isOpen,) = escapeHatch.isHatchOpen(epoch);
       escapeHatchEpochs[epochIndex] = isOpen;
     }
   }

--- a/l1-contracts/test/escape-hatch/base.sol
+++ b/l1-contracts/test/escape-hatch/base.sol
@@ -11,6 +11,7 @@ import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Timestamp, Epoch} from "@aztec/shared/libraries/TimeMath.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {FakeRollup} from "./mocks/FakeRollup.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
 
 /// @notice Configuration struct for EscapeHatch deployment
 /// @dev Foundry can fuzz this struct directly when passed as a test parameter
@@ -98,6 +99,10 @@ contract EscapeHatchBase is TestBase {
       DEFAULT_PROPOSING_EXIT_DELAY
     );
 
+    // Register escape hatch with the rollup so selectCandidates deactivation guard passes
+    vm.prank(Ownable(address(rollup)).owner());
+    rollup.updateEscapeHatch(address(escapeHatch));
+
     vm.label(address(rollup), "Rollup");
     vm.label(address(bondToken), "BondToken");
     vm.label(address(escapeHatch), "EscapeHatch");
@@ -132,6 +137,9 @@ contract EscapeHatchBase is TestBase {
       config.proposingExitDelay
     );
     vm.label(address(escapeHatch), "EscapeHatchWithFakeRollup");
+
+    // Register escape hatch with the fake rollup so selectCandidates deactivation guard passes
+    fakeRollup.setEscapeHatch(address(escapeHatch));
   }
 
   function _mintAndApprove(address _candidate, uint256 _amount) internal {
@@ -247,6 +255,14 @@ contract EscapeHatchBase is TestBase {
     );
 
     vm.label(address(escapeHatch), "FuzzedEscapeHatch");
+
+    // Register the new escape hatch so selectCandidates deactivation guard passes
+    if (useFakeRollup) {
+      fakeRollup.setEscapeHatch(address(escapeHatch));
+    } else {
+      vm.prank(Ownable(address(rollup)).owner());
+      rollup.updateEscapeHatch(address(escapeHatch));
+    }
 
     // Warp to safe epoch to avoid HatchTooEarly errors
     _warpToSafeEpoch();

--- a/l1-contracts/test/escape-hatch/e2e/escapeHatchReplacement.t.sol
+++ b/l1-contracts/test/escape-hatch/e2e/escapeHatchReplacement.t.sol
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {EscapeHatchIntegrationBase} from "../integration/EscapeHatchIntegrationBase.sol";
+import {EscapeHatch} from "@aztec/core/EscapeHatch.sol";
+import {IEscapeHatchCore, IEscapeHatch, Status, CandidateInfo, Hatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {Epoch, Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {ProposeArgs, OracleInput, ProposeLib, ProposePayload} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+import {ProposedHeader, ProposedHeaderLib, GasFees} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
+import {
+  CommitteeAttestations,
+  CommitteeAttestation,
+  Signature,
+  AttestationLib
+} from "@aztec/core/libraries/rollup/AttestationLib.sol";
+import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+import {AttestationLibHelper} from "@test/helper_libraries/AttestationLibHelper.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
+
+/**
+ * @title EscapeHatchReplacementTest
+ * @notice E2E tests for escape hatch governance replacement scenarios.
+ *
+ * @dev These tests assert the DESIRED behavior when governance replaces the escape hatch.
+ *      They currently FAIL (before #20363) because the escape hatch lookup is not epoch-stable:
+ *
+ *      - ProposeLib queries the CURRENT escape hatch for the proposal path decision,
+ *        so a mid-epoch replacement retroactively blocks an already-selected proposer.
+ *
+ *      - EscapeHatch.selectCandidates has no deactivation guard, so candidates are
+ *        selected on a contract the rollup no longer uses.
+ *
+ *      - EscapeHatch.validateProofSubmission punishes candidates who had no way to
+ *        propose because the rollup stopped recognizing the old escape hatch.
+ *
+ *      - EpochProofLib skips attestation verification for retroactively classified
+ *        escape hatch epochs, allowing proofs with bad attestations through.
+ *
+ *      - InvalidateLib blocks invalidation for retroactively classified escape hatch
+ *        epochs, protecting checkpoints with bad attestations from removal.
+ *
+ *      After epoch-stable snapshotting is implemented, these tests should PASS.
+ */
+contract EscapeHatchReplacementTest is EscapeHatchIntegrationBase {
+  using stdStorage for StdStorage;
+
+  // ============================================================================
+  // Helpers for retroactive escape hatch deployment
+  // ============================================================================
+
+  struct BadAttestationData {
+    CommitteeAttestations packedAttestations;
+    CommitteeAttestation[] attestations;
+    address[] committee;
+    uint256 invalidSignatureIndex;
+    Epoch proposalEpoch;
+  }
+
+  /**
+   * @notice Propose a checkpoint during a normal epoch with one bad attestation signature
+   * @dev Adapted from invalidate.t.sol - creates a valid proposal except one committee
+   *      member's signature is replaced with a signature from an unrelated key.
+   */
+  function _proposeWithBadAttestation() internal returns (BadAttestationData memory data) {
+    ProposedHeader memory header = full.checkpoint.header;
+
+    vm.warp(max(block.timestamp, Timestamp.unwrap(full.checkpoint.header.timestamp)));
+
+    rollup.setupEpoch();
+    data.proposalEpoch = rollup.getCurrentEpoch();
+
+    address proposer = rollup.getCurrentProposer();
+    data.committee = rollup.getEpochCommittee(data.proposalEpoch);
+
+    {
+      uint128 manaMinFee = SafeCast.toUint128(rollup.getManaMinFeeAt(Timestamp.wrap(block.timestamp), true));
+      header.gasFees.feePerL2Gas = manaMinFee;
+    }
+
+    ProposeArgs memory proposeArgs =
+      ProposeArgs({header: header, archive: full.checkpoint.archive, oracleInput: OracleInput(0)});
+
+    skipBlobCheck(address(rollup));
+
+    ProposePayload memory proposePayload = ProposePayload({
+      archive: proposeArgs.archive, oracleInput: proposeArgs.oracleInput, headerHash: ProposedHeaderLib.hash(header)
+    });
+
+    // Create attestations - all valid except one
+    uint256 committeeSize = data.committee.length;
+    data.attestations = new CommitteeAttestation[](committeeSize);
+    address[] memory signers = new address[](committeeSize);
+    bytes32 digest = ProposeLib.digest(proposePayload);
+
+    for (uint256 i = 0; i < committeeSize; i++) {
+      data.attestations[i] = _createAttestation(data.committee[i], digest);
+      signers[i] = data.committee[i];
+    }
+
+    // Make one attestation invalid (not the proposer's)
+    for (uint256 i = 0; i < committeeSize; i++) {
+      if (data.committee[i] != proposer) {
+        uint256 invalidKey = uint256(keccak256(abi.encode("invalid", block.timestamp)));
+        address invalidSigner = vm.addr(invalidKey);
+        attesterPrivateKeys[invalidSigner] = invalidKey;
+        data.attestations[i] = _createAttestation(invalidSigner, digest);
+        data.invalidSignatureIndex = i;
+        break;
+      }
+    }
+
+    data.packedAttestations = AttestationLibHelper.packAttestations(data.attestations);
+
+    // Proposer signs over attestations and signers
+    Signature memory attestationsAndSignersSignature =
+    _createAttestation(proposer, AttestationLib.getAttestationsAndSignersDigest(data.packedAttestations, signers))
+    .signature;
+
+    vm.prank(proposer);
+    rollup.propose(
+      proposeArgs, data.packedAttestations, signers, attestationsAndSignersSignature, full.checkpoint.blobCommitments
+    );
+
+    assertEq(rollup.getPendingCheckpointNumber(), 1, "Checkpoint should be proposed");
+  }
+
+  /**
+   * @notice Deploy an escape hatch that retroactively classifies a given epoch as an escape hatch epoch
+   * @dev Deploys a new EscapeHatch with frequency/activeDuration chosen so the target epoch
+   *      falls in the active window, then uses stdstore to set a designated proposer.
+   */
+  function _deployRetroactiveEscapeHatch(Epoch _epoch) internal {
+    uint256 epochNum = Epoch.unwrap(_epoch);
+
+    // Choose parameters so epoch % frequency < activeDuration
+    // With frequency = epochNum + 2, activeDuration = epochNum + 1:
+    //   epochNum % (epochNum + 2) = epochNum < epochNum + 1 ✓
+    uint256 proofSubmissionEpochs = rollup.getProofSubmissionEpochs();
+    uint256 newActiveDuration = epochNum + 1;
+    if (newActiveDuration < proofSubmissionEpochs + 1) {
+      newActiveDuration = proofSubmissionEpochs + 1;
+    }
+    uint256 newFrequency = newActiveDuration + 1;
+    // Ensure frequency > LAG_IN_EPOCHS_FOR_SET_SIZE (2)
+    if (newFrequency <= 2) {
+      newFrequency = 3;
+      newActiveDuration = 2;
+    }
+
+    EscapeHatch retroactiveEscapeHatch = new EscapeHatch(
+      address(rollup),
+      address(testERC20),
+      DEFAULT_BOND_SIZE,
+      DEFAULT_WITHDRAWAL_TAX,
+      DEFAULT_FAILED_HATCH_PUNISHMENT,
+      newFrequency,
+      newActiveDuration,
+      DEFAULT_LAG_IN_HATCHES,
+      DEFAULT_PROPOSING_EXIT_DELAY
+    );
+    vm.label(address(retroactiveEscapeHatch), "RetroactiveEscapeHatch");
+
+    // Set designated proposer so isHatchOpen returns true
+    uint256 hatchNumber = epochNum / newFrequency;
+    stdstore.target(address(retroactiveEscapeHatch)).sig("getDesignatedProposer(uint256)").with_key(hatchNumber)
+      .checked_write(address(0xBEEF));
+
+    // Update rollup to use the new escape hatch
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(retroactiveEscapeHatch));
+
+    // Verify the epoch is now classified as escape hatch
+    (bool isOpen,) = retroactiveEscapeHatch.isHatchOpen(_epoch);
+    assertTrue(isOpen, "Epoch should be retroactively classified as escape hatch");
+  }
+
+  /**
+   * @notice Variant of _proposeWithHatch that expects the rollup.propose() call to revert.
+   */
+  function _proposeWithHatchExpectRevert(address _proposer) internal {
+    (ProposeArgs memory args, bytes memory blobs) = _buildProposeArgs(_proposer);
+    skipBlobCheck(address(rollup));
+
+    vm.expectRevert();
+    vm.prank(_proposer);
+    rollup.propose(
+      args,
+      CommitteeAttestations({signatureIndices: "", signaturesOrAddresses: ""}),
+      new address[](0),
+      Signature({v: 0, r: 0, s: 0}),
+      blobs
+    );
+  }
+
+  /**
+   * @notice Proposer should still be able to propose after mid-epoch replacement
+   *
+   *         A proposer selected for an escape hatch epoch should still be able to propose
+   *         even if governance replaces the escape hatch mid-epoch.
+   *
+   * @dev DESIRED: Proposal succeeds because epoch-stable snapshotting preserves the
+   *      escape hatch that was active when the epoch started.
+   */
+  function test_proposerCanStillProposeAfterMidEpochReplacement() public setup(48, 48) progressEpochsToInclusion {
+    full = load("empty_checkpoint_1");
+    _deployEscapeHatch();
+
+    // Setup: candidate joins, is selected, warp to hatch window
+    _joinCandidateSet(CANDIDATE1);
+    targetHatch = _selectCandidateForHatch();
+    assertEq(escapeHatch.getDesignatedProposer(targetHatch), CANDIDATE1, "CANDIDATE1 should be proposer");
+
+    _warpToHatch(targetHatch);
+
+    // Governance replaces escape hatch mid-epoch
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    // DESIRED: Proposal should still succeed (epoch-stable snapshot preserves escape hatch)
+    // CURRENT: This REVERTS because ProposeLib uses the current escape hatch (address(0))
+    _proposeWithHatch(CANDIDATE1);
+    assertEq(rollup.getPendingCheckpointNumber(), 1, "Proposal should succeed with epoch-stable escape hatch");
+  }
+
+  /**
+   * @notice Already-selected candidate should NOT be punished after deactivation
+   *
+   *         A candidate selected before escape hatch deactivation should not be
+   *         punished for failing to propose - they had no way to fulfill their duty.
+   *
+   * @dev DESIRED: validateProofSubmission recognizes the escape hatch was deactivated
+   *      and does NOT apply punishment. Bond stays at DEFAULT_BOND_SIZE.
+   */
+  function test_alreadySelectedCandidateNotPunishedAfterDeactivation() public setup(48, 48) progressEpochsToInclusion {
+    full = load("empty_checkpoint_1");
+    _deployEscapeHatch();
+
+    // Step 1: Candidate joins and is selected for a hatch
+    _joinCandidateSet(CANDIDATE1);
+    targetHatch = _selectCandidateForHatch();
+
+    assertEq(escapeHatch.getDesignatedProposer(targetHatch), CANDIDATE1, "Should be designated proposer");
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.PROPOSING), "Should be in PROPOSING state");
+    assertEq(info.amount, DEFAULT_BOND_SIZE, "Should have full bond");
+
+    // Step 2: Governance removes escape hatch BEFORE the hatch window
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    // Step 3: The hatch window arrives - demonstrate the candidate CANNOT propose.
+    //         The rollup no longer recognizes any escape hatch, so ProposeLib falls
+    //         through to the committee attestation path, which fails for escape hatch
+    //         proposals (they carry no committee attestations).
+    _warpToHatch(targetHatch);
+    assertEq(address(rollup.getEscapeHatch()), address(0), "Rollup should have no escape hatch");
+
+    _proposeWithHatchExpectRevert(CANDIDATE1);
+
+    // Step 4: The candidate is stuck in PROPOSING on the dead escape hatch contract.
+    //         They can't propose (step 3) and can't exit until exitable at.
+    //         This is true in both current and fixed implementations since the
+    //         governance update moved us to a future epoch from the update.
+    info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.PROPOSING), "Still stuck in PROPOSING on dead contract");
+
+    // Step 5: Warp to exitable at and validate proof submission
+    _warpToExitableAt(CANDIDATE1);
+    escapeHatch.validateProofSubmission(targetHatch);
+
+    // DESIRED: Candidate should NOT be punished - they had no way to propose
+    // CURRENT: info.amount == DEFAULT_BOND_SIZE - DEFAULT_FAILED_HATCH_PUNISHMENT
+    info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertTrue(info.status == Status.EXITING, "Should be EXITING after validation");
+    assertEq(info.amount, DEFAULT_BOND_SIZE, "Candidate should NOT be punished when escape hatch was deactivated");
+  }
+
+  /**
+   * @notice selectCandidates should be no-op on deactivated escape hatch
+   *
+   *         selectCandidates() should not select new candidates on a deactivated
+   *         escape hatch contract. Candidates selected on a dead contract can never
+   *         propose and inevitably get punished.
+   *
+   * @dev DESIRED: selectCandidates() is a no-op when the contract is no longer the
+   *      active escape hatch. Candidate remains in ACTIVE state.
+   */
+  function test_selectCandidatesNoOpOnDeactivatedEscapeHatch() public setup(48, 48) progressEpochsToInclusion {
+    full = load("empty_checkpoint_1");
+    _deployEscapeHatch();
+
+    // Step 1: Candidate joins escape hatch
+    _joinCandidateSet(CANDIDATE1);
+
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.ACTIVE), "Should be ACTIVE after joining");
+
+    // Step 2: Governance deactivates the escape hatch BEFORE selection
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    assertEq(address(rollup.getEscapeHatch()), address(0), "Rollup should have no escape hatch");
+
+    // Step 3: Call selectCandidates on the deactivated escape hatch
+    _setRandomPrevrandao();
+    _warpForwardEpochs(DEFAULT_FREQUENCY);
+    escapeHatch.selectCandidates();
+
+    // DESIRED: Candidate should remain in ACTIVE state (selectCandidates is no-op)
+    // CURRENT: Candidate transitions to PROPOSING on a dead contract
+    info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertTrue(info.status == Status.ACTIVE, "Candidate should remain ACTIVE on deactivated escape hatch");
+  }
+
+  /**
+   * @notice Proof submission should verify attestations for normal epochs
+   *
+   *         Proof submission should still verify attestation signatures for checkpoints
+   *         proposed during a normal epoch, even if the escape hatch is retroactively
+   *         configured to classify that epoch as an escape hatch epoch.
+   *
+   * @dev DESIRED: Proof fails because attestation verification catches the bad signature.
+   *      The epoch was normal at propose time, so attestation verification should run.
+   */
+  function test_proofSubmissionVerifiesAttestationsForNormalEpoch() public setup(4, 4) progressEpochsToInclusion {
+    full = load("mixed_checkpoint_1");
+
+    // Step 1: Propose during a normal epoch (no escape hatch configured)
+    //         One attestation has an invalid signature
+    BadAttestationData memory data = _proposeWithBadAttestation();
+
+    // Step 2: Deploy an escape hatch that retroactively covers the proposal epoch
+    _deployRetroactiveEscapeHatch(data.proposalEpoch);
+
+    // Step 3: Submit proof with the stored attestations
+    // DESIRED: Proof fails (attestation verification catches bad signature)
+    // CURRENT: Proof succeeds (attestation verification SKIPPED due to retroactive escape hatch)
+    bytes32 previousArchive = rollup.archiveAt(0);
+    bytes32 endArchive = rollup.archiveAt(1);
+
+    bytes32[] memory fees = new bytes32[](64);
+    fees[0] = bytes32(uint256(uint160(bytes20(("sequencer")))));
+    fees[1] = bytes32(0);
+
+    vm.expectRevert();
+    rollup.submitEpochRootProof(
+      SubmitEpochRootProofArgs({
+        start: 1,
+        end: 1,
+        args: PublicInputArgs({
+          previousArchive: previousArchive,
+          endArchive: endArchive,
+          outHash: full.checkpoint.header.outHash,
+          proverId: address(this)
+        }),
+        fees: fees,
+        attestations: data.packedAttestations,
+        blobInputs: full.checkpoint.batchedBlobInputs,
+        proof: ""
+      })
+    );
+  }
+
+  /**
+   * @notice Invalidation should work for normal epoch checkpoints
+   *
+   *         A checkpoint proposed during a normal epoch with a bad attestation should
+   *         be invalidatable, even if the escape hatch is retroactively configured to
+   *         classify that epoch as an escape hatch epoch.
+   *
+   * @dev DESIRED: Invalidation succeeds because the epoch was normal at propose time.
+   *      The bad attestation is detected and the checkpoint is removed.
+   */
+  function test_invalidationWorksForNormalEpochCheckpoint() public setup(4, 4) progressEpochsToInclusion {
+    full = load("mixed_checkpoint_1");
+
+    // Step 1: Propose during a normal epoch (no escape hatch configured)
+    //         One attestation has an invalid signature
+    BadAttestationData memory data = _proposeWithBadAttestation();
+
+    // Step 2: Deploy an escape hatch that retroactively covers the proposal epoch
+    _deployRetroactiveEscapeHatch(data.proposalEpoch);
+
+    // Step 3: Invalidate the checkpoint using the bad attestation
+    // DESIRED: Invalidation succeeds (epoch was normal, bad attestation detected)
+    // CURRENT: Reverts with CannotInvalidateEscapeHatch (retroactive classification blocks invalidation)
+    rollup.invalidateBadAttestation(1, data.packedAttestations, data.committee, data.invalidSignatureIndex);
+
+    assertEq(rollup.getPendingCheckpointNumber(), 0, "Checkpoint should be invalidated");
+  }
+
+  /**
+   * @notice Mid-window deactivation - candidate who proposed is still punished
+   *
+   *         When the escape hatch is deactivated mid-window and the candidate DID propose
+   *         during the first epoch, they are still held to normal validation. If their proof
+   *         was not submitted, they get punished.
+   *
+   * @dev Scenario:
+   *      1. Candidate selected, proposes during first epoch of active window
+   *      2. Governance deactivates escape hatch during the first epoch. With next-epoch
+   *         activation, the second epoch no longer has the escape hatch.
+   *      3. Proof for the proposed checkpoint is never submitted
+   *      4. At validation: candidate proposed something and is "living up to that" -
+   *         normal validation applies, punishment for unproven checkpoint.
+   *
+   *      This test PASSES in both current and fixed implementations because the
+   *      candidate took on responsibility by proposing and must be held accountable.
+   */
+  function test_midWindowDeactivation_proposedThenDeactivated_stillPunished()
+    public
+    setup(48, 48)
+    progressEpochsToInclusion
+  {
+    full = load("empty_checkpoint_1");
+    _deployEscapeHatch();
+
+    // Step 1: Candidate joins and is selected for a hatch
+    _joinCandidateSet(CANDIDATE1);
+    targetHatch = _selectCandidateForHatch();
+    assertEq(escapeHatch.getDesignatedProposer(targetHatch), CANDIDATE1, "Should be designated proposer");
+
+    // Step 2: Warp to first epoch of hatch window and propose successfully
+    _warpToHatch(targetHatch);
+    _proposeWithHatch(CANDIDATE1);
+    assertEq(rollup.getPendingCheckpointNumber(), 1, "Checkpoint should be proposed");
+
+    // Step 3: Governance deactivates escape hatch during the first epoch of the window.
+    //         With next-epoch activation, the second epoch no longer has the escape hatch,
+    //         so the candidate loses coverage for the latter half of their window.
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    // Step 4: Candidate proposed but proof was never submitted - should be punished
+    _warpToExitableAt(CANDIDATE1);
+    escapeHatch.validateProofSubmission(targetHatch);
+
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.EXITING), "Should be EXITING after validation");
+    assertEq(
+      info.amount,
+      DEFAULT_BOND_SIZE - DEFAULT_FAILED_HATCH_PUNISHMENT,
+      "Should be punished - proposed but proof not submitted"
+    );
+  }
+
+  /**
+   * @notice Mid-window deactivation - candidate who did NOT propose is free
+   *
+   *         When the escape hatch is deactivated mid-window and the candidate did NOT
+   *         propose, they should NOT be punished - the disruption from governance's
+   *         mid-window change excuses them even though they could have proposed during
+   *         the first epoch of the window.
+   *
+   * @dev Scenario:
+   *      1. Candidate selected for a hatch but does NOT propose during first epoch
+   *      2. Governance deactivates escape hatch during the first epoch. With next-epoch
+   *         activation, the second epoch no longer has the escape hatch.
+   *      3. At validation: candidate did nothing AND escape hatch was disrupted -
+   *         no punishment despite the candidate potentially stalling for one epoch.
+   *
+   *      DESIRED: No punishment (candidate gets benefit of the doubt under disruption).
+   */
+  function test_midWindowDeactivation_didNotPropose_notPunished() public setup(48, 48) progressEpochsToInclusion {
+    full = load("empty_checkpoint_1");
+    _deployEscapeHatch();
+
+    // Step 1: Candidate joins and is selected for a hatch
+    _joinCandidateSet(CANDIDATE1);
+    targetHatch = _selectCandidateForHatch();
+    assertEq(escapeHatch.getDesignatedProposer(targetHatch), CANDIDATE1, "Should be designated proposer");
+
+    // Step 2: Warp to first epoch of hatch window but do NOT propose
+    _warpToHatch(targetHatch);
+
+    // Step 3: Governance deactivates escape hatch during the first epoch of the window.
+    //         With next-epoch activation, the second epoch no longer has the escape hatch,
+    //         so the candidate's window is disrupted partway through.
+    address rollupOwner = Ownable(address(rollup)).owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    // Step 4: Candidate didn't propose and escape hatch was deactivated mid-window.
+    //         Even though they could have stalled for one epoch, the benefit of the
+    //         doubt is given since governance disrupted the active window.
+    _warpToExitableAt(CANDIDATE1);
+    escapeHatch.validateProofSubmission(targetHatch);
+
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.EXITING), "Should be EXITING after validation");
+    assertEq(info.amount, DEFAULT_BOND_SIZE, "Should NOT be punished - did not propose and escape hatch was disrupted");
+  }
+}

--- a/l1-contracts/test/escape-hatch/mocks/FakeRollup.sol
+++ b/l1-contracts/test/escape-hatch/mocks/FakeRollup.sol
@@ -2,6 +2,7 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {IEscapeHatch} from "@aztec/core/interfaces/IEscapeHatch.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {TestConstants} from "@test/harnesses/TestConstants.sol";
 
@@ -16,6 +17,11 @@ contract FakeRollup {
   // Controllable state
   uint256 public provenCheckpointNumber;
   mapping(uint256 => bytes32) public archives;
+  address public escapeHatchAddress;
+
+  // Per-epoch escape hatch overrides for testing partial deactivation scenarios
+  mapping(uint256 => address) internal escapeHatchByEpoch;
+  mapping(uint256 => bool) internal hasEscapeHatchByEpoch;
 
   constructor() {
     TimeLib.initialize(
@@ -34,6 +40,15 @@ contract FakeRollup {
 
   function setArchiveAt(uint256 _checkpointNumber, bytes32 _archive) external {
     archives[_checkpointNumber] = _archive;
+  }
+
+  function setEscapeHatch(address _escapeHatch) external {
+    escapeHatchAddress = _escapeHatch;
+  }
+
+  function setEscapeHatchForEpoch(uint256 _epoch, address _escapeHatch) external {
+    escapeHatchByEpoch[_epoch] = _escapeHatch;
+    hasEscapeHatchByEpoch[_epoch] = true;
   }
 
   // ============ IRollup methods used by EscapeHatch ============
@@ -63,5 +78,17 @@ contract FakeRollup {
   function getSampleSeedAt(Timestamp _ts) external pure returns (uint256) {
     // Return deterministic seed based on timestamp for reproducible tests
     return uint256(keccak256(abi.encodePacked("seed", _ts)));
+  }
+
+  function getEscapeHatch() external view returns (IEscapeHatch) {
+    return IEscapeHatch(escapeHatchAddress);
+  }
+
+  function getEscapeHatchForEpoch(Epoch _epoch) external view returns (IEscapeHatch) {
+    uint256 epochNum = Epoch.unwrap(_epoch);
+    if (hasEscapeHatchByEpoch[epochNum]) {
+      return IEscapeHatch(escapeHatchByEpoch[epochNum]);
+    }
+    return IEscapeHatch(escapeHatchAddress);
   }
 }

--- a/l1-contracts/test/escape-hatch/unit/leaveCandidateSet.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/leaveCandidateSet.t.sol
@@ -165,6 +165,8 @@ contract EscapeHatchLeaveCandidateSetTest is EscapeHatchBase {
     assertEq(uint8(info.status), uint8(Status.NONE), "Status should be NONE");
     assertEq(info.amount, 0, "Amount should be 0");
     assertEq(info.exitableAt, 0, "exitableAt should be 0");
+    assertEq(info.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0");
+    assertEq(info.lastSubmittedArchive, bytes32(0), "lastSubmittedArchive should be 0");
 
     // Verify token transfer
     assertEq(bondToken.balanceOf(CANDIDATE1), balanceBefore + expectedRefund, "Refund amount mismatch");
@@ -233,6 +235,8 @@ contract EscapeHatchLeaveCandidateSetTest is EscapeHatchBase {
     assertEq(uint8(info.status), uint8(Status.NONE), "Status should be NONE");
     assertEq(info.amount, 0, "Amount should be 0");
     assertEq(info.exitableAt, 0, "exitableAt should be 0");
+    assertEq(info.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0");
+    assertEq(info.lastSubmittedArchive, bytes32(0), "lastSubmittedArchive should be 0");
 
     // Verify token transfer
     assertEq(bondToken.balanceOf(CANDIDATE1), balanceBefore + expectedRefund, "Refund after punishment mismatch");

--- a/l1-contracts/test/escape-hatch/unit/validateProofSubmission.t.sol
+++ b/l1-contracts/test/escape-hatch/unit/validateProofSubmission.t.sol
@@ -117,11 +117,184 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     _;
   }
 
+  modifier givenEscapeHatchWasNOTActiveForEntirePeriod() {
+    // Simulate deactivation: FakeRollup now reports no escape hatch for any epoch.
+    // This makes wasActiveEntirePeriod = false.
+    fakeRollup.setEscapeHatch(address(0));
+    _;
+  }
+
   function test_GivenProposerNeverSubmitted(EscapeHatchConfig memory _config)
     external
     givenProposerWasDesignatedForTheHatch(_config)
     givenProposerStatusIsPROPOSING
     whenExitableAtHasBeenReached
+    givenEscapeHatchWasNOTActiveForEntirePeriod
+  {
+    // it should not apply punishment
+    // it should set status to EXITING
+    // it should clear lastCheckpointNumber and lastSubmittedArchive
+    // it should set isHatchValidated to true
+    // it should emit ProofValidated with success true and zero punishment
+    //
+    // Simulates governance deactivating the escape hatch during the proposer's window.
+    // The proposer did nothing (lastCheckpointNumber == 0) and the escape hatch was disrupted,
+    // so no punishment is applied.
+
+    CandidateInfo memory infoBefore = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(infoBefore.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0");
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
+    vm.expectEmit(true, true, true, true);
+    emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, true, 0);
+
+    escapeHatch.validateProofSubmission(preparedHatch);
+
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
+    CandidateInfo memory infoAfter = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(infoAfter.status), uint8(Status.EXITING), "Status should be EXITING");
+    assertEq(infoAfter.amount, config.bondSize, "Punishment should NOT be applied");
+    assertEq(infoAfter.lastCheckpointNumber, 0, "lastCheckpointNumber should be cleared");
+    assertEq(infoAfter.lastSubmittedArchive, bytes32(0), "lastSubmittedArchive should be cleared");
+  }
+
+  function test_GivenProposerDidSubmit(EscapeHatchConfig memory _config)
+    external
+    givenProposerWasDesignatedForTheHatch(_config)
+    givenProposerStatusIsPROPOSING
+    whenExitableAtHasBeenReached
+    givenEscapeHatchWasNOTActiveForEntirePeriod
+  {
+    // it should apply normal validation (punish on failure)
+    //
+    // Even though the escape hatch was deactivated, the proposer submitted a checkpoint.
+    // They are on the hook for normal validation regardless of escape hatch changes,
+    // since proofs go to the rollup directly and are unaffected by escape hatch changes.
+
+    uint128 checkpointNumber = 10;
+    bytes32 archive = bytes32(uint256(0xdeadbeef));
+
+    // Proposer submitted a checkpoint before deactivation
+    vm.prank(address(fakeRollup));
+    escapeHatch.updateSubmittedArchive(CANDIDATE1, checkpointNumber, archive);
+
+    // provenCheckpointNumber is 0 by default (proofs not submitted up to checkpoint)
+    // Normal validation kicks in and punishes for failed proof submission.
+
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
+    vm.expectEmit(true, true, true, true);
+    emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, false, config.failedHatchPunishment);
+
+    escapeHatch.validateProofSubmission(preparedHatch);
+
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
+    CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(info.status), uint8(Status.EXITING), "Status should be EXITING");
+    assertEq(info.amount, config.bondSize - config.failedHatchPunishment, "Punishment should be applied");
+  }
+
+  // ============ Middle-epoch gap tests ============
+  //
+  // These tests verify the loop in validateProofSubmission that checks EVERY epoch in the
+  // active period. A simpler first-and-last check would miss the case where governance
+  // briefly deactivates and re-activates the escape hatch mid-window, creating a gap only
+  // in the middle epochs.
+  //
+  // Requires activeDuration >= 3 so there exists a middle epoch distinct from first and last.
+
+  modifier givenMiddleEpochGap() {
+    // Skip fuzz runs where activeDuration < 3 (no distinct middle epoch exists)
+    vm.assume(config.activeDuration >= 3);
+
+    // Override a middle epoch to address(0) while first and last remain active.
+    // This simulates governance briefly deactivating and re-activating the escape hatch.
+    Epoch firstEpoch = escapeHatch.getFirstEpoch(preparedHatch);
+    fakeRollup.setEscapeHatchForEpoch(Epoch.unwrap(firstEpoch) + 1, address(0));
+    _;
+  }
+
+  function test_GivenMiddleEpochGapAndProposerNeverSubmitted(EscapeHatchConfig memory _config)
+    external
+    givenProposerWasDesignatedForTheHatch(_config)
+    givenProposerStatusIsPROPOSING
+    whenExitableAtHasBeenReached
+    givenMiddleEpochGap
+  {
+    // it should detect the gap via the epoch loop
+    // it should not apply punishment
+    // it should set status to EXITING
+    // it should clear lastCheckpointNumber and lastSubmittedArchive
+    // it should set isHatchValidated to true
+    //
+    // First and last epochs are active, but a middle epoch is not.
+    // A first-and-last check would incorrectly report wasActiveEntirePeriod = true.
+
+    CandidateInfo memory infoBefore = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(infoBefore.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0");
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
+    vm.expectEmit(true, true, true, true);
+    emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, true, 0);
+
+    escapeHatch.validateProofSubmission(preparedHatch);
+
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
+    CandidateInfo memory infoAfter = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(infoAfter.status), uint8(Status.EXITING), "Status should be EXITING");
+    assertEq(infoAfter.amount, config.bondSize, "Punishment should NOT be applied");
+    assertEq(infoAfter.lastCheckpointNumber, 0, "lastCheckpointNumber should be cleared");
+    assertEq(infoAfter.lastSubmittedArchive, bytes32(0), "lastSubmittedArchive should be cleared");
+  }
+
+  function test_GivenMiddleEpochGapAndProposerDidSubmit(EscapeHatchConfig memory _config)
+    external
+    givenProposerWasDesignatedForTheHatch(_config)
+    givenProposerStatusIsPROPOSING
+    whenExitableAtHasBeenReached
+    givenMiddleEpochGap
+  {
+    // it should detect the gap via the epoch loop
+    // it should apply normal validation and punish on failure
+    // it should set status to EXITING
+    //
+    // Same governance flip-flop as above, but the proposer DID submit a checkpoint.
+    // Even though the escape hatch had a gap, the proposer is on the hook because they proposed.
+    // Proofs go to the rollup directly and are unaffected by escape hatch changes.
+
+    uint128 checkpointNumber = 10;
+    bytes32 archive = bytes32(uint256(0xdeadbeef));
+
+    vm.prank(address(fakeRollup));
+    escapeHatch.updateSubmittedArchive(CANDIDATE1, checkpointNumber, archive);
+
+    // provenCheckpointNumber is 0 by default (proofs not submitted up to checkpoint)
+
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
+    vm.expectEmit(true, true, true, true);
+    emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, false, config.failedHatchPunishment);
+
+    escapeHatch.validateProofSubmission(preparedHatch);
+
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
+    CandidateInfo memory infoAfter = escapeHatch.getCandidateInfo(CANDIDATE1);
+    assertEq(uint8(infoAfter.status), uint8(Status.EXITING), "Status should be EXITING");
+    assertEq(infoAfter.amount, config.bondSize - config.failedHatchPunishment, "Punishment should be applied");
+  }
+
+  modifier givenEscapeHatchWasActiveForEntirePeriod() {
+    // FakeRollup already reports this contract as the escape hatch for all epochs.
+    // This modifier is a marker for tree structure clarity.
+    _;
+  }
+
+  function test_GivenNoCheckpointWasSubmitted(EscapeHatchConfig memory _config)
+    external
+    givenProposerWasDesignatedForTheHatch(_config)
+    givenProposerStatusIsPROPOSING
+    whenExitableAtHasBeenReached
+    givenEscapeHatchWasActiveForEntirePeriod
   {
     // it should have lastCheckpointNumber EQ zero
     // it should apply FAILED_HATCH_PUNISHMENT
@@ -131,12 +304,14 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
 
     CandidateInfo memory infoBefore = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(infoBefore.lastCheckpointNumber, 0, "lastCheckpointNumber should be 0");
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
 
     vm.expectEmit(true, true, true, true);
     emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, false, config.failedHatchPunishment);
 
     escapeHatch.validateProofSubmission(preparedHatch);
 
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
     CandidateInfo memory infoAfter = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(uint8(infoAfter.status), uint8(Status.EXITING), "Status should be EXITING");
     assertEq(infoAfter.amount, config.bondSize - config.failedHatchPunishment, "Punishment not applied");
@@ -149,6 +324,7 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     givenProposerWasDesignatedForTheHatch(_config)
     givenProposerStatusIsPROPOSING
     whenExitableAtHasBeenReached
+    givenEscapeHatchWasActiveForEntirePeriod
   {
     // it should apply FAILED_HATCH_PUNISHMENT
     // it should set status to EXITING
@@ -164,11 +340,14 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
 
     // provenCheckpointNumber is 0 by default (proofs not submitted up to checkpoint)
 
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
     vm.expectEmit(true, true, true, true);
     emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, false, config.failedHatchPunishment);
 
     escapeHatch.validateProofSubmission(preparedHatch);
 
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
     CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(uint8(info.status), uint8(Status.EXITING), "Status should be EXITING");
     assertEq(info.amount, config.bondSize - config.failedHatchPunishment, "Punishment not applied");
@@ -179,6 +358,7 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     givenProposerWasDesignatedForTheHatch(_config)
     givenProposerStatusIsPROPOSING
     whenExitableAtHasBeenReached
+    givenEscapeHatchWasActiveForEntirePeriod
   {
     // it should apply FAILED_HATCH_PUNISHMENT
     // it should set status to EXITING
@@ -199,11 +379,14 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     // But the archive at that checkpoint is different (pruned/reorged)
     fakeRollup.setArchiveAt(checkpointNumber, differentArchive);
 
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
     vm.expectEmit(true, true, true, true);
     emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, false, config.failedHatchPunishment);
 
     escapeHatch.validateProofSubmission(preparedHatch);
 
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
     CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(uint8(info.status), uint8(Status.EXITING), "Status should be EXITING");
     assertEq(info.amount, config.bondSize - config.failedHatchPunishment, "Punishment not applied");
@@ -216,6 +399,7 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     givenProposerWasDesignatedForTheHatch(_config)
     givenProposerStatusIsPROPOSING
     whenExitableAtHasBeenReached
+    givenEscapeHatchWasActiveForEntirePeriod
   {
     // it should not apply punishment
     // it should set status to EXITING
@@ -244,11 +428,14 @@ contract EscapeHatchValidateProofSubmissionTest is EscapeHatchBase {
     // Archive matches what proposer submitted
     fakeRollup.setArchiveAt(checkpointNumber, archive);
 
+    assertFalse(escapeHatch.isHatchValidated(preparedHatch), "Hatch should not be validated yet");
+
     vm.expectEmit(true, true, true, true);
     emit IEscapeHatchCore.ProofValidated(preparedHatch, CANDIDATE1, true, 0);
 
     escapeHatch.validateProofSubmission(preparedHatch);
 
+    assertTrue(escapeHatch.isHatchValidated(preparedHatch), "Hatch should be validated");
     CandidateInfo memory info = escapeHatch.getCandidateInfo(CANDIDATE1);
     assertEq(uint8(info.status), uint8(Status.EXITING), "Status should be EXITING");
     assertEq(info.amount, config.bondSize, "Punishment should NOT be applied");

--- a/l1-contracts/test/escape-hatch/unit/validateProofSubmission.tree
+++ b/l1-contracts/test/escape-hatch/unit/validateProofSubmission.tree
@@ -11,28 +11,51 @@ EscapeHatchValidateProofSubmissionTest
             ├── when exitableAt has not been reached
             │   └── it should revert {EscapeHatch__NotExitableYet}
             └── when exitableAt has been reached
-                ├── given proposer never submitted
-                │   ├── it should have lastCheckpointNumber EQ zero
-                │   ├── it should apply FAILED_HATCH_PUNISHMENT
-                │   ├── it should set status to EXITING
-                │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
-                │   ├── it should set isHatchValidated to true
-                │   └── it should emit ProofValidated with success false
-                ├── given proofs not submitted up to checkpoint
-                │   ├── it should apply FAILED_HATCH_PUNISHMENT
-                │   ├── it should set status to EXITING
-                │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
-                │   ├── it should set isHatchValidated to true
-                │   └── it should emit ProofValidated with success false
-                ├── given checkpoint archive was pruned
-                │   ├── it should apply FAILED_HATCH_PUNISHMENT
-                │   ├── it should set status to EXITING
-                │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
-                │   ├── it should set isHatchValidated to true
-                │   └── it should emit ProofValidated with success false
-                └── given all conditions pass
-                    ├── it should not apply punishment
-                    ├── it should set status to EXITING
-                    ├── it should clear lastCheckpointNumber and lastSubmittedArchive
-                    ├── it should set isHatchValidated to true
-                    └── it should emit ProofValidated with success true
+                ├── given escape hatch was NOT active for entire period
+                │   ├── given proposer never submitted
+                │   │   ├── it should not apply punishment
+                │   │   ├── it should set status to EXITING
+                │   │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                │   │   ├── it should set isHatchValidated to true
+                │   │   └── it should emit ProofValidated with success true and zero punishment
+                │   └── given proposer did submit
+                │       ├── it should apply normal validation (punish on failure)
+                │       └── it should set isHatchValidated to true
+                ├── given middle epoch gap
+                │   ├── given middle epoch gap and proposer never submitted
+                │   │   ├── it should detect the gap via the epoch loop
+                │   │   ├── it should not apply punishment
+                │   │   ├── it should set status to EXITING
+                │   │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                │   │   └── it should set isHatchValidated to true
+                │   └── given middle epoch gap and proposer did submit
+                │       ├── it should detect the gap via the epoch loop
+                │       ├── it should apply normal validation and punish on failure
+                │       ├── it should set status to EXITING
+                │       └── it should set isHatchValidated to true
+                └── given escape hatch was active for entire period
+                    ├── given no checkpoint was submitted
+                    │   ├── it should have lastCheckpointNumber EQ zero
+                    │   ├── it should apply FAILED_HATCH_PUNISHMENT
+                    │   ├── it should set status to EXITING
+                    │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                    │   ├── it should set isHatchValidated to true
+                    │   └── it should emit ProofValidated with success false
+                    ├── given proofs not submitted up to checkpoint
+                    │   ├── it should apply FAILED_HATCH_PUNISHMENT
+                    │   ├── it should set status to EXITING
+                    │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                    │   ├── it should set isHatchValidated to true
+                    │   └── it should emit ProofValidated with success false
+                    ├── given checkpoint archive was pruned
+                    │   ├── it should apply FAILED_HATCH_PUNISHMENT
+                    │   ├── it should set status to EXITING
+                    │   ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                    │   ├── it should set isHatchValidated to true
+                    │   └── it should emit ProofValidated with success false
+                    └── given all conditions pass
+                        ├── it should not apply punishment
+                        ├── it should set status to EXITING
+                        ├── it should clear lastCheckpointNumber and lastSubmittedArchive
+                        ├── it should set isHatchValidated to true
+                        └── it should emit ProofValidated with success true

--- a/l1-contracts/test/shouting.t.sol
+++ b/l1-contracts/test/shouting.t.sol
@@ -21,27 +21,27 @@ contract ScreamAndShoutTest is Test {
     bytes memory creationCode = type(Governance).creationCode;
     bytes32 codeHash = keccak256(creationCode);
 
-    assertEq(codeHash, 0xf302136f8b3a84d3c36be87e283cda0d6ad04392b7e3c5379c55b2d5b2634c1c, ERR_STRING);
+    assertEq(codeHash, 0xa203e2daeeca86ed3a98e2c91f670eb6105a681dc12b90fe192e8cf2c552d2ff, ERR_STRING);
   }
 
   function test_HonkVerifierCreationCode() public pure {
     bytes memory creationCode = type(HonkVerifier).creationCode;
     bytes32 codeHash = keccak256(creationCode);
 
-    assertEq(codeHash, 0xe64a1670c48b0e0f03d405cdf00a7bc6823a47f89851e02680f827e055fd3c60, ERR_STRING);
+    assertEq(codeHash, 0x76d4c44263992208898c3a78d02a7d7ab611d4876d2c644f3ca6c3ccc4a7a0ae, ERR_STRING);
   }
 
   function test_RegistryCreationCode() public pure {
     bytes memory creationCode = type(Registry).creationCode;
     bytes32 codeHash = keccak256(creationCode);
 
-    assertEq(codeHash, 0x2cb444995a1644607bd5bdeb3ce0027a8484849810c28b57e641cdf61d786c4c, ERR_STRING);
+    assertEq(codeHash, 0x2b712e7690ded388fd1e1d9863af22179d6c94fae39dd2a31d058b31e32fd9c8, ERR_STRING);
   }
 
   function test_RollupCreationCode() public pure {
     bytes memory creationCode = type(Rollup).creationCode;
     bytes32 codeHash = keccak256(creationCode);
 
-    assertEq(codeHash, 0xb87a83463eba5f258db1166fb43f2cd6c55169fb5ef39412157d3acea384f7ce, ERR_STRING);
+    assertEq(codeHash, 0xbc7a3bce77d152425c10e6d437c57bd329d22e4c49bc16176225ab11fc310628, ERR_STRING);
   }
 }

--- a/l1-contracts/test/slashing/TallySlashingProposerRetroactive.t.sol
+++ b/l1-contracts/test/slashing/TallySlashingProposerRetroactive.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {TallySlashingProposerEscapeHatchTest} from "./TallySlashingProposerEscapeHatch.t.sol";
+import {TallySlashingProposer} from "@aztec/core/slashing/TallySlashingProposer.sol";
+import {SlashRound} from "@aztec/core/libraries/SlashRoundLib.sol";
+import {Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
+
+/**
+ * @title TallySlashingProposerRetroactiveTest
+ * @notice Tests that retroactively configuring an escape hatch should NOT grant slashing
+ *         immunity for epochs that were normal at the time.
+ *
+ * @dev Inherits from TallySlashingProposerEscapeHatchTest to reuse all setup and helpers.
+ *      setUp deploys the escape hatch and registers it. The test immediately removes it,
+ *      then re-registers it later to simulate retroactive configuration.
+ *
+ *      CURRENTLY FAILS because _getEscapeHatchEpochFlags queries the CURRENT escape hatch
+ *      (which retroactively reports historical epochs as open), granting unearned immunity.
+ *
+ *      After epoch-stable snapshotting, getEscapeHatchForEpoch returns address(0) for
+ *      historical epochs where no escape hatch was configured, so no immunity is granted.
+ */
+contract TallySlashingProposerRetroactiveTest is TallySlashingProposerEscapeHatchTest {
+  using stdStorage for StdStorage;
+
+  /**
+   * @notice Validators should remain slashable when escape hatch is configured after the fact
+   *
+   * @dev Scenario:
+   *      1. Escape hatch is removed (simulating "no escape hatch during target epochs")
+   *      2. Votes are cast to slash all validators
+   *      3. Governance re-configures the escape hatch that covers the target epochs
+   *      4. Tally is computed
+   *
+   *      DESIRED: All 8 validators slashable (2 epochs x 4 committee members).
+   *      No immunity because no escape hatch was active during those epochs.
+   */
+  function test_retroactiveEscapeHatchDoesNotGrantSlashingImmunity() public {
+    // Remove escape hatch so the rollup has none during target epochs.
+    // The escapeHatch contract itself is preserved for re-use below.
+    address rollupOwner = rollup.owner();
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(0));
+
+    // Step 1: Find a round where at least one target epoch falls in the escape hatch
+    //         active window (epoch % ESCAPE_FREQUENCY < ESCAPE_ACTIVE_DURATION)
+    //         so that retroactive deployment would grant immunity
+    uint256 targetRound = SLASH_OFFSET_IN_ROUNDS;
+    bool foundProtectedEpoch = false;
+
+    while (!foundProtectedEpoch) {
+      for (uint256 i; i < ROUND_SIZE_IN_EPOCHS; i++) {
+        Epoch epoch = slashingProposer.getSlashTargetEpoch(SlashRound.wrap(targetRound), i);
+        if (Epoch.unwrap(epoch) % ESCAPE_FREQUENCY < ESCAPE_ACTIVE_DURATION) {
+          foundProtectedEpoch = true;
+          break;
+        }
+      }
+      if (!foundProtectedEpoch) {
+        ++targetRound;
+      }
+    }
+
+    _jumpToSlashRound(targetRound);
+    SlashRound currentRound = slashingProposer.getCurrentRound();
+
+    // Step 2: Cast votes to slash all validators (no escape hatch active)
+    uint8 slashIndex = 3;
+    bytes memory voteData = _createUniformVoteData(slashIndex);
+    _castVotes(QUORUM, voteData);
+
+    // Step 3: Re-configure the escape hatch AFTER the target epochs
+    vm.prank(rollupOwner);
+    rollup.updateEscapeHatch(address(escapeHatch));
+
+    // Set designated proposers for hatches covering target epochs
+    for (uint256 i; i < ROUND_SIZE_IN_EPOCHS; i++) {
+      Epoch epoch = slashingProposer.getSlashTargetEpoch(currentRound, i);
+      if (Epoch.unwrap(epoch) % ESCAPE_FREQUENCY < ESCAPE_ACTIVE_DURATION) {
+        uint256 hatchNumber = Epoch.unwrap(epoch) / ESCAPE_FREQUENCY;
+        stdstore.target(address(escapeHatch)).sig("getDesignatedProposer(uint256)").with_key(hatchNumber)
+          .checked_write(address(0xBEEF));
+      }
+    }
+
+    // Step 4: Get tally results
+    address[][] memory committees = slashingProposer.getSlashTargetCommittees(currentRound);
+    TallySlashingProposer.SlashAction[] memory actions = slashingProposer.getTally(currentRound, committees);
+
+    // DESIRED: All validators should be slashable (no escape hatch was active during target epochs)
+    // CURRENT: Some validators have retroactive immunity - actions.length < expected
+    uint256 totalValidators = ROUND_SIZE_IN_EPOCHS * COMMITTEE_SIZE;
+    assertEq(
+      actions.length,
+      totalValidators,
+      "All validators should be slashable - no escape hatch was active during target epochs"
+    );
+  }
+}


### PR DESCRIPTION
In the implementation we had just a single value to store the escape hatch, but since it is updatable by governance, and are not always used with exactly the value that it currently has, we are back into the good ol' case of snapshots.

Essentially, when there is only one value for the escape hatch to look at, the consumers (which might depend on specific timing) could retroactively have their logic altered. 

Consumers:
- Epoch Proof Library
- Invalidation Library
- Propose Library
- Slashing

By being able to alter "all" view of the escape hatch it was possible to make failure cases as these:

- After a hatch has been used to submit checkpoints, the escape hatch is updated, and when it comes time to prove, the proof will fail because no committee signatures 😭
- As above, possible to invalidate the block early
- If the update happens after a provider was selected but before their duty starts, they could end up in a case where it is impossible for them to propose and they will then get punished because they also did not prove anything
- For the case of slashing, because we do not slash during the escape hatch, it could be abused to avoid slashing entirely. 

Another point of interest, not for the rollup, but for the candidates, is that the escape hatch could keep selecting them for duty, without being able to actually propose. So the escape hatch must also take a look at the rollup to see if it is currently the active hatch.


Solving the problems are as mentioned simple, use a snapshot, and then read historical values. When updating the escape hatch we will then do it for the **NEXT** epoch, since it could otherwise happen after a checkpoint was already proposed in the same L1 block. 

In the case where the update happens during an open hatch, we allow the proposer to do nothing without getting punished, but if he does propose thing he must fulfill them. 
