### PR TITLE
feat: better kernelless simulation

### DIFF
--- a/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_kernelless_simulation.test.ts
@@ -5,6 +5,7 @@ import type { Logger } from '@aztec/aztec.js/log';
 import type { AztecNode } from '@aztec/aztec.js/node';
 import { AMMContract } from '@aztec/noir-contracts.js/AMM';
 import { type TokenContract, TokenContractArtifact } from '@aztec/noir-contracts.js/Token';
+import { PendingNoteHashesContract } from '@aztec/noir-test-contracts.js/PendingNoteHashes';
 import { type AbiDecoded, decodeFromAbi, getFunctionArtifact } from '@aztec/stdlib/abi';
 import { computeOuterAuthWitHash } from '@aztec/stdlib/auth-witness';
 
@@ -27,6 +28,7 @@ describe('Kernelless simulation', () => {
 
   let adminAddress: AztecAddress;
   let liquidityProviderAddress: AztecAddress;
+  let swapperAddress: AztecAddress;
 
   let token0: TokenContract;
   let token1: TokenContract;
@@ -41,9 +43,9 @@ describe('Kernelless simulation', () => {
       aztecNode,
       teardown,
       wallet,
-      accounts: [adminAddress, liquidityProviderAddress],
+      accounts: [adminAddress, liquidityProviderAddress, swapperAddress],
       logger,
-    } = await setup(2));
+    } = await setup(3));
 
     ({ contract: token0 } = await deployToken(wallet, adminAddress, 0n, logger));
     ({ contract: token1 } = await deployToken(wallet, adminAddress, 0n, logger));
@@ -58,11 +60,14 @@ describe('Kernelless simulation', () => {
     // We mint the tokens to the liquidity provider
     await mintTokensToPrivate(token0, adminAddress, liquidityProviderAddress, INITIAL_TOKEN_BALANCE);
     await mintTokensToPrivate(token1, adminAddress, liquidityProviderAddress, INITIAL_TOKEN_BALANCE);
+
+    // Note that the swapper only holds token0, not token1
+    await mintTokensToPrivate(token0, adminAddress, swapperAddress, INITIAL_TOKEN_BALANCE);
   });
 
   afterAll(() => teardown());
 
-  describe('AMM', () => {
+  describe('Authwits and gas', () => {
     type Balance = {
       token0: bigint;
       token1: bigint;
@@ -72,6 +77,13 @@ describe('Kernelless simulation', () => {
       return {
         token0: await token0.methods.balance_of_private(lpAddress).simulate({ from: lpAddress }),
         token1: await token1.methods.balance_of_private(lpAddress).simulate({ from: lpAddress }),
+      };
+    }
+
+    async function getAmmBalances(): Promise<Balance> {
+      return {
+        token0: await token0.methods.balance_of_public(amm.address).simulate({ from: adminAddress }),
+        token1: await token1.methods.balance_of_public(amm.address).simulate({ from: adminAddress }),
       };
     }
 
@@ -116,7 +128,7 @@ describe('Kernelless simulation', () => {
       expect(token1AuthwitRequest.data).toHaveLength(9);
 
       const token0CallAuthorizationRequest = await CallAuthorizationRequest.fromFields(token0AuthwitRequest.data);
-      const token1CallAuthorizationRequest = await CallAuthorizationRequest.fromFields(token0AuthwitRequest.data);
+      const token1CallAuthorizationRequest = await CallAuthorizationRequest.fromFields(token1AuthwitRequest.data);
 
       expect(token0CallAuthorizationRequest.selector).toEqual(token1CallAuthorizationRequest.selector);
 
@@ -185,6 +197,135 @@ describe('Kernelless simulation', () => {
 
       expect(token0AuthwitHash).toEqual(token0Authwit.requestHash);
       expect(token1AuthwitHash).toEqual(token1Authwit.requestHash);
+
+      const token0AuthwitFromOffchainEffect = await wallet.createAuthWit(liquidityProviderAddress, {
+        consumer: token0.address,
+        innerHash: token0CallAuthorizationRequest.innerHash,
+      });
+
+      const token1AuthwitFromOffchainEffect = await wallet.createAuthWit(liquidityProviderAddress, {
+        consumer: token1.address,
+        innerHash: token1CallAuthorizationRequest.innerHash,
+      });
+
+      await expect(
+        addLiquidityInteraction.send({
+          from: liquidityProviderAddress,
+          authWitnesses: [token0AuthwitFromOffchainEffect, token1AuthwitFromOffchainEffect],
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('produces matching gas estimates between kernelless and with-kernels simulation', async () => {
+      const swapperBalancesBefore = await getWalletBalances(swapperAddress);
+      const ammBalancesBefore = await getAmmBalances();
+
+      const amountIn = swapperBalancesBefore.token0 / 10n;
+
+      const nonceForAuthwits = Fr.random();
+
+      const amountOutMin = await amm.methods
+        .get_amount_out_for_exact_in(ammBalancesBefore.token0, ammBalancesBefore.token1, amountIn)
+        .simulate({ from: swapperAddress });
+
+      const swapExactTokensInteraction = amm.methods.swap_exact_tokens_for_tokens(
+        token0.address,
+        token1.address,
+        amountIn,
+        amountOutMin,
+        nonceForAuthwits,
+      );
+
+      wallet.enableSimulatedSimulations();
+      const { estimatedGas: swapKernellessGas } = await swapExactTokensInteraction.simulate({
+        from: swapperAddress,
+        includeMetadata: true,
+      });
+
+      const swapAuthwit = await wallet.createAuthWit(swapperAddress, {
+        caller: amm.address,
+        action: token0.methods.transfer_to_public(swapperAddress, amm.address, amountIn, nonceForAuthwits),
+      });
+
+      wallet.disableSimulatedSimulations();
+      const { estimatedGas: swapWithKernelsGas } = await swapExactTokensInteraction.simulate({
+        from: swapperAddress,
+        includeMetadata: true,
+        authWitnesses: [swapAuthwit],
+      });
+
+      logger.info(`Kernelless gas: L2=${swapKernellessGas.gasLimits.l2Gas} DA=${swapKernellessGas.gasLimits.daGas}`);
+      logger.info(
+        `With kernels gas: L2=${swapWithKernelsGas.gasLimits.l2Gas} DA=${swapWithKernelsGas.gasLimits.daGas}`,
+      );
+
+      expect(swapKernellessGas.gasLimits.daGas).toEqual(swapWithKernelsGas.gasLimits.daGas);
+      expect(swapKernellessGas.gasLimits.l2Gas).toEqual(swapWithKernelsGas.gasLimits.l2Gas);
+    });
+  });
+
+  describe('Note squashing', () => {
+    let pendingNoteHashesContract: PendingNoteHashesContract;
+
+    beforeAll(async () => {
+      pendingNoteHashesContract = await PendingNoteHashesContract.deploy(wallet).send({ from: adminAddress });
+    });
+
+    it('squashing produces same gas estimates as with-kernels path', async () => {
+      const mintAmount = 42n;
+
+      const interaction = pendingNoteHashesContract.methods.test_insert_then_get_then_nullify_all_in_nested_calls(
+        mintAmount,
+        adminAddress,
+        adminAddress,
+        await pendingNoteHashesContract.methods.insert_note.selector(),
+        await pendingNoteHashesContract.methods.get_then_nullify_note.selector(),
+      );
+
+      wallet.enableSimulatedSimulations();
+      const { estimatedGas: kernellessGas } = await interaction.simulate({
+        from: adminAddress,
+        includeMetadata: true,
+      });
+
+      wallet.disableSimulatedSimulations();
+      const { estimatedGas: withKernelsGas } = await interaction.simulate({
+        from: adminAddress,
+        includeMetadata: true,
+      });
+
+      logger.info(`Kernelless gas: L2=${kernellessGas.gasLimits.l2Gas} DA=${kernellessGas.gasLimits.daGas}`);
+      logger.info(`With kernels gas: L2=${withKernelsGas.gasLimits.l2Gas} DA=${withKernelsGas.gasLimits.daGas}`);
+
+      expect(kernellessGas.gasLimits.daGas).toEqual(withKernelsGas.gasLimits.daGas);
+      expect(kernellessGas.gasLimits.l2Gas).toEqual(withKernelsGas.gasLimits.l2Gas);
+    });
+  });
+
+  describe('read request verification', () => {
+    let pendingNoteHashesContract: PendingNoteHashesContract;
+
+    beforeAll(async () => {
+      pendingNoteHashesContract = await PendingNoteHashesContract.deploy(wallet).send({ from: adminAddress });
+    });
+
+    it('verifies settled read requests against the note hash tree', async () => {
+      const mintAmount = 100n;
+
+      // Insert a note with real kernels so it lands on-chain
+      wallet.disableSimulatedSimulations();
+      await pendingNoteHashesContract.methods.insert_note(mintAmount, adminAddress, adminAddress).send({
+        from: adminAddress,
+      });
+
+      // Kernelless simulation of reading + nullifying that settled note produces a settled
+      // read request that gets verified against the note hash tree at the anchor block
+      wallet.enableSimulatedSimulations();
+      await expect(
+        pendingNoteHashesContract.methods.get_then_nullify_note(mintAmount, adminAddress).simulate({
+          from: adminAddress,
+        }),
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -9,12 +9,17 @@ import {
   FIXED_L2_GAS,
   GeneratorIndex,
   L2_GAS_PER_CONTRACT_CLASS_LOG,
+  L2_GAS_PER_L2_TO_L1_MSG,
+  L2_GAS_PER_NOTE_HASH,
+  L2_GAS_PER_NULLIFIER,
   L2_GAS_PER_PRIVATE_LOG,
   MAX_CONTRACT_CLASS_LOGS_PER_TX,
   MAX_ENQUEUED_CALLS_PER_TX,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
+  MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
   MAX_NULLIFIERS_PER_TX,
+  MAX_NULLIFIER_READ_REQUESTS_PER_TX,
   MAX_PRIVATE_LOGS_PER_TX,
 } from '@aztec/constants';
 import { arrayNonEmptyLength, padArrayEnd } from '@aztec/foundation/collection';
@@ -38,6 +43,7 @@ import type { FunctionCall } from '@aztec/stdlib/abi';
 import { FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { BlockParameter } from '@aztec/stdlib/block';
 import { Gas } from '@aztec/stdlib/gas';
 import {
   computeNoteHashNonce,
@@ -48,6 +54,7 @@ import {
 } from '@aztec/stdlib/hash';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import {
+  ClaimedLengthArray,
   PartialPrivateTailPublicInputsForPublic,
   PartialPrivateTailPublicInputsForRollup,
   type PrivateExecutionStep,
@@ -56,7 +63,14 @@ import {
   PrivateToPublicAccumulatedData,
   PrivateToRollupAccumulatedData,
   PublicCallRequest,
+  ReadRequestActionEnum,
   ScopedLogHash,
+  ScopedNoteHash,
+  ScopedNullifier,
+  ScopedReadRequest,
+  buildTransientDataHints,
+  getNoteHashReadRequestResetActions,
+  getNullifierReadRequestResetActions,
 } from '@aztec/stdlib/kernel';
 import { PrivateLog } from '@aztec/stdlib/logs';
 import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
@@ -69,6 +83,7 @@ import {
   TxConstantData,
   TxExecutionRequest,
   collectNested,
+  collectNoteHashNullifierCounterMap,
   getFinalMinRevertibleSideEffectCounter,
 } from '@aztec/stdlib/tx';
 
@@ -387,7 +402,8 @@ class OrderedSideEffect<T> {
  * (allowing state overrides) and is much faster, while still generating a valid
  * output that can be sent to the node for public simulation
  * @param privateExecutionResult - The result of the private execution.
- * @param contractStore - A provider for contract data in order to get function names and debug info.
+ * @param debugFunctionNameGetter - A provider for contract data in order to get function names and debug info.
+ * @param node - AztecNode for verifying settled read requests against the note hash and nullifier trees.
  * @param minRevertibleSideEffectCounterOverride - Optional override for the min revertible side effect counter.
  * Used by TXE to simulate account contract behavior (setting the counter before app execution).
  * @returns The simulated proving result.
@@ -395,15 +411,23 @@ class OrderedSideEffect<T> {
 export async function generateSimulatedProvingResult(
   privateExecutionResult: PrivateExecutionResult,
   debugFunctionNameGetter: (contractAddress: AztecAddress, functionSelector: FunctionSelector) => Promise<string>,
+  node: AztecNode,
   minRevertibleSideEffectCounterOverride?: number,
 ): Promise<PrivateKernelExecutionProofOutput<PrivateKernelTailCircuitPublicInputs>> {
-  const siloedNoteHashes: OrderedSideEffect<Fr>[] = [];
-  const nullifiers: OrderedSideEffect<Fr>[] = [];
   const taggedPrivateLogs: OrderedSideEffect<PrivateLog>[] = [];
   const l2ToL1Messages: OrderedSideEffect<ScopedL2ToL1Message>[] = [];
   const contractClassLogsHashes: OrderedSideEffect<ScopedLogHash>[] = [];
   const publicCallRequests: OrderedSideEffect<PublicCallRequest>[] = [];
   const executionSteps: PrivateExecutionStep[] = [];
+
+  // Unsiloed scoped arrays — used for squashing, read request verification,
+  // and siloed at the end only for the surviving items
+  const scopedNoteHashes: ScopedNoteHash[] = [];
+  const scopedNullifiers: ScopedNullifier[] = [];
+
+  // Read requests for verification
+  const noteHashReadRequests: ScopedReadRequest[] = [];
+  const nullifierReadRequests: ScopedReadRequest[] = [];
 
   let publicTeardownCallRequest;
 
@@ -415,38 +439,28 @@ export async function generateSimulatedProvingResult(
 
     const { contractAddress } = execution.publicInputs.callContext;
 
-    const noteHashesFromExecution = await Promise.all(
-      execution.publicInputs.noteHashes
+    scopedNoteHashes.push(
+      ...execution.publicInputs.noteHashes
         .getActiveItems()
-        .filter(noteHash => !noteHash.isEmpty())
-        .map(
-          async noteHash =>
-            new OrderedSideEffect(await siloNoteHash(contractAddress, noteHash.value), noteHash.counter),
-        ),
+        .filter(nh => !nh.isEmpty())
+        .map(nh => nh.scope(contractAddress)),
+    );
+    scopedNullifiers.push(...execution.publicInputs.nullifiers.getActiveItems().map(n => n.scope(contractAddress)));
+
+    taggedPrivateLogs.push(
+      ...(await Promise.all(
+        execution.publicInputs.privateLogs.getActiveItems().map(async metadata => {
+          metadata.log.fields[0] = await poseidon2HashWithSeparator(
+            [contractAddress, metadata.log.fields[0]],
+            GeneratorIndex.PRIVATE_LOG_FIRST_FIELD,
+          );
+          return new OrderedSideEffect(metadata.log, metadata.counter);
+        }),
+      )),
     );
 
-    const nullifiersFromExecution = await Promise.all(
-      execution.publicInputs.nullifiers
-        .getActiveItems()
-        .map(
-          async nullifier =>
-            new OrderedSideEffect(await siloNullifier(contractAddress, nullifier.value), nullifier.counter),
-        ),
-    );
-
-    const privateLogsFromExecution = await Promise.all(
-      execution.publicInputs.privateLogs.getActiveItems().map(async metadata => {
-        metadata.log.fields[0] = await poseidon2HashWithSeparator(
-          [contractAddress, metadata.log.fields[0]],
-          GeneratorIndex.PRIVATE_LOG_FIRST_FIELD,
-        );
-        return new OrderedSideEffect(metadata.log, metadata.counter);
-      }),
-    );
-
-    siloedNoteHashes.push(...noteHashesFromExecution);
-    taggedPrivateLogs.push(...privateLogsFromExecution);
-    nullifiers.push(...nullifiersFromExecution);
+    noteHashReadRequests.push(...execution.publicInputs.noteHashReadRequests.getActiveItems());
+    nullifierReadRequests.push(...execution.publicInputs.nullifierReadRequests.getActiveItems());
     l2ToL1Messages.push(
       ...execution.publicInputs.l2ToL1Msgs
         .getActiveItems()
@@ -486,6 +500,47 @@ export async function generateSimulatedProvingResult(
     });
   }
 
+  const noteHashNullifierCounterMap = collectNoteHashNullifierCounterMap(privateExecutionResult);
+  const minRevertibleSideEffectCounter =
+    minRevertibleSideEffectCounterOverride ?? getFinalMinRevertibleSideEffectCounter(privateExecutionResult);
+
+  const scopedNoteHashesCLA = new ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>(
+    padArrayEnd(scopedNoteHashes, ScopedNoteHash.empty(), MAX_NOTE_HASHES_PER_TX),
+    scopedNoteHashes.length,
+  );
+  const scopedNullifiersCLA = new ClaimedLengthArray<ScopedNullifier, typeof MAX_NULLIFIERS_PER_TX>(
+    padArrayEnd(scopedNullifiers, ScopedNullifier.empty(), MAX_NULLIFIERS_PER_TX),
+    scopedNullifiers.length,
+  );
+
+  const { filteredNoteHashes, filteredNullifiers, filteredPrivateLogs } = squashTransientSideEffects(
+    taggedPrivateLogs,
+    scopedNoteHashesCLA,
+    scopedNullifiersCLA,
+    noteHashNullifierCounterMap,
+    minRevertibleSideEffectCounter,
+  );
+
+  await verifyReadRequests(
+    node,
+    await privateExecutionResult.entrypoint.publicInputs.anchorBlockHeader.hash(),
+    noteHashReadRequests,
+    nullifierReadRequests,
+    scopedNoteHashesCLA,
+    scopedNullifiersCLA,
+  );
+
+  const siloedNoteHashes = await Promise.all(
+    filteredNoteHashes
+      .sort((a, b) => a.counter - b.counter)
+      .map(async nh => new OrderedSideEffect(await siloNoteHash(nh.contractAddress, nh.value), nh.counter)),
+  );
+  const siloedNullifiers = await Promise.all(
+    filteredNullifiers
+      .sort((a, b) => a.counter - b.counter)
+      .map(async n => new OrderedSideEffect(await siloNullifier(n.contractAddress, n.value), n.counter)),
+  );
+
   const constantData = new TxConstantData(
     privateExecutionResult.entrypoint.publicInputs.anchorBlockHeader,
     privateExecutionResult.entrypoint.publicInputs.txContext,
@@ -502,11 +557,9 @@ export async function generateSimulatedProvingResult(
   const getEffect = <T>(orderedSideEffect: OrderedSideEffect<T>) => orderedSideEffect.sideEffect;
 
   const isPrivateOnlyTx = privateExecutionResult.publicFunctionCalldata.length === 0;
-  const minRevertibleSideEffectCounter =
-    minRevertibleSideEffectCounterOverride ?? getFinalMinRevertibleSideEffectCounter(privateExecutionResult);
 
   const [nonRevertibleNullifiers, revertibleNullifiers] = splitOrderedSideEffects(
-    nullifiers.sort(sortByCounter),
+    siloedNullifiers,
     minRevertibleSideEffectCounter,
   );
   const nonceGenerator = privateExecutionResult.firstNullifier;
@@ -520,7 +573,7 @@ export async function generateSimulatedProvingResult(
     // We must make the note hashes unique by using the
     // nonce generator and their index in the tx.
     const uniqueNoteHashes = await Promise.all(
-      siloedNoteHashes.sort(sortByCounter).map(async (orderedSideEffect, i) => {
+      siloedNoteHashes.map(async (orderedSideEffect, i) => {
         const siloedNoteHash = orderedSideEffect.sideEffect;
         const nonce = await computeNoteHashNonce(nonceGenerator, i);
         const uniqueNoteHash = await computeUniqueNoteHash(nonce, siloedNoteHash);
@@ -535,18 +588,18 @@ export async function generateSimulatedProvingResult(
         ScopedL2ToL1Message.empty(),
         MAX_L2_TO_L1_MSGS_PER_TX,
       ),
-      padArrayEnd(taggedPrivateLogs.sort(sortByCounter).map(getEffect), PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
+      padArrayEnd(filteredPrivateLogs.sort(sortByCounter).map(getEffect), PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
       padArrayEnd(
         contractClassLogsHashes.sort(sortByCounter).map(getEffect),
         ScopedLogHash.empty(),
         MAX_CONTRACT_CLASS_LOGS_PER_TX,
       ),
     );
-    gasUsed = meterGasUsed(accumulatedDataForRollup);
+    gasUsed = meterGasUsed(accumulatedDataForRollup, isPrivateOnlyTx);
     inputsForRollup = new PartialPrivateTailPublicInputsForRollup(accumulatedDataForRollup);
   } else {
     const [nonRevertibleNoteHashes, revertibleNoteHashes] = splitOrderedSideEffects(
-      siloedNoteHashes.sort(sortByCounter),
+      siloedNoteHashes,
       minRevertibleSideEffectCounter,
     );
     const nonRevertibleUniqueNoteHashes = await Promise.all(
@@ -560,7 +613,7 @@ export async function generateSimulatedProvingResult(
       minRevertibleSideEffectCounter,
     );
     const [nonRevertibleTaggedPrivateLogs, revertibleTaggedPrivateLogs] = splitOrderedSideEffects(
-      taggedPrivateLogs,
+      filteredPrivateLogs,
       minRevertibleSideEffectCounter,
     );
     const [nonRevertibleContractClassLogHashes, revertibleContractClassLogHashes] = splitOrderedSideEffects(
@@ -589,9 +642,9 @@ export async function generateSimulatedProvingResult(
       padArrayEnd(revertibleContractClassLogHashes, ScopedLogHash.empty(), MAX_CONTRACT_CLASS_LOGS_PER_TX),
       padArrayEnd(revertiblePublicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
     );
-    gasUsed = meterGasUsed(revertibleData).add(meterGasUsed(nonRevertibleData));
+    gasUsed = meterGasUsed(revertibleData, isPrivateOnlyTx).add(meterGasUsed(nonRevertibleData, isPrivateOnlyTx));
     if (publicTeardownCallRequest) {
-      gasUsed.add(privateExecutionResult.entrypoint.publicInputs.txContext.gasSettings.teardownGasLimits);
+      gasUsed = gasUsed.add(privateExecutionResult.entrypoint.publicInputs.txContext.gasSettings.teardownGasLimits);
     }
 
     inputsForPublic = new PartialPrivateTailPublicInputsForPublic(
@@ -617,6 +670,119 @@ export async function generateSimulatedProvingResult(
   };
 }
 
+/**
+ * Squashes transient note hashes and nullifiers, mimicking the behavior
+ * of the reset kernels. Returns the filtered (surviving) scoped items and private logs.
+ */
+function squashTransientSideEffects(
+  taggedPrivateLogs: OrderedSideEffect<PrivateLog>[],
+  scopedNoteHashesCLA: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
+  scopedNullifiersCLA: ClaimedLengthArray<ScopedNullifier, typeof MAX_NULLIFIERS_PER_TX>,
+  noteHashNullifierCounterMap: Map<number, number>,
+  minRevertibleSideEffectCounter: number,
+) {
+  const { numTransientData, hints: transientDataHints } = buildTransientDataHints(
+    scopedNoteHashesCLA,
+    scopedNullifiersCLA,
+    /*futureNoteHashReads=*/ [],
+    /*futureNullifierReads=*/ [],
+    noteHashNullifierCounterMap,
+    minRevertibleSideEffectCounter,
+  );
+
+  const squashedNoteHashCounters = new Set<number>();
+  const squashedNullifierCounters = new Set<number>();
+  for (let i = 0; i < numTransientData; i++) {
+    const hint = transientDataHints[i];
+    squashedNoteHashCounters.add(scopedNoteHashesCLA.array[hint.noteHashIndex].counter);
+    squashedNullifierCounters.add(scopedNullifiersCLA.array[hint.nullifierIndex].counter);
+  }
+
+  return {
+    filteredNoteHashes: scopedNoteHashesCLA.getActiveItems().filter(nh => !squashedNoteHashCounters.has(nh.counter)),
+    filteredNullifiers: scopedNullifiersCLA.getActiveItems().filter(n => !squashedNullifierCounters.has(n.counter)),
+    filteredPrivateLogs: taggedPrivateLogs.filter(log => {
+      for (let i = 0; i < numTransientData; i++) {
+        const hint = transientDataHints[i];
+        const noteHashCounter = scopedNoteHashesCLA.array[hint.noteHashIndex].counter;
+        const nullifierCounter = scopedNullifiersCLA.array[hint.nullifierIndex].counter;
+        if (log.counter > noteHashCounter && log.counter < nullifierCounter) {
+          return false;
+        }
+      }
+      return true;
+    }),
+  };
+}
+
+/**
+ * Verifies settled read requests by checking membership in the note hash and nullifier trees
+ * at the tx's anchor block, mimicking the behavior of the kernels
+ */
+async function verifyReadRequests(
+  node: Pick<AztecNode, 'getNoteHashMembershipWitness' | 'getNullifierMembershipWitness'>,
+  anchorBlockHash: BlockParameter,
+  noteHashReadRequests: ScopedReadRequest[],
+  nullifierReadRequests: ScopedReadRequest[],
+  scopedNoteHashesCLA: ClaimedLengthArray<ScopedNoteHash, typeof MAX_NOTE_HASHES_PER_TX>,
+  scopedNullifiersCLA: ClaimedLengthArray<ScopedNullifier, typeof MAX_NULLIFIERS_PER_TX>,
+) {
+  const noteHashReadRequestsCLA = new ClaimedLengthArray<ScopedReadRequest, typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX>(
+    padArrayEnd(noteHashReadRequests, ScopedReadRequest.empty(), MAX_NOTE_HASH_READ_REQUESTS_PER_TX),
+    noteHashReadRequests.length,
+  );
+  const nullifierReadRequestsCLA = new ClaimedLengthArray<ScopedReadRequest, typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX>(
+    padArrayEnd(nullifierReadRequests, ScopedReadRequest.empty(), MAX_NULLIFIER_READ_REQUESTS_PER_TX),
+    nullifierReadRequests.length,
+  );
+
+  const noteHashResetActions = getNoteHashReadRequestResetActions(
+    noteHashReadRequestsCLA,
+    scopedNoteHashesCLA,
+    /*futureNoteHashes=*/ [],
+  );
+  const nullifierResetActions = getNullifierReadRequestResetActions(
+    nullifierReadRequestsCLA,
+    scopedNullifiersCLA,
+    /*futureNullifiers=*/ [],
+  );
+
+  const settledNoteHashReads: { index: number; value: Fr }[] = [];
+  for (let i = 0; i < noteHashResetActions.actions.length; i++) {
+    if (noteHashResetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
+      settledNoteHashReads.push({ index: i, value: noteHashReadRequests[i].value });
+    }
+  }
+
+  const settledNullifierReads: { index: number; value: Fr }[] = [];
+  for (let i = 0; i < nullifierResetActions.actions.length; i++) {
+    if (nullifierResetActions.actions[i] === ReadRequestActionEnum.READ_AS_SETTLED) {
+      settledNullifierReads.push({ index: i, value: nullifierReadRequests[i].value });
+    }
+  }
+
+  const [noteHashWitnesses, nullifierWitnesses] = await Promise.all([
+    Promise.all(settledNoteHashReads.map(({ value }) => node.getNoteHashMembershipWitness(anchorBlockHash, value))),
+    Promise.all(settledNullifierReads.map(({ value }) => node.getNullifierMembershipWitness(anchorBlockHash, value))),
+  ]);
+
+  for (let i = 0; i < settledNoteHashReads.length; i++) {
+    if (!noteHashWitnesses[i]) {
+      throw new Error(
+        `Note hash read request at index ${settledNoteHashReads[i].index} is reading an unknown note hash: ${settledNoteHashReads[i].value}`,
+      );
+    }
+  }
+
+  for (let i = 0; i < settledNullifierReads.length; i++) {
+    if (!nullifierWitnesses[i]) {
+      throw new Error(
+        `Nullifier read request at index ${settledNullifierReads[i].index} is reading an unknown nullifier: ${settledNullifierReads[i].value}`,
+      );
+    }
+  }
+}
+
 function splitOrderedSideEffects<T>(effects: OrderedSideEffect<T>[], minRevertibleSideEffectCounter: number) {
   const revertibleSideEffects: T[] = [];
   const nonRevertibleSideEffects: T[] = [];
@@ -630,21 +796,24 @@ function splitOrderedSideEffects<T>(effects: OrderedSideEffect<T>[], minRevertib
   return [nonRevertibleSideEffects, revertibleSideEffects];
 }
 
-function meterGasUsed(data: PrivateToRollupAccumulatedData | PrivateToPublicAccumulatedData) {
+function meterGasUsed(data: PrivateToRollupAccumulatedData | PrivateToPublicAccumulatedData, isPrivateOnlyTx: boolean) {
   let meteredDAFields = 0;
   let meteredL2Gas = 0;
 
   const numNoteHashes = arrayNonEmptyLength(data.noteHashes, hash => hash.isEmpty());
   meteredDAFields += numNoteHashes;
-  meteredL2Gas += numNoteHashes * AVM_EMITNOTEHASH_BASE_L2_GAS;
+  const noteHashBaseGas = isPrivateOnlyTx ? L2_GAS_PER_NOTE_HASH : AVM_EMITNOTEHASH_BASE_L2_GAS;
+  meteredL2Gas += numNoteHashes * noteHashBaseGas;
 
   const numNullifiers = arrayNonEmptyLength(data.nullifiers, nullifier => nullifier.isEmpty());
   meteredDAFields += numNullifiers;
-  meteredL2Gas += numNullifiers * AVM_EMITNULLIFIER_BASE_L2_GAS;
+  const nullifierBaseGas = isPrivateOnlyTx ? L2_GAS_PER_NULLIFIER : AVM_EMITNULLIFIER_BASE_L2_GAS;
+  meteredL2Gas += numNullifiers * nullifierBaseGas;
 
   const numL2toL1Messages = arrayNonEmptyLength(data.l2ToL1Msgs, msg => msg.isEmpty());
   meteredDAFields += numL2toL1Messages;
-  meteredL2Gas += numL2toL1Messages * AVM_SENDL2TOL1MSG_BASE_L2_GAS;
+  const l2ToL1MessageBaseGas = isPrivateOnlyTx ? L2_GAS_PER_L2_TO_L1_MSG : AVM_SENDL2TOL1MSG_BASE_L2_GAS;
+  meteredL2Gas += numL2toL1Messages * l2ToL1MessageBaseGas;
 
   const numPrivatelogs = arrayNonEmptyLength(data.privateLogs, log => log.isEmpty());
   // Every private log emits its length as an additional field

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -927,6 +927,7 @@ export class PXE {
           ({ publicInputs, executionSteps } = await generateSimulatedProvingResult(
             privateExecutionResult,
             (addr, sel) => this.contractStore.getDebugFunctionName(addr, sel),
+            this.node,
           ));
         } else {
           // Kernel logic, plus proving of all private functions and kernels.

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -407,6 +407,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     const { publicInputs } = await generateSimulatedProvingResult(
       result,
       (addr, sel) => this.contractStore.getDebugFunctionName(addr, sel),
+      this.stateMachine.node,
       minRevertibleSideEffectCounter,
     );
 

--- a/yarn-project/wallet-sdk/src/base-wallet/utils.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/utils.ts
@@ -126,6 +126,7 @@ async function simulateBatchViaNode(
   const provingResult = await generateSimulatedProvingResult(
     privateResult,
     (_contractAddress: AztecAddress, _functionSelector: FunctionSelector) => Promise.resolve(''),
+    node,
     1, // minRevertibleSideEffectCounter
   );
 


### PR DESCRIPTION
Introduces squashing and read request verification for the kernelless simulations.
It also adds some smoke testing, so we can have at least some sort of equivalence assurances before killing the brillig kernels
