### PR TITLE
fix: async dispose() lint rule

### DIFF
--- a/yarn-project/foundation/eslint-rules/no-async-dispose.js
+++ b/yarn-project/foundation/eslint-rules/no-async-dispose.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+/**
+ * @fileoverview Rule to disallow async [Symbol.dispose]() methods.
+ * Use [Symbol.asyncDispose]() with AsyncDisposable instead.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow async [Symbol.dispose]() methods',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      asyncDispose:
+        '[Symbol.dispose]() should not be async. Use [Symbol.asyncDispose]() with AsyncDisposable instead.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      MethodDefinition(node) {
+        // Match computed property keys like [Symbol.dispose]
+        if (!node.computed || !node.key || node.key.type !== 'MemberExpression') {
+          return;
+        }
+
+        const key = node.key;
+        if (
+          key.object.type !== 'Identifier' ||
+          key.object.name !== 'Symbol' ||
+          key.property.type !== 'Identifier' ||
+          key.property.name !== 'dispose'
+        ) {
+          return;
+        }
+
+        // Check if the method is async
+        if (node.value.async) {
+          context.report({ node, messageId: 'asyncDispose' });
+          return;
+        }
+
+        // Check if the return type annotation contains Promise
+        // @ts-expect-error returnType is a typescript-eslint AST extension
+        const returnType = node.value.returnType?.typeAnnotation;
+        if (
+          returnType &&
+          returnType.type === 'TSTypeReference' &&
+          returnType.typeName?.type === 'Identifier' &&
+          returnType.typeName.name === 'Promise'
+        ) {
+          context.report({ node, messageId: 'asyncDispose' });
+        }
+      },
+    };
+  },
+};

--- a/yarn-project/foundation/eslint.config.js
+++ b/yarn-project/foundation/eslint.config.js
@@ -8,6 +8,7 @@ import { globalIgnores } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+import noAsyncDispose from './eslint-rules/no-async-dispose.js';
 import noNonPrimitiveInCollections from './eslint-rules/no-non-primitive-in-collections.js';
 import noUnsafeBrandedTypeConversion from './eslint-rules/no-unsafe-branded-type-conversion.js';
 
@@ -51,6 +52,7 @@ export default [
       importPlugin,
       'aztec-custom': {
         rules: {
+          'no-async-dispose': noAsyncDispose,
           'no-non-primitive-in-collections': noNonPrimitiveInCollections,
           'no-unsafe-branded-type-conversion': noUnsafeBrandedTypeConversion,
         },
@@ -116,6 +118,7 @@ export default [
       'import-x/no-extraneous-dependencies': 'error',
       // this unfortunately doesn't block `fit` and `fdescribe`
       'no-only-tests/no-only-tests': ['error'],
+      'aztec-custom/no-async-dispose': 'error',
       'aztec-custom/no-non-primitive-in-collections': 'error',
       'aztec-custom/no-unsafe-branded-type-conversion': 'error',
     },

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.test.ts
@@ -196,7 +196,9 @@ describe('CheckpointProposalJob', () => {
     p2p.broadcastProposal.mockResolvedValue(undefined);
 
     worldState = mockDeep<WorldStateSynchronizer>();
-    const mockFork = mock<MerkleTreeWriteOperations>({ [Symbol.dispose]: jest.fn() });
+    const mockFork = mock<MerkleTreeWriteOperations>({
+      [Symbol.asyncDispose]: jest.fn().mockReturnValue(Promise.resolve()) as () => Promise<void>,
+    });
     worldState.fork.mockResolvedValue(mockFork);
 
     // Create fake CheckpointsBuilder and CheckpointBuilder

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.timing.test.ts
@@ -415,7 +415,9 @@ describe('CheckpointProposalJob Timing Tests', () => {
     p2p.getPendingTxCount.mockResolvedValue(100); // Always have enough txs
 
     worldState = mockDeep<WorldStateSynchronizer>();
-    const mockFork = mock<MerkleTreeWriteOperations>({ [Symbol.dispose]: jest.fn() });
+    const mockFork = mock<MerkleTreeWriteOperations>({
+      [Symbol.asyncDispose]: jest.fn().mockReturnValue(Promise.resolve()) as () => Promise<void>,
+    });
     worldState.fork.mockResolvedValue(mockFork);
 
     l1ToL2MessageSource = mock<L1ToL2MessageSource>();

--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -194,7 +194,7 @@ export class CheckpointProposalJob implements Traceable {
       const feeAssetPriceModifier = await this.publisher.getFeeAssetPriceModifier();
 
       // Create a long-lived forked world state for the checkpoint builder
-      using fork = await this.worldState.fork(this.syncedToBlockNumber, { closeDelayMs: 12_000 });
+      await using fork = await this.worldState.fork(this.syncedToBlockNumber, { closeDelayMs: 12_000 });
 
       // Create checkpoint builder for the entire slot
       const checkpointBuilder = await this.checkpointsBuilder.startCheckpoint(

--- a/yarn-project/simulator/src/public/hinting_db_sources.ts
+++ b/yarn-project/simulator/src/public/hinting_db_sources.ts
@@ -572,7 +572,7 @@ export class HintingMerkleWriteOperations implements MerkleTreeWriteOperations {
     return await this.db.close();
   }
 
-  async [Symbol.dispose](): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }
 

--- a/yarn-project/simulator/src/public/public_processor/guarded_merkle_tree.ts
+++ b/yarn-project/simulator/src/public/public_processor/guarded_merkle_tree.ts
@@ -82,7 +82,7 @@ export class GuardedMerkleTreeOperations implements MerkleTreeWriteOperations {
     return this.guardAndPush(() => this.target.close());
   }
 
-  async [Symbol.dispose](): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }
   getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo> {

--- a/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
@@ -254,7 +254,7 @@ export interface MerkleTreeCheckpointOperations {
 export interface MerkleTreeWriteOperations
   extends MerkleTreeReadOperations,
     MerkleTreeCheckpointOperations,
-    Disposable {
+    AsyncDisposable {
   /**
    * Appends leaves to a given tree.
    * @param treeId - The tree to be updated.

--- a/yarn-project/validator-client/src/block_proposal_handler.ts
+++ b/yarn-project/validator-client/src/block_proposal_handler.ts
@@ -453,7 +453,7 @@ export class BlockProposalHandler {
     // Fork before the block to be built
     const parentBlockNumber = BlockNumber(blockNumber - 1);
     await this.worldState.syncImmediate(parentBlockNumber);
-    using fork = await this.worldState.fork(parentBlockNumber);
+    await using fork = await this.worldState.fork(parentBlockNumber);
 
     // Build checkpoint constants from proposal (excludes blockNumber which is per-block)
     const constants: CheckpointGlobalVariables = {

--- a/yarn-project/validator-client/src/validator.integration.test.ts
+++ b/yarn-project/validator-client/src/validator.integration.test.ts
@@ -282,7 +282,7 @@ describe('ValidatorClient Integration', () => {
       timestamp: BigInt(Date.now()),
     };
 
-    using fork = await proposer.worldStateDb.fork();
+    await using fork = await proposer.worldStateDb.fork();
     const builder = await proposer.checkpointsBuilder.startCheckpoint(
       checkpointNumber,
       globalVariables,

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -310,7 +310,7 @@ describe('ValidatorClient', () => {
       checkpointsBuilder.openCheckpoint.mockResolvedValue(mockCheckpointBuilder);
       worldState.fork.mockResolvedValue({
         close: () => Promise.resolve(),
-        [Symbol.dispose]: () => {},
+        [Symbol.asyncDispose]: () => Promise.resolve(),
       } as never);
     };
 

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -304,7 +304,7 @@ export class MerkleTreesForkFacade extends MerkleTreesFacade implements MerkleTr
     }
   }
 
-  async [Symbol.dispose](): Promise<void> {
+  async [Symbol.asyncDispose](): Promise<void> {
     if (this.opts.closeDelayMs) {
       void sleep(this.opts.closeDelayMs)
         .then(() => this.close())


### PR DESCRIPTION
`Symbol.dispose` was being incorrectly used in a couple of places for async disposal. This should be using `Symbol.asyncDispose` coupled with `await using foo = ...`.

This PR also adds a custom lint rule to catch this in the future

