### PR TITLE
chore(ci): run ci job on draft PRs

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     # exclusive with ci3-external.yml: never run on forks
     # (github.event.pull_request.head.repo.fork resolves to nil if not a pull request)
-    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false
+    if: github.event.pull_request.head.repo.fork != true
     environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'master' || '' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Network-level tests and iOS builds are still only run on non-drafts.
