### PR TITLE
feat(foundation): add pino format string support to Logger

### DIFF
--- a/yarn-project/foundation/src/log/log_fn.ts
+++ b/yarn-project/foundation/src/log/log_fn.ts
@@ -1,5 +1,13 @@
 /** Structured log data to include with the message. */
 export type LogData = Record<string, string | number | bigint | boolean | { toString(): string } | undefined | null>;
 
-/** A callable logger instance. */
-export type LogFn = (msg: string, data?: unknown) => void;
+/**
+ * A callable logger instance.
+ * Supports pino-style format strings with %s, %d, %o placeholders.
+ * @example
+ * log('Simple message');
+ * log('Message with %s placeholder', 'value');
+ * log('Message with data', { key: 'value' });
+ * log('Message with %s and data', 'value', { key: 'data' });
+ */
+export type LogFn = (msg: string, ...args: unknown[]) => void;

--- a/yarn-project/foundation/src/log/pino-logger.test.ts
+++ b/yarn-project/foundation/src/log/pino-logger.test.ts
@@ -198,6 +198,47 @@ describe('pino-logger', () => {
     });
   });
 
+  it('supports pino-style format strings with %s substitution', () => {
+    const testLogger = createLogger('format-test');
+    capturingStream.clear();
+    testLogger.info('Hello %s', 'world');
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ module: 'format-test', msg: 'Hello world' });
+  });
+
+  it('supports multiple format arguments', () => {
+    const testLogger = createLogger('multi-format-test');
+    capturingStream.clear();
+    testLogger.info('User %s logged in from %s', 'alice', '192.168.1.1');
+    const entries = capturingStream.getJsonLines();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ module: 'multi-format-test', msg: 'User alice logged in from 192.168.1.1' });
+  });
+
+  it('supports format strings with data object', () => {
+    const testLogger = createLogger('format-data-test');
+    capturingStream.clear();
+    testLogger.info('Processing block %s', 42, { txCount: 10 });
+    const entries = capturingStream.getJsonLines() as any[];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].module).toBe('format-data-test');
+    expect(entries[0].msg).toBe('Processing block 42');
+    expect(entries[0].txCount).toBe(10);
+  });
+
+  it('handles format strings at different log levels', () => {
+    const testLogger = createLogger('level-format-test');
+    capturingStream.clear();
+    testLogger.debug('Debug %s', 'message');
+    testLogger.verbose('Verbose %s', 'message');
+    testLogger.trace('Trace %s', 'message');
+    testLogger.warn('Warn %s', 'message');
+    const entries = capturingStream.getJsonLines() as any[];
+    expect(entries).toHaveLength(4);
+    expect(entries.map(e => e.msg)).toEqual(['Debug message', 'Verbose message', 'Trace message', 'Warn message']);
+  });
+
   describe('actor colors', () => {
     beforeEach(() => {
       resetActorColors();

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -46,6 +46,11 @@ function getBindingsFromHandlers(): LoggerBindings | undefined {
   return undefined;
 }
 
+/** Check if value is a plain object (not null, array, Date, etc.) - used to detect data argument. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date);
+}
+
 export function createLogger(module: string, bindings?: LoggerBindings): Logger {
   module = module.replace(/^aztec:/, '');
 
@@ -60,26 +65,36 @@ export function createLogger(module: string, bindings?: LoggerBindings): Logger 
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
-  const logFn = (level: LogLevel, msg: string, data?: unknown) =>
-    isLevelEnabled(pinoLogger, level) && pinoLogger[level](processLogData((data as LogData) ?? {}), msg);
+  const logFn = (level: LogLevel, msg: string, ...args: unknown[]) => {
+    if (!isLevelEnabled(pinoLogger, level)) {
+      return;
+    }
+    const lastArg = args[args.length - 1];
+    const hasDataObject = args.length > 0 && isPlainObject(lastArg);
+    const data = hasDataObject ? (args.pop() as LogData) : {};
+    pinoLogger[level](processLogData(data), msg, ...args);
+  };
+
+  const logErrFn = (level: LogLevel, msg: string, err?: unknown, data?: unknown) =>
+    logFn(level, formatErr(msg, err), ...(data !== undefined ? [data] : []));
 
   return {
     silent: () => {},
     // TODO(palla/log): Should we move err to data instead of the text message?
     /** Log as fatal. Use when an error has brought down the system. */
-    fatal: (msg: string, err?: unknown, data?: unknown) => logFn('fatal', formatErr(msg, err), data),
+    fatal: (msg: string, err?: unknown, data?: unknown) => logErrFn('fatal', msg, err, data),
     /** Log as error. Use for errors in general. */
-    error: (msg: string, err?: unknown, data?: unknown) => logFn('error', formatErr(msg, err), data),
+    error: (msg: string, err?: unknown, data?: unknown) => logErrFn('error', msg, err, data),
     /** Log as warn. Use for when we stray from the happy path. */
-    warn: (msg: string, data?: unknown) => logFn('warn', msg, data),
+    warn: (msg: string, ...args: unknown[]) => logFn('warn', msg, ...args),
     /** Log as info. Use for providing an operator with info on what the system is doing. */
-    info: (msg: string, data?: unknown) => logFn('info', msg, data),
+    info: (msg: string, ...args: unknown[]) => logFn('info', msg, ...args),
     /** Log as verbose. Use for when we need additional insight on what a subsystem is doing. */
-    verbose: (msg: string, data?: unknown) => logFn('verbose', msg, data),
+    verbose: (msg: string, ...args: unknown[]) => logFn('verbose', msg, ...args),
     /** Log as debug. Use for when we need debugging info to troubleshoot an issue on a specific component. */
-    debug: (msg: string, data?: unknown) => logFn('debug', msg, data),
+    debug: (msg: string, ...args: unknown[]) => logFn('debug', msg, ...args),
     /** Log as trace. Use for when we want to denial-of-service any recipient of the logs. */
-    trace: (msg: string, data?: unknown) => logFn('trace', msg, data),
+    trace: (msg: string, ...args: unknown[]) => logFn('trace', msg, ...args),
     /** Level of the logger */
     level: pinoLogger.level as LogLevel,
     /** Whether the given level is enabled for this logger. */


### PR DESCRIPTION
## Summary

Adds support for pino-style format strings (`%s`, `%d`, `%o`) to the Logger wrapper. Currently `LogFn` only accepts `(msg: string, data?: unknown)`, which doesn't support format string arguments that pino natively supports.

**Changes:**
- `LogFn` type in `log_fn.ts` now accepts variadic args: `(msg: string, ...args: unknown[]) => void`
- `pino-logger.ts` updated to detect format string args vs data objects using `isPlainObject` helper
- All log level methods (`warn`, `info`, `verbose`, `debug`, `trace`) accept variadic args
- `error`/`fatal` retain their existing `(msg, err?, data?)` signature via a dedicated `logErrFn` helper
- Dedicated tests for format string functionality added

This is a resubmission of #20269.

## Test Results

All 14 tests pass (10 existing + 4 new):

```
PASS src/log/pino-logger.test.ts
  pino-logger
    ✓ logs messages with the correct module and level (4 ms)
    ✓ logs at different levels (2 ms)
    ✓ can use overwriteLoggingStream for isolated capture (1 ms)
    ✓ generates pretty output when using pino-pretty (15 ms)
    ✓ logs instanceId in the output (2 ms)
    ✓ creates child logger preserving bindings (1 ms)
    ✓ returns bindings via getBindings (1 ms)
    ✓ supports pino-style format strings with %s substitution (1 ms)
    ✓ supports multiple format arguments (1 ms)
    ✓ supports format strings with data object
    ✓ handles format strings at different log levels
    actor colors
      ✓ returns the same color for the same actor (1 ms)
      ✓ resets actor colors with resetActorColors
      ✓ cycles through colors when more actors than colors

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

## Backward Compatibility

Fully backward compatible. Existing call patterns continue to work:
- `log('message')` -- simple message
- `log('message', { key: 'value' })` -- message with structured data
- New patterns now also work:
  - `log('Hello %s', 'world')` -- format string substitution
  - `log('Block %s processed', blockNum, { txCount: 10 })` -- format string with data object