### PR TITLE
chore(e2e): reenable block building test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -309,6 +309,11 @@ tests:
     owners:
       - *palla
 
+  - regex: "src/e2e_block_building.test.ts"
+    error_regex: "✕ processes txs until hitting timetable"
+    owners:
+      - *palla
+
   # http://ci.aztec-labs.com/e8228a36afda93b8
   # Test passed but there was an error on stopping
   - regex: "playground/scripts/run_test.sh"

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -79,8 +79,7 @@ describe('e2e_block_building', () => {
 
     afterAll(() => teardown());
 
-    // TODO(palla/mbps): We've seen these errors on syncing world state if we abort a tx processing halfway through.
-    it.skip('processes txs until hitting timetable', async () => {
+    it('processes txs until hitting timetable', async () => {
       // We send enough txs so they are spread across multiple blocks, but not
       // so many so that we don't end up hitting a reorg or timing out the tx wait().
       const TX_COUNT = 16;


### PR DESCRIPTION
Flags as flake just in case, but seems to be working properly.
