### PR TITLE
feat: run LowPriorityEvictionRule.evict() on CHAIN_PRUNED

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -370,6 +370,53 @@ describe('KV TX pool', () => {
     expect(pendingTxHashes).toHaveLength(2);
   });
 
+  it('Evicts low priority txs after a chain prune when pool exceeds the limit', async () => {
+    txPool = new AztecKVTxPool(await openTmpStore('p2p'), await openTmpStore('archive'), worldState, undefined, {
+      maxPendingTxCount: 2,
+    });
+
+    const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) }); // lowest priority
+    const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+    const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) }); // highest priority
+
+    await txPool.addTxs([tx1, tx2, tx3]);
+    // Mine all three so pending pool is empty
+    await txPool.markAsMined([tx1.getTxHash(), tx2.getTxHash(), tx3.getTxHash()], block1Header);
+    expect(await txPool.getPendingTxCount()).toBe(0);
+
+    // Reorg: move all three back to pending, temporarily exceeding the limit of 2
+    await txPool.markMinedAsPending([tx1.getTxHash(), tx2.getTxHash(), tx3.getTxHash()], BlockNumber(0));
+
+    // Low priority eviction should have trimmed the pool back to the limit, evicting tx1 (lowest priority)
+    await checkPendingTxConsistency();
+    const pending = await txPool.getPendingTxHashes();
+    expect(pending).toHaveLength(2);
+    expect(pending).toContainEqual(tx2.getTxHash());
+    expect(pending).toContainEqual(tx3.getTxHash());
+    expect(pending).not.toContainEqual(tx1.getTxHash());
+  });
+
+  it('Does not evict txs after a chain prune when pool is within the limit', async () => {
+    txPool = new AztecKVTxPool(await openTmpStore('p2p'), await openTmpStore('archive'), worldState, undefined, {
+      maxPendingTxCount: 3,
+    });
+
+    const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+
+    await txPool.addTxs([tx1, tx2]);
+    await txPool.markAsMined([tx1.getTxHash(), tx2.getTxHash()], block1Header);
+
+    // 2 txs back to pending, limit is 3 — no eviction should occur
+    await txPool.markMinedAsPending([tx1.getTxHash(), tx2.getTxHash()], BlockNumber(0));
+
+    await checkPendingTxConsistency();
+    const pending = await txPool.getPendingTxHashes();
+    expect(pending).toHaveLength(2);
+    expect(pending).toContainEqual(tx1.getTxHash());
+    expect(pending).toContainEqual(tx2.getTxHash());
+  });
+
   it('Does not evict low priority txs marked as non-evictable', async () => {
     txPool = new AztecKVTxPool(await openTmpStore('p2p'), await openTmpStore('archive'), worldState, undefined, {
       maxPendingTxCount: 3,

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.test.ts
@@ -38,7 +38,7 @@ describe('LowPriorityEvictionRule', () => {
   });
 
   describe('evict method', () => {
-    describe('non-TXS_ADDED events', () => {
+    describe('BLOCK_MINED events', () => {
       it('returns empty result for BLOCK_MINED event', async () => {
         const context: EvictionContext = {
           event: EvictionEvent.BLOCK_MINED,
@@ -55,8 +55,33 @@ describe('LowPriorityEvictionRule', () => {
           txsEvicted: [],
         });
       });
+    });
 
-      it('returns empty result for CHAIN_PRUNED event', async () => {
+    describe('CHAIN_PRUNED events', () => {
+      it('evicts transactions when pool is over limit', async () => {
+        rule.updateConfig({ maxPendingTxCount: 1 });
+
+        const tx1 = TxHash.random();
+        const tx2 = TxHash.random();
+
+        txPool.getPendingTxCount.mockResolvedValue(3);
+        txPool.getLowestPriorityEvictable.mockResolvedValue([tx1, tx2]);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const result = await rule.evict(context, txPool);
+
+        expect(result.success).toBe(true);
+        expect(result.txsEvicted).toEqual([tx1, tx2]);
+        expect(txPool.deleteTxs).toHaveBeenCalledWith([tx1, tx2]);
+      });
+
+      it('returns empty result when pool is under limit', async () => {
+        txPool.getPendingTxCount.mockResolvedValue(Math.floor(config.maxPoolSize / 2));
+
         const context: EvictionContext = {
           event: EvictionEvent.CHAIN_PRUNED,
           blockNumber: BlockNumber(1),
@@ -69,6 +94,43 @@ describe('LowPriorityEvictionRule', () => {
           success: true,
           txsEvicted: [],
         });
+        expect(txPool.deleteTxs).not.toHaveBeenCalled();
+      });
+
+      it('returns empty result when maxPoolSize is 0', async () => {
+        rule.updateConfig({ maxPendingTxCount: 0 });
+
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const result = await rule.evict(context, txPool);
+
+        expect(result).toEqual({
+          reason: 'low_priority',
+          success: true,
+          txsEvicted: [],
+        });
+        expect(txPool.getPendingTxCount).not.toHaveBeenCalled();
+      });
+
+      it('handles error from txPool operations', async () => {
+        const error = new Error('Test error');
+        txPool.getPendingTxCount.mockRejectedValue(error);
+
+        const context: EvictionContext = {
+          event: EvictionEvent.CHAIN_PRUNED,
+          blockNumber: BlockNumber(1),
+        };
+
+        const result = await rule.evict(context, txPool);
+
+        expect(result.success).toBe(false);
+        expect(result.txsEvicted).toEqual([]);
+        expect(result.error).toBeInstanceOf(Error);
+        expect(result.error?.message).toContain('Failed to evict low priority txs');
+        expect(result.error?.cause).toBe(error);
       });
     });
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/low_priority_eviction_rule.ts
@@ -17,7 +17,7 @@ export interface LowPriorityEvictionConfig {
 
 /**
  * Eviction rule that removes low-priority transactions when the number of pending transactions exceeds configured limits.
- * Only triggers on TXS_ADDED events and respects non-evictable transactions.
+ * Triggers on TXS_ADDED and CHAIN_PRUNED events, and respects non-evictable transactions.
  */
 export class LowPriorityEvictionRule implements EvictionRule {
   public readonly name = 'LowPriorityEviction';
@@ -27,7 +27,7 @@ export class LowPriorityEvictionRule implements EvictionRule {
   constructor(private config: LowPriorityEvictionConfig) {}
 
   public async evict(context: EvictionContext, txPool: TxPoolOperations): Promise<EvictionResult> {
-    if (context.event !== EvictionEvent.TXS_ADDED) {
+    if (context.event !== EvictionEvent.TXS_ADDED && context.event !== EvictionEvent.CHAIN_PRUNED) {
       return {
         reason: 'low_priority',
         success: true,
@@ -64,13 +64,19 @@ export class LowPriorityEvictionRule implements EvictionRule {
         await txPool.deleteTxs(txsToEvict);
       }
 
-      const numNewTxsEvicted = context.newTxs.filter(newTxHash =>
-        txsToEvict.some(evictedTx => evictedTx.equals(newTxHash)),
-      ).length;
-
-      this.log.verbose(`Evicted ${txsToEvict.length} low priority txs, including ${numNewTxsEvicted} newly added txs`, {
-        txsEvicted: txsToEvict,
-      });
+      if (context.event === EvictionEvent.TXS_ADDED) {
+        const numNewTxsEvicted = context.newTxs.filter(newTxHash =>
+          txsToEvict.some(evictedTx => evictedTx.equals(newTxHash)),
+        ).length;
+        this.log.verbose(
+          `Evicted ${txsToEvict.length} low priority txs, including ${numNewTxsEvicted} newly added txs`,
+          { txsEvicted: txsToEvict },
+        );
+      } else {
+        this.log.verbose(`Evicted ${txsToEvict.length} low priority txs after chain prune`, {
+          txsEvicted: txsToEvict,
+        });
+      }
 
       return {
         reason: 'low_priority',


### PR DESCRIPTION
## Summary

After a chain prune, `AztecKVTxPool.markMinedAsPending()` moves previously-mined transactions back to the pending pool, which can temporarily push the pool over its size limit. The `EvictionManager` dispatches a `CHAIN_PRUNED` event to handle this, but `LowPriorityEvictionRule` was only handling `TXS_ADDED` events — leaving the pool potentially over its limit until the next `addTxs()` call.

- Extend `LowPriorityEvictionRule.evict()` to also run on `CHAIN_PRUNED` events, so the pool size limit is enforced immediately after a reorg re-adds mined txs to pending.
- Guard the `context.newTxs` log access (only present on the `TXS_ADDED` variant of the `EvictionContext` discriminated union) with an event-type check, logging a distinct message for the chain-prune case.
- Update the class JSDoc to reflect the expanded trigger set.

## Tests

Unit tests (`low_priority_eviction_rule.test.ts`):
- Replaced the old "returns empty result for CHAIN_PRUNED event" test with a dedicated `CHAIN_PRUNED events` describe block covering: evicts when pool is over limit, no-op when under limit, no-op when the rule is disabled (`maxPoolSize = 0`), and error handling.
- Renamed the old `non-TXS_ADDED events` describe to `BLOCK_MINED events` since `CHAIN_PRUNED` is no longer a passthrough.

Integration tests (`aztec_kv_tx_pool.test.ts`):
- Added a test that exercises the full call chain — `addTxs` → `markAsMined` → `markMinedAsPending` — and asserts that the lowest-priority tx is evicted when the reorg pushes the pool over its configured limit.
- Added a companion test confirming no eviction occurs when the pool stays within the limit after the reorg.

Fixes A-560

