### PR TITLE
fix: extension disconnect

### DIFF
--- a/playground/src/components/navbar/components/WalletHub.tsx
+++ b/playground/src/components/navbar/components/WalletHub.tsx
@@ -167,6 +167,9 @@ export function WalletHub() {
       establishSecureChannel: async () => {
         throw new Error('Embedded wallet should use directConnect');
       },
+      disconnect: async () => {},
+      onDisconnect: () => () => {},
+      isDisconnected: () => false,
       callback: () => {
         setOpenWalletModal(true);
       },
@@ -200,7 +203,7 @@ export function WalletHub() {
       setLoading(true);
       setOpen(false);
 
-      if (selectedProvider && selectedProvider.disconnect) {
+      if (selectedProvider) {
         if (disconnectUnsubscribeRef.current) {
           disconnectUnsubscribeRef.current();
           disconnectUnsubscribeRef.current = null;
@@ -255,15 +258,13 @@ export function WalletHub() {
       setSelectedProvider(pendingProvider);
       setIsEmbeddedWalletSelected(false);
 
-      if (pendingProvider.onDisconnect) {
-        disconnectUnsubscribeRef.current = pendingProvider.onDisconnect(() => {
-          setWallet(null);
-          setSelectedProvider(null);
-          setFrom(null);
-          disconnectUnsubscribeRef.current = null;
-          discoverWallets();
-        });
-      }
+      disconnectUnsubscribeRef.current = pendingProvider.onDisconnect(() => {
+        setWallet(null);
+        setSelectedProvider(null);
+        setFrom(null);
+        disconnectUnsubscribeRef.current = null;
+        discoverWallets();
+      });
 
       setWallet(connectedWallet);
       setConnectionPhase('idle');

--- a/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.ts
+++ b/yarn-project/wallet-sdk/src/extension/provider/extension_wallet.ts
@@ -109,7 +109,7 @@ export class ExtensionWallet {
     sharedKey: CryptoKey,
     chainInfo: ChainInfo,
     appId: string,
-  ): Wallet {
+  ): ExtensionWallet {
     const wallet = new ExtensionWallet(chainInfo, appId, extensionId, port, sharedKey);
 
     // Set up message handler for encrypted responses and unencrypted control messages
@@ -127,8 +127,10 @@ export class ExtensionWallet {
     wallet.port.start();
 
     return new Proxy(wallet, {
-      get: (target, prop) => {
-        if (schemaHasMethod(WalletSchema, prop.toString())) {
+      get: (target, prop, receiver) => {
+        if (prop === 'asWallet') {
+          return () => receiver as unknown as Wallet;
+        } else if (schemaHasMethod(WalletSchema, prop.toString())) {
           return async (...args: unknown[]) => {
             const result = await target.postMessage({
               type: prop.toString() as keyof FunctionsOf<Wallet>,
@@ -140,7 +142,13 @@ export class ExtensionWallet {
           return target[prop as keyof ExtensionWallet];
         }
       },
-    }) as unknown as Wallet;
+    });
+  }
+
+  asWallet(): Wallet {
+    // Overridden by the proxy in create() to return the proxy itself.
+    // This body is never reached when accessed through create().
+    return this as unknown as Wallet;
   }
 
   /**

--- a/yarn-project/wallet-sdk/src/manager/types.ts
+++ b/yarn-project/wallet-sdk/src/manager/types.ts
@@ -116,18 +116,18 @@ export interface WalletProvider {
    * After calling this, the wallet returned from confirm() should no longer be used.
    * @returns A promise that resolves when disconnection is complete
    */
-  disconnect?(): Promise<void>;
+  disconnect(): Promise<void>;
   /**
    * Registers a callback to be invoked when the wallet disconnects unexpectedly.
    * @param callback - Function to call when wallet disconnects
    * @returns A function to unregister the callback
    */
-  onDisconnect?(callback: ProviderDisconnectionCallback): () => void;
+  onDisconnect(callback: ProviderDisconnectionCallback): () => void;
   /**
    * Returns whether the provider's wallet connection has been disconnected.
    * @returns true if the wallet is no longer connected
    */
-  isDisconnected?(): boolean;
+  isDisconnected(): boolean;
 }
 
 /**

--- a/yarn-project/wallet-sdk/src/manager/wallet_manager.ts
+++ b/yarn-project/wallet-sdk/src/manager/wallet_manager.ts
@@ -196,15 +196,14 @@ export class WalletManager {
         return {
           verificationHash: connection.info.verificationHash!,
           confirm: () => {
-            return Promise.resolve(
-              ExtensionWallet.create(
-                connection.info.id,
-                connection.port,
-                connection.sharedKey,
-                chainInfo,
-                connectAppId,
-              ),
+            extensionWallet = ExtensionWallet.create(
+              connection.info.id,
+              connection.port,
+              connection.sharedKey,
+              chainInfo,
+              connectAppId,
             );
+            return Promise.resolve(extensionWallet.asWallet());
           },
           cancel: () => {
             // Send disconnect to terminate the session on the extension side
@@ -213,7 +212,6 @@ export class WalletManager {
               type: WalletMessageType.DISCONNECT,
               requestId: discoveredWallet.requestId,
             });
-            // Don't close the port - allow retry with fresh key exchange
           },
         };
       },


### PR DESCRIPTION
The extension wallet closure never captured the created wallet, so disconnect handlers failed