### PR TITLE
chore: updated `cargo.lock`

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "ark-ff",
  "ark-grumpkin",
  "hex",
+ "lazy_static",
 ]
 
 [[package]]


### PR DESCRIPTION
Not sure why I was getting cargo.lock failure in [this PR](https://github.com/AztecProtocol/aztec-packages/pull/20397) but the change looks inconsequential so I am updating it. I guess I messed up the `next` merge to `merge-train/fairies`.