### PR TITLE
fix: bootstrap just one contract

### DIFF
--- a/noir-projects/noir-contracts/scripts/bootstrap_just_one_contract.sh
+++ b/noir-projects/noir-contracts/scripts/bootstrap_just_one_contract.sh
@@ -41,13 +41,46 @@ echo "Transpiling contract..."
 TRANSPILER=${TRANSPILER:-../../../avm-transpiler/target/release/avm-transpiler}
 "$TRANSPILER" "../target/$JSON_NAME.json" "../target/$JSON_NAME.json"
 
-# Postprocess the contract
-echo "Postprocessing contract..."
+# Strip aztec nr prefix
+echo "Stripping aztec nr prefix..."
+STRIP_AZTEC_NR_PREFIX=${STRIP_AZTEC_NR_PREFIX:-./strip_aztec_nr_prefix.sh}
+$STRIP_AZTEC_NR_PREFIX "../target/$JSON_NAME.json"
+
+# Generate verification keys for private functions
+echo "Generating verification keys..."
+BB=${BB:-../../../barretenberg/cpp/build/bin/bb}
 BB_HASH=${BB_HASH:-$(cd ../../../ && git ls-tree -r HEAD | grep 'barretenberg/cpp' | awk '{print $3}' | git hash-object --stdin)}
 echo "Using BB hash $BB_HASH"
 
 tempDir="../target/tmp"
 mkdir -p "$tempDir"
 
-BB_HASH=$BB_HASH node ./postprocess_contract.js "../target/$JSON_NAME.json" "$tempDir"
+json_path="../target/$JSON_NAME.json"
+num_functions=$(jq '.functions | length' "$json_path")
+
+for ((i=0; i<num_functions; i++)); do
+  func=$(jq -c ".functions[$i]" "$json_path")
+  name=$(echo "$func" | jq -r '.name')
+
+  # Check if the function is private (not public and not unconstrained).
+  is_public=$(echo "$func" | jq '(.custom_attributes | index("public") != null)')
+  is_unconstrained=$(echo "$func" | jq '.is_unconstrained')
+
+  if [ "$is_public" == "true" ] || [ "$is_unconstrained" == "true" ]; then
+    echo "Skipping VK for $name (public or unconstrained)"
+    continue
+  fi
+
+  echo "Generating VK for $name..."
+  bytecode_b64=$(echo "$func" | jq -r '.bytecode')
+  outdir=$(mktemp -d -p "$tempDir")
+  echo "$bytecode_b64" | base64 -d | gunzip | "$BB" write_vk --scheme chonk -b - -o "$outdir" -v
+  vk=$(cat "$outdir/vk" | base64 -w 0)
+
+  # Update the function's verification_key in the JSON
+  jq --arg vk "$vk" --argjson idx "$i" '.functions[$idx].verification_key = $vk' "$json_path" > "$json_path.tmp"
+  mv "$json_path.tmp" "$json_path"
+done
+
+echo "Done."
 


### PR DESCRIPTION
The command was broken so I told Claude to fix it.

I also added the `boo1` alias to my `.zshrc` aliases (boo1 at the end of the file):

```bash
# Function to get the aztec-packages root directory
# Alternatively you could use $(git rev-parse --show-toplevel)
get_aztec_packages() {
    local current_dir=$(pwd)
    local path1="/mnt/user-data/jan/aztec-packages1"
    local path2="/mnt/user-data/jan/aztec-packages2"
    local path3="/mnt/user-data/jan/aztec-packages3"

    if [[ "$current_dir" == "$path1"* ]]; then
        echo "$path1/"
    elif [[ "$current_dir" == "$path2"* ]]; then
        echo "$path2/"
    elif [[ "$current_dir" == "$path3"* ]]; then
        echo "$path3/"
    else
        return 1
    fi
}

# Entry commands to each repo
alias cda1="cd /mnt/user-data/jan/aztec-packages1"
alias cda2="cd /mnt/user-data/jan/aztec-packages2"
alias cda3="cd /mnt/user-data/jan/aztec-packages3"

# Update aztec-packages aliases to be relative to the current repository instance
alias cdd="cd $(get_aztec_packages)/docs"
alias cdar="cd $(get_aztec_packages)/yarn-project/archiver"
alias cde="cd $(get_aztec_packages)/yarn-project/end-to-end"
alias cdy="cd $(get_aztec_packages)/yarn-project"
alias cdl1="cd $(get_aztec_packages)/l1-contracts"
alias cdnc="cd $(get_aztec_packages)/noir-projects/noir-contracts"
alias cdnp="cd $(get_aztec_packages)/noir-projects/noir-protocol-circuits"
alias cdnpt="cd $(get_aztec_packages)/yarn-project/noir-protocol-circuits-types"
alias cdaj="cd $(get_aztec_packages)/yarn-project/aztec.js"
alias cdc="cd $(get_aztec_packages)/yarn-project/cli"
alias cdp="cd $(get_aztec_packages)/yarn-project/pxe"
alias cdt="cd $(get_aztec_packages)/yarn-project/txe"
alias cdf="cd $(get_aztec_packages)/yarn-project/foundation"
alias cds="cd $(get_aztec_packages)/yarn-project/simulator"
alias cdpc="cd $(get_aztec_packages)/yarn-project/protocol-contracts"
alias cdan="cd $(get_aztec_packages)/noir-projects/aztec-nr/aztec"
alias cdstd="cd $(get_aztec_packages)/yarn-project/stdlib"

# Update the bootstrap aliases to use relative paths and print the directory
alias boo='clear && ./bootstrap.sh'
alias boof='clear && echo "Compiling in $(get_aztec_packages)" && $(get_aztec_packages)/bootstrap.sh'
alias boony='clear && echo "Compiling in $(get_aztec_packages)" && $(get_aztec_packages)/noir-projects/bootstrap.sh && $(get_aztec_packages)/yarn-project/boot>
alias boonc='clear && echo "Compiling in $(get_aztec_packages)" && $(get_aztec_packages)/noir-projects/noir-contracts/bootstrap.sh && $(get_aztec_packages)/ya>

# Update nargo and nf aliases
alias nargo="$(get_aztec_packages)/noir/noir-repo/target/release/nargo"
alias nf="(cd $(get_aztec_packages)/noir-projects/noir-protocol-circuits/crates/types && nargo fmt) && (cd $(get_aztec_packages)/noir-projects/noir-contracts >
alias nt="clear && nargo test --silence-warnings --show-output"
alias nto="clear && nargo test --oracle-resolver http://localhost:8080 --silence-warnings --show-output"
alias nco="clear && nargo compile --package"
alias nce="clear && nargo check --package"

alias gtget="gt get --no-restack"
alias gtsync=" gt sync --no-restack"

alias e2e="cde && clear && yarn test:e2e"
alias flame="$(get_aztec_packages)/noir-projects/noir-contracts/scripts/flamegraph.sh"

boo1() {
    clear
    echo "Compiling in $(get_aztec_packages)"
    $(get_aztec_packages)/noir-projects/noir-contracts/scripts/bootstrap_just_one_contract.sh "$@" && $(get_aztec_packages)/yarn-project/bootstrap.sh
}
```

With this alias I can then rebuild e.g. only the AMM contract and the yarn-project with:

`boo1 amm_contract AMM`