### PR TITLE
refactor: replace undefined scopes with 'ALL_SCOPES' string literal

### DIFF
--- a/boxes/boxes/vanilla/app/embedded-wallet.ts
+++ b/boxes/boxes/vanilla/app/embedded-wallet.ts
@@ -366,6 +366,7 @@ export class EmbeddedWallet extends BaseWallet {
       skipTxValidation: true,
       skipFeeEnforcement: true,
       overrides: { contracts: contractOverrides },
+      scopes: this.scopesFor(opts.from)
     });
   }
 }

--- a/yarn-project/cli-wallet/src/cmds/check_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/check_tx.ts
@@ -88,7 +88,7 @@ async function inspectTx(wallet: CLIWallet, aztecNode: AztecNode, txHash: TxHash
     for (const nullifier of effects.nullifiers) {
       const deployed = deployNullifiers[nullifier.toString()];
       const note = deployed
-        ? (await wallet.getNotes({ siloedNullifier: nullifier, contractAddress: deployed }))[0]
+        ? (await wallet.getNotes({ siloedNullifier: nullifier, contractAddress: deployed, scopes: 'ALL_SCOPES' }))[0]
         : undefined;
       const initialized = initNullifiers[nullifier.toString()];
       const registered = classNullifiers[nullifier.toString()];

--- a/yarn-project/cli-wallet/src/utils/wallet.ts
+++ b/yarn-project/cli-wallet/src/utils/wallet.ts
@@ -13,13 +13,14 @@ import { AccountManager, type Aliased, type SimulateOptions } from '@aztec/aztec
 import type { DefaultAccountEntrypointOptions } from '@aztec/entrypoints/account';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { LogFn } from '@aztec/foundation/log';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import type { PXEConfig } from '@aztec/pxe/config';
 import type { PXE } from '@aztec/pxe/server';
 import { createPXE, getPXEConfig } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { deriveSigningKey } from '@aztec/stdlib/keys';
-import { NoteDao } from '@aztec/stdlib/note';
 import type { NotesFilter } from '@aztec/stdlib/note';
+import { NoteDao } from '@aztec/stdlib/note';
 import type { TxProvingResult, TxSimulationResult } from '@aztec/stdlib/tx';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 import { BaseWallet, type FeeOptions } from '@aztec/wallet-sdk/base-wallet';
@@ -226,11 +227,19 @@ export class CLIWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     from: AztecAddress,
     feeOptions: FeeOptions,
+    scopes: AccessScopes,
     skipTxValidation?: boolean,
     skipFeeEnforcement?: boolean,
   ): Promise<TxSimulationResult> {
     if (from.equals(AztecAddress.ZERO)) {
-      return super.simulateViaEntrypoint(executionPayload, from, feeOptions, skipTxValidation, skipFeeEnforcement);
+      return super.simulateViaEntrypoint(
+        executionPayload,
+        from,
+        feeOptions,
+        scopes,
+        skipTxValidation,
+        skipFeeEnforcement,
+      );
     }
 
     const feeExecutionPayload = await feeOptions.walletFeePaymentMethod?.getExecutionPayload();
@@ -258,6 +267,7 @@ export class CLIWallet extends BaseWallet {
       overrides: {
         contracts: { [from.toString()]: { instance, artifact } },
       },
+      scopes,
     });
   }
 

--- a/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/test_wallet.ts
@@ -16,6 +16,7 @@ import { AccountManager, type SendOptions } from '@aztec/aztec.js/wallet';
 import type { DefaultAccountEntrypointOptions } from '@aztec/entrypoints/account';
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
 import { GrumpkinScalar } from '@aztec/foundation/curves/grumpkin';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import { type PXEConfig, getPXEConfig } from '@aztec/pxe/config';
 import { PXE, type PXECreationOptions, createPXE } from '@aztec/pxe/server';
 import { AuthWitness } from '@aztec/stdlib/auth-witness';
@@ -227,18 +228,18 @@ export class TestWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     from: AztecAddress,
     feeOptions: FeeOptions,
+    scopes: AccessScopes,
     skipTxValidation?: boolean,
     skipFeeEnforcement?: boolean,
-    scopes?: AztecAddress[],
   ): Promise<TxSimulationResult> {
     if (!this.simulatedSimulations) {
       return super.simulateViaEntrypoint(
         executionPayload,
         from,
         feeOptions,
+        scopes,
         skipTxValidation,
         skipFeeEnforcement,
-        scopes,
       );
     }
 

--- a/yarn-project/pxe/src/access_scopes.ts
+++ b/yarn-project/pxe/src/access_scopes.ts
@@ -1,0 +1,9 @@
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+
+/**
+ * Controls which accounts' private state and keys are accessible during execution.
+ * - `'ALL_SCOPES'`: All registered accounts' private state and keys are accessible.
+ * - `AztecAddress[]` with entries: Only the specified accounts' private state and keys are accessible.
+ * - `[]` (empty array): Deny-all. No private state is visible and no keys are accessible.
+ */
+export type AccessScopes = 'ALL_SCOPES' | AztecAddress[];

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -87,6 +87,7 @@ import {
   getFinalMinRevertibleSideEffectCounter,
 } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
 import type { AddressStore } from '../storage/address_store/address_store.js';
 import type { CapsuleStore } from '../storage/capsule_store/capsule_store.js';
@@ -117,8 +118,8 @@ export type ContractSimulatorRunOpts = {
   anchorBlockHeader: BlockHeader;
   /** The address used as a tagging sender when emitting private logs. */
   senderForTags?: AztecAddress;
-  /** The accounts whose notes we can access in this call. Defaults to all. */
-  scopes?: AztecAddress[];
+  /** The accounts whose notes we can access in this call. */
+  scopes: AccessScopes;
   /** The job ID for staged writes. */
   jobId: string;
 };
@@ -311,7 +312,7 @@ export class ContractFunctionSimulator {
     call: FunctionCall,
     authwits: AuthWitness[],
     anchorBlockHeader: BlockHeader,
-    scopes: AztecAddress[] | undefined,
+    scopes: AccessScopes,
     jobId: string,
   ): Promise<Fr[]> {
     const entryPointArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(call.to, call.selector);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -146,6 +146,7 @@ describe('Oracle Version Check test suite', () => {
         anchorBlockHeader,
         senderForTags,
         jobId: 'test',
+        scopes: 'ALL_SCOPES',
       });
 
       expect(utilityAssertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.test.ts
@@ -222,6 +222,7 @@ describe('Private Execution test suite', () => {
       anchorBlockHeader,
       senderForTags,
       jobId: TEST_JOB_ID,
+      scopes: 'ALL_SCOPES',
     });
   };
 
@@ -330,11 +331,12 @@ describe('Private Execution test suite', () => {
           contractAddress,
           contractStore,
           functionToInvokeAfterSync,
-          call => utilityExecutor(call, undefined),
+          utilityExecutor,
           noteStore,
           aztecNode,
           anchorBlockHeader,
           jobId,
+          'ALL_SCOPES',
         );
       },
     );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -25,6 +25,7 @@ import {
   type TxContext,
 } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../../access_scopes.js';
 import type { ContractSyncService } from '../../contract_sync/contract_sync_service.js';
 import { NoteService } from '../../notes/note_service.js';
 import type { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_store.js';
@@ -43,7 +44,7 @@ export type PrivateExecutionOracleArgs = Omit<UtilityExecutionOracleArgs, 'contr
   txContext: TxContext;
   callContext: CallContext;
   /** Needed to trigger contract synchronization before nested calls */
-  utilityExecutor: (call: FunctionCall, scopes: undefined | AztecAddress[]) => Promise<void>;
+  utilityExecutor: (call: FunctionCall, scopes: AccessScopes) => Promise<void>;
   executionCache: HashedValuesCache;
   noteCache: ExecutionNoteCache;
   taggingIndexCache: ExecutionTaggingIndexCache;
@@ -78,7 +79,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
   private readonly argsHash: Fr;
   private readonly txContext: TxContext;
   private readonly callContext: CallContext;
-  private readonly utilityExecutor: (call: FunctionCall, scopes: undefined | AztecAddress[]) => Promise<void>;
+  private readonly utilityExecutor: (call: FunctionCall, scopes: AccessScopes) => Promise<void>;
   private readonly executionCache: HashedValuesCache;
   private readonly noteCache: ExecutionNoteCache;
   private readonly taggingIndexCache: ExecutionTaggingIndexCache;
@@ -531,7 +532,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     // We only expand for registered accounts because the log service needs the recipient's keys to derive
     // tagging secrets, which are only available for registered accounts.
     const expandedScopes =
-      this.scopes && (await this.keyStore.hasAccount(targetContractAddress))
+      this.scopes !== 'ALL_SCOPES' && (await this.keyStore.hasAccount(targetContractAddress))
         ? [...this.scopes, targetContractAddress]
         : this.scopes;
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -220,6 +220,7 @@ describe('Utility Execution test suite', () => {
         capsuleStore,
         privateEventStore,
         jobId: 'test-job-id',
+        scopes: 'ALL_SCOPES',
       });
     });
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -20,6 +20,7 @@ import type { NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, Capsule } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../../access_scopes.js';
 import { EventService } from '../../events/event_service.js';
 import { LogService } from '../../logs/log_service.js';
 import { NoteService } from '../../notes/note_service.js';
@@ -58,7 +59,7 @@ export type UtilityExecutionOracleArgs = {
   privateEventStore: PrivateEventStore;
   jobId: string;
   log?: ReturnType<typeof createLogger>;
-  scopes?: AztecAddress[];
+  scopes: AccessScopes;
 };
 
 /**
@@ -85,7 +86,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly privateEventStore: PrivateEventStore;
   protected readonly jobId: string;
   protected log: ReturnType<typeof createLogger>;
-  protected readonly scopes?: AztecAddress[];
+  protected readonly scopes: AccessScopes;
 
   constructor(args: UtilityExecutionOracleArgs) {
     this.contractAddress = args.contractAddress;
@@ -129,7 +130,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    */
   public async utilityGetKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest> {
     // If scopes are defined, check that the key belongs to an account in the scopes.
-    if (this.scopes && this.scopes.length > 0) {
+    if (this.scopes !== 'ALL_SCOPES' && this.scopes.length > 0) {
       let hasAccess = false;
       for (let i = 0; i < this.scopes.length && !hasAccess; i++) {
         if (await this.keyStore.accountHasKey(this.scopes[i], pkMHash)) {

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.test.ts
@@ -9,6 +9,7 @@ import { makeBlockHeader } from '@aztec/stdlib/testing';
 import { jest } from '@jest/globals';
 import { mock } from 'jest-mock-extended';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 import { ContractSyncService } from './contract_sync_service.js';
@@ -18,7 +19,7 @@ describe('ContractSyncService', () => {
   let contractStore: ReturnType<typeof mock<ContractStore>>;
   let noteStore: ReturnType<typeof mock<NoteStore>>;
   let service: ContractSyncService;
-  let utilityExecutor: jest.Mock<(call: FunctionCall, scopes: undefined | AztecAddress[]) => Promise<void>>;
+  let utilityExecutor: jest.Mock<(call: FunctionCall, scopes: AccessScopes) => Promise<void>>;
 
   const contractAddress = AztecAddress.fromBigInt(100n);
   const scopeA = AztecAddress.fromBigInt(200n);
@@ -28,11 +29,11 @@ describe('ContractSyncService', () => {
   const classId = Fr.fromHexString('0xdeadbeef');
 
   /** Sentinel for undefined scopes (sync all accounts). */
-  const ALL_SCOPES = undefined;
+  const ALL_SCOPES = 'ALL_SCOPES' as const;
 
   beforeEach(() => {
     utilityExecutor = jest
-      .fn<(call: FunctionCall, scopes: undefined | AztecAddress[]) => Promise<void>>()
+      .fn<(call: FunctionCall, scopes: AccessScopes) => Promise<void>>()
       .mockResolvedValue(undefined);
 
     contractStore = mock<ContractStore>();
@@ -78,8 +79,15 @@ describe('ContractSyncService', () => {
       expectSyncedScopes([scopeA], [scopeA]);
     });
 
-    it('skips scope-specific syncs after syncing with undefined scopes', async () => {
-      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, undefined);
+    it('skips scope-specific syncs after syncing with all scopes', async () => {
+      await service.ensureContractSynced(
+        contractAddress,
+        null,
+        utilityExecutor,
+        anchorBlockHeader,
+        jobId,
+        'ALL_SCOPES',
+      );
       expectSyncedScopes(ALL_SCOPES);
 
       // After syncing all scopes, scope-specific calls should be skipped
@@ -88,9 +96,16 @@ describe('ContractSyncService', () => {
       expectSyncedScopes(ALL_SCOPES);
     });
 
-    it('still syncs undefined scopes even after scope-specific sync', async () => {
+    it('still syncs all scopes even after scope-specific sync', async () => {
       await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, [scopeA]);
-      await service.ensureContractSynced(contractAddress, null, utilityExecutor, anchorBlockHeader, jobId, undefined);
+      await service.ensureContractSynced(
+        contractAddress,
+        null,
+        utilityExecutor,
+        anchorBlockHeader,
+        jobId,
+        'ALL_SCOPES',
+      );
       expectSyncedScopes([scopeA], ALL_SCOPES);
     });
 
@@ -219,7 +234,7 @@ describe('ContractSyncService', () => {
   });
 
   /** Asserts the utility executor was called exactly with the given sequence of scope arrays. */
-  const expectSyncedScopes = (...expectedScopes: (undefined | AztecAddress[])[]) => {
+  const expectSyncedScopes = (...expectedScopes: AccessScopes[]) => {
     expect(utilityExecutor).toHaveBeenCalledTimes(expectedScopes.length);
     for (let i = 0; i < expectedScopes.length; i++) {
       const [, actualScopes] = utilityExecutor.mock.calls[i];

--- a/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
+++ b/yarn-project/pxe/src/contract_sync/contract_sync_service.ts
@@ -4,6 +4,7 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { StagedStore } from '../job_coordinator/job_coordinator.js';
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
@@ -45,15 +46,15 @@ export class ContractSyncService implements StagedStore {
    * @param functionToInvokeAfterSync - The function selector that will be called after sync (used to validate it's
    * not sync_state itself).
    * @param utilityExecutor - Executor function for running the sync_state utility function.
-   * @param scopes - Scopes to pass through to the utility executor (affects which notes are discovered).
+   * @param scopes - Access scopes to pass through to the utility executor (affects whose account's private state is discovered).
    */
   async ensureContractSynced(
     contractAddress: AztecAddress,
     functionToInvokeAfterSync: FunctionSelector | null,
-    utilityExecutor: (call: FunctionCall, scopes: undefined | AztecAddress[]) => Promise<any>,
+    utilityExecutor: (call: FunctionCall, scopes: AccessScopes) => Promise<any>,
     anchorBlockHeader: BlockHeader,
     jobId: string,
-    scopes: undefined | AztecAddress[],
+    scopes: AccessScopes,
   ): Promise<void> {
     // Skip sync if this contract has an override for this job (overrides are keyed by contract address only)
     const overrides = this.overriddenContracts.get(jobId);
@@ -62,13 +63,16 @@ export class ContractSyncService implements StagedStore {
     }
 
     // Skip sync if we already synced for "all scopes", or if we have an empty list of scopes
-    const allScopesKey = toKey(contractAddress, undefined);
+    const allScopesKey = toKey(contractAddress, 'ALL_SCOPES');
     const allScopesExisting = this.syncedContracts.get(allScopesKey);
-    if (allScopesExisting || (scopes && scopes.length == 0)) {
+    if (allScopesExisting || (scopes !== 'ALL_SCOPES' && scopes.length == 0)) {
       return;
     }
 
-    const unsyncedScopes = scopes?.filter(scope => !this.syncedContracts.has(toKey(contractAddress, scope)));
+    const unsyncedScopes =
+      scopes === 'ALL_SCOPES'
+        ? scopes
+        : scopes.filter(scope => !this.syncedContracts.has(toKey(contractAddress, scope)));
     const unsyncedScopesKeys = toKeys(contractAddress, unsyncedScopes);
 
     if (unsyncedScopesKeys.length > 0) {
@@ -76,9 +80,10 @@ export class ContractSyncService implements StagedStore {
       const promise = this.#doSync(
         contractAddress,
         functionToInvokeAfterSync,
-        call => utilityExecutor(call, unsyncedScopes),
+        utilityExecutor,
         anchorBlockHeader,
         jobId,
+        unsyncedScopes,
       ).catch(err => {
         // There was an error syncing the contract, so we remove it from the cache so that it can be retried.
         unsyncedScopesKeys.forEach(key => this.syncedContracts.delete(key));
@@ -94,9 +99,10 @@ export class ContractSyncService implements StagedStore {
   async #doSync(
     contractAddress: AztecAddress,
     functionToInvokeAfterSync: FunctionSelector | null,
-    utilityExecutor: (call: FunctionCall) => Promise<any>,
+    utilityExecutor: (call: FunctionCall, scopes: AccessScopes) => Promise<any>,
     anchorBlockHeader: BlockHeader,
     jobId: string,
+    scopes: AccessScopes,
   ): Promise<void> {
     this.log.debug(`Syncing contract ${contractAddress}`);
     await Promise.all([
@@ -109,6 +115,7 @@ export class ContractSyncService implements StagedStore {
         this.aztecNode,
         anchorBlockHeader,
         jobId,
+        scopes,
       ),
       verifyCurrentClassId(contractAddress, this.aztecNode, this.contractStore, anchorBlockHeader),
     ]);
@@ -136,10 +143,10 @@ export class ContractSyncService implements StagedStore {
   }
 }
 
-function toKeys(contract: AztecAddress, scopes: undefined | AztecAddress[]) {
-  return scopes === undefined ? [toKey(contract, undefined)] : scopes.map(scope => toKey(contract, scope));
+function toKeys(contract: AztecAddress, scopes: AccessScopes) {
+  return scopes === 'ALL_SCOPES' ? [toKey(contract, scopes)] : scopes.map(scope => toKey(contract, scope));
 }
 
-function toKey(contract: AztecAddress, scope: AztecAddress | undefined) {
-  return scope === undefined ? `${contract.toString()}:*` : `${contract.toString()}:${scope.toString()}`;
+function toKey(contract: AztecAddress, scope: AztecAddress | 'ALL_SCOPES') {
+  return scope === 'ALL_SCOPES' ? `${contract.toString()}:*` : `${contract.toString()}:${scope.toString()}`;
 }

--- a/yarn-project/pxe/src/contract_sync/helpers.ts
+++ b/yarn-project/pxe/src/contract_sync/helpers.ts
@@ -6,6 +6,7 @@ import { DelayedPublicMutableValues, DelayedPublicMutableValuesWithHash } from '
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import { NoteService } from '../notes/note_service.js';
 import type { ContractStore } from '../storage/contract_store/contract_store.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
@@ -42,11 +43,12 @@ export async function syncState(
   contractAddress: AztecAddress,
   contractStore: ContractStore,
   functionToInvokeAfterSync: FunctionSelector | null,
-  utilityExecutor: (privateSyncCall: FunctionCall) => Promise<any>,
+  utilityExecutor: (privateSyncCall: FunctionCall, scopes: AccessScopes) => Promise<any>,
   noteStore: NoteStore,
   aztecNode: AztecNode,
   anchorBlockHeader: BlockHeader,
   jobId: string,
+  scopes: AccessScopes,
 ) {
   // Protocol contracts don't have private state to sync
   if (!isProtocolContract(contractAddress)) {
@@ -61,7 +63,10 @@ export async function syncState(
 
     // Both sync_state and syncNoteNullifiers interact with the note store, but running them in parallel is safe
     // because note store is designed to handle concurrent operations.
-    await Promise.all([utilityExecutor(syncStateFunctionCall), noteService.syncNoteNullifiers(contractAddress)]);
+    await Promise.all([
+      utilityExecutor(syncStateFunctionCall, scopes),
+      noteService.syncNoteNullifiers(contractAddress, scopes),
+    ]);
   }
 }
 

--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -1,9 +1,9 @@
 import type { FunctionCall } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
-import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { NoteDao, NotesFilter } from '@aztec/stdlib/note';
 import type { ContractOverrides } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { BlockSynchronizer } from '../block_synchronizer/block_synchronizer.js';
 import type { ContractFunctionSimulator } from '../contract_function_simulator/contract_function_simulator.js';
 import type { ContractSyncService } from '../contract_sync/contract_sync_service.js';
@@ -21,7 +21,7 @@ export class PXEDebugUtils {
     contractFunctionSimulator: ContractFunctionSimulator,
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
-    scopes: AztecAddress[] | undefined,
+    scopes: AccessScopes,
     jobId: string,
   ) => Promise<any>;
 
@@ -40,7 +40,7 @@ export class PXEDebugUtils {
       contractFunctionSimulator: ContractFunctionSimulator,
       call: FunctionCall,
       authWitnesses: AuthWitness[] | undefined,
-      scopes: AztecAddress[] | undefined,
+      scopes: AccessScopes,
       jobId: string,
     ) => Promise<any>,
   ) {

--- a/yarn-project/pxe/src/entrypoints/client/bundle/index.ts
+++ b/yarn-project/pxe/src/entrypoints/client/bundle/index.ts
@@ -1,3 +1,4 @@
+export * from '../../../access_scopes.js';
 export * from '../../../pxe.js';
 export * from '../../../config/index.js';
 export * from '../../../error_enriching.js';

--- a/yarn-project/pxe/src/entrypoints/client/lazy/index.ts
+++ b/yarn-project/pxe/src/entrypoints/client/lazy/index.ts
@@ -1,3 +1,4 @@
+export * from '../../../access_scopes.js';
 export * from '../../../pxe.js';
 export * from '../../../config/index.js';
 export * from '../../../storage/index.js';

--- a/yarn-project/pxe/src/entrypoints/server/index.ts
+++ b/yarn-project/pxe/src/entrypoints/server/index.ts
@@ -1,3 +1,4 @@
+export * from '../../access_scopes.js';
 export * from '../../pxe.js';
 export * from '../../config/index.js';
 export * from '../../error_enriching.js';

--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -6,6 +6,7 @@ import type { AztecNode } from '@aztec/stdlib/interfaces/server';
 import { DirectionalAppTaggingSecret, PendingTaggedLog, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { LogRetrievalRequest } from '../contract_function_simulator/noir-structs/log_retrieval_request.js';
 import { LogRetrievalResponse } from '../contract_function_simulator/noir-structs/log_retrieval_response.js';
 import { AddressStore } from '../storage/address_store/address_store.js';
@@ -107,11 +108,7 @@ export class LogService {
     );
   }
 
-  public async fetchTaggedLogs(
-    contractAddress: AztecAddress,
-    pendingTaggedLogArrayBaseSlot: Fr,
-    scopes?: AztecAddress[],
-  ) {
+  public async fetchTaggedLogs(contractAddress: AztecAddress, pendingTaggedLogArrayBaseSlot: Fr, scopes: AccessScopes) {
     this.log.verbose(`Fetching tagged logs for ${contractAddress.toString()}`);
 
     // We only load logs from block up to and including the anchor block number
@@ -119,7 +116,7 @@ export class LogService {
     const anchorBlockHash = await this.anchorBlockHeader.hash();
 
     // Determine recipients: use scopes if provided, otherwise get all accounts
-    const recipients = scopes && scopes.length > 0 ? scopes : await this.keyStore.getAccounts();
+    const recipients = scopes !== 'ALL_SCOPES' && scopes.length > 0 ? scopes : await this.keyStore.getAccounts();
 
     // For each recipient, fetch secrets, load logs, and store them.
     // We run these per-recipient tasks in parallel so that logs are loaded for all recipients concurrently.

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -41,7 +41,7 @@ describe('NoteService', () => {
 
     contractAddress = await AztecAddress.random();
 
-    const notes = await noteStore.getNotes({ contractAddress }, 'test');
+    const notes = await noteStore.getNotes({ contractAddress, scopes: 'ALL_SCOPES' }, 'test');
     expect(notes).toHaveLength(0);
 
     const accounts = await keyStore.getAccounts();
@@ -65,7 +65,7 @@ describe('NoteService', () => {
     const nullifierIndex = randomDataInBlock(123n);
     aztecNode.findLeavesIndexes.mockResolvedValue([nullifierIndex]);
 
-    await noteService.syncNoteNullifiers(contractAddress);
+    await noteService.syncNoteNullifiers(contractAddress, 'ALL_SCOPES');
 
     const remainingNotes = await noteStore.getNotes(
       {
@@ -103,7 +103,7 @@ describe('NoteService', () => {
     // No nullifier found in merkle tree
     aztecNode.findLeavesIndexes.mockResolvedValue([undefined]);
 
-    await noteService.syncNoteNullifiers(contractAddress);
+    await noteService.syncNoteNullifiers(contractAddress, 'ALL_SCOPES');
 
     const remainingNotes = await noteStore.getNotes(
       {
@@ -148,7 +148,7 @@ describe('NoteService', () => {
       return Promise.resolve([undefined]);
     });
 
-    await noteService.syncNoteNullifiers(contractAddress);
+    await noteService.syncNoteNullifiers(contractAddress, 'ALL_SCOPES');
 
     // Verify note still exists
     const remainingNotes = await noteStore.getNotes(
@@ -186,7 +186,7 @@ describe('NoteService', () => {
 
     const getNotesSpy = jest.spyOn(noteStore, 'getNotes');
 
-    await noteService.syncNoteNullifiers(contractAddress);
+    await noteService.syncNoteNullifiers(contractAddress, 'ALL_SCOPES');
 
     // Verify applyNullifiers was called once for all accounts
     expect(getNotesSpy).toHaveBeenCalledTimes(1);

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -7,6 +7,7 @@ import { Note, NoteDao, NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
+import type { AccessScopes } from '../access_scopes.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
 export class NoteService {
@@ -31,7 +32,7 @@ export class NoteService {
     owner: AztecAddress | undefined,
     storageSlot: Fr,
     status: NoteStatus,
-    scopes?: AztecAddress[],
+    scopes: AccessScopes,
   ) {
     const noteDaos = await this.noteStore.getNotes(
       {
@@ -70,10 +71,10 @@ export class NoteService {
    *
    * @param contractAddress - The contract whose notes should be checked and nullified.
    */
-  public async syncNoteNullifiers(contractAddress: AztecAddress): Promise<void> {
+  public async syncNoteNullifiers(contractAddress: AztecAddress, scopes: AccessScopes): Promise<void> {
     const anchorBlockHash = await this.anchorBlockHeader.hash();
 
-    const contractNotes = await this.noteStore.getNotes({ contractAddress }, this.jobId);
+    const contractNotes = await this.noteStore.getNotes({ contractAddress, scopes }, this.jobId);
 
     if (contractNotes.length === 0) {
       return;

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -52,6 +52,7 @@ import {
 
 import { inspect } from 'util';
 
+import type { AccessScopes } from './access_scopes.js';
 import { BlockSynchronizer } from './block_synchronizer/index.js';
 import type { PXEConfig } from './config/index.js';
 import { BenchmarkedNodeFactory } from './contract_function_simulator/benchmarked_node.js';
@@ -93,7 +94,7 @@ export type ProfileTxOpts = {
   /** If true, proof generation is skipped during profiling. Defaults to true. */
   skipProofGeneration?: boolean;
   /** Addresses whose private state and keys are accessible during private execution. */
-  scopes?: AztecAddress[];
+  scopes: AccessScopes;
 };
 
 /** Options for PXE.simulateTx. */
@@ -106,16 +107,16 @@ export type SimulateTxOpts = {
   skipFeeEnforcement?: boolean;
   /** State overrides for the simulation, such as contract instances and artifacts. */
   overrides?: SimulationOverrides;
-  /** Addresses whose private state and keys are accessible during private execution. Defaults to all. */
-  scopes?: AztecAddress[];
+  /** Addresses whose private state and keys are accessible during private execution */
+  scopes: AccessScopes;
 };
 
 /** Options for PXE.simulateUtility. */
 export type SimulateUtilityOpts = {
   /** The authentication witnesses required for the function call. */
   authwits?: AuthWitness[];
-  /** The accounts whose notes we can access in this call. Defaults to all. */
-  scopes?: AztecAddress[];
+  /** The accounts whose notes we can access in this call */
+  scopes: AccessScopes;
 };
 
 /** Args for PXE.create. */
@@ -357,7 +358,7 @@ export class PXE {
   async #executePrivate(
     contractFunctionSimulator: ContractFunctionSimulator,
     txRequest: TxExecutionRequest,
-    scopes: AztecAddress[] | undefined,
+    scopes: AccessScopes,
     jobId: string,
   ): Promise<PrivateExecutionResult> {
     const { origin: contractAddress, functionSelector } = txRequest;
@@ -406,7 +407,7 @@ export class PXE {
     contractFunctionSimulator: ContractFunctionSimulator,
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
-    scopes: AztecAddress[] | undefined,
+    scopes: AccessScopes,
     jobId: string,
   ) {
     try {
@@ -1005,7 +1006,7 @@ export class PXE {
           inspect(txRequest),
           `simulatePublic=${simulatePublic}`,
           `skipTxValidation=${skipTxValidation}`,
-          `scopes=${scopes?.map(s => s.toString()).join(', ') ?? 'undefined'}`,
+          `scopes=${scopes === 'ALL_SCOPES' ? scopes : scopes.map(s => s.toString()).join(', ')}`,
         );
       }
     });
@@ -1017,7 +1018,7 @@ export class PXE {
    */
   public simulateUtility(
     call: FunctionCall,
-    { authwits, scopes }: SimulateUtilityOpts = {},
+    { authwits, scopes }: SimulateUtilityOpts = { scopes: 'ALL_SCOPES' },
   ): Promise<UtilitySimulationResult> {
     // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
@@ -1070,7 +1071,7 @@ export class PXE {
         throw this.#contextualizeError(
           err,
           `simulateUtility ${to}:${name}(${stringifiedArgs})`,
-          `scopes=${scopes?.map(s => s.toString()).join(', ') ?? 'undefined'}`,
+          `scopes=${scopes === 'ALL_SCOPES' ? scopes : scopes.map(s => s.toString()).join(', ')}`,
         );
       }
     });

--- a/yarn-project/pxe/src/storage/note_store/note_store.test.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.test.ts
@@ -99,7 +99,7 @@ describe('NoteStore', () => {
       const noteStore = new NoteStore(store);
 
       await verifyAndCommitForEachJob(['pre-commit', 'post-commit'], noteStore, async (jobId: string) => {
-        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         expect(Array.isArray(notes)).toBe(true);
         expect(notes).toHaveLength(0);
       });
@@ -123,8 +123,8 @@ describe('NoteStore', () => {
       const noteStore2 = new NoteStore(store);
 
       await verifyAndCommitForEachJob(['second-store', 'fresh-job'], noteStore2, async (jobId: string) => {
-        const notesA = await noteStore2.getNotes({ contractAddress: CONTRACT_A }, jobId);
-        const notesB = await noteStore2.getNotes({ contractAddress: CONTRACT_B }, jobId);
+        const notesA = await noteStore2.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
+        const notesB = await noteStore2.getNotes({ contractAddress: CONTRACT_B, scopes: 'ALL_SCOPES' }, jobId);
 
         expect(nullifierSet(notesA)).toEqual(nullifierSet([SILOED_NULLIFIER_1]));
         expect(nullifierSet(notesB)).toEqual(nullifierSet([SILOED_NULLIFIER_2]));
@@ -150,13 +150,16 @@ describe('NoteStore', () => {
     });
 
     it('filters notes matching only the contractAddress', async () => {
-      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
       // note1 and note2 match CONTRACT_A
       expect(nullifierSet(notes)).toEqual(nullifierSet([note1, note2]));
     });
 
     it('filters notes matching contractAddress and storageSlot', async () => {
-      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, storageSlot: SLOT_Y }, 'test');
+      const notes = await noteStore.getNotes(
+        { contractAddress: CONTRACT_A, storageSlot: SLOT_Y, scopes: 'ALL_SCOPES' },
+        'test',
+      );
       expect(nullifierSet(notes)).toEqual(nullifierSet([note2]));
     });
 
@@ -207,13 +210,14 @@ describe('NoteStore', () => {
       const nullifiers = [mkNullifier(note2)];
       await expect(noteStore.applyNullifiers(nullifiers, 'test')).resolves.toEqual([note2]);
 
-      const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
       expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1]));
 
       const allNotes = await noteStore.getNotes(
         {
           contractAddress: CONTRACT_A,
           status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          scopes: 'ALL_SCOPES',
         },
         'test',
       );
@@ -266,6 +270,7 @@ describe('NoteStore', () => {
       const filter = {
         contractAddress: CONTRACT_A,
         siloedNullifier: note1.siloedNullifier,
+        scopes: 'ALL_SCOPES' as const,
       };
 
       const notes = await noteStore.getNotes(filter, 'test');
@@ -276,6 +281,7 @@ describe('NoteStore', () => {
         {
           contractAddress: CONTRACT_A,
           siloedNullifier: note2.siloedNullifier,
+          scopes: 'ALL_SCOPES',
         },
         'test',
       );
@@ -297,12 +303,15 @@ describe('NoteStore', () => {
     });
 
     it('returns no notes when filtering by non-existing contractAddress', async () => {
-      const notes = await noteStore.getNotes({ contractAddress: FAKE_ADDRESS }, 'test');
+      const notes = await noteStore.getNotes({ contractAddress: FAKE_ADDRESS, scopes: 'ALL_SCOPES' }, 'test');
       expect(notes).toHaveLength(0);
     });
 
     it('returns no notes when filtering by non-existing storageSlot', async () => {
-      const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, storageSlot: NON_EXISTING_SLOT }, 'test');
+      const notes = await noteStore.getNotes(
+        { contractAddress: CONTRACT_A, storageSlot: NON_EXISTING_SLOT, scopes: 'ALL_SCOPES' },
+        'test',
+      );
       expect(notes).toHaveLength(0);
     });
 
@@ -320,6 +329,7 @@ describe('NoteStore', () => {
       const filter = {
         contractAddress: CONTRACT_A,
         siloedNullifier: NON_EXISTING_SLOT,
+        scopes: 'ALL_SCOPES' as const,
       };
 
       const notes = await noteStore.getNotes(filter, 'test');
@@ -330,6 +340,7 @@ describe('NoteStore', () => {
       const filter = {
         contractAddress: CONTRACT_B,
         siloedNullifier: note2.siloedNullifier,
+        scopes: 'ALL_SCOPES' as const,
       };
 
       const notes = await noteStore.getNotes(filter, 'test');
@@ -361,11 +372,12 @@ describe('NoteStore', () => {
       const result = await noteStore.applyNullifiers([mkNullifier(note1)], 'test');
       expect(result).toEqual([note1]);
 
-      const active = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+      const active = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
       const all = await noteStore.getNotes(
         {
           contractAddress: CONTRACT_A,
           status: NoteStatus.ACTIVE_OR_NULLIFIED,
+          scopes: 'ALL_SCOPES',
         },
         'test',
       );
@@ -378,8 +390,8 @@ describe('NoteStore', () => {
       const nullifiers = [mkNullifier(note1), mkNullifier(note3)];
       const result = await noteStore.applyNullifiers(nullifiers, 'test');
 
-      const activeA = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
-      const activeB = await noteStore.getNotes({ contractAddress: CONTRACT_B }, 'test');
+      const activeA = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
+      const activeB = await noteStore.getNotes({ contractAddress: CONTRACT_B, scopes: 'ALL_SCOPES' }, 'test');
 
       expect(result).toEqual([note1, note3]); // returned nullified notes
       expect(nullifierSet(activeA)).toEqual(nullifierSet([note2])); // note2 remains active
@@ -393,6 +405,7 @@ describe('NoteStore', () => {
         contractAddress: CONTRACT_A,
         siloedNullifier: note2.siloedNullifier,
         status: NoteStatus.ACTIVE_OR_NULLIFIED,
+        scopes: 'ALL_SCOPES' as const,
       };
 
       const notes = await noteStore.getNotes(filter, 'test');
@@ -466,7 +479,7 @@ describe('NoteStore', () => {
 
       // Verify notes are still active (transaction rolled back)
       await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1, note2]));
       });
     });
@@ -482,7 +495,7 @@ describe('NoteStore', () => {
       expect(result).toEqual([]);
 
       await verifyAndCommitForEachJob(['test', 'after-job-commit'], noteStore, async (jobId: string) => {
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note2]));
       });
     });
@@ -506,11 +519,11 @@ describe('NoteStore', () => {
 
       // Verify note is now in nullified state
       await verifyAndCommitForEachJob(['fresh-job', 'after-job-commit'], noteStore, async (jobId: string) => {
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         expect(nullifierSet(activeNotes)).not.toContain(freshNullifier.toBigInt());
 
         const allNotes = await noteStore.getNotes(
-          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: 'ALL_SCOPES' },
           jobId,
         );
         expect(nullifierSet(allNotes)).toContain(freshNullifier.toBigInt());
@@ -540,14 +553,14 @@ describe('NoteStore', () => {
 
       // Verify all notes are nullified
       await verifyAndCommitForEachJob(['concurrent-job', 'after-job-commit'], noteStore, async (jobId: string) => {
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         const activeNullifiers = nullifierSet(activeNotes);
         for (const nullifier of noteNullifiers) {
           expect(activeNullifiers).not.toContain(nullifier.toBigInt());
         }
 
         const allNotes = await noteStore.getNotes(
-          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: 'ALL_SCOPES' },
           jobId,
         );
         expect(nullifierSet(allNotes)).toEqual(nullifierSet([note1, note2, ...noteNullifiers]));
@@ -565,11 +578,11 @@ describe('NoteStore', () => {
 
       // Verify the note is in nullified state
       await verifyAndCommitForEachJob(['new-job', 'after-job-commit'], noteStore, async (jobId: string) => {
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, jobId);
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, jobId);
         expect(nullifierSet(activeNotes)).not.toContain(note1.siloedNullifier.toBigInt());
 
         const allNotes = await noteStore.getNotes(
-          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: 'ALL_SCOPES' },
           jobId,
         );
         expect(nullifierSet(allNotes)).toContain(note1.siloedNullifier.toBigInt());
@@ -609,7 +622,7 @@ describe('NoteStore', () => {
       // Verify the note is nullified and has both scopes
       await verifyAndCommitForEachJob(['duplicate-job', 'after-job-commit'], noteStore, async (jobId: string) => {
         const allNotes = await noteStore.getNotes(
-          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED },
+          { contractAddress: CONTRACT_A, status: NoteStatus.ACTIVE_OR_NULLIFIED, scopes: 'ALL_SCOPES' },
           jobId,
         );
         expect(nullifierSet(allNotes)).toContain(duplicateNullifier.toBigInt());
@@ -665,7 +678,7 @@ describe('NoteStore', () => {
 
       it('restores notes that were nullified after the rollback block', async () => {
         // noteBlock2 remains active, noteBlock3 was nullified at block 4 should be restored
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(nullifierSet(activeNotes)).toEqual(nullifierSet([noteBlock2, noteBlock3]));
       });
 
@@ -674,6 +687,7 @@ describe('NoteStore', () => {
           {
             contractAddress: CONTRACT_A,
             status: NoteStatus.ACTIVE_OR_NULLIFIED,
+            scopes: 'ALL_SCOPES',
           },
           'test',
         );
@@ -682,13 +696,13 @@ describe('NoteStore', () => {
         expect(nullifierSet(allNotes)).toEqual(nullifierSet([noteBlock1, noteBlock2, noteBlock3]));
 
         // Verify noteBlock1 is not in active notes
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(nullifierSet(activeNotes)).not.toContain(noteBlock1.siloedNullifier.toBigInt());
       });
 
       it('preserves active notes created before the rollback block that were never nullified', async () => {
         // noteBlock2 was created at block 2 (before rollback block 3) and never nullified
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(nullifierSet(activeNotes)).toEqual(nullifierSet([noteBlock2, noteBlock3]));
       });
 
@@ -697,6 +711,7 @@ describe('NoteStore', () => {
           {
             contractAddress: CONTRACT_A,
             status: NoteStatus.ACTIVE_OR_NULLIFIED,
+            scopes: 'ALL_SCOPES',
           },
           'test',
         );
@@ -727,13 +742,14 @@ describe('NoteStore', () => {
         await noteStore.commit('test');
         await noteStore.rollback(5, 5);
 
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(activeNotes).toHaveLength(0);
 
         const allNotes = await noteStore.getNotes(
           {
             contractAddress: CONTRACT_A,
             status: NoteStatus.ACTIVE_OR_NULLIFIED,
+            scopes: 'ALL_SCOPES',
           },
           'test',
         );
@@ -758,13 +774,14 @@ describe('NoteStore', () => {
         await noteStore.commit('test');
         await noteStore.rollback(6, 4);
 
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(activeNotes).toHaveLength(0);
 
         const allNotes = await noteStore.getNotes(
           {
             contractAddress: CONTRACT_A,
             status: NoteStatus.ACTIVE_OR_NULLIFIED,
+            scopes: 'ALL_SCOPES',
           },
           'test',
         );
@@ -791,13 +808,13 @@ describe('NoteStore', () => {
 
         // note1 should be restored (nullified at block 7 > rollback block 5)
         // note2 should be deleted (created at block 10 > rollback block 5)
-        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const activeNotes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(nullifierSet(activeNotes)).toEqual(nullifierSet([note1Nullifier]));
       });
 
       it('handles rollback on empty PXE database gracefully', async () => {
         await expect(noteStore.rollback(10, 20)).resolves.not.toThrow();
-        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A }, 'test');
+        const notes = await noteStore.getNotes({ contractAddress: CONTRACT_A, scopes: 'ALL_SCOPES' }, 'test');
         expect(notes).toHaveLength(0);
       });
 

--- a/yarn-project/pxe/src/storage/note_store/note_store.ts
+++ b/yarn-project/pxe/src/storage/note_store/note_store.ts
@@ -105,7 +105,7 @@ export class NoteStore implements StagedStore {
    * returned once if this is the case)
    */
   getNotes(filter: NotesFilter, jobId: string): Promise<NoteDao[]> {
-    if (filter.scopes !== undefined && filter.scopes.length === 0) {
+    if (filter.scopes !== 'ALL_SCOPES' && filter.scopes.length === 0) {
       return Promise.resolve([]);
     }
 
@@ -179,7 +179,10 @@ export class NoteStore implements StagedStore {
           continue;
         }
 
-        if (filter.scopes && note.scopes.intersection(new Set(filter.scopes.map(s => s.toString()))).size === 0) {
+        if (
+          filter.scopes !== 'ALL_SCOPES' &&
+          note.scopes.intersection(new Set(filter.scopes.map(s => s.toString()))).size === 0
+        ) {
           continue;
         }
 

--- a/yarn-project/stdlib/src/note/notes_filter.ts
+++ b/yarn-project/stdlib/src/note/notes_filter.ts
@@ -24,11 +24,8 @@ export type NotesFilter = {
   status?: NoteStatus;
   /** The siloed nullifier for the note. */
   siloedNullifier?: Fr;
-  /**
-   * The scopes in which to get notes from
-   * Undefined scopes means all scopes, while empty list of scopes means no scope at all
-   */
-  scopes?: AztecAddress[];
+  /** The scopes in which to get notes from */
+  scopes: 'ALL_SCOPES' | AztecAddress[];
 };
 
 export const NotesFilterSchema: ZodFor<NotesFilter> = z.object({
@@ -37,5 +34,5 @@ export const NotesFilterSchema: ZodFor<NotesFilter> = z.object({
   storageSlot: schemas.Fr.optional(),
   status: z.nativeEnum(NoteStatus).optional(),
   siloedNullifier: schemas.Fr.optional(),
-  scopes: z.array(schemas.AztecAddress).optional(),
+  scopes: z.union([z.literal('ALL_SCOPES'), z.array(schemas.AztecAddress)]),
 });

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -12,6 +12,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { LogLevels, type Logger, applyStringFormatting, createLogger } from '@aztec/foundation/log';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import type { KeyStore } from '@aztec/key-store';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import {
   AddressStore,
   CapsuleStore,
@@ -302,7 +303,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     const effectiveScopes = from.isZero() ? [] : [from];
 
     // Sync notes before executing private function to discover notes from previous transactions
-    const utilityExecutor = async (call: FunctionCall, execScopes: undefined | AztecAddress[]) => {
+    const utilityExecutor = async (call: FunctionCall, execScopes: AccessScopes) => {
       await this.executeUtilityCall(call, execScopes);
     };
 
@@ -678,7 +679,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       },
       blockHeader,
       this.jobId,
-      undefined,
+      'ALL_SCOPES',
     );
 
     const call = FunctionCall.from({
@@ -692,10 +693,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       returnTypes: [],
     });
 
-    return this.executeUtilityCall(call, undefined);
+    return this.executeUtilityCall(call, 'ALL_SCOPES');
   }
 
-  private async executeUtilityCall(call: FunctionCall, scopes: undefined | AztecAddress[]): Promise<Fr[]> {
+  private async executeUtilityCall(call: FunctionCall, scopes: AccessScopes): Promise<Fr[]> {
     const entryPointArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(call.to, call.selector);
     if (entryPointArtifact.functionType !== FunctionType.UTILITY) {
       throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -4,6 +4,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { KeyStore } from '@aztec/key-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import {
   AddressStore,
   AnchorBlockStore,
@@ -323,6 +324,7 @@ export class TXESession implements TXESessionStateHandler {
 
     await new NoteService(this.noteStore, this.stateMachine.node, anchorBlock!, this.currentJobId).syncNoteNullifiers(
       contractAddress,
+      'ALL_SCOPES',
     );
     const latestBlock = await this.stateMachine.node.getBlockHeader('latest');
 
@@ -362,6 +364,7 @@ export class TXESession implements TXESessionStateHandler {
       privateEventStore: this.privateEventStore,
       contractSyncService: this.stateMachine.contractSyncService,
       jobId: this.currentJobId,
+      scopes: 'ALL_SCOPES',
     });
 
     // We store the note and tagging index caches fed into the PrivateExecutionOracle (along with some other auxiliary
@@ -414,7 +417,7 @@ export class TXESession implements TXESessionStateHandler {
       this.stateMachine.node,
       anchorBlockHeader,
       this.currentJobId,
-    ).syncNoteNullifiers(contractAddress);
+    ).syncNoteNullifiers(contractAddress, 'ALL_SCOPES');
 
     this.oracleHandler = new UtilityExecutionOracle({
       contractAddress,
@@ -431,6 +434,7 @@ export class TXESession implements TXESessionStateHandler {
       capsuleStore: this.capsuleStore,
       privateEventStore: this.privateEventStore,
       jobId: this.currentJobId,
+      scopes: 'ALL_SCOPES',
     });
 
     this.state = { name: 'UTILITY' };
@@ -499,7 +503,7 @@ export class TXESession implements TXESessionStateHandler {
   }
 
   private utilityExecutorForContractSync(anchorBlock: any) {
-    return async (call: FunctionCall, scopes: undefined | AztecAddress[]) => {
+    return async (call: FunctionCall, scopes: AccessScopes) => {
       const entryPointArtifact = await this.contractStore.getFunctionArtifactWithDebugMetadata(call.to, call.selector);
       if (entryPointArtifact.functionType !== FunctionType.UTILITY) {
         throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -28,6 +28,7 @@ import type { ChainInfo } from '@aztec/entrypoints/interfaces';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { createLogger } from '@aztec/foundation/log';
 import type { FieldsOf } from '@aztec/foundation/types';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import type { PXE, PackedPrivateEvent } from '@aztec/pxe/server';
 import {
   type ContractArtifact,
@@ -304,9 +305,9 @@ export abstract class BaseWallet implements Wallet {
     executionPayload: ExecutionPayload,
     from: AztecAddress,
     feeOptions: FeeOptions,
+    scopes: AccessScopes,
     skipTxValidation?: boolean,
     skipFeeEnforcement?: boolean,
-    scopes?: AztecAddress[],
   ) {
     const txRequest = await this.createTxExecutionRequestFromPayloadAndFee(executionPayload, from, feeOptions);
     return this.pxe.simulateTx(txRequest, { simulatePublic: true, skipTxValidation, skipFeeEnforcement, scopes });
@@ -354,9 +355,9 @@ export abstract class BaseWallet implements Wallet {
             remainingPayload,
             opts.from,
             feeOptions,
+            this.scopesFor(opts.from),
             opts.skipTxValidation,
             opts.skipFeeEnforcement ?? true,
-            this.scopesFor(opts.from),
           )
         : Promise.resolve(null),
     ]);

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -4,6 +4,7 @@ import { AccountManager } from '@aztec/aztec.js/wallet';
 import type { DefaultAccountEntrypointOptions } from '@aztec/entrypoints/account';
 import { Fq, Fr } from '@aztec/foundation/curves/bn254';
 import type { Logger } from '@aztec/foundation/log';
+import type { AccessScopes } from '@aztec/pxe/client/lazy';
 import type { PXE } from '@aztec/pxe/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
@@ -78,9 +79,9 @@ export class EmbeddedWallet extends BaseWallet {
     executionPayload: ExecutionPayload,
     from: AztecAddress,
     feeOptions: FeeOptions,
+    scopes: AccessScopes,
     _skipTxValidation?: boolean,
     _skipFeeEnforcement?: boolean,
-    scopes?: AztecAddress[],
   ): Promise<TxSimulationResult> {
     const { account: fromAccount, instance, artifact } = await this.getFakeAccountDataFor(from);
 


### PR DESCRIPTION
## Summary

- Replace `undefined` with the `'ALL_SCOPES'` string literal across the scopes type (`'ALL_SCOPES' | AztecAddress[]`) to make the "all accounts" semantic explicit rather than relying on `undefined`
- Update all call sites across `pxe`, `txe`, `wallet-sdk`, `wallets`, `cli-wallet`, `end-to-end`