### PR TITLE
refactor: split ContractSelf into context-specific structs

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_private.nr
@@ -1,32 +1,23 @@
-//! The `self` contract value.
+//! The `self` contract value for private execution contexts.
 
 use crate::{
-    context::{
-        calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall},
-        PrivateContext,
-        PublicContext,
-        UtilityContext,
-    },
-    event::{
-        event_emission::{emit_event_in_private, emit_event_in_public},
-        event_interface::EventInterface,
-        EventMessage,
-    },
+    context::{calls::{PrivateCall, PrivateStaticCall, PublicCall, PublicStaticCall}, PrivateContext},
+    event::{event_emission::emit_event_in_private, event_interface::EventInterface, EventMessage},
 };
 use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
 
-/// Core interface for interacting with aztec-nr contract features.
+/// Core interface for interacting with aztec-nr contract features in private execution contexts.
 ///
 /// This struct is automatically injected into every [`external`](crate::macros::functions::external) and
-/// [`internal`](crate::macros::functions::internal) contract function by the Aztec macro system and is accessible
-/// through the `self` variable.
+/// [`internal`](crate::macros::functions::internal) contract function marked with `"private"` by the Aztec macro
+/// system and is accessible through the `self` variable.
 ///
 /// ## Usage in Contract Functions
 ///
 /// Once injected, you can use `self` to:
 /// - Access storage: `self.storage.balances.at(owner).read()`
 /// - Call contracts: `self.call(Token::at(address).transfer(recipient, amount))`
-/// - Emit events: `self.emit(event).deliver_to(recipient, delivery_mode)` (private) or `self.emit(event)` (public)
+/// - Emit events: `self.emit(event).deliver_to(recipient, delivery_mode)`
 /// - Get the contract address: `self.address`
 /// - Get the caller: `self.msg_sender()`
 /// - Access low-level Aztec.nr APIs through the context: `self.context`
@@ -49,14 +40,14 @@ use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
 ///
 /// ## Type Parameters
 ///
-/// - `Context`: The execution context type - either `&mut PrivateContext`, `PublicContext`, or `UtilityContext`
 /// - `Storage`: The contract's storage struct (defined with [`storage`](crate::macros::storage::storage), or `()` if
 /// the contract has no storage
 /// - `CallSelf`: Macro-generated type for calling contract's own non-view functions
 /// - `EnqueueSelf`: Macro-generated type for enqueuing calls to the contract's own non-view functions
 /// - `CallSelfStatic`: Macro-generated type for calling contract's own view functions
 /// - `EnqueueSelfStatic`: Macro-generated type for enqueuing calls to the contract's own view functions
-pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
+/// - `CallInternal`: Macro-generated type for calling internal functions
+pub struct ContractSelfPrivate<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
     /// The address of this contract
     pub address: AztecAddress,
 
@@ -64,10 +55,8 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// [`storage`](crate::macros::storage::storage) macro was applied in your contract. If the contract has no
     /// storage, the type of this will be `()`.
     ///
-    /// This storage instance is specialized for the current execution context (private, public, or utility) and
-    /// provides access to the contract's state variables. Each state variable accepts the context as a generic
-    /// parameter, which determines its available functionality. For example, a PublicImmutable variable can be read
-    /// from any context (public, private, or utility) but can only be written to from public contexts.
+    /// This storage instance is specialized for the current execution context (private) and
+    /// provides access to the contract's state variables.
     ///
     /// ## Developer Note
     ///
@@ -75,17 +64,12 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     /// to unit type `()`, it means you haven't yet defined a Storage struct using the
     /// [`storage`](crate::macros::storage::storage) macro in your contract. For guidance on setting this up, please
     /// refer to our docs: https://docs.aztec.network/developers/docs/guides/smart_contracts/storage
-
     pub storage: Storage,
 
-    /// The execution context whose type is determined by the [`external`](crate::macros::functions::external)
-    /// attribute of the contract function based on the external function type (private, public, or utility).
-    pub context: Context,
+    /// The private execution context.
+    pub context: &mut PrivateContext,
 
     /// Provides type-safe methods for calling this contract's own non-view functions.
-    ///
-    /// In private and public contexts this will be a struct with appropriate methods; in utility context it will be
-    /// the unit type `()`.
     ///
     /// Example API:
     /// ```noir
@@ -95,9 +79,6 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
 
     /// Provides type-safe methods for enqueuing calls to this contract's own non-view functions.
     ///
-    /// In private context this will be a struct with appropriate methods; in public and utility contexts it will be
-    /// the unit type `()`.
-    ///
     /// Example API:
     /// ```noir
     /// self.enqueue_self.some_public_function(args)
@@ -106,19 +87,13 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
 
     /// Provides type-safe methods for calling this contract's own view functions.
     ///
-    /// In private and public contexts this will be a struct with appropriate methods; in utility context it will be
-    /// the unit type `()`.
-    ///
     /// Example API:
     /// ```noir
     /// self.call_self_static.some_view_function(args)
     /// ```
     pub call_self_static: CallSelfStatic,
 
-    /// Provides type-safe methods for enqueuing calls to this contract's own view functions.
-    ///
-    /// In private context this will be a struct with appropriate methods; in public and utility contexts it will be
-    /// the unit type `()`.
+    /// Provides type-safe methods for enqueuing calls to the contract's own view functions.
     ///
     /// Example API:
     /// ```noir
@@ -128,9 +103,6 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
 
     /// Provides type-safe methods for calling internal functions.
     ///
-    /// In private and public contexts this will be a struct with appropriate methods; in utility context it will be
-    /// the unit type `()`.
-    ///
     /// Example API:
     /// ```noir
     /// self.internal.some_internal_function(args)
@@ -138,14 +110,11 @@ pub struct ContractSelf<Context, Storage, CallSelf, EnqueueSelf, CallSelfStatic,
     pub internal: CallInternal,
 }
 
-// Implementation for `ContractSelf` in private execution contexts.
-//
-// This implementation is used when an external or internal contract function is marked with "private".
-impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> ContractSelf<&mut PrivateContext, Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
-    /// Creates a new `ContractSelf` instance for a private function.
+impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> ContractSelfPrivate<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInternal> {
+    /// Creates a new `ContractSelfPrivate` instance for a private function.
     ///
     /// This constructor is called automatically by the macro system and should not be called directly.
-    pub fn new_private(
+    pub fn new(
         context: &mut PrivateContext,
         storage: Storage,
         call_self: CallSelf,
@@ -335,8 +304,8 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
 
     /// Enqueues a privacy-preserving public contract call function.
     ///
-    /// This is the same as [`ContractSelf::enqueue`], except it hides this calling contract's address from the target
-    /// public function (i.e. [`ContractSelf::msg_sender`] will panic).
+    /// This is the same as [`ContractSelfPrivate::enqueue`], except it hides this calling contract's address from the
+    /// target public function (i.e. [`ContractSelfPrivate::msg_sender`] will panic).
     ///
     /// This means the origin of the call (msg_sender) will not be publicly visible to any blockchain observers, nor to
     /// the target public function. If the target public function reads `self.msg_sender()` the call will revert.
@@ -424,143 +393,5 @@ impl<Storage, CallSelf, EnqueueSelf, CallSelfStatic, EnqueueSelfStatic, CallInte
     ///
     pub fn set_as_teardown_incognito<let M: u32, let N: u32, T>(&mut self, call: PublicCall<M, N, T>) {
         call.set_as_teardown_incognito(self.context)
-    }
-}
-
-// Implementation for `ContractSelf` in public execution contexts.
-//
-// This implementation is used when an external or internal contract function is marked with "public".
-impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelf<PublicContext, Storage, CallSelf, (), CallSelfStatic, (), CallInternal> {
-    /// Creates a new `ContractSelf` instance for a public function.
-    ///
-    /// This constructor is called automatically by the macro system and should not be called directly.
-    pub fn new_public(
-        context: PublicContext,
-        storage: Storage,
-        call_self: CallSelf,
-        call_self_static: CallSelfStatic,
-        internal: CallInternal,
-    ) -> Self {
-        Self {
-            context,
-            storage,
-            address: context.this_address(),
-            call_self,
-            enqueue_self: (),
-            call_self_static,
-            enqueue_self_static: (),
-            internal,
-        }
-    }
-
-    /// The address of the contract address that made this function call.
-    ///
-    /// This is similar to Solidity's `msg.sender` value.
-    ///
-    /// ## Incognito Calls
-    ///
-    /// Contracts can call public functions from private ones hiding their identity (see
-    /// [`enqueue_incognito`](ContractSelf::enqueue_incognito)). This function reverts when executed in such a context.
-    ///
-    /// If you need to handle these cases, use [`PublicContext::maybe_msg_sender`].
-    pub fn msg_sender(self: Self) -> AztecAddress {
-        self.context.maybe_msg_sender().unwrap()
-    }
-
-    /// Emits an event publicly.
-    ///
-    /// Public events are emitted as plaintext and are therefore visible to everyone. This is is the same as Solidity
-    /// events on EVM chains.
-    ///
-    /// Unlike private events, they don't require delivery of an event message.
-    ///
-    /// # Example
-    /// ```noir
-    /// #[event]
-    /// struct Update { value: Field }
-    ///
-    /// #[external("public")]
-    /// fn publish_update(value: Field) {
-    ///     self.emit(Update { value });
-    /// }
-    /// ```
-    ///
-    /// # Cost
-    ///
-    /// Public event emission is achieved by emitting public transaction logs. A total of `N+1` fields are emitted,
-    /// where `N` is the serialization length of the event.
-    pub fn emit<Event>(&mut self, event: Event)
-    where
-        Event: EventInterface + Serialize,
-    {
-        emit_event_in_public(self.context, event);
-    }
-
-    /// Makes a public contract call.
-    ///
-    /// Will revert if the called function reverts or runs out of gas.
-    ///
-    /// # Arguments
-    /// * `call` - The object representing the public function to invoke.
-    ///
-    /// # Returns
-    /// * `T` - Whatever data the called function has returned.
-    ///
-    /// # Example
-    /// ```noir
-    /// self.call(Token::at(address).transfer_in_public(recipient, amount));
-    /// ```
-    ///
-    pub unconstrained fn call<let M: u32, let N: u32, T>(self, call: PublicCall<M, N, T>) -> T
-    where
-        T: Deserialize,
-    {
-        call.call(self.context)
-    }
-
-    /// Makes a public read-only contract call.
-    ///
-    /// This is similar to Solidity's `staticcall`. The called function cannot modify state or emit events. Any nested
-    /// calls are constrained to also be static calls.
-    ///
-    /// Will revert if the called function reverts or runs out of gas.
-    ///
-    /// # Arguments
-    /// * `call` - The object representing the read-only public function to invoke.
-    ///
-    /// # Returns
-    /// * `T` - Whatever data the called function has returned.
-    ///
-    /// # Example
-    /// ```noir
-    /// self.view(Token::at(address).balance_of_public(recipient));
-    /// ```
-    ///
-    pub unconstrained fn view<let M: u32, let N: u32, T>(self, call: PublicStaticCall<M, N, T>) -> T
-    where
-        T: Deserialize,
-    {
-        call.view(self.context)
-    }
-}
-
-// Implementation for `ContractSelf` in utility execution contexts.
-//
-// This implementation is used when an external or internal contract function is marked with "utility".
-impl<Storage> ContractSelf<UtilityContext, Storage, (), (), (), (), ()> {
-    /// Creates a new `ContractSelf` instance for a utility function.
-    ///
-    /// This constructor is called automatically by the macro system and should not be called directly.
-    pub fn new_utility(context: UtilityContext, storage: Storage) -> Self {
-        Self {
-            context,
-            storage,
-            address: context.this_address(),
-            call_self: (),
-            enqueue_self: (),
-            call_self_static: (),
-            enqueue_self_static: (),
-            internal: (),
-        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
@@ -1,0 +1,173 @@
+//! The `self` contract value for public execution contexts.
+
+use crate::{
+    context::{calls::{PublicCall, PublicStaticCall}, PublicContext},
+    event::{event_emission::emit_event_in_public, event_interface::EventInterface},
+};
+use crate::protocol::{address::AztecAddress, traits::{Deserialize, Serialize}};
+
+/// Core interface for interacting with aztec-nr contract features in public execution contexts.
+///
+/// This struct is automatically injected into every [`external`](crate::macros::functions::external) and
+/// [`internal`](crate::macros::functions::internal) contract function marked with `"public"` by the Aztec macro
+/// system and is accessible through the `self` variable.
+///
+/// ## Type Parameters
+///
+/// - `Storage`: The contract's storage struct (defined with [`storage`](crate::macros::storage::storage), or `()` if
+/// the contract has no storage
+/// - `CallSelf`: Macro-generated type for calling contract's own non-view functions
+/// - `CallSelfStatic`: Macro-generated type for calling contract's own view functions
+/// - `CallInternal`: Macro-generated type for calling internal functions
+pub struct ContractSelfPublic<Storage, CallSelf, CallSelfStatic, CallInternal> {
+    /// The address of this contract
+    pub address: AztecAddress,
+
+    /// The contract's storage instance, representing the struct to which the
+    /// [`storage`](crate::macros::storage::storage) macro was applied in your contract. If the contract has no
+    /// storage, the type of this will be `()`.
+    ///
+    /// This storage instance is specialized for the current execution context (public) and
+    /// provides access to the contract's state variables.
+    ///
+    /// ## Developer Note
+    ///
+    /// If you've arrived here while trying to access your contract's storage while the `Storage` generic type is set
+    /// to unit type `()`, it means you haven't yet defined a Storage struct using the
+    /// [`storage`](crate::macros::storage::storage) macro in your contract. For guidance on setting this up, please
+    /// refer to our docs: https://docs.aztec.network/developers/docs/guides/smart_contracts/storage
+    pub storage: Storage,
+
+    /// The public execution context.
+    pub context: PublicContext,
+
+    /// Provides type-safe methods for calling this contract's own non-view functions.
+    ///
+    /// Example API:
+    /// ```noir
+    /// self.call_self.some_public_function(args)
+    /// ```
+    pub call_self: CallSelf,
+
+    /// Provides type-safe methods for calling this contract's own view functions.
+    ///
+    /// Example API:
+    /// ```noir
+    /// self.call_self_static.some_view_function(args)
+    /// ```
+    pub call_self_static: CallSelfStatic,
+
+    /// Provides type-safe methods for calling internal functions.
+    ///
+    /// Example API:
+    /// ```noir
+    /// self.internal.some_internal_function(args)
+    /// ```
+    pub internal: CallInternal,
+}
+
+impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelfPublic<Storage, CallSelf, CallSelfStatic, CallInternal> {
+    /// Creates a new `ContractSelfPublic` instance for a public function.
+    ///
+    /// This constructor is called automatically by the macro system and should not be called directly.
+    pub fn new(
+        context: PublicContext,
+        storage: Storage,
+        call_self: CallSelf,
+        call_self_static: CallSelfStatic,
+        internal: CallInternal,
+    ) -> Self {
+        Self { context, storage, address: context.this_address(), call_self, call_self_static, internal }
+    }
+
+    /// The address of the contract address that made this function call.
+    ///
+    /// This is similar to Solidity's `msg.sender` value.
+    ///
+    /// ## Incognito Calls
+    ///
+    /// Contracts can call public functions from private ones hiding their identity (see
+    /// [`ContractSelfPrivate::enqueue_incognito`](crate::contract_self::ContractSelfPrivate::enqueue_incognito)).
+    /// This function reverts when executed in such a context.
+    ///
+    /// If you need to handle these cases, use [`PublicContext::maybe_msg_sender`].
+    pub fn msg_sender(self: Self) -> AztecAddress {
+        self.context.maybe_msg_sender().unwrap()
+    }
+
+    /// Emits an event publicly.
+    ///
+    /// Public events are emitted as plaintext and are therefore visible to everyone. This is is the same as Solidity
+    /// events on EVM chains.
+    ///
+    /// Unlike private events, they don't require delivery of an event message.
+    ///
+    /// # Example
+    /// ```noir
+    /// #[event]
+    /// struct Update { value: Field }
+    ///
+    /// #[external("public")]
+    /// fn publish_update(value: Field) {
+    ///     self.emit(Update { value });
+    /// }
+    /// ```
+    ///
+    /// # Cost
+    ///
+    /// Public event emission is achieved by emitting public transaction logs. A total of `N+1` fields are emitted,
+    /// where `N` is the serialization length of the event.
+    pub fn emit<Event>(&mut self, event: Event)
+    where
+        Event: EventInterface + Serialize,
+    {
+        emit_event_in_public(self.context, event);
+    }
+
+    /// Makes a public contract call.
+    ///
+    /// Will revert if the called function reverts or runs out of gas.
+    ///
+    /// # Arguments
+    /// * `call` - The object representing the public function to invoke.
+    ///
+    /// # Returns
+    /// * `T` - Whatever data the called function has returned.
+    ///
+    /// # Example
+    /// ```noir
+    /// self.call(Token::at(address).transfer_in_public(recipient, amount));
+    /// ```
+    ///
+    pub unconstrained fn call<let M: u32, let N: u32, T>(self, call: PublicCall<M, N, T>) -> T
+    where
+        T: Deserialize,
+    {
+        call.call(self.context)
+    }
+
+    /// Makes a public read-only contract call.
+    ///
+    /// This is similar to Solidity's `staticcall`. The called function cannot modify state or emit events. Any nested
+    /// calls are constrained to also be static calls.
+    ///
+    /// Will revert if the called function reverts or runs out of gas.
+    ///
+    /// # Arguments
+    /// * `call` - The object representing the read-only public function to invoke.
+    ///
+    /// # Returns
+    /// * `T` - Whatever data the called function has returned.
+    ///
+    /// # Example
+    /// ```noir
+    /// self.view(Token::at(address).balance_of_public(recipient));
+    /// ```
+    ///
+    pub unconstrained fn view<let M: u32, let N: u32, T>(self, call: PublicStaticCall<M, N, T>) -> T
+    where
+        T: Deserialize,
+    {
+        call.view(self.context)
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_public.nr
@@ -87,6 +87,7 @@ impl<Storage, CallSelf, CallSelfStatic, CallInternal> ContractSelfPublic<Storage
     /// ## Incognito Calls
     ///
     /// Contracts can call public functions from private ones hiding their identity (see
+    ///
     /// [`ContractSelfPrivate::enqueue_incognito`](crate::contract_self::ContractSelfPrivate::enqueue_incognito)).
     /// This function reverts when executed in such a context.
     ///

--- a/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/contract_self_utility.nr
@@ -1,0 +1,45 @@
+//! The `self` contract value for utility execution contexts.
+
+use crate::context::UtilityContext;
+use crate::protocol::address::AztecAddress;
+
+/// Core interface for interacting with aztec-nr contract features in utility execution contexts.
+///
+/// This struct is automatically injected into every [`external`](crate::macros::functions::external) contract function
+/// marked with `"utility"` by the Aztec macro system and is accessible through the `self` variable.
+///
+/// ## Type Parameters
+///
+/// - `Storage`: The contract's storage struct (defined with [`storage`](crate::macros::storage::storage), or `()` if
+/// the contract has no storage
+pub struct ContractSelfUtility<Storage> {
+    /// The address of this contract
+    pub address: AztecAddress,
+
+    /// The contract's storage instance, representing the struct to which the
+    /// [`storage`](crate::macros::storage::storage) macro was applied in your contract. If the contract has no
+    /// storage, the type of this will be `()`.
+    ///
+    /// This storage instance is specialized for the current execution context (utility) and
+    /// provides access to the contract's state variables.
+    ///
+    /// ## Developer Note
+    ///
+    /// If you've arrived here while trying to access your contract's storage while the `Storage` generic type is set
+    /// to unit type `()`, it means you haven't yet defined a Storage struct using the
+    /// [`storage`](crate::macros::storage::storage) macro in your contract. For guidance on setting this up, please
+    /// refer to our docs: https://docs.aztec.network/developers/docs/guides/smart_contracts/storage
+    pub storage: Storage,
+
+    /// The utility execution context.
+    pub context: UtilityContext,
+}
+
+impl<Storage> ContractSelfUtility<Storage> {
+    /// Creates a new `ContractSelfUtility` instance for a utility function.
+    ///
+    /// This constructor is called automatically by the macro system and should not be called directly.
+    pub fn new(context: UtilityContext, storage: Storage) -> Self {
+        Self { context, storage, address: context.this_address() }
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/contract_self/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/mod.nr
@@ -1,3 +1,7 @@
 pub mod contract_self_private;
 pub mod contract_self_public;
 pub mod contract_self_utility;
+
+pub use contract_self_private::ContractSelfPrivate;
+pub use contract_self_public::ContractSelfPublic;
+pub use contract_self_utility::ContractSelfUtility;

--- a/noir-projects/aztec-nr/aztec/src/contract_self/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/contract_self/mod.nr
@@ -1,0 +1,3 @@
+pub mod contract_self_private;
+pub mod contract_self_public;
+pub mod contract_self_utility;

--- a/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_emission.nr
@@ -11,7 +11,7 @@ pub struct NewEvent<Event> {
     pub(crate) randomness: Field,
 }
 
-/// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelf::emit`].
+/// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelfPrivate::emit`].
 pub fn emit_event_in_private<Event>(context: &mut PrivateContext, event: Event) -> EventMessage<Event>
 where
     Event: EventInterface + Serialize,
@@ -34,7 +34,7 @@ where
     EventMessage::new(NewEvent { event, randomness }, context)
 }
 
-/// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelf::emit`].
+/// Equivalent to `self.emit(event)`: see [`crate::contract_self::ContractSelfPublic::emit`].
 pub fn emit_event_in_public<Event>(context: PublicContext, event: Event)
 where
     Event: EventInterface + Serialize,

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -28,8 +28,7 @@
 //! [`TestEnvironment`](crate::test::helpers::test_environment::TestEnvironment) and [mocks](crate::test::mocks).
 
 pub mod context;
-mod contract_self;
-pub use contract_self::ContractSelf;
+pub mod contract_self;
 pub mod publish_contract_instance;
 pub mod hash;
 pub mod history;

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -220,7 +220,7 @@ pub comptime fn only_self(f: FunctionDefinition) {
 /// ## Guarantees
 ///
 /// [`view`] functions can *only* be called in a static execution context, which is typically achieved by calling the
-/// [`crate::contract_self::ContractSelf::view`] method on `self`.
+/// [`crate::contract_self::ContractSelfPublic::view`] method on `self`.
 ///
 /// No compile time checks are performed on whether a function can be made [`view`]. If a function marked as view
 /// attempts to modify state, that will result in *runtime* failures.

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -55,7 +55,7 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
             let call_self_static: CallSelfStatic<&mut aztec::context::PrivateContext> = CallSelfStatic { address: self_address, context: &mut context };
             let enqueue_self_static: EnqueueSelfStatic<&mut aztec::context::PrivateContext> = EnqueueSelfStatic { address: self_address, context: &mut context };
             let internal: CallInternal<&mut aztec::context::PrivateContext> = CallInternal { context: &mut context };
-            aztec::contract_self::contract_self_private::ContractSelfPrivate::new(&mut context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
+            aztec::contract_self::ContractSelfPrivate::new(&mut context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -35,9 +35,8 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
         }
     } else {
         // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelfPrivate
-        // requires a
-        // storage struct in its constructor. Using an Option type would lead to worse developer experience and higher
-        // constraint counts so we use the unit type `()` instead.
+        // requires a storage struct in its constructor. Using an Option type would lead to worse developer experience
+        // and higher constraint counts so we use the unit type `()` instead.
         quote {
             let storage = ();
         }

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/private.nr
@@ -34,7 +34,8 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
             let storage = Storage::init(&mut context);
         }
     } else {
-        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelf requires a
+        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelfPrivate
+        // requires a
         // storage struct in its constructor. Using an Option type would lead to worse developer experience and higher
         // constraint counts so we use the unit type `()` instead.
         quote {
@@ -55,7 +56,7 @@ pub(crate) comptime fn generate_private_external(f: FunctionDefinition) -> Quote
             let call_self_static: CallSelfStatic<&mut aztec::context::PrivateContext> = CallSelfStatic { address: self_address, context: &mut context };
             let enqueue_self_static: EnqueueSelfStatic<&mut aztec::context::PrivateContext> = EnqueueSelfStatic { address: self_address, context: &mut context };
             let internal: CallInternal<&mut aztec::context::PrivateContext> = CallInternal { context: &mut context };
-            aztec::ContractSelf::new_private(&mut context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
+            aztec::contract_self::contract_self_private::ContractSelfPrivate::new(&mut context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
@@ -33,7 +33,8 @@ pub(crate) comptime fn generate_public_external(f: FunctionDefinition) -> Quoted
             let storage = Storage::init(context);
         }
     } else {
-        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelf requires a
+        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelfPublic requires
+        // a
         // storage struct in its constructor. Using an Option type would lead to worse developer experience and higher
         // constraint counts so we use the unit type `()` instead.
         quote {
@@ -55,7 +56,7 @@ pub(crate) comptime fn generate_public_external(f: FunctionDefinition) -> Quoted
             let call_self: CallSelf<aztec::context::PublicContext> = CallSelf { address: self_address, context };
             let call_self_static: CallSelfStatic<aztec::context::PublicContext> = CallSelfStatic { address: self_address, context };
             let internal: CallInternal<aztec::context::PublicContext> = CallInternal { context };
-            aztec::ContractSelf::new_public(context, storage, call_self, call_self_static, internal)
+            aztec::contract_self::contract_self_public::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
@@ -34,9 +34,8 @@ pub(crate) comptime fn generate_public_external(f: FunctionDefinition) -> Quoted
         }
     } else {
         // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelfPublic requires
-        // a
-        // storage struct in its constructor. Using an Option type would lead to worse developer experience and higher
-        // constraint counts so we use the unit type `()` instead.
+        // a storage struct in its constructor. Using an Option type would lead to worse developer experience and
+        // higher constraint counts so we use the unit type `()` instead.
         quote {
             let storage = ();
         }

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/public.nr
@@ -55,7 +55,7 @@ pub(crate) comptime fn generate_public_external(f: FunctionDefinition) -> Quoted
             let call_self: CallSelf<aztec::context::PublicContext> = CallSelf { address: self_address, context };
             let call_self_static: CallSelfStatic<aztec::context::PublicContext> = CallSelfStatic { address: self_address, context };
             let internal: CallInternal<aztec::context::PublicContext> = CallInternal { context };
-            aztec::contract_self::contract_self_public::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
+            aztec::contract_self::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/utility.nr
@@ -22,7 +22,7 @@ pub(crate) comptime fn generate_utility_external(f: FunctionDefinition) -> Quote
         let mut self = {
             let context = aztec::context::UtilityContext::new();
             $storage_init
-            aztec::contract_self::contract_self_utility::ContractSelfUtility::new(context, storage)
+            aztec::contract_self::ContractSelfUtility::new(context, storage)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/utility.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/external/utility.nr
@@ -7,7 +7,8 @@ pub(crate) comptime fn generate_utility_external(f: FunctionDefinition) -> Quote
             let storage = Storage::init(context);
         }
     } else {
-        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelf requires a
+        // Contract does not have Storage defined, so we set storage to the unit type `()`. ContractSelfUtility
+        // requires a
         // storage struct in its constructor. Using an Option type would lead to worse developer experience and higher
         // constraint counts so we use the unit type `()` instead.
         quote {
@@ -21,7 +22,7 @@ pub(crate) comptime fn generate_utility_external(f: FunctionDefinition) -> Quote
         let mut self = {
             let context = aztec::context::UtilityContext::new();
             $storage_init
-            aztec::ContractSelf::new_utility(context, storage)
+            aztec::contract_self::contract_self_utility::ContractSelfUtility::new(context, storage)
         };
     };
 

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/internal.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/internal.nr
@@ -42,7 +42,7 @@ pub(crate) comptime fn generate_private_internal(f: FunctionDefinition) -> Quote
                 let call_self_static: CallSelfStatic<&mut aztec::context::PrivateContext> = CallSelfStatic { address: self_address, context };
                 let enqueue_self_static: EnqueueSelfStatic<&mut aztec::context::PrivateContext> = EnqueueSelfStatic { address: self_address, context };
                 let internal: CallInternal<&mut aztec::context::PrivateContext> = CallInternal { context };
-                aztec::contract_self::contract_self_private::ContractSelfPrivate::new(context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
+                aztec::contract_self::ContractSelfPrivate::new(context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
             };
             
             $body
@@ -92,7 +92,7 @@ pub(crate) comptime fn generate_public_internal(f: FunctionDefinition) -> Quoted
                 let call_self: CallSelf<aztec::context::PublicContext> = CallSelf { address: self_address, context };
                 let call_self_static: CallSelfStatic<aztec::context::PublicContext> = CallSelfStatic { address: self_address, context };
                 let internal: CallInternal<aztec::context::PublicContext> = CallInternal { context };
-                aztec::contract_self::contract_self_public::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
+                aztec::contract_self::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
             };
 
             $body

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/internal.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/internal.nr
@@ -42,7 +42,7 @@ pub(crate) comptime fn generate_private_internal(f: FunctionDefinition) -> Quote
                 let call_self_static: CallSelfStatic<&mut aztec::context::PrivateContext> = CallSelfStatic { address: self_address, context };
                 let enqueue_self_static: EnqueueSelfStatic<&mut aztec::context::PrivateContext> = EnqueueSelfStatic { address: self_address, context };
                 let internal: CallInternal<&mut aztec::context::PrivateContext> = CallInternal { context };
-                aztec::ContractSelf::new_private(context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
+                aztec::contract_self::contract_self_private::ContractSelfPrivate::new(context, storage, call_self, enqueue_self, call_self_static, enqueue_self_static, internal)
             };
             
             $body
@@ -92,7 +92,7 @@ pub(crate) comptime fn generate_public_internal(f: FunctionDefinition) -> Quoted
                 let call_self: CallSelf<aztec::context::PublicContext> = CallSelf { address: self_address, context };
                 let call_self_static: CallSelfStatic<aztec::context::PublicContext> = CallSelfStatic { address: self_address, context };
                 let internal: CallInternal<aztec::context::PublicContext> = CallInternal { context };
-                aztec::ContractSelf::new_public(context, storage, call_self, call_self_static, internal)
+                aztec::contract_self::contract_self_public::ContractSelfPublic::new(context, storage, call_self, call_self_static, internal)
             };
 
             $body

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -29,7 +29,8 @@ mod test;
 ///
 /// Unlike [`PublicMutable`](crate::state_vars::PublicMutable) it is **also** possible to read a `PublicImmutable` from
 /// a private contract function, though it is not possible to initialize one. A common pattern is to have these
-/// functions [enqueue a public self calls](crate::contract_self::ContractSelf::enqueue_self) in which the
+/// functions [enqueue a public self calls](crate::contract_self::ContractSelfPrivate::enqueue)
+/// in which the
 /// initialization operation is performed.
 ///
 /// For a mutable (with restrictions) variant which also can be read from private functions see

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -15,7 +15,8 @@ use crate::state_vars::StateVariable;
 /// A value stored in a `PublicMutable` can be read and written from public contract functions.
 ///
 /// It is not possible to read or write a `PublicMutable` from private contract functions. A common pattern is to have
-/// these functions [enqueue a public self calls](crate::contract_self::ContractSelf::enqueue_self) in which the
+/// these functions [enqueue a public self
+/// calls](crate::contract_self::ContractSelfPrivate::enqueue) in which the
 /// required operation is performed.
 ///
 /// For an immutable variant which can be read from private functions, see


### PR DESCRIPTION
When I initially implemented `ContractSelf` I chose an incorrect pattern and that is having 1 ContractSelf struct for all the function types and then having there a generic `Context` param that specializes it for the given execution context. This has undesirable effects like needing to use unit types to disable certain functionality in utility and public contexts:

<img width="966" height="487" alt="image" src="https://github.com/user-attachments/assets/08ea1e55-8195-4943-8a0b-2d3188c8a375" />

Another advantage with the change is that we follow the pattern of having `PrivateContext`, `PublicContext` and `UtilityContext`.

## Summary
- Split the monolithic `ContractSelf` generic struct into three context-specific structs: `ContractSelfPrivate`, `ContractSelfPublic`, and `ContractSelfUtility`
- Each struct lives in its own file under `contract_self/` and only carries the type parameters and fields relevant to its context (e.g. `ContractSelfPublic` has no `enqueue_self`/`enqueue_self_static` fields, `ContractSelfUtility` has no call/enqueue fields)
- Updated all macro code generation to use the new struct names

## Test plan
- [x] `nargo compile --package nft_contract` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)