### PR TITLE
chore: update skill to correct path and add changelog docs for new endpoints and error codes

### DIFF
--- a/.claude/skills/updating-changelog/SKILL.md
+++ b/.claude/skills/updating-changelog/SKILL.md
@@ -14,7 +14,7 @@ Read `.release-please-manifest.json` to get the version (e.g., `{"." : "4.0.0"}`
 **Target files:**
 
 - Aztec contract developers: `docs/docs-developers/docs/resources/migration_notes.md`
-- Node operators and Ethereum contract developers: `docs/docs-network/reference/changelog/v{major}.md`
+- Node operators and Ethereum contract developers: `docs/docs-operate/operators/reference/changelog/v{major}.md`
 
 ### 2. Analyze Branch Changes
 
@@ -60,7 +60,7 @@ Explanation of what changed.
 
 ## Node Operator Changelog Format
 
-**File:** `docs/docs-network/reference/changelog/v{major}.md`
+**File:** `docs/docs-operate/operators/reference/changelog/v{major}.md`
 
 **Breaking changes:**
 ````markdown

--- a/docs/docs-operate/operators/reference/changelog/v4.md
+++ b/docs/docs-operate/operators/reference/changelog/v4.md
@@ -88,6 +88,55 @@ A new environment variable `AZTEC_INITIAL_ETH_PER_FEE_ASSET` has been added to c
 
 This replaces the previous hardcoded default and allows network operators to set the starting price point for the fee asset.
 
+### `reloadKeystore` admin RPC endpoint
+
+Node operators can now update validator attester keys, coinbase, and fee recipient without restarting the node by calling the new `reloadKeystore` admin RPC endpoint.
+
+What is updated on reload:
+- Validator attester keys (add, remove, or replace)
+- Coinbase and fee recipient per validator
+- Publisher-to-validator mapping
+
+What is NOT updated (requires restart):
+- L1 publisher signers
+- Prover keys
+- HA signer connections
+
+New validators must use a publisher key already initialized at startup. Reload is rejected with a clear error if validation fails.
+
+### Admin API key authentication
+
+The admin JSON-RPC endpoint now supports auto-generated API key authentication.
+
+**Behavior:**
+- A cryptographically secure API key is auto-generated at first startup and displayed once via stdout
+- Only the SHA-256 hash is persisted to `<dataDirectory>/admin/api_key_hash`
+- The key is reused across restarts when `--data-directory` is set
+- Supports both `x-api-key` and `Authorization: Bearer <key>` headers
+- Health check endpoint (`GET /status`) is excluded from auth (for k8s probes)
+
+**Configuration:**
+
+```bash
+--admin-api-key-hash <hex>                 ($AZTEC_ADMIN_API_KEY_HASH)    # Use a pre-generated SHA-256 key hash
+--no-admin-api-key                         ($AZTEC_NO_ADMIN_API_KEY)      # Disable auth entirely
+--reset-admin-api-key                      ($AZTEC_RESET_ADMIN_API_KEY)   # Force key regeneration
+```
+
+**Helm charts**: Admin API key auth is disabled by default (`noAdminApiKey: true`). Set to `false` in production values to enable.
+
+**Migration**: No action required — auth is opt-out. To enable, ensure `--no-admin-api-key` is not set and note the key printed at startup.
+
+### Transaction pool error codes for RPC callers
+
+Transaction submission via RPC now returns structured rejection codes when a transaction is rejected by the mempool:
+
+- `LOW_PRIORITY_FEE` — tx priority fee is too low
+- `INSUFFICIENT_FEE_PAYER_BALANCE` — fee payer doesn't have enough balance
+- `NULLIFIER_CONFLICT` — conflicting nullifier already in pool
+
+**Impact**: Improved developer experience — callers can now programmatically handle specific rejection reasons.
+
 ## Changed defaults
 
 ## Troubleshooting


### PR DESCRIPTION
- update  `updating-changelog` skill to point to correct path for node operators
- add changelog docs for the reloadKeystore, admin API key, and error codes for RPC calls
