### PR TITLE
feat: custom message handlers in Aztec.nr

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -764,7 +764,18 @@
     # A warning that is shown when `aztec compile` is run and the contract crate contains tests
     to = "/developers/docs/aztec-nr/testing_contracts#keep-tests-in-the-test-crate"
 
+[[redirects]]
+    # Aztec-nr: custom message was received but no handler was configured
+    from = "/errors/2"
+    to = "/aztec-nr-api/nightly/noir_aztec/macros/struct.AztecConfig.html"
+
+[[redirects]]
+    # Aztec-nr: message received with message type ID in the range reserved for future aztec.nr built-in message types
+    from = "/errors/3"
+    to = "/aztec-nr-api/nightly/noir_aztec/messages/msg_type/index.html"
+
 # Example (uncomment and modify when adding error codes):
 # [[redirects]]
-#     from = "/errors/2"
+#     from = "/errors/4"
 #     to = "/developers/docs/aztec-nr/framework-description/functions/how_to_define_functions"
+

--- a/noir-projects/aztec-nr/CLAUDE.md
+++ b/noir-projects/aztec-nr/CLAUDE.md
@@ -1,0 +1,34 @@
+# aztec-nr Development Guidelines
+
+## Formatting
+
+- Lines should not exceed 120 characters, especially in comments.
+
+## Noir Idioms
+
+- Use `panic("message")` instead of `assert(false, "message")` for unconditional failures. `panic` returns the parent function's return type, making it usable in expression position (e.g. in if/else branches). Even when the return type doesn't matter, `panic` is the idiomatic choice.
+
+## Doc Comments
+
+Follow the Rust stdlib style roughly. See `PublicImmutable` in `state_vars/public_immutable.nr` for a thorough example.
+
+### Structure
+
+- **First paragraph is a short summary.** Keep it to a single, concise sentence — this is what shows up in documentation summary lists. E.g. `/// Immutable public values.`
+- **Expand in subsequent paragraphs.** After the summary sentence, add more detail about what the thing is and how it works.
+- **Use `##` section headings** to organize longer docs. These generate anchors for linking. Common sections and their typical order:
+  - `## Access Patterns` — where/how this can be used (public, private, utility)
+  - `## Privacy` — what information is leaked and what is kept private
+  - `## Use Cases` — when to use this and when to prefer alternatives
+  - `## Examples` — code blocks showing declaration, initialization, and usage
+  - `## Requirements` — trait bounds or constraints the user must satisfy
+  - `## Implementation Details` — how it works under the hood (storage layout, nullifiers, etc.)
+  - `## Cost` — AVM opcodes invoked, storage reads/writes (for individual methods)
+
+### Style
+
+- **Link to related items** using doc links like `[`PublicMutable`](crate::state_vars::PublicMutable)` for discoverability, especially from entrypoint methods and when mentioning alternatives.
+- **Mention alternatives.** When documenting a type, point to related types that users might want instead (e.g. `PublicImmutable` docs mention `DelayedPublicMutable` as a mutable alternative).
+- **Be precise with terminology.** For example, messages sent onchain are "messages that use logs", not "logs" themselves.
+- **Show practical patterns in examples.** Don't just show the API call — show it in context (e.g. inside a `#[external("public")]` function with realistic variable names).
+- **Document cost for methods.** When relevant, note which AVM opcodes are invoked and how many times (e.g. "`SLOAD` is invoked a number of times equal to `T`'s packed length").

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -38,7 +38,7 @@ pub mod note;
 pub mod nullifier;
 pub mod oracle;
 pub mod state_vars;
-mod capsules;
+pub mod capsules;
 pub mod event;
 pub mod messages;
 pub use protocol_types as protocol;

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -1,23 +1,89 @@
-use crate::macros::{
-    calls_generation::{
-        external_functions::{generate_external_function_calls, generate_external_function_self_calls_structs},
-        internal_functions::generate_call_internal_struct,
+use crate::{
+    macros::{
+        calls_generation::{
+            external_functions::{generate_external_function_calls, generate_external_function_self_calls_structs},
+            internal_functions::generate_call_internal_struct,
+        },
+        dispatch::generate_public_dispatch,
+        internals_functions_generation::{create_fn_abi_exports, process_functions},
+        notes::NOTES,
+        storage::STORAGE_LAYOUT_NAME,
+        utils::{
+            get_trait_impl_method, is_fn_contract_library_method, is_fn_external, is_fn_internal, is_fn_test,
+            module_has_storage,
+        },
     },
-    dispatch::generate_public_dispatch,
-    internals_functions_generation::{create_fn_abi_exports, process_functions},
-    notes::NOTES,
-    storage::STORAGE_LAYOUT_NAME,
-    utils::{
-        get_trait_impl_method, is_fn_contract_library_method, is_fn_external, is_fn_internal, is_fn_test,
-        module_has_storage,
-    },
+    messages::discovery::CustomMessageHandler,
 };
 
-/// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
-/// the `sync_state` utility function.
+/// Configuration for the [`aztec`] macro.
 ///
-/// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
-pub comptime fn aztec(m: Module) -> Quoted {
+/// This type lets users override different parts of the default aztec-nr contract behavior, such
+/// as message handling. These are advanced features that require careful understanding of
+/// the behavior of these systems.
+///
+/// ## Examples
+///
+/// ```noir
+/// #[aztec(aztec::macros::AztecConfig::new().custom_message_handler(my_handler))]
+/// contract MyContract { ... }
+/// ```
+pub struct AztecConfig {
+    custom_message_handler: Option<CustomMessageHandler<()>>,
+}
+
+impl AztecConfig {
+    /// Creates a new `AztecConfig` with default values.
+    ///
+    /// Calling `new` is equivalent to invoking the [`aztec`] macro with no parameters. The different methods
+    /// (e.g. [`AztecConfig::custom_message_handler`]) can then be used to change the default behavior.
+    pub comptime fn new() -> Self {
+        Self { custom_message_handler: Option::none() }
+    }
+
+    /// Sets a handler for custom messages.
+    ///
+    /// This enables contracts to process non-standard messages (i.e. any with a message type that is not in
+    /// [`crate::messages::msg_type`]).
+    ///
+    /// `handler` must be a `#[contract_library_method]` function that conforms to the
+    /// [`crate::messages::discovery::CustomMessageHandler`] type signature.
+    pub comptime fn custom_message_handler(_self: Self, handler: CustomMessageHandler<()>) -> Self {
+        Self { custom_message_handler: Option::some(handler) }
+    }
+}
+
+/// Enables aztec-nr features on a `contract`.
+///
+/// All aztec-nr contracts should have this macro invoked on them, as it is the one that processes all contract
+/// functions, notes, storage, generates interfaces for external calls, and creates the message processing
+/// boilerplate.
+///
+/// ## Examples
+///
+/// Most contracts can simply invoke the macro with no parameters, resulting in default aztec-nr behavior:
+/// ```noir
+/// #[aztec]
+/// contract MyContract { ... }
+/// ```
+///
+/// Advanced contracts can use [`AztecConfig`] to customize parts of its behavior, such as message
+/// processing.
+/// ```noir
+/// #[aztec(aztec::macros::AztecConfig::new().custom_message_handler(my_handler))]
+/// contract MyAdvancedContract { ... }
+/// ```
+#[varargs]
+pub comptime fn aztec(m: Module, args: [AztecConfig]) -> Quoted {
+    let num_args = args.len();
+    let config = if num_args == 0 {
+        AztecConfig::new()
+    } else if num_args == 1 {
+        args[0]
+    } else {
+        panic(f"#[aztec] expects 0 or 1 arguments, got {num_args}")
+    };
+
     // Functions that don't have #[external(...)], #[contract_library_method], or #[test] are not allowed in contracts.
     check_each_fn_macroified(m);
 
@@ -42,14 +108,21 @@ pub comptime fn aztec(m: Module) -> Quoted {
     } else {
         quote {}
     };
+    let process_custom_message_option = if config.custom_message_handler.is_some() {
+        let handler = config.custom_message_handler.unwrap();
+        quote { Option::some($handler) }
+    } else {
+        quote { Option::<aztec::messages::discovery::CustomMessageHandler<()>>::none() }
+    };
+
     let sync_state_fn_and_abi_export = if !m.functions().any(|f| f.name() == quote { sync_state }) {
-        generate_sync_state()
+        generate_sync_state(process_custom_message_option)
     } else {
         quote {}
     };
 
     let process_message_fn_and_abi_export = if !m.functions().any(|f| f.name() == quote { process_message }) {
-        generate_process_message()
+        generate_process_message(process_custom_message_option)
     } else {
         quote {}
     };
@@ -263,7 +336,8 @@ comptime fn generate_contract_library_method_compute_note_hash_and_nullifier() -
     }
 }
 
-comptime fn generate_sync_state() -> Quoted {
+/// Generates the `sync_state` utility function that performs message discovery.
+comptime fn generate_sync_state(process_custom_message_option: Quoted) -> Quoted {
     quote {
         pub struct sync_state_parameters {}
 
@@ -275,13 +349,17 @@ comptime fn generate_sync_state() -> Quoted {
         #[aztec::macros::internals_functions_generation::abi_attributes::abi_utility]
         unconstrained fn sync_state() {
             let address = aztec::context::UtilityContext::new().this_address();
-            
-            aztec::messages::discovery::do_sync_state(address, _compute_note_hash_and_nullifier);
+            aztec::messages::discovery::do_sync_state(
+                address,
+                _compute_note_hash_and_nullifier,
+                $process_custom_message_option,
+            );
         }
     }
 }
 
-comptime fn generate_process_message() -> Quoted {
+/// Generates the `process_message` utility function that processes a single message ciphertext.
+comptime fn generate_process_message(process_custom_message_option: Quoted) -> Quoted {
     quote {
         pub struct process_message_parameters {
             pub message_ciphertext: BoundedVec<Field, aztec::messages::encoding::MESSAGE_CIPHERTEXT_LEN>,
@@ -303,6 +381,7 @@ comptime fn generate_process_message() -> Quoted {
             aztec::messages::discovery::process_message::process_message_ciphertext(
                 address,
                 _compute_note_hash_and_nullifier,
+                $process_custom_message_option,
                 message_ciphertext,
                 message_context,
             );
@@ -317,7 +396,7 @@ comptime fn generate_process_message() -> Quoted {
 /// Checks that all functions in the module have a context macro applied.
 ///
 /// Non-macroified functions are not allowed in contracts. They must all be one of
-/// [`external`](crate::macros::functions::external), [`internal`](crate::macros::functions::internal) or `test`.
+/// [`crate::macros::functions::external`], [`crate::macros::functions::internal`] or `test`.
 comptime fn check_each_fn_macroified(m: Module) {
     for f in m.functions() {
         let name = f.name();

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -1,6 +1,8 @@
 //! Definition of Aztec contract functions, storage, notes and events.
 
-pub mod aztec;
+mod aztec;
+pub use aztec::{aztec, AztecConfig};
+
 pub mod dispatch;
 pub(crate) mod calls_generation;
 pub mod internals_functions_generation;
@@ -10,5 +12,3 @@ pub mod notes;
 pub mod storage;
 pub mod events;
 pub mod authorization;
-
-pub use aztec::aztec;

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -9,9 +9,11 @@ pub mod process_message;
 use crate::{
     messages::{
         discovery::process_message::process_message_ciphertext,
+        encoding::MAX_MESSAGE_CONTENT_LEN,
         logs::note::MAX_NOTE_PACKED_LEN,
         processing::{
-            get_private_logs, pending_tagged_log::PendingTaggedLog, validate_and_store_enqueued_notes_and_events,
+            get_private_logs, MessageContext, pending_tagged_log::PendingTaggedLog,
+            validate_and_store_enqueued_notes_and_events,
         },
     },
     utils::array,
@@ -64,6 +66,18 @@ pub type ComputeNoteHashAndNullifier<Env> = unconstrained fn[Env](/* packed_note
  owner */ AztecAddress, /* storage_slot */ Field, /* note_type_id */ Field, /* contract_address */ AztecAddress, /*
 randomness */ Field, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 
+/// A handler for custom messages.
+///
+/// Contracts that emit custom messages (i.e. any with a message type that is not in [`crate::messages::msg_type`])
+/// need to use [`crate::macros::AztecConfig::custom_message_handler`] with a function of this type in order to
+/// process them. They will otherwise be **silently ignored**.
+pub type CustomMessageHandler<Env> = unconstrained fn[Env](
+/* contract_address */AztecAddress,
+/* msg_type_id */ u64,
+/* msg_metadata */ u64,
+/* msg_content */ BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
+/* message_context */ MessageContext);
+
 /// Performs the state synchronization process, in which private logs are downloaded and inspected to find new private
 /// notes, partial notes and events, etc., and pending partial notes are processed to search for their completion logs.
 /// This is the mechanism via which a contract updates its knowledge of its private state.
@@ -72,11 +86,11 @@ randomness */ Field, /* note nonce */ Field) -> Option<NoteHashAndNullifier>;
 /// That should be close to the chain tip as block synchronization is performed before contract function simulation is
 /// done.
 ///
-/// Receives the address of the contract on which discovery is performed along with its
-/// `compute_note_hash_and_nullifier` function.
-pub unconstrained fn do_sync_state<Env>(
+/// Receives the address of the contract on which discovery is performed along with the contract's configuration.
+pub unconstrained fn do_sync_state<ComputeNoteHashAndNullifierEnv, CustomMessageHandlerEnv>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ComputeNoteHashAndNullifierEnv>,
+    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
 ) {
     debug_log("Performing state synchronization");
 
@@ -95,6 +109,7 @@ pub unconstrained fn do_sync_state<Env>(
         process_message_ciphertext(
             contract_address,
             compute_note_hash_and_nullifier,
+            process_custom_message,
             message_ciphertext,
             pending_tagged_log.context,
         );

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -1,11 +1,13 @@
 use crate::messages::{
     discovery::{
-        ComputeNoteHashAndNullifier, partial_notes::process_partial_note_private_msg,
+        ComputeNoteHashAndNullifier, CustomMessageHandler, partial_notes::process_partial_note_private_msg,
         private_events::process_private_event_msg, private_notes::process_private_note_msg,
     },
     encoding::{decode_message, MESSAGE_CIPHERTEXT_LEN, MESSAGE_PLAINTEXT_LEN},
     encryption::{aes128::AES128, message_encryption::MessageEncryption},
-    msg_type::{PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID},
+    msg_type::{
+        MIN_CUSTOM_MSG_TYPE_ID, PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
+    },
     processing::MessageContext,
 };
 
@@ -23,9 +25,10 @@ use crate::protocol::{address::AztecAddress, logging::{debug_log, debug_log_form
 ///
 /// Events are processed by computing an event commitment from the serialized event data and its randomness field, then
 /// enqueueing the event data and commitment for validation.
-pub unconstrained fn process_message_ciphertext<Env>(
+pub unconstrained fn process_message_ciphertext<ComputeNoteHashAndNullifierEnv, CustomMessageHandlerEnv>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ComputeNoteHashAndNullifierEnv>,
+    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
     message_ciphertext: BoundedVec<Field, MESSAGE_CIPHERTEXT_LEN>,
     message_context: MessageContext,
 ) {
@@ -35,6 +38,7 @@ pub unconstrained fn process_message_ciphertext<Env>(
         process_message_plaintext(
             contract_address,
             compute_note_hash_and_nullifier,
+            process_custom_message,
             message_plaintext_option.unwrap(),
             message_context,
         );
@@ -46,9 +50,10 @@ pub unconstrained fn process_message_ciphertext<Env>(
     }
 }
 
-pub unconstrained fn process_message_plaintext<Env>(
+pub unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifierEnv, CustomMessageHandlerEnv>(
     contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ComputeNoteHashAndNullifierEnv>,
+    process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
     message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
     message_context: MessageContext,
 ) {
@@ -90,7 +95,28 @@ pub unconstrained fn process_message_plaintext<Env>(
             msg_content,
             message_context.tx_hash,
         );
+    } else if msg_type_id < MIN_CUSTOM_MSG_TYPE_ID {
+        // The message type ID falls in the range reserved for aztec.nr built-in types but wasn't matched above. This
+        // most likely means the message is malformed or a custom message was incorrectly assigned a reserved ID.
+        // Custom message types must use IDs allocated via `custom_msg_type_id`.
+        debug_log_format(
+            "Message type ID {0} is in the reserved range but is not recognized, ignoring. See https://docs.aztec.network/errors/3",
+            [msg_type_id as Field],
+        );
+    } else if process_custom_message.is_some() {
+        process_custom_message.unwrap()(
+            contract_address,
+            msg_type_id,
+            msg_metadata,
+            msg_content,
+            message_context,
+        );
     } else {
-        debug_log_format("Unknown msg type id {0}", [msg_type_id as Field]);
+        // A custom message was received but no handler is configured. This likely means the contract emits custom
+        // messages but forgot to register a handler via `AztecConfig::custom_message_handler`.
+        debug_log_format(
+            "Received custom message with type id {0} but no handler is configured, ignoring. See https://docs.aztec.network/errors/2",
+            [msg_type_id as Field],
+        );
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/message_encryption.nr
@@ -19,7 +19,7 @@ use crate::protocol::address::AztecAddress;
 pub trait MessageEncryption {
     /// Encrypts a plaintext message to `recipient`.
     ///
-    /// The returned message ciphertext can be passed to [`decrypt`](MessageEncryption::decrypt) in order to obtain the
+    /// The returned message ciphertext can be passed to [`MessageEncryption::decrypt`] in order to obtain the
     /// original `plaintext`.
     ///
     /// ## Privacy
@@ -38,7 +38,7 @@ pub trait MessageEncryption {
 
     /// Decrypts a message ciphertext into its original plaintext.
     ///
-    /// Typically invoked with ciphertext obtained from calling [`encrypt`](MessageEncryption::encrypt) with
+    /// Typically invoked with ciphertext obtained from calling [`MessageEncryption::encrypt`] with
     /// `recipient`.
     ///
     /// Note that this function is unconstrained: decryption typically happens when processing messages in utility

--- a/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/message_delivery.nr
@@ -192,7 +192,7 @@ pub global MessageDelivery: MessageDeliveryEnum =
 /// be created, there is no point in delivering the message.
 ///
 /// `delivery_mode` must be one of [`MessageDeliveryEnum`].
-pub(crate) fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
+pub fn do_private_message_delivery<Env, let MESSAGE_PLAINTEXT_LEN: u32>(
     context: &mut PrivateContext,
     encode_into_message_plaintext: fn[Env]() -> [Field; MESSAGE_PLAINTEXT_LEN],
     maybe_note_hash_counter: Option<u32>,

--- a/noir-projects/aztec-nr/aztec/src/messages/msg_type.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/msg_type.nr
@@ -1,10 +1,33 @@
+/// The minimum message type ID that custom message handlers may use.
+///
+/// IDs below this value are reserved for current and future aztec.nr built-in message types (notes, partial notes,
+/// events, etc). If a message is received with a type ID below this threshold that aztec.nr doesn't recognize as its
+/// own, processing will fail with an error instructing the developer to use a higher ID.
+pub global MIN_CUSTOM_MSG_TYPE_ID: u64 = 2.pow_32(16) as u64;
+
+/// Creates a custom message type ID from a local index.
+///
+/// Custom message handlers must use message type IDs >= `MIN_CUSTOM_MSG_TYPE_ID`. This function offsets the provided
+/// `local_id` by that minimum, making it clear at the call site that a custom (non-built-in) message type is being
+/// defined.
+///
+/// ## Examples
+///
+/// ```noir
+/// global MY_MSG_TYPE_ID: u64 = custom_msg_type_id(0);
+/// global MY_OTHER_MSG_TYPE_ID: u64 = custom_msg_type_id(1);
+/// ```
+pub comptime fn custom_msg_type_id(local_id: u64) -> u64 {
+    MIN_CUSTOM_MSG_TYPE_ID + local_id
+}
+
 /// A message containing the information about a private note, i.e. one that has been created fully privately with no
 /// public fields.
 ///
 /// This message contains all information necessary in order to prove existence of the note.
 pub global PRIVATE_NOTE_MSG_TYPE_ID: u64 = 0;
 
-/// A message containing the private informatio of a partial note, i.e. one that has both private and public fields.
+/// A message containing the private information of a partial note, i.e. one that has both private and public fields.
 ///
 /// This message contains all information necessary in order to find the public note information once it is created,
 /// and then prove existence of the note.

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -54,9 +54,10 @@ pub(crate) unconstrained fn get_private_logs(contract_address: AztecAddress) -> 
     CapsuleArray::at(contract_address, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT)
 }
 
-/// Enqueues a note for validation by PXE, so that it becomes aware of a note's existence allowing for later retrieval
-/// via `get_notes` oracle. The note will be scoped to `contract_address`, meaning other contracts will not be able to
-/// access it unless authorized.
+/// Enqueues a note for validation and storage by PXE.
+///
+/// Once validated, the note becomes retrievable via the `get_notes` oracle. The note will be scoped to
+/// `contract_address`, meaning other contracts will not be able to access it unless authorized.
 ///
 /// In order for the note validation and insertion to occur, `validate_and_store_enqueued_notes_and_events` must be
 /// later called. For optimal performance, accumulate as many note validation requests as possible and then validate
@@ -75,7 +76,7 @@ pub(crate) unconstrained fn get_private_logs(contract_address: AztecAddress) -> 
 /// This determines which PXE account can see the note - other accounts will not be able to access it (e.g. other
 /// accounts will not be able to see one another's token balance notes, even in the same PXE) unless authorized. In
 /// most cases `recipient` equals `owner`, but they can differ in scenarios like delegated discovery.
-pub(crate) unconstrained fn enqueue_note_for_validation(
+pub unconstrained fn enqueue_note_for_validation(
     contract_address: AztecAddress,
     owner: AztecAddress,
     storage_slot: Field,
@@ -105,13 +106,19 @@ pub(crate) unconstrained fn enqueue_note_for_validation(
     )
 }
 
-/// Enqueues an event for validation by PXE, so that it can be efficiently validated and then inserted into the event
-/// store.
+/// Enqueues an event for validation and storage by PXE.
+///
+/// This is the primary way for custom message handlers (registered via
+/// [`crate::macros::AztecConfig::custom_message_handler`]) to deliver reassembled events back to PXE after processing
+/// application-specific message formats.
 ///
 /// In order for the event validation and insertion to occur, `validate_and_store_enqueued_notes_and_events` must be
 /// later called. For optimal performance, accumulate as many event validation requests as possible and then validate
 /// them all at the end (which results in PXE minimizing the number of network round-trips).
-pub(crate) unconstrained fn enqueue_event_for_validation(
+///
+/// Note that `validate_and_store_enqueued_notes_and_events` is called by Aztec.nr after processing messages, so custom
+/// message processors do not need to be concerned with this.
+pub unconstrained fn enqueue_event_for_validation(
     contract_address: AztecAddress,
     event_type_id: EventSelector,
     randomness: Field,
@@ -135,9 +142,11 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
     )
 }
 
-/// Validates all note and event validation requests enqueued via `enqueue_note_for_validation` and
-/// `enqueue_event_for_validation`, inserting them into the note database and event store respectively, making them
-/// queryable via `get_notes` oracle and our TS API (PXE::getPrivateEvents).
+/// Validates and stores all enqueued notes and events.
+///
+/// Processes all requests enqueued via [`enqueue_note_for_validation`] and [`enqueue_event_for_validation`], inserting
+/// them into the note database and event store respectively, making them queryable via `get_notes` oracle and our TS
+/// API (PXE::getPrivateEvents).
 ///
 /// This automatically clears both validation request queues, so no further work needs to be done by the caller.
 pub unconstrained fn validate_and_store_enqueued_notes_and_events(contract_address: AztecAddress) {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -12,7 +12,10 @@ use crate::{
     event::{event_interface::EventInterface, EventMessage},
     hash::hash_args,
     messages::{
-        discovery::{ComputeNoteHashAndNullifier, NoteHashAndNullifier, process_message::process_message_plaintext},
+        discovery::{
+            ComputeNoteHashAndNullifier, CustomMessageHandler, NoteHashAndNullifier,
+            process_message::process_message_plaintext,
+        },
         encoding::MESSAGE_PLAINTEXT_LEN,
         logs::{event::encode_private_event_message, note::encode_private_note_message},
         processing::{MessageContext, validate_and_store_enqueued_notes_and_events},
@@ -758,11 +761,13 @@ impl TestEnvironment {
             Option::some(NoteHashAndNullifier { note_hash, inner_nullifier })
         };
 
+        let process_custom_message: Option<CustomMessageHandler<()>> = Option::none();
         self.discover_data_in_message_plaintext(
             message_plaintext,
             opts.contract_address,
             Option::some(note_message.new_note.owner),
             compute_note_hash_and_nullifier,
+            process_custom_message,
         );
     }
 
@@ -863,20 +868,23 @@ impl TestEnvironment {
             )
         };
 
+        let process_custom_message: Option<CustomMessageHandler<()>> = Option::none();
         self.discover_data_in_message_plaintext(
             message_plaintext,
             opts.contract_address,
             Option::some(recipient),
             compute_note_hash_and_nullifier,
+            process_custom_message,
         );
     }
 
-    unconstrained fn discover_data_in_message_plaintext<Env>(
+    unconstrained fn discover_data_in_message_plaintext<ComputeNoteHashAndNullifierEnv, CustomMessageHandlerEnv>(
         self,
         message_plaintext: BoundedVec<Field, MESSAGE_PLAINTEXT_LEN>,
         contract_address: Option<AztecAddress>,
         recipient: Option<AztecAddress>,
-        compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
+        compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ComputeNoteHashAndNullifierEnv>,
+        process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
     ) {
         // This function will emulate the message discovery and processing that would happen in a real contract, based
         // on a message plaintext.
@@ -905,6 +913,7 @@ impl TestEnvironment {
             process_message_plaintext(
                 context.this_address(),
                 compute_note_hash_and_nullifier,
+                process_custom_message,
                 message_plaintext,
                 message_context,
             );

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -42,6 +42,7 @@ members = [
     "contracts/test/benchmarking_contract",
     "contracts/test/child_contract",
     "contracts/test/counter_contract/contract",
+    "contracts/test/custom_message_contract",
     "contracts/test/event_only_contract",
     "contracts/test/import_test_contract",
     "contracts/test/invalid_account_contract",

--- a/noir-projects/noir-contracts/contracts/test/custom_message_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/custom_message_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "custom_message_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/main.nr
@@ -1,0 +1,194 @@
+mod multi_log;
+
+use crate::multi_log::{MULTI_LOG_PARTS_SEPARATOR, MultiLog};
+use ::aztec::{
+    event::{event_interface::compute_private_serialized_event_commitment, EventSelector},
+    messages::{
+        encoding::MAX_MESSAGE_CONTENT_LEN,
+        logs::event::MAX_EVENT_SERIALIZED_LEN,
+        msg_type::custom_msg_type_id,
+        processing::{enqueue_event_for_validation, MessageContext},
+    },
+    oracle::capsules,
+    protocol::{address::AztecAddress, hash::poseidon2_hash, traits::FromField},
+};
+use ::aztec::macros::aztec;
+
+/// Custom message type ID for multi-log messages.
+global MULTI_LOG_MSG_TYPE_ID: u64 = custom_msg_type_id(0);
+
+/// Number of parts this contract splits multi-log events into.
+global NUM_MULTI_LOG_PARTS: u32 = 2;
+
+/// Reassembles multi-log messages.
+///
+/// Parts of an event are accumulated in a single capsule keyed by `message_id`. Each part is placed directly at
+/// its index in a fixed-size array; a part with `len() == 0` hasn't arrived yet. When all parts are present, the
+/// full event is reconstructed and enqueued for validation.
+// #[contract_library_method]
+unconstrained fn handle_multi_log_message(
+    contract_address: AztecAddress,
+    msg_type_id: u64,
+    msg_metadata: u64,
+    msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
+    message_context: MessageContext,
+) {
+    if msg_type_id == MULTI_LOG_MSG_TYPE_ID {
+        let part_number = MultiLog::<NUM_MULTI_LOG_PARTS>::unpack_part_number(msg_metadata);
+
+        // First field of every part's content is the message_id (= randomness).
+        let message_id = msg_content.get(0);
+        let slot = poseidon2_hash([MULTI_LOG_PARTS_SEPARATOR, message_id]);
+
+        // Load (or initialize) the pending event and place this part at its index.
+        let mut multi_log: MultiLog<NUM_MULTI_LOG_PARTS> = capsules::load(contract_address, slot)
+            .unwrap_or(MultiLog { parts: [BoundedVec::new(); NUM_MULTI_LOG_PARTS] });
+        multi_log.parts[part_number] = msg_content;
+
+        if multi_log.is_complete() {
+            // All parts present, reassemble the event in part order.
+            // Part 0 content: [randomness, event_type_id, ...event_fields]
+            // Part N content: [randomness, ...event_fields]
+            let randomness = message_id;
+            let mut event_type_id_field: Field = 0;
+            let mut serialized_event: BoundedVec<Field, MAX_EVENT_SERIALIZED_LEN> =
+                BoundedVec::new();
+
+            for part_index in 0..NUM_MULTI_LOG_PARTS {
+                let content = multi_log.parts[part_index];
+                let content_start = if part_index == 0 {
+                    // Part 0: content[1] is event_type_id, content[2..] are event fields
+                    event_type_id_field = content.get(1);
+                    2
+                } else {
+                    // Other parts: content[1..] are event fields
+                    1
+                };
+
+                for content_index in content_start..content.len() {
+                    serialized_event.push(content.get(content_index));
+                }
+            }
+
+            capsules::delete(contract_address, slot);
+
+            let event_type_id = EventSelector::from_field(event_type_id_field);
+            let event_commitment = compute_private_serialized_event_commitment(
+                serialized_event,
+                randomness,
+                event_type_id_field,
+            );
+
+            enqueue_event_for_validation(
+                contract_address,
+                event_type_id,
+                randomness,
+                serialized_event,
+                event_commitment,
+                message_context.tx_hash,
+                message_context.recipient,
+            );
+        } else {
+            capsules::store(contract_address, slot, multi_log);
+        }
+    } else {
+        panic(f"Unknown message type id: {msg_type_id}");
+    }
+}
+
+/// Tests the custom message handler feature by implementing a multi-log event pattern: a single event is split across
+/// multiple private messages (each carrying a part), and the custom message handler reassembles the parts into the full
+/// event before enqueueing it for validation. This exercises custom message type IDs, the `AztecConfig` builder, and
+/// capsule-based accumulation of out-of-order message parts.
+#[aztec(::aztec::macros::AztecConfig::new().custom_message_handler(crate::handle_multi_log_message))]
+contract CustomMessage {
+    use crate::multi_log::MultiLog;
+    use crate::{MULTI_LOG_MSG_TYPE_ID, NUM_MULTI_LOG_PARTS};
+    use aztec::{
+        event::event_interface::{compute_private_event_commitment, EventInterface},
+        macros::{events::event, functions::external},
+        messages::{
+            encoding::encode_message,
+            message_delivery::{do_private_message_delivery, MessageDelivery},
+        },
+        oracle::random::random,
+        protocol::{address::AztecAddress, traits::ToField},
+    };
+
+    /// An event with 4 fields, too large to demonstrate fitting in one message content.
+    ///
+    /// In practice we'd probably use this for events exceeding MAX_EVENT_SERIALIZED_LEN.
+    #[event]
+    struct MultiLogEvent {
+        value0: Field,
+        value1: Field,
+        value2: Field,
+        value3: Field,
+    }
+
+    /// Emits a multi-log event split across 2 private messages.
+    ///
+    /// This demonstrates the multi-log event pattern: the event data is split into parts, each sent as a separate
+    /// message with a custom message type. The receiver's custom message handler reassembles them.
+    ///
+    /// Each part includes `randomness` as its first content field, which serves as a `message_id` for correlating
+    /// parts belonging to the same multi-log event (allowing multiple multi-log events per transaction).
+    ///
+    /// # Privacy considerations
+    ///
+    /// Each part is sent as a separate onchain message (using private logs as transport). While the content is
+    /// encrypted, the number of logs per transaction is publicly observable. This means an observer can distinguish
+    /// transactions using the multi-log pattern (N logs) from those emitting standard single-log messages, and can
+    /// infer the number of parts from the log count.
+    ///
+    /// Split layout:
+    ///   Part 0 (metadata=pack(0,2)): content = [randomness, event_type_id, value0, value1]
+    ///   Part 1 (metadata=pack(1,2)): content = [randomness, value2, value3]
+    #[external("private")]
+    fn emit_multi_log_event(
+        value0: Field,
+        value1: Field,
+        value2: Field,
+        value3: Field,
+        recipient: AztecAddress,
+    ) {
+        let event = MultiLogEvent { value0, value1, value2, value3 };
+
+        // Safety: randomness produced by the sender, same trust model as standard events.
+        let randomness = unsafe { random() };
+
+        // Emit commitment as nullifier computed from FULL event (same as standard events)
+        let commitment = compute_private_event_commitment(event, randomness);
+        self.context.push_nullifier(commitment);
+
+        let event_type_id = MultiLogEvent::get_event_type_id().to_field();
+
+        // Part 0: randomness (message_id), event_type_id, and first 2 event fields
+        let msg0 = encode_message(
+            MULTI_LOG_MSG_TYPE_ID,
+            MultiLog::<NUM_MULTI_LOG_PARTS>::pack_part_metadata(0),
+            [randomness, event_type_id, value0, value1],
+        );
+        do_private_message_delivery(
+            self.context,
+            || msg0,
+            Option::none(),
+            recipient,
+            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+        );
+
+        // Part 1: randomness (message_id) and remaining event fields
+        let msg1 = encode_message(
+            MULTI_LOG_MSG_TYPE_ID,
+            MultiLog::<NUM_MULTI_LOG_PARTS>::pack_part_metadata(1),
+            [randomness, value2, value3],
+        );
+        do_private_message_delivery(
+            self.context,
+            || msg1,
+            Option::none(),
+            recipient,
+            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+        );
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/multi_log.nr
+++ b/noir-projects/noir-contracts/contracts/test/custom_message_contract/src/multi_log.nr
@@ -1,0 +1,48 @@
+use aztec::{
+    messages::encoding::MAX_MESSAGE_CONTENT_LEN,
+    protocol::{hash::poseidon2_hash_bytes, traits::{Deserialize, Serialize}},
+};
+
+/// Domain separator for deriving the capsule slot of a pending multi-log event from its message_id.
+pub global MULTI_LOG_PARTS_SEPARATOR: Field =
+    comptime { poseidon2_hash_bytes("CUSTOM_MSG::MULTI_LOG_PARTS".as_bytes()) };
+
+/// Accumulates parts of a multi-log event in a single capsule. Each part is placed at its index in the `parts`
+/// array. A part with `len() == 0` has not yet arrived. `N` is the maximum number of parts.
+#[derive(Serialize, Deserialize)]
+pub struct MultiLog<let N: u32> {
+    pub parts: [BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>; N],
+}
+
+impl<let N: u32> MultiLog<N> {
+    /// Returns true if the given part has already been received.
+    pub unconstrained fn has_received_part(self, part_number: u32) -> bool {
+        self.parts[part_number].len() != 0
+    }
+
+    /// Returns true if all parts have been received.
+    pub unconstrained fn is_complete(self) -> bool {
+        let mut complete = true;
+        for i in 0..N {
+            if !self.has_received_part(i) {
+                complete = false;
+            }
+        }
+        complete
+    }
+
+    /// Packs part_number and N (total_parts) into a u64 for use as msg_metadata.
+    pub fn pack_part_metadata(part_number: u32) -> u64 {
+        (part_number as u64) * 0x100000000 + (N as u64)
+    }
+
+    /// Unpacks part_number from msg_metadata.
+    pub unconstrained fn unpack_part_number(packed: u64) -> u32 {
+        (packed / 0x100000000) as u32
+    }
+
+    /// Unpacks total_parts from msg_metadata.
+    pub unconstrained fn unpack_total_parts(packed: u64) -> u32 {
+        (packed % 0x100000000) as u32
+    }
+}

--- a/yarn-project/end-to-end/src/e2e_custom_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_custom_message.test.ts
@@ -1,0 +1,87 @@
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import { BatchCall } from '@aztec/aztec.js/contracts';
+import { Fr } from '@aztec/aztec.js/fields';
+import type { Wallet } from '@aztec/aztec.js/wallet';
+import { BlockNumber } from '@aztec/foundation/branded-types';
+import { CustomMessageContract, type MultiLogEvent } from '@aztec/noir-test-contracts.js/CustomMessage';
+
+import { jest } from '@jest/globals';
+
+import { ensureAccountContractsPublished, setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+describe('CustomMessage - Multi-Log Pattern', () => {
+  let contract: CustomMessageContract;
+  jest.setTimeout(TIMEOUT);
+
+  let wallet: Wallet;
+  let account: AztecAddress;
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({
+      teardown,
+      wallet,
+      accounts: [account],
+    } = await setup(1));
+    await ensureAccountContractsPublished(wallet, [account]);
+    contract = await CustomMessageContract.deploy(wallet).send({ from: account });
+  });
+
+  afterAll(() => teardown());
+
+  it('reassembles a multi-log event from multiple private logs', async () => {
+    const values = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+
+    const tx = await contract.methods
+      .emit_multi_log_event(values[0], values[1], values[2], values[3], account)
+      .send({ from: account });
+
+    const events = await wallet.getPrivateEvents<MultiLogEvent>(CustomMessageContract.events.MultiLogEvent, {
+      contractAddress: contract.address,
+      fromBlock: BlockNumber(tx.blockNumber!),
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [account],
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0].event.value0).toBe(values[0].toBigInt());
+    expect(events[0].event.value1).toBe(values[1].toBigInt());
+    expect(events[0].event.value2).toBe(values[2].toBigInt());
+    expect(events[0].event.value3).toBe(values[3].toBigInt());
+  });
+
+  it('reassembles multiple multi-log events from the same transaction', async () => {
+    const valuesA = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+    const valuesB = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+
+    const tx = await new BatchCall(wallet, [
+      contract.methods.emit_multi_log_event(valuesA[0], valuesA[1], valuesA[2], valuesA[3], account),
+      contract.methods.emit_multi_log_event(valuesB[0], valuesB[1], valuesB[2], valuesB[3], account),
+    ]).send({ from: account });
+
+    const events = await wallet.getPrivateEvents<MultiLogEvent>(CustomMessageContract.events.MultiLogEvent, {
+      contractAddress: contract.address,
+      fromBlock: BlockNumber(tx.blockNumber!),
+      toBlock: BlockNumber(tx.blockNumber! + 1),
+      scopes: [account],
+    });
+
+    expect(events.length).toBe(2);
+
+    // Events may arrive in any order, so match by value0
+    const eventA = events.find(e => e.event.value0 === valuesA[0].toBigInt())!;
+    const eventB = events.find(e => e.event.value0 === valuesB[0].toBigInt())!;
+
+    expect(eventA).toBeDefined();
+    expect(eventA.event.value1).toBe(valuesA[1].toBigInt());
+    expect(eventA.event.value2).toBe(valuesA[2].toBigInt());
+    expect(eventA.event.value3).toBe(valuesA[3].toBigInt());
+
+    expect(eventB).toBeDefined();
+    expect(eventB.event.value1).toBe(valuesB[1].toBigInt());
+    expect(eventB.event.value2).toBe(valuesB[2].toBigInt());
+    expect(eventB.event.value3).toBe(valuesB[3].toBigInt());
+  });
+});


### PR DESCRIPTION
Adds an extension point to Aztec.nr letting devs provide custom message processing logic for their own message types. 

Shows how the extension point allows can be used to implement "multi-part" logs in userland. I must emphasize that the multilog example is a construction to test the custom message handlers mechanism: implementing this made me realize there's many possible design directions for multilogs so that merits more thought (eg privacy considerations, fixed amount of parts vs variable+a termination message, userland vs enshrined in Aztec.nr, etc)

Closes F-105

Applying `backport-to-v4` workflow since all API changes are additive (see analysis of API impact below).

---

## Breaking Changes

None. Existing contracts that use `#[aztec]` with no arguments continue to work identically. The `#[aztec]` macro now accepts an optional `AztecConfig` argument via `#[varargs]`, but the zero-argument form is unchanged.

---

## New API Surface for Contract Developers

### 1. `AztecConfig` builder (`aztec::macros::AztecConfig`)

Configures the `#[aztec]` macro. Currently has one option:

```noir
#[aztec(AztecConfig::new().custom_message_handler(my_handler))]
contract MyContract { ... }
```

### 2. `CustomMessageHandler` type (`aztec::messages::discovery::CustomMessageHandler`)

The signature a custom handler must conform to:

```noir
pub type CustomMessageHandler<Env> = unconstrained fn[Env](
    AztecAddress,       // contract_address
    u64,                // msg_type_id
    u64,                // msg_metadata
    BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,  // msg_content
    MessageContext,     // message_context (contains tx_hash, recipient, etc.)
);
```

The handler must be a `#[contract_library_method]`.

### 3. `custom_msg_type_id` helper (`aztec::messages::msg_type::custom_msg_type_id`)

```noir
pub comptime fn custom_msg_type_id(local_id: u64) -> u64
```

Offsets a local index by `MIN_CUSTOM_MSG_TYPE_ID` (2^16). Custom messages must use IDs >= this threshold; IDs below it are reserved for aztec-nr built-in types.

### 4. `enqueue_note_for_validation` — visibility changed from `pub(crate)` to `pub`

Custom message handlers that reassemble notes can now call this to feed notes back to PXE. Previously internal-only.

### 5. `enqueue_event_for_validation` — visibility changed from `pub(crate)` to `pub`

Same as above but for events. This is the primary way custom handlers deliver reassembled events to PXE.

### 6. `capsules` module — visibility changed from `mod` to `pub mod`

`aztec::capsules` (wrapping `store`, `load`, `delete` oracles for per-contract non-volatile storage) is now publicly accessible. Custom handlers need this to accumulate state across multiple message parts (e.g. multi-log patterns).

### 7. `MessageContext` — already public, now re-exported from `aztec::messages::processing`

Contains `tx_hash` and `recipient`, passed to custom handlers so they can enqueue notes/events with proper provenance.

---

## No Impact on Wallet Implementors / PXE / TS SDK

All custom message processing happens inside the contract's Noir code during `sync_state`. From PXE's perspective, the contract still calls the same `enqueue_note_for_validation` / `enqueue_event_for_validation` / `validate_and_store_enqueued_notes_and_events` pipeline. No new oracles, no TS API changes, no protocol-level changes.

Events reassembled by a custom handler are indistinguishable from standard events once enqueued — `wallet.getPrivateEvents()` works unchanged.

---

## Summary Table

| Change | Who cares | Breaking? |
|---|---|---|
| `#[aztec]` now accepts optional `AztecConfig` | Contract devs (opt-in) | No |
| `AztecConfig::custom_message_handler()` | Contract devs writing custom handlers | N/A (new) |
| `custom_msg_type_id()` helper | Contract devs defining custom msg types | N/A (new) |
| `CustomMessageHandler` type alias | Contract devs | N/A (new) |
| `enqueue_note_for_validation` now `pub` | Contract devs in custom handlers | No |
| `enqueue_event_for_validation` now `pub` | Contract devs in custom handlers | No |
| `capsules` module now `pub` | Contract devs in custom handlers | No |
| `MIN_CUSTOM_MSG_TYPE_ID` constant | Contract devs | N/A (new) |
| Error pages `/errors/1`, `/errors/2` | Devs debugging unknown mesage types | N/A (new) |

