### PR TITLE
chore: remove non cross-platform, dead code

### DIFF
--- a/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
+++ b/barretenberg/sol/scripts/copy_optimized_to_cpp.sh
@@ -97,22 +97,17 @@ awk '
 awk '
     BEGIN {
         in_unroll = 0
-        unroll_label = ""
     }
     # Detect UNROLL_SECTION_START
     /\{\{[[:space:]]*UNROLL_SECTION_START[[:space:]]+[^}]+\}\}/ {
         print  # Print the start marker
         in_unroll = 1
-        # Extract the label for matching with END
-        match($0, /UNROLL_SECTION_START[[:space:]]+([^[:space:]}\]]+)/, arr)
-        unroll_label = arr[1]
         next
     }
     # Detect UNROLL_SECTION_END
     /\{\{[[:space:]]*UNROLL_SECTION_END[[:space:]]+[^}]+\}\}/ {
         print  # Print the end marker
         in_unroll = 0
-        unroll_label = ""
         next
     }
     # Skip lines inside unroll sections


### PR DESCRIPTION
Root cause: copy_optimized_to_cpp.sh line 107 uses match($0, regex, arr) - a 3-argument form of match() that is a gawk  extension. This system has mawk as /usr/bin/awk, which only supports the 2-argument form. The error awk: line 11: syntax error at or near , is mawk choking on the third argument.

  Why it didn't abort the script: The awk command is part of an awk ... && mv ... compound, and set -e doesn't trigger on  non-final commands in AND-OR lists (per POSIX). So the awk fails silently, the UNROLL_SECTION stripping is skipped, and  the generated hpp ends up with expanded unroll sections that shouldn't be there.

  The fix: Removed the 3-argument match() call and the unroll_label variable entirely. They were dead code - the label was  extracted but never used in any condition or comparison. The UNROLL_SECTION_END detection already works via its own regex  pattern, independent of any label matching.

  The bug has existed since the script was first written (22aab972e2f - "feat: script to generate honk_optimized hpp") but  likely wasn't triggered because CI environments use gawk, or the code path wasn't exercised in bootstrap until recently.  The recent PR b6753c330a1 ("refactor: verifier contracts" by LHerskind) didn't introduce the awk bug itself, but it  committed BlakeHonkOpt.sol to git and changed the script's input path, which means the sync check now actually runs during  bootstrap.
