### PR TITLE
fix: (A-370) don't propagate on tx mempool add failure

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -15,6 +15,7 @@ import {
   makeBlockProposal,
   makeCheckpointHeader,
   makeCheckpointProposal,
+  mockTx,
 } from '@aztec/stdlib/testing';
 import { type Tx, TxArray, TxHashArray, type TxValidator } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
@@ -123,6 +124,97 @@ describe('LibP2PService', () => {
 
       // Verify that the peer was penalized
       expect(mockPeerManager.penalizePeer).toHaveBeenCalledWith(mockPeerId, PeerErrorSeverity.LowToleranceError);
+    });
+  });
+
+  describe('handleGossipedTx - propagation based on pool acceptance', () => {
+    let txService: TestLibP2PService;
+    let txPeerManager: MockProxy<PeerManagerInterface>;
+    let txPeerId: MockProxy<PeerId>;
+    let txReportSpy: jest.Mock;
+    let txPool: MockProxy<TxPoolV2>;
+
+    beforeEach(() => {
+      txPeerManager = mock<PeerManagerInterface>();
+      txPeerId = mock<PeerId>({
+        toString: () => MOCK_PEER_ID,
+      });
+      txReportSpy = jest.fn();
+      txPool = mock<TxPoolV2>();
+
+      const txNode = mock<PubSubLibp2p>();
+      txNode.services = {
+        pubsub: {
+          reportMessageValidationResult: txReportSpy,
+        },
+      } as any;
+
+      txService = createTestLibP2PService({
+        peerManager: txPeerManager,
+        node: txNode,
+        txPool,
+      });
+      // Make validatePropagatedTx pass by default
+      txService.validatePropagatedTxMock.mockResolvedValue(true);
+    });
+
+    it('should propagate (Accept) when pool accepts the transaction', async () => {
+      const tx = await mockTx();
+      const txHash = tx.getTxHash();
+
+      txPool.addPendingTxs.mockResolvedValue({
+        accepted: [txHash],
+        ignored: [],
+        rejected: [],
+      });
+
+      await txService.handleGossipedTx(tx.toBuffer(), 'test-msg-id', txPeerId);
+
+      expect(txReportSpy).toHaveBeenCalledWith('test-msg-id', MOCK_PEER_ID, TopicValidatorResult.Accept);
+      expect(txPool.addPendingTxs).toHaveBeenCalled();
+    });
+
+    it('should NOT propagate (Ignore) when pool ignores the transaction', async () => {
+      const tx = await mockTx();
+      const txHash = tx.getTxHash();
+
+      txPool.addPendingTxs.mockResolvedValue({
+        accepted: [],
+        ignored: [txHash],
+        rejected: [],
+      });
+
+      await txService.handleGossipedTx(tx.toBuffer(), 'test-msg-id', txPeerId);
+
+      expect(txReportSpy).toHaveBeenCalledWith('test-msg-id', MOCK_PEER_ID, TopicValidatorResult.Ignore);
+      expect(txPool.addPendingTxs).toHaveBeenCalled();
+    });
+
+    it('should NOT propagate (Reject) when pool rejects the transaction', async () => {
+      const tx = await mockTx();
+      const txHash = tx.getTxHash();
+
+      txPool.addPendingTxs.mockResolvedValue({
+        accepted: [],
+        ignored: [],
+        rejected: [txHash],
+      });
+
+      await txService.handleGossipedTx(tx.toBuffer(), 'test-msg-id', txPeerId);
+
+      expect(txReportSpy).toHaveBeenCalledWith('test-msg-id', MOCK_PEER_ID, TopicValidatorResult.Reject);
+      expect(txPool.addPendingTxs).toHaveBeenCalled();
+    });
+
+    it('should NOT propagate (Reject) when gossip validation fails', async () => {
+      const tx = await mockTx();
+
+      txService.validatePropagatedTxMock.mockResolvedValue(false);
+
+      await txService.handleGossipedTx(tx.toBuffer(), 'test-msg-id', txPeerId);
+
+      expect(txReportSpy).toHaveBeenCalledWith('test-msg-id', MOCK_PEER_ID, TopicValidatorResult.Reject);
+      expect(txPool.addPendingTxs).not.toHaveBeenCalled();
     });
   });
 
@@ -884,6 +976,9 @@ class TestLibP2PService extends LibP2PService {
   /** Mocked validateRequestedTx for testing. */
   public validateRequestedTxMock: jest.Mock;
 
+  /** Mocked validatePropagatedTx for testing gossip tx handling. */
+  public validatePropagatedTxMock: jest.Mock<(tx: Tx, peerId: PeerId) => Promise<boolean>>;
+
   /** Stub validator returned by createRequestedTxValidator. */
   private stubValidator: TxValidator;
 
@@ -937,6 +1032,7 @@ class TestLibP2PService extends LibP2PService {
 
     this.testEpochCache = epochCache;
     this.validateRequestedTxMock = jest.fn(() => Promise.resolve());
+    this.validatePropagatedTxMock = jest.fn(() => Promise.resolve(true));
     this.stubValidator = {
       validateTx: () => Promise.resolve({ result: 'valid' as const }),
     };
@@ -945,6 +1041,16 @@ class TestLibP2PService extends LibP2PService {
   /** Exposes the protected handleNewGossipMessage for testing. */
   public override handleNewGossipMessage(msg: Message, msgId: string, source: PeerId): Promise<void> {
     return super.handleNewGossipMessage(msg, msgId, source);
+  }
+
+  /** Exposes the protected handleGossipedTx for testing. */
+  public override handleGossipedTx(payloadData: Buffer, msgId: string, source: PeerId): Promise<void> {
+    return super.handleGossipedTx(payloadData, msgId, source);
+  }
+
+  /** Override to use the mock for validatePropagatedTx. */
+  protected override validatePropagatedTx(tx: Tx, peerId: PeerId): Promise<boolean> {
+    return this.validatePropagatedTxMock(tx, peerId);
   }
 
   /** Exposes the protected validateRequestedBlock for testing. */

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,6 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
-import { randomInt } from '@aztec/foundation/crypto/random';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -903,20 +902,33 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const validationFunc: () => Promise<ReceivedMessageValidationResult<Tx>> = async () => {
       const tx = Tx.fromBuffer(payloadData);
       const isValid = await this.validatePropagatedTx(tx, source);
-      const exists = isValid && (await this.mempools.txPool.hasTxs([tx.getTxHash()]))[0];
+      if (!isValid) {
+        this.logger.trace(`Rejecting invalid propagated tx`, {
+          [Attributes.P2P_ID]: source.toString(),
+        });
+        return { result: TopicValidatorResult.Reject };
+      }
+
+      // Propagate only on pool acceptance
+      const txHash = tx.getTxHash();
+      const addResult = await this.mempools.txPool.addPendingTxs([tx], { source: 'gossip' });
+
+      const wasAccepted = addResult.accepted.some(h => h.equals(txHash));
+      const wasIgnored = addResult.ignored.some(h => h.equals(txHash));
 
       this.logger.trace(`Validate propagated tx`, {
         isValid,
-        exists,
+        wasAccepted,
+        wasIgnored,
         [Attributes.P2P_ID]: source.toString(),
       });
 
-      if (!isValid) {
-        return { result: TopicValidatorResult.Reject };
-      } else if (exists) {
+      if (wasAccepted) {
+        return { result: TopicValidatorResult.Accept, obj: tx };
+      } else if (wasIgnored) {
         return { result: TopicValidatorResult.Ignore, obj: tx };
       } else {
-        return { result: TopicValidatorResult.Accept, obj: tx };
+        return { result: TopicValidatorResult.Reject };
       }
     };
 
@@ -925,6 +937,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       return;
     }
 
+    // Tx was accepted into pool and will be propagated - just log and record metrics
     const txHash = tx.getTxHash();
     const txHashString = txHash.toString();
     this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()} via gossip`, {
@@ -932,13 +945,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       txHash: txHashString,
     });
 
-    if (this.config.dropTransactions && randomInt(1000) < this.config.dropTransactionsProbability * 1000) {
-      this.logger.warn(`Intentionally dropping tx ${txHashString} (probability rule)`);
-      return;
-    }
-
     this.instrumentation.incrementTxReceived(1);
-    await this.mempools.txPool.addPendingTxs([tx]);
   }
 
   /**
@@ -1534,7 +1541,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   @trackSpan('Libp2pService.validatePropagatedTx', tx => ({
     [Attributes.TX_HASH]: tx.getTxHash().toString(),
   }))
-  private async validatePropagatedTx(tx: Tx, peerId: PeerId): Promise<boolean> {
+  protected async validatePropagatedTx(tx: Tx, peerId: PeerId): Promise<boolean> {
     const currentBlockNumber = await this.archiver.getBlockNumber();
 
     // We accept transactions if they are not expired by the next slot (checked based on the IncludeByTimestamp field)


### PR DESCRIPTION
- On gossip tx handling, first checks if it can be added to the pool before propagation
- tests to enforce this behavior