### PR TITLE
docs: protocol contracts

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/auth_registry_contract/src/main.nr
@@ -1,9 +1,20 @@
-/**
- * @title AuthRegistry Contract
- * @notice Manages authorization of public actions through authentication witnesses (authwits)
- * @dev This contract allows users to approve/reject public actions that can be performed on their behalf by other
- * addresses
- */
+/// A contract that manages public authentication witnesses (authwits) on the Aztec network.
+///
+/// In Aztec, private authwits are verified by account contracts directly (via oracles on the user's device). Public
+/// authwits, however, require this onchain registry because local oracles cannot be used for global execution. Users pre-approve
+/// actions by storing `message_hash -> true` mappings via `set_authorized`, and consumer contracts verify and
+/// atomically revoke these approvals via `consume`.
+///
+/// The `message_hash` includes the consumer address, chain ID, and protocol version, preventing cross-chain and
+/// cross-contract replay. Each approval can only be consumed once. Users can also enable `reject_all` as an emergency
+/// kill switch to invalidate all outstanding approvals at once.
+///
+/// A private-to-public bridge is provided via `set_authorized_private`: a user signs a private authwit, and any party
+/// holding it can call this function to insert the corresponding public approval.
+///
+/// Note that there is no expiration time enforced on the approved actions in this contract as this can be achieved by
+/// including an expiration timestamp in the `message` (`message_hash` preimage) and having the consumer contract
+/// constrain that value.
 pub contract AuthRegistry {
     use aztec::{
         authwit::auth::{
@@ -22,19 +33,16 @@ pub contract AuthRegistry {
     };
 
     struct Storage<Context> {
-        /// Map of addresses that have rejected all actions
+        /// Per-address flag that, when true, causes all `consume` calls for that address to revert. Provides an
+        /// emergency "mass revocation" mechanism. Does not delete existing approvals - if later set back to false,
+        /// unconsumed approvals become consumable again.
         reject_all: Map<AztecAddress, PublicMutable<bool, Context>, Context>,
-        /// Nested map of approvers to their authorized message hashes
-        /// First key is the approver address, second key is the message hash, value is authorization status
+        /// Per-user, per-message authorization status. `approved_actions[user][message_hash]` is set to true by
+        /// `set_authorized` and atomically revoked by `consume` to prevent replay.
         approved_actions: Map<AztecAddress, Map<Field, PublicMutable<bool, Context>, Context>, Context>,
     }
 
-    /**
-     * Updates the `authorized` value for `msg_sender` for `message_hash`.
-     *
-     * @param message_hash The message hash being authorized
-     * @param authorize True if the caller is authorized to perform the message hash, false otherwise
-     */
+    /// Approves or revokes a `message_hash` for the caller.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     unconstrained fn set_authorized(message_hash: Field, authorize: bool) {
         // MACRO CODE START
@@ -51,13 +59,8 @@ pub contract AuthRegistry {
         storage.approved_actions.at(avm::sender()).at(message_hash).write(authorize);
     }
 
-    /**
-     * Updates the `reject_all` value for `msg_sender`.
-     *
-     * When `reject_all` is `true` any `consume` on `msg_sender` will revert.
-     *
-     * @param reject True if all actions should be rejected, false otherwise
-     */
+    /// Enables or disables mass rejection of all authwits for the caller. When enabled, all `consume` calls for the
+    /// caller's address will revert regardless of individual approvals.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     unconstrained fn set_reject_all(reject: bool) {
         // MACRO CODE START
@@ -73,16 +76,19 @@ pub contract AuthRegistry {
         storage.reject_all.at(avm::sender()).write(reject);
     }
 
-    /**
-     * Consumes an `inner_hash` on behalf of `on_behalf_of` if the caller is authorized to do so.
-     *
-     * Will revert even if the caller is authorized if `reject_all` is set to true for `on_behalf_of`.
-     * This is to support "mass-revoke".
-     *
-     * @param on_behalf_of The address on whose behalf the action is being consumed
-     * @param inner_hash The inner_hash of the authwit
-     * @return `IS_VALID_SELECTOR` if the action was consumed, revert otherwise
-     */
+    /// Consumes (verifies and atomically revokes) an authorization on behalf of `on_behalf_of`.
+    ///
+    /// Called by consumer contracts (e.g. Token) to verify a user has authorized an action. This function:
+    /// 1. Checks that `on_behalf_of` has not enabled `reject_all`.
+    /// 2. Recomputes the `message_hash` from the caller (consumer), chain ID, version, and `inner_hash`, binding the
+    ///    approval to this specific consumer contract.
+    /// 3. Verifies the message was approved and atomically revokes it to prevent replay.
+    ///
+    /// Returns `IS_VALID_SELECTOR` (0x47dacd73) on success instead of a boolean. This follows the EIP-1271 pattern:
+    /// a failed or malformed call would return the default zero value, which is indistinguishable from `false`. By
+    /// requiring a specific magic value, the caller can reliably distinguish a successful validation from a failed
+    /// call. The function also reverts on failure as a first line of defense, making the magic return value a
+    /// defense-in-depth measure against subtle integration bugs on the caller side.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     unconstrained fn consume(on_behalf_of: AztecAddress, inner_hash: Field) -> pub Field {
         // MACRO CODE START
@@ -96,8 +102,11 @@ pub contract AuthRegistry {
         let storage: Storage<PublicContext> = Storage::init(context);
         // MACRO CODE END
 
+        // reject_all is checked first so it takes precedence over individual approvals.
         assert_eq(false, storage.reject_all.at(on_behalf_of).read(), "rejecting all");
 
+        // The msg_sender here is the consumer contract, not the original user. This binds
+        // the approval to a specific consumer, preventing cross-contract replay.
         let message_hash = compute_authwit_message_hash(
             context.maybe_msg_sender().unwrap(),
             context.chain_id(),
@@ -106,24 +115,23 @@ pub contract AuthRegistry {
         );
 
         let authorized = storage.approved_actions.at(on_behalf_of).at(message_hash).read();
-
         assert_eq(true, authorized, "unauthorized");
+        // Revoke the approval to prevent replay.
         storage.approved_actions.at(on_behalf_of).at(message_hash).write(false);
 
         IS_VALID_SELECTOR
     }
 
-    /**
-     * Updates a public authwit using a private authwit
-     *
-     * Useful for the case where you want someone else to insert a public authwit for you.
-     * For example, if Alice wants Bob to insert an authwit in public, such that they can execute
-     * a trade, Alice can create a private authwit, and Bob can call this function with it.
-     *
-     * @param approver The address of the approver (Alice in the example)
-     * @param message_hash The message hash to authorize
-     * @param authorize True if the message hash should be authorized, false otherwise
-     */
+    /// Bridges a private authwit into a public authorization entry.
+    ///
+    /// Allows any party to insert a public approval on behalf of `approver`, provided they present a valid private
+    /// authwit from that approver. Useful when e.g. Alice wants Bob to insert a public authwit for her so they can
+    /// execute a trade - Alice signs a private authwit and Bob calls this function.
+    ///
+    /// This function:
+    /// 1. Verifies the approver's private authwit via `assert_current_call_valid_authwit` (static call + nullifier
+    ///    emission to prevent replay).
+    /// 2. Enqueues a public call to `_set_authorized` to write the approval during the public phase.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn set_authorized_private(
         inputs: aztec::context::inputs::PrivateContextInputs,
@@ -143,12 +151,10 @@ pub contract AuthRegistry {
 
         // MACRO CODE END
 
-        // 3 corresponds to the number of arguments of the function
+        // The generic parameter `3` is the number of function arguments (approver, message_hash, authorize).
         assert_current_call_valid_authwit::<3>(&mut context, approver);
 
-        // Enqueue call to _set_authorized
-        // Note: This was originally just `self.enqueue_self._set_authorized(approver, message_hash, authorize);`
-        // before de-macroification.
+        // Enqueue a public call to _set_authorized to write the approval into public storage.
         {
             let enqueue_params: [Field; 3] =
                 [approver.to_field(), message_hash, authorize.to_field()];
@@ -169,14 +175,8 @@ pub contract AuthRegistry {
         // MACRO CODE END
     }
 
-    /**
-     * Internal function to update the `authorized` value for `approver` for `messageHash`.
-     * Used along with `set_authorized_private` to update the public authwit.
-     *
-     * @param approver The address of the approver
-     * @param message_hash The message hash being authorized
-     * @param authorize True if the caller is authorized to perform the message hash, false otherwise
-     */
+    /// A function that writes an authorization entry for an arbitrary `approver`. Only callable by this contract
+    /// itself (`#[only_self]`), ensuring it is only reachable through the validated `set_authorized_private` flow.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_only_self]
     unconstrained fn _set_authorized(approver: AztecAddress, message_hash: Field, authorize: bool) {
@@ -193,7 +193,6 @@ pub contract AuthRegistry {
         );
         let storage: Storage<PublicContext> = Storage::init(context);
 
-        // Originally injected by the #[only_self] macro
         assert(
             avm::sender() == context.this_address(),
             "Function _set_authorized can only be called by the same contract",
@@ -203,12 +202,7 @@ pub contract AuthRegistry {
         storage.approved_actions.at(approver).at(message_hash).write(authorize);
     }
 
-    /**
-     * Fetches the `reject_all` value for `on_behalf_of`.
-     *
-     * @param on_behalf_of The address to check
-     * @return True if all actions are rejected, false otherwise
-     */
+    /// Returns whether `on_behalf_of` has enabled the `reject_all` flag.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
     unconstrained fn is_reject_all(on_behalf_of: AztecAddress) -> pub bool {
@@ -222,20 +216,14 @@ pub contract AuthRegistry {
         );
         let storage: Storage<PublicContext> = Storage::init(context);
 
-        // Originally injected by the #[view] macro
         assert(context.is_static_call(), "Function is_reject_all can only be called statically");
         // MACRO CODE END
 
         storage.reject_all.at(on_behalf_of).read()
     }
 
-    /**
-     * Fetches the `authorized` value for `on_behalf_of` for `message_hash`.
-     *
-     * @param on_behalf_of The address on whose behalf the action is being consumed
-     * @param message_hash The message hash to check
-     * @return True if the caller is authorized to perform the action, false otherwise
-     */
+    /// Returns whether a specific `message_hash` is currently approved for `on_behalf_of`.
+    /// Does NOT check the `reject_all` flag - also check `is_reject_all` for a complete picture.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
     unconstrained fn is_consumable(on_behalf_of: AztecAddress, message_hash: Field) -> pub bool {
@@ -249,16 +237,13 @@ pub contract AuthRegistry {
         );
         let storage: Storage<PublicContext> = Storage::init(context);
 
-        // Originally injected by the #[view] macro
         assert(context.is_static_call(), "Function is_consumable can only be called statically");
         // MACRO CODE END
 
         storage.approved_actions.at(on_behalf_of).at(message_hash).read()
     }
 
-    /**
-     * Just like `is_consumable`, but a utility function and not public.
-     */
+    /// Utility version of `is_consumable`
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_utility]
     unconstrained fn utility_is_consumable(
         on_behalf_of: AztecAddress,
@@ -274,20 +259,24 @@ pub contract AuthRegistry {
         storage.approved_actions.at(on_behalf_of).at(message_hash).read()
     }
 
-    // // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
 
-    // Function selectors computed at comptime from function signatures
     global SET_AUTHORIZED_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("set_authorized(Field,bool)").to_field() };
+
     global SET_REJECT_ALL_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("set_reject_all(bool)").to_field() };
+
     global CONSUME_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("consume((Field),Field)").to_field() };
+
     global _SET_AUTHORIZED_SELECTOR: Field = comptime {
         FunctionSelector::from_signature("_set_authorized((Field),Field,bool)").to_field()
     };
+
     global IS_REJECT_ALL_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("is_reject_all((Field))").to_field() };
+
     global IS_CONSUMABLE_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("is_consumable((Field),Field)").to_field() };
 
@@ -365,7 +354,6 @@ pub contract AuthRegistry {
         }
     }
 
-    // Parameter structs for ABI
     pub struct _set_authorized_parameters {
         pub _approver: AztecAddress,
         pub _message_hash: Field,
@@ -406,7 +394,6 @@ pub contract AuthRegistry {
         pub _message_hash: Field,
     }
 
-    // ABI structs
     #[abi(functions)]
     pub struct _set_authorized_abi {
         parameters: _set_authorized_parameters,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_class_registry_contract/src/main.nr
@@ -1,6 +1,24 @@
 mod events;
 mod validate_bytecode;
 
+/// Protocol contract that tracks which contract classes have been published to the network.
+///
+/// In Aztec, contracts are split into *classes* and *instances* (deployments of a class at a unique address). This
+/// contract handles publishing of contract classes.
+///
+/// Every contract class must be registered here before any instance of that class can be deployed via the
+/// ContractInstanceRegistry - this applies even to contracts with no public functions. Registration is also
+/// a prerequisite for contract upgrades: the *new* class must be published before an existing deployed contract
+/// instance can update its class id (a contract instance that is not registered in ContractInstanceRegistry cannot
+/// be upgraded).
+///
+/// Registration works by emitting a nullifier keyed to the contract class id. Other protocol contracts
+/// (e.g. ContractInstanceRegistry) verify registration by asserting this nullifier exists.
+///
+/// Contracts with public functions need to have their bytecode published in order for for the sequencer to be
+/// guaranteed to be able to execute a public function (this is achieved by checking contract instance address
+/// nullifier exists by the AVM - see ContractInstanceRegistry for more details). ACIR of private functions does not
+/// need to be published here as private functions are executed on user devices.
 pub contract ContractClassRegistry {
     use crate::events::class_published::ContractClassPublished;
     use crate::validate_bytecode::validate_packed_public_bytecode;
@@ -16,6 +34,23 @@ pub contract ContractClassRegistry {
         },
     };
 
+    /// Publishes a contract class to the network.
+    ///
+    /// The caller provides the three components of the contract class id (artifact_hash, private_functions_root,
+    /// public_bytecode_commitment) together with the packed public bytecode loaded via a capsule. For contracts with
+    /// no public functions the bytecode is empty, but registration is still possible so that the instance can later be
+    /// deployed or upgraded.
+    ///
+    /// Note that there is only one public bytecode commitment per contract instead of per contract-function as
+    /// bytecode of public functions is merged into one `public_dispatch` function and the relevant code branch is then
+    /// executed based on the function selector.
+    ///
+    /// This function:
+    /// 1. Validates the packed bytecode against the provided commitment.
+    /// 2. Recomputes and emits the contract class id as a nullifier (preventing duplicate registration and serving as
+    /// a proof of publication).
+    /// 3. Broadcasts a `ContractClassPublished` event containing the full class metadata and bytecode so that nodes
+    /// can reconstruct the class.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn publish(
         inputs: aztec::context::inputs::PrivateContextInputs,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
@@ -1,8 +1,8 @@
-/**
- * @title ContractInstanceRegistry Contract
- * @notice Manages the registration and updating of contract instances
- * @dev This contract allows deploying new contract instances and updating their class IDs
- */
+/// Protocol contract responsible for deploying contract instances and managing contract upgrades.
+///
+/// In Aztec, contracts are split into *classes* (code, registered via ContractClassRegistry) and *instances*
+/// (deployments of a class at a unique address). This contract handles contract instance publishing and contract
+/// updates (updating instance to a new class).
 pub contract ContractInstanceRegistry {
     use aztec::{
         context::{PrivateContext, PublicContext},
@@ -37,35 +37,8 @@ pub contract ContractInstanceRegistry {
         deployer: AztecAddress,
     }
 
-    // We need to impl this separately because ts deserializes a point as two fields only.
-    // We had issues that:
-    // Notice how the 'is_infinite' field is deserialized as the next point.
-    // {
-    //     masterNullifierPublicKey: Point {
-    //   x: Fr<0x0000000000000000000000000000000000000000000000000000000000000012>,
-    //   y: Fr<0x0000000000000000000000000000000000000000000000000000000000000034>,
-    //   isInfinite: false,
-    //   kind: 'point'
-    // },
-    // masterIncomingViewingPublicKey: Point {
-    //   x: Fr<0x0000000000000000000000000000000000000000000000000000000000000000>,
-    //   y: Fr<0x0000000000000000000000000000000000000000000000000000000000000056>,
-    //   isInfinite: false,
-    //   kind: 'point'
-    // },
-    // masterOutgoingViewingPublicKey: Point {
-    //   x: Fr<0x0000000000000000000000000000000000000000000000000000000000000078>,
-    //   y: Fr<0x0000000000000000000000000000000000000000000000000000000000000000>,
-    //   isInfinite: false,
-    //   kind: 'point'
-    // },
-    // masterTaggingPublicKey: Point {
-    //   x: Fr<0x0000000000000000000000000000000000000000000000000000000000000910>,
-    //   y: Fr<0x0000000000000000000000000000000000000000000000000000000000001112>,
-    //   isInfinite: false,
-    //   kind: 'point'
-    // }
-
+    // Custom serialization is required because we don't want to waste one field for the `is_infinite` flag of public
+    // key points (public key points will never be the infinity point).
     impl ContractInstancePublished {
         fn serialize_non_standard(self) -> [Field; 15] {
             [
@@ -99,9 +72,24 @@ pub contract ContractInstanceRegistry {
     }
 
     struct Storage<Context> {
+        /// Map from contract instance address to a `DelayedPublicMutable` holding the updated contract class ID.
         updated_class_ids: Map<AztecAddress, DelayedPublicMutable<ContractClassId, DEFAULT_UPDATE_DELAY, Context>, Context>,
     }
 
+    /// Publishes a new contract instance.
+    ///
+    /// The caller provides deployment parameters (salt, class_id, init_hash, public_keys, universal_deploy).
+    /// The `universal_deploy` flag controls whether the deployer address is bound into the contract address:
+    /// when true, deployer is zero (anyone can deploy the same instance); when false, deployer is the caller.
+    ///
+    /// This function:
+    /// 1. Verifies the contract class is registered in ContractClassRegistry (nullifier existence check).
+    /// 2. Validates public key points are on the Grumpkin curve (preventing AVM DoS via invalid points).
+    /// 3. Computes the deterministic contract address from the deployment parameters.
+    /// 4. Emits the address as a nullifier (proving publication preventing duplicate deployment)
+    ///    --> this address nullifier is then checked to exist by the AVM upon public function execution (if it doesn't
+    ///        exist AVM reverts)
+    /// 5. Broadcasts a `ContractInstancePublished` event so nodes can reconstruct the instance.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn publish_for_public_execution(
         inputs: aztec::context::inputs::PrivateContextInputs,
@@ -128,14 +116,15 @@ pub contract ContractInstanceRegistry {
         let mut context: PrivateContext = PrivateContext::new(inputs, args_hash);
         // MACRO CODE END
 
-        // Verify that the contract class is registered
+        // Verify the contract class is registered by checking for its nullifier at the ContractClassRegistry address.
         let nullifier_existence_request = compute_nullifier_existence_request(
             contract_class_id.to_field(),
             CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,
         );
         context.assert_nullifier_exists(nullifier_existence_request);
 
-        // Determine the deployer based on universal_deploy flag
+        // For universal deployments, deployer is zero so the resulting address is the same regardless of who initiates
+        // deployment.
         let deployer = if universal_deploy {
             AztecAddress::zero()
         } else {
@@ -145,22 +134,19 @@ pub contract ContractInstanceRegistry {
         let partial_address =
             PartialAddress::compute(contract_class_id, salt, initialization_hash, deployer);
 
-        // Note: Out of all the public keys, only the Ivpk_m is checked to be on the curve
-        // (implicitly as part of the `add` operation of deriving the address). This at least
-        // protects the AVM against DoS attacks.
-        // For thoroughness, we also ensure the other points are on the curve:
+        // Validate public key points lie on the Grumpkin curve to prevent AVM DoS.
+        // ivpk_m is validated implicitly during address derivation.
         validate_on_curve(public_keys.npk_m.inner);
         validate_on_curve(public_keys.ovpk_m.inner);
         validate_on_curve(public_keys.tpk_m.inner);
 
         let address = AztecAddress::compute(public_keys, partial_address);
 
-        // Emit the address as a nullifier:
-        // - to demonstrate that this contract instance hasn't been published before
-        // - to enable apps to read that this contract instance has been published.
+        // Emit address as nullifier: prevents duplicate deployment and proves publication.
         context.push_nullifier(address.to_field());
 
-        // Emit the deployment event
+        // Broadcast deployment event. Uses non-standard serialization (2 fields per point,
+        // omitting is_infinite) for TypeScript SDK compatibility.
         let event = ContractInstancePublished {
             CONTRACT_INSTANCE_PUBLISHED_MAGIC_VALUE,
             contract_class_id,
@@ -182,6 +168,15 @@ pub contract ContractInstanceRegistry {
         // MACRO CODE END
     }
 
+    /// Schedules an upgrade of the calling contract instance to a new contract class.
+    ///
+    /// The change is time-delayed via `DelayedPublicMutable` and only takes effect after the configured
+    /// delay has elapsed. Only the contract instance itself can call this function (msg.sender == address).
+    ///
+    /// This function:
+    /// 1. Verifies msg.sender is a deployed contract (its address nullifier exists).
+    /// 2. Verifies the new class is registered in ContractClassRegistry.
+    /// 3. Schedules the class ID change and emits a `ContractInstanceUpdated` event.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     unconstrained fn update(new_contract_class_id: ContractClassId) {
         // MACRO CODE START
@@ -230,6 +225,9 @@ pub contract ContractInstanceRegistry {
         context.emit_public_log(event);
     }
 
+    /// Schedules a change to the upgrade delay for the calling contract instance. The delay change is
+    /// itself delayed (preventing atomically reducing delay + scheduling an instant upgrade). The new
+    /// delay must be at least `MINIMUM_UPDATE_DELAY`.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     unconstrained fn set_update_delay(new_update_delay: u64) {
         // MACRO CODE START
@@ -256,11 +254,7 @@ pub contract ContractInstanceRegistry {
         storage.updated_class_ids.at(msg_sender).schedule_delay_change(new_update_delay);
     }
 
-    /**
-     * Gets the current update delay for the caller's contract instance.
-     *
-     * @return The current update delay value
-     */
+    /// Returns the current update delay for the calling contract instance.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
     unconstrained fn get_update_delay() -> pub u64 {
@@ -278,9 +272,8 @@ pub contract ContractInstanceRegistry {
         storage.updated_class_ids.at(avm::sender()).get_current_delay()
     }
 
-    // // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
+    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
 
-    // Function selectors computed at comptime from function signatures
     global UPDATE_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("update((Field))").to_field() };
     global SET_UPDATE_DELAY_SELECTOR: Field =
@@ -313,8 +306,6 @@ pub contract ContractInstanceRegistry {
         panic(f"Unknown selector {selector}")
     }
 
-    // THE REST OF THE CODE IN THIS CONTRACT WAS ORIGINALLY INJECTED BY THE #[aztec] MACRO.
-
     impl<Context> Storage<Context> {
         fn init(context: Context) -> Self {
             Self {
@@ -326,7 +317,6 @@ pub contract ContractInstanceRegistry {
         }
     }
 
-    // Parameter structs for ABI
     pub struct publish_for_public_execution_parameters {
         pub _salt: Field,
         pub _contract_class_id: ContractClassId,
@@ -345,7 +335,6 @@ pub contract ContractInstanceRegistry {
 
     pub struct get_update_delay_parameters {}
 
-    // ABI structs
     #[abi(functions)]
     pub struct publish_for_public_execution_abi {
         parameters: publish_for_public_execution_parameters,

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/lib.nr
@@ -7,6 +7,11 @@ pub fn calculate_fee<TPublicContext>(context: PublicContext) -> Field {
     context.transaction_fee()
 }
 
+/// Computes the content hash for an L1-to-L2 "bridge gas" message, matching the hash produced on L1 by
+/// `FeeJuicePortal.depositToAztecPublic`: `sha256ToField(abi.encodeWithSignature("claim(bytes32,uint256)", to, amount))`.
+///
+/// The 68-byte buffer is: [4-byte selector of "claim(bytes32,uint256)"][32-byte recipient][32-byte amount], hashed
+/// with `sha256_to_field` to produce a single Field.
 pub fn get_bridge_gas_msg_hash(owner: AztecAddress, amount: u128) -> Field {
     let mut hash_bytes = [0; 68];
     let recipient_bytes: [u8; 32] = owner.to_field().to_be_bytes();

--- a/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/fee_juice_contract/src/main.nr
@@ -1,3 +1,16 @@
+/// Protocol contract that manages the native gas token ("Fee Juice") used to pay transaction fees.
+///
+/// Fee Juice is minted on L2 by bridging from L1: a user deposits ERC-20 tokens into the L1 FeeJuicePortal, which
+/// sends an L1-to-L2 message. On L2, `claim` or `claim_and_end_setup` consumes that message and credits the
+/// recipient's balance via an enqueued public call to `_increase_public_balance`.
+///
+/// The protocol's base rollup circuits read directly from this contract's `balances` storage map (at slot 1) to verify
+/// fee payers can cover their transaction costs. This storage layout is protocol-critical and must not change without
+/// updating the base rollup circuits.
+///
+/// There is no withdrawal mechanism -- Fee Juice can only be bridged in, not withdrawn or transferred by users. Tokens
+/// leave the L1 portal only via `distributeFees` called by the Rollup contract to pay sequencers.
+
 mod lib;
 
 pub contract FeeJuice {
@@ -14,21 +27,23 @@ pub contract FeeJuice {
     use std::ops::Add;
 
     struct Storage<Context> {
-        // This map is accessed directly by protocol circuits to check balances for fee payment.
-        // Do not change this storage layout unless you also update the base rollup circuits.
+        // contract address --> public fee juice balance
         balances: Map<AztecAddress, PublicMutable<u128, Context>, Context>,
     }
 
     global INCREASE_PUBLIC_BALANCE_SELECTOR: Field = comptime {
         FunctionSelector::from_signature("_increase_public_balance((Field),u128)").to_field()
     };
+
     global CHECK_BALANCE_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("check_balance(u128)").to_field() };
+
     global BALANCE_OF_PUBLIC_SELECTOR: Field =
         comptime { FunctionSelector::from_signature("balance_of_public((Field))").to_field() };
 
-    /// Verifies that a message from L1 exists with the correct claim information, consumes it (emitting a nullifier)
-    /// and enqueues the increase in public balance of the recipient.
+    /// A helper implementing the core L1-to-L2 message claim logic shared by `claim` and `claim_and_end_setup`.
+    /// Computes the expected content hash, consumes the L1-to-L2 message (emitting a nullifier to prevent
+    /// double-claiming), and enqueues a public call to `_increase_public_balance` to credit the recipient.
     #[contract_library_method]
     fn claim_helper(
         context: &mut aztec::context::PrivateContext,
@@ -41,12 +56,10 @@ pub contract FeeJuice {
         let portal_address: EthAddress = EthAddress::from_field(FEE_JUICE_ADDRESS.to_field());
         assert(!portal_address.is_zero());
 
-        // Consume message and emit nullifier
+        // Consume the L1-to-L2 message (verifies existence + emits nullifier to prevent replay).
         context.consume_l1_to_l2_message(content_hash, secret, portal_address, message_leaf_index);
 
-        // Enqueue call to _increase_public_balance
-        // Note: The rest of the function body used to be `self.enqueue_self._increase_public_balance(to, amount);`
-        // before de-macroification.
+        // Enqueue a public call to _increase_public_balance to credit the recipient.
         let serialized_params: [Field; 2] = [to.to_field(), amount.to_field()];
         let calldata: [Field; 1 + 2] = [INCREASE_PUBLIC_BALANCE_SELECTOR].concat(serialized_params);
         let calldata_hash: Field = aztec::hash::hash_calldata_array(calldata);
@@ -59,7 +72,10 @@ pub contract FeeJuice {
         );
     }
 
-    /// Claims FeeJuice by consuming an L1 to L2 message with the provided information.
+    /// Claims Fee Juice by consuming an L1-to-L2 message from the FeeJuicePortal.
+    ///
+    /// Use this variant when the claimed Fee Juice is NOT intended to pay for the current transaction's fees (e.g.,
+    /// pre-funding an account for future transactions).
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn claim(
         inputs: aztec::context::inputs::PrivateContextInputs,
@@ -69,7 +85,7 @@ pub contract FeeJuice {
         message_leaf_index: Field,
     ) -> return_data aztec::protocol::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs {
         // MACRO CODE START
-        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function.
+        // Note: The macros initially inserted a phase check here, but since there is no phase change in this function
         // nor in the claim helper function or the enqueued public function call, I have removed that check.
         aztec::oracle::version::assert_compatible_oracle_version();
         let serialized_params: [Field; 4] =
@@ -86,10 +102,12 @@ pub contract FeeJuice {
         // MACRO CODE END
     }
 
-    /// Claims FeeJuice by consuming an L1 to L2 message with the provided information. After enqueuing the
-    /// the balance increase it ends the setup phase, making sure the claim happens in the non-revertible phase
-    /// of the transaction. This variant should only be used when the intent is to pay the transaction fee via
-    /// the claimed fee juice in a single interaction.
+    /// Claims Fee Juice and ends the transaction setup phase.
+    ///
+    /// Use this variant when the claimed Fee Juice is intended to pay for THIS transaction's fees. By ending setup
+    /// after the claim, the balance increase is placed in the non-revertible phase, ensuring the fee payer's balance
+    /// is credited even if the revertible portion of the transaction fails. This guarantees the sequencer can collect
+    /// fees.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_private]
     fn claim_and_end_setup(
         inputs: aztec::context::inputs::PrivateContextInputs,
@@ -110,11 +128,15 @@ pub contract FeeJuice {
         claim_helper(&mut context, to, amount, secret, message_leaf_index);
 
         // MACRO CODE START
+        // End setup: everything before this point (including the enqueued _increase_public_balance
+        // call) is non-revertible. Everything after is revertible.
         context.end_setup();
         context.finish()
         // MACRO CODE END
     }
 
+    /// Internal function that credits a recipient's Fee Juice balance. Only callable by this contract itself
+    /// (`#[only_self]`), enqueued by `claim` / `claim_and_end_setup` after consuming an L1-to-L2 message.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_only_self]
     unconstrained fn _increase_public_balance(to: AztecAddress, amount: u128) {
@@ -142,6 +164,8 @@ pub contract FeeJuice {
         storage.balances.at(to).write(new_balance);
     }
 
+    /// Asserts the caller has at least `fee_limit` Fee Juice. Used during transaction validation to verify the fee
+    /// payer can cover the transaction's fee limit.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
     unconstrained fn check_balance(fee_limit: u128) {
@@ -167,6 +191,7 @@ pub contract FeeJuice {
         );
     }
 
+    /// Returns the Fee Juice balance of the given address.
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_public]
     #[aztec::macros::internals_functions_generation::abi_attributes::abi_view]
     unconstrained fn balance_of_public(owner: AztecAddress) -> pub u128 {
@@ -260,6 +285,7 @@ pub contract FeeJuice {
             }
         }
     }
+
     pub struct _increase_public_balance_parameters {
         pub _to: AztecAddress,
         pub _amount: u128,


### PR DESCRIPTION
Code docs in protocol contracts where needed as it's a core piece of infrastructure and they are going for an audit today. For this reason I decided to go ahead and write them.

**Update**: Just realized that AuthRegistry is not a protocol contracts. I've already wrote the docs so sending it for the review here. We really need to move the non-protocol contracts out.