### PR TITLE
fix: enable contract debug logs in `aztec test`

### DIFF
--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -21,7 +21,7 @@ function aztec {
 
 case $cmd in
   test)
-    export LOG_LEVEL="${LOG_LEVEL:-error}"
+    export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract_log"}"
     aztec start --txe --port 8081 &
     server_pid=$!
     trap 'kill $server_pid &>/dev/null || true' EXIT


### PR DESCRIPTION
## Summary
- Changes the default `LOG_LEVEL` for `aztec test` from `"error"` to `"error;trace:contract_log"`, so that contract debug log output (from `dep::aztec::oracle::debug_log`) is visible during test runs while keeping other log noise suppressed. This was a common source of confusion for contract devs.

## Test plan
- [ ] Run `aztec test` on a contract with `debug_log` calls and verify logs appear
- [ ] Run `LOG_LEVEL=info aztec test` and verify the user override still takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://linear.app/aztec-labs/issue/F-267/feature-avoid-so-much-noise-on-test-debugging