### PR TITLE
fix(aztec-up): add redirect support and installation verification

### DIFF
--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -128,15 +128,26 @@ function cmd_install {
 
   local install_url="$INSTALL_URI/$resolved_version/install"
 
-  # Check if install script exists
-  if ! curl --head --silent --fail "$install_url" > /dev/null; then
+  # Check if install script exists (use -L to follow redirects)
+  if ! curl -L --head --silent --fail "$install_url" > /dev/null; then
     echo "Error: Version installer not found at $install_url"
     echo "Please check the version specified."
     exit 1
   fi
 
   # Download and run the version-specific installer
-  curl -fsSL "$install_url" | VERSION="$resolved_version" bash
+  if ! curl -fsSL "$install_url" | VERSION="$resolved_version" bash; then
+    echo "Error: Failed to install version $resolved_version"
+    exit 1
+  fi
+
+  # Verify installation succeeded
+  if [ ! -d "$AZTEC_HOME/versions/$resolved_version" ]; then
+    echo "Error: Installation of version $resolved_version failed - version directory not created"
+    exit 1
+  fi
+
+  echo "Successfully installed aztec version $resolved_version"
 
   # Update the current symlink
   ln -sfn "$AZTEC_HOME/versions/$resolved_version" "$AZTEC_HOME/current"


### PR DESCRIPTION
## Summary

- Add `-L` flag to `curl --head` check to follow HTTP redirects (fixes false-positive version detection when `INSTALL_URI` points to a redirecting domain)
- Add error handling for the install `curl | bash` pipeline
- Add post-install verification that the version directory was actually created

## Problem

`curl --head --silent --fail` treats HTTP 301 redirects as success (exit 0), because `--fail` only catches 4xx/5xx. When `INSTALL_URI` points to a domain that redirects (e.g. `install.aztec.network` → `install.aztec-labs.com`), a non-existent version check silently passes:

```bash
# Without -L: 301 redirect treated as success
$ curl --head --silent --fail "https://install.aztec.network/99.99.99/install" > /dev/null 2>&1; echo $?
0   # BUG: thinks non-existent version exists

# With -L: follows redirect, gets 404, correctly fails
$ curl -L --head --silent --fail "https://install.aztec.network/99.99.99/install" > /dev/null 2>&1; echo $?
56  # CORRECT
```

## Test Results (ran locally)

| Test | Result |
|------|--------|
| Syntax check (`bash -n aztec-up/bin/aztec-up`) | PASS |
| `aztec-up --help` | PASS — clean output, exit 0 |
| `aztec-up install 99.99.99` (non-existent version) | PASS — "Error: Version installer not found", exit 1 |
| `INSTALL_URI=https://install.aztec.network aztec-up install 99.99.99` (old domain + redirect) | PASS — correctly detects error with `-L` |
| `aztec-up list` | PASS — "No versions installed", exit 0 |
| Invalid command | PASS — "Unknown command", shows help, exit 1 |