### PR TITLE
fix: set PXE sync chain tip to proposed for scenario bot

### DIFF
--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Run real proving benchmarks
-        timeout-minutes: 150
+        timeout-minutes: 180
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -57,7 +57,7 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           RUN_ID: ${{ github.run_id }}
-          AWS_SHUTDOWN_TIME: 150
+          AWS_SHUTDOWN_TIME: 180
           NO_SPOT: 1
         run: |
           ./.github/ci3.sh network-proving-bench prove-n-tps-real prove-n-tps-real "aztecprotocol/aztec:${{ steps.nightly-tag.outputs.nightly_tag }}"

--- a/yarn-project/end-to-end/src/spartan/utils/bot.ts
+++ b/yarn-project/end-to-end/src/spartan/utils/bot.ts
@@ -35,6 +35,7 @@ export async function installTransferBot({
   replicas = 1,
   txIntervalSeconds = 10,
   followChain = 'CHECKPOINTED',
+  pxeSyncChainTip = 'proposed',
   mnemonic = process.env.LABS_INFRA_MNEMONIC ?? 'test test test test test test test test test test test junk',
   mnemonicStartIndex,
   botPrivateKey = process.env.BOT_TRANSFERS_L2_PRIVATE_KEY ?? '0xcafe01',
@@ -49,6 +50,7 @@ export async function installTransferBot({
   replicas?: number;
   txIntervalSeconds?: number;
   followChain?: string;
+  pxeSyncChainTip?: string;
   mnemonic?: string;
   mnemonicStartIndex?: number | string;
   botPrivateKey?: string;
@@ -67,6 +69,7 @@ export async function installTransferBot({
     'bot.replicaCount': replicas,
     'bot.txIntervalSeconds': txIntervalSeconds,
     'bot.followChain': followChain,
+    'bot.pxeSyncChainTip': pxeSyncChainTip,
     'bot.botPrivateKey': botPrivateKey,
     'bot.nodeUrl': resolvedNodeUrl,
     'bot.mnemonic': mnemonic,


### PR DESCRIPTION
- fixes a timeout issue where the default chart pointed to checkpointed insted of on proposed.
- also bumps timeout for proving benchmarks by 30 min
