### PR TITLE
feat: add BB_POLY_STATS for prover polynomial memory analysis

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial_stats.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial_stats.hpp
@@ -4,11 +4,42 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <iomanip>
 #include <sstream>
 #include <string>
 
 namespace bb {
+
+/**
+ * @brief Get the current process resident set size (RSS) in MB.
+ * @details Reads from /proc/self/status on Linux. Returns 0 on other platforms.
+ */
+inline double get_rss_mb()
+{
+#ifdef __linux__
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.starts_with("VmRSS:")) {
+            // Format: "VmRSS:    <value> kB"
+            size_t kb = std::stoul(line.substr(6));
+            return static_cast<double>(kb) / 1024.0;
+        }
+    }
+#endif
+    return 0;
+}
+
+/**
+ * @brief Log current RSS with a label. Only does anything when BB_POLY_STATS is set.
+ */
+inline void log_rss(const std::string& label)
+{
+    if (std::getenv("BB_POLY_STATS") != nullptr) {
+        info("[RSS] ", label, ": ", std::fixed, std::setprecision(1), get_rss_mb(), " MB");
+    }
+}
 
 /**
  * @brief Compute the minimum number of bytes needed to represent a field element's value.

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.hpp
@@ -97,6 +97,7 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
     {
         BB_BENCH_NAME("ProverInstance(Circuit&)");
         vinfo("Constructing ProverInstance");
+        log_rss("before ProverInstance (circuit alive)");
         auto start = std::chrono::steady_clock::now();
 
         // Check pairing point tagging: either no pairing points were created,
@@ -151,6 +152,7 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
             // Set the shifted polynomials now that all of the to_be_shifted polynomials are defined.
             polynomials.set_shifted();
         }
+        log_rss("after polynomial allocation (circuit + polys)");
 
         // Construct and add to proving key the wire, selector and copy constraint polynomials
         vinfo("populating trace...");
@@ -195,8 +197,9 @@ template <IsUltraOrMegaHonk Flavor_> class ProverInstance_ {
         auto end = std::chrono::steady_clock::now();
         auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
         vinfo("time to construct proving key: ", diff.count(), " ms.");
+        log_rss("after ProverInstance complete (circuit still alive)");
 
-        if (std::getenv("BB_POLY_STATS")) {
+        if (std::getenv("BB_POLY_STATS") != nullptr) {
             analyze_prover_polynomials(polynomials);
         }
     }


### PR DESCRIPTION
## Summary

- Adds RSS (resident set size) tracking at key lifecycle points in ProverInstance construction, gated behind `BB_POLY_STATS`
- Confirms that circuit data and polynomial data coexist in memory, validating the motivation for AztecProtocol/barretenberg#1500

## RSS output (2^19 mock app circuit)

```
[RSS] before ProverInstance (circuit alive): 228.1 MB
[RSS] after polynomial allocation (circuit + polys): 576.3 MB
[RSS] after ProverInstance complete (circuit still alive): 631.1 MB
```

~400 MB growth while circuit data is still alive, confirming the overlap that early deallocation (#1500) would address.

## Test plan

- [x] `BB_POLY_STATS=1 ./build/bin/chonk_bench` produces RSS readings at each lifecycle point
- [x] No output when `BB_POLY_STATS` is unset