### PR TITLE
docs: fix getting started on local network instructions

### DIFF
--- a/docs/docs-developers/getting_started_on_devnet.md
+++ b/docs/docs-developers/getting_started_on_devnet.md
@@ -80,6 +80,12 @@ aztec-wallet create-account \
 The first transaction will take longer as it downloads proving keys. If you see `Timeout awaiting isMined`, the transaction is still processing - this is normal on devnet.
 :::
 
+If this happens, check the transaction against the devnet node:
+
+```bash
+aztec-wallet get-tx --node-url $NODE_URL <tx_hash>
+```
+
 ### Step 3: Deploy and interact with contracts
 
 Deploy a token contract as an example:

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -92,7 +92,7 @@ We'll use the first test account, `test0`, throughout to pay for transactions.
 ## Creating an account in the local network
 
 ```bash
-aztec-wallet create-account -a my-wallet -f test0
+aztec-wallet create-account -a my-wallet --payment method=fee_juice,feePayer=accounts:test0
 ```
 
 :::info

--- a/docs/docs-developers/getting_started_on_local_network.md
+++ b/docs/docs-developers/getting_started_on_local_network.md
@@ -48,7 +48,7 @@ This will install the following tools:
 Once these have been installed, to start the local network, run:
 
 ```bash
-aztec start --local-network
+aztec start --sandbox
 ```
 
 **Congratulations, you have just installed and run the Aztec local network!**


### PR DESCRIPTION
fix getting started on local network instructions

- (current docs give `error: unknown option '--local-network'`)
- aztec-wallet create-account -f flag doesn't exist