### PR TITLE
chore: rename simulateUtility -> executeUtility

### DIFF
--- a/docs/docs-developers/docs/resources/migration_notes.md
+++ b/docs/docs-developers/docs/resources/migration_notes.md
@@ -9,6 +9,27 @@ Aztec is in active development. Each version may introduce breaking changes that
 
 ## TBD
 
+### `simulateUtility` renamed to `executeUtility`
+
+The `simulateUtility` method and related types have been renamed to `executeUtility` across the entire stack to better reflect that utility functions are executed, not simulated.
+
+**TypeScript:**
+
+```diff
+- import { SimulateUtilityOptions, UtilitySimulationResult } from '@aztec/aztec.js';
++ import { ExecuteUtilityOptions, UtilityExecutionResult } from '@aztec/aztec.js';
+
+- const result: UtilitySimulationResult = await wallet.simulateUtility(functionCall, opts);
++ const result: UtilityExecutionResult = await wallet.executeUtility(functionCall, opts);
+```
+
+**Noir (test environment):**
+
+```diff
+- let result = env.simulate_utility(my_contract_address, selector);
++ let result = env.execute_utility(my_contract_address, selector);
+```
+
 ### [Protocol] `include_by_timestamp` renamed to `expiration_timestamp`
 
 The `include_by_timestamp` field has been renamed to `expiration_timestamp` across the protocol to better convey its meaning.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -550,14 +550,14 @@ impl TestEnvironment {
     /// ```noir
     /// let caller = env.create_light_account();
     /// let contract_addr = env.deploy("SampleContract").without_initializer();
-    /// let return_value = env.simulate_utility(SampleContract::at(contract_addr).sample_utility_function());
+    /// let return_value = env.execute_utility(SampleContract::at(contract_addr).sample_utility_function());
     /// ```
-    pub unconstrained fn simulate_utility<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
+    pub unconstrained fn execute_utility<let M: u32, let N: u32, T>(_self: Self, call: UtilityCall<M, N, T>) -> T
     where
         T: Deserialize,
     {
         let serialized_return_values =
-            txe_oracles::simulate_utility_function(call.target_contract, call.selector, call.args);
+            txe_oracles::execute_utility_function(call.target_contract, call.selector, call.args);
 
         T::deserialize(serialized_return_values)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -55,12 +55,12 @@ pub unconstrained fn public_call_new_flow<let M: u32, let N: u32>(
     public_call_new_flow_oracle(from, contract_address, calldata, is_static_call)
 }
 
-pub unconstrained fn simulate_utility_function<let M: u32, let N: u32>(
+pub unconstrained fn execute_utility_function<let M: u32, let N: u32>(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args: [Field; M],
 ) -> [Field; N] {
-    simulate_utility_function_oracle(contract_address, function_selector, args)
+    execute_utility_function_oracle(contract_address, function_selector, args)
 }
 
 #[oracle(txeGetNextBlockNumber)]
@@ -145,8 +145,8 @@ unconstrained fn public_call_new_flow_oracle<let M: u32, let N: u32>(
     is_static_call: bool,
 ) -> [Field; N] {}
 
-#[oracle(txeSimulateUtilityFunction)]
-unconstrained fn simulate_utility_function_oracle<let M: u32, let N: u32>(
+#[oracle(txeExecuteUtilityFunction)]
+unconstrained fn execute_utility_function_oracle<let M: u32, let N: u32>(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args: [Field; M],

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/test/test.nr
@@ -76,9 +76,9 @@ unconstrained fn add_liquidity_twice_and_remove_liquidity() {
     );
 
     // Liquidity provider 2 should have 0 token0 and the refund amount of token1
-    assert_eq(env.simulate_utility(token0.balance_of_private(liquidity_provider_2)), 0);
+    assert_eq(env.execute_utility(token0.balance_of_private(liquidity_provider_2)), 0);
     assert_eq(
-        env.simulate_utility(token1.balance_of_private(liquidity_provider_2)),
+        env.execute_utility(token1.balance_of_private(liquidity_provider_2)),
         expected_refund_amount1,
     );
 
@@ -86,7 +86,7 @@ unconstrained fn add_liquidity_twice_and_remove_liquidity() {
     let expected_liquidity_tokens =
         (expected_amount_0_in * initial_liquidity_token_supply) / initial_amount0;
     assert_eq(
-        env.simulate_utility(liquidity_token.balance_of_private(liquidity_provider_2)),
+        env.execute_utility(liquidity_token.balance_of_private(liquidity_provider_2)),
         expected_liquidity_tokens,
     );
 
@@ -111,17 +111,17 @@ unconstrained fn add_liquidity_twice_and_remove_liquidity() {
     let expected_token1_back =
         (liquidity_to_remove * initial_amount1) / initial_liquidity_token_supply;
     assert_eq(
-        env.simulate_utility(token0.balance_of_private(liquidity_provider_1)),
+        env.execute_utility(token0.balance_of_private(liquidity_provider_1)),
         expected_token0_back,
     );
     assert_eq(
-        env.simulate_utility(token1.balance_of_private(liquidity_provider_1)),
+        env.execute_utility(token1.balance_of_private(liquidity_provider_1)),
         expected_token1_back,
     );
 
     // Check remaining liquidity tokens
     assert_eq(
-        env.simulate_utility(liquidity_token.balance_of_private(liquidity_provider_1)),
+        env.execute_utility(liquidity_token.balance_of_private(liquidity_provider_1)),
         // The expected remaining liquidity is the other half of the initial liquidity.
         AMM::INITIAL_LIQUIDITY / 2,
     );
@@ -182,9 +182,9 @@ unconstrained fn swap_exact_tokens_for_tokens() {
     );
 
     // Verify swap occurred - all of input tokens should be spent and hence the swapper should have 0 token0 balance.
-    assert_eq(env.simulate_utility(token0.balance_of_private(swapper)), 0);
+    assert_eq(env.execute_utility(token0.balance_of_private(swapper)), 0);
     // The exact amount out depends on the AMM formula, but should be > amount_out_min
-    assert(env.simulate_utility(token1.balance_of_private(swapper)) >= amount_out_min);
+    assert(env.execute_utility(token1.balance_of_private(swapper)) >= amount_out_min);
 }
 
 #[test]
@@ -243,9 +243,9 @@ unconstrained fn swap_tokens_for_exact_tokens() {
     );
 
     // Verify swap occurred - should get exact amount out
-    assert_eq(env.simulate_utility(token1.balance_of_private(swapper)), amount_out);
+    assert_eq(env.execute_utility(token1.balance_of_private(swapper)), amount_out);
     // Should have some token0 change returned
-    let swapper_token0_balance = env.simulate_utility(token0.balance_of_private(swapper));
+    let swapper_token0_balance = env.execute_utility(token0.balance_of_private(swapper));
     assert(swapper_token0_balance > 0);
     assert(swapper_token0_balance < amount_in_max);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -72,7 +72,7 @@ pub unconstrained fn assert_owns_private_nft(
     token_id: Field,
 ) {
     let (private_nfts, _) =
-        env.simulate_utility(NFT::at(nft_contract_address).get_private_nfts(owner, 0));
+        env.execute_utility(NFT::at(nft_contract_address).get_private_nfts(owner, 0));
 
     let mut nft_found = false;
     for obtained_token_id in private_nfts {

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/test/test.nr
@@ -45,7 +45,7 @@ unconstrained fn full_flow() {
     );
 
     // Get order and verify it's active
-    let (order, is_fulfilled) = env.simulate_utility(orderbook.get_order(order_id));
+    let (order, is_fulfilled) = env.execute_utility(orderbook.get_order(order_id));
 
     assert_eq(order.bid_amount, BID_AMOUNT);
     assert_eq(order.ask_amount, ASK_AMOUNT);
@@ -54,7 +54,7 @@ unconstrained fn full_flow() {
 
     // Verify that all maker's tokens were transferred to orderbook's public balance
     assert_eq(env.view_public(token0.balance_of_public(orderbook_address)), BID_AMOUNT);
-    assert_eq(env.simulate_utility(token0.balance_of_private(maker)), 0);
+    assert_eq(env.execute_utility(token0.balance_of_private(maker)), 0);
 
     // ORDER FULFILLMENT
 
@@ -72,13 +72,13 @@ unconstrained fn full_flow() {
     env.call_private(taker, orderbook.fulfill_order(order_id, FULFILL_ORDER_AUTHWIT_NONCE));
 
     // Verify final balances
-    assert_eq(env.simulate_utility(token0.balance_of_private(maker)), 0);
-    assert_eq(env.simulate_utility(token1.balance_of_private(maker)), ASK_AMOUNT);
-    assert_eq(env.simulate_utility(token0.balance_of_private(taker)), BID_AMOUNT);
-    assert_eq(env.simulate_utility(token1.balance_of_private(taker)), 0);
+    assert_eq(env.execute_utility(token0.balance_of_private(maker)), 0);
+    assert_eq(env.execute_utility(token1.balance_of_private(maker)), ASK_AMOUNT);
+    assert_eq(env.execute_utility(token0.balance_of_private(taker)), BID_AMOUNT);
+    assert_eq(env.execute_utility(token1.balance_of_private(taker)), 0);
 
     // Get order and verify it's fulfilled
-    let (order, is_fulfilled) = env.simulate_utility(orderbook.get_order(order_id));
+    let (order, is_fulfilled) = env.execute_utility(orderbook.get_order(order_id));
 
     assert_eq(order.bid_amount, BID_AMOUNT);
     assert_eq(order.ask_amount, ASK_AMOUNT);

--- a/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/private_voting_contract/src/test/first.nr
@@ -63,7 +63,7 @@ unconstrained fn test_cast_vote() {
         PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
     );
 
-    let tally = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+    let tally = env.execute_utility(PrivateVoting::at(voting_contract_address).get_tally(
         election_id,
         candidate,
     ));
@@ -90,7 +90,7 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
         PrivateVoting::at(voting_contract_address).cast_vote(election_id, candidate),
     );
 
-    let tally = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+    let tally = env.execute_utility(PrivateVoting::at(voting_contract_address).get_tally(
         election_id,
         candidate,
     ));
@@ -139,11 +139,11 @@ unconstrained fn test_vote_in_two_different_elections() {
         PrivateVoting::at(voting_contract_address).cast_vote(election_id_54, candidate),
     );
 
-    let vote_count_42 = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+    let vote_count_42 = env.execute_utility(PrivateVoting::at(voting_contract_address).get_tally(
         election_id_42,
         candidate,
     ));
-    let vote_count_54 = env.simulate_utility(PrivateVoting::at(voting_contract_address).get_tally(
+    let vote_count_54 = env.execute_utility(PrivateVoting::at(voting_contract_address).get_tally(
         election_id_54,
         candidate,
     ));

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -81,7 +81,7 @@ pub unconstrained fn check_private_balance(
     address_amount: u128,
 ) {
     assert_eq(
-        env.simulate_utility(Token::at(token_contract_address).balance_of_private(address)),
+        env.execute_utility(Token::at(token_contract_address).balance_of_private(address)),
         address_amount,
     );
 }

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -110,7 +110,7 @@ pub contract Counter {
 
             // Read the stored value in the note
             let initial_counter =
-                env.simulate_utility(Counter::at(contract_address).get_counter(owner));
+                env.execute_utility(Counter::at(contract_address).get_counter(owner));
             assert(
                 initial_counter == initial_value,
                 f"Expected {initial_value} but got {initial_counter}",
@@ -120,7 +120,7 @@ pub contract Counter {
             env.call_private(owner, Counter::at(contract_address).increment(owner));
 
             let incremented_counter =
-                env.simulate_utility(Counter::at(contract_address).get_counter(owner));
+                env.execute_utility(Counter::at(contract_address).get_counter(owner));
             let expected_current_value = initial_value + 1;
             assert(
                 expected_current_value == incremented_counter,
@@ -135,21 +135,21 @@ pub contract Counter {
 
             // Checking that the note was discovered from private logs
             let initial_note_value =
-                env.simulate_utility(Counter::at(contract_address).get_counter(owner));
+                env.execute_utility(Counter::at(contract_address).get_counter(owner));
             assert(initial_note_value == initial_value);
 
             env.call_private(owner, Counter::at(contract_address).increment_twice(owner));
 
-            assert_eq(env.simulate_utility(Counter::at(contract_address).get_counter(owner)), 7);
+            assert_eq(env.execute_utility(Counter::at(contract_address).get_counter(owner)), 7);
 
             let _ = env.call_private(
                 owner,
                 Counter::at(contract_address).increment_and_decrement(owner),
             );
-            assert_eq(env.simulate_utility(Counter::at(contract_address).get_counter(owner)), 7);
+            assert_eq(env.execute_utility(Counter::at(contract_address).get_counter(owner)), 7);
 
             env.call_private(owner, Counter::at(contract_address).decrement(owner));
-            assert_eq(env.simulate_utility(Counter::at(contract_address).get_counter(owner)), 6);
+            assert_eq(env.execute_utility(Counter::at(contract_address).get_counter(owner)), 6);
         }
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/note_delivery.nr
@@ -47,7 +47,7 @@ unconstrained fn create_note_private_only_tx_and_read_in_utility() {
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
 
-    let retrieved = env.simulate_utility(test_contract.call_view_notes(
+    let retrieved = env.execute_utility(test_contract.call_view_notes(
         recipient,
         STORAGE_SLOT,
         ACTIVE_OR_NULLIFIED,
@@ -85,7 +85,7 @@ unconstrained fn create_note_hybrid_tx_and_read_in_utility() {
         test_contract.call_create_note(VALUE, recipient, STORAGE_SLOT, make_tx_hybrid),
     );
 
-    let retrieved = env.simulate_utility(test_contract.call_view_notes(
+    let retrieved = env.execute_utility(test_contract.call_view_notes(
         recipient,
         STORAGE_SLOT,
         ACTIVE_OR_NULLIFIED,
@@ -121,7 +121,7 @@ unconstrained fn create_partial_note_in_one_tx_and_read_in_utility() {
         test_contract.call_create_and_complete_partial_note(recipient, STORAGE_SLOT, VALUE),
     );
 
-    let retrieved = env.simulate_utility(test_contract.call_view_notes(
+    let retrieved = env.execute_utility(test_contract.call_view_notes(
         recipient,
         STORAGE_SLOT,
         ACTIVE_OR_NULLIFIED,
@@ -157,7 +157,7 @@ unconstrained fn create_partial_note_in_two_txs_and_read_in_utility() {
 
     env.call_public(sender, test_contract.call_complete_partial_note(partial_note, VALUE));
 
-    let retrieved = env.simulate_utility(test_contract.call_view_notes(
+    let retrieved = env.execute_utility(test_contract.call_view_notes(
         recipient,
         STORAGE_SLOT,
         ACTIVE_OR_NULLIFIED,

--- a/yarn-project/aztec.js/src/api/wallet.ts
+++ b/yarn-project/aztec.js/src/api/wallet.ts
@@ -1,7 +1,7 @@
 export {
   type Aliased,
   type SimulateOptions,
-  type SimulateUtilityOptions,
+  type ExecuteUtilityOptions,
   type ProfileOptions,
   type SendOptions,
   type BatchableMethods,

--- a/yarn-project/aztec.js/src/contract/batch_call.test.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.test.ts
@@ -1,7 +1,7 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { FunctionCall, FunctionSelector, FunctionType } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { ExecutionPayload, TxSimulationResult, UtilitySimulationResult } from '@aztec/stdlib/tx';
+import { ExecutionPayload, TxSimulationResult, UtilityExecutionResult } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -107,8 +107,8 @@ describe('BatchCall', () => {
       batchCall = new BatchCall(wallet, [utilityPayload1, privatePayload, utilityPayload2, publicPayload]);
 
       // Mock utility simulation results
-      const utilityResult1 = UtilitySimulationResult.random();
-      const utilityResult2 = UtilitySimulationResult.random();
+      const utilityResult1 = UtilityExecutionResult.random();
+      const utilityResult2 = UtilityExecutionResult.random();
 
       // Mock tx simulation result
       const privateReturnValues = [Fr.random(), Fr.random()];
@@ -122,8 +122,8 @@ describe('BatchCall', () => {
 
       // Mock wallet.batch to return both utility results and simulateTx result
       wallet.batch.mockResolvedValue([
-        { name: 'simulateUtility', result: utilityResult1 },
-        { name: 'simulateUtility', result: utilityResult2 },
+        { name: 'executeUtility', result: utilityResult1 },
+        { name: 'executeUtility', result: utilityResult2 },
         { name: 'simulateTx', result: txSimResult },
       ] as any);
 
@@ -133,14 +133,14 @@ describe('BatchCall', () => {
       expect(wallet.batch).toHaveBeenCalledTimes(1);
       expect(wallet.batch).toHaveBeenCalledWith([
         {
-          name: 'simulateUtility',
+          name: 'executeUtility',
           args: [
             expect.objectContaining({ name: 'getBalance', to: contractAddress1 }),
             expect.objectContaining({ scope: expect.any(AztecAddress) }),
           ],
         },
         {
-          name: 'simulateUtility',
+          name: 'executeUtility',
           args: [
             expect.objectContaining({ name: 'checkPermission', to: contractAddress3 }),
             expect.objectContaining({ scope: expect.any(AztecAddress) }),
@@ -160,9 +160,9 @@ describe('BatchCall', () => {
         },
       ]);
 
-      // Verify wallet.simulateTx/simulateUtility were NOT called directly
+      // Verify wallet.simulateTx/executeUtility were NOT called directly
       expect(wallet.simulateTx).not.toHaveBeenCalled();
-      expect(wallet.simulateUtility).not.toHaveBeenCalled();
+      expect(wallet.executeUtility).not.toHaveBeenCalled();
 
       expect(results).toHaveLength(4);
       // First utility - decoded from Fr[] to bigint (single field returns the value directly, not as array)
@@ -184,13 +184,13 @@ describe('BatchCall', () => {
 
       batchCall = new BatchCall(wallet, [utilityPayload1, utilityPayload2]);
 
-      // Mock utility simulation results
-      const utilityResult1 = UtilitySimulationResult.random();
-      const utilityResult2 = UtilitySimulationResult.random();
+      // Mock utility execution results
+      const utilityResult1 = UtilityExecutionResult.random();
+      const utilityResult2 = UtilityExecutionResult.random();
 
       wallet.batch.mockResolvedValue([
-        { name: 'simulateUtility', result: utilityResult1 },
-        { name: 'simulateUtility', result: utilityResult2 },
+        { name: 'executeUtility', result: utilityResult1 },
+        { name: 'executeUtility', result: utilityResult2 },
       ] as any);
 
       const results = await batchCall.simulate({ from: await AztecAddress.random() });
@@ -198,14 +198,14 @@ describe('BatchCall', () => {
       expect(wallet.batch).toHaveBeenCalledTimes(1);
       expect(wallet.batch).toHaveBeenCalledWith([
         {
-          name: 'simulateUtility',
+          name: 'executeUtility',
           args: [
             expect.objectContaining({ name: 'view1', to: contractAddress1 }),
             expect.objectContaining({ scope: expect.any(AztecAddress) }),
           ],
         },
         {
-          name: 'simulateUtility',
+          name: 'executeUtility',
           args: [
             expect.objectContaining({ name: 'view2', to: contractAddress2 }),
             expect.objectContaining({ scope: expect.any(AztecAddress) }),

--- a/yarn-project/aztec.js/src/contract/batch_call.ts
+++ b/yarn-project/aztec.js/src/contract/batch_call.ts
@@ -1,10 +1,5 @@
 import { type FunctionCall, FunctionType, decodeFromAbi } from '@aztec/stdlib/abi';
-import {
-  ExecutionPayload,
-  TxSimulationResult,
-  UtilitySimulationResult,
-  mergeExecutionPayloads,
-} from '@aztec/stdlib/tx';
+import { ExecutionPayload, TxSimulationResult, UtilityExecutionResult, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 
 import type { BatchedMethod, Wallet } from '../wallet/wallet.js';
 import { BaseContractInteraction } from './base_contract_interaction.js';
@@ -42,9 +37,9 @@ export class BatchCall extends BaseContractInteraction {
   }
 
   /**
-   * Simulates the batch, supporting private, public and utility functions. Although this is a single
+   * Simulates/executes the batch, supporting private, public and utility functions. Although this is a single
    * interaction with the wallet, private and public functions will be grouped into a single ExecutionPayload
-   * that the wallet will simulate as a single transaction. Utility function calls will simply be executed
+   * that the wallet will simulate as a single transaction. Utility function calls will be executed
    * one by one.
    * @param options - An optional object containing additional configuration for the interaction.
    * @returns The results of all the interactions that make up the batch
@@ -81,7 +76,7 @@ export class BatchCall extends BaseContractInteraction {
     // Add utility calls to batch
     for (const [call] of utility) {
       batchRequests.push({
-        name: 'simulateUtility' as const,
+        name: 'executeUtility' as const,
         args: [call, { scope: options.from, authWitnesses: options.authWitnesses }],
       });
     }
@@ -111,8 +106,8 @@ export class BatchCall extends BaseContractInteraction {
     for (let i = 0; i < utility.length; i++) {
       const [call, resultIndex] = utility[i];
       const wrappedResult = batchResults[i];
-      if (wrappedResult.name === 'simulateUtility') {
-        const rawReturnValues = (wrappedResult.result as UtilitySimulationResult).result;
+      if (wrappedResult.name === 'executeUtility') {
+        const rawReturnValues = (wrappedResult.result as UtilityExecutionResult).result;
         results[resultIndex] = rawReturnValues ? decodeFromAbi(call.returnTypes, rawReturnValues) : [];
       }
     }

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -11,7 +11,7 @@ import type {
   TxHash,
   TxReceipt,
   TxSimulationResult,
-  UtilitySimulationResult,
+  UtilityExecutionResult,
 } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -31,7 +31,7 @@ describe('Contract Class', () => {
   const _mockTxHash = { type: 'TxHash' } as any as TxHash;
   const mockTxReceipt = { type: 'TxReceipt' } as any as TxReceipt;
   const mockTxSimulationResult = { type: 'TxSimulationResult', result: 1n } as any as TxSimulationResult;
-  const mockUtilityResultValue = { result: [new Fr(42)] } as any as UtilitySimulationResult;
+  const mockUtilityResultValue = { result: [new Fr(42)] } as any as UtilityExecutionResult;
 
   const defaultArtifact: ContractArtifact = {
     name: 'FooContract',
@@ -137,7 +137,7 @@ describe('Contract Class', () => {
     account.createTxExecutionRequest.mockResolvedValue(mockTxRequest);
     wallet.registerContract.mockResolvedValue(contractInstance);
     wallet.sendTx.mockResolvedValue(mockTxReceipt);
-    wallet.simulateUtility.mockResolvedValue(mockUtilityResultValue);
+    wallet.executeUtility.mockResolvedValue(mockUtilityResultValue);
   });
 
   it('should create and send a contract method tx', async () => {
@@ -153,8 +153,8 @@ describe('Contract Class', () => {
   it('should call view on a utility function', async () => {
     const fooContract = Contract.at(contractAddress, defaultArtifact, wallet);
     const result = await fooContract.methods.qux(123n).simulate({ from: account.getAddress() });
-    expect(wallet.simulateUtility).toHaveBeenCalledTimes(1);
-    expect(wallet.simulateUtility).toHaveBeenCalledWith(
+    expect(wallet.executeUtility).toHaveBeenCalledTimes(1);
+    expect(wallet.executeUtility).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'qux', to: contractAddress }),
       expect.objectContaining({ scope: account.getAddress() }),
     );

--- a/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/contract_function_interaction.ts
@@ -111,7 +111,7 @@ export class ContractFunctionInteraction extends BaseContractInteraction {
     // docs:end:simulate
     if (this.functionDao.functionType == FunctionType.UTILITY) {
       const call = await this.getFunctionCall();
-      const utilityResult = await this.wallet.simulateUtility(call, {
+      const utilityResult = await this.wallet.executeUtility(call, {
         scope: options.from,
         authWitnesses: options.authWitnesses,
       });

--- a/yarn-project/aztec.js/src/wallet/capabilities.ts
+++ b/yarn-project/aztec.js/src/wallet/capabilities.ts
@@ -180,11 +180,11 @@ export interface ContractClassesCapability {
 export interface GrantedContractClassesCapability extends ContractClassesCapability {}
 
 /**
- * Transaction simulation capability - for simulating transactions and utilities.
+ * Transaction simulation capability - for simulating transactions and executing utilities.
  *
  * Maps to wallet methods:
  * - simulateTx (when transactions scope specified)
- * - simulateUtility (when utilities scope specified)
+ * - executeUtility (when utilities scope specified)
  * - profileTx (when transactions scope specified)
  *
  * @example
@@ -200,7 +200,7 @@ export interface GrantedContractClassesCapability extends ContractClassesCapabil
  * \}
  *
  * @example
- * // Simulate any transaction and utility call
+ * // Simulate any transaction and execute any utility call
  * \{
  *   type: 'simulation',
  *   transactions: \{ scope: '*' \},
@@ -221,7 +221,7 @@ export interface SimulationCapability {
     scope: '*' | ContractFunctionPattern[];
   };
 
-  /** Utility simulation scope (unconstrained calls). Maps to: simulateUtility */
+  /** Utility execution scope (unconstrained calls). Maps to: executeUtility */
   utilities?: {
     /**
      * Which contracts/functions to allow:

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -15,7 +15,7 @@ import {
   TxProfileResult,
   TxReceipt,
   TxSimulationResult,
-  UtilitySimulationResult,
+  UtilityExecutionResult,
 } from '@aztec/stdlib/tx';
 
 import { type InteractionWaitOptions, NO_WAIT, type SendReturn } from '../contract/interaction_options.js';
@@ -163,7 +163,7 @@ describe('WalletSchema', () => {
     expect(result).toBeInstanceOf(TxSimulationResult);
   });
 
-  it('simulateUtility', async () => {
+  it('executeUtility', async () => {
     const call = FunctionCall.from({
       name: 'testFunction',
       to: await AztecAddress.random(),
@@ -174,11 +174,11 @@ describe('WalletSchema', () => {
       args: [Fr.random()],
       returnTypes: [],
     });
-    const result = await context.client.simulateUtility(call, {
+    const result = await context.client.executeUtility(call, {
       scope: await AztecAddress.random(),
       authWitnesses: [AuthWitness.random()],
     });
-    expect(result).toBeInstanceOf(UtilitySimulationResult);
+    expect(result).toBeInstanceOf(UtilityExecutionResult);
   });
 
   it('profileTx', async () => {
@@ -325,7 +325,7 @@ describe('WalletSchema', () => {
       { name: 'getAccounts', args: [] },
       { name: 'registerContract', args: [mockInstance, mockArtifact, undefined] },
       { name: 'simulateTx', args: [exec, simulateOpts] },
-      { name: 'simulateUtility', args: [call, { scope: address3, authWitnesses: [AuthWitness.random()] }] },
+      { name: 'executeUtility', args: [call, { scope: address3, authWitnesses: [AuthWitness.random()] }] },
       { name: 'profileTx', args: [exec, profileOpts] },
       { name: 'sendTx', args: [exec, opts] },
       { name: 'createAuthWit', args: [address1, { consumer: await AztecAddress.random(), innerHash: Fr.random() }] },
@@ -351,7 +351,7 @@ describe('WalletSchema', () => {
       result: expect.objectContaining({ address: expect.any(AztecAddress) }),
     });
     expect(results[8]).toEqual({ name: 'simulateTx', result: expect.any(TxSimulationResult) });
-    expect(results[9]).toEqual({ name: 'simulateUtility', result: expect.any(UtilitySimulationResult) });
+    expect(results[9]).toEqual({ name: 'executeUtility', result: expect.any(UtilityExecutionResult) });
     expect(results[10]).toEqual({ name: 'profileTx', result: expect.any(TxProfileResult) });
     expect(results[11]).toEqual({ name: 'sendTx', result: expect.any(TxReceipt) });
     expect(results[12]).toEqual({ name: 'createAuthWit', result: expect.any(AuthWitness) });
@@ -430,11 +430,11 @@ class MockWallet implements Wallet {
     return Promise.resolve(TxSimulationResult.random());
   }
 
-  simulateUtility(
+  executeUtility(
     _call: any,
     _opts: { scope: AztecAddress; authWitnesses?: AuthWitness[] },
-  ): Promise<UtilitySimulationResult> {
-    return Promise.resolve(UtilitySimulationResult.random());
+  ): Promise<UtilityExecutionResult> {
+    return Promise.resolve(UtilityExecutionResult.random());
   }
 
   profileTx(_exec: ExecutionPayload, _opts: ProfileOptions): Promise<TxProfileResult> {

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -22,7 +22,7 @@ import {
   TxProfileResult,
   TxReceipt,
   TxSimulationResult,
-  UtilitySimulationResult,
+  UtilityExecutionResult,
   inTxSchema,
 } from '@aztec/stdlib/tx';
 
@@ -226,10 +226,10 @@ export type ContractClassMetadata = {
 };
 
 /**
- * Options for simulating a utility function call.
+ * Options for executing a utility function call.
  */
-export type SimulateUtilityOptions = {
-  /** The scope for the utility simulation (determines which notes and keys are visible). */
+export type ExecuteUtilityOptions = {
+  /** The scope for the utility execution (determines which notes and keys are visible). */
   scope: AztecAddress;
   /** Optional auth witnesses to use during execution. */
   authWitnesses?: AuthWitness[];
@@ -255,7 +255,7 @@ export type Wallet = {
     secretKey?: Fr,
   ): Promise<ContractInstanceWithAddress>;
   simulateTx(exec: ExecutionPayload, opts: SimulateOptions): Promise<TxSimulationResult>;
-  simulateUtility(call: FunctionCall, opts: SimulateUtilityOptions): Promise<UtilitySimulationResult>;
+  executeUtility(call: FunctionCall, opts: ExecuteUtilityOptions): Promise<UtilityExecutionResult>;
   profileTx(exec: ExecutionPayload, opts: ProfileOptions): Promise<TxProfileResult>;
   sendTx<W extends InteractionWaitOptions = undefined>(
     exec: ExecutionPayload,
@@ -518,7 +518,7 @@ const WalletMethodSchemas = {
     .args(ContractInstanceWithAddressSchema, optional(ContractArtifactSchema), optional(schemas.Fr))
     .returns(ContractInstanceWithAddressSchema),
   simulateTx: z.function().args(ExecutionPayloadSchema, SimulateOptionsSchema).returns(TxSimulationResult.schema),
-  simulateUtility: z
+  executeUtility: z
     .function()
     .args(
       FunctionCall.schema,
@@ -527,7 +527,7 @@ const WalletMethodSchemas = {
         authWitnesses: optional(z.array(AuthWitness.schema)),
       }),
     )
-    .returns(UtilitySimulationResult.schema),
+    .returns(UtilityExecutionResult.schema),
   profileTx: z.function().args(ExecutionPayloadSchema, ProfileOptionsSchema).returns(TxProfileResult.schema),
   sendTx: z
     .function()

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -361,7 +361,7 @@ export class ContractFunctionSimulator {
           );
         });
 
-      this.log.verbose(`Utility simulation for ${call.to}.${call.selector} completed`);
+      this.log.verbose(`Utility execution for ${call.to}.${call.selector} completed`);
       return witnessMapToFields(acirExecutionResult.returnWitness);
     } catch (err) {
       throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during private execution'));

--- a/yarn-project/pxe/src/debug/pxe_debug_utils.ts
+++ b/yarn-project/pxe/src/debug/pxe_debug_utils.ts
@@ -18,7 +18,7 @@ import type { NoteStore } from '../storage/note_store/note_store.js';
 export class PXEDebugUtils {
   #putJobInQueue!: <T>(job: (jobId: string) => Promise<T>) => Promise<T>;
   #getSimulatorForTx!: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator;
-  #simulateUtility!: (
+  #executeUtility!: (
     contractFunctionSimulator: ContractFunctionSimulator,
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
@@ -37,7 +37,7 @@ export class PXEDebugUtils {
   public setPXEHelpers(
     putJobInQueue: <T>(job: (jobId: string) => Promise<T>) => Promise<T>,
     getSimulatorForTx: (overrides?: { contracts?: ContractOverrides }) => ContractFunctionSimulator,
-    simulateUtility: (
+    executeUtility: (
       contractFunctionSimulator: ContractFunctionSimulator,
       call: FunctionCall,
       authWitnesses: AuthWitness[] | undefined,
@@ -47,7 +47,7 @@ export class PXEDebugUtils {
   ) {
     this.#putJobInQueue = putJobInQueue;
     this.#getSimulatorForTx = getSimulatorForTx;
-    this.#simulateUtility = simulateUtility;
+    this.#executeUtility = executeUtility;
   }
 
   /**
@@ -73,7 +73,7 @@ export class PXEDebugUtils {
         filter.contractAddress,
         null,
         async (privateSyncCall, execScopes) =>
-          await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          await this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
         anchorBlockHeader,
         jobId,
         filter.scopes,

--- a/yarn-project/pxe/src/pxe.test.ts
+++ b/yarn-project/pxe/src/pxe.test.ts
@@ -326,6 +326,6 @@ describe('PXE', () => {
       });
     });
   });
-  // Note: Not testing a successful run of `proveTx`, `sendTx`, `getTxReceipt` and `simulateUtility` here as it
+  // Note: Not testing a successful run of `proveTx`, `sendTx`, `getTxReceipt` and `executeUtility` here as it
   //       requires a larger setup and it's sufficiently tested in the e2e tests.
 });

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -47,7 +47,7 @@ import {
   TxProfileResult,
   TxProvingResult,
   TxSimulationResult,
-  UtilitySimulationResult,
+  UtilityExecutionResult,
 } from '@aztec/stdlib/tx';
 
 import { inspect } from 'util';
@@ -111,8 +111,8 @@ export type SimulateTxOpts = {
   scopes: AccessScopes;
 };
 
-/** Options for PXE.simulateUtility. */
-export type SimulateUtilityOpts = {
+/** Options for PXE.executeUtility. */
+export type ExecuteUtilityOpts = {
   /** The authentication witnesses required for the function call. */
   authwits?: AuthWitness[];
   /** The accounts whose notes we can access in this call */
@@ -264,7 +264,7 @@ export class PXE {
     debugUtils.setPXEHelpers(
       pxe.#putInJobQueue.bind(pxe),
       pxe.#getSimulatorForTx.bind(pxe),
-      pxe.#simulateUtility.bind(pxe),
+      pxe.#executeUtility.bind(pxe),
     );
 
     pxe.jobQueue.start();
@@ -370,7 +370,7 @@ export class PXE {
         contractAddress,
         functionSelector,
         (privateSyncCall, execScopes) =>
-          this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
         anchorBlockHeader,
         jobId,
         scopes,
@@ -394,16 +394,16 @@ export class PXE {
   }
 
   /**
-   * Simulate a utility function call on the given contract.
+   * Execute a utility function call on the given contract.
    * @param contractFunctionSimulator - The simulator to use for the function call.
    * @param call - The function call to execute.
    * @param authWitnesses - Authentication witnesses required for the function call.
    * @param scopes - Optional array of account addresses whose notes can be accessed in this call. Defaults to all
    * accounts if not specified.
    * @param jobId - The job ID for staged writes.
-   * @returns The simulation result containing the outputs of the utility function.
+   * @returns The execution result containing the outputs of the utility function.
    */
-  async #simulateUtility(
+  async #executeUtility(
     contractFunctionSimulator: ContractFunctionSimulator,
     call: FunctionCall,
     authWitnesses: AuthWitness[] | undefined,
@@ -1013,16 +1013,16 @@ export class PXE {
   }
 
   /**
-   * Simulates the execution of a contract utility function.
+   * Executes a contract utility function.
    * @param call - The function call containing the function details, arguments, and target contract address.
    */
-  public simulateUtility(
+  public executeUtility(
     call: FunctionCall,
-    { authwits, scopes }: SimulateUtilityOpts = { scopes: 'ALL_SCOPES' },
-  ): Promise<UtilitySimulationResult> {
-    // We disable concurrent simulations since those might execute oracles which read and write to the PXE stores (e.g.
+    { authwits, scopes }: ExecuteUtilityOpts = { scopes: 'ALL_SCOPES' },
+  ): Promise<UtilityExecutionResult> {
+    // We disable concurrent executions since those might execute oracles which read and write to the PXE stores (e.g.
     // to the capsules), and we need to prevent concurrent runs from interfering with one another (e.g. attempting to
-    // delete the same read value, or reading values that another simulation is currently modifying).
+    // delete the same read value, or reading values that another execution is currently modifying).
     return this.#putInJobQueue(async jobId => {
       try {
         const totalTimer = new Timer();
@@ -1037,13 +1037,13 @@ export class PXE {
           call.to,
           call.selector,
           (privateSyncCall, execScopes) =>
-            this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+            this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
           anchorBlockHeader,
           jobId,
           scopes,
         );
 
-        const executionResult = await this.#simulateUtility(
+        const executionResult = await this.#executeUtility(
           contractFunctionSimulator,
           call,
           authwits ?? [],
@@ -1070,7 +1070,7 @@ export class PXE {
         const stringifiedArgs = args.map(arg => arg.toString()).join(', ');
         throw this.#contextualizeError(
           err,
-          `simulateUtility ${to}:${name}(${stringifiedArgs})`,
+          `executeUtility ${to}:${name}(${stringifiedArgs})`,
           `scopes=${scopes === 'ALL_SCOPES' ? scopes : scopes.map(s => s.toString()).join(', ')}`,
         );
       }
@@ -1108,7 +1108,7 @@ export class PXE {
         filter.contractAddress,
         null,
         async (privateSyncCall, execScopes) =>
-          await this.#simulateUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
+          await this.#executeUtility(contractFunctionSimulator, privateSyncCall, [], execScopes, jobId),
         anchorBlockHeader,
         jobId,
         filter.scopes,

--- a/yarn-project/stdlib/src/tx/profiling.ts
+++ b/yarn-project/stdlib/src/tx/profiling.ts
@@ -157,23 +157,23 @@ export class TxProfileResult {
   }
 }
 
-export class UtilitySimulationResult {
+export class UtilityExecutionResult {
   constructor(
     public result: Fr[],
     public stats?: SimulationStats,
   ) {}
 
-  static get schema(): ZodFor<UtilitySimulationResult> {
+  static get schema(): ZodFor<UtilityExecutionResult> {
     return z
       .object({
         result: z.array(schemas.Fr),
         stats: optional(SimulationStatsSchema),
       })
-      .transform(({ result, stats }) => new UtilitySimulationResult(result, stats));
+      .transform(({ result, stats }) => new UtilityExecutionResult(result, stats));
   }
 
-  static random(): UtilitySimulationResult {
-    return new UtilitySimulationResult([Fr.random()], {
+  static random(): UtilityExecutionResult {
+    return new UtilityExecutionResult([Fr.random()], {
       nodeRPCCalls: {
         perMethod: { getBlockHeader: { times: [1] } },
         roundTrips: {

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -72,7 +72,7 @@ export interface ITxeExecutionOracle {
     argsHash: Fr,
     isStaticCall: boolean,
   ): Promise<Fr[]>;
-  txeSimulateUtilityFunction(
+  txeExecuteUtilityFunction(
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
     args: Fr[],

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -659,11 +659,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return returnValues ?? [];
   }
 
-  async txeSimulateUtilityFunction(
-    targetContractAddress: AztecAddress,
-    functionSelector: FunctionSelector,
-    args: Fr[],
-  ) {
+  async txeExecuteUtilityFunction(targetContractAddress: AztecAddress, functionSelector: FunctionSelector, args: Fr[]) {
     const artifact = await this.contractStore.getFunctionArtifact(targetContractAddress, functionSelector);
     if (!artifact) {
       throw new Error(`Cannot call ${functionSelector} as there is no artifact found at ${targetContractAddress}.`);
@@ -741,10 +737,10 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
           );
         });
 
-      this.logger.verbose(`Utility simulation for ${call.to}.${call.selector} completed`);
+      this.logger.verbose(`Utility execution for ${call.to}.${call.selector} completed`);
       return witnessMapToFields(acirExecutionResult.returnWitness);
     } catch (err) {
-      throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during utility simulation'));
+      throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during utility execution'));
     }
   }
 

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -1043,7 +1043,7 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(returnValues)]);
   }
 
-  async txeSimulateUtilityFunction(
+  async txeExecuteUtilityFunction(
     foreignTargetContractAddress: ForeignCallSingle,
     foreignFunctionSelector: ForeignCallSingle,
     foreignArgs: ForeignCallArray,
@@ -1052,7 +1052,7 @@ export class RPCTranslator {
     const functionSelector = FunctionSelector.fromField(fromSingle(foreignFunctionSelector));
     const args = fromArray(foreignArgs);
 
-    const returnValues = await this.handlerAsTxe().txeSimulateUtilityFunction(
+    const returnValues = await this.handlerAsTxe().txeExecuteUtilityFunction(
       targetContractAddress,
       functionSelector,
       args,

--- a/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/base_wallet.ts
@@ -8,12 +8,12 @@ import type {
   AppCapabilities,
   BatchResults,
   BatchedMethod,
+  ExecuteUtilityOptions,
   PrivateEvent,
   PrivateEventFilter,
   ProfileOptions,
   SendOptions,
   SimulateOptions,
-  SimulateUtilityOptions,
   Wallet,
   WalletCapabilities,
 } from '@aztec/aztec.js/wallet';
@@ -52,7 +52,7 @@ import {
   type TxExecutionRequest,
   type TxProfileResult,
   TxSimulationResult,
-  type UtilitySimulationResult,
+  type UtilityExecutionResult,
 } from '@aztec/stdlib/tx';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 
@@ -417,8 +417,8 @@ export abstract class BaseWallet implements Wallet {
     return err;
   }
 
-  simulateUtility(call: FunctionCall, opts: SimulateUtilityOptions): Promise<UtilitySimulationResult> {
-    return this.pxe.simulateUtility(call, { authwits: opts.authWitnesses, scopes: [opts.scope] });
+  executeUtility(call: FunctionCall, opts: ExecuteUtilityOptions): Promise<UtilityExecutionResult> {
+    return this.pxe.executeUtility(call, { authwits: opts.authWitnesses, scopes: [opts.scope] });
   }
 
   async getPrivateEvents<T>(


### PR DESCRIPTION
Fixes https://linear.app/aztec-labs/issue/F-285/renames-simulateutility-executeutility

## Summary
- Renames `simulateUtility` to `executeUtility` across the entire codebase (TypeScript, Noir, TXE oracle layers)
- Renames `UtilitySimulationResult` to `UtilityExecutionResult`
- Renames associated types: `SimulateUtilityOpts` → `ExecuteUtilityOpts`, `SimulateUtilityOptions` → `ExecuteUtilityOptions`
- Renames Noir functions: `simulate_utility_function` → `execute_utility_function`, `env.simulate_utility()` → `env.execute_utility()`
- Renames TXE oracle: `txeSimulateUtilityFunction` → `txeExecuteUtilityFunction`
- Updates all jsdoc comments and log messages to reflect the new terminology

Utility functions are executed, not simulated — this rename makes the terminology consistent: `simulateTx` simulates transactions, while `executeUtility` executes utility (unconstrained) functions.

## Test plan
- [ ] Existing unit tests pass (renamed test names and assertions updated)
- [ ] TypeScript compilation succeeds across all affected packages
- [ ] Noir contract tests compile and pass with renamed `execute_utility` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)