### PR TITLE
fix(prover): store simulation duration as ms

### DIFF
--- a/yarn-project/bb-prover/src/instrumentation.ts
+++ b/yarn-project/bb-prover/src/instrumentation.ts
@@ -58,10 +58,18 @@ export class ProverInstrumentation {
     circuitName: CircuitName,
     timerOrMS: Timer | number,
   ) {
-    const s = typeof timerOrMS === 'number' ? timerOrMS / 1000 : timerOrMS.s();
-    this[metric].record(s, {
-      [Attributes.PROTOCOL_CIRCUIT_NAME]: circuitName,
-    });
+    // Simulation duration is stored in ms, while the others are stored in seconds
+    if (metric === 'simulationDuration') {
+      const ms = typeof timerOrMS === 'number' ? timerOrMS : timerOrMS.ms();
+      this[metric].record(Math.trunc(ms), {
+        [Attributes.PROTOCOL_CIRCUIT_NAME]: circuitName,
+      });
+    } else {
+      const s = typeof timerOrMS === 'number' ? timerOrMS / 1000 : timerOrMS.s();
+      this[metric].record(s, {
+        [Attributes.PROTOCOL_CIRCUIT_NAME]: circuitName,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Metric `CIRCUIT_SIMULATION_DURATION` was defined as int ms, but was stored as floating-point seconds. This caused errors `INT value type cannot accept a floating-point value for aztec.circuit.simulation.duration, ignoring the fractional digits.` in the logs.

This fixes it so simulation duration is stored in truncated ms. Alternative fix is to convert the metric type to floating-point seconds, as the other durations.
