### PR TITLE
chore: ensure consistent HA DB timestamps

### DIFF
--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -14,14 +14,17 @@ import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { GovernanceProposerContract } from '@aztec/ethereum/contracts';
 import type { DeployAztecL1ContractsReturnType } from '@aztec/ethereum/deploy-aztec-l1-contracts';
-import { SlotNumber } from '@aztec/foundation/branded-types';
+import { BlockNumber, SlotNumber } from '@aztec/foundation/branded-types';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { SecretValue } from '@aztec/foundation/config';
 import { withLoggerBindings } from '@aztec/foundation/log/server';
 import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
 import type { TestDateProvider } from '@aztec/foundation/timer';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { type AttestationInfo, getAttestationInfoFromPublishedCheckpoint } from '@aztec/stdlib/block';
-import { type DutyRow, DutyStatus } from '@aztec/validator-ha-signer/types';
+import { PostgresSlashingProtectionDatabase } from '@aztec/validator-ha-signer/db';
+import { type DutyRow, DutyStatus, DutyType } from '@aztec/validator-ha-signer/types';
 
 import { jest } from '@jest/globals';
 import { Pool } from 'pg';
@@ -261,6 +264,9 @@ describe('HA Full Setup', () => {
   });
 
   afterEach(async () => {
+    // Restore any mocked functions
+    jest.restoreAllMocks();
+
     // Clean up database state between tests
     try {
       await mainPool.query('DELETE FROM validator_duties');
@@ -670,5 +676,224 @@ describe('HA Full Setup', () => {
         expect(checkpointValidatorAddresses.has(validatorAddress)).toBe(true);
       }
     }
+  });
+
+  describe('Clock Skew and Timezone Safety', () => {
+    const rollupAddress = EthAddress.random();
+    const validatorAddress = EthAddress.random();
+    it('should not be affected by process.env.TZ changes', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(mainPool);
+      const originalTZ = process.env.TZ;
+
+      try {
+        // Node 1 in UTC creates and signs a duty
+        process.env.TZ = 'UTC';
+        const duty1 = await spDb.tryInsertOrGetExisting({
+          rollupAddress,
+          validatorAddress,
+          slot: SlotNumber(100),
+          blockNumber: BlockNumber(100),
+          dutyType: DutyType.ATTESTATION,
+          messageHash: Buffer32.random().toString(),
+          nodeId: 'node-utc',
+        });
+        expect(duty1.isNew).toBe(true);
+        await spDb.updateDutySigned(
+          rollupAddress,
+          validatorAddress,
+          SlotNumber(100),
+          DutyType.ATTESTATION,
+          '0xsig',
+          duty1.record.lockToken,
+          -1,
+        );
+
+        await sleep(100);
+
+        // Node 2 in Tokyo creates and signs a duty at approximately the same time
+        process.env.TZ = 'Asia/Tokyo';
+        const duty2 = await spDb.tryInsertOrGetExisting({
+          rollupAddress,
+          validatorAddress,
+          slot: SlotNumber(101),
+          blockNumber: BlockNumber(101),
+          dutyType: DutyType.ATTESTATION,
+          messageHash: Buffer32.random().toString(),
+          nodeId: 'node-tokyo',
+        });
+        expect(duty2.isNew).toBe(true);
+        await spDb.updateDutySigned(
+          rollupAddress,
+          validatorAddress,
+          SlotNumber(101),
+          DutyType.ATTESTATION,
+          '0xsig',
+          duty2.record.lockToken,
+          -1,
+        );
+
+        // Verify both duties were stored at correct absolute times (seconds apart, not hours)
+        const result = await mainPool.query<{ slot: string; unix_timestamp: string }>(
+          `SELECT slot, EXTRACT(EPOCH FROM started_at) as unix_timestamp
+           FROM validator_duties
+           WHERE slot IN ('100', '101')
+           ORDER BY slot DESC`,
+        );
+
+        const timestamp1 = parseFloat(result.rows[0].unix_timestamp);
+        const timestamp2 = parseFloat(result.rows[1].unix_timestamp);
+        const diffSeconds = Math.abs(timestamp1 - timestamp2);
+
+        // Should be less than 10 seconds apart (not hours due to timezone interpretation)
+        expect(diffSeconds).toBeLessThan(10);
+      } finally {
+        process.env.TZ = originalTZ;
+      }
+    });
+
+    it('should not delete recent duties when node clock is ahead (using cleanupOldDuties)', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(mainPool);
+
+      // Ensure clean slate for this test
+      await mainPool.query('DELETE FROM validator_duties WHERE slot = $1', ['200']);
+
+      // Create and sign a duty using our actual methods
+      const duty = await spDb.tryInsertOrGetExisting({
+        rollupAddress,
+        validatorAddress,
+        slot: SlotNumber(200),
+        blockNumber: BlockNumber(200),
+        dutyType: DutyType.ATTESTATION,
+        messageHash: Buffer32.random().toString(),
+        nodeId: 'test-node',
+      });
+      expect(duty.isNew).toBe(true);
+
+      await spDb.updateDutySigned(
+        rollupAddress,
+        validatorAddress,
+        SlotNumber(200),
+        DutyType.ATTESTATION,
+        '0xsig',
+        duty.record.lockToken,
+        -1,
+      );
+
+      // Verify duty exists before cleanup
+      const beforeCleanup = await mainPool.query<DutyRow>(
+        `SELECT * FROM validator_duties WHERE slot = $1 AND validator_address = $2`,
+        ['200', validatorAddress.toString().toLowerCase()],
+      );
+      expect(beforeCleanup.rows.length).toBe(1);
+      expect(beforeCleanup.rows[0].status).toBe('signed');
+
+      // Simulate node with clock 2 hours ahead
+      const realNow = Date.now;
+      jest.spyOn(Date, 'now').mockImplementation(() => realNow() + 2 * 60 * 60 * 1000);
+
+      // Use our actual cleanupOldDuties method
+      const numCleaned = await spDb.cleanupOldDuties(60 * 60 * 1000); // 1 hour
+
+      // Should NOT delete the duty we just created (it uses DB's clock, not node's)
+      expect(numCleaned).toBe(0);
+
+      // Verify duty still exists
+      const result = await mainPool.query<DutyRow>(
+        `SELECT * FROM validator_duties WHERE slot = $1 AND validator_address = $2`,
+        ['200', validatorAddress.toString().toLowerCase()],
+      );
+      expect(result.rows.length).toBe(1);
+    });
+
+    it('should delete old duties based on DB time, not node time (using cleanupOldDuties)', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(mainPool);
+
+      // Ensure clean slate for this test
+      await mainPool.query('DELETE FROM validator_duties WHERE slot = $1', ['300']);
+
+      // Create and sign a duty using our actual methods
+      const duty = await spDb.tryInsertOrGetExisting({
+        rollupAddress,
+        validatorAddress,
+        slot: SlotNumber(300),
+        blockNumber: BlockNumber(300),
+        dutyType: DutyType.ATTESTATION,
+        messageHash: Buffer32.random().toString(),
+        nodeId: 'test-node',
+      });
+      expect(duty.isNew).toBe(true);
+
+      await spDb.updateDutySigned(
+        rollupAddress,
+        validatorAddress,
+        SlotNumber(300),
+        DutyType.ATTESTATION,
+        '0xsig',
+        duty.record.lockToken,
+        -1,
+      );
+
+      // Manually backdate the duty to 2 hours old (simulating an old duty from DB's perspective)
+      const updateResult = await mainPool.query(
+        `UPDATE validator_duties
+         SET started_at = CURRENT_TIMESTAMP - INTERVAL '2 hours',
+             completed_at = CURRENT_TIMESTAMP - INTERVAL '2 hours'
+         WHERE slot = $1 AND validator_address = $2`,
+        ['300', validatorAddress.toString().toLowerCase()],
+      );
+      expect(updateResult.rowCount).toBe(1);
+
+      // Verify duty is backdated (should be ~2 hours old)
+      const beforeCleanup = await mainPool.query<DutyRow & { age_seconds: string }>(
+        `SELECT *, EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - started_at)) as age_seconds
+         FROM validator_duties WHERE slot = $1`,
+        ['300'],
+      );
+      expect(beforeCleanup.rows.length).toBe(1);
+      expect(beforeCleanup.rows[0].status).toBe('signed');
+      expect(parseFloat(beforeCleanup.rows[0].age_seconds)).toBeGreaterThan(7000); // ~2 hours in seconds
+
+      // Simulate node with clock 1 hour behind
+      const realNow = Date.now;
+      jest.spyOn(Date, 'now').mockImplementation(() => realNow() - 1 * 60 * 60 * 1000);
+
+      // Use our actual cleanupOldDuties method - should delete based on DB time
+      const numCleaned = await spDb.cleanupOldDuties(60 * 60 * 1000); // 1 hour
+      expect(numCleaned).toBeGreaterThanOrEqual(1);
+
+      // Verify duty was deleted
+      const result = await mainPool.query<DutyRow>(
+        `SELECT * FROM validator_duties WHERE slot = $1 AND validator_address = $2`,
+        ['300', validatorAddress.toString().toLowerCase()],
+      );
+      expect(result.rows.length).toBe(0);
+    });
+
+    it('should not delete recent stuck duties when node clock is ahead (using cleanupOwnStuckDuties)', async () => {
+      const spDb = new PostgresSlashingProtectionDatabase(mainPool);
+
+      // Create a signing duty (stuck, not completed) using our actual method
+      const duty = await spDb.tryInsertOrGetExisting({
+        rollupAddress,
+        validatorAddress,
+        slot: SlotNumber(400),
+        blockNumber: BlockNumber(400),
+        dutyType: DutyType.ATTESTATION,
+        messageHash: Buffer32.random().toString(),
+        nodeId: 'stuck-node',
+      });
+      expect(duty.isNew).toBe(true);
+      // Don't call updateDutySigned - leave it in 'signing' state (stuck)
+
+      // Simulate node with clock 3 hours ahead
+      const realNow = Date.now;
+      jest.spyOn(Date, 'now').mockImplementation(() => realNow() + 3 * 60 * 60 * 1000);
+
+      // Use our actual cleanupOwnStuckDuties method
+      const numCleaned = await spDb.cleanupOwnStuckDuties('stuck-node', 60 * 60 * 1000); // 1 hour
+
+      // Should NOT delete the duty (it uses DB's clock, not node's)
+      expect(numCleaned).toBe(0);
+    });
   });
 });

--- a/yarn-project/validator-ha-signer/README.md
+++ b/yarn-project/validator-ha-signer/README.md
@@ -178,6 +178,16 @@ All signing operations require a `SigningContext` that includes:
 
 Note: `AUTH_REQUEST` duties bypass HA protection since signing multiple times is safe for authentication requests.
 
+## Important Limitations
+
+### Database Isolation Per Rollup Version
+
+**You cannot use the same database to provide slashing protection for validator nodes running on different rollup versions** (e.g., current rollup and old rollup simultaneously).
+
+When the HA signer performs background cleanup via `cleanupOutdatedRollupDuties()`, it removes all duties where the rollup address doesn't match the current rollup address. If two validators running on different rollup versions share the same database, they will delete each other's duties during cleanup.
+
+**Solution**: Use separate databases for validators running on different rollup versions. Each rollup version requires its own isolated slashing protection database.
+
 ## Development
 
 ```bash

--- a/yarn-project/validator-ha-signer/src/db/postgres.test.ts
+++ b/yarn-project/validator-ha-signer/src/db/postgres.test.ts
@@ -1476,15 +1476,16 @@ describe('PostgresSlashingProtectionDatabase', () => {
 
     it('should only clean up old signed duties, not signing or recent duties', async () => {
       const spDb = new PostgresSlashingProtectionDatabase(pool);
-      const oldTimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
 
-      // Insert old signed duties (should be cleaned up)
+      // Insert old signed duties (should be cleaned up) - 2 hours old
       for (let i = 0; i < 2; i++) {
         await pglite.query(
           `INSERT INTO validator_duties (
             rollup_address, validator_address, slot, block_number, block_index_within_checkpoint,
             duty_type, status, message_hash, signature, node_id, lock_token, started_at, completed_at
-          ) VALUES ($1, $2, $3, $4, $5, $6, 'signed', $7, '0xsignature', $8, 'token', $9, $9)`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, 'signed', $7, '0xsignature', $8, 'token',
+            CURRENT_TIMESTAMP - INTERVAL '2 hours',
+            CURRENT_TIMESTAMP - INTERVAL '2 hours')`,
           [
             ROLLUP_ADDRESS.toString(),
             VALIDATOR_ADDRESS.toString(),
@@ -1494,18 +1495,18 @@ describe('PostgresSlashingProtectionDatabase', () => {
             DutyType.BLOCK_PROPOSAL,
             Buffer32.random().toString(),
             NODE_ID,
-            oldTimestamp,
           ],
         );
       }
 
-      // Insert old signing duties (should NOT be cleaned up)
+      // Insert old signing duties (should NOT be cleaned up) - 2 hours old but still signing
       for (let i = 0; i < 2; i++) {
         await pglite.query(
           `INSERT INTO validator_duties (
             rollup_address, validator_address, slot, block_number, block_index_within_checkpoint,
             duty_type, status, message_hash, node_id, lock_token, started_at
-          ) VALUES ($1, $2, $3, $4, $5, $6, 'signing', $7, $8, 'token', $9)`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, 'signing', $7, $8, 'token',
+            CURRENT_TIMESTAMP - INTERVAL '2 hours')`,
           [
             ROLLUP_ADDRESS.toString(),
             VALIDATOR_ADDRESS.toString(),
@@ -1515,7 +1516,6 @@ describe('PostgresSlashingProtectionDatabase', () => {
             DutyType.BLOCK_PROPOSAL,
             Buffer32.random().toString(),
             NODE_ID,
-            oldTimestamp,
           ],
         );
       }

--- a/yarn-project/validator-ha-signer/src/db/postgres.ts
+++ b/yarn-project/validator-ha-signer/src/db/postgres.ts
@@ -254,8 +254,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
    * @returns the number of duties cleaned up
    */
   async cleanupOwnStuckDuties(nodeId: string, maxAgeMs: number): Promise<number> {
-    const cutoff = new Date(Date.now() - maxAgeMs);
-    const result = await this.pool.query(CLEANUP_OWN_STUCK_DUTIES, [nodeId, cutoff]);
+    const result = await this.pool.query(CLEANUP_OWN_STUCK_DUTIES, [nodeId, maxAgeMs]);
     return result.rowCount ?? 0;
   }
 
@@ -277,8 +276,7 @@ export class PostgresSlashingProtectionDatabase implements SlashingProtectionDat
    * @returns the number of duties cleaned up
    */
   async cleanupOldDuties(maxAgeMs: number): Promise<number> {
-    const cutoff = new Date(Date.now() - maxAgeMs);
-    const result = await this.pool.query(CLEANUP_OLD_DUTIES, [cutoff]);
+    const result = await this.pool.query(CLEANUP_OLD_DUTIES, [maxAgeMs]);
     return result.rowCount ?? 0;
   }
 }

--- a/yarn-project/validator-ha-signer/src/db/schema.ts
+++ b/yarn-project/validator-ha-signer/src/db/schema.ts
@@ -203,23 +203,24 @@ WHERE status = 'signed'
 
 /**
  * Query to clean up old duties (for maintenance)
- * Removes SIGNED duties older than a specified timestamp
+ * Removes SIGNED duties older than a specified age (in milliseconds)
  */
 export const CLEANUP_OLD_DUTIES = `
 DELETE FROM validator_duties
 WHERE status = 'signed'
-  AND started_at < $1;
+  AND started_at < CURRENT_TIMESTAMP - ($1 || ' milliseconds')::INTERVAL;
 `;
 
 /**
  * Query to cleanup own stuck duties
  * Removes duties in 'signing' status for a specific node that are older than maxAgeMs
+ * Uses DB's CURRENT_TIMESTAMP to avoid clock skew issues between nodes
  */
 export const CLEANUP_OWN_STUCK_DUTIES = `
 DELETE FROM validator_duties
 WHERE node_id = $1
   AND status = 'signing'
-  AND started_at < $2;
+  AND started_at < CURRENT_TIMESTAMP - ($2 || ' milliseconds')::INTERVAL;
 `;
 
 /**


### PR DESCRIPTION
Fixes [A-543](https://linear.app/aztec-labs/issue/A-543/ensure-no-timezone-issues-when-cleaning-up-old-duties)

Also add note to docs for users to know that they can't use the same DB for nodes running on different rollup versions

Follow-up from comments on #20060