### PR TITLE
refactor: improve use of authwit proxy in e2e tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -3,10 +3,12 @@ import { computeInnerAuthWitHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 import { AuthRegistryContract } from '@aztec/noir-contracts.js/AuthRegistry';
 import { AuthWitTestContract } from '@aztec/noir-test-contracts.js/AuthWitTest';
+import { GenericProxyContract } from '@aztec/noir-test-contracts.js/GenericProxy';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 
 import { jest } from '@jest/globals';
 
+import { sendThroughAuthwitProxy } from './fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR } from './fixtures/fixtures.js';
 import { ensureAccountContractsPublished, setup } from './fixtures/utils.js';
 import type { TestWallet } from './test-wallet/test_wallet.js';
@@ -21,6 +23,7 @@ describe('e2e_authwit_tests', () => {
   let account2Address: AztecAddress;
 
   let auth: AuthWitTestContract;
+  let authwitProxy: GenericProxyContract;
 
   beforeAll(async () => {
     ({
@@ -30,6 +33,7 @@ describe('e2e_authwit_tests', () => {
     await ensureAccountContractsPublished(wallet, [account1Address, account2Address]);
 
     auth = await AuthWitTestContract.deploy(wallet).send({ from: account1Address });
+    authwitProxy = await GenericProxyContract.deploy(wallet).send({ from: account1Address });
   });
 
   describe('Private', () => {
@@ -60,9 +64,10 @@ describe('e2e_authwit_tests', () => {
         });
 
         // Consume the inner hash using the account1 as the "on behalf of".
-        await auth.methods
-          .consume(account1Address, innerHash)
-          .send({ from: account2Address, authWitnesses: [witness] });
+        // We send through the proxy so the proxy becomes msg_sender in consume,
+        // while account1 remains the tx sender (with their keys in scope).
+        const action = auth.methods.consume(account1Address, innerHash);
+        await sendThroughAuthwitProxy(authwitProxy, action, { from: account1Address, authWitnesses: [witness] });
 
         expect(await wallet.lookupValidity(account1Address, intent, witness)).toEqual({
           isValidInPrivate: false,
@@ -71,7 +76,10 @@ describe('e2e_authwit_tests', () => {
 
         // Try to consume the same authwit again, it should fail
         await expect(
-          auth.methods.consume(account1Address, innerHash).send({ from: account2Address, authWitnesses: [witness] }),
+          sendThroughAuthwitProxy(authwitProxy, auth.methods.consume(account1Address, innerHash), {
+            from: account1Address,
+            authWitnesses: [witness],
+          }),
         ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
       });
     });

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -54,7 +54,7 @@ export class BlacklistTokenContractTest {
   asset!: TokenBlacklistContract;
   tokenSim!: TokenSimulator;
   badAccount!: InvalidAccountContract;
-  proxy!: GenericProxyContract;
+  authwitProxy!: GenericProxyContract;
   cheatCodes!: CheatCodes;
   sequencer!: SequencerClient;
   aztecNode!: AztecNode;
@@ -120,8 +120,8 @@ export class BlacklistTokenContractTest {
     // (so their notes are in scope), but msg_sender in the target must differ from the note owner
     // to trigger authwit validation. The proxy forwards calls so that msg_sender != tx sender.
     this.logger.verbose(`Deploying generic proxy...`);
-    this.proxy = await GenericProxyContract.deploy(this.wallet).send({ from: this.adminAddress });
-    this.logger.verbose(`Deployed to ${this.proxy.address}.`);
+    this.authwitProxy = await GenericProxyContract.deploy(this.wallet).send({ from: this.adminAddress });
+    this.logger.verbose(`Deployed to ${this.authwitProxy.address}.`);
 
     await this.crossTimestampOfChange();
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/burn.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/burn.test.ts
@@ -1,6 +1,7 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR, U128_UNDERFLOW_ERROR } from '../fixtures/index.js';
 import { BlacklistTokenContractTest } from './blacklist_token_contract_test.js';
 
@@ -151,19 +152,16 @@ describe('e2e_blacklist_token_contract burn', () => {
       expect(amount).toBeGreaterThan(0n);
 
       const action = asset.methods.burn(adminAddress, amount, authwitNonce);
-      const call = await action.getFunctionCall();
-      const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      await t.proxy.methods
-        .forward_private_3(call.to, call.selector, call.args)
-        .send({ from: adminAddress, authWitnesses: [witness] });
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
       tokenSim.burnPrivate(adminAddress, amount);
 
       // Perform the transfer again, should fail
-      const txReplay = t.proxy.methods
-        .forward_private_3(call.to, call.selector, call.args)
-        .send({ from: adminAddress, authWitnesses: [witness] });
-      await expect(txReplay).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
+      await expect(
+        sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
     });
 
     describe('failure cases', () => {
@@ -191,16 +189,13 @@ describe('e2e_blacklist_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn(adminAddress, amount, authwitNonce);
+        const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-        // Both wallets are connected to same node and PXE so we could just insert directly
-        // But doing it in two actions to show the flow.
-        const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
-
-        await expect(action.simulate({ from: otherAddress, authWitnesses: [witness] })).rejects.toThrow(
-          'Assertion failed: Balance too low',
-        );
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(
+          simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+        ).rejects.toThrow('Assertion failed: Balance too low');
       });
 
       it('burn on behalf of other without approval', async () => {
@@ -209,14 +204,15 @@ describe('e2e_blacklist_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn(adminAddress, amount, authwitNonce);
+        const call = await action.getFunctionCall();
         const messageHash = await computeAuthWitMessageHash(
-          { caller: otherAddress, call: await action.getFunctionCall() },
+          { caller: t.authwitProxy.address, call },
           await wallet.getChainInfo(),
         );
 
-        await expect(action.simulate({ from: otherAddress })).rejects.toThrow(
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress })).rejects.toThrow(
           `Unknown auth witness for message hash ${messageHash.toString()}`,
         );
       });
@@ -227,18 +223,19 @@ describe('e2e_blacklist_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn(adminAddress, amount, authwitNonce);
+        const call = await action.getFunctionCall();
         const expectedMessageHash = await computeAuthWitMessageHash(
-          { caller: blacklistedAddress, call: await action.getFunctionCall() },
+          { caller: t.authwitProxy.address, call },
           await wallet.getChainInfo(),
         );
 
         const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
 
-        await expect(action.simulate({ from: blacklistedAddress, authWitnesses: [witness] })).rejects.toThrow(
-          `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-        );
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(
+          simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+        ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
       });
 
       it('burn from blacklisted account', async () => {

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/transfer_private.test.ts
@@ -1,6 +1,7 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR } from '../fixtures/fixtures.js';
 import { BlacklistTokenContractTest } from './blacklist_token_contract_test.js';
 
@@ -49,19 +50,16 @@ describe('e2e_blacklist_token_contract transfer private', () => {
     expect(amount).toBeGreaterThan(0n);
 
     const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
-    const call = await action.getFunctionCall();
-    const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+    const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-    await t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
+    // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+    await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
     tokenSim.transferPrivate(adminAddress, otherAddress, amount);
 
     // Perform the transfer again, should fail
-    const txReplay = t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
-    await expect(txReplay).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
+    await expect(
+      sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+    ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
   });
 
   describe('failure cases', () => {
@@ -94,17 +92,13 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      // Both wallets are connected to same node and PXE so we could just insert directly
-      // But doing it in two actions to show the flow.
-      const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
-
-      // Perform the transfer
-      await expect(action.simulate({ from: otherAddress, authWitnesses: [witness] })).rejects.toThrow(
-        'Assertion failed: Balance too low',
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow('Assertion failed: Balance too low');
       expect(await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress })).toEqual(balance0);
       expect(await asset.methods.balance_of_private(otherAddress).simulate({ from: otherAddress })).toEqual(balance1);
     });
@@ -122,14 +116,15 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const messageHash = await computeAuthWitMessageHash(
-        { caller: otherAddress, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
-      await expect(action.simulate({ from: otherAddress })).rejects.toThrow(
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress })).rejects.toThrow(
         `Unknown auth witness for message hash ${messageHash.toString()}`,
       );
     });
@@ -140,18 +135,19 @@ describe('e2e_blacklist_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer(adminAddress, otherAddress, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: blacklistedAddress, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
       const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
 
-      await expect(action.simulate({ from: blacklistedAddress, authWitnesses: [witness] })).rejects.toThrow(
-        `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
       expect(await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress })).toEqual(balance0);
     });
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/unshielding.test.ts
@@ -1,6 +1,7 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR } from '../fixtures/fixtures.js';
 import { BlacklistTokenContractTest } from './blacklist_token_contract_test.js';
 
@@ -41,19 +42,16 @@ describe('e2e_blacklist_token_contract unshielding', () => {
     expect(amount).toBeGreaterThan(0n);
 
     const action = asset.methods.unshield(adminAddress, otherAddress, amount, authwitNonce);
-    const call = await action.getFunctionCall();
-    const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+    const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-    await t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
+    // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+    await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
     tokenSim.transferToPublic(adminAddress, otherAddress, amount);
 
     // Perform the transfer again, should fail
-    const txReplay = t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
-    await expect(txReplay).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
+    await expect(
+      sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+    ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
   });
 
   describe('failure cases', () => {
@@ -85,16 +83,13 @@ describe('e2e_blacklist_token_contract unshielding', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.unshield(adminAddress, otherAddress, amount, authwitNonce);
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      // Both wallets are connected to same node and PXE so we could just insert directly
-      // But doing it in two actions to show the flow.
-      const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
-
-      await expect(action.simulate({ from: otherAddress, authWitnesses: [witness] })).rejects.toThrow(
-        'Assertion failed: Balance too low',
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow('Assertion failed: Balance too low');
     });
 
     it('on behalf of other (invalid designated caller)', async () => {
@@ -103,20 +98,19 @@ describe('e2e_blacklist_token_contract unshielding', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.unshield(adminAddress, otherAddress, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: blacklistedAddress, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
-      // Both wallets are connected to same node and PXE so we could just insert directly
-      // But doing it in two actions to show the flow.
       const witness = await wallet.createAuthWit(adminAddress, { caller: otherAddress, action });
 
-      await expect(action.simulate({ from: blacklistedAddress, authWitnesses: [witness] })).rejects.toThrow(
-        `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
     });
 
     it('unshield from blacklisted account', async () => {

--- a/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/burn.test.ts
@@ -1,19 +1,20 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR, U128_UNDERFLOW_ERROR } from '../fixtures/index.js';
 import { TokenContractTest } from './token_contract_test.js';
 
 describe('e2e_token_contract burn', () => {
   const t = new TokenContractTest('burn');
-  let { asset, tokenSim, wallet, adminAddress, account1Address, account2Address } = t;
+  let { asset, tokenSim, wallet, adminAddress, account1Address } = t;
 
   beforeAll(async () => {
     t.applyBaseSnapshots();
     t.applyMintSnapshot();
     await t.setup();
     // Have to destructure again to ensure we have latest refs.
-    ({ asset, wallet, adminAddress, tokenSim, adminAddress, account1Address, account2Address } = t);
+    ({ asset, wallet, adminAddress, tokenSim, adminAddress, account1Address } = t);
   });
 
   afterAll(async () => {
@@ -145,19 +146,15 @@ describe('e2e_token_contract burn', () => {
       expect(amount).toBeGreaterThan(0n);
 
       const action = asset.methods.burn_private(adminAddress, amount, authwitNonce);
-      const call = await action.getFunctionCall();
-      const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      await t.proxy.methods
-        .forward_private_3(call.to, call.selector, call.args)
-        .send({ from: adminAddress, authWitnesses: [witness] });
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
       tokenSim.burnPrivate(adminAddress, amount);
 
       // Perform the transfer again, should fail
       await expect(
-        t.proxy.methods
-          .forward_private_3(call.to, call.selector, call.args)
-          .send({ from: adminAddress, authWitnesses: [witness] }),
+        sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
       ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
     });
 
@@ -188,16 +185,13 @@ describe('e2e_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn_private(adminAddress, amount, authwitNonce);
+        const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-        // Both wallets are connected to same node and PXE so we could just insert directly
-        // But doing it in two actions to show the flow.
-        const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
-
-        await expect(action.simulate({ from: account1Address, authWitnesses: [witness] })).rejects.toThrow(
-          'Assertion failed: Balance too low',
-        );
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(
+          simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+        ).rejects.toThrow('Assertion failed: Balance too low');
       });
 
       it('burn on behalf of other without approval', async () => {
@@ -206,14 +200,15 @@ describe('e2e_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn_private(adminAddress, amount, authwitNonce);
+        const call = await action.getFunctionCall();
         const messageHash = await computeAuthWitMessageHash(
-          { caller: account1Address, call: await action.getFunctionCall() },
+          { caller: t.authwitProxy.address, call },
           await wallet.getChainInfo(),
         );
 
-        await expect(action.simulate({ from: account1Address })).rejects.toThrow(
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress })).rejects.toThrow(
           `Unknown auth witness for message hash ${messageHash.toString()}`,
         );
       });
@@ -224,18 +219,19 @@ describe('e2e_token_contract burn', () => {
         const authwitNonce = Fr.random();
         expect(amount).toBeGreaterThan(0n);
 
-        // We need to compute the message we want to sign and add it to the wallet as approved
         const action = asset.methods.burn_private(adminAddress, amount, authwitNonce);
+        const call = await action.getFunctionCall();
         const expectedMessageHash = await computeAuthWitMessageHash(
-          { caller: account2Address, call: await action.getFunctionCall() },
+          { caller: t.authwitProxy.address, call },
           await wallet.getChainInfo(),
         );
 
         const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
 
-        await expect(action.simulate({ from: account2Address, authWitnesses: [witness] })).rejects.toThrow(
-          `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-        );
+        // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+        await expect(
+          simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+        ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
       });
     });
   });

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -26,7 +26,7 @@ export class TokenContractTest {
   node!: AztecNode;
 
   badAccount!: InvalidAccountContract;
-  proxy!: GenericProxyContract;
+  authwitProxy!: GenericProxyContract;
   wallet!: TestWallet;
   adminAddress!: AztecAddress;
   account1Address!: AztecAddress;
@@ -98,8 +98,8 @@ export class TokenContractTest {
     // (so their notes are in scope), but msg_sender in the target must differ from the note owner
     // to trigger authwit validation. The proxy forwards calls so that msg_sender != tx sender.
     this.logger.verbose(`Deploying generic proxy...`);
-    this.proxy = await GenericProxyContract.deploy(this.wallet).send({ from: this.adminAddress });
-    this.logger.verbose(`Deployed to ${this.proxy.address}.`);
+    this.authwitProxy = await GenericProxyContract.deploy(this.wallet).send({ from: this.adminAddress });
+    this.logger.verbose(`Deployed to ${this.authwitProxy.address}.`);
 
     this.tokenSim = new TokenSimulator(this.asset, this.wallet, this.adminAddress, this.logger, [
       this.adminAddress,

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
@@ -1,18 +1,19 @@
 import { computeAuthWitMessageHash, computeInnerAuthWitHashFromAction } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR } from '../fixtures/fixtures.js';
 import { TokenContractTest } from './token_contract_test.js';
 
 describe('e2e_token_contract transfer private', () => {
   const t = new TokenContractTest('transfer_private');
-  let { asset, tokenSim, wallet, adminAddress, account1Address, account2Address, badAccount } = t;
+  let { asset, tokenSim, wallet, adminAddress, account1Address, badAccount } = t;
 
   beforeAll(async () => {
     t.applyBaseSnapshots();
     t.applyMintSnapshot();
     await t.setup();
-    ({ asset, tokenSim, wallet, adminAddress, account1Address, account2Address, badAccount } = t);
+    ({ asset, tokenSim, wallet, adminAddress, account1Address, badAccount } = t);
   });
 
   afterAll(async () => {
@@ -30,19 +31,15 @@ describe('e2e_token_contract transfer private', () => {
     expect(amount).toBeGreaterThan(0n);
 
     const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
-    const call = await action.getFunctionCall();
-    const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+    const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-    await t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
+    // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+    await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
     tokenSim.transferPrivate(adminAddress, account1Address, amount);
 
     // Perform the transfer again, should fail
     await expect(
-      t.proxy.methods
-        .forward_private_4(call.to, call.selector, call.args)
-        .send({ from: adminAddress, authWitnesses: [witness] }),
+      sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
     ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
   });
 
@@ -70,15 +67,13 @@ describe('e2e_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
-
-      // Perform the transfer
-      await expect(action.simulate({ from: account1Address, authWitnesses: [witness] })).rejects.toThrow(
-        'Assertion failed: Balance too low',
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow('Assertion failed: Balance too low');
       expect(await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress })).toEqual(balance0);
       expect(await asset.methods.balance_of_private(account1Address).simulate({ from: account1Address })).toEqual(
         balance1,
@@ -98,14 +93,15 @@ describe('e2e_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const messageHash = await computeAuthWitMessageHash(
-        { caller: account1Address, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
-      await expect(action.simulate({ from: account1Address })).rejects.toThrow(
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress })).rejects.toThrow(
         `Unknown auth witness for message hash ${messageHash.toString()}`,
       );
     });
@@ -116,18 +112,19 @@ describe('e2e_token_contract transfer private', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: account2Address, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
       const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
 
-      await expect(action.simulate({ from: account2Address, authWitnesses: [witness] })).rejects.toThrow(
-        `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
       expect(await asset.methods.balance_of_private(adminAddress).simulate({ from: adminAddress })).toEqual(balance0);
     });
 
@@ -138,20 +135,18 @@ describe('e2e_token_contract transfer private', () => {
       expect(amount).toBeGreaterThan(0n);
 
       const action = asset.methods.transfer_in_private(adminAddress, account1Address, amount, authwitNonce);
-      const call = await action.getFunctionCall();
 
-      const intent = { caller: t.proxy.address, action };
+      const intent = { caller: t.authwitProxy.address, action };
 
       const witness = await wallet.createAuthWit(adminAddress, intent);
 
-      const innerHash = await computeInnerAuthWitHashFromAction(t.proxy.address, action);
+      const innerHash = await computeInnerAuthWitHashFromAction(t.authwitProxy.address, action);
       await asset.methods.cancel_authwit(innerHash).send({ from: adminAddress });
 
-      // Perform the transfer, should fail because nullifier already emitted
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      // The transfer should fail because nullifier already emitted
       await expect(
-        t.proxy.methods
-          .forward_private_4(call.to, call.selector, call.args)
-          .send({ from: adminAddress, authWitnesses: [witness] }),
+        sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
       ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
     });
 

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_to_public.test.ts
@@ -1,19 +1,20 @@
 import { computeAuthWitMessageHash } from '@aztec/aztec.js/authorization';
 import { Fr } from '@aztec/aztec.js/fields';
 
+import { sendThroughAuthwitProxy, simulateThroughAuthwitProxy } from '../fixtures/authwit_proxy.js';
 import { DUPLICATE_NULLIFIER_ERROR } from '../fixtures/fixtures.js';
 import { TokenContractTest } from './token_contract_test.js';
 
 describe('e2e_token_contract transfer_to_public', () => {
   const t = new TokenContractTest('transfer_to_public');
-  let { asset, wallet, adminAddress, account1Address, account2Address, tokenSim } = t;
+  let { asset, wallet, adminAddress, account1Address, tokenSim } = t;
 
   beforeAll(async () => {
     t.applyBaseSnapshots();
     t.applyMintSnapshot();
     await t.setup();
     // Have to destructure again to ensure we have latest refs.
-    ({ asset, wallet, adminAddress, account1Address, account2Address, tokenSim } = t);
+    ({ asset, wallet, adminAddress, account1Address, tokenSim } = t);
   });
 
   afterAll(async () => {
@@ -41,19 +42,15 @@ describe('e2e_token_contract transfer_to_public', () => {
     expect(amount).toBeGreaterThan(0n);
 
     const action = asset.methods.transfer_to_public(adminAddress, account1Address, amount, authwitNonce);
-    const call = await action.getFunctionCall();
-    const witness = await wallet.createAuthWit(adminAddress, { caller: t.proxy.address, action });
+    const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-    await t.proxy.methods
-      .forward_private_4(call.to, call.selector, call.args)
-      .send({ from: adminAddress, authWitnesses: [witness] });
+    // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+    await sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] });
     tokenSim.transferToPublic(adminAddress, account1Address, amount);
 
     // Perform the transfer again, should fail
     await expect(
-      t.proxy.methods
-        .forward_private_4(call.to, call.selector, call.args)
-        .send({ from: adminAddress, authWitnesses: [witness] }),
+      sendThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
     ).rejects.toThrow(DUPLICATE_NULLIFIER_ERROR);
   });
 
@@ -86,16 +83,13 @@ describe('e2e_token_contract transfer_to_public', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_to_public(adminAddress, account1Address, amount, authwitNonce);
+      const witness = await wallet.createAuthWit(adminAddress, { caller: t.authwitProxy.address, action });
 
-      // Both wallets are connected to same node and PXE so we could just insert directly
-      // But doing it in two actions to show the flow.
-      const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
-
-      await expect(action.simulate({ from: account1Address, authWitnesses: [witness] })).rejects.toThrow(
-        'Assertion failed: Balance too low',
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow('Assertion failed: Balance too low');
     });
 
     it('on behalf of other (invalid designated caller)', async () => {
@@ -104,20 +98,19 @@ describe('e2e_token_contract transfer_to_public', () => {
       const authwitNonce = Fr.random();
       expect(amount).toBeGreaterThan(0n);
 
-      // We need to compute the message we want to sign and add it to the wallet as approved
       const action = asset.methods.transfer_to_public(adminAddress, account1Address, amount, authwitNonce);
+      const call = await action.getFunctionCall();
       const expectedMessageHash = await computeAuthWitMessageHash(
-        { caller: account2Address, call: await action.getFunctionCall() },
+        { caller: t.authwitProxy.address, call },
         await wallet.getChainInfo(),
       );
 
-      // Both wallets are connected to same node and PXE so we could just insert directly
-      // But doing it in two actions to show the flow.
       const witness = await wallet.createAuthWit(adminAddress, { caller: account1Address, action });
 
-      await expect(action.simulate({ from: account2Address, authWitnesses: [witness] })).rejects.toThrow(
-        `Unknown auth witness for message hash ${expectedMessageHash.toString()}`,
-      );
+      // Admin sends through proxy so their keys are in scope, while proxy becomes msg_sender to trigger authwit.
+      await expect(
+        simulateThroughAuthwitProxy(t.authwitProxy, action, { from: adminAddress, authWitnesses: [witness] }),
+      ).rejects.toThrow(`Unknown auth witness for message hash ${expectedMessageHash.toString()}`);
     });
   });
 });

--- a/yarn-project/end-to-end/src/fixtures/authwit_proxy.ts
+++ b/yarn-project/end-to-end/src/fixtures/authwit_proxy.ts
@@ -1,0 +1,50 @@
+import type {
+  ContractFunctionInteraction,
+  SendInteractionOptions,
+  SimulateInteractionOptions,
+} from '@aztec/aztec.js/contracts';
+import type { GenericProxyContract } from '@aztec/noir-test-contracts.js/GenericProxy';
+
+/**
+ * Builds a proxy forwarding call from an action, selecting the right forward_private_N method.
+ */
+async function buildProxyCall(proxy: GenericProxyContract, action: ContractFunctionInteraction) {
+  const call = await action.getFunctionCall();
+  const argCount = call.args.length;
+  if (argCount === 2) {
+    return proxy.methods.forward_private_2(call.to, call.selector, call.args);
+  } else if (argCount === 3) {
+    return proxy.methods.forward_private_3(call.to, call.selector, call.args);
+  } else if (argCount === 4) {
+    return proxy.methods.forward_private_4(call.to, call.selector, call.args);
+  }
+  throw new Error(`No forward_private_${argCount} method on proxy`);
+}
+
+/**
+ * Sends a contract call through the authwit proxy.
+ * The proxy becomes msg_sender in the target (triggering authwit validation),
+ * while the actual tx sender retains their keys in scope.
+ */
+export async function sendThroughAuthwitProxy(
+  proxy: GenericProxyContract,
+  action: ContractFunctionInteraction,
+  options: SendInteractionOptions,
+) {
+  const proxyCall = await buildProxyCall(proxy, action);
+  return proxyCall.send(options);
+}
+
+/**
+ * Simulates a contract call through the authwit proxy.
+ * The proxy becomes msg_sender in the target (triggering authwit validation),
+ * while the actual tx sender retains their keys in scope.
+ */
+export async function simulateThroughAuthwitProxy(
+  proxy: GenericProxyContract,
+  action: ContractFunctionInteraction,
+  options: SimulateInteractionOptions,
+) {
+  const proxyCall = await buildProxyCall(proxy, action);
+  return proxyCall.simulate(options);
+}


### PR DESCRIPTION
## Summary

The use of the generic proxy for authwit tests made readability quite difficult. We are now improving this by adding two helper functions

At the same time, we are adding a comment to the tests that while a little repetitive, it makes the use of the proxy much clearer