### PR TITLE
feat: add GitHub Actions CI job for nightly debug build notifications

### DIFF
--- a/.github/workflows/barretenberg-nightly-debug-build.yml
+++ b/.github/workflows/barretenberg-nightly-debug-build.yml
@@ -1,0 +1,48 @@
+name: Nightly Debug Build
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-debug-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  debug-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: main
+
+      - name: Run debug build
+        timeout-minutes: 120
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          ./.github/ci3.sh barretenberg-debug
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name != 'workflow_dispatch'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [ -n "${SLACK_BOT_TOKEN}" ]; then
+            read -r -d '' data <<EOF || true
+            {
+              "channel": "#honk-team",
+              "text": "Nightly debug build FAILED: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+            }
+          EOF
+            curl -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H "Content-type: application/json" \
+              --data "$data"
+          fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -729,6 +729,13 @@ case "$cmd" in
     ./bootstrap.sh
     docs/bootstrap.sh ci
     ;;
+  "ci-barretenberg-debug")
+    export CI=1
+    export NATIVE_PRESET=debug
+    export AVM=0
+    export AVM_TRANSPILER=0
+    barretenberg/cpp/bootstrap.sh build
+    ;;
   "ci-barretenberg")
     export CI=1
     export USE_TEST_CACHE=1

--- a/ci.sh
+++ b/ci.sh
@@ -77,6 +77,12 @@ case "$cmd" in
     export JOB_ID="x-$cmd"
     bootstrap_ec2 "./bootstrap.sh ci-$cmd"
     ;;
+  barretenberg-debug)
+    export CI_DASHBOARD="nightly"
+    export JOB_ID="x-$cmd"
+    export CPUS=16
+    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    ;;
   avm-inputs-collection|avm-check-circuit)
     export CI_DASHBOARD="nightly"
     export JOB_ID="x-$cmd"


### PR DESCRIPTION
Custom ci route, ran nightly, that checks the barretenberg debug build status