### PR TITLE
chore: audit scope commit update

### DIFF
--- a/barretenberg/cpp/scripts/audit/audit_scopes/chonk_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/chonk_audit_scope.md
@@ -1,5 +1,8 @@
 # Chonk Audit Scope
 
+Repository: https://github.com/AztecProtocol/aztec-packages
+Commit hash: dac3f148132ecfc98adb6ac6444ab47861b38dd5
+
 Chonk is an RCG system designed for proving private smart contract execution on Aztec. It uses HyperNova folding to accumulate circuits with deferred PCS verification, combined with Goblin to defer non-native elliptic curve operations to a separate VM - Elliptic Curve Virtual Machine. The goal of the audit is to ensure that soundness and completeness of the protocol **assuming** the soundness of several building blocks audited separately -  Circuit Builders, Field, Bigfield, ECCVM, Translator, Biggroup, Transcript, DSL/ACIR, Sumcheck, and PCS.
 
 ---

--- a/barretenberg/cpp/scripts/audit/audit_scopes/hash_gadgets_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/hash_gadgets_audit_scope.md
@@ -1,7 +1,7 @@
 # External Audit Scope: Hash Gadgets
 
 Repository: https://github.com/AztecProtocol/aztec-packages
-Commit hash: 21476601b111f046f023474465598843e4cfd8ac
+Commit hash: dac3f148132ecfc98adb6ac6444ab47861b38dd5
 
 Note: All paths are relative to `aztec-packages/barretenberg/cpp/src/barretenberg`
 

--- a/barretenberg/cpp/scripts/audit/audit_scopes/pippenger_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/pippenger_audit_scope.md
@@ -1,7 +1,7 @@
 # External Audit Scope: pippenger
 
 Repository: https://github.com/AztecProtocol/aztec-packages
-Commit hash: TBD (link)
+Commit hash: dac3f148132ecfc98adb6ac6444ab47861b38dd5
 
 ## Files to Audit
 Note: Paths relative to `aztec-packages/barretenberg/cpp/src/barretenberg`


### PR DESCRIPTION
Update target commit in scope docs for chonk, hash gadgets and pippenger