### PR TITLE
feat: migrate CI from SSH to SSM with SSH fallback

### DIFF
--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -3,8 +3,10 @@
 # CI mode is passed as first argument.
 set -euo pipefail
 
-: "${AWS_ACCESS_KEY_ID:?required}"
-: "${AWS_SECRET_ACCESS_KEY:?required}"
+if [ "${CI_USE_SSH:-0}" -eq 1 ]; then
+  : "${AWS_ACCESS_KEY_ID:?required for SSH mode}"
+  : "${AWS_SECRET_ACCESS_KEY:?required for SSH mode}"
+fi
 : "${GITHUB_TOKEN:?required}"
 
 CI_MODE="${1:?CI_MODE must be provided as first argument}"
@@ -31,11 +33,18 @@ function setup_environment {
   fi
   # Setup SSH key for connecting to EC2 instances
   # Note: The key is used to SSH into instances but is only copied INTO instances when CI_USE_BUILD_INSTANCE_KEY=1 (internal CI only)
-  if [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
+  # SSH key is only needed when using the SSH bootstrap path.
+  if [ "${CI_USE_SSH:-0}" -eq 1 ] && [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
     mkdir -p ~/.ssh
     echo "${BUILD_INSTANCE_SSH_KEY}" | base64 --decode > ~/.ssh/build_instance_key
     chmod 600 ~/.ssh/build_instance_key
     echo "SSH key configured"
+  fi
+  # Validate instance profile and security group for SSM mode.
+  if [ "${CI_USE_SSH:-0}" -eq 0 ]; then
+    : "${CI3_INSTANCE_PROFILE_NAME:?CI3_INSTANCE_PROFILE_NAME must be set for SSM mode}"
+    : "${CI3_SECURITY_GROUP_ID:?CI3_SECURITY_GROUP_ID must be set}"
+    echo "SSM mode: using instance profile $CI3_INSTANCE_PROFILE_NAME"
   fi
 }
 
@@ -74,6 +83,7 @@ function handle_release_pr {
   github_repository=$(git remote get-url origin | sed -E 's|.*github\.com[/:]([^/]+/[^/]+)(\.git)?$|\1|')
   git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${github_repository}"
   local tag_name="v0.0.1-commit.$(git rev-parse --short HEAD)"
+  git config --unset-all http.https://github.com/.extraheader || true
   git tag "${tag_name}"
   git push origin "${tag_name}"
   echo "Created and pushed tag: ${tag_name}"

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -43,6 +43,9 @@ jobs:
     # (github.event.pull_request.head.repo.fork resolves to nil if not a pull request)
     if: github.event.pull_request.head.repo.fork != true && (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ci-draft'))
     environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'master' || '' }}
+    permissions:
+      id-token: write   # required for OIDC assume-role with AWS
+      contents: read
     steps:
       - name: Remove wakeup label
         if: contains(github.event.pull_request.labels.*.name, 'ci-wakeup-pr-after-merge')
@@ -57,7 +60,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           # Fetch PR commits depth (we'll deepen by 1 in squash script if needed)
           fetch-depth: ${{ github.event.pull_request.commits || 1 }}
-          persist-credentials: false
+          persist-credentials: true   # Required for bootstrap_ssm's git fetch
+
+      - name: Configure AWS credentials (OIDC)
+        if: vars.CI_USE_SSH != '1' || contains(github.event.pull_request.labels.*.name, 'ci-ssm')
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: ci3-${{ github.run_id }}
 
       - name: Determine CI Mode
         env:
@@ -69,8 +80,10 @@ jobs:
 
       - name: Run
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CI_USE_SSH: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && '1' || '0' }}
+          # Only override AWS creds for SSH mode; omit for SSM so OIDC credentials pass through.
+          AWS_ACCESS_KEY_ID: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && secrets.AWS_ACCESS_KEY_ID || env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && secrets.AWS_SECRET_ACCESS_KEY || env.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -96,14 +109,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_ACTOR: ${{ github.actor }}
+          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
+          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
+          AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
         # NOTE: $CI_MODE is set in the Determine CI Mode step.
         run: ./.github/ci3.sh $CI_MODE
 
       - name: Post-Actions
         env:
-          # For handling success cache, squash-and-merge, and benchmarks.
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SHOULD_SQUASH_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'ci-squash-and-merge') && '1' || '0' }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -153,6 +166,9 @@ jobs:
   # Runs two test sets in parallel.
   ci-network-scenario:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -173,11 +189,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: ci3-network-scenario-${{ github.run_id }}
+
       - name: Run Network Scenarios
         timeout-minutes: 350
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -186,6 +207,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
+          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
           RUN_ID: ${{ github.run_id }}
           AWS_SHUTDOWN_TIME: 360
           NO_SPOT: 1
@@ -210,12 +233,12 @@ jobs:
         # Clean up if this is a CI label or nightly.
         if: always() && (!startsWith(github.ref, 'refs/tags/v') || contains(github.ref_name, '-nightly.'))
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
+          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
           NO_SPOT: 1
         run: |
           ./.github/ci3.sh network-teardown next-scenario "${NAMESPACE}-${{ matrix.test_set }}" || true
@@ -225,9 +248,6 @@ jobs:
       #############
       - name: Download deploy benchmarks
         if: always() && startsWith(github.ref, 'refs/tags/v')
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           if ./ci.sh gh-deploy-bench; then
             echo "ENABLE_DEPLOY_BENCH=1" >> $GITHUB_ENV
@@ -357,6 +377,9 @@ jobs:
   # One-time use: label is removed after the job runs.
   ci-network-kind:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs: ci
     if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci-network-kind')
     timeout-minutes: 180 # 3 hours for KIND tests
@@ -371,16 +394,23 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: ci3-network-kind-${{ github.run_id }}
+
       - name: Run KIND Test
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          CI3_INSTANCE_PROFILE_NAME: ${{ secrets.CI3_INSTANCE_PROFILE_NAME }}
+          CI3_SECURITY_GROUP_ID: ${{ secrets.CI3_SECURITY_GROUP_ID }}
           RUN_ID: ${{ github.run_id }}
           AWS_SHUTDOWN_TIME: 180
         run: |

--- a/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
+++ b/barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh
@@ -152,16 +152,16 @@ if [[ "${CI:-}" == "1" ]] && [[ "${CI_USE_BUILD_INSTANCE_KEY:-0}" == "1" ]]; the
     tmp_breakdown_file="/tmp/benchmark_breakdown_${runtime}_${flow_name}_$$.json"
     cp "$benchmark_breakdown_file" "$tmp_breakdown_file"
 
-    # Upload to disk (bench/bb-breakdown subfolder) in background
+    # Upload to S3 (bench/bb-breakdown subfolder) in background
     # Key format: <runtime>-<flow_name>-<sha>
     disk_key="${runtime}-${flow_name}-${current_sha}"
     {
-      cat "$tmp_breakdown_file" | gzip | cache_disk_transfer_to "bench/bb-breakdown" "$disk_key"
+      cat "$tmp_breakdown_file" | gzip | cache_s3_transfer_to "bench/bb-breakdown" "$disk_key"
       # Clean up tmp file after upload completes
       rm -f "$tmp_breakdown_file"
     } &
 
-    echo "Uploaded benchmark breakdown to disk: bench/bb-breakdown/$disk_key"
+    echo "Uploaded benchmark breakdown to S3: bench/bb-breakdown/$disk_key"
   else
     echo "Warning: benchmark breakdown file not found at $benchmark_breakdown_file"
   fi

--- a/barretenberg/cpp/scripts/ci_benchmark_ultrahonk_circuits.sh
+++ b/barretenberg/cpp/scripts/ci_benchmark_ultrahonk_circuits.sh
@@ -149,13 +149,13 @@ if [[ "${CI:-}" == "1" ]] && [[ "${CI_USE_BUILD_INSTANCE_KEY:-0}" == "1" ]]; the
     tmp_breakdown_file="/tmp/benchmark_breakdown_ultrahonk_${circuit_name}_cpus${cpus}_$$.json"
     cp "$output/benchmark_breakdown.json" "$tmp_breakdown_file"
 
-    # Upload to disk
+    # Upload to S3
     disk_key="ultrahonk-${circuit_name}-cpus${cpus}-${current_sha}"
     {
-      cat "$tmp_breakdown_file" | gzip | cache_disk_transfer_to "bench/ultrahonk-breakdown" "$disk_key"
+      cat "$tmp_breakdown_file" | gzip | cache_s3_transfer_to "bench/ultrahonk-breakdown" "$disk_key"
       rm -f "$tmp_breakdown_file"
     } &
 
-    echo "Uploaded benchmark breakdown to disk: bench/ultrahonk-breakdown/$disk_key"
+    echo "Uploaded benchmark breakdown to S3: bench/ultrahonk-breakdown/$disk_key"
   fi
 fi

--- a/ci.sh
+++ b/ci.sh
@@ -61,12 +61,30 @@ function get_ip_for_instance {
     --output text)
 }
 
+function get_iid_for_instance {
+  iid=$(aws ec2 describe-instances \
+    --region us-east-2 \
+    --filters "Name=tag:Name,Values=$instance_name" "Name=instance-state-name,Values=running" \
+    --query "Reservations[].Instances[0].InstanceId" \
+    --output text | tr -d '\n\r' | xargs)
+}
+
 function get_latest_run_id {
   gh run list --workflow $ci3_workflow_id -b $BRANCH --limit 1 --json databaseId -q .[0].databaseId
 }
 
 # Jobs in the ci dashboards are grouped on a single line by RUN_ID.
 export RUN_ID=${RUN_ID:-$(date +%s%3N)}
+
+# Delegate to SSM (default) or SSH based on CI_USE_SSH.
+function bootstrap_remote {
+  if [ "${CI_USE_SSH:-0}" -eq 1 ]; then
+    bootstrap_ec2 "$@"
+  else
+    bootstrap_ssm "$@"
+  fi
+}
+export -f bootstrap_remote
 
 case "$cmd" in
   dash)
@@ -75,31 +93,31 @@ case "$cmd" in
   fast|docs|barretenberg|barretenberg-full)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    bootstrap_remote "./bootstrap.sh ci-$cmd"
     ;;
   socket-fix)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-socket-fix"
     export INSTANCE_POSTFIX="socket-fix"
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-socket-fix $*"
+    bootstrap_remote "./bootstrap.sh ci-socket-fix $*"
     ;;
   full|full-no-test-cache)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
     export AWS_SHUTDOWN_TIME=75
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    bootstrap_remote "./bootstrap.sh ci-$cmd"
     ;;
   barretenberg-debug)
     export CI_DASHBOARD="nightly"
     export JOB_ID="x-$cmd"
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    bootstrap_remote "./bootstrap.sh ci-$cmd"
     ;;
   avm-inputs-collection|avm-check-circuit)
     export CI_DASHBOARD="nightly"
     export JOB_ID="x-$cmd"
-    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    bootstrap_remote "./bootstrap.sh ci-$cmd"
     ;;
   grind)
     # Grind a default of 5 times.
@@ -107,7 +125,7 @@ case "$cmd" in
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
-      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_remote './bootstrap.sh $3'"
     }
     export -f run
     seq 1 ${1:-5} | parallel --jobs 100 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered \
@@ -125,7 +143,7 @@ case "$cmd" in
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
-      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_remote './bootstrap.sh $3'"
     }
     export -f run
 
@@ -149,7 +167,7 @@ case "$cmd" in
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
-      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_remote './bootstrap.sh $3'"
     }
     export -f run
 
@@ -181,7 +199,7 @@ case "$cmd" in
     export JOB_ID="grind-test-$test_hash"
     export INSTANCE_POSTFIX=$JOB_ID
     export CPUS=${CPUS:-192}
-    bootstrap_ec2 "./bootstrap.sh ci-grind-test $(printf %q "$full_cmd") $timeout $jobs_pct $memsuspend_pct $commit" | DUP=1 cache_log "Grind test CI run" $RUN_ID
+    bootstrap_remote "./bootstrap.sh ci-grind-test $(printf %q "$full_cmd") $timeout $jobs_pct $memsuspend_pct $commit" | DUP=1 cache_log "Grind test CI run" $RUN_ID
     ;;
   ##########################################
   # NETWORK DEPLOYMENTS WITH BENCHES/TESTS #
@@ -200,8 +218,9 @@ case "$cmd" in
     export CPUS=16
     run() {
       local set=$1
-      JOB_ID="x-${namespace}-${set}" INSTANCE_POSTFIX="n-deploy-${set}" \
-        bootstrap_ec2 "./bootstrap.sh ci-network-deploy $scenario ${namespace}-${set} \"$docker_image\" $set"
+      export JOB_ID="x-${namespace}-${set}"
+      export INSTANCE_POSTFIX="n-deploy-${set}"
+      bootstrap_remote "./bootstrap.sh ci-network-deploy $scenario ${namespace}-${set} \"$docker_image\" $set"
     }
     export -f run
     export scenario namespace docker_image
@@ -221,7 +240,7 @@ case "$cmd" in
     # Enough for the build, which should have a lot of caching, and the test harness.
     # Resources are on GCP.
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-network-deploy $*"
+    bootstrap_remote "./bootstrap.sh ci-network-deploy $*"
     ;;
   network-tests)
     # Args: <scenario> <namespace>
@@ -232,7 +251,7 @@ case "$cmd" in
     # Enough for the build, which should have a lot of caching, and the test harness.
     # Resources are on GCP.
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-network-tests $*"
+    bootstrap_remote "./bootstrap.sh ci-network-tests $*"
     ;;
   network-bench)
     # Args: <scenario> <namespace> [docker_image]
@@ -243,7 +262,7 @@ case "$cmd" in
     # Enough for the build, which should have a lot of caching, and the test harness.
     # Resources are on GCP.
     export CPUS=16
-    bootstrap_ec2 "./bootstrap.sh ci-network-bench $*"
+    bootstrap_remote "./bootstrap.sh ci-network-bench $*"
     ;;
   network-proving-bench)
     # Args: <scenario> <namespace> [docker_image]
@@ -251,7 +270,7 @@ case "$cmd" in
     export CI_DASHBOARD="network"
     export JOB_ID="x-${2:?namespace is required}-network-proving-bench" CPUS=16
     export INSTANCE_POSTFIX="n-proving-bench"
-    bootstrap_ec2 "./bootstrap.sh ci-network-proving-bench $*"
+    bootstrap_remote "./bootstrap.sh ci-network-proving-bench $*"
     ;;
   network-teardown)
     # Args: <scenario> <namespace>
@@ -259,7 +278,7 @@ case "$cmd" in
     export JOB_ID="x-${2:?namespace is required}-network-teardown"
     export CPUS=4
     export INSTANCE_POSTFIX="n-teardown"
-    bootstrap_ec2 "./bootstrap.sh ci-network-teardown $*"
+    bootstrap_remote "./bootstrap.sh ci-network-teardown $*"
     ;;
 
   network-tests-kind)
@@ -268,7 +287,7 @@ case "$cmd" in
     export AWS_SHUTDOWN_TIME=180 # 3 hours for KIND tests
     export CPUS=192
     export INSTANCE_POSTFIX="n-kind"
-    bootstrap_ec2 "./bootstrap.sh ci-network-kind-tests"
+    bootstrap_remote "./bootstrap.sh ci-network-kind-tests"
     ;;
   deploy-rollup-upgrade)
     # Env vars: NETWORK, GCP_PROJECT_ID (for GCP secrets)
@@ -277,7 +296,7 @@ case "$cmd" in
     export JOB_ID="x-deploy-rollup-upgrade"
     export CPUS=8
     export INSTANCE_POSTFIX="rollup-upgrade"
-    bootstrap_ec2 "./bootstrap.sh ci-deploy-rollup-upgrade $*"
+    bootstrap_remote "./bootstrap.sh ci-deploy-rollup-upgrade $*"
     ;;
 
   ############
@@ -290,7 +309,7 @@ case "$cmd" in
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
-      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-release'"
+      PARENT_LOG_ID=$RUN_ID JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_remote './bootstrap.sh ci-release'"
     }
     export -f run
 
@@ -310,17 +329,36 @@ case "$cmd" in
     ;;
   shell-container)
     # Drop into a shell in the current running build instance container.
-    get_ip_for_instance
-    [ -z "$ip" ] && echo "No instance found: $instance_name" && exit 1
-    [ "$#" -eq 0 ] && set -- "zsh" || true
-    ssh -tq -F $ci3/aws/build_instance_ssh_config ubuntu@$ip \
-      "docker start aztec_build &>/dev/null || true && docker exec -it --user aztec-dev aztec_build $@"
+    if [ "${CI_USE_SSH:-0}" -eq 1 ]; then
+      get_ip_for_instance
+      [ -z "$ip" ] && echo "No instance found: $instance_name" && exit 1
+      [ "$#" -eq 0 ] && set -- "zsh" || true
+      ssh -tq -F $ci3/aws/build_instance_ssh_config ubuntu@$ip \
+        "docker start aztec_build &>/dev/null || true && docker exec -it --user aztec-dev aztec_build $@"
+    else
+      get_iid_for_instance
+      [ -z "$iid" ] || [ "$iid" = "None" ] && echo "No instance found: $instance_name" && exit 1
+      [ "$#" -eq 0 ] && set -- "zsh" || true
+      aws ssm start-session \
+        --region us-east-2 \
+        --target "$iid" \
+        --document-name "AWS-StartInteractiveCommand" \
+        --parameters "{\"command\":[\"runuser -u ubuntu -- bash -c 'docker start aztec_build &>/dev/null || true && docker exec -it --user aztec-dev aztec_build $@'\"]}"
+    fi
     ;;
   shell-host)
     # Drop into a shell in the current running build host.
-    get_ip_for_instance
-    [ -z "$ip" ] && echo "No instance found: $instance_name" && exit 1
-    ssh -t -F $ci3/aws/build_instance_ssh_config ubuntu@$ip
+    if [ "${CI_USE_SSH:-0}" -eq 1 ]; then
+      get_ip_for_instance
+      [ -z "$ip" ] && echo "No instance found: $instance_name" && exit 1
+      ssh -t -F $ci3/aws/build_instance_ssh_config ubuntu@$ip
+    else
+      get_iid_for_instance
+      [ -z "$iid" ] || [ "$iid" = "None" ] && echo "No instance found: $instance_name" && exit 1
+      aws ssm start-session \
+        --region us-east-2 \
+        --target "$iid"
+    fi
     ;;
   kill)
     existing_instance=$(aws ec2 describe-instances \

--- a/ci3/aws_request_instance_type
+++ b/ci3/aws_request_instance_type
@@ -19,11 +19,33 @@ trap 'cleanup' SIGINT SIGTERM
 
 export AWS_DEFAULT_REGION=us-east-2
 
+# KeyName is optional: omit when KEY_NAME is empty (SSM-only mode).
+key_name_json=""
+if [ -n "${KEY_NAME:-}" ]; then
+  key_name_json="\"KeyName\": \"$KEY_NAME\","
+fi
+
+# IamInstanceProfile is only attached in SSM mode (no KEY_NAME = SSM).
+# In SSH mode, the build_instance IAM user lacks iam:PassRole for this role.
+iam_profile_json=""
+if [ -z "${KEY_NAME:-}" ] && [ -n "${CI3_INSTANCE_PROFILE_NAME:-}" ]; then
+  iam_profile_json="\"IamInstanceProfile\": { \"Name\": \"$CI3_INSTANCE_PROFILE_NAME\" },"
+fi
+
+# In SSM mode use the CI3 security group; in SSH mode use the original SG (allows port 22).
+if [ -z "${KEY_NAME:-}" ]; then
+  : "${CI3_SECURITY_GROUP_ID:?CI3_SECURITY_GROUP_ID must be set in SSM mode}"
+  sg_id="$CI3_SECURITY_GROUP_ID"
+else
+  sg_id="sg-0ccd4e5df0dcca0c9"
+fi
+
 launch_spec=$(cat <<EOF
 {
   "ImageId": "$ami",
-  "KeyName": "${KEY_NAME:-build-instance}",
-  "SecurityGroupIds": ["sg-0ccd4e5df0dcca0c9"],
+  $key_name_json
+  $iam_profile_json
+  "SecurityGroupIds": ["$sg_id"],
   "InstanceType": "$instance_type",
   "BlockDeviceMappings": [
     {
@@ -77,10 +99,11 @@ if [ "${NO_SPOT:-0}" -ne 1 ]; then
 fi
 
 if [ -z "${iid:-}" -o "${iid:-}" == "None" ]; then
-  # Request on-demand instance.
+  # Request on-demand instance (with tags at launch for IAM RequestTag conditions).
   echo "Requesting $instance_type on-demand instance $info..."
   iid=$(aws ec2 run-instances \
     --cli-input-json file://$spec_path \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$name},{Key=Group,Value=build-instance}]" \
     --query "Instances[*].[InstanceId]" \
     --output text)
   echo $iid > $iid_path
@@ -112,18 +135,50 @@ while [ -z "${ip:-}" ]; do
   echo $ip > $ip_path
 done
 
-# Wait till ssh port is open.
-echo "Waiting for SSH at $ip..."
-SECONDS=0
-SSH_CONFIG_PATH=${SSH_CONFIG_PATH:-aws/build_instance_ssh_config}
-[ "${NO_TERMINATE:-0}" -eq 1 ] && LIVE_CMD=true || LIVE_CMD="sudo shutdown -h +${AWS_SHUTDOWN_TIME:-60}"
-while ! ssh -F $SSH_CONFIG_PATH -o ConnectTimeout=1 $ip $LIVE_CMD > /dev/null 2>&1; do
-  if (( SECONDS >= 60 )); then
-    echo "Timeout: SSH could not login to $ip within 60 seconds."
+# When no key pair (SSM-only), wait for SSM registration and set the shutdown timer.
+if [ -z "${KEY_NAME:-}" ]; then
+  >&2 echo "Waiting for SSM registration for instance $iid..."
+  SECONDS=0
+  while (( SECONDS < 300 )); do
+    ssm_status=$(aws ssm describe-instance-information \
+      --region us-east-2 \
+      --filters "Key=InstanceIds,Values=$iid" \
+      --query "InstanceInformationList[0].PingStatus" \
+      --output text 2>/dev/null) || true
+    >&2 echo "SSM status: ${ssm_status:-Inactive}"
+    [ "$ssm_status" = "Online" ] && break
+    sleep 5
+  done
+
+  if [ "$ssm_status" != "Online" ]; then
+    >&2 echo "Timed out waiting for SSM to see instance $iid"
     exit 1
   fi
-  sleep 1
-done
 
-aws ec2 create-tags --resources $iid --tags "Key=Name,Value=$name"
-aws ec2 create-tags --resources $iid --tags "Key=Group,Value=build-instance"
+  # Set the shutdown timer via SSM, mirroring the SSH path. Fire-and-forget.
+  # Non-fatal: a failed timer shouldn't abort provisioning (reaper catches orphans).
+  if [ "${NO_TERMINATE:-0}" -ne 1 ]; then
+    >&2 echo "Setting shutdown timer (+${AWS_SHUTDOWN_TIME:-60} min) via SSM..."
+    SSM_NO_WAIT=1 ssm_send_command "$iid" "sudo shutdown -h +${AWS_SHUTDOWN_TIME:-60}" || \
+      >&2 echo "Warning: failed to set shutdown timer via SSM (non-fatal)."
+  fi
+else
+  # Wait till ssh port is open.
+  >&2 echo "Waiting for SSH at $ip..."
+  SECONDS=0
+  SSH_CONFIG_PATH=${SSH_CONFIG_PATH:-aws/build_instance_ssh_config}
+  [ "${NO_TERMINATE:-0}" -eq 1 ] && LIVE_CMD=true || LIVE_CMD="sudo shutdown -h +${AWS_SHUTDOWN_TIME:-60}"
+  while ! ssh -F $SSH_CONFIG_PATH -o ConnectTimeout=1 $ip $LIVE_CMD > /dev/null 2>&1; do
+    if (( SECONDS >= 60 )); then
+      >&2 echo "Timeout: SSH could not login to $ip within 60 seconds."
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+# For spot instances, tags must be applied post-launch (launch-specification doesn't support TagSpecifications).
+# On-demand instances are tagged at launch via --tag-specifications.
+if [ -n "${sir:-}" ]; then
+  aws ec2 create-tags --resources $iid --tags "Key=Name,Value=$name" "Key=Group,Value=build-instance"
+fi

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -11,6 +11,7 @@ export CI=1
 # Set to 0 in ci3-external.yml for external contributors who don't have SSH access.
 export CI_USE_BUILD_INSTANCE_KEY=${CI_USE_BUILD_INSTANCE_KEY:-1}
 
+export CI_LOG_ID=${CI_LOG_ID:-$(date +%s%3N)}
 export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-60}
 
 if [ "$arch" == "arm64" ]; then
@@ -136,7 +137,8 @@ container_script=$(
   git checkout FETCH_HEAD
   git checkout -b \$REF_NAME
   source ci3/source
-  ci_log_id=\$(log_ci_run)
+  ci_log_id=\$CI_LOG_ID
+  log_ci_run \$ci_log_id
 
   if [ -n "\$DOCKERHUB_PASSWORD" ]; then
     echo \$DOCKERHUB_PASSWORD | docker login -u \$DOCKERHUB_USERNAME --password-stdin
@@ -179,9 +181,9 @@ container_script=$(
 
   case \$code in
     155) ;;
-    0) log_ci_run PASSED \$ci_log_id ;;
+    0) log_ci_run \$ci_log_id PASSED ;;
     *)
-      log_ci_run FAILED \$ci_log_id
+      log_ci_run \$ci_log_id FAILED
       merge_train_failure_slack_notify \$ci_log_id
       release_canary_slack_notify \$ci_log_id
       ;;
@@ -294,6 +296,7 @@ function run {
         -e GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
         -e NETWORK_ENV_FILE="${NETWORK_ENV_FILE}" \
         -e CI=1 \
+        -e CI_LOG_ID=${CI_LOG_ID:-} \
         -e RUN_ID=${RUN_ID:-} \
         -e JOB_ID=${JOB_ID:-} \
         -e REF_NAME=${REF_NAME:-} \

--- a/ci3/bootstrap_ssm
+++ b/ci3/bootstrap_ssm
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# SSM-based variant of bootstrap_ec2.
+# - Launches one EC2 instance per job via aws_request_instance (no SSH key pair).
+# - Uses SSM AWS-RunShellScript to start the devbox container on the host.
+# - Polls ssm get-command-invocation for completion and streams output.
+
+NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+source $ci3/source_refname
+
+cmd=${1:?usage: $(basename "$0") '<command-to-run-inside-devbox>'}
+arch=${ARCH:-amd64}
+NO_TERMINATE=${NO_TERMINATE:-0}
+
+# Pre-generate a log ID and print the dashboard link.
+export CI_LOG_ID=${CI_LOG_ID:-$(date +%s%3N)}
+dashboard_url="http://ci.aztec-labs.com/section/${CI_DASHBOARD:?CI_DASHBOARD must be set}"
+log_url="http://ci.aztec-labs.com/$CI_LOG_ID"
+echo "CI dashboard: $dashboard_url"
+echo "CI log: $log_url"
+
+# We're always "in CI" if we're running on a remote instance.
+export CI=1
+
+if [ "$arch" == "arm64" ]; then
+  cores=64
+  export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-90}
+else
+  cores=192,128,64
+  if [ "${CI_FULL:-0}" -eq 1 ]; then
+    export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-75}
+  fi
+fi
+
+# Allow override.
+cores=${CPUS:-$cores}
+
+# Trap function to terminate our running instance when the script exits.
+function cleanup {
+  if [ -d "$state_dir" ]; then
+    aws_terminate_instance "$state_dir"
+  fi
+}
+trap 'cleanup >/dev/null' SIGINT SIGTERM EXIT
+
+# Verify that the commit exists on the remote.
+current_commit=$(git rev-parse HEAD)
+if [[ "$(git fetch origin --negotiate-only --negotiation-tip="$current_commit")" != *"$current_commit"* ]]; then
+  echo "Commit $current_commit is not pushed, exiting."
+  exit 1
+fi
+
+# IMPORTANT: Use the same dynamic instance naming as bootstrap_ec2.
+# This ensures proper instance lifecycle management across modes.
+if [[ "$REF_NAME" =~ ^gh-readonly-queue/.*(pr-[0-9]+) ]]; then
+  instance_name="${BASH_REMATCH[1]}_$arch"
+else
+  instance_name=$(echo -n "$REF_NAME" | head -c 50 | tr -c 'a-zA-Z0-9-' '_')_$arch
+fi
+
+state_dir=$(mktemp -d /tmp/aws_request_instance.XXXXXX)
+
+if semver check "$REF_NAME"; then
+  key_name="super-build-instance"
+else
+  key_name="build-instance"
+fi
+
+[ -n "${INSTANCE_POSTFIX:-}" ] && instance_name+="_$INSTANCE_POSTFIX"
+
+echo_header "request build instance (SSM)"
+# Terminate any existing instances with the same name.
+existing_instance=$(aws ec2 describe-instances \
+  --region us-east-2 \
+  --filters "Name=tag:Name,Values=$instance_name" "Name=instance-state-name,Values=running" \
+  --query "Reservations[].Instances[?State.Name!='terminated'].InstanceId[]" \
+  --output text)
+if [ -n "$existing_instance" ]; then
+  for i in $existing_instance; do
+    echo "Terminating existing instance: $i"
+    aws ec2 --region us-east-2 terminate-instances --instance-ids "$i" >/dev/null 2>&1
+  done
+fi
+
+# Request new instance: no key pair (SSM-only, no SSH).
+KEY_NAME= aws_request_instance "$instance_name" "$cores" "$arch" "$state_dir"
+ip=$(cat "$state_dir/ip")
+sir=""
+if [[ -f "$state_dir/sir" ]]; then
+  sir=$(cat "$state_dir/sir")
+fi
+iid=$(cat "$state_dir/iid" | tr -d '\n\r' | xargs)
+export EC2_INSTANCE_TYPE=$(cat "$state_dir/instance_type" 2>/dev/null || echo "unknown")
+export EC2_SPOT=$(cat "$state_dir/spot" 2>/dev/null || echo "unknown")
+
+# Build the script that will run on the EC2 host via SSM.
+# It closely mirrors the SSH-remote section of bootstrap_ec2.
+host_script=$(
+  cat <<EOF
+set -euo pipefail
+
+aws_token=\$(curl -sX PUT http://169.254.169.254/latest/api/token -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
+
+GOOGLE_APPLICATION_CREDENTIALS=\${GOOGLE_APPLICATION_CREDENTIALS:-/tmp/gcp-key.json}
+NETWORK_ENV_FILE=\${NETWORK_ENV_FILE:-/tmp/network.env}
+
+# Decode GCP service account key if provided (base64-encoded by the caller).
+if [ -n "${GCP_SA_KEY_B64:-}" ]; then
+  echo "${GCP_SA_KEY_B64:-}" | base64 -d > "\${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
+
+# Decode network env file if provided.
+if [ -n "${NETWORK_ENV_FILE_B64:-}" ]; then
+  echo "${NETWORK_ENV_FILE_B64:-}" | base64 -d > "\${NETWORK_ENV_FILE}"
+fi
+
+start_build() {
+  echo "Starting devbox via SSM..."
+  local_uid=\$(id -u)
+  local_gid=\$(id -g)
+
+  docker run --privileged --rm \${docker_args:-} \
+    --name aztec_build \
+    --hostname $instance_name \
+    -v bootstrap_ci_local_docker:/var/lib/docker \
+    -v bootstrap_ci_repo:/home/aztec-dev/aztec-packages \
+    -v \$HOME/.ssh:/home/aztec-dev/.ssh:ro \
+    -v \$HOME/.bb-crs:/home/aztec-dev/.bb-crs \
+    -v /dev/kmsg:/dev/kmsg \
+    -v /tmp:/tmp \
+    -v \${GOOGLE_APPLICATION_CREDENTIALS}:\${GOOGLE_APPLICATION_CREDENTIALS}:ro \
+    -v \${NETWORK_ENV_FILE}:\${NETWORK_ENV_FILE}:ro \
+    -e GOOGLE_APPLICATION_CREDENTIALS="\${GOOGLE_APPLICATION_CREDENTIALS}" \
+    -e NETWORK_ENV_FILE="\${NETWORK_ENV_FILE}" \
+    -e CI=1 \
+    -e CI_LOG_ID=${CI_LOG_ID:-} \
+    -e RUN_ID=${RUN_ID:-} \
+    -e JOB_ID=${JOB_ID:-} \
+    -e REF_NAME=${REF_NAME:-} \
+    -e TARGET_BRANCH=${TARGET_BRANCH:-} \
+    -e CI_DASHBOARD=${CI_DASHBOARD:-} \
+    -e PARENT_LOG_ID=${PARENT_LOG_ID:-} \
+    -e NO_CACHE=${NO_CACHE:-} \
+    -e NO_FAIL_FAST=${NO_FAIL_FAST:-} \
+    -e CI_USE_BUILD_INSTANCE_KEY=${CI_USE_BUILD_INSTANCE_KEY:-1} \
+    -e CI_SSM_MODE=1 \
+    -e CI_LOGS_S3_LOCATION=${CI_LOGS_S3_LOCATION:-s3://aztec-ci-artifacts/logs} \
+    -e CI_REDIS='ci-redis-tiered.lzka0i.ng.0001.use2.cache.amazonaws.com' \
+    -e SSH_CONNECTION=' ' \
+    -e LOCAL_USER_ID=\$local_uid \
+    -e LOCAL_GROUP_ID=\$local_gid \
+    -e GCP_PROJECT_ID=${GCP_PROJECT_ID:-} \
+    -e EXTERNAL_ETHEREUM_HOSTS=${EXTERNAL_ETHEREUM_HOSTS:-} \
+    -e EXTERNAL_ETHEREUM_CONSENSUS_HOST=${EXTERNAL_ETHEREUM_CONSENSUS_HOST:-} \
+    -e EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY=${EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY:-} \
+    -e EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY_HEADER=${EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY_HEADER:-} \
+    -e L1_DEPLOYMENT_PRIVATE_KEY=${L1_DEPLOYMENT_PRIVATE_KEY:-} \
+    -e DOCKERHUB_PASSWORD=${DOCKERHUB_PASSWORD:-} \
+    -e DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME:-} \
+    -e R2_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID:-} \
+    -e R2_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY:-} \
+    -e BUILD_SYSTEM_DEBUG=${BUILD_SYSTEM_DEBUG:-} \
+    -e GITHUB_TOKEN=${GITHUB_TOKEN:-} \
+    -e GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-aztecprotocol/aztec-packages} \
+    -e NETLIFY_SITE_ID=${NETLIFY_SITE_ID:-} \
+    -e NETLIFY_AUTH_TOKEN=${NETLIFY_AUTH_TOKEN:-} \
+    -e NPM_TOKEN=${NPM_TOKEN:-} \
+    -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-} \
+    -e AWS_TOKEN=\$aws_token \
+    -e NAMESPACE=${NAMESPACE:-} \
+    -e NETWORK=${NETWORK:-} \
+    -e GITHUB_ACTOR=${GITHUB_ACTOR:-} \
+    -e EC2_INSTANCE_TYPE=${EC2_INSTANCE_TYPE:-unknown} \
+    -e EC2_SPOT=${EC2_SPOT:-unknown} \
+    --pids-limit=32768 \
+    --shm-size=2g \
+    aztecprotocol/devbox:3.0 bash -c $(printf '%q' "$(
+      cat <<INNER
+set -euo pipefail
+while [ -f ci-started ]; do sleep 999; done
+touch ci-started
+sudo chown aztec-dev:aztec-dev aztec-packages
+git config --global user.email "tech@aztecprotocol.com"
+git config --global user.name "AztecBot"
+cd aztec-packages
+git config --global advice.detachedHead false
+git init . &>/dev/null
+if [ -n "\${GITHUB_TOKEN:-}" ]; then
+  git remote add origin "https://x-access-token:\$GITHUB_TOKEN@github.com/\$GITHUB_REPOSITORY.git"
+else
+  git remote add origin "https://github.com/\$GITHUB_REPOSITORY.git"
+fi
+git fetch --depth 1 origin $current_commit
+git checkout FETCH_HEAD
+git checkout -b \$REF_NAME
+source ci3/source
+source ci3/source_refname
+source ci3/source_redis
+source ci3/source_cache
+ci_log_id="\$CI_LOG_ID"
+log_ci_run "\$ci_log_id"
+if [ -n "\$DOCKERHUB_PASSWORD" ]; then
+  echo "\$DOCKERHUB_PASSWORD" | docker login -u "\$DOCKERHUB_USERNAME" --password-stdin
+fi
+while true; do redis_cli SETEX "hb-\$ci_log_id" 60 1 &>/dev/null || true; sleep 30; done &
+function run {
+  echo "env: REF_NAME=\$REF_NAME COMMIT_HASH=\$COMMIT_HASH CURRENT_VERSION=\$CURRENT_VERSION TARGET_BRANCH=\$TARGET_BRANCH"
+  if semver check "\$REF_NAME"; then
+    echo "Performing a release because \$REF_NAME is a semver."
+  fi
+  mpstat 2 > >(cache_log cpufile) &
+  cpu_pid=\$!
+  vmstat -w -S M 2 > >(add_timestamps | cache_log memfile) &
+  mem_pid=\$!
+  bash -c "while true; do pstree -ag; echo; echo; sleep 10; done" 2>&1 > >(add_timestamps | cache_log processes) &
+  pstree_pid=\$!
+  set +e
+  set -x
+  $cmd
+  local code=\${PIPESTATUS[0]}
+  set +x
+  sudo dmesg 2>&1 | cache_log "dmesg"
+  kill "\$cpu_pid" "\$mem_pid" "\$pstree_pid" &>/dev/null || true
+  return \$code
+}
+export -f run
+set +e
+PARENT_LOG_ID=\$ci_log_id run 2>&1 | ci3/add_timestamps | DUP=1 ci3/cache_log "CI run" "\$ci_log_id"
+code=\${PIPESTATUS[0]}
+case "\$code" in
+  155) ;;
+  0) log_ci_run "\$ci_log_id" PASSED ;;
+  *) log_ci_run "\$ci_log_id" FAILED && merge_train_failure_slack_notify "\$ci_log_id" && release_canary_slack_notify "\$ci_log_id" ;;
+esac
+exit \$code
+INNER
+    )")
+}
+
+echo "Starting build via SSM..."
+start_build &
+build_pid=\$!
+
+# While the docker container is running, check for spot termination notices.
+while kill -0 \$build_pid &>/dev/null; do
+  # The check for the file allows for testing spot termination logic.
+  if [ -f /tmp/spot_term ] || curl -fs -H "X-aws-ec2-metadata-token: \$aws_token" http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
+    echo "Spot will be terminated! Exiting early."
+    docker kill aztec_build &>/dev/null || true
+    exit 155
+  fi
+  sleep 5
+done
+
+# Returns exit code from docker run.
+wait \$build_pid
+EOF
+)
+
+echo_header "invoke SSM command"
+
+# Send host script via SSM and poll until completion.
+# Run as ubuntu to match bootstrap_ec2 behavior (SSM defaults to root).
+set +e
+SSM_RUN_AS=ubuntu SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200} \
+  ssm_send_command "$iid" "$host_script"
+exit_code=$?
+set -e
+
+# If we were spot evicted, try again using on-demand.
+if [ "$exit_code" -eq 155 ]; then
+  echo "Spot was evicted. Retrying with on-demand instance."
+  NO_SPOT=1 exec "$0" "$@"
+else
+  exit "$exit_code"
+fi

--- a/ci3/cache_upload
+++ b/ci3/cache_upload
@@ -22,9 +22,12 @@ if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:-0}" -eq 0 ]]; then
   exit 0
 fi
 
-if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]] && ! aws configure get aws_access_key_id &>/dev/null; then
-  echo_stderr "Skipping upload, no AWS credentials found."
-  exit 0
+# In SSM/instance-profile mode, AWS CLI falls back to IMDS for credentials.
+if [[ "${CI_SSM_MODE:-0}" -eq 0 ]]; then
+  if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]] && ! aws configure get aws_access_key_id &>/dev/null; then
+    echo_stderr "Skipping upload, no AWS credentials found."
+    exit 0
+  fi
 fi
 
 if [ -z "${S3_FORCE_UPLOAD:-}" ] && \

--- a/ci3/dashboard/deploy-test.sh
+++ b/ci3/dashboard/deploy-test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy a test instance of the dashboard on ports 8082/8083 via SSM.
+# Shares Redis and /logs-disk with the production instance.
+# Requires: aws cli and SSM-enabled instance.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGION="us-east-2"
+INSTANCE_NAME="${INSTANCE_NAME:-ci-dashboard}"
+
+# Resolve instance ID from Name tag (override with INSTANCE_ID env var)
+if [ -z "${INSTANCE_ID:-}" ]; then
+  INSTANCE_ID=$(aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:Name,Values=$INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[0].Instances[0].InstanceId' --output text)
+  if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+    echo "ERROR: Could not find running instance with Name=$INSTANCE_NAME"
+    echo "Set INSTANCE_ID or INSTANCE_NAME env var."
+    exit 1
+  fi
+fi
+echo "Using instance: $INSTANCE_ID"
+
+# Stage and tar files locally
+echo "Packaging dashboard files..."
+STAGING=$(mktemp -d /tmp/rk-test-stage-XXXXXX)
+TARBALL="$STAGING.tar.gz"
+rsync -a --exclude='deploy.sh' --exclude='deploy-test.sh' "$SCRIPT_DIR"/ "$STAGING"/
+rsync -a "$SCRIPT_DIR/../ci-metrics/" "$STAGING/ci-metrics/"
+tar -czf "$TARBALL" -C "$STAGING" .
+rm -rf "$STAGING"
+
+# Upload to S3 as transfer mechanism
+echo "Uploading to S3..."
+S3_TMP="s3://aztec-ci-artifacts/tmp/rk-test-deploy.tar.gz"
+aws s3 cp "$TARBALL" "$S3_TMP" --region "$REGION" --quiet
+rm -f "$TARBALL"
+
+# Encode the remote script as base64 to avoid all quoting issues.
+# The script copies env vars from the prod container (rkapp) so the test
+# instance connects to the same Redis, uses the same passwords, etc.
+REMOTE_SCRIPT_B64=$(base64 << 'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+
+cd /home/ubuntu
+mkdir -p rk-test
+echo "Downloading files from S3..."
+aws s3 cp s3://aztec-ci-artifacts/tmp/rk-test-deploy.tar.gz /tmp/rk-test.tar.gz --region us-east-2 --quiet
+tar -xzf /tmp/rk-test.tar.gz -C rk-test
+rm -f /tmp/rk-test.tar.gz
+
+cd rk-test
+echo "Building docker image..."
+docker build -t rkapp-test .
+
+echo "Stopping old container..."
+docker rm -f rkapp-test 2>/dev/null || true
+
+# Pull env vars from the production container
+echo "Reading env vars from production container..."
+PROD_ENV=""
+for var in REDIS_HOST REDIS_PORT DASHBOARD_PASSWORD LOGS_DISK_PATH S3_LOGS_BUCKET S3_LOGS_PREFIX REPO_PATH; do
+  val=$(docker exec rkapp printenv "$var" 2>/dev/null) || true
+  if [ -n "$val" ]; then
+    PROD_ENV="$PROD_ENV -e $var=$val"
+  fi
+done
+
+echo "Starting new container..."
+eval docker run -d --name rkapp-test --restart unless-stopped \
+  --network host \
+  -e CI_METRICS_PORT=8083 \
+  $PROD_ENV \
+  -v /logs-disk:/logs-disk \
+  rkapp-test \
+  gunicorn -w 4 -b 0.0.0.0:8082 rk:app
+
+echo "Container started:"
+docker ps --filter name=rkapp-test
+SCRIPT
+)
+
+PARAMS_FILE=$(mktemp /tmp/rk-test-params-XXXXXX)
+python3 -c "
+import json, sys
+cmd = 'echo $REMOTE_SCRIPT_B64 | base64 -d | bash'
+json.dump({'commands': [cmd]}, open(sys.argv[1], 'w'))
+" "$PARAMS_FILE"
+
+# Send command and wait for result
+echo "Deploying on instance..."
+COMMAND_ID=$(aws ssm send-command --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --timeout-seconds 300 \
+  --parameters "file://$PARAMS_FILE" \
+  --output text --query 'Command.CommandId')
+rm -f "$PARAMS_FILE"
+
+echo "Command ID: $COMMAND_ID"
+echo "Waiting for completion..."
+
+# Poll until done (5s intervals, up to 5 minutes)
+for i in $(seq 1 60); do
+  sleep 5
+  STATUS=$(aws ssm get-command-invocation --region "$REGION" \
+    --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+    --query 'Status' --output text 2>/dev/null) || continue
+  case "$STATUS" in
+    Success)
+      echo ""
+      echo "Deploy succeeded!"
+      aws ssm get-command-invocation --region "$REGION" \
+        --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+        --query 'StandardOutputContent' --output text
+      echo ""
+      echo "Test dashboard: http://ci.aztec-labs.com:8082"
+      exit 0
+      ;;
+    Failed|TimedOut|Cancelled)
+      echo ""
+      echo "Deploy FAILED (status: $STATUS)"
+      echo "--- stdout ---"
+      aws ssm get-command-invocation --region "$REGION" \
+        --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+        --query 'StandardOutputContent' --output text
+      echo "--- stderr ---"
+      aws ssm get-command-invocation --region "$REGION" \
+        --command-id "$COMMAND_ID" --instance-id "$INSTANCE_ID" \
+        --query 'StandardErrorContent' --output text
+      exit 1
+      ;;
+    InProgress|Pending|Delayed)
+      printf "."
+      ;;
+  esac
+done
+
+echo ""
+echo "Timed out waiting for command. Check manually:"
+echo "  aws ssm get-command-invocation --region $REGION --command-id $COMMAND_ID --instance-id $INSTANCE_ID"
+exit 1

--- a/ci3/dashboard/requirements.txt
+++ b/ci3/dashboard/requirements.txt
@@ -1,6 +1,7 @@
 flask
 gunicorn
 redis
+boto3
 ansi2html
 Flask-Compress
 requests

--- a/ci3/dashboard/rk.py
+++ b/ci3/dashboard/rk.py
@@ -21,7 +21,6 @@ from rk_core import (
     YELLOW, BLUE, GREEN, RED, PURPLE, BOLD, RESET,
     hyperlink, r, get_section_data, get_list_as_string
 )
-LOGS_DISK_PATH = os.getenv('LOGS_DISK_PATH', '/logs-disk')
 S3_LOGS_BUCKET = os.getenv('S3_LOGS_BUCKET', 'aztec-ci-artifacts')
 S3_LOGS_PREFIX = os.getenv('S3_LOGS_PREFIX', 'logs')
 
@@ -77,17 +76,6 @@ def optional_auth(f):
         return auth.login_required(f)
     return f
 
-def read_from_disk(key):
-    """Read log from disk."""
-    try:
-        prefix = key[:4]
-        log_file = f"{LOGS_DISK_PATH}/{prefix}/{key}.log.gz"
-        if os.path.exists(log_file):
-            with gzip.open(log_file, 'rb') as f:
-                return f.read().decode('utf-8', errors='replace')
-    except Exception as e:
-        print(f"Error reading from disk: {e}")
-    return None
 
 def read_from_s3(key):
     """Read log from S3 (fallback when Redis and disk both miss)."""
@@ -103,30 +91,38 @@ def read_from_s3(key):
         print(f"Error reading from S3: {e}")
     return None
 
-def read_breakdown_from_disk(runtime, flow_name, sha):
-    """Read benchmark breakdown JSON from disk."""
+def read_breakdown_from_s3(runtime, flow_name, sha):
+    """Read benchmark breakdown from S3."""
+    breakdown_name = f"{runtime}-{flow_name}-{sha}"
+    s3_prefix = f"{S3_LOGS_PREFIX}/bench/bb-breakdown"
+
+    # Exact match
     try:
-        # Breakdown files are stored in {LOGS_DISK_PATH}/bench/bb-breakdown/
-        # Format: <runtime>-<flow_name>-<sha>.log.gz
-        # SHA can be 7-40 chars (prefix or full)
-        breakdown_dir = f"{LOGS_DISK_PATH}/bench/bb-breakdown"
-
-        # First try exact match
-        breakdown_file = f"{breakdown_dir}/{runtime}-{flow_name}-{sha}.log.gz"
-        if os.path.exists(breakdown_file):
-            with gzip.open(breakdown_file, 'rb') as f:
-                return f.read().decode('utf-8', errors='replace')
-
-        # If not found, search for files starting with the SHA prefix
-        if os.path.exists(breakdown_dir):
-            prefix = f"{runtime}-{flow_name}-{sha}"
-            for filename in os.listdir(breakdown_dir):
-                if filename.startswith(prefix) and filename.endswith('.log.gz'):
-                    breakdown_file = os.path.join(breakdown_dir, filename)
-                    with gzip.open(breakdown_file, 'rb') as f:
-                        return f.read().decode('utf-8', errors='replace')
+        s3_key = f"{s3_prefix}/{breakdown_name}.log.gz"
+        obj = _s3.get_object(Bucket=S3_LOGS_BUCKET, Key=s3_key)
+        return gzip.decompress(obj['Body'].read()).decode('utf-8', errors='replace')
+    except ClientError as e:
+        if e.response['Error']['Code'] != 'NoSuchKey':
+            print(f"S3 error reading breakdown {breakdown_name}: {e}")
     except Exception as e:
-        print(f"Error reading breakdown from disk: {e}")
+        print(f"Error reading breakdown from S3: {e}")
+
+    # Prefix search (SHA may be a prefix)
+    try:
+        list_prefix = f"{s3_prefix}/{breakdown_name}"
+        paginator = _s3.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=S3_LOGS_BUCKET, Prefix=list_prefix):
+            for obj in page.get('Contents', []):
+                key = obj['Key']
+                if key.endswith('.log.gz'):
+                    try:
+                        resp = _s3.get_object(Bucket=S3_LOGS_BUCKET, Key=key)
+                        return gzip.decompress(resp['Body'].read()).decode('utf-8', errors='replace')
+                    except Exception:
+                        pass
+    except Exception as e:
+        print(f"S3 prefix search failed for breakdown {breakdown_name}: {e}")
+
     return None
 
 @auth.verify_password
@@ -420,44 +416,44 @@ def chonk_breakdowns():
 @app.route('/api/breakdown/flows')
 @optional_auth
 def list_available_flows():
-    """API endpoint to list available breakdown flows from disk, filtered by runtime and SHA."""
+    """API endpoint to list available breakdown flows from S3, filtered by runtime and SHA."""
     runtime = request.args.get('runtime')
     sha = request.args.get('sha')
     flows = set()
-    breakdown_dir = f"{LOGS_DISK_PATH}/bench/bb-breakdown"
+    s3_prefix = f"{S3_LOGS_PREFIX}/bench/bb-breakdown/"
 
     try:
-        if os.path.exists(breakdown_dir):
-            for filename in os.listdir(breakdown_dir):
-                if filename.endswith('.log.gz'):
-                    # Parse: runtime-flow_name-sha.log.gz
-                    parts = filename.replace('.log.gz', '').split('-', 1)
-                    if len(parts) == 2:
-                        file_runtime = parts[0]
-                        rest = parts[1]
-                        # Split from end to get SHA (7-40 chars)
-                        last_dash = rest.rfind('-')
-                        if last_dash != -1:
-                            flow_name = rest[:last_dash]
-                            file_sha = rest[last_dash + 1:]
+        paginator = _s3.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=S3_LOGS_BUCKET, Prefix=s3_prefix):
+            for obj in page.get('Contents', []):
+                filename = obj['Key'][len(s3_prefix):]
+                if not filename.endswith('.log.gz'):
+                    continue
+                parts = filename.replace('.log.gz', '').split('-', 1)
+                if len(parts) == 2:
+                    file_runtime = parts[0]
+                    rest = parts[1]
+                    last_dash = rest.rfind('-')
+                    if last_dash != -1:
+                        flow_name = rest[:last_dash]
+                        file_sha = rest[last_dash + 1:]
 
-                            # Filter by runtime and SHA if provided
-                            if runtime and file_runtime != runtime:
-                                continue
-                            if sha and not file_sha.startswith(sha):
-                                continue
+                        if runtime and file_runtime != runtime:
+                            continue
+                        if sha and not file_sha.startswith(sha):
+                            continue
 
-                            flows.add(flow_name)
+                        flows.add(flow_name)
     except Exception as e:
-        print(f"Error listing flows: {e}")
+        print(f"Error listing flows from S3: {e}")
 
     return Response(json.dumps(sorted(list(flows))), mimetype='application/json')
 
 @app.route('/api/breakdown/<runtime>/<flow_name>/<sha>')
 @optional_auth
 def get_breakdown(runtime, flow_name, sha):
-    """API endpoint to fetch breakdown JSON from disk."""
-    breakdown_data = read_breakdown_from_disk(runtime, flow_name, sha)
+    """API endpoint to fetch breakdown JSON."""
+    breakdown_data = read_breakdown_from_s3(runtime, flow_name, sha)
     if breakdown_data:
         return Response(breakdown_data, mimetype='application/json')
 
@@ -621,8 +617,6 @@ def get_value(key):
         key = key[:-4]  # Remove .txt extension
 
     value = r.get(key)
-    if value is None:
-        value = read_from_disk(key)
     if value is None:
         value = read_from_s3(key)
     if value is None:

--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
-status=${1:-RUNNING}
-key=${2:-}
+key=${1:?usage: log_ci_run <key> [status]}
+status=${2:-RUNNING}
 
 if [ -z "${RUN_ID:-}" ]; then
   echo_stderr "No RUN_ID set in log_ci_run. This ci run won't be seen on the dashboards."
@@ -26,8 +26,7 @@ else
   range_key="ci-run-$CI_DASHBOARD"
 fi
 
-if [ -z "$key" ]; then
-  key=$(date +%s%3N)
+if [ "$status" = "RUNNING" ]; then
   msg=$(git log -1 --pretty=format:"%s")
   author="$(git log -1 --pretty=format:"%an")"
   name=$REF_NAME

--- a/ci3/source_cache
+++ b/ci3/source_cache
@@ -1,6 +1,34 @@
-# Disk-based cache system for CI logs.
-# Logs are written to /logs-disk on bastion via SSH.
+# Cache system for CI logs.
+# Logs are written to Redis (synchronous) and S3 (background).
+# Legacy disk transfer functions (SSH to bastion) are kept but no longer used in normal flow.
 # NOTE: This file depends on source_redis being sourced first.
+
+# Transfer log to S3 (accepts gzipped data on stdin).
+# Usage: cat file.gz | cache_s3_transfer <key>
+# S3 path: <CI_LOGS_S3_LOCATION>/logs/<prefix>/<key>.log.gz
+function cache_s3_transfer {
+  local key="$1"
+  local prefix="${key:0:4}"
+  local location="${CI_LOGS_S3_LOCATION:-s3://aztec-ci-artifacts/logs}"
+  local no_scheme="${location#s3://}"
+  local bucket="${no_scheme%%/*}"
+  local base_prefix="${no_scheme#*/}"
+
+  aws s3 ${S3_BUILD_CACHE_AWS_PARAMS} cp - "s3://${bucket}/${base_prefix}/${prefix}/${key}.log.gz" &>/dev/null
+}
+
+# Transfer to S3 with explicit subfolder (accepts gzipped data on stdin).
+# Usage: cat file.gz | cache_s3_transfer_to <subfolder> <key>
+function cache_s3_transfer_to {
+  local subfolder="$1"
+  local key="$2"
+  local location="${CI_LOGS_S3_LOCATION:-s3://aztec-ci-artifacts/logs}"
+  local no_scheme="${location#s3://}"
+  local bucket="${no_scheme%%/*}"
+  local base_prefix="${no_scheme#*/}"
+
+  aws s3 ${S3_BUILD_CACHE_AWS_PARAMS} cp - "s3://${bucket}/${base_prefix}/${subfolder}/${key}.log.gz" &>/dev/null
+}
 
 # Transfer log to bastion via SSH (accepts gzipped data on stdin)
 # Usage: cat file.gz | cache_disk_transfer <key>
@@ -18,39 +46,34 @@ function cache_disk_transfer {
 
 # Transfer to bastion with explicit subfolder (accepts gzipped data on stdin)
 # Usage: cat file.gz | cache_disk_transfer_to <subfolder> <key>
+# Legacy: transfer to bastion disk via SSH. Kept for fallback but no longer called in normal flow.
 function cache_disk_transfer_to {
   local subfolder="$1"
   local key="$2"
 
-  # Transfer via SSH pipe using persistent multiplexed connection
   ssh -F "${ci3}/aws/build_instance_ssh_config" \
       -o ConnectTimeout=5 \
       ci-bastion.aztecprotocol.com \
       "mkdir -p /logs-disk/${subfolder} && cat > /logs-disk/${subfolder}/${key}.log.gz" &>/dev/null
 }
 
-# Persistent cache function that writes to both Redis and disk
+# Persistent cache function that writes to both Redis and S3
 function cache_persistent {
   local key="$1"
   local expire="$2"
   local tmpfile="/tmp/cache_log_$$_${key}.gz"
 
-  # Save gzipped data to temp file (synchronous - must complete first)
   cat | gzip > "$tmpfile"
 
-  # Write to Redis (synchronous - must complete before returning)
+  # Write to Redis (synchronous)
   cat "$tmpfile" | redis_cli -x SETEX "$key" "$expire" &>/dev/null
 
-  # Transfer to bastion disk in background (only if disk logging enabled)
-  if [ "${CI_USE_BUILD_INSTANCE_KEY:-0}" -eq 1 ]; then
-    {
-      cat "$tmpfile" | cache_disk_transfer "$key"
-      rm -f "$tmpfile"
-    } >&- 2>&- &
-  else
+  # Write to S3 in background
+  {
+    cat "$tmpfile" | cache_s3_transfer "$key"
     rm -f "$tmpfile"
-  fi
+  } >&- 2>&- &
 }
 
 # Export functions
-export -f cache_disk_transfer cache_disk_transfer_to cache_persistent
+export -f cache_s3_transfer cache_s3_transfer_to cache_disk_transfer cache_disk_transfer_to cache_persistent

--- a/ci3/source_redis
+++ b/ci3/source_redis
@@ -11,7 +11,7 @@ if [ -z "${CI_REDIS_AVAILABLE:-}" ]; then
   if nc -z $CI_REDIS 6379 &>/dev/null; then
     # Redis is found at given host, we're done.
     export CI_REDIS_AVAILABLE=1
-  elif [ -f ~/.ssh/build_instance_key ]; then
+  elif [ -f ~/.ssh/build_instance_key ] && [ "${CI_SSM_MODE:-0}" -eq 0 ]; then
     # We have the build_instance_key.
     # Attempt to open a port to the remote redis cache via ssh through the bastion.
     echo_stderr "Opening port to remote redis..."

--- a/ci3/ssm_send_command
+++ b/ci3/ssm_send_command
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# ssm_send_command - Send a shell script to an EC2 instance via SSM and wait for completion.
+#
+# Usage:
+#   ssm_send_command <instance-id> <script-string>
+#   ssm_send_command <instance-id> - < script_file
+#
+# Env:
+#   SSM_RUN_AS       - User to run the command as (default: no runuser wrapper).
+#   SSM_POLL_TIMEOUT - Max seconds to poll for completion (default: 7200 = 2h).
+#   SSM_NO_WAIT      - If set to 1, fire-and-forget: send the command and exit 0 immediately.
+#   AWS_DEFAULT_REGION - Region (default: us-east-2).
+#
+# Behaviour:
+#   1. Base64-encodes the script and sends it via AWS-RunShellScript.
+#   2. Polls get-command-invocation every 5s, printing stdout/stderr as it arrives.
+#   3. Exits with the remote command's exit code.
+
+set -euo pipefail
+
+iid=${1:?"usage: ssm_send_command <instance-id> <script | ->"}
+shift
+
+# Read the script: from argument or from stdin when "-" is given.
+if [ "${1:-}" = "-" ]; then
+  script=$(cat)
+else
+  script=${1:?"usage: ssm_send_command <instance-id> <script | ->"}
+fi
+
+region=${AWS_DEFAULT_REGION:-us-east-2}
+
+# --- Step 1: Encode and send ---
+# Base64-encode the script so it survives JSON embedding without quoting issues.
+# On Linux base64 uses -w 0 for no line wrapping; on macOS that flag doesn't exist.
+encoded=$(printf '%s' "$script" | base64 -w 0 2>/dev/null || printf '%s' "$script" | base64)
+
+# Build the shell command that SSM will execute on the instance:
+#   1. Decode the base64 payload into a temp file
+#   2. Optionally wrap with runuser if SSM_RUN_AS is set
+#   3. Execute it with bash
+if [ -n "${SSM_RUN_AS:-}" ]; then
+  run_prefix="runuser -u $SSM_RUN_AS -- "
+else
+  run_prefix=""
+fi
+
+ssm_params=$(jq -n --arg e "$encoded" --arg p "$run_prefix" \
+  '{commands: ["f=$(mktemp /tmp/ssm_cmd.XXXXXX); echo " + ($e | @json) + " | base64 -d > $f; chmod 644 $f; " + $p + "bash $f; ret=$?; rm -f $f; exit $ret"]}')
+
+command_id=$(aws ssm send-command \
+  --region "$region" \
+  --instance-ids "$iid" \
+  --document-name "AWS-RunShellScript" \
+  --parameters "$ssm_params" \
+  --query "Command.CommandId" \
+  --output text)
+
+if [ -z "$command_id" ] || [ "$command_id" = "None" ]; then
+  echo "Failed to send SSM command to instance $iid" >&2
+  exit 1
+fi
+
+echo "SSM command $command_id sent to $iid" >&2
+
+# --- Step 2: Optionally skip polling (fire-and-forget) ---
+if [ "${SSM_NO_WAIT:-0}" -eq 1 ]; then
+  exit 0
+fi
+
+# --- Step 3: Poll for completion ---
+# We poll get-command-invocation every 5 seconds.
+# StandardOutputContent / StandardErrorContent are cumulative snapshots of the
+# first 24KB of output. Each poll returns the *full* buffer so far, so we track
+# how many characters we've already printed and only emit the new portion.
+SSM_POLL_TIMEOUT=${SSM_POLL_TIMEOUT:-7200}
+poll_start=$SECONDS
+prev_stdout_len=0
+prev_stderr_len=0
+
+while true; do
+  if (( SECONDS - poll_start >= SSM_POLL_TIMEOUT )); then
+    echo "SSM command polling timed out after ${SSM_POLL_TIMEOUT}s." >&2
+    exit 1
+  fi
+
+  inv=$(aws ssm get-command-invocation \
+    --region "$region" \
+    --command-id "$command_id" \
+    --instance-id "$iid" \
+    --output json 2>/dev/null || echo '{}')
+
+  status=$(printf '%s' "$inv" | jq -r '.Status // "Unknown"')
+  stdout=$(printf '%s' "$inv" | jq -r '.StandardOutputContent // ""')
+  stderr=$(printf '%s' "$inv" | jq -r '.StandardErrorContent // ""')
+
+  # Print only the new portion of stdout/stderr since the last poll.
+  new_stdout=${stdout:$prev_stdout_len}
+  new_stderr=${stderr:$prev_stderr_len}
+  [ -n "$new_stdout" ] && printf "%s" "$new_stdout"
+  [ -n "$new_stderr" ] && printf "%s" "$new_stderr" >&2
+  prev_stdout_len=${#stdout}
+  prev_stderr_len=${#stderr}
+
+  case "$status" in
+    Success|Cancelled|TimedOut|Failed)
+      break
+      ;;
+    *)
+      sleep 5
+      ;;
+  esac
+done
+
+# --- Step 4: Exit with the remote exit code ---
+exit_code=$(printf '%s' "$inv" | jq -r '.ResponseCode // 1')
+exit "$exit_code"


### PR DESCRIPTION
## Summary

Migrates all CI build orchestration from SSH to AWS Systems Manager (SSM) as the default, with SSH preserved as a fallback via `CI_USE_SSH=1`. OIDC federation replaces static AWS credentials. The CI dashboard now reads logs exclusively from Redis + S3 (disk reads removed).

## Changes by file

| File | Change | Consequence |
|---|---|---|
| `.github/workflows/ci3.yml` | OIDC permissions, `aws-actions/configure-aws-credentials@v4`, `ci-ssm` label override, `CI_USE_SSH` from repo variable | SSM mode is default; SSH via variable toggle; per-PR override via label |
| `.github/ci3.sh` | AWS creds conditional on `CI_USE_SSH=1`; validates `CI3_INSTANCE_PROFILE_NAME` and `CI3_SECURITY_GROUP_ID` in SSM mode | No static AWS keys needed in SSM mode |
| `ci.sh` | All CI modes use `bootstrap_ssm_with_link`; SSH fallback via `CI_USE_SSH=1`; SSM shell commands; pre-generated `CI_LOG_ID` | Single entry point switches between SSM and SSH |
| `ci3/bootstrap_ssm` | **New file** — SSM equivalent of `bootstrap_ec2`: launches EC2 without key pair, waits for SSM agent, sends command via `send-command`, polls for completion, handles spot eviction | Replaces SSH for remote build execution |
| `ci3/aws_request_instance_type` | Conditional `KeyName`, `IamInstanceProfile`, `SecurityGroupIds`, skip SSH wait when no key | Supports both SSH and SSM launch modes |
| `ci3/source_cache` | `cache_persistent` always writes Redis + S3 (no flags); S3 transfer functions added; disk functions kept as legacy dead code | Logs always land in S3 regardless of mode |
| `ci3/source_redis` | Skip SSH tunnel when `CI_SSM_MODE=1` | Direct Redis access via security group |
| `ci3/cache_upload` | Skip AWS key check when `CI_SSM_MODE=1` | Uses instance profile (IMDS) for credentials |
| `ci3/log_ci_run` | Use pre-generated `CI_LOG_ID` if set | SSM can't return values mid-run |
| `ci3/dashboard/rk.py` | Removed all disk-based reads; Redis -> S3 only; `list_available_flows` reads S3 | Dashboard no longer needs `/logs-disk` volume mount |
| `ci3/dashboard/requirements.txt` | Added `boto3` | S3 SDK dependency |
| `ci3/dashboard/deploy-test.sh` | **New file** — deploys test dashboard instance via SSM on ports 8082/8083 | Test dashboard without SSH access |

## How to test

- Add `ci-ssm` label to this PR to force SSM mode
- Toggle `CI_USE_SSH` repo variable in Settings > Variables > Actions
- Test dashboard at `ci.aztec-labs.com:8082`
- Verify logs appear in S3 and on dashboard after a CI run

## Rollback

- Set `CI_USE_SSH=1` in repo variables (Settings > Variables > Actions) to revert globally
- All SSH infrastructure (keys, secrets, bastion) remains intact as fallback
- Per-PR: remove `ci-ssm` label to use global setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)