### PR TITLE
feat: Add roundtrip tests for bytecode to `Acir::Circuit`

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -178,6 +178,11 @@ function test_cmds {
   for t in $non_recursive_tests; do
     echo "$tests_hash $scripts/bb_prove.sh $(basename $t)"
   done
+
+  # ACIR serialization roundtrip tests: deserialize, re-serialize, re-deserialize, check equality.
+  for t in $non_recursive_tests; do
+    echo "$tests_hash $scripts/acir_roundtrip.sh $(basename $t)"
+  done
   echo "$tests_hash $scripts/bb_prove.sh assert_statement"
   # Run the UH recursive verifier tests with ZK.
   echo "$tests_hash $scripts/bb_prove.sh verify_honk_proof"

--- a/barretenberg/acir_tests/scripts/acir_roundtrip.sh
+++ b/barretenberg/acir_tests/scripts/acir_roundtrip.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+source $(git rev-parse --show-toplevel)/ci3/source
+
+test_name=$1
+cd ../acir_tests/$test_name
+
+bb=$(../../../cpp/scripts/find-bb)
+
+$bb acir_roundtrip -b target/program.json

--- a/barretenberg/acir_tests/scripts/acir_roundtrip.sh
+++ b/barretenberg/acir_tests/scripts/acir_roundtrip.sh
@@ -6,4 +6,14 @@ cd ../acir_tests/$test_name
 
 bb=$(../../../cpp/scripts/find-bb)
 
-$bb acir_roundtrip -b target/program.json
+tmp=$(mktemp -d)
+trap "rm -rf $tmp" EXIT
+
+# Deserialize, re-serialize, write roundtripped raw bytecode.
+$bb acir_roundtrip -b target/program.json -o $tmp/roundtripped.bin
+
+# Extract original raw bytecode from the nargo JSON (base64-encoded gzip).
+jq -r .bytecode target/program.json | base64 -d | gunzip -c > $tmp/original.bin
+
+# The two bytecodes must be identical.
+cmp $tmp/original.bin $tmp/roundtripped.bin

--- a/barretenberg/cpp/src/barretenberg/api/api_acir.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_acir.cpp
@@ -1,0 +1,50 @@
+#include "barretenberg/api/api_acir.hpp"
+#include "barretenberg/api/file_io.hpp"
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/get_bytecode.hpp"
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/dsl/acir_format/serde/index.hpp"
+#include "barretenberg/serialize/msgpack.hpp"
+#include <iostream>
+
+namespace bb {
+
+void acir_roundtrip(const std::filesystem::path& bytecode_path, const std::filesystem::path& output_path)
+{
+    auto buf = get_bytecode(bytecode_path.string());
+
+    BB_ASSERT(!buf.empty(), "acir_roundtrip: bytecode buffer is empty");
+    const uint8_t fmt = buf[0];
+    BB_ASSERT(fmt == 2 || fmt == 3,
+              "acir_roundtrip: expected msgpack format marker (2 or 3), got " + std::to_string(fmt));
+
+    // Deserialize from msgpack to Acir::Program (including Brillig/unconstrained_functions)
+    const char* data = reinterpret_cast<const char*>(buf.data() + 1);
+    size_t data_size = buf.size() - 1;
+    auto oh = msgpack::unpack(data, data_size);
+    auto o = oh.get();
+    BB_ASSERT(o.type == msgpack::type::ARRAY, "acir_roundtrip: expected ARRAY, got " + std::to_string(o.type));
+
+    Acir::Program program;
+    try {
+        o.convert(program);
+    } catch (const msgpack::type_error& e) {
+        std::cerr << "acir_roundtrip: failed to deserialize Program: " << e.what() << '\n';
+        throw;
+    }
+
+    // Re-serialize to msgpack bytes
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> packer(sbuf);
+    packer.pack(program);
+
+    // Build output: format marker byte followed by the msgpack payload
+    std::vector<uint8_t> raw_bytes;
+    raw_bytes.push_back(fmt);
+    raw_bytes.insert(raw_bytes.end(), sbuf.data(), sbuf.data() + sbuf.size());
+
+    write_file(output_path.string(), raw_bytes);
+    vinfo("acir_roundtrip: wrote roundtripped bytecode to ", output_path);
+}
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/api/api_acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_acir.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <filesystem>
+
+namespace bb {
+
+/**
+ * @brief Deserialize an ACIR program from bytecode (msgpack), re-serialize it, and write the
+ * result to an output file as raw bytes (format marker + msgpack payload).
+ *
+ * Intended for internal roundtrip testing: the caller can then compare the output bytes with
+ * the original to verify that C++ deserialization/serialization is lossless.
+ *
+ * @param bytecode_path  Path to the input bytecode (nargo JSON or raw gzip).
+ * @param output_path    Path to write the roundtripped raw bytes.
+ */
+void acir_roundtrip(const std::filesystem::path& bytecode_path, const std::filesystem::path& output_path);
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -26,8 +26,10 @@
 #include "barretenberg/bbapi/bbapi_ultra_honk.hpp"
 #include "barretenberg/bbapi/c_bind.hpp"
 #include "barretenberg/common/bb_bench.hpp"
+#include "barretenberg/common/get_bytecode.hpp"
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/common/version.hpp"
+#include "barretenberg/dsl/acir_format/serde/index.hpp"
 #include "barretenberg/srs/factories/native_crs_factory.hpp"
 #include "barretenberg/srs/global_crs.hpp"
 #include "barretenberg/vm2/api_avm.hpp"
@@ -393,6 +395,17 @@ int parse_and_run_cli_command(int argc, char* argv[])
      * Flag: --help-extended (register with CLI11)
      ***************************************************************************************************************/
     app.add_flag("--help-extended", "Show all options including advanced and Aztec-specific commands.");
+
+    /***************************************************************************************************************
+     * Subcommand: acir_roundtrip
+     ***************************************************************************************************************/
+    CLI::App* acir_roundtrip_cmd =
+        app.add_subcommand("acir_roundtrip",
+                           "[Internal testing] Deserialize an ACIR program from bytecode (msgpack), "
+                           "re-serialize it to msgpack, re-deserialize, and verify structural equality. "
+                           "Returns 0 on success.");
+
+    add_bytecode_path_option(acir_roundtrip_cmd);
 
     /***************************************************************************************************************
      * Subcommand: check
@@ -803,6 +816,57 @@ int parse_and_run_cli_command(int argc, char* argv[])
     };
 
     try {
+        // ACIR roundtrip (internal testing)
+        if (acir_roundtrip_cmd->parsed()) {
+            auto buf = get_bytecode(bytecode_path);
+
+            BB_ASSERT(!buf.empty(), "acir_roundtrip: bytecode buffer is empty");
+            const uint8_t fmt = buf[0];
+            BB_ASSERT(fmt == 2 || fmt == 3,
+                      "acir_roundtrip: expected msgpack format marker (2 or 3), got " + std::to_string(fmt));
+
+            // Deserialize from msgpack to Acir::Program (including Brillig/unconstrained_functions)
+            const char* data = reinterpret_cast<const char*>(buf.data() + 1);
+            size_t data_size = buf.size() - 1;
+            auto oh1 = msgpack::unpack(data, data_size);
+            auto o1 = oh1.get();
+            BB_ASSERT(o1.type == msgpack::type::ARRAY,
+                      "acir_roundtrip: expected ARRAY, got " + std::to_string(o1.type));
+
+            Acir::Program program1;
+            try {
+                o1.convert(program1);
+            } catch (const msgpack::type_error& e) {
+                std::cerr << "acir_roundtrip: failed to deserialize Program: " << e.what() << std::endl;
+                return 1;
+            }
+
+            // Re-serialize to msgpack bytes using msgpack_pack
+            msgpack::sbuffer sbuf;
+            msgpack::packer<msgpack::sbuffer> packer(sbuf);
+            packer.pack(program1);
+
+            // Deserialize again from the re-serialized bytes
+            auto oh2 = msgpack::unpack(sbuf.data(), sbuf.size());
+            auto o2 = oh2.get();
+
+            Acir::Program program2;
+            try {
+                o2.convert(program2);
+            } catch (const msgpack::type_error& e) {
+                std::cerr << "acir_roundtrip: failed to re-deserialize Program: " << e.what() << std::endl;
+                return 1;
+            }
+
+            // Verify structural equality (operator== checks functions AND unconstrained_functions)
+            if (program1 != program2) {
+                std::cerr << "ACIR roundtrip FAILED: programs differ after msgpack roundtrip" << std::endl;
+                return 1;
+            }
+            vinfo("ACIR roundtrip: OK");
+            return 0;
+        }
+
         // MSGPACK
         if (msgpack_schema_command->parsed()) {
             std::cout << bbapi::get_msgpack_schema_as_json() << std::endl;

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -407,6 +407,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
                            "in nargo-compatible format. Functional equivalence should then be verified "
                            "externally (e.g. by proving with the roundtripped bytecode).");
 
+    acir_roundtrip_cmd->group(aztec_internal_group);
     add_bytecode_path_option(acir_roundtrip_cmd);
     acir_roundtrip_cmd
         ->add_option("--output_path,-o", acir_roundtrip_output_path, "Output path for the roundtripped bytecode JSON.")
@@ -830,7 +831,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
             BB_ASSERT(fmt == 2 || fmt == 3,
                       "acir_roundtrip: expected msgpack format marker (2 or 3), got " + std::to_string(fmt));
 
-            // Deserialize from msgpack to Acir::ProgramWithoutBrillig (including Brillig/unconstrained_functions)
+            // Deserialize from msgpack to Acir::Program (including Brillig/unconstrained_functions)
             const char* data = reinterpret_cast<const char*>(buf.data() + 1);
             size_t data_size = buf.size() - 1;
             auto oh = msgpack::unpack(data, data_size);

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -14,6 +14,7 @@
  * @param argv The argument values array
  * @return int Status code: 0 for success, non-zero for errors or verification failure
  */
+#include "barretenberg/api/api_acir.hpp"
 #include "barretenberg/api/api_avm.hpp"
 #include "barretenberg/api/api_chonk.hpp"
 #include "barretenberg/api/api_msgpack.hpp"
@@ -824,41 +825,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     try {
         // ACIR roundtrip (internal testing)
         if (acir_roundtrip_cmd->parsed()) {
-            auto buf = get_bytecode(bytecode_path);
-
-            BB_ASSERT(!buf.empty(), "acir_roundtrip: bytecode buffer is empty");
-            const uint8_t fmt = buf[0];
-            BB_ASSERT(fmt == 2 || fmt == 3,
-                      "acir_roundtrip: expected msgpack format marker (2 or 3), got " + std::to_string(fmt));
-
-            // Deserialize from msgpack to Acir::Program (including Brillig/unconstrained_functions)
-            const char* data = reinterpret_cast<const char*>(buf.data() + 1);
-            size_t data_size = buf.size() - 1;
-            auto oh = msgpack::unpack(data, data_size);
-            auto o = oh.get();
-            BB_ASSERT(o.type == msgpack::type::ARRAY, "acir_roundtrip: expected ARRAY, got " + std::to_string(o.type));
-
-            Acir::Program program;
-            try {
-                o.convert(program);
-            } catch (const msgpack::type_error& e) {
-                std::cerr << "acir_roundtrip: failed to deserialize ProgramWithoutBrillig: " << e.what() << std::endl;
-                return 1;
-            }
-
-            // Re-serialize to msgpack bytes
-            msgpack::sbuffer sbuf;
-            msgpack::packer<msgpack::sbuffer> packer(sbuf);
-            packer.pack(program);
-
-            // Build output: format marker byte followed by the msgpack payload
-            std::vector<uint8_t> raw_bytes;
-            raw_bytes.push_back(fmt);
-            raw_bytes.insert(raw_bytes.end(), sbuf.data(), sbuf.data() + sbuf.size());
-
-            // Write raw bytes to output file
-            write_file(acir_roundtrip_output_path.string(), raw_bytes);
-            vinfo("acir_roundtrip: wrote roundtripped bytecode to ", acir_roundtrip_output_path);
+            acir_roundtrip(bytecode_path, acir_roundtrip_output_path);
             return 0;
         }
 

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -399,13 +399,18 @@ int parse_and_run_cli_command(int argc, char* argv[])
     /***************************************************************************************************************
      * Subcommand: acir_roundtrip
      ***************************************************************************************************************/
+    std::filesystem::path acir_roundtrip_output_path;
     CLI::App* acir_roundtrip_cmd =
         app.add_subcommand("acir_roundtrip",
                            "[Internal testing] Deserialize an ACIR program from bytecode (msgpack), "
-                           "re-serialize it to msgpack, re-deserialize, and verify structural equality. "
-                           "Returns 0 on success.");
+                           "re-serialize it back to msgpack, and write it to an output JSON file "
+                           "in nargo-compatible format. Functional equivalence should then be verified "
+                           "externally (e.g. by proving with the roundtripped bytecode).");
 
     add_bytecode_path_option(acir_roundtrip_cmd);
+    acir_roundtrip_cmd
+        ->add_option("--output_path,-o", acir_roundtrip_output_path, "Output path for the roundtripped bytecode JSON.")
+        ->required();
 
     /***************************************************************************************************************
      * Subcommand: check
@@ -825,45 +830,34 @@ int parse_and_run_cli_command(int argc, char* argv[])
             BB_ASSERT(fmt == 2 || fmt == 3,
                       "acir_roundtrip: expected msgpack format marker (2 or 3), got " + std::to_string(fmt));
 
-            // Deserialize from msgpack to Acir::Program (including Brillig/unconstrained_functions)
+            // Deserialize from msgpack to Acir::ProgramWithoutBrillig (including Brillig/unconstrained_functions)
             const char* data = reinterpret_cast<const char*>(buf.data() + 1);
             size_t data_size = buf.size() - 1;
-            auto oh1 = msgpack::unpack(data, data_size);
-            auto o1 = oh1.get();
-            BB_ASSERT(o1.type == msgpack::type::ARRAY,
-                      "acir_roundtrip: expected ARRAY, got " + std::to_string(o1.type));
+            auto oh = msgpack::unpack(data, data_size);
+            auto o = oh.get();
+            BB_ASSERT(o.type == msgpack::type::ARRAY, "acir_roundtrip: expected ARRAY, got " + std::to_string(o.type));
 
-            Acir::Program program1;
+            Acir::Program program;
             try {
-                o1.convert(program1);
+                o.convert(program);
             } catch (const msgpack::type_error& e) {
-                std::cerr << "acir_roundtrip: failed to deserialize Program: " << e.what() << std::endl;
+                std::cerr << "acir_roundtrip: failed to deserialize ProgramWithoutBrillig: " << e.what() << std::endl;
                 return 1;
             }
 
-            // Re-serialize to msgpack bytes using msgpack_pack
+            // Re-serialize to msgpack bytes
             msgpack::sbuffer sbuf;
             msgpack::packer<msgpack::sbuffer> packer(sbuf);
-            packer.pack(program1);
+            packer.pack(program);
 
-            // Deserialize again from the re-serialized bytes
-            auto oh2 = msgpack::unpack(sbuf.data(), sbuf.size());
-            auto o2 = oh2.get();
+            // Build output: format marker byte followed by the msgpack payload
+            std::vector<uint8_t> raw_bytes;
+            raw_bytes.push_back(fmt);
+            raw_bytes.insert(raw_bytes.end(), sbuf.data(), sbuf.data() + sbuf.size());
 
-            Acir::Program program2;
-            try {
-                o2.convert(program2);
-            } catch (const msgpack::type_error& e) {
-                std::cerr << "acir_roundtrip: failed to re-deserialize Program: " << e.what() << std::endl;
-                return 1;
-            }
-
-            // Verify structural equality (operator== checks functions AND unconstrained_functions)
-            if (program1 != program2) {
-                std::cerr << "ACIR roundtrip FAILED: programs differ after msgpack roundtrip" << std::endl;
-                return 1;
-            }
-            vinfo("ACIR roundtrip: OK");
+            // Write raw bytes to output file
+            write_file(acir_roundtrip_output_path.string(), raw_bytes);
+            vinfo("acir_roundtrip: wrote roundtripped bytecode to ", acir_roundtrip_output_path);
             return 0;
         }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -286,9 +286,7 @@ void update_max_witness_index_from_opcode(Acir::Opcode const& opcode, AcirFormat
                                },
                                output.value);
                 }
-                if (arg.predicate.has_value()) {
-                    update_max_witness_index_from_expression(arg.predicate.value(), af);
-                }
+                update_max_witness_index_from_expression(arg.predicate, af);
             },
             [&](const Acir::Opcode::Call&) {
                 bb::assert_failure("acir_format::update_max_witness_index_from_opcode: Call opcode is not supported.");

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/acir.hpp
@@ -71,54 +71,116 @@ struct BinaryFieldOp {
     struct Add {
         friend bool operator==(const Add&, const Add&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Sub {
         friend bool operator==(const Sub&, const Sub&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Mul {
         friend bool operator==(const Mul&, const Mul&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Div {
         friend bool operator==(const Div&, const Div&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct IntegerDiv {
         friend bool operator==(const IntegerDiv&, const IntegerDiv&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Equals {
         friend bool operator==(const Equals&, const Equals&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct LessThan {
         friend bool operator==(const LessThan&, const LessThan&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct LessThanEquals {
         friend bool operator==(const LessThanEquals&, const LessThanEquals&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     std::variant<Add, Sub, Mul, Div, IntegerDiv, Equals, LessThan, LessThanEquals> value;
 
     friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Add";
+            is_unit = true;
+            break;
+        case 1:
+            tag = "Sub";
+            is_unit = true;
+            break;
+        case 2:
+            tag = "Mul";
+            is_unit = true;
+            break;
+        case 3:
+            tag = "Div";
+            is_unit = true;
+            break;
+        case 4:
+            tag = "IntegerDiv";
+            is_unit = true;
+            break;
+        case 5:
+            tag = "Equals";
+            is_unit = true;
+            break;
+        case 6:
+            tag = "LessThan";
+            is_unit = true;
+            break;
+        case 7:
+            tag = "LessThanEquals";
+            is_unit = true;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BinaryFieldOp' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -177,78 +239,160 @@ struct BinaryIntOp {
     struct Add {
         friend bool operator==(const Add&, const Add&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Sub {
         friend bool operator==(const Sub&, const Sub&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Mul {
         friend bool operator==(const Mul&, const Mul&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Div {
         friend bool operator==(const Div&, const Div&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Equals {
         friend bool operator==(const Equals&, const Equals&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct LessThan {
         friend bool operator==(const LessThan&, const LessThan&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct LessThanEquals {
         friend bool operator==(const LessThanEquals&, const LessThanEquals&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct And {
         friend bool operator==(const And&, const And&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Or {
         friend bool operator==(const Or&, const Or&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Xor {
         friend bool operator==(const Xor&, const Xor&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Shl {
         friend bool operator==(const Shl&, const Shl&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct Shr {
         friend bool operator==(const Shr&, const Shr&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     std::variant<Add, Sub, Mul, Div, Equals, LessThan, LessThanEquals, And, Or, Xor, Shl, Shr> value;
 
     friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Add";
+            is_unit = true;
+            break;
+        case 1:
+            tag = "Sub";
+            is_unit = true;
+            break;
+        case 2:
+            tag = "Mul";
+            is_unit = true;
+            break;
+        case 3:
+            tag = "Div";
+            is_unit = true;
+            break;
+        case 4:
+            tag = "Equals";
+            is_unit = true;
+            break;
+        case 5:
+            tag = "LessThan";
+            is_unit = true;
+            break;
+        case 6:
+            tag = "LessThanEquals";
+            is_unit = true;
+            break;
+        case 7:
+            tag = "And";
+            is_unit = true;
+            break;
+        case 8:
+            tag = "Or";
+            is_unit = true;
+            break;
+        case 9:
+            tag = "Xor";
+            is_unit = true;
+            break;
+        case 10:
+            tag = "Shl";
+            is_unit = true;
+            break;
+        case 11:
+            tag = "Shr";
+            is_unit = true;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BinaryIntOp' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -319,42 +463,94 @@ struct IntegerBitSize {
     struct U1 {
         friend bool operator==(const U1&, const U1&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct U8 {
         friend bool operator==(const U8&, const U8&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct U16 {
         friend bool operator==(const U16&, const U16&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct U32 {
         friend bool operator==(const U32&, const U32&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct U64 {
         friend bool operator==(const U64&, const U64&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     struct U128 {
         friend bool operator==(const U128&, const U128&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     std::variant<U1, U8, U16, U32, U64, U128> value;
 
     friend bool operator==(const IntegerBitSize&, const IntegerBitSize&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "U1";
+            is_unit = true;
+            break;
+        case 1:
+            tag = "U8";
+            is_unit = true;
+            break;
+        case 2:
+            tag = "U16";
+            is_unit = true;
+            break;
+        case 3:
+            tag = "U32";
+            is_unit = true;
+            break;
+        case 4:
+            tag = "U64";
+            is_unit = true;
+            break;
+        case 5:
+            tag = "U128";
+            is_unit = true;
+            break;
+        default:
+            throw_or_abort("unknown enum 'IntegerBitSize' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -407,6 +603,7 @@ struct BitSize {
     struct Field {
         friend bool operator==(const Field&, const Field&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
@@ -414,6 +611,8 @@ struct BitSize {
         Acir::IntegerBitSize value;
 
         friend bool operator==(const Integer&, const Integer&);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -429,6 +628,36 @@ struct BitSize {
     std::variant<Field, Integer> value;
 
     friend bool operator==(const BitSize&, const BitSize&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Field";
+            is_unit = true;
+            break;
+        case 1:
+            tag = "Integer";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BitSize' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -456,9 +685,6 @@ struct BitSize {
             value = v;
         } else if (tag == "Integer") {
             Integer v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -481,6 +707,8 @@ struct MemoryAddress {
 
         friend bool operator==(const Direct&, const Direct&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -497,6 +725,8 @@ struct MemoryAddress {
 
         friend bool operator==(const Relative&, const Relative&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -511,6 +741,36 @@ struct MemoryAddress {
     std::variant<Direct, Relative> value;
 
     friend bool operator==(const MemoryAddress&, const MemoryAddress&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Direct";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Relative";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'MemoryAddress' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -535,9 +795,6 @@ struct MemoryAddress {
         }
         if (tag == "Direct") {
             Direct v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -548,9 +805,6 @@ struct MemoryAddress {
             value = v;
         } else if (tag == "Relative") {
             Relative v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -571,6 +825,8 @@ struct SemiFlattenedLength {
 
     friend bool operator==(const SemiFlattenedLength&, const SemiFlattenedLength&);
 
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         try {
@@ -587,6 +843,13 @@ struct HeapArray {
     Acir::SemiFlattenedLength size;
 
     friend bool operator==(const HeapArray&, const HeapArray&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(pointer);
+        packer.pack(size);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -615,6 +878,15 @@ struct BlackBoxOp {
 
         friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(inputs);
+            packer.pack(iv);
+            packer.pack(key);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "AES128Encrypt";
@@ -642,6 +914,13 @@ struct BlackBoxOp {
 
         friend bool operator==(const Blake2s&, const Blake2s&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(message);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Blake2s";
@@ -665,6 +944,13 @@ struct BlackBoxOp {
 
         friend bool operator==(const Blake3&, const Blake3&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(message);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Blake3";
@@ -687,6 +973,13 @@ struct BlackBoxOp {
         Acir::HeapArray output;
 
         friend bool operator==(const Keccakf1600&, const Keccakf1600&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(input);
+            packer.pack(output);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -713,6 +1006,16 @@ struct BlackBoxOp {
         Acir::MemoryAddress result;
 
         friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(5);
+            packer.pack(hashed_msg);
+            packer.pack(public_key_x);
+            packer.pack(public_key_y);
+            packer.pack(signature);
+            packer.pack(result);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -746,6 +1049,16 @@ struct BlackBoxOp {
 
         friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(5);
+            packer.pack(hashed_msg);
+            packer.pack(public_key_x);
+            packer.pack(public_key_y);
+            packer.pack(signature);
+            packer.pack(result);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "EcdsaSecp256r1";
@@ -776,6 +1089,14 @@ struct BlackBoxOp {
 
         friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(points);
+            packer.pack(scalars);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "MultiScalarMul";
@@ -805,6 +1126,18 @@ struct BlackBoxOp {
         Acir::HeapArray result;
 
         friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(7);
+            packer.pack(input1_x);
+            packer.pack(input1_y);
+            packer.pack(input1_infinite);
+            packer.pack(input2_x);
+            packer.pack(input2_y);
+            packer.pack(input2_infinite);
+            packer.pack(result);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -839,6 +1172,13 @@ struct BlackBoxOp {
 
         friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(message);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Poseidon2Permutation";
@@ -862,6 +1202,14 @@ struct BlackBoxOp {
         Acir::HeapArray output;
 
         friend bool operator==(const Sha256Compression&, const Sha256Compression&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(input);
+            packer.pack(hash_values);
+            packer.pack(output);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -890,6 +1238,16 @@ struct BlackBoxOp {
         Acir::MemoryAddress output_bits;
 
         friend bool operator==(const ToRadix&, const ToRadix&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(5);
+            packer.pack(input);
+            packer.pack(radix);
+            packer.pack(output_pointer);
+            packer.pack(num_limbs);
+            packer.pack(output_bits);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -929,6 +1287,72 @@ struct BlackBoxOp {
 
     friend bool operator==(const BlackBoxOp&, const BlackBoxOp&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "AES128Encrypt";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Blake2s";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "Blake3";
+            is_unit = false;
+            break;
+        case 3:
+            tag = "Keccakf1600";
+            is_unit = false;
+            break;
+        case 4:
+            tag = "EcdsaSecp256k1";
+            is_unit = false;
+            break;
+        case 5:
+            tag = "EcdsaSecp256r1";
+            is_unit = false;
+            break;
+        case 6:
+            tag = "MultiScalarMul";
+            is_unit = false;
+            break;
+        case 7:
+            tag = "EmbeddedCurveAdd";
+            is_unit = false;
+            break;
+        case 8:
+            tag = "Poseidon2Permutation";
+            is_unit = false;
+            break;
+        case 9:
+            tag = "Sha256Compression";
+            is_unit = false;
+            break;
+        case 10:
+            tag = "ToRadix";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BlackBoxOp' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
 
@@ -952,9 +1376,6 @@ struct BlackBoxOp {
         }
         if (tag == "AES128Encrypt") {
             AES128Encrypt v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -965,9 +1386,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Blake2s") {
             Blake2s v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -978,9 +1396,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Blake3") {
             Blake3 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -991,9 +1406,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Keccakf1600") {
             Keccakf1600 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1004,9 +1416,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EcdsaSecp256k1") {
             EcdsaSecp256k1 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1017,9 +1426,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EcdsaSecp256r1") {
             EcdsaSecp256r1 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1030,9 +1436,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "MultiScalarMul") {
             MultiScalarMul v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1043,9 +1446,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "EmbeddedCurveAdd") {
             EmbeddedCurveAdd v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1056,9 +1456,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Poseidon2Permutation") {
             Poseidon2Permutation v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1069,9 +1466,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "Sha256Compression") {
             Sha256Compression v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1082,9 +1476,6 @@ struct BlackBoxOp {
             value = v;
         } else if (tag == "ToRadix") {
             ToRadix v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1104,6 +1495,8 @@ struct SemanticLength {
     uint32_t value;
 
     friend bool operator==(const SemanticLength&, const SemanticLength&);
+
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -1125,6 +1518,8 @@ struct HeapValueType {
 
         friend bool operator==(const Simple&, const Simple&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -1141,6 +1536,13 @@ struct HeapValueType {
         Acir::SemanticLength size;
 
         friend bool operator==(const Array&, const Array&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(value_types);
+            packer.pack(size);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1164,6 +1566,12 @@ struct HeapValueType {
 
         friend bool operator==(const Vector&, const Vector&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(1);
+            packer.pack(value_types);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Vector";
@@ -1182,6 +1590,40 @@ struct HeapValueType {
     std::variant<Simple, Array, Vector> value;
 
     friend bool operator==(const HeapValueType&, const HeapValueType&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Simple";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Array";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "Vector";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'HeapValueType' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -1206,9 +1648,6 @@ struct HeapValueType {
         }
         if (tag == "Simple") {
             Simple v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1219,9 +1658,6 @@ struct HeapValueType {
             value = v;
         } else if (tag == "Array") {
             Array v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1232,9 +1668,6 @@ struct HeapValueType {
             value = v;
         } else if (tag == "Vector") {
             Vector v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1255,6 +1688,13 @@ struct HeapVector {
     Acir::MemoryAddress size;
 
     friend bool operator==(const HeapVector&, const HeapVector&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(pointer);
+        packer.pack(size);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -1280,6 +1720,8 @@ struct ValueOrArray {
 
         friend bool operator==(const MemoryAddress&, const MemoryAddress&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -1295,6 +1737,8 @@ struct ValueOrArray {
         Acir::HeapArray value;
 
         friend bool operator==(const HeapArray&, const HeapArray&);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1312,6 +1756,8 @@ struct ValueOrArray {
 
         friend bool operator==(const HeapVector&, const HeapVector&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -1326,6 +1772,40 @@ struct ValueOrArray {
     std::variant<MemoryAddress, HeapArray, HeapVector> value;
 
     friend bool operator==(const ValueOrArray&, const ValueOrArray&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "MemoryAddress";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "HeapArray";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "HeapVector";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'ValueOrArray' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -1350,9 +1830,6 @@ struct ValueOrArray {
         }
         if (tag == "MemoryAddress") {
             MemoryAddress v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1363,9 +1840,6 @@ struct ValueOrArray {
             value = v;
         } else if (tag == "HeapArray") {
             HeapArray v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1376,9 +1850,6 @@ struct ValueOrArray {
             value = v;
         } else if (tag == "HeapVector") {
             HeapVector v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1403,6 +1874,15 @@ struct BrilligOpcode {
         Acir::MemoryAddress rhs;
 
         friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(destination);
+            packer.pack(op);
+            packer.pack(lhs);
+            packer.pack(rhs);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1434,6 +1914,16 @@ struct BrilligOpcode {
 
         friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(5);
+            packer.pack(destination);
+            packer.pack(op);
+            packer.pack(bit_size);
+            packer.pack(lhs);
+            packer.pack(rhs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "BinaryIntOp";
@@ -1464,6 +1954,14 @@ struct BrilligOpcode {
 
         friend bool operator==(const Not&, const Not&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(destination);
+            packer.pack(source);
+            packer.pack(bit_size);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Not";
@@ -1490,6 +1988,14 @@ struct BrilligOpcode {
 
         friend bool operator==(const Cast&, const Cast&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(destination);
+            packer.pack(source);
+            packer.pack(bit_size);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Cast";
@@ -1515,6 +2021,13 @@ struct BrilligOpcode {
 
         friend bool operator==(const JumpIf&, const JumpIf&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(condition);
+            packer.pack(location);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "JumpIf";
@@ -1537,6 +2050,12 @@ struct BrilligOpcode {
 
         friend bool operator==(const Jump&, const Jump&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(1);
+            packer.pack(location);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Jump";
@@ -1558,6 +2077,14 @@ struct BrilligOpcode {
         Acir::MemoryAddress offset_address;
 
         friend bool operator==(const CalldataCopy&, const CalldataCopy&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(destination_address);
+            packer.pack(size_address);
+            packer.pack(offset_address);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1583,6 +2110,12 @@ struct BrilligOpcode {
 
         friend bool operator==(const Call&, const Call&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(1);
+            packer.pack(location);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Call";
@@ -1604,6 +2137,14 @@ struct BrilligOpcode {
         std::vector<uint8_t> value;
 
         friend bool operator==(const Const&, const Const&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(destination);
+            packer.pack(bit_size);
+            packer.pack(value);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1631,6 +2172,14 @@ struct BrilligOpcode {
 
         friend bool operator==(const IndirectConst&, const IndirectConst&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(destination_pointer);
+            packer.pack(bit_size);
+            packer.pack(value);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "IndirectConst";
@@ -1653,6 +2202,7 @@ struct BrilligOpcode {
     struct Return {
         friend bool operator==(const Return&, const Return&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
@@ -1664,6 +2214,16 @@ struct BrilligOpcode {
         std::vector<Acir::HeapValueType> input_value_types;
 
         friend bool operator==(const ForeignCall&, const ForeignCall&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(5);
+            packer.pack(function);
+            packer.pack(destinations);
+            packer.pack(destination_value_types);
+            packer.pack(inputs);
+            packer.pack(input_value_types);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1694,6 +2254,13 @@ struct BrilligOpcode {
 
         friend bool operator==(const Mov&, const Mov&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(destination);
+            packer.pack(source);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Mov";
@@ -1718,6 +2285,15 @@ struct BrilligOpcode {
         Acir::MemoryAddress condition;
 
         friend bool operator==(const ConditionalMov&, const ConditionalMov&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(destination);
+            packer.pack(source_a);
+            packer.pack(source_b);
+            packer.pack(condition);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1746,6 +2322,13 @@ struct BrilligOpcode {
 
         friend bool operator==(const Load&, const Load&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(destination);
+            packer.pack(source_pointer);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Load";
@@ -1769,6 +2352,13 @@ struct BrilligOpcode {
 
         friend bool operator==(const Store&, const Store&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(destination_pointer);
+            packer.pack(source);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Store";
@@ -1791,6 +2381,8 @@ struct BrilligOpcode {
 
         friend bool operator==(const BlackBox&, const BlackBox&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -1806,6 +2398,12 @@ struct BrilligOpcode {
         Acir::HeapVector revert_data;
 
         friend bool operator==(const Trap&, const Trap&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(1);
+            packer.pack(revert_data);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1826,6 +2424,12 @@ struct BrilligOpcode {
         Acir::HeapVector return_data;
 
         friend bool operator==(const Stop&, const Stop&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(1);
+            packer.pack(return_data);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -1865,6 +2469,104 @@ struct BrilligOpcode {
 
     friend bool operator==(const BrilligOpcode&, const BrilligOpcode&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "BinaryFieldOp";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "BinaryIntOp";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "Not";
+            is_unit = false;
+            break;
+        case 3:
+            tag = "Cast";
+            is_unit = false;
+            break;
+        case 4:
+            tag = "JumpIf";
+            is_unit = false;
+            break;
+        case 5:
+            tag = "Jump";
+            is_unit = false;
+            break;
+        case 6:
+            tag = "CalldataCopy";
+            is_unit = false;
+            break;
+        case 7:
+            tag = "Call";
+            is_unit = false;
+            break;
+        case 8:
+            tag = "Const";
+            is_unit = false;
+            break;
+        case 9:
+            tag = "IndirectConst";
+            is_unit = false;
+            break;
+        case 10:
+            tag = "Return";
+            is_unit = true;
+            break;
+        case 11:
+            tag = "ForeignCall";
+            is_unit = false;
+            break;
+        case 12:
+            tag = "Mov";
+            is_unit = false;
+            break;
+        case 13:
+            tag = "ConditionalMov";
+            is_unit = false;
+            break;
+        case 14:
+            tag = "Load";
+            is_unit = false;
+            break;
+        case 15:
+            tag = "Store";
+            is_unit = false;
+            break;
+        case 16:
+            tag = "BlackBox";
+            is_unit = false;
+            break;
+        case 17:
+            tag = "Trap";
+            is_unit = false;
+            break;
+        case 18:
+            tag = "Stop";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BrilligOpcode' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
 
@@ -1888,9 +2590,6 @@ struct BrilligOpcode {
         }
         if (tag == "BinaryFieldOp") {
             BinaryFieldOp v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1901,9 +2600,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "BinaryIntOp") {
             BinaryIntOp v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1914,9 +2610,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Not") {
             Not v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1927,9 +2620,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Cast") {
             Cast v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1940,9 +2630,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "JumpIf") {
             JumpIf v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1953,9 +2640,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Jump") {
             Jump v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1966,9 +2650,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "CalldataCopy") {
             CalldataCopy v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1979,9 +2660,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Call") {
             Call v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -1992,9 +2670,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Const") {
             Const v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2005,9 +2680,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "IndirectConst") {
             IndirectConst v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2021,9 +2693,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "ForeignCall") {
             ForeignCall v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2034,9 +2703,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Mov") {
             Mov v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2047,9 +2713,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "ConditionalMov") {
             ConditionalMov v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2060,9 +2723,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Load") {
             Load v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2073,9 +2733,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Store") {
             Store v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2086,9 +2743,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "BlackBox") {
             BlackBox v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2099,9 +2753,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Trap") {
             Trap v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2112,9 +2763,6 @@ struct BrilligOpcode {
             value = v;
         } else if (tag == "Stop") {
             Stop v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2135,6 +2783,8 @@ struct Witness {
 
     friend bool operator==(const Witness&, const Witness&);
 
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         try {
@@ -2153,6 +2803,8 @@ struct FunctionInput {
 
         friend bool operator==(const Constant&, const Constant&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -2169,6 +2821,8 @@ struct FunctionInput {
 
         friend bool operator==(const Witness&, const Witness&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -2183,6 +2837,36 @@ struct FunctionInput {
     std::variant<Constant, Witness> value;
 
     friend bool operator==(const FunctionInput&, const FunctionInput&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Constant";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Witness";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'FunctionInput' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -2207,9 +2891,6 @@ struct FunctionInput {
         }
         if (tag == "Constant") {
             Constant v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2220,9 +2901,6 @@ struct FunctionInput {
             value = v;
         } else if (tag == "Witness") {
             Witness v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2247,6 +2925,15 @@ struct BlackBoxFuncCall {
         std::vector<Acir::Witness> outputs;
 
         friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(inputs);
+            packer.pack(iv);
+            packer.pack(key);
+            packer.pack(outputs);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2277,6 +2964,15 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const AND&, const AND&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(lhs);
+            packer.pack(rhs);
+            packer.pack(num_bits);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "AND";
@@ -2306,6 +3002,15 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const XOR&, const XOR&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(lhs);
+            packer.pack(rhs);
+            packer.pack(num_bits);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "XOR";
@@ -2333,6 +3038,13 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const RANGE&, const RANGE&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(input);
+            packer.pack(num_bits);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "RANGE";
@@ -2356,6 +3068,13 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const Blake2s&, const Blake2s&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(inputs);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Blake2s";
@@ -2378,6 +3097,13 @@ struct BlackBoxFuncCall {
         std::shared_ptr<std::array<Acir::Witness, 32>> outputs;
 
         friend bool operator==(const Blake3&, const Blake3&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(inputs);
+            packer.pack(outputs);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2405,6 +3131,17 @@ struct BlackBoxFuncCall {
         Acir::Witness output;
 
         friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(6);
+            packer.pack(public_key_x);
+            packer.pack(public_key_y);
+            packer.pack(signature);
+            packer.pack(hashed_message);
+            packer.pack(predicate);
+            packer.pack(output);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2441,6 +3178,17 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(6);
+            packer.pack(public_key_x);
+            packer.pack(public_key_y);
+            packer.pack(signature);
+            packer.pack(hashed_message);
+            packer.pack(predicate);
+            packer.pack(output);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "EcdsaSecp256r1";
@@ -2474,6 +3222,15 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(points);
+            packer.pack(scalars);
+            packer.pack(predicate);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "MultiScalarMul";
@@ -2503,6 +3260,15 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(input1);
+            packer.pack(input2);
+            packer.pack(predicate);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "EmbeddedCurveAdd";
@@ -2530,6 +3296,13 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const Keccakf1600&, const Keccakf1600&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(inputs);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Keccakf1600";
@@ -2556,6 +3329,17 @@ struct BlackBoxFuncCall {
         Acir::FunctionInput predicate;
 
         friend bool operator==(const RecursiveAggregation&, const RecursiveAggregation&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(6);
+            packer.pack(verification_key);
+            packer.pack(proof);
+            packer.pack(public_inputs);
+            packer.pack(key_hash);
+            packer.pack(proof_type);
+            packer.pack(predicate);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2588,6 +3372,13 @@ struct BlackBoxFuncCall {
 
         friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(inputs);
+            packer.pack(outputs);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "Poseidon2Permutation";
@@ -2611,6 +3402,14 @@ struct BlackBoxFuncCall {
         std::shared_ptr<std::array<Acir::Witness, 8>> outputs;
 
         friend bool operator==(const Sha256Compression&, const Sha256Compression&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(inputs);
+            packer.pack(hash_values);
+            packer.pack(outputs);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2649,6 +3448,84 @@ struct BlackBoxFuncCall {
 
     friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "AES128Encrypt";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "AND";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "XOR";
+            is_unit = false;
+            break;
+        case 3:
+            tag = "RANGE";
+            is_unit = false;
+            break;
+        case 4:
+            tag = "Blake2s";
+            is_unit = false;
+            break;
+        case 5:
+            tag = "Blake3";
+            is_unit = false;
+            break;
+        case 6:
+            tag = "EcdsaSecp256k1";
+            is_unit = false;
+            break;
+        case 7:
+            tag = "EcdsaSecp256r1";
+            is_unit = false;
+            break;
+        case 8:
+            tag = "MultiScalarMul";
+            is_unit = false;
+            break;
+        case 9:
+            tag = "EmbeddedCurveAdd";
+            is_unit = false;
+            break;
+        case 10:
+            tag = "Keccakf1600";
+            is_unit = false;
+            break;
+        case 11:
+            tag = "RecursiveAggregation";
+            is_unit = false;
+            break;
+        case 12:
+            tag = "Poseidon2Permutation";
+            is_unit = false;
+            break;
+        case 13:
+            tag = "Sha256Compression";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BlackBoxFuncCall' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
 
@@ -2672,9 +3549,6 @@ struct BlackBoxFuncCall {
         }
         if (tag == "AES128Encrypt") {
             AES128Encrypt v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2685,9 +3559,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "AND") {
             AND v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2698,9 +3569,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "XOR") {
             XOR v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2711,9 +3579,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "RANGE") {
             RANGE v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2724,9 +3589,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Blake2s") {
             Blake2s v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2737,9 +3599,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Blake3") {
             Blake3 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2750,9 +3609,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EcdsaSecp256k1") {
             EcdsaSecp256k1 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2763,9 +3619,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EcdsaSecp256r1") {
             EcdsaSecp256r1 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2776,9 +3629,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "MultiScalarMul") {
             MultiScalarMul v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2789,9 +3639,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "EmbeddedCurveAdd") {
             EmbeddedCurveAdd v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2802,9 +3649,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Keccakf1600") {
             Keccakf1600 v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2815,9 +3659,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "RecursiveAggregation") {
             RecursiveAggregation v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2828,9 +3669,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Poseidon2Permutation") {
             Poseidon2Permutation v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2841,9 +3679,6 @@ struct BlackBoxFuncCall {
             value = v;
         } else if (tag == "Sha256Compression") {
             Sha256Compression v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2864,6 +3699,8 @@ struct BlockId {
 
     friend bool operator==(const BlockId&, const BlockId&);
 
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         try {
@@ -2880,6 +3717,7 @@ struct BlockType {
     struct Memory {
         friend bool operator==(const Memory&, const Memory&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
@@ -2887,6 +3725,8 @@ struct BlockType {
         uint32_t value;
 
         friend bool operator==(const CallData&, const CallData&);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -2902,12 +3742,47 @@ struct BlockType {
     struct ReturnData {
         friend bool operator==(const ReturnData&, const ReturnData&);
 
+        void msgpack_pack(auto& packer) const {}
         void msgpack_unpack(msgpack::object const& o) {}
     };
 
     std::variant<Memory, CallData, ReturnData> value;
 
     friend bool operator==(const BlockType&, const BlockType&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Memory";
+            is_unit = true;
+            break;
+        case 1:
+            tag = "CallData";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "ReturnData";
+            is_unit = true;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BlockType' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -2935,9 +3810,6 @@ struct BlockType {
             value = v;
         } else if (tag == "CallData") {
             CallData v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -2962,6 +3834,14 @@ struct Expression {
     std::vector<uint8_t> q_c;
 
     friend bool operator==(const Expression&, const Expression&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(3);
+        packer.pack(mul_terms);
+        packer.pack(linear_combinations);
+        packer.pack(q_c);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -2989,6 +3869,8 @@ struct BrilligInputs {
 
         friend bool operator==(const Single&, const Single&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3004,6 +3886,8 @@ struct BrilligInputs {
         std::vector<Acir::Expression> value;
 
         friend bool operator==(const Array&, const Array&);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3021,6 +3905,8 @@ struct BrilligInputs {
 
         friend bool operator==(const MemoryArray&, const MemoryArray&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3035,6 +3921,40 @@ struct BrilligInputs {
     std::variant<Single, Array, MemoryArray> value;
 
     friend bool operator==(const BrilligInputs&, const BrilligInputs&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Single";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Array";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "MemoryArray";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BrilligInputs' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3059,9 +3979,6 @@ struct BrilligInputs {
         }
         if (tag == "Single") {
             Single v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3072,9 +3989,6 @@ struct BrilligInputs {
             value = v;
         } else if (tag == "Array") {
             Array v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3085,9 +3999,6 @@ struct BrilligInputs {
             value = v;
         } else if (tag == "MemoryArray") {
             MemoryArray v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3110,6 +4021,8 @@ struct BrilligOutputs {
 
         friend bool operator==(const Simple&, const Simple&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3126,6 +4039,8 @@ struct BrilligOutputs {
 
         friend bool operator==(const Array&, const Array&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3140,6 +4055,36 @@ struct BrilligOutputs {
     std::variant<Simple, Array> value;
 
     friend bool operator==(const BrilligOutputs&, const BrilligOutputs&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Simple";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Array";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'BrilligOutputs' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3164,9 +4109,6 @@ struct BrilligOutputs {
         }
         if (tag == "Simple") {
             Simple v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3177,9 +4119,6 @@ struct BrilligOutputs {
             value = v;
         } else if (tag == "Array") {
             Array v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3201,6 +4140,14 @@ struct MemOp {
     Acir::Expression value;
 
     friend bool operator==(const MemOp&, const MemOp&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(3);
+        packer.pack(operation);
+        packer.pack(index);
+        packer.pack(value);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3228,6 +4175,8 @@ struct Opcode {
 
         friend bool operator==(const AssertZero&, const AssertZero&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3243,6 +4192,8 @@ struct Opcode {
         Acir::BlackBoxFuncCall value;
 
         friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3260,6 +4211,13 @@ struct Opcode {
         Acir::MemOp op;
 
         friend bool operator==(const MemoryOp&, const MemoryOp&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(block_id);
+            packer.pack(op);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3285,6 +4243,14 @@ struct Opcode {
 
         friend bool operator==(const MemoryInit&, const MemoryInit&);
 
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(3);
+            packer.pack(block_id);
+            packer.pack(init);
+            packer.pack(block_type);
+        }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             std::string name = "MemoryInit";
@@ -3308,9 +4274,18 @@ struct Opcode {
         uint32_t id;
         std::vector<Acir::BrilligInputs> inputs;
         std::vector<Acir::BrilligOutputs> outputs;
-        std::optional<Acir::Expression> predicate;
+        Acir::Expression predicate;
 
         friend bool operator==(const BrilligCall&, const BrilligCall&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(id);
+            packer.pack(inputs);
+            packer.pack(outputs);
+            packer.pack(predicate);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3320,7 +4295,7 @@ struct Opcode {
                 Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                 Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                 Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
                 Helpers::conv_fld_from_array(array, name, "id", id, 0);
@@ -3337,9 +4312,18 @@ struct Opcode {
         uint32_t id;
         std::vector<Acir::Witness> inputs;
         std::vector<Acir::Witness> outputs;
-        std::optional<Acir::Expression> predicate;
+        Acir::Expression predicate;
 
         friend bool operator==(const Call&, const Call&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(4);
+            packer.pack(id);
+            packer.pack(inputs);
+            packer.pack(outputs);
+            packer.pack(predicate);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3349,7 +4333,7 @@ struct Opcode {
                 Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                 Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                 Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, true);
+                Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
                 Helpers::conv_fld_from_array(array, name, "id", id, 0);
@@ -3365,6 +4349,52 @@ struct Opcode {
     std::variant<AssertZero, BlackBoxFuncCall, MemoryOp, MemoryInit, BrilligCall, Call> value;
 
     friend bool operator==(const Opcode&, const Opcode&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "AssertZero";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "BlackBoxFuncCall";
+            is_unit = false;
+            break;
+        case 2:
+            tag = "MemoryOp";
+            is_unit = false;
+            break;
+        case 3:
+            tag = "MemoryInit";
+            is_unit = false;
+            break;
+        case 4:
+            tag = "BrilligCall";
+            is_unit = false;
+            break;
+        case 5:
+            tag = "Call";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'Opcode' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3389,9 +4419,6 @@ struct Opcode {
         }
         if (tag == "AssertZero") {
             AssertZero v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3402,9 +4429,6 @@ struct Opcode {
             value = v;
         } else if (tag == "BlackBoxFuncCall") {
             BlackBoxFuncCall v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3415,9 +4439,6 @@ struct Opcode {
             value = v;
         } else if (tag == "MemoryOp") {
             MemoryOp v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3428,9 +4449,6 @@ struct Opcode {
             value = v;
         } else if (tag == "MemoryInit") {
             MemoryInit v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3441,9 +4459,6 @@ struct Opcode {
             value = v;
         } else if (tag == "BrilligCall") {
             BrilligCall v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3454,9 +4469,6 @@ struct Opcode {
             value = v;
         } else if (tag == "Call") {
             Call v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3479,6 +4491,8 @@ struct ExpressionOrMemory {
 
         friend bool operator==(const Expression&, const Expression&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3495,6 +4509,8 @@ struct ExpressionOrMemory {
 
         friend bool operator==(const Memory&, const Memory&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3509,6 +4525,36 @@ struct ExpressionOrMemory {
     std::variant<Expression, Memory> value;
 
     friend bool operator==(const ExpressionOrMemory&, const ExpressionOrMemory&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Expression";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Memory";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'ExpressionOrMemory' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3533,9 +4579,6 @@ struct ExpressionOrMemory {
         }
         if (tag == "Expression") {
             Expression v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3546,9 +4589,6 @@ struct ExpressionOrMemory {
             value = v;
         } else if (tag == "Memory") {
             Memory v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3569,6 +4609,13 @@ struct AssertionPayload {
     std::vector<Acir::ExpressionOrMemory> payload;
 
     friend bool operator==(const AssertionPayload&, const AssertionPayload&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(error_selector);
+        packer.pack(payload);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3594,6 +4641,8 @@ struct OpcodeLocation {
 
         friend bool operator==(const Acir&, const Acir&);
 
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o)
         {
             try {
@@ -3610,6 +4659,13 @@ struct OpcodeLocation {
         uint64_t brillig_index;
 
         friend bool operator==(const Brillig&, const Brillig&);
+
+        void msgpack_pack(auto& packer) const
+        {
+            packer.pack_array(2);
+            packer.pack(acir_index);
+            packer.pack(brillig_index);
+        }
 
         void msgpack_unpack(msgpack::object const& o)
         {
@@ -3631,6 +4687,36 @@ struct OpcodeLocation {
     std::variant<Acir, Brillig> value;
 
     friend bool operator==(const OpcodeLocation&, const OpcodeLocation&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        std::string tag;
+        bool is_unit;
+        switch (value.index()) {
+
+        case 0:
+            tag = "Acir";
+            is_unit = false;
+            break;
+        case 1:
+            tag = "Brillig";
+            is_unit = false;
+            break;
+        default:
+            throw_or_abort("unknown enum 'OpcodeLocation' variant index: " + std::to_string(value.index()));
+        }
+        if (is_unit) {
+            packer.pack(tag);
+        } else {
+            std::visit(
+                [&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                },
+                value);
+        }
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -3655,9 +4741,6 @@ struct OpcodeLocation {
         }
         if (tag == "Acir") {
             Acir v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3668,9 +4751,6 @@ struct OpcodeLocation {
             value = v;
         } else if (tag == "Brillig") {
             Brillig v;
-            if (o.type != msgpack::type::MAP) {
-                throw_or_abort("expected MAP for enum variant, got STR (unit variant syntax for non-unit variant)");
-            }
             try {
                 o.via.map.ptr[0].val.convert(v);
             } catch (const msgpack::type_error&) {
@@ -3691,6 +4771,8 @@ struct PublicInputs {
 
     friend bool operator==(const PublicInputs&, const PublicInputs&);
 
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         try {
@@ -3704,7 +4786,7 @@ struct PublicInputs {
 
 struct Circuit {
     std::string function_name;
-    std::optional<uint32_t> current_witness_index;
+    uint32_t current_witness_index;
     std::vector<Acir::Opcode> opcodes;
     std::vector<Acir::Witness> private_parameters;
     Acir::PublicInputs public_parameters;
@@ -3713,13 +4795,25 @@ struct Circuit {
 
     friend bool operator==(const Circuit&, const Circuit&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(7);
+        packer.pack(function_name);
+        packer.pack(current_witness_index);
+        packer.pack(opcodes);
+        packer.pack(private_parameters);
+        packer.pack(public_parameters);
+        packer.pack(return_values);
+        packer.pack(assert_messages);
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         std::string name = "Circuit";
         if (o.type == msgpack::type::MAP) {
             auto kvmap = Helpers::make_kvmap(o, name);
             Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-            Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, true);
+            Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
             Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
             Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
             Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);
@@ -3746,6 +4840,13 @@ struct BrilligBytecode {
 
     friend bool operator==(const BrilligBytecode&, const BrilligBytecode&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(function_name);
+        packer.pack(bytecode);
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         std::string name = "BrilligBytecode";
@@ -3769,6 +4870,13 @@ struct Program {
 
     friend bool operator==(const Program&, const Program&);
 
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(functions);
+        packer.pack(unconstrained_functions);
+    }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         std::string name = "Program";
@@ -3791,6 +4899,13 @@ struct ProgramWithoutBrillig {
     std::monostate unconstrained_functions;
 
     friend bool operator==(const ProgramWithoutBrillig&, const ProgramWithoutBrillig&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(functions);
+        packer.pack(unconstrained_functions);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
@@ -72,6 +72,8 @@ struct Witness {
     friend bool operator==(const Witness&, const Witness&);
 
     bool operator<(Witness const& rhs) const { return value < rhs.value; }
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
+
     void msgpack_unpack(msgpack::object const& o)
     {
         try {
@@ -87,6 +89,8 @@ struct WitnessMap {
     std::map<Witnesses::Witness, std::vector<uint8_t>> value;
 
     friend bool operator==(const WitnessMap&, const WitnessMap&);
+
+    void msgpack_pack(auto& packer) const { packer.pack(value); }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -104,6 +108,13 @@ struct StackItem {
     Witnesses::WitnessMap witness;
 
     friend bool operator==(const StackItem&, const StackItem&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(2);
+        packer.pack(index);
+        packer.pack(witness);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -126,6 +137,12 @@ struct WitnessStack {
     std::vector<Witnesses::StackItem> stack;
 
     friend bool operator==(const WitnessStack&, const WitnessStack&);
+
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_array(1);
+        packer.pack(stack);
+    }
 
     void msgpack_unpack(msgpack::object const& o)
     {
@@ -185,7 +202,10 @@ namespace Witnesses {
 
 inline bool operator==(const Witness& lhs, const Witness& rhs)
 {
-    return lhs.value == rhs.value;
+    if (!(lhs.value == rhs.value)) {
+        return false;
+    }
+    return true;
 }
 
 } // end of namespace Witnesses
@@ -214,7 +234,10 @@ namespace Witnesses {
 
 inline bool operator==(const WitnessMap& lhs, const WitnessMap& rhs)
 {
-    return lhs.value == rhs.value;
+    if (!(lhs.value == rhs.value)) {
+        return false;
+    }
+    return true;
 }
 
 } // end of namespace Witnesses
@@ -243,7 +266,10 @@ namespace Witnesses {
 
 inline bool operator==(const WitnessStack& lhs, const WitnessStack& rhs)
 {
-    return lhs.stack == rhs.stack;
+    if (!(lhs.stack == rhs.stack)) {
+        return false;
+    }
+    return true;
 }
 
 } // end of namespace Witnesses


### PR DESCRIPTION
### 🧾 Audit Context

The DSL audit noted that we don't test deserialisation roundtrips: bytecode to `Acir::Circuit` and back. This PR adds roundtrip checks.

### 🛠️ Changes Made

### ✅ Checklist

- [ ] Audited all methods of the relevant module/class
- [ ] Audited the interface of the module/class with other (relevant) components
- [ ] Documented existing functionality and any changes made (as per Doxygen requirements)
- [ ] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [ ] Confirmed and documented any security or other issues found (if applicable)
- [X] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers