### PR TITLE
feat: automatically stop node from signalling

### DIFF
--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -23,7 +23,7 @@ export interface IEmpireBase {
     signer: (msg: TypedDataDefinition) => Promise<Hex>,
   ): Promise<L1TxRequest>;
   /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
-  hasPayloadBeenProposed(payload: Hex): Promise<boolean>;
+  hasPayloadBeenProposed(payload: Hex, fromBlock: bigint): Promise<boolean>;
 }
 
 export function encodeSignal(payload: Hex): Hex {

--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -22,6 +22,8 @@ export interface IEmpireBase {
     signerAddress: Hex,
     signer: (msg: TypedDataDefinition) => Promise<Hex>,
   ): Promise<L1TxRequest>;
+  /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
+  hasPayloadBeenProposed(payload: Hex): Promise<boolean>;
 }
 
 export function encodeSignal(payload: Hex): Hex {

--- a/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
@@ -126,6 +126,12 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
     };
   }
 
+  /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
+  public async hasPayloadBeenProposed(payload: Hex): Promise<boolean> {
+    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock: 0n, strict: true });
+    return events.length > 0;
+  }
+
   public listenToSubmittablePayloads(callback: (args: { payload: `0x${string}`; round: bigint }) => unknown) {
     return this.proposer.watchEvent.PayloadSubmittable(
       {},

--- a/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/empire_slashing_proposer.ts
@@ -127,8 +127,8 @@ export class EmpireSlashingProposerContract extends EventEmitter implements IEmp
   }
 
   /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
-  public async hasPayloadBeenProposed(payload: Hex): Promise<boolean> {
-    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock: 0n, strict: true });
+  public async hasPayloadBeenProposed(payload: Hex, fromBlock: bigint): Promise<boolean> {
+    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock, strict: true });
     return events.length > 0;
   }
 

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -110,6 +110,12 @@ export class GovernanceProposerContract implements IEmpireBase {
     };
   }
 
+  /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
+  public async hasPayloadBeenProposed(payload: Hex): Promise<boolean> {
+    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock: 0n, strict: true });
+    return events.length > 0;
+  }
+
   public async submitRoundWinner(
     round: bigint,
     l1TxUtils: L1TxUtils,

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -111,8 +111,8 @@ export class GovernanceProposerContract implements IEmpireBase {
   }
 
   /** Checks if a payload was ever submitted to governance via submitRoundWinner. */
-  public async hasPayloadBeenProposed(payload: Hex): Promise<boolean> {
-    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock: 0n, strict: true });
+  public async hasPayloadBeenProposed(payload: Hex, fromBlock: bigint): Promise<boolean> {
+    const events = await this.proposer.getEvents.PayloadSubmitted({ payload }, { fromBlock, strict: true });
     return events.length > 0;
   }
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -418,4 +418,119 @@ describe('SequencerPublisher', () => {
       ),
     ).toEqual(false);
   });
+
+  it('stops signalling when payload was previously proposed', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(true);
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(false);
+  });
+
+  it('continues signalling when payload was NOT proposed', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(false);
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(true);
+  });
+
+  it('caches proposed result and prevents repeated L1 calls', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValue(true);
+
+    await publisher.enqueueGovernanceCastSignal(
+      govPayload,
+      SlotNumber(2),
+      1n,
+      EthAddress.fromString(testHarnessAttesterAccount.address),
+      msg => testHarnessAttesterAccount.signTypedData(msg),
+    );
+
+    await publisher.enqueueGovernanceCastSignal(
+      govPayload,
+      SlotNumber(3),
+      2n,
+      EthAddress.fromString(testHarnessAttesterAccount.address),
+      msg => testHarnessAttesterAccount.signTypedData(msg),
+    );
+
+    expect(governanceProposerContract.hasPayloadBeenProposed).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on transient RPC failure and succeeds', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed
+      .mockRejectedValueOnce(new Error('RPC error'))
+      .mockRejectedValueOnce(new Error('RPC error'))
+      .mockResolvedValueOnce(false);
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(true);
+  });
+
+  it('fails closed on persistent RPC failure', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed.mockRejectedValue(new Error('RPC error'));
+
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(false);
+  });
+
+  it('does not cache false result and re-checks on subsequent calls', async () => {
+    const { govPayload } = mockGovernancePayload();
+    governanceProposerContract.hasPayloadBeenProposed.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    // First call: not proposed, signalling proceeds
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(2),
+        1n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(true);
+
+    // Second call: now proposed, signalling stops
+    expect(
+      await publisher.enqueueGovernanceCastSignal(
+        govPayload,
+        SlotNumber(3),
+        2n,
+        EthAddress.fromString(testHarnessAttesterAccount.address),
+        msg => testHarnessAttesterAccount.signTypedData(msg),
+      ),
+    ).toEqual(false);
+
+    expect(governanceProposerContract.hasPayloadBeenProposed).toHaveBeenCalledTimes(2);
+  });
 });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -126,6 +126,7 @@ describe('SequencerPublisher', () => {
 
     rollup = mock<RollupContract>();
     rollup.validateHeader.mockReturnValue(Promise.resolve());
+    rollup.getL1StartBlock.mockResolvedValue(1n);
     (rollup as any).address = mockRollupAddress;
     forwardSpy = jest.spyOn(Multicall3, 'forward');
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -697,8 +697,9 @@ export class SequencerPublisher {
     const cacheKey = payload.toString();
     if (!this.payloadProposedCache.has(cacheKey)) {
       try {
+        const l1StartBlock = await this.rollupContract.getL1StartBlock();
         const proposed = await retry(
-          () => base.hasPayloadBeenProposed(payload.toString()),
+          () => base.hasPayloadBeenProposed(payload.toString(), l1StartBlock),
           'Check if payload was proposed',
           makeBackoff([0, 1, 2]),
           this.log,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -32,6 +32,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature, type ViemSignature } from '@aztec/foundation/eth-signature';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { bufferToHex } from '@aztec/foundation/string';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { EmpireBaseAbi, ErrorsAbi, RollupAbi } from '@aztec/l1-artifacts';
@@ -112,6 +113,7 @@ export class SequencerPublisher {
   protected lastActions: Partial<Record<Action, SlotNumber>> = {};
 
   private isPayloadEmptyCache: Map<string, boolean> = new Map<string, boolean>();
+  private payloadProposedCache: Set<string> = new Set<string>();
 
   protected log: Logger;
   protected ethereumSlotDuration: bigint;
@@ -688,6 +690,31 @@ export class SequencerPublisher {
 
     if (await this.isPayloadEmpty(payload)) {
       this.log.warn(`Skipping vote cast for payload with empty code`);
+      return false;
+    }
+
+    // Check if payload was already submitted to governance
+    const cacheKey = payload.toString();
+    if (!this.payloadProposedCache.has(cacheKey)) {
+      try {
+        const proposed = await retry(
+          () => base.hasPayloadBeenProposed(payload.toString()),
+          'Check if payload was proposed',
+          makeBackoff([0, 1, 2]),
+          this.log,
+          true,
+        );
+        if (proposed) {
+          this.payloadProposedCache.add(cacheKey);
+        }
+      } catch (err) {
+        this.log.warn(`Failed to check if payload ${payload} was proposed after retries, skipping signal`, err);
+        return false;
+      }
+    }
+
+    if (this.payloadProposedCache.has(cacheKey)) {
+      this.log.info(`Payload ${payload} was already proposed to governance, stopping signals`);
       return false;
     }
 


### PR DESCRIPTION
## Summary

Nodes configured with `GOVERNANCE_PROPOSER_PAYLOAD_ADDRESS` currently keep signalling every slot indefinitely, even after the payload has been submitted to governance via `submitRoundWinner`. This wastes gas and requires manual intervention to stop.

This PR adds automatic detection: before signalling, the publisher queries `PayloadSubmitted` event logs from the GovernanceProposer contract to check if the configured payload was already proposed. If so, signalling is silently stopped with an info log.

- Added `hasPayloadBeenProposed(payload)` to the `IEmpireBase` interface and both implementations (`GovernanceProposerContract`, `EmpireSlashingProposerContract`) — queries `PayloadSubmitted` events filtered by the indexed `payload` parameter
- Added a proposed-payload check in `enqueueCastSignalHelper` with retry logic (3 attempts with backoff) and fail-closed semantics on persistent RPC failure
- Results are cached in an in-memory `Set<string>` — only `true` (terminal state) is cached; `false` is re-checked each slot to detect the transition
- Added 6 unit tests covering: stop on proposed, continue on not-proposed, caching behavior, retry on transient failure, fail-closed on persistent failure, and re-check of non-cached false results

Fixes A-508