### PR TITLE
fix: use ci3_labels_to_env.sh for ci-external label

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Determines CI mode from labels and environment variables.
-# Called by ci3.yml to set CI_MODE and related environment variables.
+# Called by ci3.yml and ci3-external.yml to set CI_MODE and related environment variables.
 # Outputs environment variables to GITHUB_ENV for use in subsequent steps.
 set -euo pipefail
 
@@ -23,7 +23,7 @@ function main {
   local target_branch
   if [ "${GITHUB_EVENT_NAME:-}" == "merge_group" ]; then
     target_branch="${MERGE_GROUP_BASE_REF:-}"
-  elif [ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]; then
+  elif [ "${GITHUB_EVENT_NAME:-}" == "pull_request" ] || [ "${GITHUB_EVENT_NAME:-}" == "pull_request_target" ]; then
     target_branch="${PR_BASE_REF:-}"
   else
     target_branch="${GITHUB_REF_NAME:-}"

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -59,6 +59,14 @@ jobs:
           fi
           GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} gh pr edit ${{ github.event.pull_request.number }} --remove-label "ci-external-once"
 
+      - name: Determine CI Mode
+        env:
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+        run: ./.github/ci3_labels_to_env.sh ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+
       - name: Run
         env:
           REF_NAME: repo-fork/${{ github.repository }}/${{ github.head_ref }}
@@ -78,7 +86,7 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_COMMITS: ${{ github.event.pull_request.commits }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
-        run: ./.github/ci3.sh "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+        run: ./.github/ci3.sh $CI_MODE
 
       - name: Post-Actions
         if: always()


### PR DESCRIPTION
Updates the ci-external label configuration to use the ci3_labels_to_env.sh script instead of the current implementation. This ensures consistent label handling across the CI pipeline and aligns with the proper label conversion mechanism.