### PR TITLE
fix(node): sync ws before simulating public calls

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1129,7 +1129,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     }
 
     const txHash = tx.getTxHash();
-    const blockNumber = BlockNumber((await this.blockSource.getBlockNumber()) + 1);
+    const latestBlockNumber = await this.blockSource.getBlockNumber();
+    const blockNumber = BlockNumber.add(latestBlockNumber, 1);
 
     // If sequencer is not initialized, we just set these values to zero for simulation.
     const coinbase = EthAddress.ZERO;
@@ -1153,6 +1154,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       blockNumber,
     });
 
+    // Ensure world-state has caught up with the latest block we loaded from the archiver
+    await this.worldStateSynchronizer.syncImmediate(latestBlockNumber);
     const merkleTreeFork = await this.worldStateSynchronizer.fork();
     try {
       const config = PublicSimulatorConfig.from({


### PR DESCRIPTION
The `simulatePublicCalls` method in the aztec node would simulate using a fake block following immediately after the latest one from the archiver. However, it also used a sync of world state that didn't necessarily have all the latest changes from that block.

This means that a client who was monitoring the node for a block to be mined could send a simulation request that relied on data from that very latest block that was still not in world-state, and fail.

This was causing issues eg in [cross-chain-bot e2e tests](http://ci.aztec-labs.com/4f7378c362712da7) where the simulation for consuming the message in public land would fail since the message was flagged as ready (since that's an archiver check) but not present in world state, erroring with:

```
17:22:06     Simulation error: Assertion failed: Tried to consume nonexistent L1-to-L2 message 'self.l1_to_l2_msg_exists(message_hash, leaf_index)'
17:22:06     Context:
17:22:06     TxExecutionRequest(0x032f68986bd02951337b130a702e9041a055bdc49a8cb809e3244d252596d2f4 called 0x9d57a239)
17:22:06     simulatePublic=true
17:22:06     skipTxValidation=true
17:22:06     scopes=0x032f68986bd02951337b130a702e9041a055bdc49a8cb809e3244d252596d2f4
17:22:06
17:22:06       228 |
17:22:06       229 |         assert(!self.nullifier_exists_unsafe(nullifier, self.this_address()), "L1-to-L2 message is already nullified");
17:22:06     > 230 |         assert(self.l1_to_l2_msg_exists(message_hash, leaf_index), "Tried to consume nonexistent L1-to-L2 message");
17:22:06           |                ^
17:22:06       231 |
17:22:06       232 |         self.push_nullifier(nullifier);
17:22:06       233 |     }
```
