### PR TITLE
fix: sync world state before forking in simulatePublicCalls

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -1153,6 +1153,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       blockNumber,
     });
 
+    // Ensure world state is synced to the latest block before forking.
+    // Without this, the fork may be behind the archiver, causing lookups
+    // (e.g. L1-to-L2 message existence checks) to fail against stale state.
+    await this.#syncWorldState();
     const merkleTreeFork = await this.worldStateSynchronizer.fork();
     try {
       const config = PublicSimulatorConfig.from({


### PR DESCRIPTION
## Summary
- Fixes `e2e_bot > cross-chain-bot > sends L2→L1 and consumes L1→L2 messages` [test failure](http://ci.aztec-labs.com/e50d4d493db3ca71)
- `simulatePublicCalls` forks the world state without ensuring it's synced to the archiver's tip. Since `isL1ToL2MessageReady` checks the **archiver** but simulation runs against a **world state fork** (which polls every 100ms), the fork can be stale and miss recently added L1→L2 messages
- Adds `#syncWorldState()` before `fork()`, matching the existing pattern in `#getWorldState()` (line 1396)

## Test plan
- [ ] `e2e_bot` test suite passes (specifically the `cross-chain-bot` describe block)
- [ ] No regression in other e2e tests that use `simulatePublicCalls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)