### PR TITLE
feat: use makefile

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -269,6 +269,11 @@ tests:
       - *charlie
       - *adam
 
+  - regex: "src/e2e_epochs/epochs_l1_reorgs.parallel.test.ts"
+    skip: true
+    owners:
+      - *phil
+
   # Blanket flake patterns for unstable p2p, epoch, and l1 tx utils tests
   # This is a temporary measure while team bandwidth is constrained
   # Replaced many specific patterns - see https://github.com/AztecProtocol/aztec-packages/pull/17962 for historical context
@@ -309,7 +314,7 @@ tests:
     owners:
       - *palla
 
-  - regex: "src/e2e_block_building.test.ts"
+  - regex: "e2e_block_building"
     error_regex: "✕ processes txs until hitting timetable"
     owners:
       - *palla

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # Note that "test" targets don't *run* tests, they just output test commands to /tmp/test_cmds.
 #
 # Expectation is to run with one of the following targets:
-# - make [all]
+# - make fast
 # - make full
 # - make release
 
@@ -47,23 +47,21 @@ endef
 # PHONY TARGETS - List every target that has a file/dir of the same name.
 #==============================================================================
 
-.PHONY: all noir barretenberg noir-projects l1-contracts release-image boxes playground docs aztec-up
+.PHONY: noir barretenberg noir-projects l1-contracts release-image boxes playground docs aztec-up
 
 #==============================================================================
 # BOOTSTRAP TARGETS
 #==============================================================================
 
-# Fast bootstrap
-all: release-image barretenberg boxes playground docs aztec-up \
-		 bb-tests l1-contracts-tests yarn-project-tests boxes-tests playground-tests aztec-up-tests docs-tests noir-protocol-circuits-tests release-image-tests
+# Fast bootstrap.
+fast: release-image barretenberg boxes playground docs aztec-up \
+		  bb-tests l1-contracts-tests yarn-project-tests boxes-tests playground-tests aztec-up-tests docs-tests noir-protocol-circuits-tests release-image-tests
 
-# Full bootstrap
-full: release-image barretenberg boxes playground docs aztec-up \
-			bb-cpp-full yarn-project-benches \
-		  bb-full-tests l1-contracts-tests yarn-project-tests boxes-tests playground-tests aztec-up-tests docs-tests noir-protocol-circuits-tests release-image-tests
+# Full bootstrap.
+full: fast bb-full-tests bb-cpp-full yarn-project-benches
 
 # Release. Everything plus copy bb cross compiles to ts projects.
-release: all bb-cpp-release-dir bb-ts-cross-copy
+release: fast bb-cpp-release-dir bb-ts-cross-copy
 
 #==============================================================================
 # Noir
@@ -223,7 +221,7 @@ bb-bbup-tests: bb-bbup
 
 bb-tests: bb-cpp-native-tests bb-acir-tests bb-ts-tests bb-sol-tests bb-bbup-tests bb-docs-tests
 
-bb-full-tests: bb-cpp-native-tests bb-cpp-wasm-threads-tests bb-cpp-asan-tests bb-cpp-smt-tests  bb-acir-tests bb-ts-tests bb-sol-tests bb-bbup-tests bb-docs-tests
+bb-full-tests: bb-cpp-wasm-threads-tests bb-cpp-asan-tests bb-cpp-smt-tests
 
 #==============================================================================
 # Noir Projects

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -76,7 +76,7 @@ EOF
       echo $root/barretenberg/ts
       $root/noir/bootstrap.sh get_projects
       $root/yarn-project/bootstrap.sh get_projects
-    } | parallel --tag -k --line-buffer --halt now,fail=1 "retry 'cd {} && dump_fail \"deploy_npm latest $version\"'"
+    } | parallel --tag --line-buffer --halt now,fail=1 "retry 'cd {} && dump_fail \"deploy_npm latest $version\" >/dev/null'"
 
     # Prime the verdaccio cache by installing the packages we'll use in tests.
     # This fetches all transitive dependencies from npmjs and caches them locally.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,13 @@ export DENOISE=${DENOISE:-1}
 # Number of TXE servers to run when testing.
 export NUM_TXES=1
 
+# Number of jobs for make. Defaults to number of CPUs.
+# TODO: We should dial this back on consumer hardware, maybe to just 1.
 export MAKEFLAGS="-j${MAKE_JOBS:-$(get_num_cpus)}"
+
+# We append all test commands to this file as they become available during build.
+# The test engine feeds it into parallel.
+export test_cmds_file="/tmp/test_cmds"
 
 # Cleanup function. Called on script exit.
 function cleanup {
@@ -30,12 +36,7 @@ function cleanup {
     wait $make_pid
     make_pid=
   fi
-  if [ -n "${txe_pids:-}" ]; then
-    echo "Sending SIGTERM to TXE processes..."
-    kill -SIGTERM $txe_pids &>/dev/null
-    wait $txe_pids
-    txe_pids=
-  fi
+  stop_txes
 }
 trap cleanup EXIT
 
@@ -201,31 +202,14 @@ EOF
   chmod +x $hooks_dir/post-merge
 }
 
-function sort_by_cpus {
-  awk '
-    {
-      cpus = 0;  # Default value
-      # Split line on space, take first field ($1)
-      split($1, subfields, ":");  # Split first field on :
-      for (i in subfields) {
-        split(subfields[i], arr, "=");
-        if (arr[1] == "CPUS") {
-          cpus = arr[2];
-          break;
-        }
-      }
-      # Print padded CPUS value followed by original line
-      printf "%010d %s\n", cpus, $0
-    }
-  ' | sort -s -r -n -k1,1 | cut -d' ' -f2-
-}
-
-function test_cmds {
-  if [ "$#" -eq 0 ]; then
-    # Ordered with longest running first, to ensure they get scheduled earliest.
-    set -- yarn-project/end-to-end aztec-up yarn-project noir-projects boxes playground barretenberg l1-contracts docs ci3 release-image
+function pull_submodules {
+  echo_header "pull submodules"
+  # If it's an old standalone noir clone, nuke it.
+  if [ -d "noir/noir-repo/.git" ]; then
+    echo "Removing old noir clone..."
+    rm -rf noir/noir-repo
   fi
-  parallel -k --line-buffer './{}/bootstrap.sh test_cmds' ::: $@ | filter_test_cmds | sort_by_cpus
+  denoise "git submodule update --init --recursive --depth 1 --jobs 8 && git -C noir/noir-repo fetch --tags"
 }
 
 function start_txes {
@@ -263,21 +247,28 @@ function start_txes {
   done
 }
 
-export test_cmds_file="/tmp/test_cmds"
+function stop_txes {
+  if [ -n "${txe_pids:-}" ]; then
+    echo "Stopping TXE processes..."
+    kill -SIGTERM $txe_pids &>/dev/null || true
+    wait $txe_pids || true
+    txe_pids=
+  fi
+}
 
 function prep {
-  pull_submodules
   check_toolchains
-
-  # Ensure we have yarn set up.
-  corepack enable
-
+  pull_submodules
   rm -f $test_cmds_file
 }
 
-function build_and_test {
-  local target=${1:-}
+function build {
+  prep
+  echo_header "build"
+  make ${1:-fast}
+}
 
+function build_and_test {
   prep
   echo_header "build and test"
 
@@ -287,14 +278,11 @@ function build_and_test {
   # put it in it's own process group, we can terminate on cleanup.
   setsid color_prefix "test-engine" "denoise \"test_engine $test_cmds_file\"" &
   test_engine_pid=$!
-  test_engine_pgid=$(ps -o pgid= -p $test_engine_pid)
+  test_engine_pgid=$(ps -o pgid= -p $test_engine_pid | tr -d ' ')
   echo "Started test engine with $test_engine_pid in PGID $test_engine_pgid."
 
   # Start the build.
-  if [ -z "$target" ]; then
-    [ "$CI_FULL" -eq 0 ] && target="all" || target="full"
-  fi
-  make $target &
+  make $1 &
   make_pid=$!
 
   # As soon as one of the above fails, terminate the other (as part of exit cleanup).
@@ -305,6 +293,7 @@ function build_and_test {
 
     # If make succeeded, start txes and add tests that depend on them.
     if [ "$finished" == "$make_pid" ]; then
+      echo "Makefile build complete, starting TXEs and adding dependent tests..."
       make_pid=
 
       if [ -z "${1:-}" ]; then
@@ -318,97 +307,21 @@ function build_and_test {
     fi
 
     if [ "$finished" == "$test_engine_pid" ]; then
+      echo "Test engine completed successfully."
       test_engine_pid=
     fi
   done
 
+  stop_txes
+
   return 0
-}
-
-function test {
-  echo_header "test all"
-
-  start_txes
-
-  # We will start half as many jobs as we have cpu's.
-  # This is based on the slightly magic assumption that many tests can benefit from 2 cpus,
-  # and also that half the cpus are logical, not physical.
-  echo "Gathering tests to run..."
-  tests=$(test_cmds $@)
-
-  # Note: Capturing strips last newline. The echo re-adds it.
-  local num
-  [ -z "$tests" ] && num=0 || num=$(echo "$tests" | wc -l)
-  echo "Gathered $num tests."
-
-  echo "$tests" | parallelize
-}
-
-function pull_submodules {
-  echo_header "pull submodules"
-  # If it's an old standalone noir clone, nuke it.
-  if [ -d "noir/noir-repo/.git" ]; then
-    echo "Removing old noir clone..."
-    rm -rf noir/noir-repo
-  fi
-  denoise "git submodule update --init --recursive --depth 1 --jobs 8 && git -C noir/noir-repo fetch --tags"
-}
-
-function build {
-  prep
-
-  # These projects are dependent on each other and must be built linearly.
-  serial_projects=(
-    noir
-    avm-transpiler
-    barretenberg
-    noir-projects
-    l1-contracts
-    yarn-project
-    release-image
-  )
-  # These projects can be built in parallel.
-  parallel_cmds=(
-    yarn-project/end-to-end/bootstrap.sh
-    boxes/bootstrap.sh
-    playground/bootstrap.sh
-    docs/bootstrap.sh
-    aztec-up/bootstrap.sh
-  )
-
-  local start_building=false
-  for project in "${serial_projects[@]}"; do
-    # BOOTSTRAP_AFTER and BOOTSTRAP_TO are used to control the order of building.
-    # If BOOTSTRAP_AFTER is set, it should be one of our serial projects and we will only build projects after it.
-    # If BOOTSTRAP_TO is set, it should be one of our serial projects and we will only build projects up to it. We will skip parallel_cmds.
-
-    # Start building after we've seen BOOTSTRAP_AFTER, skipping BOOTSTRAP_AFTER itself.
-    if [ "$project" == "${BOOTSTRAP_AFTER:-}" ]; then
-      start_building=true
-      continue
-    fi
-
-    # Build the project if we should be building
-    if [[ -z "${BOOTSTRAP_AFTER:-}" || "$start_building" = true ]]; then
-      $project/bootstrap.sh ${1:-}
-    fi
-
-    # Stop the build if we've reached BOOTSTRAP_TO
-    # We therefore don't run parallel commands if BOOTSTRAP_TO is set.
-    if [ "$project" = "${BOOTSTRAP_TO:-}" ]; then
-      return
-    fi
-  done
-
-  parallel --line-buffer --tag --halt now,fail=1 "denoise '{}'" ::: ${parallel_cmds[@]}
 }
 
 function bench_cmds {
   if [ "$#" -eq 0 ]; then
-    # Ordered with longest running first, to ensure they get scheduled earliest.
     set -- yarn-project/end-to-end yarn-project barretenberg/{ts,cpp,sol} noir-projects/noir-protocol-circuits l1-contracts
   fi
-  parallel -k --line-buffer './{}/bootstrap.sh bench_cmds' ::: $@ | sort_by_cpus
+  parallel -k --line-buffer './{}/bootstrap.sh bench_cmds' ::: $@
 }
 
 function build_bench {
@@ -433,6 +346,50 @@ function bench_merge {
 
 }
 
+function isolate_bench_cpus {
+  [ "${CI:-0}" -eq 0 ] && return
+
+  # CPU layout assumption: physical cores are 0..N/2-1, hyperthreads are N/2..N-1.
+  local total_cpus=$(nproc)
+  local total_physical=$((total_cpus / 2))
+  local os_reserve=8
+  local bench_count=$((total_physical - os_reserve))
+
+  # Disable hyperthread siblings of benchmark cores (N/2 .. N/2+bench_count-1).
+  # OS cores' hyperthreads (N/2+bench_count .. N-1) stay on for extra OS capacity.
+  for cpu in $(seq $total_physical $((total_physical + bench_count - 1))); do
+    sudo sh -c "echo 0 > /sys/devices/system/cpu/cpu$cpu/online" 2>/dev/null || true
+  done
+
+  # Pin all container processes to OS CPUs so they can't land on benchmark cores.
+  # exec_test's taskset overrides this for each benchmark with its allocated CPUs.
+  local os_cpu_list="$bench_count-$((total_physical - 1)),$((total_physical + bench_count))-$((total_cpus - 1))"
+  echo "Pinning container processes to OS CPUs ($os_cpu_list)..."
+  for pid in $(ps -eo pid= 2>/dev/null); do
+    taskset -apc "$os_cpu_list" $pid &>/dev/null || true
+  done
+
+  export BENCH_CPU_COUNT=$bench_count
+
+  echo "Benchmark CPU isolation: CPUs 0-$((bench_count - 1)) ($bench_count cores, hyperthreads off) for benchmarks."
+  echo "OS CPUs: $os_cpu_list."
+}
+
+function unisolate_bench_cpus {
+  [ "${CI:-0}" -eq 0 ] && return
+
+  echo "Re-enabling all CPUs..."
+  local total_cpus=$(nproc --all)
+  for cpu in $(seq 1 $((total_cpus - 1))); do
+    sudo sh -c "echo 1 > /sys/devices/system/cpu/cpu$cpu/online" 2>/dev/null || true
+  done
+  # Unpin all processes (were pinned to OS CPUs during bench).
+  for pid in $(ps -eo pid= 2>/dev/null); do
+    taskset -apc 0-$((total_cpus - 1)) $pid &>/dev/null || true
+  done
+  echo "All CPUs re-enabled. Online CPUs: $(nproc)"
+}
+
 function bench {
   # TODO bench for arm64.
   if [ $(arch) == arm64 ]; then
@@ -440,8 +397,10 @@ function bench {
   fi
   echo_header "bench all"
   build_bench
+  isolate_bench_cpus
   find . -type d -iname bench-out | xargs rm -rf
   bench_cmds | STRICT_SCHEDULING=1 parallelize
+  unisolate_bench_cpus
   rm -rf bench-out
   mkdir -p bench-out
   bench_merge
@@ -569,30 +528,20 @@ case "$cmd" in
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=0
-    build
-    test
+    build_and_test fast
     ;;
   "ci-full")
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=1
-    build
-    test
+    build_and_test full
     bench
     ;;
   "ci-full-no-test-cache")
     export CI=1
     export USE_TEST_CACHE=0
     export CI_FULL=1
-    build
-    test
-    bench
-    ;;
-  "ci-full-no-test-cache-makefile")
-    export CI=1
-    export USE_TEST_CACHE=0
-    export CI_FULL=1
-    build_and_test
+    build_and_test full
     bench
     ;;
   "ci-grind-test")
@@ -724,7 +673,7 @@ case "$cmd" in
     if ! semver check $REF_NAME; then
       exit 1
     fi
-    build
+    build release
     release
     ;;
 

--- a/ci.sh
+++ b/ci.sh
@@ -77,7 +77,7 @@ case "$cmd" in
     export JOB_ID="x-$cmd"
     bootstrap_ec2 "./bootstrap.sh ci-$cmd"
     ;;
-  full|full-no-test-cache|full-no-test-cache-makefile)
+  full|full-no-test-cache)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
     export AWS_SHUTDOWN_TIME=75
@@ -103,7 +103,7 @@ case "$cmd" in
       JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
     }
     export -f run
-    seq 1 ${1:-5} | parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered \
+    seq 1 ${1:-5} | parallel --jobs 100 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered \
       'run $USER-x{}-full amd64 ci-full-no-test-cache'
     ;;
   merge-queue)
@@ -122,7 +122,8 @@ case "$cmd" in
     }
     export -f run
 
-    parallel --jobs 10 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
+    # Specify jobs as maybe we only have a couple of cpus.
+    parallel --jobs 100 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
       'run x1-full amd64 ci-full-no-test-cache' \
       'run x2-full amd64 ci-full-no-test-cache' \
       'run x3-full amd64 ci-full-no-test-cache' \
@@ -145,7 +146,8 @@ case "$cmd" in
     }
     export -f run
 
-    parallel --jobs 11 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
+    # Specify jobs as maybe we only have a couple of cpus.
+    parallel --jobs 100 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
       'run x1-full amd64 ci-full-no-test-cache' \
       'run x2-full amd64 ci-full-no-test-cache' \
       'run x3-full amd64 ci-full-no-test-cache' \

--- a/ci3/add_timestamps
+++ b/ci3/add_timestamps
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Close stderr to prevent holding inherited pipeline FDs open (see cache_log).
+exec 2>/dev/null
 while IFS= read -r line; do
   printf '%(%H:%M:%S)T %s\n' -1 "$line"
 done

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -155,17 +155,16 @@ container_script=$(
       echo "Performing a release because \$REF_NAME is a semver."
     fi
 
-    # Capture cpu load.
-    mpstat 2 > >(cache_log cpufile) 2>&1 &
-    cpu_pid=\$!
+    # Background monitors. cache_log and add_timestamps both close inherited pipeline
+    # fds internally, so these long-running processes won't block the outer pipeline.
+    mpstat 2>&1 | cache_log cpufile &
+    vmstat -w -S M 2>&1 | add_timestamps | cache_log memfile &
+    bash -c "while true; do pstree -agl; echo; echo; sleep 10; done" 2>&1 | add_timestamps | cache_log processes &
 
-    # Capture mem load.
-    vmstat -w -S M 2 > >(add_timestamps | cache_log memfile) 2>&1 &
-    mem_pid=\$!
-
-    # Dump process tree every 10s.
-    bash -c "while true; do pstree -agl; echo; echo; sleep 10; done" > >(add_timestamps | cache_log processes) 2>&1 &
-    pstree_pid=\$!
+    # For debugging fd leaks that prevent run from exiting.
+    # outer_pipe_1=\$(readlink /proc/self/fd/1)
+    # outer_pipe_2=\$(readlink /proc/self/fd/2)
+    # ci3/fd_monitor "\$outer_pipe_1" "\$outer_pipe_2" | add_timestamps | cache_log fdinfo &
 
     set +e
     set -x
@@ -173,7 +172,6 @@ container_script=$(
     local code=\${PIPESTATUS[0]}
 
     sudo dmesg 2>&1 | cache_log 'dmesg'
-    kill \$cpu_pid \$mem_pid \$pstree_pid &>/dev/null
 
     return \$code
   }
@@ -237,6 +235,21 @@ function run {
     sudo sysctl fs.inotify.max_user_watches=1048576 &>/dev/null
     sudo sysctl fs.inotify.max_user_instances=1048576 &>/dev/null
 
+    # Pin host processes to top CPU cores to keep benchmark cores clean.
+    # CPU layout: physical cores 0..N/2-1, hyperthreads N/2..N-1.
+    # OS gets top 8 physical cores + their hyperthread siblings.
+    # Skip dockerd so containers it spawns can use all CPUs for build/test.
+    total_cpus=\$(nproc)
+    total_physical=\$((total_cpus / 2))
+    os_start=\$((total_physical - 8))
+    os_ht_start=\$((total_cpus - 8))
+    os_cpu_list=\"\$os_start-\$((total_physical - 1)),\$os_ht_start-\$((total_cpus - 1))\"
+    for pid in \$(ps -eo pid= 2>/dev/null); do
+      comm=\$(cat /proc/\$pid/comm 2>/dev/null) || continue
+      [ \"\$comm\" = \"dockerd\" ] && continue
+      sudo taskset -apc \"\$os_cpu_list\" \$pid &>/dev/null || true
+    done
+    echo \"Host processes pinned to OS CPUs: \$os_cpu_list\"
 
     aws_token=\$(curl -sX PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
 

--- a/ci3/cache_log
+++ b/ci3/cache_log
@@ -52,12 +52,14 @@ function live_publish_log {
 if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
   log_str="$name log id: ${yellow}http://ci.aztec-labs.com/$key${reset}"
   echo_stderr -e "$log_str"
-  # Close stderr to prevent holding inherited pipeline FDs open.
-  # When cache_log runs inside a process substitution within a pipeline (e.g. in bootstrap_ec2),
-  # FD 2 points to the pipeline pipe. If we (or live_publish_log) hold it open, the pipeline
-  # hangs waiting for EOF even after the main command has finished.
+  # Close inherited pipeline FDs to prevent blocking parent pipelines.
+  # When cache_log runs inside a pipeline, fd 1/2 may reference the parent's pipe.
+  # Holding them open prevents the parent pipeline from seeing EOF.
   exec 2>/dev/null
-  live_publish_log &
+  if [ "$dup" -ne 1 ]; then
+    exec >/dev/null
+  fi
+  live_publish_log >&- 2>&- &
   if [ "$dup" -eq 1 ]; then
     redact | tee -a $outfile
     # Print a second line if the log is long enough.

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -110,7 +110,7 @@ tail --sleep-interval=0.2 -n +1 -f "$outfile" > >(
 tail_pid=$!
 
 # Execute the command in background.
-PARENT_LOG_ID=$key bash -c "$cmd" 2>&1 | redact > $outfile &
+PARENT_LOG_ID=$key bash -c "$cmd" > >(redact > $outfile) 2>&1 &
 job_pid=$!
 
 # Wait for the job to finish and get its exit status.

--- a/ci3/deploy_npm
+++ b/ci3/deploy_npm
@@ -22,16 +22,27 @@ if [ "$version" == "$published_version" ]; then
   exit 0
 fi
 
-cp package.json package.json.deploy_bkup
-# Restore package.json as we write over it.
+# Create temp directory for publishing
+tmpdir=$(mktemp -d)
 function cleanup {
-  mv package.json.deploy_bkup package.json &>/dev/null || true
+  rm -rf "$tmpdir"
 }
 trap cleanup SIGINT SIGTERM EXIT
 
+# Use npm pack instead of yarn pack. yarn pack fails on portal: dependencies (e.g. bb.js)
+# because its beforeWorkspacePacking hook can't resolve workspace:^ for portal links.
+# npm pack just packs the files without trying to resolve workspace refs.
+npm pack --pack-destination "$tmpdir" --quiet
+
+# Extract and prepare
+cd "$tmpdir"
+tar -xzf *.tgz
+cd package
+
+# Replace workspace:^ with concrete versions.
 release_prep_package_json $version
 
-# Publish.
+# Publish from temp dir
 if [ "$dry_run" -eq 1 ]; then
   denoise "npm publish --ignore-scripts --dry-run --tag $dist_tag --access public"
 else

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -34,7 +34,7 @@ Command: $full_cmd
 Commit: https://github.com/AztecProtocol/aztec-packages/commit/${COMMIT_HASH:-HEAD}
 Env: REF_NAME=${REF_NAME:-} CURRENT_VERSION=${CURRENT_VERSION:-} CI_FULL=${CI_FULL:-} NO_FLAKE=${NO_FLAKE:-}
 Date: $(date)
-System: ARCH=$(arch) CPUS=$(nproc) MEM=$(free -h | awk '/^Mem:/{print $2}') HOSTNAME=$(hostname)
+System: ARCH=$(arch) CPUS=$(nproc --all) MEM=$(free -h | awk '/^Mem:/{print $2}') HOSTNAME=$(hostname)
 Resources: CPU_LIST=$CPU_LIST CPUS=$CPUS MEM=$MEM TIMEOUT=$TIMEOUT
 History: http://ci.aztec-labs.com/list/history_$test_hash${TARGET_BRANCH:+_$TARGET_BRANCH}
 

--- a/ci3/fd_monitor
+++ b/ci3/fd_monitor
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Periodically logs which processes hold given pipe FD(s) open.
+# Used to debug container script exit hangs caused by leaked FDs.
+# Usage: fd_monitor <pipe_identifier> [<pipe_identifier2> ...]
+# Close stderr to prevent holding inherited pipeline FDs open (see cache_log).
+exec 0</dev/null 2>/dev/null
+pipes=("$@")
+while true; do
+  for pipe in "${pipes[@]}"; do
+    echo "=== Holders of $pipe ==="
+    for f in /proc/[0-9]*/fd/*; do
+      [ "$(readlink "$f" 2>/dev/null)" = "$pipe" ] || continue
+      pid=${f#/proc/}; pid=${pid%%/*}
+      fdnum=${f##*/}
+      comm=$(cat /proc/$pid/comm 2>/dev/null || echo "?")
+      ppid=$(awk '/^PPid:/{print $2}' /proc/$pid/status 2>/dev/null || echo "?")
+      cmdline=$(tr '\0' ' ' </proc/$pid/cmdline 2>/dev/null)
+      echo "  pid=$pid ppid=$ppid fd=$fdnum comm=$comm cmd=$cmdline"
+    done
+  done
+  echo
+  sleep 10
+done

--- a/ci3/parallelize_strict
+++ b/ci3/parallelize_strict
@@ -5,7 +5,9 @@ NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
 cd $root
 
-if [ -z "${1:-}" ]; then
+if [ -n "${BENCH_CPU_COUNT:-}" ]; then
+  num_cpus=$BENCH_CPU_COUNT
+elif [ -z "${1:-}" ]; then
   num_cpus=$(get_num_cpus)
   num_cpus=$((num_cpus / 2))
 else

--- a/ci3/retry
+++ b/ci3/retry
@@ -20,7 +20,7 @@ for i in $(seq 1 $ATTEMPTS); do
   wait $pid
   code=$?
   [ $code -eq 0 ] || [ $code -eq 143 ] && exit 0
-  [ "$i" != "$ATTEMPTS" ] && sleep 5
+  [ "$i" != "$ATTEMPTS" ] && sleep ${RETRY_SLEEP:-5}
 done
 
 >&2 echo "Failed after $ATTEMPTS attempts: $1"

--- a/ci3/sem_sched
+++ b/ci3/sem_sched
@@ -6,6 +6,7 @@ SHM_FILE="/dev/shm/cpu_alloc.shm"
 SEM_BIN="./semc"
 MUTEX_NAME="/cpu_alloc_mutex"
 FREE_SEM="/cpu_alloc_free"
+NUMA_FILE="/dev/shm/cpu_numa.shm"
 
 function init {
   # Build semc if not already built.
@@ -18,6 +19,21 @@ function init {
   head -c $n < /dev/zero | tr '\0' '0' > "$SHM_FILE"
   $SEM_BIN --name "$FREE_SEM" --init $n
   $SEM_BIN --name "$MUTEX_NAME" --init 1
+
+  # Write NUMA node boundaries (physical cores only) to companion file.
+  # Format: one line per node, each line is "start end" (inclusive).
+  > "$NUMA_FILE"
+  for node_dir in /sys/devices/system/node/node*; do
+    [ ! -f "$node_dir/cpulist" ] && continue
+    # Parse cpulist (e.g. "0-23,96-119") — take first range (physical cores).
+    range=$(cut -d, -f1 < "$node_dir/cpulist")
+    start=${range%-*}
+    end=${range#*-}
+    # Clamp to managed CPUs (0..n-1).
+    [ "$start" -ge "$n" ] && continue
+    [ "$end" -ge "$n" ] && end=$((n - 1))
+    echo "$start $end" >> "$NUMA_FILE"
+  done
 }
 
 # Acquire mutex to update shared memory and select free CPUs
@@ -25,23 +41,63 @@ function acquire {
   local num_cpus="${1:-2}"
   local timeout="${2:-0}"
 
-  # Block until num_cpus are available.
+  # Block until num_cpus are available globally.
   $SEM_BIN --name "$FREE_SEM" --atomic --timeout $timeout -$num_cpus
 
   # Update the shared memory to mark the allocated CPUs.
   $SEM_BIN --name "$MUTEX_NAME" -1
   data=$(cat "$SHM_FILE")
-  len=${#data}
   allocated_list=()
-  for ((i=0; i<len && ${#allocated_list[@]} < num_cpus; i++)); do
-    if [ "${data:$i:1}" == "0" ]; then
-      allocated_list+=($i)
-      data="${data:0:$i}1${data:$((i+1))}"
+
+  # Try NUMA-local allocation if topology info exists.
+  if [ -f "$NUMA_FILE" ] && [ -s "$NUMA_FILE" ]; then
+    # Check if request can fit on a single node at all.
+    local fits_on_node=0
+    while read -r ns ne; do
+      [ $((ne - ns + 1)) -ge "$num_cpus" ] && fits_on_node=1 && break
+    done < "$NUMA_FILE"
+
+    if [ "$fits_on_node" -eq 1 ]; then
+      # Find a node with enough free CPUs.
+      while read -r node_start node_end; do
+        local free=0
+        for ((i=node_start; i<=node_end; i++)); do
+          [ "${data:$i:1}" == "0" ] && free=$((free + 1))
+        done
+        if [ "$free" -ge "$num_cpus" ]; then
+          for ((i=node_start; i<=node_end && ${#allocated_list[@]} < num_cpus; i++)); do
+            if [ "${data:$i:1}" == "0" ]; then
+              allocated_list+=($i)
+              data="${data:0:$i}1${data:$((i+1))}"
+            fi
+          done
+          break
+        fi
+      done < "$NUMA_FILE"
+
+      # No single node had enough free — release semaphore and fail.
+      # Caller will wait for a job to finish and retry.
+      if [ "${#allocated_list[@]}" -lt "$num_cpus" ]; then
+        $SEM_BIN --name "$MUTEX_NAME" +1
+        $SEM_BIN --name "$FREE_SEM" +$num_cpus
+        return 1
+      fi
     fi
-  done
+  fi
+
+  # Fallback: linear scan (no NUMA file, or request exceeds any single node).
+  if [ "${#allocated_list[@]}" -lt "$num_cpus" ]; then
+    local len=${#data}
+    for ((i=0; i<len && ${#allocated_list[@]} < num_cpus; i++)); do
+      if [ "${data:$i:1}" == "0" ]; then
+        allocated_list+=($i)
+        data="${data:0:$i}1${data:$((i+1))}"
+      fi
+    done
+  fi
+
   echo -n "$data" > "$SHM_FILE"
   cpu_list=$(IFS=, ; echo "${allocated_list[*]}")
-
   $SEM_BIN --name "$MUTEX_NAME" +1
   echo $cpu_list
 }

--- a/ci3/source_cache
+++ b/ci3/source_cache
@@ -46,7 +46,7 @@ function cache_persistent {
     {
       cat "$tmpfile" | cache_disk_transfer "$key"
       rm -f "$tmpfile"
-    } &
+    } >&- 2>&- &
   else
     rm -f "$tmpfile"
   fi

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -27,20 +27,10 @@ function test_cmds {
   local run_test_script="yarn-project/end-to-end/scripts/run_test.sh"
   local prefix="$hash:ISOLATE=1"
 
-  # Longest-running tests first
-  # Can't run full prover tests on ARM because AVM is disabled.
-  if ../../barretenberg/cpp/bootstrap.sh hash | grep -qE no-avm; then
-    if [ "$CI_FULL" -eq 1 ]; then
-      echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_client_real $run_test_script simple e2e_prover/client"
-    else
-      echo "$prefix:NAME=e2e_prover_client_fake FAKE_PROOFS=1 $run_test_script simple e2e_prover/client"
-    fi
+  if [ "$CI_FULL" -eq 1 ]; then
+    echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_full_real $run_test_script simple e2e_prover/full"
   else
-    if [ "$CI_FULL" -eq 1 ]; then
-      echo "$prefix:TIMEOUT=20m:CPUS=16:MEM=96g:NAME=e2e_prover_full_real $run_test_script simple e2e_prover/full"
-    else
-      echo "$prefix:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple e2e_prover/full"
-    fi
+    echo "$prefix:NAME=e2e_prover_full_fake FAKE_PROOFS=1 $run_test_script simple e2e_prover/full"
   fi
   echo "$prefix:TIMEOUT=15m:NAME=e2e_block_building $(set_dump_avm e2e_block_building) $run_test_script simple e2e_block_building"
 


### PR DESCRIPTION
Let's just commit to the makefile and deal with issues.

* Uses process substitution in denoises redact. Think this fixes some edge case where redact lingers and prevents denoise exiting.
* `npm_deploy` mutates packages in a tmp copy to prevent clobbering tests underfoot.
* bootstrap builds are now all makefile driven. Get rid of `-makefile` commands.
* Put job counts on parallel call in ci.sh as using nproc is too low. Weak machines can spin up many strong machines.
* Adds NUMA awareness to benchmarks. If CPU's requested is < cores per NUMA node, we wait until we can get all the CPU's on a single node, else we fallback to old behaviour and just grab whatever cores we can. This is probably satisfactory as higher core count benches are generally a different longer running category of benches.