### PR TITLE
fix: heap-allocate thread-local random buffer to reduce thread creation overhead

### DIFF
--- a/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <random>
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -44,8 +45,9 @@ constexpr size_t RANDOM_BUFFER_SIZE = 1UL << 20;
 
 #endif
 struct RandomBufferWrapper {
-    // Buffer with randomness sampled from a CSPRNG
-    uint8_t buffer[RANDOM_BUFFER_SIZE];
+    // Buffer with randomness sampled from a CSPRNG (heap-allocated on first use to avoid
+    // bloating TLS — a 1 MiB inline array adds ~0.6 ms per thread creation)
+    std::unique_ptr<uint8_t[]> buffer;
     // Offset into the unused part of the buffer
     ssize_t offset = -1;
 };
@@ -67,8 +69,11 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
     // We could preserve the leftover bytes, but it's a bit messy
     if (random_buffer_wrapper.offset == -1 ||
         (static_cast<size_t>(random_buffer_wrapper.offset) + random_data_buffer_size) > RANDOM_BUFFER_SIZE) {
+        if (!random_buffer_wrapper.buffer) {
+            random_buffer_wrapper.buffer = std::make_unique<uint8_t[]>(RANDOM_BUFFER_SIZE);
+        }
         size_t bytes_left = RANDOM_BUFFER_SIZE;
-        uint8_t* current_offset = random_buffer_wrapper.buffer;
+        uint8_t* current_offset = random_buffer_wrapper.buffer.get();
         // Sample until we fill the buffer
         while (bytes_left != 0) {
 #if defined(__wasm__) || defined(__APPLE__)
@@ -97,7 +102,7 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
         random_buffer_wrapper.offset = 0;
     }
 
-    memcpy(&random_data, random_buffer_wrapper.buffer + random_buffer_wrapper.offset, random_data_buffer_size);
+    memcpy(&random_data, random_buffer_wrapper.buffer.get() + random_buffer_wrapper.offset, random_data_buffer_size);
     random_buffer_wrapper.offset += static_cast<ssize_t>(random_data_buffer_size);
     return random_data;
 }


### PR DESCRIPTION
## Summary
- Moves the 1 MiB `thread_local` random buffer in `engine.cpp` from inline TLS (`.tbss`) to heap allocation on first use
- Reduces per-thread TLS footprint from ~1 MiB to 16 bytes, dropping thread pool creation time from ~18 ms to ~1.6 ms for 31 threads
- Fixes UltraHonk verification being slower at 32 cores than at 8 cores

### Root cause

The `RandomBufferWrapper` struct had a `uint8_t buffer[1 << 20]` inline array declared `thread_local`. This placed 1 MiB in the ELF `.tbss` section, meaning every `pthread_create` had to allocate and zero-initialize 1 MiB of TLS. With 31 worker threads, this added ~18 ms to thread pool creation — which dominated verification time at high core counts.

### Benchmark results (parity_base circuit)

**With IPA (noir-rollup):**

| Cores | Before | After |
|-------|--------|-------|
| 1     | 195 ms | 197 ms |
| 8     | 63 ms  | 59 ms |
| 32    | 72 ms  | 51 ms |
| 64    | 87 ms  | 53 ms |

**Without IPA (noir-recursive-no-zk):**

| Cores | Before | After |
|-------|--------|-------|
| 1     | 19 ms  | 20 ms |
| 8     | 24 ms  | 19 ms |
| 32    | 41 ms  | 25 ms |
| 64    | 63 ms  | 25 ms |

### Remaining overhead at high core counts

After this fix there is still a small overhead at 64 cores vs 32 cores for IPA, and at 32/64 cores vs 8 cores for non-IPA. Two sources:

1. **Thread creation still costs ~1.6 ms for 31 threads / ~3 ms for 63 threads** — the baseline `pthread_create` + remaining TLS (~3 KiB) + stack mapping cost, paid once on first `parallel_for` call.

2. **`notify_all()` wakes all sleeping workers** regardless of how much work there is. For the non-IPA 66-point MSM, all 31 (or 63) threads wake up, acquire the mutex, find no work left, and go back to sleep. This mutex contention scales linearly with thread count.

Follow-up improvements that could close this gap:
- **Lazy pool growth**: only create worker threads on demand in `start_tasks()`, so a 66-point MSM never spawns 31 threads
- **Selective `notify_one`**: wake only as many workers as there are iterations, avoiding spurious wakeups
- **MSM thread capping**: cap thread count in `batch_multi_scalar_mul` based on total scalar count

## Test plan
- [ ] Existing CI tests pass (no functional change — buffer is allocated identically, just on heap instead of TLS)
- [ ] Verify `.tbss` section shrinks from ~1 MiB to ~3 KiB via `readelf -S bin/bb`

Resolves AztecProtocol/barretenberg#1624