### PR TITLE
test: remove scope expansion to see what fails on CI

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -526,22 +526,13 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     isStaticCall = isStaticCall || this.callContext.isStaticCall;
 
-    // When scopes are set and the target contract is a registered account (has keys in the keyStore),
-    // expand scopes to include it so nested private calls can sync and read the contract's own notes.
-    // We only expand for registered accounts because the log service needs the recipient's keys to derive
-    // tagging secrets, which are only available for registered accounts.
-    const expandedScopes =
-      this.scopes && (await this.keyStore.hasAccount(targetContractAddress))
-        ? [...this.scopes, targetContractAddress]
-        : this.scopes;
-
     await this.contractSyncService.ensureContractSynced(
       targetContractAddress,
       functionSelector,
       this.utilityExecutor,
       this.anchorBlockHeader,
       this.jobId,
-      expandedScopes,
+      this.scopes,
     );
 
     const targetArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(
@@ -579,7 +570,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       totalPublicCalldataCount: this.totalPublicCalldataCount,
       sideEffectCounter,
       log: this.log,
-      scopes: expandedScopes,
+      scopes: this.scopes,
       senderForTags: this.senderForTags,
       simulator: this.simulator!,
     });


### PR DESCRIPTION
## Summary
- Removes the `expandedScopes` logic in `private_execution_oracle.ts` that auto-expands scopes to include the target contract address when it's a registered account
- This is a test PR to identify which CI tests depend on scope expansion for nested private calls (e.g. authwit verification)

## Test plan
- Let CI run and observe failures