### PR TITLE
docs: fix avm docs - l2 gas is not the same as mana

### DIFF
--- a/yarn-project/simulator/docs/avm/README.md
+++ b/yarn-project/simulator/docs/avm/README.md
@@ -39,7 +39,7 @@ public execution requests.
 The AVM:
 * Executes specified public bytecode, instruction by instruction, given some arguments.
 * Meters execution by tracking gas costs per-executed-instruction.
-* Tracks both "mana" (aka L2 gas) and "data availability" gas.
+* Tracks both L2 gas (computation) and DA gas (data availability).
 * Supports nested contract calls and conditional error recovery.
 * Manages access to public state, L1↔L2 messages, public logs, and some limited private state.
 * Finalizes state updates initiated during private execution.

--- a/yarn-project/simulator/docs/avm/gas.md
+++ b/yarn-project/simulator/docs/avm/gas.md
@@ -1,10 +1,10 @@
 # Gas Metering
 
-The AVM tracks gas consumption across two dimensions: **L2 gas** (execution costs, also called **mana**) and **DA gas** (data availability costs).
+The AVM tracks gas consumption across two dimensions: **L2 gas** (execution costs) and **DA gas** (data availability costs). Note that L2 gas is _not_ the same as mana: mana is the higher-level unit of account that incorporates L2 gas, DA gas, and L1 gas costs together.
 
 ## Gas Dimensions
 
-* **L2 Gas** (mana): roughly represents the computational cost of executing (and especially proving) operations.
+* **L2 Gas**: roughly represents the computational cost of executing (and especially proving) operations.
 * **DA Gas**: represents the cost of publishing data to Layer 1 for data availability. This includes:
   - State updates that must be published to L1
   - Emitting logs


### PR DESCRIPTION
fix avm docs - l2 gas is not the same as mana