### PR TITLE
fix: validate ivpk on curve in instance registry

### DIFF
--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_registry_contract/src/main.nr
@@ -17,7 +17,6 @@ pub contract ContractInstanceRegistry {
                 CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE, DEFAULT_UPDATE_DELAY, MINIMUM_UPDATE_DELAY,
             },
             contract_class_id::ContractClassId,
-            point::validate_on_curve,
             public_keys::PublicKeys,
             traits::{Deserialize, Serialize, ToField},
             utils::reader::Reader,
@@ -134,11 +133,8 @@ pub contract ContractInstanceRegistry {
         let partial_address =
             PartialAddress::compute(contract_class_id, salt, initialization_hash, deployer);
 
-        // Validate public key points lie on the Grumpkin curve to prevent AVM DoS.
-        // ivpk_m is validated implicitly during address derivation.
-        validate_on_curve(public_keys.npk_m.inner);
-        validate_on_curve(public_keys.ovpk_m.inner);
-        validate_on_curve(public_keys.tpk_m.inner);
+        // Validate public key points lie on the Grumpkin curve to prevent AVM DoS attacks.
+        public_keys.validate_on_curve();
 
         let address = AztecAddress::compute(public_keys, partial_address);
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
@@ -5,6 +5,7 @@ use crate::{
         DEFAULT_OVPK_M_Y, DEFAULT_TPK_M_X, DEFAULT_TPK_M_Y, DOM_SEP__PUBLIC_KEYS_HASH,
     },
     hash::poseidon2_hash_with_separator,
+    point::validate_on_curve,
     traits::{Deserialize, Hash, Serialize},
 };
 
@@ -105,6 +106,13 @@ impl PublicKeys {
             self.serialize(),
             DOM_SEP__PUBLIC_KEYS_HASH as Field,
         ))
+    }
+
+    pub fn validate_on_curve(self) {
+        validate_on_curve(self.npk_m.inner);
+        validate_on_curve(self.ivpk_m.inner);
+        validate_on_curve(self.ovpk_m.inner);
+        validate_on_curve(self.tpk_m.inner);
     }
 }
 


### PR DESCRIPTION
Not technincally needed (because grumpkin add will ensure the ivpk_m is on the curve), but Miranda pointed out that if the stdlib `add` changes, we would be in trouble. Since it's only a handful of constraints to validate it, let's add it.
