### PR TITLE
docs: Improve overview page clarity and fix terminology

### DIFF
--- a/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/overview.md
+++ b/docs/developer_versioned_docs/version-v3.0.0-devnet.6-patch.1/overview.md
@@ -7,7 +7,7 @@ description: Overview of Aztec, a privacy-first Layer 2 on Ethereum supporting s
 
 import Image from "@theme/IdealImage";
 
-This page outlines Aztec's fundamental technical concepts. It is recommended to read this before diving into building on Aztec.
+This page outlines Aztec's fundamental technical concepts. Read this first to understand Aztec's core concepts before you start building.
 
 ## What is Aztec?
 
@@ -21,18 +21,25 @@ Aztec is a privacy-first Layer 2 on Ethereum. It supports smart contracts with b
 
 1. A user interacts with Aztec through Aztec.js (like web3js or ethersjs)
 2. Private functions are executed in the PXE, which is client-side
-3. Proofs and tree updates are sent to the Public VM (running on an Aztec node)
-4. Public functions are executed in the Public VM
-5. The Public VM rolls up the transactions that include private and public state updates into blocks
+3. Proofs and tree updates are sent to the Aztec Node
+4. Public functions are executed by the AVM (Aztec Virtual Machine)
+5. The sequencer rolls up transactions with private and public state updates into blocks
 6. The block data and proof of a correct state transition are submitted to Ethereum for verification
 
 ## Private and public execution
 
-Private functions are executed client side, on user devices to maintain maximum privacy. Public functions are executed by a remote network of nodes, similar to other blockchains. These distinct execution environments create a directional execution flow for a single transaction--a transaction begins in the private context on the user's device then moves to the public network. This means that private functions executed by a transaction can enqueue public functions to be executed later in the transaction life cycle, but public functions cannot call private functions.
+Private functions execute **client-side** (on user devices) to maintain maximum privacy. Public functions execute on a **remote network of nodes**, similar to other blockchains.
+
+This creates a **directional flow** within each transaction:
+
+1. Private execution happens first (on user's device)
+2. Public execution happens second (on the network)
+
+**Important:** Private functions can enqueue public functions to be executed later in the transaction lifecycle, but public functions **cannot** call private functions.
 
 ### Private Execution Environment (PXE)
 
-Private functions are executed on the user's device in the Private Execution Environment (PXE, pronounced 'pixie'), then it generates proofs for onchain verification. It is a client-side library for execution and proof-generation of private operations. It holds keys, notes, and generates proofs. It is included in aztec.js, a TypeScript library, and can be run within Node or the browser.
+Private functions are executed on the user's device in the Private Execution Environment (PXE, pronounced 'pixie'), which then generates proofs for onchain verification. The PXE is a client-side library for the execution and proof-generation of private operations. It holds keys, notes, and generates proofs. The PXE is included in aztec.js, a TypeScript library, and can be run within Node or the browser.
 
 Note: It is easy for private functions to be written in a detrimentally unoptimized way, because many intuitions of regular program execution do not apply to proving. For more about writing performant private functions in Noir, see [this page](https://noir-lang.org/docs/explainers/explainer-writing-noir) of the Noir documentation.
 
@@ -40,20 +47,27 @@ Note: It is easy for private functions to be written in a detrimentally unoptimi
 
 Public functions are executed by the Aztec Virtual Machine (AVM), which is conceptually similar to the Ethereum Virtual Machine (EVM). As such, writing efficient public functions follow the same intuition as gas-efficient solidity contracts.
 
-The PXE is unaware of the Public VM. And the Public VM is unaware of the PXE. They are completely separate execution environments. This means:
+The PXE and AVM are completely separate execution environments and they cannot directly communicate with each other. This means:
 
-- The PXE and the Public VM cannot directly communicate with each other
-- Private transactions in the PXE are executed first, followed by public transactions
+- Private functions are executed first in the PXE, followed by public functions in the AVM
+- Data can only flow from private to public, never the reverse
 
 ## Private and public state
 
-Private state works with UTXOs, which are chunks of data that we call notes. To keep things private, notes are stored in an [append-only UTXO tree](./docs/foundational-topics/advanced/storage/indexed_merkle_tree.mdx), and a nullifier is created when notes are invalidated (aka deleted). Nullifiers are stored in their own [nullifier tree](./docs/foundational-topics/advanced/storage/indexed_merkle_tree.mdx).
+Private state uses a UTXO (Unspent Transaction Output) model. Think of **notes** as sealed envelopes containing private data where only the owner can decrypt and read them. To "update" private data, you don't modify it directly. Instead, you destroy the old note and create a new one.
+
+Notes are stored in an append-only tree, meaning data can only be added and never modified or deleted. When a note is consumed, a **nullifier** is created. A nullifier is a unique identifier that proves a note was used without revealing which specific note it was. This is how Aztec maintains privacy: observers can see that some note was spent, but they cannot tell which one.
+
+Nullifiers are stored in their own [nullifier tree](./docs/foundational-topics/advanced/storage/indexed_merkle_tree.mdx).
 
 Public state works similarly to other chains like Ethereum, behaving like a public ledger. Public data is stored in a public data tree.
 
 ![Public vs private state](@site/static/img/public-and-private-state-diagram.png)
 
-Aztec [smart contract](./docs/aztec-nr/framework-description/contract_structure.md) developers should keep in mind that different data types are used when manipulating private or public state. Working with private state is creating commitments and nullifiers to state, whereas working with public state is directly updating state.
+Aztec [smart contract](./docs/aztec-nr/framework-description/contract_structure.md) developers must use different patterns depending on state type:
+
+- **Private state**: Create commitments (cryptographic hashes that hide the data) and nullifiers (proofs that data was consumed)
+- **Public state**: Directly update values, similar to Ethereum smart contracts
 
 ## Accounts and keys
 
@@ -70,8 +84,8 @@ Learn more about account contracts [here](./docs/foundational-topics/accounts/in
 Each account in Aztec is backed by 3 key pairs:
 
 - A **nullifier key pair** used for note nullifier computation
-- A **incoming viewing key pair** used to encrypt a note for the recipient
-- A **outgoing viewing key pair** used to encrypt a note for the sender
+- An **incoming viewing key pair** used to encrypt a note for the recipient
+- An **outgoing viewing key pair** used to encrypt a note for the sender
 
 As Aztec has native account abstraction, accounts do not automatically have a signing key pair to authenticate transactions. This is up to the account contract developer to implement.
 


### PR DESCRIPTION
## Summary

This PR improves the devnet overview page to help developers new to Aztec understand core concepts more quickly.

Fixes #20552

## Changes

### Grammar Fixes
- "A incoming" → "An incoming"
- "A outgoing" → "An outgoing"

### Terminology Corrections
- Replaced "Public VM" with "Aztec Node" and "AVM" to match the architecture diagrams
- Changed "private transactions...public transactions" to "private functions...public functions" for accuracy

### Added Explanations
- **Notes**: Explained as "sealed envelopes containing private data" with context on how updates work (destroy old, create new)
- **Nullifiers**: Explained why they exist and how they preserve privacy (proves a note was used without revealing which one)
- **Commitments**: Added brief definition in context

### Improved Readability
- Restructured dense paragraphs into bullet points
- Added numbered list for private/public execution flow
- Clarified PXE and AVM separation

## Why This Matters

The overview page is often the first stop for developers exploring Aztec. These changes:
- Align written content with visual diagrams
- Reduce confusion for developers unfamiliar with UTXO models
- Make the page easier to scan and reference

## Test Plan
- [ ] Verified changes render correctly in local docs preview
- [ ] Confirmed terminology matches architecture diagrams
- [ ] Reviewed explanations against source documentation