### PR TITLE
feat: notify slack on merge train PR merge

### DIFF
--- a/.github/workflows/merge-queue-dequeue-notify.yml
+++ b/.github/workflows/merge-queue-dequeue-notify.yml
@@ -1,14 +1,14 @@
-name: Notify Slack on Merge Queue Dequeue
+name: Notify Slack on Merge Train Events
 
 on:
   pull_request:
-    types: [dequeued]
+    types: [dequeued, closed]
 
 jobs:
-  notify-slack:
-    name: Notify Slack
+  notify-dequeued:
+    name: Notify Slack (Dequeued)
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.event.pull_request.merged != true
+    if: github.event.action == 'dequeued' && startsWith(github.event.pull_request.head.ref, 'merge-train/') && github.event.pull_request.merged != true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,3 +21,20 @@ jobs:
           REF_NAME: ${{ github.event.pull_request.head.ref }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: ./ci3/merge_train_failure_slack_notify --dequeued
+
+  notify-merged:
+    name: Notify Slack (Merged)
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'merge-train/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Send Slack notification
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          REF_NAME: ${{ github.event.pull_request.head.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: ./ci3/merge_train_failure_slack_notify --merged

--- a/ci3/merge_train_failure_slack_notify
+++ b/ci3/merge_train_failure_slack_notify
@@ -2,11 +2,15 @@
 set -eu
 
 # Parse arguments
-DEQUEUED=false
+MODE=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --dequeued)
-      DEQUEUED=true
+      MODE="dequeued"
+      shift
+      ;;
+    --merged)
+      MODE="merged"
       shift
       ;;
     *)
@@ -52,8 +56,10 @@ EOF
 
 set -x
 
-if [[ "$DEQUEUED" == "true" ]]; then
+if [[ "$MODE" == "dequeued" ]]; then
   send_slack_message "PR was removed from the merge queue: <$PR_URL|View PR>"
+elif [[ "$MODE" == "merged" ]]; then
+  send_slack_message "PR merged: <$PR_URL|$commit_title> by $commit_author"
 else
   send_slack_message "There was a failure (http://ci.aztec-labs.com/$ci_log_id) in the merge-train:\\n$commit_title by $commit_author"
 fi


### PR DESCRIPTION
Extends the merge-queue dequeue notification workflow to also notify on merge
