### PR TITLE
fix(avm): skippable in bitwise

### DIFF
--- a/barretenberg/cpp/pil/vm2/bitwise.pil
+++ b/barretenberg/cpp/pil/vm2/bitwise.pil
@@ -85,7 +85,7 @@ sel * (1 - sel) = 0;
 
 // No relations will be checked if this identity is satisfied.
 #[skippable_if]
-sel = 0;
+sel + last = 0;
 
 pol commit start; // @boolean Identifies when we want to capture the output to the main trace.
 // Must be constrained as a boolean as any selector used in a lookup/permutation.

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
@@ -22,7 +22,7 @@ template <typename FF_> class bitwiseImpl {
     {
         using C = ColumnAndShifts;
 
-        return (in.get(C::bitwise_sel)).is_zero();
+        return ((in.get(C::bitwise_sel) + in.get(C::bitwise_last))).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>


### PR DESCRIPTION
The existing skippable condition might be too broad.

tl;dr
In the case of an error,  `sel = 0` but `last = 1`. There are constraints that are gated by `last` and **not** by `sel`: `BITW_INIT_A` , `BITW_INIT_B` and `BITW_INIT_C`

Not entirely sure this is the only way to solve this (perhaps we can also add the `sel` gating to all relations at the expense of degrees) but this will suffice give time constraints