### PR TITLE
fix(ethereum): check timeout before consuming nonce in L1TxUtils

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.test.ts
@@ -918,6 +918,21 @@ describe('L1TxUtils', () => {
       expect(result.receipt.status).toBe('reverted');
     });
 
+    it('does not consume nonce when transaction times out before sending', async () => {
+      // Get the expected nonce before any transaction
+      const expectedNonce = await l1Client.getTransactionCount({ address: l1Client.account.address });
+
+      // Try to send with an already-expired timeout (epoch 0 is well in the past)
+      const pastTimeout = new Date(0);
+      await expect(gasUtils.sendTransaction(request, { txTimeoutAt: pastTimeout })).rejects.toThrow(
+        /timed out before sending/,
+      );
+
+      // The next transaction should use the same nonce (not skip one due to a leaked consume)
+      const { state } = await gasUtils.sendTransaction(request);
+      expect(state.nonce).toBe(expectedNonce);
+    }, 10_000);
+
     it('stops trying after timeout once block is mined', async () => {
       await cheatCodes.setAutomine(false);
       await cheatCodes.setIntervalMining(0);

--- a/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils/l1_tx_utils.ts
@@ -244,6 +244,16 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
         throw new InterruptError(`Transaction sending is interrupted`);
       }
 
+      // Check timeout before consuming nonce to avoid leaking a nonce that was never sent.
+      // A leaked nonce creates a gap (e.g. nonce 107 consumed but unsent), so all subsequent
+      // transactions (108, 109, ...) can never be mined since the chain expects 107 first.
+      const now = new Date(await this.getL1Timestamp());
+      if (gasConfig.txTimeoutAt && now > gasConfig.txTimeoutAt) {
+        throw new TimeoutError(
+          `Transaction timed out before sending (now ${now.toISOString()} > timeoutAt ${gasConfig.txTimeoutAt.toISOString()})`,
+        );
+      }
+
       const nonce = await this.nonceManager.consume({
         client: this.client,
         address: account,
@@ -252,13 +262,6 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
 
       const baseState = { request, gasLimit, blobInputs, gasPrice, nonce };
       const txData = this.makeTxData(baseState, { isCancelTx: false });
-
-      const now = new Date(await this.getL1Timestamp());
-      if (gasConfig.txTimeoutAt && now > gasConfig.txTimeoutAt) {
-        throw new TimeoutError(
-          `Transaction timed out before sending (now ${now.toISOString()} > timeoutAt ${gasConfig.txTimeoutAt.toISOString()})`,
-        );
-      }
 
       // Send the new tx
       const signedRequest = await this.prepareSignedTransaction(txData);


### PR DESCRIPTION
## Summary

- Move the `txTimeoutAt` check before `nonceManager.consume()` in `L1TxUtils.sendTransaction` to prevent nonce leaks
- Add regression test verifying that a timed-out send does not consume a nonce

When a transaction timed out before sending (e.g. due to `advanceInboxInProgress` warping L1 time), the nonce was consumed but the tx was never submitted to L1. This created a permanent gap: all subsequent transactions used higher nonces (108, 109, ...) but the chain expected the leaked nonce (107) first. The sequencer got stuck in an infinite prune-rebuild loop.

Flaky failure: http://ci.aztec-labs.com/6b46aa90848758e1 (`e2e_bot > creates bot after inbox drift`)

## Test plan

- New unit test: `does not consume nonce when transaction times out before sending`
- Full `l1_tx_utils.test.ts` suite passes (46/46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)