### PR TITLE
fix: increase waitForTx timeout in epochs_invalidate_block test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_invalidate_block.parallel.test.ts
@@ -184,7 +184,7 @@ describe('e2e_epochs/epochs_invalidate_block', () => {
     );
 
     // Verify the transaction was eventually included
-    const receipt = await waitForTx(context.aztecNode, sentTx, { timeout: test.L2_SLOT_DURATION_IN_S * 4 });
+    const receipt = await waitForTx(context.aztecNode, sentTx, { timeout: test.L2_SLOT_DURATION_IN_S * 8 });
     expect(receipt.isMined()).toBeTrue();
     logger.warn(`Transaction included in block ${receipt.blockNumber}`);
 


### PR DESCRIPTION
## Summary

- Increases the `waitForTx` timeout in the `epochs_invalidate_block` test from `L2_SLOT_DURATION_IN_S * 4` (144s) to `L2_SLOT_DURATION_IN_S * 8` (288s)
- The sentTx must survive a checkpoint invalidation cycle, and with `maxTxsPerBlock: 1` and 8 txs in the mempool, it could be picked up anywhere from 1st to 8th
- With the previous timeout, node-0 could only sync ~2 checkpoints (4 txs) before timing out, causing intermittent failures when the sentTx was ordered 5th or later

## Test plan

- This only increases a timeout value, no logic changes
- The fix aligns with the timeout already used later in the same test for `waitUntilCheckpointNumber` (line 205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)