### PR TITLE
fix: limit prover node to 1 pending job in long proving time test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_long_proving_time.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_long_proving_time.test.ts
@@ -24,7 +24,12 @@ describe('e2e_epochs/epochs_long_proving_time', () => {
     const { aztecSlotDuration } = EpochsTestContext.getSlotDurations({ aztecEpochDuration });
     const epochDurationInSeconds = aztecSlotDuration * aztecEpochDuration;
     const proverTestDelayMs = (epochDurationInSeconds * 1000 * 3) / 4;
-    test = await EpochsTestContext.setup({ aztecEpochDuration, aztecProofSubmissionEpochs: 8, proverTestDelayMs });
+    test = await EpochsTestContext.setup({
+      aztecEpochDuration,
+      aztecProofSubmissionEpochs: 8,
+      proverTestDelayMs,
+      proverNodeConfig: { proverNodeMaxPendingJobs: 1 },
+    });
     ({ logger, monitor, L1_BLOCK_TIME_IN_S } = test);
     logger.warn(`Initialized with prover delay set to ${proverTestDelayMs}ms (epoch is ${epochDurationInSeconds}s)`);
   });


### PR DESCRIPTION
## Summary

- Fixes intermittent timeout (~8% failure rate) in `e2e_epochs/epochs_long_proving_time` by setting `proverNodeMaxPendingJobs: 1` in the test setup
- When checkpoints land in different epochs due to timing, a second proof is needed but gets aborted when a newer epoch's proving job starts and triggers broker cleanup of the older epoch's data
- Limiting to 1 pending job prevents the abort, matching the test's own assertion that `maxJobCount === 1`

## Test plan

- CI should pass the `epochs_long_proving_time` test consistently now

🤖 Generated with [Claude Code](https://claude.com/claude-code)