### PR TITLE
feat: dedup arrays before reset

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,7 @@
     "dbanks",
     "DCMAKE",
     "decrementation",
+    "dedup",
     "deduped",
     "defi",
     "deinit",

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer.nr
@@ -162,20 +162,24 @@ impl ResetOutputComposer {
     unconstrained fn get_propagated_validation_requests<let KeyValidationAmount: u32>(
         self,
     ) -> PrivateValidationRequests {
-        let validation_requests = self.previous_kernel.validation_requests;
+        // Propagation works with arrays that have already been deduplicated.
+        // This is because each reset circuit iteration performs costly processing, so we eliminate duplicates up front,
+        // since doing so is comparatively cheap, to prevent redundant work on the same logical request.
+        // All corresponding hints and validation amounts are calculated after deduplication, ensuring that expensive
+        // operations are performed only on unique requests.
 
         let kept_note_hash_read_requests = get_propagated_read_requests(
-            validation_requests.note_hash_read_requests,
+            self.squashed_output_array_hints.deduped_note_hash_read_requests,
             self.note_hash_read_request_actions_hints,
         );
 
         let kept_nullifier_read_requests = get_propagated_read_requests(
-            validation_requests.nullifier_read_requests,
+            self.squashed_output_array_hints.deduped_nullifier_read_requests,
             self.nullifier_read_request_actions_hints,
         );
 
         let scoped_key_validation_requests_and_generators = get_propagated_key_validation_requests(
-            validation_requests.scoped_key_validation_requests_and_generators,
+            self.squashed_output_array_hints.deduped_key_validation_requests,
             KeyValidationAmount,
         );
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
@@ -1,10 +1,20 @@
-use crate::reset::{squash_transient_data, TransientDataSquashingHint};
+use crate::{
+    components::reset_output_validator::check_duplicates::{
+        are_duplicate_key_validation_requests, are_duplicate_read_requests,
+    },
+    reset::{dedup_array, squash_transient_data, TransientDataSquashingHint},
+};
 use types::{
     abis::{
         kernel_circuit_public_inputs::PrivateKernelCircuitPublicInputs, note_hash::NoteHash,
         nullifier::Nullifier, private_log::PrivateLogData,
+        validation_requests::KeyValidationRequestAndGenerator,
     },
-    constants::{MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX, MAX_PRIVATE_LOGS_PER_TX},
+    constants::{
+        MAX_KEY_VALIDATION_REQUESTS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+        MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_NULLIFIERS_PER_TX,
+        MAX_PRIVATE_LOGS_PER_TX,
+    },
     side_effect::{Counted, Scoped},
     utils::arrays::ClaimedLengthArray,
 };
@@ -16,6 +26,15 @@ pub struct SquashedOutputArrayHints {
     pub kept_note_hashes: ClaimedLengthArray<Scoped<Counted<NoteHash>>, MAX_NOTE_HASHES_PER_TX>,
     pub kept_nullifiers: ClaimedLengthArray<Scoped<Counted<Nullifier>>, MAX_NULLIFIERS_PER_TX>,
     pub kept_private_logs: ClaimedLengthArray<Scoped<Counted<PrivateLogData>>, MAX_PRIVATE_LOGS_PER_TX>,
+    // "deduped" requests are the result after removing duplicates.
+    // For read requests, duplicates are identified by matching value + contract_address (ignoring counter).
+    // For key validation, duplicates are exact matches of all fields.
+    pub deduped_note_hash_read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, MAX_NOTE_HASH_READ_REQUESTS_PER_TX>,
+    pub note_hash_read_request_dedup_hints: [u32; MAX_NOTE_HASH_READ_REQUESTS_PER_TX],
+    pub deduped_nullifier_read_requests: ClaimedLengthArray<Scoped<Counted<Field>>, MAX_NULLIFIER_READ_REQUESTS_PER_TX>,
+    pub nullifier_read_request_dedup_hints: [u32; MAX_NULLIFIER_READ_REQUESTS_PER_TX],
+    pub deduped_key_validation_requests: ClaimedLengthArray<Scoped<KeyValidationRequestAndGenerator>, MAX_KEY_VALIDATION_REQUESTS_PER_TX>,
+    pub key_validation_request_dedup_hints: [u32; MAX_KEY_VALIDATION_REQUESTS_PER_TX],
 }
 
 // Splice-removes some transient notes, nullifiers, and private logs, from the previous kernel's
@@ -37,5 +56,32 @@ pub unconstrained fn generate_squashed_output_array_hints<let TransientDataSquas
         transient_data_squashing_hints,
     );
 
-    SquashedOutputArrayHints { kept_note_hashes, kept_nullifiers, kept_private_logs }
+    // Deduplicate validation requests to reduce the number of expensive validations
+    // (merkle membership checks for reads, EC operations for key validation).
+    let (deduped_note_hash_read_requests, note_hash_read_request_dedup_hints) = dedup_array(
+        previous_kernel.validation_requests.note_hash_read_requests,
+        are_duplicate_read_requests,
+    );
+
+    let (deduped_nullifier_read_requests, nullifier_read_request_dedup_hints) = dedup_array(
+        previous_kernel.validation_requests.nullifier_read_requests,
+        are_duplicate_read_requests,
+    );
+
+    let (deduped_key_validation_requests, key_validation_request_dedup_hints) = dedup_array(
+        previous_kernel.validation_requests.scoped_key_validation_requests_and_generators,
+        are_duplicate_key_validation_requests,
+    );
+
+    SquashedOutputArrayHints {
+        kept_note_hashes,
+        kept_nullifiers,
+        kept_private_logs,
+        deduped_note_hash_read_requests,
+        note_hash_read_request_dedup_hints,
+        deduped_nullifier_read_requests,
+        nullifier_read_request_dedup_hints,
+        deduped_key_validation_requests,
+        key_validation_request_dedup_hints,
+    }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
@@ -1,4 +1,7 @@
+pub mod check_duplicates;
 mod validate_note_logs_linked_to_note_hashes;
+
+use check_duplicates::{are_duplicate_key_validation_requests, are_duplicate_read_requests};
 
 use crate::{
     abis::{PaddedSideEffects, PrivateKernelResetHints},
@@ -7,7 +10,10 @@ use crate::{
         assert_sorted_padded_transformed_i_array_capped_size,
     },
     components::reset_output_composer::SquashedOutputArrayHints,
-    reset::{KeyValidationRequestsValidator, ReadRequestValidator, TransientDataValidator},
+    reset::{
+        KeyValidationRequestsValidator, ReadRequestValidator, TransientDataValidator,
+        validate_deduped_array,
+    },
 };
 use types::{
     abis::{
@@ -17,7 +23,10 @@ use types::{
         private_log::{PrivateLog, PrivateLogData},
     },
     address::AztecAddress,
-    constants::{MAX_U32_VALUE, SIDE_EFFECT_MASKING_ADDRESS},
+    constants::{
+        MAX_KEY_VALIDATION_REQUESTS_PER_TX, MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+        MAX_NULLIFIER_READ_REQUESTS_PER_TX, MAX_U32_VALUE, SIDE_EFFECT_MASKING_ADDRESS,
+    },
     hash::{
         compute_note_nonce_and_unique_note_hash, compute_siloed_note_hash, compute_siloed_nullifier,
         compute_siloed_private_log_first_field,
@@ -242,10 +251,37 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
         let validation_requests = self.previous_kernel.validation_requests;
         let tree_snapshots = self.previous_kernel.constants.anchor_block_header.state.partial;
         let output = self.output.validation_requests;
+        let hints = self.squashed_output_array_hints;
+
+        // In this function, if we're not performing a full reset, we first check that the deduped array correctly
+        // represents the original requests, i.e., each original item maps to a matching deduped item.
+        // We then perform the expensive reset validations (Merkle membership proofs and elliptic curve operations) only
+        // on the deduped array.
+        // Deduplication is only beneficial when this reset variant processes a subset of the requests (i.e., the Amount
+        // generics are less than MAX). In these cases, eliminating duplicates means more unique requests actually get
+        // validated, and fewer requests to propagate to the next kernel circuit.
+        // If the variant is already processing all requests, the validation loops run for MAX iterations regardless of
+        // the actual array length, so deduplication simply adds unnecessary overhead.
 
         // note_hash_read_requests
+        let note_hash_read_requests = if (
+            NoteHashPendingReadAmount == MAX_NOTE_HASH_READ_REQUESTS_PER_TX
+        )
+            & (NoteHashSettledReadAmount == MAX_NOTE_HASH_READ_REQUESTS_PER_TX) {
+            // Skip deduplication if the variant is processing all requests.
+            validation_requests.note_hash_read_requests
+        } else {
+            validate_deduped_array(
+                validation_requests.note_hash_read_requests,
+                hints.deduped_note_hash_read_requests,
+                hints.note_hash_read_request_dedup_hints,
+                are_duplicate_read_requests,
+            );
+            hints.deduped_note_hash_read_requests
+        };
+
         ReadRequestValidator {
-            read_requests: validation_requests.note_hash_read_requests,
+            read_requests: note_hash_read_requests,
             pending_values: self.previous_kernel.end.note_hashes,
             tree_root: tree_snapshots.note_hash_tree.root,
             propagated_read_requests: output.note_hash_read_requests,
@@ -254,8 +290,24 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
             .validate::<NoteHashPendingReadAmount, NoteHashSettledReadAmount>();
 
         // nullifier_read_requests
+        let nullifier_read_requests = if (
+            NullifierPendingReadAmount == MAX_NULLIFIER_READ_REQUESTS_PER_TX
+        )
+            & (NullifierSettledReadAmount == MAX_NULLIFIER_READ_REQUESTS_PER_TX) {
+            // Skip deduplication if the variant is processing all requests.
+            validation_requests.nullifier_read_requests
+        } else {
+            validate_deduped_array(
+                validation_requests.nullifier_read_requests,
+                hints.deduped_nullifier_read_requests,
+                hints.nullifier_read_request_dedup_hints,
+                are_duplicate_read_requests,
+            );
+            hints.deduped_nullifier_read_requests
+        };
+
         ReadRequestValidator {
-            read_requests: validation_requests.nullifier_read_requests,
+            read_requests: nullifier_read_requests,
             pending_values: self.previous_kernel.end.nullifiers,
             tree_root: tree_snapshots.nullifier_tree.root,
             propagated_read_requests: output.nullifier_read_requests,
@@ -264,9 +316,21 @@ impl<let NoteHashPendingReadHintsLen: u32, let NoteHashSettledReadHintsLen: u32,
             .validate::<NullifierPendingReadAmount, NullifierSettledReadAmount>();
 
         // key_validation_requests
+        let key_validation_requests = if KeyValidationAmount == MAX_KEY_VALIDATION_REQUESTS_PER_TX {
+            // Skip deduplication if the variant is processing all requests.
+            validation_requests.scoped_key_validation_requests_and_generators
+        } else {
+            validate_deduped_array(
+                validation_requests.scoped_key_validation_requests_and_generators,
+                hints.deduped_key_validation_requests,
+                hints.key_validation_request_dedup_hints,
+                are_duplicate_key_validation_requests,
+            );
+            hints.deduped_key_validation_requests
+        };
+
         KeyValidationRequestsValidator {
-            key_validation_requests: validation_requests
-                .scoped_key_validation_requests_and_generators,
+            key_validation_requests,
             propagated_key_validation_requests: output
                 .scoped_key_validation_requests_and_generators,
             hints: self.reset_hints.key_validation_hints,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator/check_duplicates.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator/check_duplicates.nr
@@ -1,0 +1,18 @@
+use types::{
+    abis::validation_requests::KeyValidationRequestAndGenerator,
+    side_effect::{Counted, Scoped},
+};
+
+/// Two read requests are considered duplicates if they read the same value from the same contract.
+/// The counter (when the read happened) is irrelevant for dedup purposes.
+pub fn are_duplicate_read_requests(a: Scoped<Counted<Field>>, b: Scoped<Counted<Field>>) -> bool {
+    (a.inner.inner == b.inner.inner) & (a.contract_address == b.contract_address)
+}
+
+/// Two key validation requests are considered duplicates if they are exactly the same.
+pub fn are_duplicate_key_validation_requests(
+    a: Scoped<KeyValidationRequestAndGenerator>,
+    b: Scoped<KeyValidationRequestAndGenerator>,
+) -> bool {
+    a == b
+}

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/dedup_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/dedup_array.nr
@@ -1,0 +1,110 @@
+use types::{traits::Empty, utils::arrays::ClaimedLengthArray};
+
+/// Unconstrained function to generate a deduplicated array and index hints.
+///
+/// For each item in `original`, checks if an equal item (under `eq_fn`) already exists in the
+/// deduped output. If so, records the existing index in `dedup_hints`. If not, appends the item
+/// to the deduped output and records the new index.
+///
+/// Returns: (deduped_array, dedup_hints) where dedup_hints[i] is the index in deduped_array
+/// that original[i] maps to.
+pub unconstrained fn dedup_array<T, let N: u32, Env>(
+    original: ClaimedLengthArray<T, N>,
+    eq_fn: fn[Env](T, T) -> bool,
+) -> (ClaimedLengthArray<T, N>, [u32; N])
+where
+    T: Empty,
+{
+    let mut deduped: ClaimedLengthArray<T, N> = ClaimedLengthArray::empty();
+    let mut hints = [0 as u32; N];
+
+    for i in 0..original.length {
+        let item = original.array[i];
+
+        // Search for an existing match in the deduped array.
+        let mut found = false;
+        let mut found_index = 0;
+        for j in 0..deduped.length {
+            if eq_fn(item, deduped.array[j]) {
+                found = true;
+                found_index = j;
+                break;
+            }
+        }
+
+        if found {
+            hints[i] = found_index;
+        } else {
+            hints[i] = deduped.length;
+            deduped.push(item);
+        }
+    }
+
+    (deduped, hints)
+}
+
+mod tests {
+    use super::dedup_array;
+    use types::utils::arrays::ClaimedLengthArray;
+
+    fn field_eq(a: Field, b: Field) -> bool {
+        a == b
+    }
+
+    #[test]
+    unconstrained fn all_unique() {
+        let original = ClaimedLengthArray { array: [11, 22, 33, 0], length: 3 };
+        let (deduped, hints) = dedup_array(original, field_eq);
+        assert_eq(deduped.length, 3);
+        assert_eq(deduped.array[0], 11);
+        assert_eq(deduped.array[1], 22);
+        assert_eq(deduped.array[2], 33);
+        assert_eq(hints[0], 0);
+        assert_eq(hints[1], 1);
+        assert_eq(hints[2], 2);
+    }
+
+    #[test]
+    unconstrained fn all_duplicates() {
+        let original = ClaimedLengthArray { array: [11, 11, 11, 0], length: 3 };
+        let (deduped, hints) = dedup_array(original, field_eq);
+        assert_eq(deduped.length, 1);
+        assert_eq(deduped.array[0], 11);
+        assert_eq(hints[0], 0);
+        assert_eq(hints[1], 0);
+        assert_eq(hints[2], 0);
+    }
+
+    #[test]
+    unconstrained fn mix_of_unique_and_duplicate() {
+        let original = ClaimedLengthArray { array: [11, 22, 11, 33, 22, 0, 0], length: 5 };
+        let (deduped, hints) = dedup_array(original, field_eq);
+        assert_eq(deduped.length, 3);
+        assert_eq(deduped.array[0], 11);
+        assert_eq(deduped.array[1], 22);
+        assert_eq(deduped.array[2], 33);
+        assert_eq(hints[0], 0);
+        assert_eq(hints[1], 1);
+        assert_eq(hints[2], 0);
+        assert_eq(hints[3], 2);
+        assert_eq(hints[4], 1);
+        assert_eq(hints[5], 0);
+        assert_eq(hints[6], 0);
+    }
+
+    #[test]
+    unconstrained fn empty_array() {
+        let original = ClaimedLengthArray { array: [0, 0, 0, 0], length: 0 };
+        let (deduped, _hints) = dedup_array(original, field_eq);
+        assert_eq(deduped.length, 0);
+    }
+
+    #[test]
+    unconstrained fn single_item() {
+        let original = ClaimedLengthArray { array: [42, 0, 0, 0], length: 1 };
+        let (deduped, hints) = dedup_array(original, field_eq);
+        assert_eq(deduped.length, 1);
+        assert_eq(deduped.array[0], 42);
+        assert_eq(hints[0], 0);
+    }
+}

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/mod.nr
@@ -1,0 +1,2 @@
+pub mod dedup_array;
+pub mod validate_deduped_array;

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/validate_deduped_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/deduped_array/validate_deduped_array.nr
@@ -1,0 +1,136 @@
+use types::utils::arrays::ClaimedLengthArray;
+
+/// Validates that no original items are lost in the deduped array.
+///
+/// The prover provides `dedup_hints` mapping each original item to its position in the deduped array,
+/// and `are_duplicates` defines what "duplicate" means for dedup purposes (e.g., ignoring counters for read requests).
+///
+/// This function enforces that each original item (within length) matches its hinted deduped item under are_duplicates,
+/// ensuring no original requests are dropped.
+///
+/// The deduped array may contain extra items beyond what's in the original. This is acceptable because
+/// the prover gains no advantage from injecting extra validation requests -- they would only need to
+/// be processed in a subsequent reset circuit.
+pub fn validate_deduped_array<T, let N: u32, Env>(
+    original: ClaimedLengthArray<T, N>,
+    deduped: ClaimedLengthArray<T, N>,
+    dedup_hints: [u32; N],
+    are_duplicates: fn[Env](T, T) -> bool,
+) {
+    // Each original item must match its hinted deduped item.
+    original.for_each_i(|item, i| {
+        let hint_index = dedup_hints[i];
+        assert(hint_index < deduped.length, "Dedup hint index out of bounds");
+        assert(
+            are_duplicates(item, deduped.array[hint_index]),
+            "Original item does not match hinted deduped item",
+        );
+    });
+}
+
+mod tests {
+    use super::validate_deduped_array;
+    use types::utils::arrays::ClaimedLengthArray;
+
+    fn are_duplicate_fields(a: Field, b: Field) -> bool {
+        a == b
+    }
+
+    // ==================== Success cases ====================
+
+    #[test]
+    fn all_unique_items() {
+        let original = ClaimedLengthArray { array: [10, 20, 30, 0], length: 3 };
+        let deduped = ClaimedLengthArray { array: [10, 20, 30, 0], length: 3 };
+        let hints = [0, 1, 2, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn all_duplicates() {
+        let original = ClaimedLengthArray { array: [10, 10, 10, 0], length: 3 };
+        let deduped = ClaimedLengthArray { array: [10, 0, 0, 0], length: 1 };
+        let hints = [0, 0, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn mix_of_unique_and_duplicate() {
+        let original = ClaimedLengthArray { array: [10, 20, 10, 20], length: 4 };
+        let deduped = ClaimedLengthArray { array: [10, 20, 0, 0], length: 2 };
+        let hints = [0, 1, 0, 1];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn single_item() {
+        let original = ClaimedLengthArray { array: [42, 0, 0, 0], length: 1 };
+        let deduped = ClaimedLengthArray { array: [42, 0, 0, 0], length: 1 };
+        let hints = [0, 0, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn empty_arrays() {
+        let original: ClaimedLengthArray<Field, 4> =
+            ClaimedLengthArray { array: [0, 0, 0, 0], length: 0 };
+        let deduped: ClaimedLengthArray<Field, 4> =
+            ClaimedLengthArray { array: [0, 0, 0, 0], length: 0 };
+        let hints = [0, 0, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn deduped_order_differs() {
+        // Deduped array can reorder items as long as hints are correct.
+        let original = ClaimedLengthArray { array: [10, 20, 10, 20], length: 4 };
+        let deduped = ClaimedLengthArray { array: [20, 10, 0, 0], length: 2 };
+        let hints = [1, 0, 1, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn deduped_has_extra_items() {
+        // The prover gains nothing from adding extra requests, so this is allowed.
+        let original = ClaimedLengthArray { array: [10, 20, 0, 0], length: 2 };
+        let deduped = ClaimedLengthArray { array: [10, 20, 30, 0], length: 3 };
+        let hints = [0, 1, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn unreferenced_deduped_item_allowed() {
+        // Deduped[1] is not referenced by any original item. This is fine.
+        let original = ClaimedLengthArray { array: [10, 10, 0, 0], length: 2 };
+        let deduped = ClaimedLengthArray { array: [10, 99, 0, 0], length: 2 };
+        let hints = [0, 0, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test]
+    fn duplicate_in_deduped_allowed() {
+        // Duplicates in the deduped array are allowed; the prover just does extra work.
+        let original = ClaimedLengthArray { array: [10, 10, 0, 0], length: 2 };
+        let deduped = ClaimedLengthArray { array: [10, 10, 0, 0], length: 2 };
+        let hints = [0, 1, 0, 0];
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    // ==================== Failure cases ====================
+
+    #[test(should_fail_with = "Dedup hint index out of bounds")]
+    fn hint_out_of_bounds() {
+        let original = ClaimedLengthArray { array: [10, 20, 0, 0], length: 2 };
+        let deduped = ClaimedLengthArray { array: [10, 0, 0, 0], length: 1 };
+        let hints = [0, 1, 0, 0]; // hint 1 is out of bounds (deduped.length == 1)
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+
+    #[test(should_fail_with = "Original item does not match hinted deduped item")]
+    fn mismatch_between_original_and_deduped() {
+        let original = ClaimedLengthArray { array: [10, 20, 0, 0], length: 2 };
+        let deduped = ClaimedLengthArray { array: [10, 99, 0, 0], length: 2 };
+        let hints = [0, 1, 0, 0]; // original[1]=20 doesn't match deduped[1]=99
+        validate_deduped_array(original, deduped, hints, are_duplicate_fields);
+    }
+}

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/reset/mod.nr
@@ -1,7 +1,9 @@
+mod deduped_array;
 mod key_validation_request;
 mod read_request;
 mod transient_data;
 
+pub use deduped_array::{dedup_array::dedup_array, validate_deduped_array::validate_deduped_array};
 pub use key_validation_request::{
     get_propagated_key_validation_requests::get_propagated_key_validation_requests,
     KeyValidationHint, KeyValidationRequestsValidator,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/read_request_tests.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_reset/read_request_tests.nr
@@ -17,11 +17,13 @@ fn validate_and_propagate_note_hash_read_requests() {
     builder.previous_kernel.append_note_hashes(3);
 
     // Append 3 pending note hash reads, 2 settled reads, and 2 reads without hints.
+    // The un-hinted reads use unique values (77 and 99) that won't match any hinted reads,
+    // so that deduplication doesn't merge them with validated requests.
     builder.read_pending_note_hash(0);
-    builder.previous_kernel.append_note_hash_read_requests(1);
+    builder.previous_kernel.add_note_hash_read_request(77, builder.previous_kernel.contract_address);
     builder.read_settled_note_hash(1);
     builder.read_settled_note_hash(2);
-    builder.previous_kernel.append_note_hash_read_requests(1);
+    builder.previous_kernel.add_note_hash_read_request(99, builder.previous_kernel.contract_address);
     builder.read_pending_note_hash(1);
     builder.read_pending_note_hash(2);
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/claimed_length_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/claimed_length_array.nr
@@ -12,15 +12,15 @@ pub struct ClaimedLengthArray<T, let N: u32> {
     pub length: u32,
 }
 
-impl<T, let N: u32> ClaimedLengthArray<T, N>
-where
-    T: Empty,
-{
+impl<T, let N: u32> ClaimedLengthArray<T, N> {
     // No constructor. Append to an empty one.
 
     // For constrained append functions, see the dedicated file: assert_array_appended.nr
 
-    pub fn assert_dense_trimmed(self) {
+    pub fn assert_dense_trimmed(self)
+    where
+        T: Empty,
+    {
         for_i_in_0_(
             self.length,
             N,
@@ -34,7 +34,10 @@ where
         );
     }
 
-    pub fn assert_empty<let S: u32>(self, msg: str<S>) {
+    pub fn assert_empty<let S: u32>(self, msg: str<S>)
+    where
+        T: Empty,
+    {
         for i in 0..N {
             self.array[i].assert_empty(msg);
         }
@@ -53,7 +56,10 @@ where
         self.length += 1;
     }
 
-    pub fn pop(&mut self) -> T {
+    pub fn pop(&mut self) -> T
+    where
+        T: Empty,
+    {
         assert(self.length != 0, "Array empty");
 
         let mut top_index = self.length - 1;

--- a/yarn-project/pxe/src/private_kernel/hints/dedup_array.test.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/dedup_array.test.ts
@@ -1,0 +1,159 @@
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { Point } from '@aztec/foundation/curves/grumpkin';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import {
+  ClaimedLengthArray,
+  KeyValidationRequest,
+  KeyValidationRequestAndGenerator,
+  ReadRequest,
+  ScopedKeyValidationRequestAndGenerator,
+  ScopedReadRequest,
+} from '@aztec/stdlib/kernel';
+
+import { areDuplicateKeyValidationRequests, areDuplicateReadRequests, dedupClaimedLengthArray } from './dedup_array.js';
+
+describe('areDuplicateReadRequests', () => {
+  const makeRequest = ({
+    value = new Fr(12),
+    counter = 345,
+    contractAddress = AztecAddress.fromBigInt(6789n),
+  }: { value?: Fr; counter?: number; contractAddress?: AztecAddress } = {}) =>
+    new ScopedReadRequest(new ReadRequest(value, counter), contractAddress);
+
+  it('returns true for identical requests', () => {
+    const a = makeRequest();
+    const b = makeRequest();
+    expect(areDuplicateReadRequests(a, b)).toBe(true);
+  });
+
+  it('ignores counter differences', () => {
+    const a = makeRequest({ counter: 100 });
+    const b = makeRequest({ counter: 999 });
+    expect(areDuplicateReadRequests(a, b)).toBe(true);
+  });
+
+  it('returns false for different values', () => {
+    const a = makeRequest({ value: new Fr(1) });
+    const b = makeRequest({ value: new Fr(2) });
+    expect(areDuplicateReadRequests(a, b)).toBe(false);
+  });
+
+  it('returns false for different contractAddresses', () => {
+    const a = makeRequest({ contractAddress: AztecAddress.fromBigInt(1n) });
+    const b = makeRequest({ contractAddress: AztecAddress.fromBigInt(2n) });
+    expect(areDuplicateReadRequests(a, b)).toBe(false);
+  });
+});
+
+describe('areDuplicateKeyValidationRequests', () => {
+  const makeRequest = ({
+    pkM = Point.fromFields([new Fr(12), new Fr(34), Fr.ZERO]),
+    skApp = new Fr(56),
+    generator = new Fr(78),
+    address = AztecAddress.fromBigInt(90n),
+  }: { pkM?: Point; skApp?: Fr; generator?: Fr; address?: AztecAddress } = {}) =>
+    new ScopedKeyValidationRequestAndGenerator(
+      new KeyValidationRequestAndGenerator(new KeyValidationRequest(pkM, skApp), generator),
+      address,
+    );
+
+  it('returns true for identical requests', () => {
+    const a = makeRequest();
+    const b = makeRequest();
+    expect(areDuplicateKeyValidationRequests(a, b)).toBe(true);
+  });
+
+  it('returns false when skApp differs', () => {
+    const a = makeRequest({ skApp: new Fr(1) });
+    const b = makeRequest({ skApp: new Fr(2) });
+    expect(areDuplicateKeyValidationRequests(a, b)).toBe(false);
+  });
+
+  it('returns false when generator differs', () => {
+    const a = makeRequest({ generator: new Fr(1) });
+    const b = makeRequest({ generator: new Fr(2) });
+    expect(areDuplicateKeyValidationRequests(a, b)).toBe(false);
+  });
+
+  it('returns false when contractAddress differs', () => {
+    const a = makeRequest({ address: AztecAddress.fromBigInt(1n) });
+    const b = makeRequest({ address: AztecAddress.fromBigInt(2n) });
+    expect(areDuplicateKeyValidationRequests(a, b)).toBe(false);
+  });
+});
+
+describe('dedupClaimedLengthArray', () => {
+  const MAX = 8;
+  const address = AztecAddress.fromBigInt(42n);
+
+  const makeRequests = (requestValues: (number | { value: number; counter: number })[]) => {
+    const requests = requestValues.map(value => {
+      if (typeof value === 'number') {
+        return new ScopedReadRequest(new ReadRequest(new Fr(BigInt(value)), 0), address);
+      }
+      return new ScopedReadRequest(new ReadRequest(new Fr(BigInt(value.value)), value.counter), address);
+    });
+    return new ClaimedLengthArray(padArrayEnd(requests, ScopedReadRequest.empty(), MAX), requests.length);
+  };
+
+  const dedup = (requests: ClaimedLengthArray<ScopedReadRequest, number>) =>
+    dedupClaimedLengthArray(requests, areDuplicateReadRequests, ScopedReadRequest.empty());
+
+  const expectResult = (
+    result: ClaimedLengthArray<ScopedReadRequest, number>,
+    expectedActiveItems: ScopedReadRequest[],
+  ) => {
+    expect(result.claimedLength).toBe(expectedActiveItems.length);
+    expect(result.getActiveItems()).toEqual(expectedActiveItems);
+  };
+
+  it('returns empty array for empty input', () => {
+    const original = makeRequests([]);
+    const result = dedup(original);
+    expectResult(result, []);
+  });
+
+  it('returns same items when no duplicates', () => {
+    const original = makeRequests([1, 2, 3]);
+    const result = dedup(original);
+    const items = original.getActiveItems();
+    expectResult(result, [items[0], items[1], items[2]]);
+  });
+
+  it('removes all duplicates', () => {
+    const original = makeRequests([5, 5, 5]);
+    const result = dedup(original);
+    const items = original.getActiveItems();
+    expectResult(result, [items[0]]);
+  });
+
+  it('removes all duplicates from a full array', () => {
+    const duplicates = Array.from({ length: MAX }).map((_, i) => ({ value: 5, counter: i + 1 }));
+    const original = makeRequests(duplicates);
+    const result = dedup(original);
+    const items = original.getActiveItems();
+    expectResult(result, [items[0]]);
+  });
+
+  it('removes nothing from a full array', () => {
+    const uniqueItems = Array.from({ length: MAX }).map((_, i) => i + 1);
+    const original = makeRequests(uniqueItems);
+    const result = dedup(original);
+    const items = original.getActiveItems();
+    expectResult(result, items);
+  });
+
+  it('keeps first occurrence and preserves order', () => {
+    const original = makeRequests([
+      { value: 1, counter: 10 },
+      { value: 2, counter: 20 },
+      { value: 1, counter: 30 },
+      { value: 3, counter: 40 },
+      { value: 2, counter: 50 },
+    ]);
+    const result = dedup(original);
+    const items = original.getActiveItems();
+    expectResult(result, [items[0], items[1], items[3]]);
+  });
+});

--- a/yarn-project/pxe/src/private_kernel/hints/dedup_array.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/dedup_array.ts
@@ -1,0 +1,29 @@
+import { padArrayEnd } from '@aztec/foundation/collection';
+import type { Serializable, Tuple } from '@aztec/foundation/serialize';
+import { ClaimedLengthArray, ScopedKeyValidationRequestAndGenerator, ScopedReadRequest } from '@aztec/stdlib/kernel';
+
+export function areDuplicateReadRequests(a: ScopedReadRequest, b: ScopedReadRequest): boolean {
+  return a.value.equals(b.value) && a.contractAddress.equals(b.contractAddress);
+}
+
+export function areDuplicateKeyValidationRequests(
+  a: ScopedKeyValidationRequestAndGenerator,
+  b: ScopedKeyValidationRequestAndGenerator,
+): boolean {
+  return a.toBuffer().equals(b.toBuffer());
+}
+
+export function dedupClaimedLengthArray<T extends Serializable, N extends number>(
+  original: ClaimedLengthArray<T, N>,
+  areDuplicates: (a: T, b: T) => boolean,
+  empty: T,
+): ClaimedLengthArray<T, N> {
+  const items = original.getActiveItems();
+  const deduped: T[] = [];
+  for (const item of items) {
+    if (!deduped.some(d => areDuplicates(item, d))) {
+      deduped.push(item);
+    }
+  }
+  return new ClaimedLengthArray(padArrayEnd(deduped, empty, original.array.length) as Tuple<T, N>, deduped.length);
+}

--- a/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.test.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.test.ts
@@ -1,0 +1,461 @@
+import { BackendType, BarretenbergSync } from '@aztec/bb.js';
+import {
+  MAX_KEY_VALIDATION_REQUESTS_PER_CALL,
+  MAX_KEY_VALIDATION_REQUESTS_PER_TX,
+  MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+  MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
+  MAX_NULLIFIER_READ_REQUESTS_PER_CALL,
+  MAX_NULLIFIER_READ_REQUESTS_PER_TX,
+  NOTE_HASH_TREE_HEIGHT,
+  VK_TREE_HEIGHT,
+} from '@aztec/constants';
+import { padArrayEnd } from '@aztec/foundation/collection';
+import { Fr } from '@aztec/foundation/curves/bn254';
+import { GrumpkinScalar, Point } from '@aztec/foundation/curves/grumpkin';
+import { createLogger } from '@aztec/foundation/log';
+import { MembershipWitness } from '@aztec/foundation/trees';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import {
+  ClaimedLengthArray,
+  KeyValidationRequest,
+  KeyValidationRequestAndGenerator,
+  PrivateCircuitPublicInputs,
+  PrivateKernelCircuitPublicInputs,
+  ReadRequest,
+  ScopedKeyValidationRequestAndGenerator,
+  ScopedReadRequest,
+} from '@aztec/stdlib/kernel';
+import { NullifierMembershipWitness } from '@aztec/stdlib/trees';
+import { PrivateCallExecutionResult } from '@aztec/stdlib/tx';
+import { VerificationKeyData } from '@aztec/stdlib/vks';
+
+import { mock } from 'jest-mock-extended';
+
+import type { PrivateKernelOracle } from '../private_kernel_oracle.js';
+import { PrivateKernelResetPrivateInputsBuilder } from './private_kernel_reset_private_inputs_builder.js';
+
+describe('PrivateKernelResetPrivateInputsBuilder', () => {
+  let oracle: ReturnType<typeof mock<PrivateKernelOracle>>;
+
+  beforeAll(async () => {
+    await BarretenbergSync.initSingleton({
+      backend: BackendType.NativeSharedMemory,
+      logger: createLogger('test').debug,
+    });
+  });
+
+  beforeEach(() => {
+    oracle = mock<PrivateKernelOracle>();
+    oracle.getVkMembershipWitness.mockResolvedValue(MembershipWitness.random(VK_TREE_HEIGHT));
+    oracle.getMasterSecretKey.mockResolvedValue(GrumpkinScalar.random());
+  });
+
+  function makeKernelOutput(opts: {
+    noteHashReadRequests?: ScopedReadRequest[];
+    nullifierReadRequests?: ScopedReadRequest[];
+    keyValidationRequests?: ScopedKeyValidationRequestAndGenerator[];
+  }) {
+    const publicInputs = PrivateKernelCircuitPublicInputs.empty();
+
+    if (opts.noteHashReadRequests?.length) {
+      publicInputs.validationRequests.noteHashReadRequests = new ClaimedLengthArray(
+        padArrayEnd(opts.noteHashReadRequests, ScopedReadRequest.empty(), MAX_NOTE_HASH_READ_REQUESTS_PER_TX),
+        opts.noteHashReadRequests.length,
+      );
+    }
+
+    if (opts.nullifierReadRequests?.length) {
+      publicInputs.validationRequests.nullifierReadRequests = new ClaimedLengthArray(
+        padArrayEnd(opts.nullifierReadRequests, ScopedReadRequest.empty(), MAX_NULLIFIER_READ_REQUESTS_PER_TX),
+        opts.nullifierReadRequests.length,
+      );
+    }
+
+    if (opts.keyValidationRequests?.length) {
+      publicInputs.validationRequests.scopedKeyValidationRequestsAndGenerators = new ClaimedLengthArray(
+        padArrayEnd(
+          opts.keyValidationRequests,
+          ScopedKeyValidationRequestAndGenerator.empty(),
+          MAX_KEY_VALIDATION_REQUESTS_PER_TX,
+        ),
+        opts.keyValidationRequests.length,
+      );
+    }
+
+    return {
+      publicInputs,
+      verificationKey: VerificationKeyData.empty(),
+      outputWitness: new Map<number, string>(),
+      bytecode: Buffer.from([]),
+    };
+  }
+
+  const makeReadRequest = ({
+    value = new Fr(12),
+    counter = 100,
+    address = AztecAddress.fromBigInt(123n),
+  }: { value?: Fr; counter?: number; address?: AztecAddress } = {}) =>
+    new ScopedReadRequest(new ReadRequest(value, counter), address);
+
+  /** Creates a minimal execution stack entry whose publicInputs drive the "next iteration" overflow check. */
+  function makeNextCallResult(publicInputs: PrivateCircuitPublicInputs): PrivateCallExecutionResult {
+    return new PrivateCallExecutionResult(
+      Buffer.alloc(0),
+      Buffer.alloc(0),
+      new Map(),
+      publicInputs,
+      [],
+      new Map(),
+      [],
+      [],
+      [],
+      [],
+      [],
+    );
+  }
+
+  describe('note hash read requests', () => {
+    beforeEach(() => {
+      oracle.getNoteHashMembershipWitness.mockResolvedValue(MembershipWitness.random(NOTE_HASH_TREE_HEIGHT));
+    });
+
+    it('deduplicates note hash read requests', async () => {
+      // Three identical requests → should dedup to 1.
+      const req = makeReadRequest();
+      const kernelOutput = makeKernelOutput({
+        noteHashReadRequests: [req, req, req],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // Oracle should only be called once for the single unique settled read (not 3 times).
+      expect(oracle.getNoteHashMembershipWitness).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not dedup distinct note hash read requests', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      const kernelOutput = makeKernelOutput({
+        noteHashReadRequests: [req1, req2],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // Both requests are distinct → oracle is called for each.
+      expect(oracle.getNoteHashMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates note hash read requests with a mix of duplicates and unique', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      // [req1, req1, req2, req1] → should dedup to [req1, req2] (2 unique).
+      const kernelOutput = makeKernelOutput({
+        noteHashReadRequests: [req1, req1, req2, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // After dedup, only 2 unique requests → oracle called twice (not 4 times).
+      expect(oracle.getNoteHashMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects a smaller circuit variant when duplicates reduce the count below a threshold', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+      const req3 = makeReadRequest({ value: new Fr(3) });
+
+      // 7 total requests, but only 3 unique. Without dedup: NOTE_HASH_SETTLED_READ >= 7 → would
+      // select dimension 16. With dedup: >= 3 → selects dimension 4.
+      const kernelOutput = makeKernelOutput({
+        noteHashReadRequests: [req1, req1, req2, req1, req2, req3, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      expect(oracle.getNoteHashMembershipWitness).toHaveBeenCalledTimes(3);
+      expect(inputs.dimensions.NOTE_HASH_SETTLED_READ).toBe(4);
+    });
+
+    it('triggers reset on overflow even when deduped count is small', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      // 55 requests in the kernel (only 2 unique values).
+      const requests = Array.from({ length: 55 }, (_, i) => (i % 2 === 0 ? req1 : req2));
+      const kernelOutput = makeKernelOutput({ noteHashReadRequests: requests });
+
+      // Next call has 10 read requests → total 65 > MAX (64) → overflow.
+      const nextPublicInputs = PrivateCircuitPublicInputs.empty();
+      nextPublicInputs.noteHashReadRequests = new ClaimedLengthArray(
+        padArrayEnd(
+          Array.from({ length: 10 }, () => makeReadRequest({ value: Fr.random() })),
+          ScopedReadRequest.empty(),
+          MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+        ),
+        10,
+      );
+      const executionStack = [makeNextCallResult(nextPublicInputs)];
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, executionStack, new Map(), 0);
+
+      // Overflow detected using original count (55 + 10 = 65 > 64), even though dedup → only 2 unique.
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // After dedup, only 2 unique settled reads → oracle called twice (not 55 times).
+      expect(oracle.getNoteHashMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('nullifier read requests', () => {
+    beforeEach(() => {
+      oracle.getNullifierMembershipWitness.mockResolvedValue(NullifierMembershipWitness.random());
+    });
+
+    it('deduplicates nullifier read requests', async () => {
+      // Three identical requests → should dedup to 1.
+      const req = makeReadRequest();
+      const kernelOutput = makeKernelOutput({
+        nullifierReadRequests: [req, req, req],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // Oracle should only be called once for the single unique settled read (not 3 times).
+      expect(oracle.getNullifierMembershipWitness).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not dedup distinct nullifier read requests', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      const kernelOutput = makeKernelOutput({
+        nullifierReadRequests: [req1, req2],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // Both requests are distinct → oracle is called for each.
+      expect(oracle.getNullifierMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates nullifier read requests with a mix of duplicates and unique', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      // [req1, req1, req2, req1] → should dedup to [req1, req2] (2 unique).
+      const kernelOutput = makeKernelOutput({
+        nullifierReadRequests: [req1, req1, req2, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // After dedup, only 2 unique requests → oracle called twice (not 4 times).
+      expect(oracle.getNullifierMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects a smaller circuit variant when duplicates reduce the count below a threshold', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+      const req3 = makeReadRequest({ value: new Fr(3) });
+
+      // 7 total requests, but only 3 unique. Without dedup: NULLIFIER_SETTLED_READ >= 7 → would
+      // select dimension 16. With dedup: >= 3 → selects dimension 4.
+      const kernelOutput = makeKernelOutput({
+        nullifierReadRequests: [req1, req1, req2, req1, req2, req3, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      expect(oracle.getNullifierMembershipWitness).toHaveBeenCalledTimes(3);
+      expect(inputs.dimensions.NULLIFIER_SETTLED_READ).toBe(4);
+    });
+
+    it('triggers reset on overflow even when deduped count is small', async () => {
+      const req1 = makeReadRequest({ value: new Fr(1) });
+      const req2 = makeReadRequest({ value: new Fr(2) });
+
+      // 55 requests in the kernel (only 2 unique values).
+      const requests = Array.from({ length: 55 }, (_, i) => (i % 2 === 0 ? req1 : req2));
+      const kernelOutput = makeKernelOutput({ nullifierReadRequests: requests });
+
+      // Next call has 10 read requests → total 65 > MAX (64) → overflow.
+      const nextPublicInputs = PrivateCircuitPublicInputs.empty();
+      nextPublicInputs.nullifierReadRequests = new ClaimedLengthArray(
+        padArrayEnd(
+          Array.from({ length: 10 }, () => makeReadRequest({ value: Fr.random() })),
+          ScopedReadRequest.empty(),
+          MAX_NULLIFIER_READ_REQUESTS_PER_CALL,
+        ),
+        10,
+      );
+      const executionStack = [makeNextCallResult(nextPublicInputs)];
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, executionStack, new Map(), 0);
+
+      // Overflow detected using original count (55 + 10 = 65 > 64), even though dedup → only 2 unique.
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // After dedup, only 2 unique settled reads → oracle called twice (not 55 times).
+      expect(oracle.getNullifierMembershipWitness).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('key validation requests', () => {
+    const makeRequest = ({
+      pkM = Point.fromFields([new Fr(12), new Fr(34), Fr.ZERO]),
+      skApp = new Fr(56),
+      generator = new Fr(78),
+      address = AztecAddress.fromBigInt(90n),
+    }: { pkM?: Point; skApp?: Fr; generator?: Fr; address?: AztecAddress } = {}) =>
+      new ScopedKeyValidationRequestAndGenerator(
+        new KeyValidationRequestAndGenerator(new KeyValidationRequest(pkM, skApp), generator),
+        address,
+      );
+
+    it('deduplicates key validation requests', async () => {
+      // Three identical requests → should dedup to 1.
+      const req = makeRequest();
+      const kernelOutput = makeKernelOutput({
+        keyValidationRequests: [req, req, req],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      // Oracle should only be called once for the single unique request (not 3 times for the originals).
+      expect(oracle.getMasterSecretKey).toHaveBeenCalledTimes(1);
+
+      // The smallest KEY_VALIDATION circuit variant that fits 1 unique request has dimension 4.
+      expect(inputs.dimensions.KEY_VALIDATION).toBe(4);
+    });
+
+    it('does not dedup distinct key validation requests', async () => {
+      const req1 = makeRequest({ skApp: new Fr(1) });
+      const req2 = makeRequest({ skApp: new Fr(2) });
+
+      const kernelOutput = makeKernelOutput({
+        keyValidationRequests: [req1, req2],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      // Both requests are distinct → oracle is called for each.
+      expect(oracle.getMasterSecretKey).toHaveBeenCalledTimes(2);
+
+      // The smallest KEY_VALIDATION circuit variant that fits 2 unique requests has dimension 4.
+      expect(inputs.dimensions.KEY_VALIDATION).toBe(4);
+    });
+
+    it('deduplicates key validation requests with a mix of duplicates and unique', async () => {
+      const req1 = makeRequest({ skApp: new Fr(1) });
+      const req2 = makeRequest({ skApp: new Fr(2) });
+
+      // [req1, req1, req2, req1] → should dedup to [req1, req2] (2 unique).
+      const kernelOutput = makeKernelOutput({
+        keyValidationRequests: [req1, req1, req2, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      // After dedup, only 2 unique requests → oracle called twice (not 4 times).
+      expect(oracle.getMasterSecretKey).toHaveBeenCalledTimes(2);
+
+      // The smallest KEY_VALIDATION circuit variant that fits 2 unique requests has dimension 4.
+      expect(inputs.dimensions.KEY_VALIDATION).toBe(4);
+    });
+
+    it('selects a smaller circuit variant when duplicates reduce the count below a threshold', async () => {
+      // Create 3 unique key validation requests.
+      const req1 = makeRequest({ skApp: new Fr(1) });
+      const req2 = makeRequest({ skApp: new Fr(2) });
+      const req3 = makeRequest({ skApp: new Fr(3) });
+
+      // 7 total requests, but only 3 unique. Without dedup: needs dimension >= 7 → would select
+      // the 16-wide variant. With dedup: needs dimension >= 3 → selects the 4-wide variant.
+      const kernelOutput = makeKernelOutput({
+        keyValidationRequests: [req1, req1, req2, req1, req2, req3, req1],
+      });
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, [], new Map(), 0);
+      expect(builder.needsReset()).toBe(true);
+
+      const inputs = await builder.build(oracle);
+
+      // After dedup, only 3 unique requests → oracle called 3 times (not 7 times).
+      expect(oracle.getMasterSecretKey).toHaveBeenCalledTimes(3);
+
+      // The smallest KEY_VALIDATION circuit variant that fits 3 unique requests has dimension 4.
+      // Without dedup, 7 requests would require dimension 16.
+      expect(inputs.dimensions.KEY_VALIDATION).toBe(4);
+    });
+
+    it('triggers reset on overflow even when deduped count is small', async () => {
+      const req1 = makeRequest({ skApp: new Fr(1) });
+      const req2 = makeRequest({ skApp: new Fr(2) });
+
+      // 55 requests in the kernel (only 2 unique).
+      const requests = Array.from({ length: 55 }, (_, i) => (i % 2 === 0 ? req1 : req2));
+      const kernelOutput = makeKernelOutput({ keyValidationRequests: requests });
+
+      // Next call has 10 key validation requests → total 65 > MAX (64) → overflow.
+      const nextPublicInputs = PrivateCircuitPublicInputs.empty();
+      nextPublicInputs.keyValidationRequestsAndGenerators = new ClaimedLengthArray(
+        padArrayEnd(
+          Array.from({ length: 10 }, () => makeRequest({ skApp: Fr.random() })),
+          ScopedKeyValidationRequestAndGenerator.empty(),
+          MAX_KEY_VALIDATION_REQUESTS_PER_CALL,
+        ),
+        10,
+      );
+      const executionStack = [makeNextCallResult(nextPublicInputs)];
+
+      const builder = new PrivateKernelResetPrivateInputsBuilder(kernelOutput, executionStack, new Map(), 0);
+
+      // Overflow detected using original count (55 + 10 = 65 > 64), even though dedup → only 2 unique.
+      expect(builder.needsReset()).toBe(true);
+
+      await builder.build(oracle);
+
+      // After dedup, only 2 unique requests → oracle called twice (not 55 times).
+      expect(oracle.getMasterSecretKey).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
+++ b/yarn-project/pxe/src/private_kernel/hints/private_kernel_reset_private_inputs_builder.ts
@@ -26,7 +26,7 @@ import {
   type PrivateKernelSimulateOutput,
   ReadRequestActionEnum,
   ReadRequestResetActions,
-  type ScopedKeyValidationRequestAndGenerator,
+  ScopedKeyValidationRequestAndGenerator,
   ScopedNoteHash,
   ScopedNullifier,
   ScopedReadRequest,
@@ -43,6 +43,7 @@ import { type PrivateCallExecutionResult, collectNested } from '@aztec/stdlib/tx
 import { VkData } from '@aztec/stdlib/vks';
 
 import type { PrivateKernelOracle } from '../private_kernel_oracle.js';
+import { areDuplicateKeyValidationRequests, areDuplicateReadRequests, dedupClaimedLengthArray } from './dedup_array.js';
 
 function collectNestedReadRequests<N extends number>(
   executionStack: PrivateCallExecutionResult[],
@@ -96,6 +97,18 @@ export class PrivateKernelResetPrivateInputsBuilder {
   private numTransientData?: number;
   private transientDataSquashingHints: Tuple<TransientDataSquashingHint, typeof MAX_NULLIFIERS_PER_TX>;
   private requestedDimensions: PrivateKernelResetDimensions;
+  private dedupedNoteHashReadRequests?: ClaimedLengthArray<
+    ScopedReadRequest,
+    typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
+  >;
+  private dedupedNullifierReadRequests?: ClaimedLengthArray<
+    ScopedReadRequest,
+    typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX
+  >;
+  private dedupedKeyValidationRequests?: ClaimedLengthArray<
+    ScopedKeyValidationRequestAndGenerator,
+    typeof MAX_KEY_VALIDATION_REQUESTS_PER_TX
+  >;
 
   constructor(
     private previousKernelOutput: PrivateKernelSimulateOutput<PrivateKernelCircuitPublicInputs>,
@@ -169,31 +182,32 @@ export class PrivateKernelResetPrivateInputsBuilder {
     );
 
     // Execute all the expensive node querying operations in parallel.
+    // Use deduped arrays when available: the Reset circuit deduplicates validation requests before
+    // performing expensive operations, so hints must correspond to the deduped arrays.
+    const noteHashReadRequests =
+      this.dedupedNoteHashReadRequests ?? this.previousKernel.validationRequests.noteHashReadRequests;
+    const nullifierReadRequests =
+      this.dedupedNullifierReadRequests ?? this.previousKernel.validationRequests.nullifierReadRequests;
+    const keyValidationRequests =
+      this.dedupedKeyValidationRequests ??
+      this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators;
+
     const [previousVkMembershipWitness, noteHashReadRequestHints, nullifierReadRequestHints, keyValidationHints] =
       await Promise.all([
         oracle.getVkMembershipWitness(this.previousKernelOutput.verificationKey.keyAsFields),
         buildNoteHashReadRequestHintsFromResetActions<
           typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX,
           typeof MAX_NOTE_HASH_READ_REQUESTS_PER_TX
-        >(
-          oracle,
-          this.previousKernel.validationRequests.noteHashReadRequests,
-          this.previousKernel.end.noteHashes,
-          this.noteHashResetActions,
-        ),
+        >(oracle, noteHashReadRequests, this.previousKernel.end.noteHashes, this.noteHashResetActions),
         buildNullifierReadRequestHintsFromResetActions<
           typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX,
           typeof MAX_NULLIFIER_READ_REQUESTS_PER_TX
         >(
           { getNullifierMembershipWitness: getNullifierMembershipWitnessResolver(oracle) },
-          this.previousKernel.validationRequests.nullifierReadRequests,
+          nullifierReadRequests,
           this.nullifierResetActions,
         ),
-        getMasterSecretKeysAndAppKeyGenerators(
-          this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
-          dimensions.KEY_VALIDATION,
-          oracle,
-        ),
+        getMasterSecretKeysAndAppKeyGenerators(keyValidationRequests, dimensions.KEY_VALIDATION, oracle),
       ]);
 
     const vkData = new VkData(
@@ -254,6 +268,16 @@ export class PrivateKernelResetPrivateInputsBuilder {
       return false;
     }
 
+    // Dedup before computing reset actions: the Reset circuit deduplicates read requests before
+    // performing expensive validations (Merkle membership proofs), so actions and hints must
+    // correspond to the deduped array.
+    const dedupedReadRequests = dedupClaimedLengthArray(
+      this.previousKernel.validationRequests.noteHashReadRequests,
+      areDuplicateReadRequests,
+      ScopedReadRequest.empty(),
+    );
+    this.dedupedNoteHashReadRequests = dedupedReadRequests;
+
     const futureNoteHashes = collectNested(this.executionStack, executionResult => {
       return executionResult.publicInputs.noteHashes
         .getActiveItems()
@@ -261,7 +285,7 @@ export class PrivateKernelResetPrivateInputsBuilder {
     });
 
     const resetActions = getNoteHashReadRequestResetActions(
-      this.previousKernel.validationRequests.noteHashReadRequests,
+      dedupedReadRequests,
       this.previousKernel.end.noteHashes,
       futureNoteHashes,
     );
@@ -309,6 +333,16 @@ export class PrivateKernelResetPrivateInputsBuilder {
       return false;
     }
 
+    // Dedup before computing reset actions: the Reset circuit deduplicates read requests before
+    // performing expensive validations (Merkle membership proofs), so actions and hints must
+    // correspond to the deduped array.
+    const dedupedReadRequests = dedupClaimedLengthArray(
+      this.previousKernel.validationRequests.nullifierReadRequests,
+      areDuplicateReadRequests,
+      ScopedReadRequest.empty(),
+    );
+    this.dedupedNullifierReadRequests = dedupedReadRequests;
+
     const futureNullifiers = collectNested(this.executionStack, executionResult => {
       return executionResult.publicInputs.nullifiers
         .getActiveItems()
@@ -316,7 +350,7 @@ export class PrivateKernelResetPrivateInputsBuilder {
     });
 
     const resetActions = getNullifierReadRequestResetActions(
-      this.previousKernel.validationRequests.nullifierReadRequests,
+      dedupedReadRequests,
       this.previousKernel.end.nullifiers,
       futureNullifiers,
     );
@@ -364,7 +398,16 @@ export class PrivateKernelResetPrivateInputsBuilder {
       return false;
     }
 
-    this.requestedDimensions.KEY_VALIDATION = numCurr;
+    // Dedup before setting the dimension: the Reset circuit deduplicates key validation requests
+    // before performing expensive EC operations, so the dimension and hints must reflect unique
+    // requests only.
+    const dedupedRequests = dedupClaimedLengthArray(
+      this.previousKernel.validationRequests.scopedKeyValidationRequestsAndGenerators,
+      areDuplicateKeyValidationRequests,
+      ScopedKeyValidationRequestAndGenerator.empty(),
+    );
+    this.dedupedKeyValidationRequests = dedupedRequests;
+    this.requestedDimensions.KEY_VALIDATION = dedupedRequests.claimedLength;
 
     return true;
   }


### PR DESCRIPTION
Deduplicate `note_hash_read_requests`, `nullifier_read_requests` and `key_validation_requests_and_generators` before validating the requests.

The cost for dudup:
- read requests: ~1.5k
- key validation requests: ~3.4k