### PR TITLE
fix(avm): ff gt key

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/field_gt_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/field_gt_event.hpp
@@ -32,7 +32,7 @@ struct FieldGreaterThanEvent {
     bool gt_result = false; // Not relevant for operation == FieldGreaterOperation::CANONICAL_DECOMPOSITIONs
 
     // To be used with deduplicating event emitters.
-    using Key = std::tuple<FieldGreaterOperation, const FF&, const FF&>;
+    using Key = std::tuple<FieldGreaterOperation, FF, FF>;
     Key get_key() const { return { operation, a, b }; }
 
     bool operator==(const FieldGreaterThanEvent& other) const = default;


### PR DESCRIPTION
The references were causing a Stack use after return (checked with ASAN) when the de-duplicating emitter ran.