### PR TITLE
fix(aztec.nr): remove Context from AccountActions init definition

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/authwit/account.nr
+++ b/noir-projects/aztec-nr/aztec/src/authwit/account.nr
@@ -7,11 +7,11 @@ use crate::authwit::entrypoint::app::AppPayload;
 
 pub struct AccountActions<Context> {
     context: Context,
-    is_valid_impl: fn(&mut PrivateContext, Field) -> bool,
+    is_valid_impl: fn(Context, Field) -> bool,
 }
 
 impl<Context> AccountActions<Context> {
-    pub fn init(context: Context, is_valid_impl: fn(&mut PrivateContext, Field) -> bool) -> Self {
+    pub fn init(context: Context, is_valid_impl: fn(Context, Field) -> bool) -> Self {
         AccountActions { context, is_valid_impl }
     }
 }


### PR DESCRIPTION
## Description

The `AccountActions` struct is generic over `Context`, but the `is_valid_impl` function pointer in the struct definition and `init` method hardcodes `&mut PrivateContext` instead of using the generic `Context` parameter. This makes the generic parameter inconsistent with the actual field type.

This change replaces `fn(&mut PrivateContext, Field) -> bool` with `fn(Context, Field) -> bool` in both the struct field and the `init` method signature.

## Verification

All 6 callers of `AccountActions::init` were verified:

| Contract | `is_valid_impl` signature | Compatible |
|---|---|---|
| `ecdsa_r_account_contract` | `fn(context: &mut PrivateContext, outer_hash: Field) -> bool` | Yes |
| `schnorr_account_contract` | `fn(context: &mut PrivateContext, outer_hash: Field) -> bool` | Yes |
| `ecdsa_k_account_contract` | `fn(context: &mut PrivateContext, outer_hash: Field) -> bool` | Yes |
| `schnorr_hardcoded_account_contract` | `fn(_context: &mut PrivateContext, outer_hash: Field) -> bool` | Yes |
| `schnorr_single_key_account_contract` | `fn(context: &mut PrivateContext, outer_hash: Field) -> bool` | Yes |
| `simulated_account_contract` | `fn(_context: &mut PrivateContext, _outer_hash: Field) -> bool` | Yes |

All callers pass `self.context` (which is `&mut PrivateContext` in private functions) as the first argument to `AccountActions::init`, so `Context` resolves to `&mut PrivateContext`. The function type `fn(Context, Field) -> bool` then becomes `fn(&mut PrivateContext, Field) -> bool`, matching every caller's `is_valid_impl` signature exactly.

The `impl AccountActions<&mut PrivateContext>` block (containing `entrypoint` and `verify_private_authwit`) is unchanged and continues to work correctly since `self.is_valid_impl` resolves to `fn(&mut PrivateContext, Field) -> bool` when `Context = &mut PrivateContext`.

Note: `nargo` was not available locally for compilation, but the type analysis confirms this is a safe, non-breaking change.

This is a resubmission of #20268.