### PR TITLE
fix: do not ignore test artifacts

### DIFF
--- a/release-image/Dockerfile.dockerignore
+++ b/release-image/Dockerfile.dockerignore
@@ -18,6 +18,7 @@
 !/yarn-project/noir-protocol-circuits-types/artifacts/
 !/yarn-project/protocol-contracts/artifacts/
 !/yarn-project/noir-contracts.js/artifacts/
+!/yarn-project/noir-test-contracts.js/artifacts/
 !/yarn-project/simulator/artifacts/
 # This includes all files needed for l1-contracts deployment via forge script.
 !/yarn-project/l1-artifacts/l1-contracts/


### PR DESCRIPTION
Needed in the release image for the cross chain messaging bot, otherwise it fails with:

`Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/usr/src/yarn-project/noir-test-contracts.js/artifacts/test_contract-Test.json' imported from /usr/src/yarn-project/noir-test-contracts.js/dest/Test.j`

Quick n' dirty fix to unbrick nextnet, but we should either make the contract "not test", create a specific one or rethink the bot CC @just-mitch 