### PR TITLE
chore: update avm-transpiler Cargo.lock

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -446,7 +446,6 @@ dependencies = [
  "ark-ff",
  "ark-grumpkin",
  "hex",
- "lazy_static",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Removes a stale entry from `avm-transpiler/Cargo.lock`

## Test plan
- CI should pass with the updated lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)