### PR TITLE
chore(p2p): add mock reqresp layer for tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
@@ -250,10 +250,9 @@ describe('e2e_epochs/epochs_mbps', () => {
     }
     logger.warn(`All txs have been mined`);
 
-    // TODO(palla/mbps): Reenable
     // We are fine with at least 2 blocks per checkpoint, since we may lose one sub-slot if assembling a tx is slow
-    // const multiBlockCheckpoint = await assertMultipleBlocksPerSlot(2, logger);
-    // await waitForProvenCheckpoint(multiBlockCheckpoint);
+    const multiBlockCheckpoint = await assertMultipleBlocksPerSlot(2, logger);
+    await waitForProvenCheckpoint(multiBlockCheckpoint);
   });
 
   it('builds multiple blocks per slot with L2 to L1 messages', async () => {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -213,10 +213,14 @@ export class EpochsTestContext {
     this.logger.warn('Creating and syncing a simulated prover node...');
     const proverNodePrivateKey = this.getNextPrivateKey();
     const proverIndex = this.proverNodes.length + 1;
+    const { mockGossipSubNetwork } = this.context;
     const proverNode = await withLoggerBindings({ actor: `prover-${proverIndex}` }, () =>
       createAndSyncProverNode(
         proverNodePrivateKey,
-        { ...this.context.config },
+        {
+          ...this.context.config,
+          p2pEnabled: this.context.config.p2pEnabled || mockGossipSubNetwork !== undefined,
+        },
         {
           dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
           proverId: EthAddress.fromNumber(proverIndex),
@@ -225,7 +229,12 @@ export class EpochsTestContext {
         },
         this.context.aztecNode,
         this.context.prefilledPublicData ?? [],
-        { dateProvider: this.context.dateProvider },
+        {
+          dateProvider: this.context.dateProvider,
+          p2pClientDeps: mockGossipSubNetwork
+            ? { p2pServiceFactory: getMockPubSubP2PServiceFactory(mockGossipSubNetwork) }
+            : undefined,
+        },
       ),
     );
     this.proverNodes.push(proverNode);

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -505,7 +505,7 @@ export async function setup(
       const proverNodeConfig = {
         ...config.proverNodeConfig,
         dataDirectory: proverNodeDataDirectory,
-        p2pEnabled: false,
+        p2pEnabled: !!mockGossipSubNetwork,
       };
       proverNode = await createAndSyncProverNode(
         proverNodePrivateKeyHex,
@@ -513,6 +513,11 @@ export async function setup(
         proverNodeConfig,
         aztecNodeService,
         prefilledPublicData,
+        {
+          p2pClientDeps: mockGossipSubNetwork
+            ? { p2pServiceFactory: getMockPubSubP2PServiceFactory(mockGossipSubNetwork) }
+            : undefined,
+        },
       );
     }
 

--- a/yarn-project/p2p/src/client/test/p2p_client.integration_reqresp.test.ts
+++ b/yarn-project/p2p/src/client/test/p2p_client.integration_reqresp.test.ts
@@ -1,0 +1,229 @@
+import type { EpochAndSlot, EpochCache } from '@aztec/epoch-cache';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+import { emptyChainConfig } from '@aztec/stdlib/config';
+import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { Tx, TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import type { P2PClient } from '../../client/p2p_client.js';
+import { type P2PConfig, getP2PDefaultConfig } from '../../config.js';
+import type { AttestationPool } from '../../mem_pools/attestation_pool/attestation_pool.js';
+import type { TxPoolV2 } from '../../mem_pools/tx_pool_v2/interfaces.js';
+import type { LibP2PService } from '../../services/libp2p/libp2p_service.js';
+import type { ReqRespInterface } from '../../services/reqresp/interface.js';
+import { ReqRespSubProtocol } from '../../services/reqresp/interface.js';
+import { ReqRespStatus } from '../../services/reqresp/status.js';
+import { makeAndStartTestP2PClients } from '../../test-helpers/make-test-p2p-clients.js';
+import { MockGossipSubNetwork } from '../../test-helpers/mock-pubsub.js';
+import { createMockTxWithMetadata } from '../../test-helpers/mock-tx-helpers.js';
+
+const TEST_TIMEOUT = 120_000;
+jest.setTimeout(TEST_TIMEOUT);
+
+// Tests general reqresp flow using the MockReqResp class.
+describe('p2p client integration reqresp', () => {
+  let txPool: MockProxy<TxPoolV2>;
+  let attestationPool: MockProxy<AttestationPool>;
+  let epochCache: MockProxy<EpochCache>;
+  let worldState: MockProxy<WorldStateSynchronizer>;
+
+  let logger: Logger;
+  let p2pBaseConfig: P2PConfig;
+
+  let clients: P2PClient[] = [];
+
+  beforeEach(() => {
+    clients = [];
+    txPool = mock<TxPoolV2>();
+    attestationPool = mock<AttestationPool>();
+    epochCache = mock<EpochCache>();
+    worldState = mock<WorldStateSynchronizer>();
+
+    logger = createLogger('p2p:test:integration-reqresp');
+    p2pBaseConfig = { ...emptyChainConfig, ...getP2PDefaultConfig() };
+
+    epochCache.getEpochAndSlotInNextL1Slot.mockReturnValue({ ts: BigInt(0) } as EpochAndSlot & { now: bigint });
+    epochCache.getRegisteredValidators.mockResolvedValue([]);
+    epochCache.getL1Constants.mockReturnValue({
+      l1StartBlock: 0n,
+      l1GenesisTime: 0n,
+      slotDuration: 24,
+      epochDuration: 16,
+      ethereumSlotDuration: 12,
+      proofSubmissionEpochs: 2,
+      targetCommitteeSize: 48,
+    });
+
+    txPool.isEmpty.mockResolvedValue(true);
+    txPool.hasTxs.mockResolvedValue([]);
+    txPool.addPendingTxs.mockResolvedValue({ accepted: [], ignored: [], rejected: [] });
+    txPool.getTxsByHash.mockImplementation(() => {
+      return Promise.resolve([] as Tx[]);
+    });
+
+    attestationPool.isEmpty.mockResolvedValue(true);
+    attestationPool.tryAddBlockProposal.mockResolvedValue({ added: true, alreadyExists: false, count: 1 });
+
+    worldState.status.mockResolvedValue({
+      state: mock(),
+      syncSummary: {
+        latestBlockNumber: BlockNumber.ZERO,
+        latestBlockHash: '',
+        finalizedBlockNumber: BlockNumber.ZERO,
+        treesAreSynched: false,
+        oldestHistoricBlockNumber: BlockNumber.ZERO,
+      },
+    });
+    logger.info(`Starting test ${expect.getState().currentTestName}`);
+  });
+
+  afterEach(async () => {
+    logger.info(`Tearing down state for ${expect.getState().currentTestName}`);
+    await shutdown(clients);
+    logger.info('Shut down p2p clients');
+
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+
+    clients = [];
+  });
+
+  const shutdown = async (clients: P2PClient[]) => {
+    await Promise.all(clients.map(client => client.stop()));
+    await sleep(1000);
+  };
+
+  /** Extracts the reqresp interface from a P2PClient via the private p2pService. */
+  const getReqResp = (client: P2PClient): ReqRespInterface => {
+    const p2pService = (client as any).p2pService as LibP2PService;
+    return (p2pService as any).reqresp as ReqRespInterface;
+  };
+
+  /** Extracts the peer ID from a P2PClient via the mock PubSub node. */
+  const getPeerId = (client: P2PClient) => {
+    const p2pService = (client as any).p2pService as LibP2PService;
+    return (p2pService as any).node.peerId;
+  };
+
+  it('can request txs from peers via mock reqresp', async () => {
+    const numberOfNodes = 2;
+    const mockGossipSubNetwork = new MockGossipSubNetwork();
+
+    const testConfig = {
+      p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1 },
+      mockAttestationPool: attestationPool,
+      mockTxPool: txPool,
+      mockEpochCache: epochCache,
+      mockWorldState: worldState,
+      alwaysTrueVerifier: true,
+      mockGossipSubNetwork,
+      logger,
+    };
+
+    const clientsAndConfig = await makeAndStartTestP2PClients(numberOfNodes, testConfig);
+    clients = clientsAndConfig.map(c => c.client);
+
+    await sleep(1000);
+
+    // Create a mock tx and configure the shared pool to return it
+    const tx = await createMockTxWithMetadata(testConfig.p2pBaseConfig);
+    const txHash = tx.getTxHash();
+
+    txPool.getTxByHash.mockImplementation((hash: TxHash) => Promise.resolve(hash.equals(txHash) ? tx : undefined));
+
+    // Request the tx from node-2, which will route to node-1 via the mock network
+    const reqresp = getReqResp(clients[1]);
+    const responses = await reqresp.sendBatchRequest(ReqRespSubProtocol.TX, [new TxHashArray(txHash)], undefined);
+
+    expect(responses).toHaveLength(1);
+    const txArray = responses[0] as TxArray;
+    expect(txArray).toHaveLength(1);
+
+    const receivedTxHash = txArray[0].getTxHash();
+    expect(receivedTxHash.toString()).toEqual(txHash.toString());
+  });
+
+  it('sendRequestToPeer routes to the correct peer handler', async () => {
+    const numberOfNodes = 2;
+    const mockGossipSubNetwork = new MockGossipSubNetwork();
+
+    const testConfig = {
+      p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1 },
+      mockAttestationPool: attestationPool,
+      mockTxPool: txPool,
+      mockEpochCache: epochCache,
+      mockWorldState: worldState,
+      alwaysTrueVerifier: true,
+      mockGossipSubNetwork,
+      logger,
+    };
+
+    const clientsAndConfig = await makeAndStartTestP2PClients(numberOfNodes, testConfig);
+    clients = clientsAndConfig.map(c => c.client);
+
+    await sleep(1000);
+
+    // Create a mock tx and configure the shared pool to return it
+    const tx = await createMockTxWithMetadata(testConfig.p2pBaseConfig);
+    const txHash = tx.getTxHash();
+
+    txPool.getTxByHash.mockImplementation((hash: TxHash) => Promise.resolve(hash.equals(txHash) ? tx : undefined));
+
+    // Get node-1's peer ID and node-2's reqresp
+    const node1PeerId = getPeerId(clients[0]);
+    const reqresp = getReqResp(clients[1]);
+
+    // Send a direct request to node-1
+    const response = await reqresp.sendRequestToPeer(
+      node1PeerId,
+      ReqRespSubProtocol.TX,
+      new TxHashArray(txHash).toBuffer(),
+    );
+
+    expect(response.status).toBe(ReqRespStatus.SUCCESS);
+    if (response.status === ReqRespStatus.SUCCESS) {
+      const txArray = TxArray.fromBuffer(response.data);
+      expect(txArray).toHaveLength(1);
+
+      const receivedTxHash = txArray[0].getTxHash();
+      expect(receivedTxHash.toString()).toEqual(txHash.toString());
+    }
+  });
+
+  it('reqresp returns empty when peer has no matching txs', async () => {
+    const numberOfNodes = 2;
+    const mockGossipSubNetwork = new MockGossipSubNetwork();
+
+    const testConfig = {
+      p2pBaseConfig: { ...p2pBaseConfig, rollupVersion: 1 },
+      mockAttestationPool: attestationPool,
+      mockTxPool: txPool,
+      mockEpochCache: epochCache,
+      mockWorldState: worldState,
+      alwaysTrueVerifier: true,
+      mockGossipSubNetwork,
+      logger,
+    };
+
+    const clientsAndConfig = await makeAndStartTestP2PClients(numberOfNodes, testConfig);
+    clients = clientsAndConfig.map(c => c.client);
+
+    await sleep(1000);
+
+    // Request a random tx hash that no peer has
+    const randomTxHash = TxHash.random();
+    const reqresp = getReqResp(clients[1]);
+    const responses = await reqresp.sendBatchRequest(ReqRespSubProtocol.TX, [new TxHashArray(randomTxHash)], undefined);
+
+    // The handler returns an empty TxArray (serialized as a 4-byte vector with count 0),
+    // so sendBatchRequest includes it as a response with an empty TxArray.
+    expect(responses).toHaveLength(1);
+    const txArray = responses[0] as TxArray;
+    expect(txArray).toHaveLength(0);
+  });
+});

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -19,8 +19,20 @@ import {
 
 import type { P2PConfig } from '../config.js';
 import type { MemPools } from '../mem_pools/interface.js';
-import { DummyPeerDiscoveryService, DummyPeerManager, DummyReqResp, LibP2PService } from '../services/index.js';
-import type { ReqRespInterface } from '../services/reqresp/interface.js';
+import { DummyPeerDiscoveryService, DummyPeerManager, LibP2PService } from '../services/index.js';
+import type { P2PReqRespConfig } from '../services/reqresp/config.js';
+import type { ConnectionSampler } from '../services/reqresp/connection-sampler/connection_sampler.js';
+import {
+  type ReqRespInterface,
+  type ReqRespResponse,
+  type ReqRespSubProtocol,
+  type ReqRespSubProtocolHandler,
+  type ReqRespSubProtocolHandlers,
+  type ReqRespSubProtocolValidators,
+  type SubProtocolMap,
+  responseFromBuffer,
+} from '../services/reqresp/interface.js';
+import { ReqRespStatus } from '../services/reqresp/status.js';
 import { GossipSubEvent } from '../types/index.js';
 import type { PubSubLibp2p } from '../util.js';
 
@@ -52,7 +64,7 @@ export function getMockPubSubP2PServiceFactory<T extends P2PClientType>(
     deps.logger.verbose('Creating mock PubSub service');
     const libp2p = new MockPubSub(peerId, network);
     const peerManager = new DummyPeerManager(peerId, network);
-    const reqresp: ReqRespInterface = new DummyReqResp();
+    const reqresp: ReqRespInterface = new MockReqResp(peerId, network);
     const peerDiscoveryService = new DummyPeerDiscoveryService();
     const service = new LibP2PService<T>(
       clientType as T,
@@ -72,6 +84,115 @@ export function getMockPubSubP2PServiceFactory<T extends P2PClientType>(
 
     return Promise.resolve(service);
   };
+}
+
+/**
+ * Mock implementation of ReqRespInterface that routes requests to other peers' handlers through the mock network.
+ * When a peer calls sendBatchRequest, the mock iterates over network peers and invokes their registered handler
+ * for the sub-protocol, simulating the request-response protocol without actual libp2p streams.
+ */
+class MockReqResp implements ReqRespInterface {
+  private handlers: Partial<ReqRespSubProtocolHandlers> = {};
+  private logger = createLogger('p2p:test:mock-reqresp');
+
+  constructor(
+    private peerId: PeerId,
+    private network: MockGossipSubNetwork,
+  ) {
+    network.registerReqRespPeer(this);
+  }
+
+  updateConfig(_config: Partial<P2PReqRespConfig>): void {}
+
+  start(
+    subProtocolHandlers: Partial<ReqRespSubProtocolHandlers>,
+    _subProtocolValidators: ReqRespSubProtocolValidators,
+  ): Promise<void> {
+    Object.assign(this.handlers, subProtocolHandlers);
+    return Promise.resolve();
+  }
+
+  addSubProtocol(
+    subProtocol: ReqRespSubProtocol,
+    handler: ReqRespSubProtocolHandler,
+    _validator?: ReqRespSubProtocolValidators[ReqRespSubProtocol],
+  ): Promise<void> {
+    this.handlers[subProtocol] = handler;
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    this.handlers = {};
+    return Promise.resolve();
+  }
+
+  getHandler(subProtocol: ReqRespSubProtocol): ReqRespSubProtocolHandler | undefined {
+    return this.handlers[subProtocol];
+  }
+
+  async sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
+    subProtocol: SubProtocol,
+    requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
+    pinnedPeer: PeerId | undefined,
+    _timeoutMs?: number,
+    _maxPeers?: number,
+    _maxRetryAttempts?: number,
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[]> {
+    const responses: InstanceType<SubProtocolMap[SubProtocol]['response']>[] = [];
+    const peers = this.network.getReqRespPeers().filter(p => !p.peerId.equals(this.peerId));
+    const targetPeers = pinnedPeer ? peers.filter(p => p.peerId.equals(pinnedPeer)) : peers;
+
+    for (const request of requests) {
+      const requestBuffer = request.toBuffer();
+      for (const peer of targetPeers) {
+        const handler = peer.getHandler(subProtocol);
+        if (!handler) {
+          continue;
+        }
+        try {
+          const responseBuffer = await handler(this.peerId, requestBuffer);
+          if (responseBuffer.length > 0) {
+            const response = responseFromBuffer(subProtocol, responseBuffer);
+            responses.push(response as InstanceType<SubProtocolMap[SubProtocol]['response']>);
+            break;
+          }
+        } catch (err) {
+          this.logger.debug(`Mock reqresp handler error from peer ${peer.peerId}`, { err });
+        }
+      }
+    }
+
+    return responses;
+  }
+
+  async sendRequestToPeer(
+    peerId: PeerId,
+    subProtocol: ReqRespSubProtocol,
+    payload: Buffer,
+    _dialTimeout?: number,
+  ): Promise<ReqRespResponse> {
+    const peer = this.network.getReqRespPeers().find(p => p.peerId.equals(peerId));
+    const handler = peer?.getHandler(subProtocol);
+    if (!handler) {
+      return { status: ReqRespStatus.SUCCESS, data: Buffer.from([]) };
+    }
+    try {
+      const data = await handler(this.peerId, payload);
+      return { status: ReqRespStatus.SUCCESS, data };
+    } catch {
+      return { status: ReqRespStatus.FAILURE };
+    }
+  }
+
+  getConnectionSampler(): Pick<ConnectionSampler, 'getPeerListSortedByConnectionCountAsc'> {
+    return {
+      getPeerListSortedByConnectionCountAsc: () =>
+        this.network
+          .getReqRespPeers()
+          .filter(p => !p.peerId.equals(this.peerId))
+          .map(p => p.peerId),
+    };
+  }
 }
 
 /**
@@ -157,6 +278,7 @@ class MockGossipSubService extends TypedEventEmitter<GossipsubEvents> implements
  */
 export class MockGossipSubNetwork {
   private peers: MockGossipSubService[] = [];
+  private reqRespPeers: MockReqResp[] = [];
   private nextMsgId = 0;
 
   private logger = createLogger('p2p:test:mock-gossipsub-network');
@@ -167,6 +289,14 @@ export class MockGossipSubNetwork {
 
   public registerPeer(peer: MockGossipSubService): void {
     this.peers.push(peer);
+  }
+
+  public registerReqRespPeer(peer: MockReqResp): void {
+    this.reqRespPeers.push(peer);
+  }
+
+  public getReqRespPeers(): MockReqResp[] {
+    return this.reqRespPeers;
   }
 
   public publishToPeers(topic: TopicStr, data: Uint8Array, sender: PeerId): void {

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -16,7 +16,7 @@ import {
   createForwarderL1TxUtilsFromEthSigner,
   createL1TxUtilsFromEthSignerWithStore,
 } from '@aztec/node-lib/factories';
-import { NodeRpcTxSource, createP2PClient } from '@aztec/p2p';
+import { NodeRpcTxSource, type P2PClientDeps, createP2PClient } from '@aztec/p2p';
 import { type ProverClientConfig, createProverClient } from '@aztec/prover-client';
 import { createAndStartProvingBroker } from '@aztec/prover-client/broker';
 import type { AztecNode, ProvingJobBroker } from '@aztec/stdlib/interfaces/server';
@@ -42,6 +42,7 @@ export type ProverNodeDeps = {
   broker?: ProvingJobBroker;
   l1TxUtils?: L1TxUtils;
   dateProvider?: DateProvider;
+  p2pClientDeps?: P2PClientDeps<P2PClientType.Prover>;
 };
 
 /** Creates a new prover node given a config. */
@@ -175,9 +176,11 @@ export async function createProverNode(
     dateProvider,
     telemetry,
     {
-      txCollectionNodeSources: deps.aztecNodeTxProvider
-        ? [new NodeRpcTxSource(deps.aztecNodeTxProvider, 'TestNode')]
-        : [],
+      ...deps.p2pClientDeps,
+      txCollectionNodeSources: [
+        ...(deps.p2pClientDeps?.txCollectionNodeSources ?? []),
+        ...(deps.aztecNodeTxProvider ? [new NodeRpcTxSource(deps.aztecNodeTxProvider, 'TestNode')] : []),
+      ],
     },
   );
 


### PR DESCRIPTION
Similar to how we had a MockGossipSub network we used in tests for nodes
to talk to each other, this commit adds a MockReqResp layer to enable
reqresp. Also adds an integration_reqresp test in p2p to test it (we
should be able to migrate other integration tests in p2p to it as
well?).

This allows us to re-enable the mbps assertion for proving blocks with
txs anchored to uncheckpointed blocks. It was failing because the prover
node failed to follow the uncheckpointed chain, so it rejected the txs
anchored to those blocks, and then could not fetch them via reqresp
since it was not enabled.

Proper fix is actually having the prover node follow the uncheckpointed
chain. But that will come in a later PR.

Builds on #20354
