### PR TITLE
feat: worker thread wallet

### DIFF
--- a/yarn-project/end-to-end/src/spartan/n_tps_prove.test.ts
+++ b/yarn-project/end-to-end/src/spartan/n_tps_prove.test.ts
@@ -1,6 +1,9 @@
-import { NO_WAIT } from '@aztec/aztec.js/contracts';
+import { SchnorrAccountContract } from '@aztec/accounts/schnorr';
+import { AztecAddress } from '@aztec/aztec.js/addresses';
+import { toSendOptions } from '@aztec/aztec.js/contracts';
 import { SponsoredFeePaymentMethod } from '@aztec/aztec.js/fee';
 import { type AztecNode, createAztecNodeClient } from '@aztec/aztec.js/node';
+import { AccountManager } from '@aztec/aztec.js/wallet';
 import { RollupCheatCodes } from '@aztec/aztec/testing';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
@@ -13,6 +16,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { DateProvider } from '@aztec/foundation/timer';
 import { BenchmarkingContract } from '@aztec/noir-test-contracts.js/Benchmarking';
 import { GasFees } from '@aztec/stdlib/gas';
+import { deriveSigningKey } from '@aztec/stdlib/keys';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
@@ -20,15 +24,10 @@ import type { ChildProcess } from 'child_process';
 import { mkdir, writeFile } from 'fs/promises';
 import { dirname } from 'path';
 
-import { getSponsoredFPCAddress } from '../fixtures/utils.js';
+import { getSponsoredFPCAddress, registerSponsoredFPC } from '../fixtures/utils.js';
 import { PrometheusClient } from '../quality_of_service/prometheus_client.js';
-import type { TestWallet } from '../test-wallet/test_wallet.js';
-import { ProvenTx, proveInteraction } from '../test-wallet/utils.js';
-import {
-  type WalletWrapper,
-  createWalletAndAztecNodeClient,
-  deploySponsoredTestAccounts,
-} from './setup_test_wallets.js';
+import type { WorkerWallet } from '../test-wallet/worker_wallet.js';
+import { type WorkerWalletWrapper, createWorkerWalletClient } from './setup_test_wallets.js';
 import { ProvingMetrics } from './tx_metrics.js';
 import {
   getExternalIP,
@@ -99,9 +98,10 @@ type MetricsSnapshot = {
 
 /** A wallet that produces transactions in the background. */
 type WalletTxProducer = {
-  wallet: TestWallet;
-  prototypeTx: ProvenTx | undefined; // Each wallet's own prototype (for fake proving)
-  readyTx: ProvenTx | null;
+  wallet: WorkerWallet;
+  accountAddress: AztecAddress;
+  prototypeTx: Tx | undefined; // Each wallet's own prototype (for fake proving)
+  readyTx: Tx | null;
 };
 
 describe(`prove ${TARGET_TPS}TPS test`, () => {
@@ -110,8 +110,9 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
 
   const logger = createLogger(`e2e:spartan-test:prove-${TARGET_TPS}tps`);
 
-  let testWallets: WalletWrapper[];
-  let wallets: TestWallet[];
+  let testWallets: WorkerWalletWrapper[];
+  let wallets: WorkerWallet[];
+  let accountAddresses: AztecAddress[];
   let producers: WalletTxProducer[];
 
   let producerAbortController: AbortController;
@@ -267,18 +268,41 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
     logger.info(`Creating ${NUM_WALLETS} wallet(s)...`);
     testWallets = await timesAsync(NUM_WALLETS, i => {
       logger.info(`Creating wallet ${i + 1}/${NUM_WALLETS}`);
-      return createWalletAndAztecNodeClient(rpcUrl, config.REAL_VERIFIER, logger);
+      return createWorkerWalletClient(rpcUrl, config.REAL_VERIFIER, logger);
     });
+    wallets = testWallets.map(tw => tw.wallet);
 
-    const localTestAccounts = await Promise.all(
-      testWallets.map(tw => deploySponsoredTestAccounts(tw.wallet, aztecNode, logger, 0)),
-    );
-    wallets = localTestAccounts.map(acc => acc.wallet);
+    // Register FPC and create/deploy accounts
+    const fpcAddress = await getSponsoredFPCAddress();
+    const sponsor = new SponsoredFeePaymentMethod(fpcAddress);
+    accountAddresses = [];
+    for (const wallet of wallets) {
+      const secret = Fr.random();
+      const salt = Fr.random();
+      // Register account inside worker (populates TestWallet.accounts map)
+      const address = await wallet.registerAccount(secret, salt);
+      // Register FPC in worker's PXE
+      await registerSponsoredFPC(wallet);
+      // Deploy via standard AccountManager flow (from: ZERO -> SignerlessAccount, no account lookup)
+      const manager = await AccountManager.create(
+        wallet,
+        secret,
+        new SchnorrAccountContract(deriveSigningKey(secret)),
+        salt,
+      );
+      const deployMethod = await manager.getDeployMethod();
+      await deployMethod.send({
+        from: AztecAddress.ZERO,
+        fee: { paymentMethod: sponsor },
+        wait: { timeout: 2400 },
+      });
+      logger.info(`Account deployed at ${address}`);
+      accountAddresses.push(address);
+    }
 
     logger.info('Deploying benchmark contract...');
-    const sponsor = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
-    benchmarkContract = await BenchmarkingContract.deploy(localTestAccounts[0].wallet).send({
-      from: localTestAccounts[0].recipientAddress,
+    benchmarkContract = await BenchmarkingContract.deploy(wallets[0]).send({
+      from: accountAddresses[0],
       fee: { paymentMethod: sponsor },
     });
 
@@ -288,9 +312,12 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
   beforeEach(async () => {
     logger.info(`Creating ${wallets.length} tx producers`);
     producers = await Promise.all(
-      wallets.map(async wallet => {
-        const proto = config.REAL_VERIFIER ? undefined : await createTx(wallet, benchmarkContract, logger);
-        return { wallet, prototypeTx: proto, readyTx: null };
+      wallets.map(async (wallet, i) => {
+        const accountAddress = accountAddresses[i];
+        const proto = config.REAL_VERIFIER
+          ? undefined
+          : await createTx(wallet, accountAddress, benchmarkContract, logger);
+        return { wallet, accountAddress, prototypeTx: proto, readyTx: null };
       }),
     );
 
@@ -362,7 +389,8 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
       // consume tx
       const tx = producer.readyTx;
       producer.readyTx = null;
-      sentTxs.push(await tx.send({ wait: NO_WAIT }));
+      await aztecNode.sendTx(tx);
+      sentTxs.push(tx.getTxHash());
 
       logger.info(`Sent tx ${i + 1}/${txsToSend}`);
 
@@ -486,48 +514,51 @@ describe(`prove ${TARGET_TPS}TPS test`, () => {
 });
 
 async function createTx(
-  wallet: TestWallet,
+  wallet: WorkerWallet,
+  accountAddress: AztecAddress,
   benchmarkContract: BenchmarkingContract,
   logger: Logger,
-): Promise<ProvenTx> {
+): Promise<Tx> {
   logger.info('Creating prototype transaction...');
   const sponsor = new SponsoredFeePaymentMethod(await getSponsoredFPCAddress());
-  const tx = await proveInteraction(wallet, benchmarkContract.methods.sha256_hash_1024(Array(1024).fill(42)), {
-    from: (await wallet.getAccounts())[0].item,
+  const options = {
+    from: accountAddress,
     fee: { paymentMethod: sponsor, gasSettings: { maxPriorityFeesPerGas: GasFees.empty() } },
-  });
+  };
+  const interaction = benchmarkContract.methods.sha256_hash_1024(Array(1024).fill(42));
+  const execPayload = await interaction.request(options);
+  const tx = await wallet.proveTx(execPayload, toSendOptions(options));
   logger.info('Prototype transaction created');
   return tx;
 }
 
-async function cloneTx(tx: ProvenTx, aztecNode: AztecNode): Promise<ProvenTx> {
-  const clonedTxData = Tx.clone(tx, false);
+async function cloneTx(tx: Tx, aztecNode: AztecNode): Promise<Tx> {
+  const clonedTx = Tx.clone(tx, false);
 
   // Fetch current minimum fees and apply 50% buffer for safety
   const currentFees = await aztecNode.getCurrentMinFees();
   const paddedFees = currentFees.mul(1.5);
 
   // Update gas settings with current fees
-  (clonedTxData.data.constants.txContext.gasSettings as any).maxFeesPerGas = paddedFees;
+  (clonedTx.data.constants.txContext.gasSettings as any).maxFeesPerGas = paddedFees;
 
   // Randomize nullifiers to avoid conflicts
-  if (clonedTxData.data.forRollup) {
-    for (let i = 0; i < clonedTxData.data.forRollup.end.nullifiers.length; i++) {
-      if (clonedTxData.data.forRollup.end.nullifiers[i].isZero()) {
+  if (clonedTx.data.forRollup) {
+    for (let i = 0; i < clonedTx.data.forRollup.end.nullifiers.length; i++) {
+      if (clonedTx.data.forRollup.end.nullifiers[i].isZero()) {
         continue;
       }
-      clonedTxData.data.forRollup.end.nullifiers[i] = Fr.random();
+      clonedTx.data.forRollup.end.nullifiers[i] = Fr.random();
     }
-  } else if (clonedTxData.data.forPublic) {
-    for (let i = 0; i < clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers.length; i++) {
-      if (clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[i].isZero()) {
+  } else if (clonedTx.data.forPublic) {
+    for (let i = 0; i < clonedTx.data.forPublic.nonRevertibleAccumulatedData.nullifiers.length; i++) {
+      if (clonedTx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[i].isZero()) {
         continue;
       }
-      clonedTxData.data.forPublic.nonRevertibleAccumulatedData.nullifiers[i] = Fr.random();
+      clonedTx.data.forPublic.nonRevertibleAccumulatedData.nullifiers[i] = Fr.random();
     }
   }
 
-  const clonedTx = new ProvenTx((tx as any).node, clonedTxData, tx.offchainEffects, tx.stats);
   await clonedTx.recomputeHash();
   return clonedTx;
 }
@@ -548,7 +579,7 @@ async function startProducing(
 
     try {
       const tx = config.REAL_VERIFIER
-        ? await createTx(producer.wallet, benchmarkContract, logger)
+        ? await createTx(producer.wallet, producer.accountAddress, benchmarkContract, logger)
         : await cloneTx(producer.prototypeTx!, aztecNode);
 
       producer.readyTx = tx;

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -20,6 +20,7 @@ import { getBBConfig } from '../fixtures/get_bb_config.js';
 import { getSponsoredFPCAddress, registerSponsoredFPC } from '../fixtures/utils.js';
 import { TestWallet } from '../test-wallet/test_wallet.js';
 import { proveInteraction } from '../test-wallet/utils.js';
+import { WorkerWallet } from '../test-wallet/worker_wallet.js';
 
 export interface TestAccounts {
   aztecNode: AztecNode;
@@ -394,6 +395,45 @@ export async function createWalletAndAztecNodeClient(
       await wallet.stop();
       await bbConfig?.cleanup();
       await acvmConfig?.cleanup();
+    },
+  };
+}
+
+export type WorkerWalletWrapper = {
+  wallet: WorkerWallet;
+  aztecNode: AztecNode;
+  cleanup: () => Promise<void>;
+};
+
+export async function createWorkerWalletClient(
+  nodeUrl: string,
+  proverEnabled: boolean,
+  logger: Logger,
+): Promise<WorkerWalletWrapper> {
+  const aztecNode = createAztecNodeClient(nodeUrl);
+  const [bbConfig, acvmConfig] = await Promise.all([getBBConfig(logger), getACVMConfig(logger)]);
+
+  // Strip cleanup functions — they can't be structured-cloned for worker transfer
+  const { cleanup: bbCleanup, ...bbPaths } = bbConfig ?? {};
+  const { cleanup: acvmCleanup, ...acvmPaths } = acvmConfig ?? {};
+
+  const pxeConfig = {
+    dataDirectory: undefined,
+    dataStoreMapSizeKb: 1024 * 1024,
+    ...bbPaths,
+    ...acvmPaths,
+    proverEnabled,
+  };
+
+  const wallet = await WorkerWallet.create(nodeUrl, pxeConfig);
+
+  return {
+    wallet,
+    aztecNode,
+    async cleanup() {
+      await wallet.stop();
+      await bbCleanup?.();
+      await acvmCleanup?.();
     },
   };
 }

--- a/yarn-project/end-to-end/src/test-wallet/wallet_worker_script.ts
+++ b/yarn-project/end-to-end/src/test-wallet/wallet_worker_script.ts
@@ -1,0 +1,43 @@
+import { createAztecNodeClient } from '@aztec/aztec.js/node';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+import type { ApiSchema } from '@aztec/foundation/schemas';
+import { parseWithOptionals, schemaHasMethod } from '@aztec/foundation/schemas';
+import { NodeListener, TransportServer } from '@aztec/foundation/transport';
+
+import { workerData } from 'worker_threads';
+
+import { TestWallet } from './test_wallet.js';
+import { WorkerWalletSchema } from './worker_wallet_schema.js';
+
+const { nodeUrl, pxeConfig } = workerData as { nodeUrl: string; pxeConfig?: Record<string, unknown> };
+
+const node = createAztecNodeClient(nodeUrl);
+const wallet = await TestWallet.create(node, pxeConfig);
+
+/** Handlers for methods that need custom implementation (not direct wallet passthrough). */
+const handlers: Record<string, (...args: any[]) => Promise<any>> = {
+  proveTx: async (exec, opts) => {
+    const provenTx = await wallet.proveTx(exec, opts);
+    // ProvenTx has non-serializable fields (node proxy, etc.) — extract only Tx-compatible fields
+    const { data, chonkProof, contractClassLogFields, publicFunctionCalldata } = provenTx;
+    return { data, chonkProof, contractClassLogFields, publicFunctionCalldata };
+  },
+  registerAccount: async (secret, salt) => {
+    const manager = await wallet.createSchnorrAccount(secret, salt);
+    return manager.address;
+  },
+};
+
+const schema = WorkerWalletSchema as ApiSchema;
+const listener = new NodeListener();
+const server = new TransportServer<{ fn: string; args: string }>(listener, async msg => {
+  if (!schemaHasMethod(schema, msg.fn)) {
+    throw new Error(`Unknown method: ${msg.fn}`);
+  }
+  const jsonParams = JSON.parse(msg.args) as unknown[];
+  const args = await parseWithOptionals(jsonParams, schema[msg.fn].parameters());
+  const handler = handlers[msg.fn];
+  const result = handler ? await handler(...args) : await (wallet as any)[msg.fn](...args);
+  return jsonStringify(result);
+});
+server.start();

--- a/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
+++ b/yarn-project/end-to-end/src/test-wallet/worker_wallet.ts
@@ -1,0 +1,165 @@
+import type { CallIntent, IntentInnerHash } from '@aztec/aztec.js/authorization';
+import type { InteractionWaitOptions, SendReturn } from '@aztec/aztec.js/contracts';
+import type {
+  Aliased,
+  AppCapabilities,
+  BatchResults,
+  BatchedMethod,
+  ContractClassMetadata,
+  ContractMetadata,
+  PrivateEvent,
+  PrivateEventFilter,
+  ProfileOptions,
+  SendOptions,
+  SimulateOptions,
+  SimulateUtilityOptions,
+  Wallet,
+  WalletCapabilities,
+} from '@aztec/aztec.js/wallet';
+import type { ChainInfo } from '@aztec/entrypoints/interfaces';
+import type { Fr } from '@aztec/foundation/curves/bn254';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
+import type { ApiSchema } from '@aztec/foundation/schemas';
+import { NodeConnector, TransportClient } from '@aztec/foundation/transport';
+import type { PXEConfig } from '@aztec/pxe/config';
+import type { ContractArtifact, EventMetadataDefinition, FunctionCall } from '@aztec/stdlib/abi';
+import type { AuthWitness } from '@aztec/stdlib/auth-witness';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
+import type { ExecutionPayload, TxProfileResult, TxSimulationResult, UtilitySimulationResult } from '@aztec/stdlib/tx';
+import { Tx } from '@aztec/stdlib/tx';
+
+import { Worker } from 'worker_threads';
+
+import { WorkerWalletSchema } from './worker_wallet_schema.js';
+
+type WorkerMsg = { fn: string; args: string };
+
+/**
+ * Wallet implementation that offloads all work to a worker thread.
+ * Implements the Wallet interface by proxying calls over a transport layer
+ * using JSON serialization with Zod schema parsing on both ends.
+ */
+export class WorkerWallet implements Wallet {
+  private constructor(
+    private worker: Worker,
+    private client: TransportClient<WorkerMsg>,
+  ) {}
+
+  /**
+   * Creates a WorkerWallet by spawning a worker thread that creates a TestWallet internally.
+   * @param nodeUrl - URL of the Aztec node to connect to.
+   * @param pxeConfig - Optional PXE configuration overrides.
+   * @returns A WorkerWallet ready to use.
+   */
+  static async create(nodeUrl: string, pxeConfig?: Partial<PXEConfig>): Promise<WorkerWallet> {
+    const worker = new Worker(new URL('./wallet_worker_script.js', import.meta.url), {
+      workerData: { nodeUrl, pxeConfig },
+    });
+
+    const connector = new NodeConnector(worker);
+    const client = new TransportClient<WorkerMsg>(connector);
+    await client.open();
+
+    const wallet = new WorkerWallet(worker, client);
+    // Warmup / readiness check — blocks until the worker has finished creating the TestWallet.
+    await wallet.getChainInfo();
+    return wallet;
+  }
+
+  private async callRaw(fn: string, ...args: any[]): Promise<string> {
+    const argsJson = jsonStringify(args);
+    return (await this.client.request({ fn, args: argsJson })) as string;
+  }
+
+  private async call(fn: string, ...args: any[]): Promise<any> {
+    const resultJson = await this.callRaw(fn, ...args);
+    const methodSchema = (WorkerWalletSchema as ApiSchema)[fn];
+    return methodSchema.returnType().parseAsync(JSON.parse(resultJson));
+  }
+
+  getChainInfo(): Promise<ChainInfo> {
+    return this.call('getChainInfo');
+  }
+
+  getContractMetadata(address: AztecAddress): Promise<ContractMetadata> {
+    return this.call('getContractMetadata', address);
+  }
+
+  getContractClassMetadata(id: Fr): Promise<ContractClassMetadata> {
+    return this.call('getContractClassMetadata', id);
+  }
+
+  getPrivateEvents<T>(
+    eventMetadata: EventMetadataDefinition,
+    eventFilter: PrivateEventFilter,
+  ): Promise<PrivateEvent<T>[]> {
+    return this.call('getPrivateEvents', eventMetadata, eventFilter);
+  }
+
+  registerSender(address: AztecAddress, alias?: string): Promise<AztecAddress> {
+    return this.call('registerSender', address, alias);
+  }
+
+  getAddressBook(): Promise<Aliased<AztecAddress>[]> {
+    return this.call('getAddressBook');
+  }
+
+  getAccounts(): Promise<Aliased<AztecAddress>[]> {
+    return this.call('getAccounts');
+  }
+
+  registerContract(
+    instance: ContractInstanceWithAddress,
+    artifact?: ContractArtifact,
+    secretKey?: Fr,
+  ): Promise<ContractInstanceWithAddress> {
+    return this.call('registerContract', instance, artifact, secretKey);
+  }
+
+  simulateTx(exec: ExecutionPayload, opts: SimulateOptions): Promise<TxSimulationResult> {
+    return this.call('simulateTx', exec, opts);
+  }
+
+  simulateUtility(call: FunctionCall, opts: SimulateUtilityOptions): Promise<UtilitySimulationResult> {
+    return this.call('simulateUtility', call, opts);
+  }
+
+  profileTx(exec: ExecutionPayload, opts: ProfileOptions): Promise<TxProfileResult> {
+    return this.call('profileTx', exec, opts);
+  }
+
+  sendTx<W extends InteractionWaitOptions = undefined>(
+    exec: ExecutionPayload,
+    opts: SendOptions<W>,
+  ): Promise<SendReturn<W>> {
+    return this.call('sendTx', exec, opts);
+  }
+
+  proveTx(exec: ExecutionPayload, opts: Omit<SendOptions, 'wait'>): Promise<Tx> {
+    return this.call('proveTx', exec, opts);
+  }
+
+  /** Registers an account inside the worker's TestWallet, populating its accounts map. */
+  registerAccount(secret: Fr, salt: Fr): Promise<AztecAddress> {
+    return this.call('registerAccount', secret, salt);
+  }
+
+  createAuthWit(from: AztecAddress, messageHashOrIntent: IntentInnerHash | CallIntent): Promise<AuthWitness> {
+    return this.call('createAuthWit', from, messageHashOrIntent);
+  }
+
+  requestCapabilities(manifest: AppCapabilities): Promise<WalletCapabilities> {
+    return this.call('requestCapabilities', manifest);
+  }
+
+  batch<const T extends readonly BatchedMethod[]>(methods: T): Promise<BatchResults<T>> {
+    return this.call('batch', methods);
+  }
+
+  /** Shuts down the worker thread and closes the transport. */
+  async stop(): Promise<void> {
+    this.client.close();
+    await this.worker.terminate();
+  }
+}

--- a/yarn-project/end-to-end/src/test-wallet/worker_wallet_schema.ts
+++ b/yarn-project/end-to-end/src/test-wallet/worker_wallet_schema.ts
@@ -1,0 +1,13 @@
+import { ExecutionPayloadSchema, SendOptionsSchema, WalletSchema } from '@aztec/aztec.js/wallet';
+import { schemas } from '@aztec/foundation/schemas';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { Tx } from '@aztec/stdlib/tx';
+
+import { z } from 'zod';
+
+/** Schema for the WorkerWallet API — extends WalletSchema with proveTx and registerAccount. */
+export const WorkerWalletSchema = {
+  ...WalletSchema,
+  proveTx: z.function().args(ExecutionPayloadSchema, SendOptionsSchema).returns(Tx.schema),
+  registerAccount: z.function().args(schemas.Fr, schemas.Fr).returns(AztecAddress.schema),
+};


### PR DESCRIPTION
This PR adds a worker-thread based wallet such that it can be used to drive high TPS from a single Jest test. (using N TestWallets doens't work because they all share singleton BB instance)