### PR TITLE
feat: ci-metrics data quality + dashboard improvements

### DIFF
--- a/ci3/ci-metrics/app.py
+++ b/ci3/ci-metrics/app.py
@@ -37,7 +37,7 @@ def verify_password(username, password):
 
 
 def _init():
-    """Initialize SQLite and start background threads."""
+    """Initialize SQLite, warm caches, and start background threads."""
     try:
         db.get_db()
         metrics.start_test_listener(r)
@@ -45,6 +45,18 @@ def _init():
         print("[ci-metrics] Background threads started")
     except Exception as e:
         print(f"[ci-metrics] Warning: startup failed: {e}")
+    # Warm billing caches so first request isn't slow
+    try:
+        from billing.gcp import _ensure_cached as _warm_gcp
+        _warm_gcp()
+        print("[ci-metrics] GCP billing cache warmed")
+    except Exception as e:
+        print(f"[ci-metrics] GCP billing warmup failed: {e}")
+    try:
+        billing_aws.get_costs_overview()
+        print("[ci-metrics] AWS costs cache warmed")
+    except Exception as e:
+        print(f"[ci-metrics] AWS costs warmup failed: {e}")
 
 threading.Thread(target=_init, daemon=True, name='metrics-init').start()
 

--- a/ci3/ci-metrics/app.py
+++ b/ci3/ci-metrics/app.py
@@ -178,7 +178,7 @@ def api_ci_runs():
     ts_from = int(datetime.strptime(date_from, '%Y-%m-%d').timestamp() * 1000) if date_from else None
     ts_to = int((datetime.strptime(date_to, '%Y-%m-%d') + timedelta(days=1)).timestamp() * 1000) if date_to else None
 
-    runs = metrics.get_ci_runs(r, ts_from, ts_to)
+    runs = metrics.get_ci_runs(ts_from, ts_to)
 
     if status_filter:
         runs = [run for run in runs if run.get('status') == status_filter]
@@ -197,7 +197,7 @@ def api_ci_runs():
 @auth.login_required
 def api_ci_stats():
     ts_from = int((datetime.now() - timedelta(days=7)).timestamp() * 1000)
-    runs = metrics.get_ci_runs(r, ts_from)
+    runs = metrics.get_ci_runs(ts_from)
 
     total = len(runs)
     passed = sum(1 for run in runs if run.get('status') == 'PASSED')
@@ -300,7 +300,7 @@ def api_costs_attribution():
     ts_from = int(datetime.strptime(date_from, '%Y-%m-%d').timestamp() * 1000)
     ts_to = int((datetime.strptime(date_to, '%Y-%m-%d') + timedelta(days=1)).timestamp() * 1000)
 
-    runs = metrics.get_ci_runs(r, ts_from, ts_to)
+    runs = metrics.get_ci_runs(ts_from, ts_to)
     runs_with_cost = [run for run in runs if run.get('cost_usd') is not None]
 
     # Enrich merge queue runs with PR author from GitHub
@@ -435,7 +435,7 @@ def api_costs_runners():
     ts_from = int(datetime.strptime(date_from, '%Y-%m-%d').timestamp() * 1000)
     ts_to = int((datetime.strptime(date_to, '%Y-%m-%d') + timedelta(days=1)).timestamp() * 1000)
 
-    runs = metrics.get_ci_runs(r, ts_from, ts_to)
+    runs = metrics.get_ci_runs(ts_from, ts_to)
     runs_with_cost = [run for run in runs if run.get('cost_usd') is not None]
     if dashboard:
         runs_with_cost = [run for run in runs_with_cost if run.get('dashboard') == dashboard]
@@ -511,7 +511,7 @@ def api_ci_performance():
     ts_from = int(datetime.strptime(date_from, '%Y-%m-%d').timestamp() * 1000)
     ts_to = int((datetime.strptime(date_to, '%Y-%m-%d') + timedelta(days=1)).timestamp() * 1000)
 
-    runs = metrics.get_ci_runs(r, ts_from, ts_to)
+    runs = metrics.get_ci_runs(ts_from, ts_to)
     runs = [run for run in runs if run.get('status') in ('PASSED', 'FAILED')]
     if dashboard:
         runs = [run for run in runs if run.get('dashboard') == dashboard]
@@ -672,7 +672,7 @@ def api_pr_metrics():
     author = request.args.get('author', '')
     ts_from = int(datetime.strptime(date_from, '%Y-%m-%d').timestamp() * 1000)
     ts_to = int((datetime.strptime(date_to, '%Y-%m-%d') + timedelta(days=1)).timestamp() * 1000)
-    ci_runs = metrics.get_ci_runs(r, ts_from, ts_to)
+    ci_runs = metrics.get_ci_runs(ts_from, ts_to)
     return _json(github_data.get_pr_metrics(date_from, date_to, author, ci_runs))
 
 

--- a/ci3/ci-metrics/app.py
+++ b/ci3/ci-metrics/app.py
@@ -245,6 +245,7 @@ def api_costs_overview():
             buckets[key]['aws_total'] += entry.get('aws_total', 0)
             buckets[key]['gcp_total'] += entry.get('gcp_total', 0)
         result['by_date'] = sorted(buckets.values(), key=lambda x: x['date'])
+    result['period'] = {'from': date_from, 'to': date_to}
     return _json(result)
 
 
@@ -417,6 +418,7 @@ def api_costs_attribution():
         'by_date': by_date_list,
         'run_types': all_types,
         'instances': instances[:500],
+        'period': {'from': date_from, 'to': date_to},
         'totals': {'aws': round(total_aws, 2), 'gcp': round(gcp_total, 2),
                    'gcp_unattributed': round(gcp_total, 2),
                    'combined': round(total_aws + gcp_total, 2)},
@@ -487,6 +489,7 @@ def api_costs_runners():
         'by_date': by_date,
         'by_instance_type': by_instance,
         'by_dashboard': by_dashboard,
+        'period': {'from': date_from, 'to': date_to},
         'summary': {
             'total_cost': round(total_cost, 2),
             'spot_pct': round(100.0 * spot_cost / max(total_cost, 0.01), 1),
@@ -541,45 +544,33 @@ def api_ci_performance():
             'avg_duration_mins': round(sum(d['durations']) / len(d['durations']), 1) if d['durations'] else None,
         })
 
+    # Merge test outcome counts from test_daily_stats before aggregation
+    ds_conditions = ['date >= ?', 'date <= ?']
+    ds_params = [date_from, date_to]
+    if dashboard:
+        ds_conditions.append('dashboard = ?')
+        ds_params.append(dashboard)
+    ds_where = 'WHERE ' + ' AND '.join(ds_conditions)
+
+    daily_test_counts = db.query(f'''
+        SELECT date, SUM(passed) as passed, SUM(failed) as failed, SUM(flaked) as flaked
+        FROM test_daily_stats {ds_where}
+        GROUP BY date
+    ''', ds_params)
+    daily_test_map = {r['date']: r for r in daily_test_counts}
+    for d in by_date:
+        tc = daily_test_map.get(d['date'], {})
+        d['flake_count'] = tc.get('flaked', 0) or 0
+        d['test_failure_count'] = tc.get('failed', 0) or 0
+        d['test_success_count'] = tc.get('passed', 0) or 0
+
     by_date = _aggregate_dates(by_date, granularity,
-                               sum_fields=['total', 'passed', 'failed'],
+                               sum_fields=['total', 'passed', 'failed',
+                                           'flake_count', 'test_failure_count', 'test_success_count'],
                                avg_fields=['avg_duration_mins'])
     for d in by_date:
         d['pass_rate'] = round(100.0 * d['passed'] / max(d['total'], 1), 1)
         d['failure_rate'] = round(100.0 * d['failed'] / max(d['total'], 1), 1)
-
-    # Daily flake/failure counts from test_events
-    if dashboard:
-        flake_daily = db.query('''
-            SELECT substr(timestamp, 1, 10) as date, COUNT(*) as count
-            FROM test_events WHERE status = 'flaked' AND dashboard = ?
-            AND timestamp >= ? AND timestamp < ?
-            GROUP BY substr(timestamp, 1, 10)
-        ''', (dashboard, date_from, date_to + 'T23:59:59'))
-        fail_test_daily = db.query('''
-            SELECT substr(timestamp, 1, 10) as date, COUNT(*) as count
-            FROM test_events WHERE status = 'failed' AND dashboard = ?
-            AND timestamp >= ? AND timestamp < ?
-            GROUP BY substr(timestamp, 1, 10)
-        ''', (dashboard, date_from, date_to + 'T23:59:59'))
-    else:
-        flake_daily = db.query('''
-            SELECT substr(timestamp, 1, 10) as date, COUNT(*) as count
-            FROM test_events WHERE status = 'flaked'
-            AND timestamp >= ? AND timestamp < ?
-            GROUP BY substr(timestamp, 1, 10)
-        ''', (date_from, date_to + 'T23:59:59'))
-        fail_test_daily = db.query('''
-            SELECT substr(timestamp, 1, 10) as date, COUNT(*) as count
-            FROM test_events WHERE status = 'failed'
-            AND timestamp >= ? AND timestamp < ?
-            GROUP BY substr(timestamp, 1, 10)
-        ''', (date_from, date_to + 'T23:59:59'))
-    flake_daily_map = {r['date']: r['count'] for r in flake_daily}
-    fail_test_daily_map = {r['date']: r['count'] for r in fail_test_daily}
-    for d in by_date:
-        d['flake_count'] = flake_daily_map.get(d['date'], 0)
-        d['test_failure_count'] = fail_test_daily_map.get(d['date'], 0)
 
     # Top flakes/failures
     if dashboard:
@@ -618,38 +609,22 @@ def api_ci_performance():
         if complete and ts:
             durations.append((complete - ts) / 60000.0)
 
-    if dashboard:
-        flake_count = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status='flaked' AND dashboard = ?
-            AND timestamp >= ? AND timestamp <= ?
-        ''', (dashboard, date_from, date_to + 'T23:59:59'))
-        total_tests = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status IN ('failed','flaked') AND dashboard = ?
-            AND timestamp >= ? AND timestamp <= ?
-        ''', (dashboard, date_from, date_to + 'T23:59:59'))
-        total_failures_count = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status='failed' AND dashboard = ?
-            AND timestamp >= ? AND timestamp <= ?
-        ''', (dashboard, date_from, date_to + 'T23:59:59'))
-    else:
-        flake_count = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status='flaked' AND timestamp >= ? AND timestamp <= ?
-        ''', (date_from, date_to + 'T23:59:59'))
-        total_tests = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status IN ('failed','flaked') AND timestamp >= ? AND timestamp <= ?
-        ''', (date_from, date_to + 'T23:59:59'))
-        total_failures_count = db.query('''
-            SELECT COUNT(*) as c FROM test_events WHERE status='failed' AND timestamp >= ? AND timestamp <= ?
-        ''', (date_from, date_to + 'T23:59:59'))
-
-    fc = flake_count[0]['c'] if flake_count else 0
-    tc = total_tests[0]['c'] if total_tests else 0
-    tfc = total_failures_count[0]['c'] if total_failures_count else 0
+    # Test outcome summary from test_daily_stats
+    ds_summary = db.query(f'''
+        SELECT SUM(passed) as passed, SUM(failed) as failed, SUM(flaked) as flaked
+        FROM test_daily_stats {ds_where}
+    ''', ds_params)
+    ds_s = ds_summary[0] if ds_summary else {}
+    fc = ds_s.get('flaked', 0) or 0
+    tfc = ds_s.get('failed', 0) or 0
+    tpc = ds_s.get('passed', 0) or 0
+    tc = fc + tfc + tpc
 
     return _json({
         'by_date': by_date,
         'top_flakes': top_flakes,
         'top_failures': top_failures,
+        'period': {'from': date_from, 'to': date_to},
         'summary': {
             'total_runs': total,
             'pass_rate': round(100.0 * passed / max(total, 1), 1),
@@ -658,6 +633,7 @@ def api_ci_performance():
             'flake_rate': round(100.0 * fc / max(tc, 1), 1) if tc else 0,
             'total_flakes': fc,
             'total_test_failures': tfc,
+            'total_test_successes': tpc,
         },
     })
 
@@ -746,55 +722,110 @@ def api_test_timings():
 
     where = 'WHERE ' + ' AND '.join(conditions)
 
-    # Per-test stats
+    # Per-test timing from test_events (failed/flaked only — passed not persisted)
     by_test = db.query(f'''
         SELECT test_cmd,
-               COUNT(*) as count,
+               COUNT(*) as event_count,
                ROUND(AVG(duration_secs), 1) as avg_secs,
                ROUND(MIN(duration_secs), 1) as min_secs,
                ROUND(MAX(duration_secs), 1) as max_secs,
-               SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as passed,
-               SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-               SUM(CASE WHEN status = 'flaked' THEN 1 ELSE 0 END) as flaked,
                dashboard
         FROM test_events {where}
         GROUP BY test_cmd
-        ORDER BY count DESC
+        ORDER BY event_count DESC
         LIMIT 200
     ''', params)
 
-    # Add pass rate
-    for row in by_test:
-        total = row['passed'] + row['failed'] + row['flaked']
-        row['pass_rate'] = round(100.0 * row['passed'] / max(total, 1), 1)
-        row['total_time_secs'] = round(row['avg_secs'] * row['count'], 0)
+    # Per-test counts from daily stats (includes passed)
+    ds_conditions = ['date >= ?', 'date <= ?']
+    ds_params = [date_from, date_to]
+    if dashboard:
+        ds_conditions.append('dashboard = ?')
+        ds_params.append(dashboard)
+    if test_cmd:
+        ds_conditions.append('test_cmd = ?')
+        ds_params.append(test_cmd)
+    ds_where = 'WHERE ' + ' AND '.join(ds_conditions)
 
-    # Daily time series (aggregate across all tests or filtered test)
+    daily_stats_by_test = {r['test_cmd']: r for r in db.query(f'''
+        SELECT test_cmd,
+               SUM(passed) as passed, SUM(failed) as failed, SUM(flaked) as flaked
+        FROM test_daily_stats {ds_where}
+        GROUP BY test_cmd
+    ''', ds_params)}
+
+    # Merge counts into timing data
+    for row in by_test:
+        ds = daily_stats_by_test.get(row['test_cmd'], {})
+        row['passed'] = ds.get('passed', 0) or 0
+        row['failed'] = ds.get('failed', 0) or row['event_count']
+        row['flaked'] = ds.get('flaked', 0) or 0
+        row['count'] = row['passed'] + row['failed'] + row['flaked']
+        total = max(row['count'], 1)
+        row['pass_rate'] = round(100.0 * row['passed'] / total, 1)
+        row['total_time_secs'] = round(row['avg_secs'] * row['event_count'], 0)
+        del row['event_count']
+
+    # Also add tests that only have daily stats (all passed, no individual events)
+    existing_cmds = {r['test_cmd'] for r in by_test}
+    for cmd, ds in daily_stats_by_test.items():
+        if cmd not in existing_cmds and not status:
+            passed = ds.get('passed', 0) or 0
+            failed = ds.get('failed', 0) or 0
+            flaked = ds.get('flaked', 0) or 0
+            total = passed + failed + flaked
+            if total > 0:
+                by_test.append({
+                    'test_cmd': cmd, 'count': total,
+                    'avg_secs': None, 'min_secs': None, 'max_secs': None,
+                    'passed': passed, 'failed': failed, 'flaked': flaked,
+                    'pass_rate': round(100.0 * passed / total, 1),
+                    'total_time_secs': 0, 'dashboard': '',
+                })
+    by_test.sort(key=lambda r: r['count'], reverse=True)
+
+    # Daily time series from daily stats
     by_date = db.query(f'''
+        SELECT date,
+               SUM(passed) as passed, SUM(failed) as failed, SUM(flaked) as flaked,
+               SUM(passed) + SUM(failed) + SUM(flaked) as count
+        FROM test_daily_stats {ds_where}
+        GROUP BY date
+        ORDER BY date
+    ''', ds_params)
+
+    # Enrich with timing from test_events
+    timing_by_date = {r['date']: r for r in db.query(f'''
         SELECT substr(timestamp, 1, 10) as date,
-               COUNT(*) as count,
                ROUND(AVG(duration_secs), 1) as avg_secs,
-               ROUND(MAX(duration_secs), 1) as max_secs,
-               SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as passed,
-               SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-               SUM(CASE WHEN status = 'flaked' THEN 1 ELSE 0 END) as flaked
+               ROUND(MAX(duration_secs), 1) as max_secs
         FROM test_events {where}
         GROUP BY substr(timestamp, 1, 10)
-        ORDER BY date
-    ''', params)
+    ''', params)}
+    for d in by_date:
+        t = timing_by_date.get(d['date'], {})
+        d['avg_secs'] = t.get('avg_secs')
+        d['max_secs'] = t.get('max_secs')
 
-    # Summary
-    summary_rows = db.query(f'''
-        SELECT COUNT(*) as count,
-               ROUND(AVG(duration_secs), 1) as avg_secs,
+    # Summary from daily stats
+    ds_summary = db.query(f'''
+        SELECT SUM(passed) as passed, SUM(failed) as failed, SUM(flaked) as flaked
+        FROM test_daily_stats {ds_where}
+    ''', ds_params)
+    ds_s = ds_summary[0] if ds_summary else {}
+
+    # Timing summary from test_events
+    timing_summary = db.query(f'''
+        SELECT ROUND(AVG(duration_secs), 1) as avg_secs,
                ROUND(MAX(duration_secs), 1) as max_secs,
-               SUM(duration_secs) as total_secs,
-               SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END) as passed,
-               SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-               SUM(CASE WHEN status = 'flaked' THEN 1 ELSE 0 END) as flaked
+               SUM(duration_secs) as total_secs
         FROM test_events {where}
     ''', params)
-    s = summary_rows[0] if summary_rows else {}
+    ts = timing_summary[0] if timing_summary else {}
+
+    passed = ds_s.get('passed', 0) or 0
+    failed = ds_s.get('failed', 0) or 0
+    flaked = ds_s.get('flaked', 0) or 0
 
     # Slowest individual test runs
     slowest = db.query(f'''
@@ -809,14 +840,15 @@ def api_test_timings():
         'by_test': by_test,
         'by_date': by_date,
         'slowest': slowest,
+        'period': {'from': date_from, 'to': date_to},
         'summary': {
-            'total_runs': s.get('count', 0),
-            'avg_duration_secs': s.get('avg_secs'),
-            'max_duration_secs': s.get('max_secs'),
-            'total_compute_secs': round(s.get('total_secs', 0) or 0, 0),
-            'passed': s.get('passed', 0),
-            'failed': s.get('failed', 0),
-            'flaked': s.get('flaked', 0),
+            'total_runs': passed + failed + flaked,
+            'avg_duration_secs': ts.get('avg_secs'),
+            'max_duration_secs': ts.get('max_secs'),
+            'total_compute_secs': round(ts.get('total_secs', 0) or 0, 0),
+            'passed': passed,
+            'failed': failed,
+            'flaked': flaked,
         },
     })
 

--- a/ci3/ci-metrics/billing/billing-dashboard.html
+++ b/ci3/ci-metrics/billing/billing-dashboard.html
@@ -58,6 +58,7 @@
     <a href="/cost-overview">cost overview</a>
     <a href="/namespace-billing" class="active">namespace billing</a>
     <a href="/ci-insights">ci insights</a>
+    <a href="/test-timings">test timings</a>
   </div>
   <h2 style="margin:8px 0;color:#ccc;">namespace billing</h2>
 

--- a/ci3/ci-metrics/db.py
+++ b/ci3/ci-metrics/db.py
@@ -7,7 +7,8 @@ import os
 import sqlite3
 import threading
 
-_DB_PATH = os.path.join(os.getenv('LOGS_DISK_PATH', '/logs-disk'), 'metrics.db')
+_DB_PATH = os.getenv('METRICS_DB_PATH',
+                     os.path.join(os.getenv('LOGS_DISK_PATH', '/logs-disk'), 'metrics.db'))
 _local = threading.local()
 
 SCHEMA = """

--- a/ci3/ci-metrics/db.py
+++ b/ci3/ci-metrics/db.py
@@ -65,6 +65,18 @@ CREATE TABLE IF NOT EXISTS ci_runs (
 CREATE INDEX IF NOT EXISTS idx_ci_runs_ts ON ci_runs(timestamp_ms);
 CREATE INDEX IF NOT EXISTS idx_ci_runs_name ON ci_runs(name);
 CREATE INDEX IF NOT EXISTS idx_ci_runs_dashboard ON ci_runs(dashboard);
+
+CREATE TABLE IF NOT EXISTS test_daily_stats (
+    date          TEXT NOT NULL,
+    test_cmd      TEXT NOT NULL,
+    dashboard     TEXT NOT NULL DEFAULT '',
+    passed        INTEGER NOT NULL DEFAULT 0,
+    failed        INTEGER NOT NULL DEFAULT 0,
+    flaked        INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (date, test_cmd, dashboard)
+);
+CREATE INDEX IF NOT EXISTS idx_tds_date ON test_daily_stats(date);
+CREATE INDEX IF NOT EXISTS idx_tds_dashboard ON test_daily_stats(dashboard);
 """
 
 

--- a/ci3/ci-metrics/ec2_pricing.py
+++ b/ci3/ci-metrics/ec2_pricing.py
@@ -16,12 +16,20 @@ from datetime import datetime, timezone
 # ---- Hardcoded fallback rates (us-east-2, USD/hr) ----
 
 _HARDCODED_RATES = {
-    ('m6a.48xlarge', True):  8.31,   # spot
-    ('m6a.48xlarge', False): 16.56,  # on-demand
-    ('m6a.32xlarge', True):  5.54,
-    ('m6a.32xlarge', False): 11.04,
+    ('m6a.xlarge',   True):  0.07,   # spot
+    ('m6a.xlarge',   False): 0.1728, # on-demand
+    ('m6a.4xlarge',  True):  0.28,
+    ('m6a.4xlarge',  False): 0.6912,
+    ('m6a.8xlarge',  True):  0.55,
+    ('m6a.8xlarge',  False): 1.3824,
     ('m6a.16xlarge', True):  2.77,
     ('m6a.16xlarge', False): 5.52,
+    ('m6a.24xlarge', True):  1.66,
+    ('m6a.24xlarge', False): 4.1472,
+    ('m6a.32xlarge', True):  5.54,
+    ('m6a.32xlarge', False): 11.04,
+    ('m6a.48xlarge', True):  8.31,
+    ('m6a.48xlarge', False): 16.56,
     ('m7a.48xlarge', True):  8.31,
     ('m7a.48xlarge', False): 16.56,
     ('m7a.16xlarge', True):  2.77,
@@ -145,8 +153,19 @@ def _fetch_all_spot(instance_types: list[str]) -> dict[str, float]:
 # ---- Cache refresh ----
 
 def _get_known_instance_types() -> list[str]:
-    """Return the set of instance types we need pricing for."""
-    return sorted({itype for itype, _ in _HARDCODED_RATES})
+    """Return the set of instance types we need pricing for (hardcoded + from DB)."""
+    types = {itype for itype, _ in _HARDCODED_RATES}
+    try:
+        import db
+        conn = db.get_db()
+        rows = conn.execute(
+            "SELECT DISTINCT instance_type FROM ci_runs "
+            "WHERE instance_type IS NOT NULL AND instance_type != '' AND instance_type != 'unknown'"
+        ).fetchall()
+        types.update(r['instance_type'] for r in rows)
+    except Exception:
+        pass
+    return sorted(types)
 
 
 def _refresh_cache():

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -568,32 +568,52 @@ _ct_resolve_ts = 0
 _CT_RESOLVE_TTL = 6 * 3600  # 6 hours
 
 
-def _fetch_cloudtrail_events(ct, event_name, start_time, end_time, max_events=5000):
-    """Paginate through CloudTrail lookup_events for a given event name."""
+def _fetch_cloudtrail_daily(ct, event_name, start_time, end_time, max_per_day=10000):
+    """Fetch CloudTrail events in daily chunks to avoid the 5000-event global limit."""
     events = []
-    kwargs = {
-        'LookupAttributes': [
-            {'AttributeKey': 'EventName', 'AttributeValue': event_name},
-        ],
-        'StartTime': start_time,
-        'EndTime': end_time,
-        'MaxResults': 50,
-    }
-    while True:
-        resp = ct.lookup_events(**kwargs)
-        events.extend(resp.get('Events', []))
-        token = resp.get('NextToken')
-        if not token or len(events) >= max_events:
-            break
-        kwargs['NextToken'] = token
+    day = start_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    while day < end_time:
+        day_end = min(day + timedelta(days=1), end_time)
+        kwargs = {
+            'LookupAttributes': [
+                {'AttributeKey': 'EventName', 'AttributeValue': event_name},
+            ],
+            'StartTime': day,
+            'EndTime': day_end,
+            'MaxResults': 50,
+        }
+        while True:
+            resp = ct.lookup_events(**kwargs)
+            events.extend(resp.get('Events', []))
+            token = resp.get('NextToken')
+            if not token or len(events) >= max_per_day:
+                break
+            kwargs['NextToken'] = token
+        day += timedelta(days=1)
     return events
+
+
+# Name tag format: <branch_normalized>_<arch>[_<postfix>]
+_NAME_TAG_RE = re.compile(r'^(.+)_(amd64|arm64)(?:_.*)?$')
+
+
+def _normalize_branch_name(name):
+    """Normalize a branch name the same way bootstrap_ec2 does for the EC2 Name tag."""
+    m = re.match(r'^gh-readonly-queue/[^/]+/pr-(\d+)', name)
+    if m:
+        return f'pr-{m.group(1)}'
+    name = re.sub(r'\s*\(queue\)$', '', name)
+    return re.sub(r'[^a-zA-Z0-9-]', '_', name[:50])
 
 
 def resolve_unknown_instance_types():
     """Query CloudTrail for RunInstances + CreateTags events to resolve unknown instance types.
 
-    Correlates by joining RunInstances and CreateTags on instance ID, then
-    matching to ci_runs via the Dashboard and Name tags set on each EC2 instance.
+    Strategy:
+    1. Fetch RunInstances events (daily chunks) → instance_id → instance_type + launch_time
+    2. Fetch CreateTags events (daily chunks) → instance_id → {Name, Group, Dashboard, ...}
+       Tags are accumulated across multiple events then filtered to Group=build-instance.
+    3. Join by instance_id, then match to ci_runs by normalized branch name + arch + time window.
     """
     global _ct_resolve_ts
     now = time.time()
@@ -624,19 +644,20 @@ def resolve_unknown_instance_types():
             min(r['timestamp_ms'] for r in unknown_runs) / 1000 - 300, tz=timezone.utc)
         end_time = datetime.now(timezone.utc)
 
-        # Fetch RunInstances events → instance_id → instance_type
-        run_events = _fetch_cloudtrail_events(ct, 'RunInstances', start_time, end_time)
-        instance_types = {}  # instance_id → instance_type
-        instance_launch_times = {}  # instance_id → launch time ms
+        # Step 1: Fetch RunInstances events in daily chunks → instance_id → type + launch time
+        run_events = _fetch_cloudtrail_daily(ct, 'RunInstances', start_time, end_time)
+        instance_types = {}
+        instance_launch_times = {}
         for event in run_events:
             try:
                 detail = json.loads(event.get('CloudTrailEvent', '{}'))
-                resp_items = detail.get('responseElements', {}).get('instancesSet', {}).get('items', [])
-                for item in resp_items:
+                itype = detail.get('requestParameters', {}).get('instanceType', '')
+                items = (detail.get('responseElements') or {}).get('instancesSet', {}).get('items', [])
+                for item in items:
                     iid = item.get('instanceId', '')
-                    itype = item.get('instanceType', '') or detail.get('requestParameters', {}).get('instanceType', '')
-                    if iid and itype:
-                        instance_types[iid] = itype
+                    item_type = item.get('instanceType', '') or itype
+                    if iid and item_type:
+                        instance_types[iid] = item_type
                         instance_launch_times[iid] = int(event['EventTime'].timestamp() * 1000)
             except Exception:
                 continue
@@ -645,9 +666,12 @@ def resolve_unknown_instance_types():
             print("[rk_metrics] CloudTrail: no RunInstances events found")
             return
 
-        # Fetch CreateTags events → instance_id → {Name, Dashboard} tags
-        tag_events = _fetch_cloudtrail_events(ct, 'CreateTags', start_time, end_time)
-        instance_tags = {}  # instance_id → {Name, Dashboard, GithubActor}
+        # Step 2: Fetch CreateTags events in daily chunks.
+        # Accumulate ALL tags per instance first, then filter to build instances.
+        # This handles the case where Name, Group, and Dashboard are set in separate
+        # create-tags API calls (aws_request_instance_type lines 97, 126, 127).
+        tag_events = _fetch_cloudtrail_daily(ct, 'CreateTags', start_time, end_time)
+        all_instance_tags = {}
         for event in tag_events:
             try:
                 detail = json.loads(event.get('CloudTrailEvent', '{}'))
@@ -655,73 +679,78 @@ def resolve_unknown_instance_types():
                 resources = req.get('resourcesSet', {}).get('items', [])
                 tags = req.get('tagSet', {}).get('items', [])
                 tag_dict = {t.get('key', ''): t.get('value', '') for t in tags}
-                # Only care about build instances
-                if tag_dict.get('Group') != 'build-instance' and 'Dashboard' not in tag_dict:
-                    continue
                 for res in resources:
                     rid = res.get('resourceId', '')
                     if rid.startswith('i-'):
-                        if rid not in instance_tags:
-                            instance_tags[rid] = {}
-                        instance_tags[rid].update(tag_dict)
+                        if rid not in all_instance_tags:
+                            all_instance_tags[rid] = {}
+                        all_instance_tags[rid].update(tag_dict)
             except Exception:
                 continue
 
-        # Join: build list of instances with both type and tags
+        # Filter to build instances
+        instance_tags = {
+            iid: tags for iid, tags in all_instance_tags.items()
+            if tags.get('Group') == 'build-instance'
+        }
+
+        # Step 3: Join RunInstances + CreateTags by instance_id
         instances = []
         for iid, itype in instance_types.items():
             tags = instance_tags.get(iid, {})
+            if not tags.get('Name'):
+                continue
             instances.append({
-                'instance_id': iid,
                 'instance_type': itype,
                 'launch_ms': instance_launch_times.get(iid, 0),
                 'dashboard': tags.get('Dashboard', ''),
                 'name_tag': tags.get('Name', ''),
-                'actor': tags.get('GithubActor', ''),
             })
 
-        # Match unknown runs to instances using tags
+        # Build index: normalized branch name → [instances]
+        tag_index = {}
+        for inst in instances:
+            m = _NAME_TAG_RE.match(inst['name_tag'])
+            if m:
+                tag_index.setdefault(m.group(1), []).append(inst)
+            else:
+                tag_index.setdefault(inst['name_tag'], []).append(inst)
+
+        # Step 4: Match unknown runs to instances
         updated = 0
         for run in unknown_runs:
-            run_dashboard = run['dashboard']
+            run_name = run['name']
+            run_arch = run['arch'] or ''
             run_ts = run['timestamp_ms']
+            run_dashboard = run['dashboard']
+
+            expected_name = _normalize_branch_name(run_name)
+            candidates = tag_index.get(expected_name, [])
 
             best = None
-            best_score = -1
-            for inst in instances:
-                score = 0
-                # Dashboard tag must match
-                if inst['dashboard'] and inst['dashboard'] == run_dashboard:
-                    score += 10
-                elif inst['dashboard']:
-                    continue  # Dashboard mismatch — skip
+            for inst in candidates:
+                # Verify arch matches
+                if run_arch:
+                    m = _NAME_TAG_RE.match(inst['name_tag'])
+                    if m and m.group(2) != run_arch:
+                        continue
 
-                # Name tag contains branch_arch; match components
-                name_tag = inst['name_tag']
-                if name_tag:
-                    # Name tag format: "branch-name_arch" (e.g. "pr-123_amd64")
-                    run_arch = run['arch'] or ''
-                    if run_arch and name_tag.endswith('_' + run_arch):
-                        score += 3
-                    # Check PR number in name tag
-                    run_pr = run['pr_number']
-                    if run_pr:
-                        tag_pr = extract_pr_number(name_tag)
-                        if tag_pr == run_pr:
-                            score += 5
-
-                # Timestamp proximity (within 10 min)
-                delta = abs(inst['launch_ms'] - run_ts)
-                if delta > 600_000:
+                # Verify dashboard matches (if tag present)
+                if inst['dashboard'] and inst['dashboard'] != run_dashboard:
                     continue
-                # Closer timestamps score higher
-                score += max(0, 5 - delta / 120_000)
 
-                if score > best_score:
-                    best_score = score
+                # CI run starts after instance launch; allow up to 90 min (instance lifetime)
+                delta = run_ts - inst['launch_ms']
+                if delta < -60_000 or delta > 5400_000:
+                    continue
+
+                # Prefer most recently launched instance before the run
+                if delta >= 0 and (best is None or inst['launch_ms'] > best['launch_ms']):
+                    best = inst
+                elif best is None and abs(delta) < 60_000:
                     best = inst
 
-            if best and best_score >= 10:
+            if best:
                 itype = best['instance_type']
                 is_spot = bool(run['spot'])
                 rate = ec2_pricing.get_instance_rate(itype, is_spot)
@@ -739,8 +768,8 @@ def resolve_unknown_instance_types():
         if updated:
             print(f"[rk_metrics] CloudTrail: resolved {updated}/{len(unknown_runs)} unknown instance types")
         else:
-            print(f"[rk_metrics] CloudTrail: {len(instances)} instances found, "
-                  f"{len(instance_tags)} tagged, 0/{len(unknown_runs)} matched")
+            print(f"[rk_metrics] CloudTrail: {len(instances)} instances, "
+                  f"0/{len(unknown_runs)} matched")
     except Exception as e:
         print(f"[rk_metrics] CloudTrail resolution failed: {e}")
 

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -568,8 +568,33 @@ _ct_resolve_ts = 0
 _CT_RESOLVE_TTL = 6 * 3600  # 6 hours
 
 
+def _fetch_cloudtrail_events(ct, event_name, start_time, end_time, max_events=5000):
+    """Paginate through CloudTrail lookup_events for a given event name."""
+    events = []
+    kwargs = {
+        'LookupAttributes': [
+            {'AttributeKey': 'EventName', 'AttributeValue': event_name},
+        ],
+        'StartTime': start_time,
+        'EndTime': end_time,
+        'MaxResults': 50,
+    }
+    while True:
+        resp = ct.lookup_events(**kwargs)
+        events.extend(resp.get('Events', []))
+        token = resp.get('NextToken')
+        if not token or len(events) >= max_events:
+            break
+        kwargs['NextToken'] = token
+    return events
+
+
 def resolve_unknown_instance_types():
-    """Query CloudTrail for RunInstances events to fill in unknown instance types."""
+    """Query CloudTrail for RunInstances + CreateTags events to resolve unknown instance types.
+
+    Correlates by joining RunInstances and CreateTags on instance ID, then
+    matching to ci_runs via the Dashboard and Name tags set on each EC2 instance.
+    """
     global _ct_resolve_ts
     now = time.time()
     if now - _ct_resolve_ts < _CT_RESOLVE_TTL:
@@ -577,9 +602,9 @@ def resolve_unknown_instance_types():
     _ct_resolve_ts = now
 
     conn = db.get_db()
-    # Find runs with unknown/empty instance_type
     unknown_runs = conn.execute('''
-        SELECT dashboard, name, timestamp_ms, complete_ms, instance_vcpus, spot, cost_usd
+        SELECT dashboard, name, timestamp_ms, complete_ms, instance_vcpus, spot,
+               cost_usd, arch, pr_number
         FROM ci_runs
         WHERE (instance_type IS NULL OR instance_type = '' OR instance_type = 'unknown')
         AND timestamp_ms > ?
@@ -595,69 +620,108 @@ def resolve_unknown_instance_types():
 
     try:
         ct = boto3.client('cloudtrail', region_name='us-east-2')
-        # Fetch RunInstances events from CloudTrail
-        events = []
-        kwargs = {
-            'LookupAttributes': [
-                {'AttributeKey': 'EventName', 'AttributeValue': 'RunInstances'},
-            ],
-            'StartTime': datetime.fromtimestamp(
-                min(r['timestamp_ms'] for r in unknown_runs) / 1000 - 300, tz=timezone.utc),
-            'EndTime': datetime.now(timezone.utc),
-            'MaxResults': 50,
-        }
-        # Paginate through results
-        while True:
-            resp = ct.lookup_events(**kwargs)
-            events.extend(resp.get('Events', []))
-            token = resp.get('NextToken')
-            if not token or len(events) >= 5000:
-                break
-            kwargs['NextToken'] = token
+        start_time = datetime.fromtimestamp(
+            min(r['timestamp_ms'] for r in unknown_runs) / 1000 - 300, tz=timezone.utc)
+        end_time = datetime.now(timezone.utc)
 
-        if not events:
-            print(f"[rk_metrics] CloudTrail: no RunInstances events found")
-            return
-
-        # Build time-indexed list of instance launches
-        launches = []
-        for event in events:
+        # Fetch RunInstances events → instance_id → instance_type
+        run_events = _fetch_cloudtrail_events(ct, 'RunInstances', start_time, end_time)
+        instance_types = {}  # instance_id → instance_type
+        instance_launch_times = {}  # instance_id → launch time ms
+        for event in run_events:
             try:
                 detail = json.loads(event.get('CloudTrailEvent', '{}'))
-                req = detail.get('requestParameters', {})
-                instance_type = req.get('instanceType', '')
-                if not instance_type:
-                    # Try to get from instancesSet in response
-                    resp_items = detail.get('responseElements', {}).get('instancesSet', {}).get('items', [])
-                    if resp_items:
-                        instance_type = resp_items[0].get('instanceType', '')
-                if instance_type:
-                    event_time_ms = int(event['EventTime'].timestamp() * 1000)
-                    launches.append({
-                        'time_ms': event_time_ms,
-                        'instance_type': instance_type,
-                    })
+                resp_items = detail.get('responseElements', {}).get('instancesSet', {}).get('items', [])
+                for item in resp_items:
+                    iid = item.get('instanceId', '')
+                    itype = item.get('instanceType', '') or detail.get('requestParameters', {}).get('instanceType', '')
+                    if iid and itype:
+                        instance_types[iid] = itype
+                        instance_launch_times[iid] = int(event['EventTime'].timestamp() * 1000)
             except Exception:
                 continue
 
-        if not launches:
+        if not instance_types:
+            print("[rk_metrics] CloudTrail: no RunInstances events found")
             return
 
-        launches.sort(key=lambda x: x['time_ms'])
+        # Fetch CreateTags events → instance_id → {Name, Dashboard} tags
+        tag_events = _fetch_cloudtrail_events(ct, 'CreateTags', start_time, end_time)
+        instance_tags = {}  # instance_id → {Name, Dashboard, GithubActor}
+        for event in tag_events:
+            try:
+                detail = json.loads(event.get('CloudTrailEvent', '{}'))
+                req = detail.get('requestParameters', {})
+                resources = req.get('resourcesSet', {}).get('items', [])
+                tags = req.get('tagSet', {}).get('items', [])
+                tag_dict = {t.get('key', ''): t.get('value', '') for t in tags}
+                # Only care about build instances
+                if tag_dict.get('Group') != 'build-instance' and 'Dashboard' not in tag_dict:
+                    continue
+                for res in resources:
+                    rid = res.get('resourceId', '')
+                    if rid.startswith('i-'):
+                        if rid not in instance_tags:
+                            instance_tags[rid] = {}
+                        instance_tags[rid].update(tag_dict)
+            except Exception:
+                continue
 
-        # Match unknown runs to CloudTrail events by timestamp proximity
+        # Join: build list of instances with both type and tags
+        instances = []
+        for iid, itype in instance_types.items():
+            tags = instance_tags.get(iid, {})
+            instances.append({
+                'instance_id': iid,
+                'instance_type': itype,
+                'launch_ms': instance_launch_times.get(iid, 0),
+                'dashboard': tags.get('Dashboard', ''),
+                'name_tag': tags.get('Name', ''),
+                'actor': tags.get('GithubActor', ''),
+            })
+
+        # Match unknown runs to instances using tags
         updated = 0
         for run in unknown_runs:
+            run_dashboard = run['dashboard']
             run_ts = run['timestamp_ms']
-            # Find closest launch within 10 minutes
+
             best = None
-            best_delta = 600_000  # 10 min in ms
-            for launch in launches:
-                delta = abs(launch['time_ms'] - run_ts)
-                if delta < best_delta:
-                    best_delta = delta
-                    best = launch
-            if best:
+            best_score = -1
+            for inst in instances:
+                score = 0
+                # Dashboard tag must match
+                if inst['dashboard'] and inst['dashboard'] == run_dashboard:
+                    score += 10
+                elif inst['dashboard']:
+                    continue  # Dashboard mismatch — skip
+
+                # Name tag contains branch_arch; match components
+                name_tag = inst['name_tag']
+                if name_tag:
+                    # Name tag format: "branch-name_arch" (e.g. "pr-123_amd64")
+                    run_arch = run['arch'] or ''
+                    if run_arch and name_tag.endswith('_' + run_arch):
+                        score += 3
+                    # Check PR number in name tag
+                    run_pr = run['pr_number']
+                    if run_pr:
+                        tag_pr = extract_pr_number(name_tag)
+                        if tag_pr == run_pr:
+                            score += 5
+
+                # Timestamp proximity (within 10 min)
+                delta = abs(inst['launch_ms'] - run_ts)
+                if delta > 600_000:
+                    continue
+                # Closer timestamps score higher
+                score += max(0, 5 - delta / 120_000)
+
+                if score > best_score:
+                    best_score = score
+                    best = inst
+
+            if best and best_score >= 10:
                 itype = best['instance_type']
                 is_spot = bool(run['spot'])
                 rate = ec2_pricing.get_instance_rate(itype, is_spot)
@@ -674,6 +738,9 @@ def resolve_unknown_instance_types():
         conn.commit()
         if updated:
             print(f"[rk_metrics] CloudTrail: resolved {updated}/{len(unknown_runs)} unknown instance types")
+        else:
+            print(f"[rk_metrics] CloudTrail: {len(instances)} instances found, "
+                  f"{len(instance_tags)} tagged, 0/{len(unknown_runs)} matched")
     except Exception as e:
         print(f"[rk_metrics] CloudTrail resolution failed: {e}")
 

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -1,8 +1,9 @@
-"""CI metrics: direct Redis reads + test event listener.
+"""CI metrics: SQLite source of truth + Redis ingestion + test event listener.
 
-Reads CI run data directly from Redis sorted sets on each request.
+CI runs are ingested from Redis (written by log_ci_run on CI instances) and
+stored in SQLite. All reads go through SQLite so enriched fields (instance_type
+from CloudTrail, recalculated costs) are preserved.
 Test events stored in SQLite since they only arrive via pub/sub.
-CI runs periodically synced from Redis to SQLite for flake correlation.
 """
 import json
 import re
@@ -116,31 +117,14 @@ def _get_ci_runs_from_sqlite(date_from_ms=None, date_to_ms=None):
     return runs
 
 
-def get_ci_runs(redis_conn, date_from_ms=None, date_to_ms=None):
-    """Read CI runs from Redis, backfilled with SQLite for data that Redis has flushed."""
-    redis_runs = _get_ci_runs_from_redis(redis_conn, date_from_ms, date_to_ms)
+def get_ci_runs(date_from_ms=None, date_to_ms=None):
+    """Read CI runs from SQLite (the source of truth).
 
-    # Find the earliest timestamp in Redis to know what SQLite needs to fill
-    redis_keys = set()
-    redis_min_ts = float('inf')
-    for run in redis_runs:
-        ts = run.get('timestamp', 0)
-        redis_keys.add((run.get('dashboard', ''), ts, run.get('name', '')))
-        if ts < redis_min_ts:
-            redis_min_ts = ts
-
-    # If requesting data older than what Redis has, backfill from SQLite
-    sqlite_runs = []
-    need_sqlite = (date_from_ms is not None and date_from_ms < redis_min_ts) or not redis_runs
-    if need_sqlite:
-        sqlite_to = int(redis_min_ts) if redis_runs else date_to_ms
-        sqlite_runs = _get_ci_runs_from_sqlite(date_from_ms, sqlite_to)
-        # Deduplicate: only include SQLite runs not already in Redis
-        sqlite_runs = [r for r in sqlite_runs
-                       if (r.get('dashboard', ''), r.get('timestamp', 0), r.get('name', ''))
-                       not in redis_keys]
-
-    return sqlite_runs + redis_runs
+    Redis is only an ingestion pipe — sync_ci_runs_to_sqlite() copies data in.
+    All reads go through SQLite so enriched fields (instance_type from CloudTrail,
+    recalculated costs) are always reflected.
+    """
+    return _get_ci_runs_from_sqlite(date_from_ms, date_to_ms)
 
 
 def _ts_to_date(ts_ms):
@@ -496,14 +480,19 @@ _CI_SYNC_TTL = 3600  # 1 hour
 
 
 def sync_ci_runs_to_sqlite(redis_conn):
-    """Sync all CI runs from Redis into SQLite for persistence."""
+    """Ingest CI runs from Redis into SQLite.
+
+    Redis is the ingestion pipe (log_ci_run writes there from CI instances).
+    SQLite is the source of truth. Fields enriched post-ingestion (instance_type,
+    cost_usd from CloudTrail resolution) are preserved — only overwritten if
+    Redis has a non-empty value.
+    """
     global _ci_sync_ts
     now = time.time()
     if now - _ci_sync_ts < _CI_SYNC_TTL:
         return
     _ci_sync_ts = now
 
-    # Sync everything Redis has (not just 30 days)
     runs = _get_ci_runs_from_redis(redis_conn)
 
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -512,11 +501,32 @@ def sync_ci_runs_to_sqlite(redis_conn):
     for run in runs:
         try:
             conn.execute('''
-                INSERT OR REPLACE INTO ci_runs
+                INSERT INTO ci_runs
                 (dashboard, name, timestamp_ms, complete_ms, status, author,
                  pr_number, instance_type, instance_vcpus, spot, cost_usd,
                  job_id, arch, synced_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(dashboard, timestamp_ms, name) DO UPDATE SET
+                    complete_ms = excluded.complete_ms,
+                    status = excluded.status,
+                    author = excluded.author,
+                    pr_number = excluded.pr_number,
+                    instance_vcpus = excluded.instance_vcpus,
+                    spot = excluded.spot,
+                    job_id = excluded.job_id,
+                    arch = excluded.arch,
+                    synced_at = excluded.synced_at,
+                    -- Preserve enriched fields: only overwrite if Redis has real data
+                    instance_type = CASE
+                        WHEN excluded.instance_type IS NOT NULL AND excluded.instance_type != ''
+                        THEN excluded.instance_type
+                        ELSE ci_runs.instance_type
+                    END,
+                    cost_usd = CASE
+                        WHEN excluded.instance_type IS NOT NULL AND excluded.instance_type != ''
+                        THEN excluded.cost_usd
+                        ELSE ci_runs.cost_usd
+                    END
             ''', (
                 run.get('dashboard', ''),
                 run.get('name', ''),

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -784,6 +784,35 @@ def resolve_unknown_instance_types():
         print(f"[rk_metrics] CloudTrail resolution failed: {e}")
 
 
+def recalculate_all_costs():
+    """Recalculate cost_usd for all ci_runs based on current instance_type and pricing."""
+    conn = db.get_db()
+    runs = conn.execute('''
+        SELECT dashboard, name, timestamp_ms, complete_ms, instance_type,
+               instance_vcpus, spot, cost_usd
+        FROM ci_runs
+        WHERE complete_ms IS NOT NULL AND complete_ms > 0
+    ''').fetchall()
+    updated = 0
+    for run in runs:
+        cost = compute_run_cost({
+            'complete': run['complete_ms'],
+            'timestamp': run['timestamp_ms'],
+            'instance_type': run['instance_type'] or 'unknown',
+            'spot': run['spot'],
+            'instance_vcpus': run['instance_vcpus'],
+        })
+        if cost is not None and cost != run['cost_usd']:
+            conn.execute('''
+                UPDATE ci_runs SET cost_usd = ?
+                WHERE dashboard = ? AND timestamp_ms = ? AND name = ?
+            ''', (cost, run['dashboard'], run['timestamp_ms'], run['name']))
+            updated += 1
+    conn.commit()
+    print(f"[rk_metrics] Recalculated costs: {updated}/{len(runs)} changed")
+    return updated
+
+
 def start_ci_run_sync(redis_conn):
     """Start periodic CI run + test event sync thread."""
     _load_seed_data()

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -149,6 +149,19 @@ def _ts_to_date(ts_ms):
 
 # ---- Test event handling (only thing needing SQLite) ----
 
+def _upsert_daily_stats(status: str, test_cmd: str, dashboard: str, timestamp: str):
+    """Increment the daily counter for a test status."""
+    date = timestamp[:10]  # 'YYYY-MM-DD'
+    col = status if status in ('passed', 'failed', 'flaked') else None
+    if not col:
+        return
+    db.execute(f'''
+        INSERT INTO test_daily_stats (date, test_cmd, dashboard, {col})
+        VALUES (?, ?, ?, 1)
+        ON CONFLICT(date, test_cmd, dashboard) DO UPDATE SET {col} = {col} + 1
+    ''', (date, test_cmd, dashboard))
+
+
 def _handle_test_event(channel: str, data: dict):
     status = channel.split(':')[-1]
     # Handle field name mismatches: run_test_cmd publishes 'cmd' for failed/flaked
@@ -157,6 +170,17 @@ def _handle_test_event(channel: str, data: dict):
     log_url = data.get('log_url') or data.get('log_key')
     if log_url and not log_url.startswith('http'):
         log_url = f'http://ci.aztec-labs.com/{log_url}'
+    dashboard = data.get('dashboard', '')
+    timestamp = data.get('timestamp', datetime.now(timezone.utc).isoformat())
+
+    # Always update daily stats (lightweight aggregate)
+    _upsert_daily_stats(status, test_cmd, dashboard, timestamp)
+
+    # Only persist individual rows for failed/flaked (for drill-down / log URLs).
+    # Passed events are tracked via daily stats only.
+    if status == 'passed':
+        return
+
     db.execute('''
         INSERT INTO test_events
         (status, test_cmd, log_url, ref_name, commit_hash, commit_author,
@@ -176,8 +200,8 @@ def _handle_test_event(channel: str, data: dict):
         1 if data.get('is_scenario_test') else 0,
         json.dumps(data['owners']) if data.get('owners') else None,
         data.get('flake_group_id'),
-        data.get('dashboard', ''),
-        data.get('timestamp', datetime.now(timezone.utc).isoformat()),
+        dashboard,
+        timestamp,
     ))
 
 
@@ -516,15 +540,155 @@ def sync_ci_runs_to_sqlite(redis_conn):
     print(f"[rk_metrics] Synced {count} CI runs to SQLite")
 
 
+def _backfill_daily_stats():
+    """Populate test_daily_stats from existing test_events rows (one-time)."""
+    conn = db.get_db()
+    # Check if daily stats are already populated
+    row = conn.execute("SELECT COUNT(*) as c FROM test_daily_stats").fetchone()
+    if row['c'] > 0:
+        return
+    conn.execute('''
+        INSERT OR IGNORE INTO test_daily_stats (date, test_cmd, dashboard, passed, failed, flaked)
+        SELECT substr(timestamp, 1, 10) as date, test_cmd, dashboard,
+               SUM(CASE WHEN status = 'passed' THEN 1 ELSE 0 END),
+               SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END),
+               SUM(CASE WHEN status = 'flaked' THEN 1 ELSE 0 END)
+        FROM test_events
+        GROUP BY substr(timestamp, 1, 10), test_cmd, dashboard
+    ''')
+    conn.commit()
+    count = conn.execute("SELECT COUNT(*) as c FROM test_daily_stats").fetchone()['c']
+    if count:
+        print(f"[rk_metrics] Backfilled {count} daily stat rows from test_events")
+
+
+# ---- CloudTrail instance type resolution ----
+
+_ct_resolve_ts = 0
+_CT_RESOLVE_TTL = 6 * 3600  # 6 hours
+
+
+def resolve_unknown_instance_types():
+    """Query CloudTrail for RunInstances events to fill in unknown instance types."""
+    global _ct_resolve_ts
+    now = time.time()
+    if now - _ct_resolve_ts < _CT_RESOLVE_TTL:
+        return
+    _ct_resolve_ts = now
+
+    conn = db.get_db()
+    # Find runs with unknown/empty instance_type
+    unknown_runs = conn.execute('''
+        SELECT dashboard, name, timestamp_ms, complete_ms, instance_vcpus, spot, cost_usd
+        FROM ci_runs
+        WHERE (instance_type IS NULL OR instance_type = '' OR instance_type = 'unknown')
+        AND timestamp_ms > ?
+    ''', (int((time.time() - 90 * 86400) * 1000),)).fetchall()
+
+    if not unknown_runs:
+        return
+
+    try:
+        import boto3
+    except ImportError:
+        return
+
+    try:
+        ct = boto3.client('cloudtrail', region_name='us-east-2')
+        # Fetch RunInstances events from CloudTrail
+        events = []
+        kwargs = {
+            'LookupAttributes': [
+                {'AttributeKey': 'EventName', 'AttributeValue': 'RunInstances'},
+            ],
+            'StartTime': datetime.fromtimestamp(
+                min(r['timestamp_ms'] for r in unknown_runs) / 1000 - 300, tz=timezone.utc),
+            'EndTime': datetime.now(timezone.utc),
+            'MaxResults': 50,
+        }
+        # Paginate through results
+        while True:
+            resp = ct.lookup_events(**kwargs)
+            events.extend(resp.get('Events', []))
+            token = resp.get('NextToken')
+            if not token or len(events) >= 5000:
+                break
+            kwargs['NextToken'] = token
+
+        if not events:
+            print(f"[rk_metrics] CloudTrail: no RunInstances events found")
+            return
+
+        # Build time-indexed list of instance launches
+        launches = []
+        for event in events:
+            try:
+                detail = json.loads(event.get('CloudTrailEvent', '{}'))
+                req = detail.get('requestParameters', {})
+                instance_type = req.get('instanceType', '')
+                if not instance_type:
+                    # Try to get from instancesSet in response
+                    resp_items = detail.get('responseElements', {}).get('instancesSet', {}).get('items', [])
+                    if resp_items:
+                        instance_type = resp_items[0].get('instanceType', '')
+                if instance_type:
+                    event_time_ms = int(event['EventTime'].timestamp() * 1000)
+                    launches.append({
+                        'time_ms': event_time_ms,
+                        'instance_type': instance_type,
+                    })
+            except Exception:
+                continue
+
+        if not launches:
+            return
+
+        launches.sort(key=lambda x: x['time_ms'])
+
+        # Match unknown runs to CloudTrail events by timestamp proximity
+        updated = 0
+        for run in unknown_runs:
+            run_ts = run['timestamp_ms']
+            # Find closest launch within 10 minutes
+            best = None
+            best_delta = 600_000  # 10 min in ms
+            for launch in launches:
+                delta = abs(launch['time_ms'] - run_ts)
+                if delta < best_delta:
+                    best_delta = delta
+                    best = launch
+            if best:
+                itype = best['instance_type']
+                is_spot = bool(run['spot'])
+                rate = ec2_pricing.get_instance_rate(itype, is_spot)
+                new_cost = run['cost_usd']
+                if rate and run['complete_ms'] and run['timestamp_ms']:
+                    hours = (run['complete_ms'] - run['timestamp_ms']) / 3_600_000
+                    new_cost = round(hours * rate, 4)
+                conn.execute('''
+                    UPDATE ci_runs SET instance_type = ?, cost_usd = ?
+                    WHERE dashboard = ? AND timestamp_ms = ? AND name = ?
+                ''', (itype, new_cost, run['dashboard'], run['timestamp_ms'], run['name']))
+                updated += 1
+
+        conn.commit()
+        if updated:
+            print(f"[rk_metrics] CloudTrail: resolved {updated}/{len(unknown_runs)} unknown instance types")
+    except Exception as e:
+        print(f"[rk_metrics] CloudTrail resolution failed: {e}")
+
+
 def start_ci_run_sync(redis_conn):
     """Start periodic CI run + test event sync thread."""
     _load_seed_data()
+    _backfill_daily_stats()
 
     def loop():
         while True:
             try:
                 sync_ci_runs_to_sqlite(redis_conn)
                 sync_failed_tests_to_sqlite(redis_conn)
+                resolve_unknown_instance_types()
             except Exception as e:
                 print(f"[rk_metrics] sync error: {e}")
             time.sleep(600)  # check every 10 min (TTL gates actual work)

--- a/ci3/ci-metrics/metrics.py
+++ b/ci3/ci-metrics/metrics.py
@@ -32,7 +32,9 @@ def compute_run_cost(data: dict) -> float | None:
     is_spot = bool(data.get('spot'))
     rate = ec2_pricing.get_instance_rate(instance_type, is_spot)
     if not rate:
-        vcpus = data.get('instance_vcpus', 192)
+        vcpus = data.get('instance_vcpus')
+        if not vcpus:
+            return None  # unknown instance type and no vCPU data
         rate = vcpus * ec2_pricing.get_fallback_vcpu_rate(is_spot)
     return round(hours * rate, 4)
 

--- a/ci3/ci-metrics/views/ci-insights.html
+++ b/ci3/ci-metrics/views/ci-insights.html
@@ -62,6 +62,7 @@
     <a href="/cost-overview">cost overview</a>
     <a href="/namespace-billing">namespace billing</a>
     <a href="/ci-insights" class="active">ci insights</a>
+    <a href="/test-timings">test timings</a>
   </div>
 
   <h2 style="margin:8px 0;color:#ccc;">ci insights</h2>

--- a/ci3/ci-metrics/views/ci-insights.html
+++ b/ci3/ci-metrics/views/ci-insights.html
@@ -65,7 +65,7 @@
     <a href="/test-timings">test timings</a>
   </div>
 
-  <h2 style="margin:8px 0;color:#ccc;">ci insights</h2>
+  <h2 style="margin:8px 0;color:#ccc;">ci insights <span id="period-label" style="font-size:12px;color:#666;font-weight:normal"></span></h2>
 
   <div class="controls">
     <button data-range="14">2w</button>
@@ -108,7 +108,7 @@
       <div class="chart-wrap med"><canvas id="mqChart"></canvas></div>
     </div>
     <div class="chart-box">
-      <h3>flakes + test failures per day</h3>
+      <h3>test outcomes per day</h3>
       <div class="chart-wrap med"><canvas id="flakeChart"></canvas></div>
     </div>
   </div>
@@ -231,6 +231,12 @@
     function render() {
       Object.values(charts).forEach(c => c.destroy());
       charts = {};
+
+      // Show period
+      const period = perfData?.period || costData?.period;
+      if (period) {
+        document.getElementById('period-label').textContent = `(${period.from} to ${period.to})`;
+      }
 
       renderKPIs();
       renderCostChart();
@@ -400,7 +406,7 @@
       });
     }
 
-    // ---- Flake / test failure chart ----
+    // ---- Test outcomes chart (successes + flakes + failures) ----
     function renderFlakeChart() {
       const byDate = perfData?.by_date || [];
       const dates = byDate.map(d => d.date);
@@ -409,8 +415,9 @@
         data: {
           labels: dates.map(fmtDate),
           datasets: [
-            { type: 'bar', label: 'Flakes', data: byDate.map(d => d.flake_count || 0), backgroundColor: '#f0883e', borderWidth: 0, order: 2 },
-            { type: 'bar', label: 'Test Failures', data: byDate.map(d => d.test_failure_count || 0), backgroundColor: '#f85149', borderWidth: 0, order: 2 },
+            { type: 'bar', label: 'Successes', data: byDate.map(d => d.test_success_count || 0), backgroundColor: '#3fb950', borderWidth: 0, order: 3 },
+            { type: 'bar', label: 'Flakes', data: byDate.map(d => d.flake_count || 0), backgroundColor: '#f0883e', borderWidth: 0, order: 3 },
+            { type: 'bar', label: 'Test Failures', data: byDate.map(d => d.test_failure_count || 0), backgroundColor: '#f85149', borderWidth: 0, order: 3 },
             { type: 'line', label: 'CI Failure Rate %', data: byDate.map(d => d.failure_rate || 0), borderColor: '#ff7b72', borderWidth: 2, pointRadius: 0, tension: 0.3, yAxisID: 'y1', order: 1 },
           ]
         },
@@ -418,8 +425,8 @@
           responsive: true, maintainAspectRatio: false,
           interaction: { mode: 'index', intersect: false },
           scales: {
-            x: { ticks: { color: '#555', maxRotation: 45 }, grid: { color: '#181818' } },
-            y: { position: 'left', ticks: { color: '#555' }, grid: { color: '#181818' } },
+            x: { stacked: true, ticks: { color: '#555', maxRotation: 45 }, grid: { color: '#181818' } },
+            y: { stacked: true, position: 'left', ticks: { color: '#555' }, grid: { color: '#181818' } },
             y1: { position: 'right', min: 0, ticks: { color: '#ff7b72', callback: v => v + '%' }, grid: { display: false } }
           },
           plugins: {

--- a/ci3/ci-metrics/views/cost-overview.html
+++ b/ci3/ci-metrics/views/cost-overview.html
@@ -77,7 +77,7 @@
     <a href="/test-timings">test timings</a>
   </div>
 
-  <h2 style="margin:8px 0;color:#ccc;">cost overview</h2>
+  <h2 style="margin:8px 0;color:#ccc;">cost overview <span id="period-label" style="font-size:12px;color:#666;font-weight:normal"></span></h2>
 
   <div class="controls">
     <button data-range="30">1m</button>
@@ -248,6 +248,10 @@
     function render() {
       Object.values(charts).forEach(c => c.destroy());
       charts = {};
+
+      if (apiData.period) {
+        document.getElementById('period-label').textContent = `(${apiData.period.from} to ${apiData.period.to})`;
+      }
 
       const byDate = apiData.by_date;
       const totals = apiData.totals;

--- a/ci3/ci-metrics/views/cost-overview.html
+++ b/ci3/ci-metrics/views/cost-overview.html
@@ -74,6 +74,7 @@
     <a href="/cost-overview" class="active">cost overview</a>
     <a href="/namespace-billing">namespace billing</a>
     <a href="/ci-insights">ci insights</a>
+    <a href="/test-timings">test timings</a>
   </div>
 
   <h2 style="margin:8px 0;color:#ccc;">cost overview</h2>

--- a/ci3/ci-metrics/views/test-timings.html
+++ b/ci3/ci-metrics/views/test-timings.html
@@ -54,7 +54,7 @@
     <a href="/test-timings" class="active">test timings</a>
   </div>
 
-  <h2 style="margin:8px 0;color:#ccc;">test timings</h2>
+  <h2 style="margin:8px 0;color:#ccc;">test timings <span id="period-label" style="font-size:12px;color:#666;font-weight:normal"></span></h2>
 
   <div class="controls">
     <button data-range="7">1w</button>
@@ -193,6 +193,9 @@ async function load() {
 }
 
 function render(d) {
+  if (d.period) {
+    document.getElementById('period-label').textContent = `(${d.period.from} to ${d.period.to})`;
+  }
   const s = d.summary;
   $('#kpis').innerHTML = [
     kpi('total runs', fmt(s.total_runs)),

--- a/ci3/dashboard/Dockerfile
+++ b/ci3/dashboard/Dockerfile
@@ -24,4 +24,4 @@ RUN pip install --no-cache-dir -r ci-metrics/requirements.txt
 RUN git config --global --add safe.directory /aztec-packages
 COPY . .
 EXPOSE 8080 8081
-CMD ["gunicorn", "-w", "100", "-b", "0.0.0.0:8080", "rk:app"]
+CMD ["gunicorn", "-w", "50", "-b", "0.0.0.0:8080", "rk:app"]

--- a/ci3/dashboard/rk.py
+++ b/ci3/dashboard/rk.py
@@ -54,7 +54,7 @@ if os.path.isdir(_ci_metrics_dir):
             pass
         _ci_metrics_env = {**os.environ, 'CI_METRICS_PORT': str(CI_METRICS_PORT)}
         subprocess.Popen(
-            ['gunicorn', '-w', '4', '-b', f'0.0.0.0:{CI_METRICS_PORT}',
+            ['gunicorn', '-w', '1', '-b', f'0.0.0.0:{CI_METRICS_PORT}',
              '--timeout', '120', '--preload', 'app:app'],
             cwd=_ci_metrics_dir,
             env=_ci_metrics_env,
@@ -562,7 +562,7 @@ def _proxy(path):
             data=request.get_data(),
             headers={k: v for k, v in request.headers if k.lower() not in _STRIP_REQUEST_HEADERS},
             stream=True,
-            timeout=60,
+            timeout=180,
         )
         # Strip hop-by-hop headers
         headers = {k: v for k, v in resp.headers.items() if k.lower() not in _HOP_BY_HOP}

--- a/ci3/dashboard/rk.py
+++ b/ci3/dashboard/rk.py
@@ -27,30 +27,43 @@ app = Flask(__name__)
 Compress(app)
 auth = HTTPBasicAuth()
 
-# Start the ci-metrics server as a subprocess
-# Check sibling dir (repo layout) then subdirectory (Docker layout)
+# Start the ci-metrics server as a subprocess (once across all workers).
+# Uses a file lock so only the first gunicorn worker to import this module
+# actually spawns the process; the rest skip silently.
+import fcntl
+import signal
+import time as _time
+
 _ci_metrics_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ci-metrics')
 if not os.path.isdir(_ci_metrics_dir):
     _ci_metrics_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ci-metrics')
 if os.path.isdir(_ci_metrics_dir):
-    # Kill any stale process on the port (e.g. leftover from previous reload)
-    import signal
+    _lock_path = f'/tmp/ci-metrics-{CI_METRICS_PORT}.lock'
     try:
-        out = subprocess.check_output(
-            ['lsof', '-ti', f':{CI_METRICS_PORT}'], stderr=subprocess.DEVNULL, text=True)
-        for pid in out.strip().split('\n'):
-            if pid:
-                os.kill(int(pid), signal.SIGTERM)
-        import time; time.sleep(0.5)
-    except (subprocess.CalledProcessError, OSError):
+        _lock_fd = open(_lock_path, 'w')
+        fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # We hold the lock — kill stale process and spawn fresh one
+        try:
+            out = subprocess.check_output(
+                ['lsof', '-ti', f':{CI_METRICS_PORT}'], stderr=subprocess.DEVNULL, text=True)
+            for pid in out.strip().split('\n'):
+                if pid:
+                    os.kill(int(pid), signal.SIGTERM)
+            _time.sleep(0.5)
+        except (subprocess.CalledProcessError, OSError):
+            pass
+        _ci_metrics_env = {**os.environ, 'CI_METRICS_PORT': str(CI_METRICS_PORT)}
+        subprocess.Popen(
+            ['gunicorn', '-w', '4', '-b', f'0.0.0.0:{CI_METRICS_PORT}',
+             '--timeout', '120', '--preload', 'app:app'],
+            cwd=_ci_metrics_dir,
+            env=_ci_metrics_env,
+        )
+        print(f"[rk.py] ci-metrics server started on port {CI_METRICS_PORT}")
+        # Hold the lock until this process exits so other workers skip
+    except OSError:
+        # Another worker already holds the lock — nothing to do
         pass
-    _ci_metrics_env = {**os.environ, 'CI_METRICS_PORT': str(CI_METRICS_PORT)}
-    subprocess.Popen(
-        ['gunicorn', '-w', '4', '-b', f'0.0.0.0:{CI_METRICS_PORT}', '--timeout', '120', 'app:app'],
-        cwd=_ci_metrics_dir,
-        env=_ci_metrics_env,
-    )
-    print(f"[rk.py] ci-metrics server started on port {CI_METRICS_PORT}")
 
 def read_from_disk(key):
     """Read log from disk as fallback when Redis key not found."""

--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -35,7 +35,8 @@ if [ -z "$key" ]; then
   author="$(git log -1 --pretty=format:"%an")"
   name=$REF_NAME
   [ "$(aws_get_meta_data instance-life-cycle)" == "spot" ] && spot=true || spot=false
-  instance_type=$(aws_get_meta_data instance-type 2>/dev/null || echo "unknown")
+  instance_type=${EC2_INSTANCE_TYPE:-$(aws_get_meta_data instance-type 2>/dev/null)}
+  instance_type=${instance_type:-unknown}
   instance_vcpus=$(nproc 2>/dev/null || echo 0)
 
   # Extract PR number from branch name or merge queue ref

--- a/ci3/merge_train_failure_slack_notify
+++ b/ci3/merge_train_failure_slack_notify
@@ -27,6 +27,8 @@ elif [[ "$REF_NAME" == "merge-train/ci" ]]; then
   channel="#help-ci"
 elif [[ "$REF_NAME" == "merge-train/docs" ]]; then
   channel="#dev-rels"
+elif [[ "$REF_NAME" == "merge-train/fairies" ]]; then
+  channel="#team-fairies"
 elif [[ "$REF_NAME" == "merge-train/spartan" ]]; then
   channel="#team-alpha"
 else

--- a/ci3/merge_train_failure_slack_notify
+++ b/ci3/merge_train_failure_slack_notify
@@ -27,8 +27,6 @@ elif [[ "$REF_NAME" == "merge-train/ci" ]]; then
   channel="#help-ci"
 elif [[ "$REF_NAME" == "merge-train/docs" ]]; then
   channel="#dev-rels"
-elif [[ "$REF_NAME" == "merge-train/fairies" ]]; then
-  channel="#team-fairies"
 elif [[ "$REF_NAME" == "merge-train/spartan" ]]; then
   channel="#team-alpha"
 else


### PR DESCRIPTION
## Summary
- **Test success tracking**: New `test_daily_stats` table tracks daily passed/failed/flaked counts per test command without persisting individual passed events. Backfills from existing `test_events` on startup.
- **Instance type fix**: `log_ci_run` now prefers `EC2_INSTANCE_TYPE` env var over metadata endpoint (which fails inside Docker containers). Fixes 99% of CI runs showing "unknown" instance type.
- **CloudTrail backfill**: Resolves historical unknown instance types by querying CloudTrail `RunInstances` events and matching by timestamp proximity. Recalculates costs with correct instance rates.
- **CI Insights chart**: "Test outcomes per day" now shows stacked bars for successes (green), flakes (orange), and failures (red).
- **Time period display**: All API responses include `period` metadata; dashboard headers show the active date range.
- **Proxy timeout**: Increased from 60s to 180s for slow BigQuery billing fetches.
- **Single worker**: ci-metrics reduced to 1 gunicorn worker to avoid redundant cache warmups and SQLite lock contention.

## Test plan
- [ ] Deploy to bastion via `ci3/dashboard/deploy.sh`
- [ ] Verify `test_daily_stats` table created and backfilled
- [ ] Verify CI Insights chart shows successes bar
- [ ] Verify period labels appear on all dashboard pages
- [ ] Verify new CI runs report correct instance types
- [ ] Check CloudTrail resolution logs: `sudo journalctl -u rkapp | grep cloudtrail`
- [ ] Verify namespace billing still loads within timeout