### PR TITLE
fix: allocate non-gate selectors at trace-active size instead of dyadic size

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/prover_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/prover_polynomials.hpp
@@ -31,7 +31,7 @@ class ProverPolynomialsBase : public AllEntitiesBase {
     ProverPolynomialsBase(ProverPolynomialsBase&& o) noexcept = default;
     ProverPolynomialsBase& operator=(ProverPolynomialsBase&& o) noexcept = default;
     ~ProverPolynomialsBase() = default;
-    [[nodiscard]] size_t get_polynomial_size() const { return this->q_c.size(); }
+    [[nodiscard]] size_t get_polynomial_size() const { return this->q_c.virtual_size(); }
     [[nodiscard]] AllValuesType get_row(size_t row_idx) const
     {
         AllValuesType result;

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -81,6 +81,21 @@ Polynomial<HypernovaFoldingProver::FF> HypernovaFoldingProver::batch_polynomials
     BB_ASSERT_EQ(
         challenges.size(), N, "The number of challenges provided does not match the number of polynomials to batch.");
 
+    // Ensure the first polynomial has enough backing to accumulate all others (they may have different backing sizes)
+    size_t max_end = polynomials_to_batch[0].end_index();
+    for (size_t idx = 1; idx < N; idx++) {
+        max_end = std::max(max_end, polynomials_to_batch[idx].end_index());
+    }
+
+    if (max_end > polynomials_to_batch[0].end_index()) {
+        Polynomial<FF> result(max_end, full_batched_size);
+        result += polynomials_to_batch[0];
+        for (size_t idx = 1; idx < N; idx++) {
+            result.add_scaled(polynomials_to_batch[idx], challenges[idx]);
+        }
+        return result;
+    }
+
     for (size_t idx = 1; idx < N; idx++) {
         polynomials_to_batch[0].add_scaled(polynomials_to_batch[idx], challenges[idx]);
     }

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_prover.cpp
@@ -81,14 +81,17 @@ Polynomial<HypernovaFoldingProver::FF> HypernovaFoldingProver::batch_polynomials
     BB_ASSERT_EQ(
         challenges.size(), N, "The number of challenges provided does not match the number of polynomials to batch.");
 
-    // Ensure the first polynomial has enough backing to accumulate all others (they may have different backing sizes)
+    // Ensure the first polynomial has enough backing to accumulate all others (they may have different backing sizes
+    // and/or start indices). add_scaled requires destination start_index <= source start_index.
+    size_t min_start = polynomials_to_batch[0].start_index();
     size_t max_end = polynomials_to_batch[0].end_index();
     for (size_t idx = 1; idx < N; idx++) {
+        min_start = std::min(min_start, polynomials_to_batch[idx].start_index());
         max_end = std::max(max_end, polynomials_to_batch[idx].end_index());
     }
 
-    if (max_end > polynomials_to_batch[0].end_index()) {
-        Polynomial<FF> result(max_end, full_batched_size);
+    if (min_start < polynomials_to_batch[0].start_index() || max_end > polynomials_to_batch[0].end_index()) {
+        Polynomial<FF> result(max_end - min_start, full_batched_size, min_start);
         result += polynomials_to_batch[0];
         for (size_t idx = 1; idx < N; idx++) {
             result.add_scaled(polynomials_to_batch[idx], challenges[idx]);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/prover_instance.cpp
@@ -176,9 +176,9 @@ template <typename Flavor> void ProverInstance_<Flavor>::allocate_selectors(cons
         selector = Polynomial(block.size(), dyadic_size(), block.trace_offset());
     }
 
-    // Set the other non-gate selector polynomials (e.g. q_l, q_r, q_m etc.) to full size
+    // Set the other non-gate selector polynomials (e.g. q_l, q_r, q_m etc.) to active trace size
     for (auto& selector : polynomials.get_non_gate_selectors()) {
-        selector = Polynomial(dyadic_size());
+        selector = Polynomial(trace_active_range_size(), dyadic_size());
     }
 }
 


### PR DESCRIPTION
## Summary

- Allocate non-gate selectors (`q_m`, `q_c`, `q_l`, `q_r`, `q_o`, `q_4`) at `trace_active_range_size()` instead of `dyadic_size()`, using virtual zeroes for the rest
- Fix `get_polynomial_size()` to return `virtual_size()` instead of `size()`, since the logical polynomial size is the dyadic circuit size
- Fix `batch_polynomials` in Hypernova to handle polynomials with different backing sizes (non-gate selectors now have smaller backing than other entities like table polynomials)

## Benchmark results

```bash
cd barretenberg/cpp/build
BB_VERBOSE=1 BB_BENCH=1 ./bin/ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates_dyadic_2_20$" --benchmark_repetitions=1
BB_VERBOSE=1 BB_BENCH=1 ./bin/ultra_honk_bench --benchmark_filter="construct_proof_ultrahonk_1M_gates_dyadic_2_21$" --benchmark_repetitions=1
```

Circuits ~2000 gates apart straddling the 2^20 boundary:

| Metric | Before | After |
|---|---|---|
| Peak RSS (2^21 dyadic) | 2854 MiB | **2375 MiB** (-479 MiB, -17%) |
| Memory gap 2^20 vs 2^21 | 603 MiB | **126 MiB** (-79%) |
| Peak RSS (2^20 dyadic) | 2251 MiB | 2249 MiB (unchanged) |

## Test plan

- [x] `ultra_honk_tests` — 260 passed, 5 skipped
- [x] `chonk_tests` — 20 passed
- [x] `circuit_checker_tests` — 80 passed
- [x] `hypernova_tests` — 9 passed

Resolves AztecProtocol/barretenberg#1625.