### PR TITLE
chore: use commit override markers for backport staging PR bodies

### DIFF
--- a/.claude/skills/merge-train-infra/SKILL.md
+++ b/.claude/skills/merge-train-infra/SKILL.md
@@ -13,7 +13,7 @@ The merge-train system is fully automated via GitHub Actions in `.github/workflo
 
 1. **PR Creation** (`merge-train-create-pr.yml`): Triggered on push to `merge-train/*` branches. Creates a PR targeting `next` with the `ci-no-squash` label (and `ci-full-no-test-cache` for spartan). Skips merge commits and commits already in `next`.
 
-2. **Body Updates** (`merge-train-update-pr-body.yml`): Triggered on push to `merge-train/**`. Updates the PR body with meaningful commits (those containing PR references like `(#1234)`). The body uses `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` markers for release-please.
+2. **Body Updates** (`merge-train-update-pr-body.yml`): Triggered on push to `merge-train/**` and `backport-to-*-staging` branches. Updates the PR body with meaningful commits (those containing PR references like `(#1234)`). The body uses `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` markers for release-please. Backport staging PRs also call `update-pr-body.sh` inline from `scripts/backport_to_staging.sh` to handle the first-push case (where the PR doesn't exist yet when the workflow fires).
 
 3. **Next Integration** (`merge-train-next-to-branches.yml`): Triggered on push to `next`. Merges `next` into each active merge-train branch via `scripts/merge-train/merge-next.sh`. Uses `continue-on-error: true` so a conflict in one branch does not block others. Skips branches whose PR already has auto-merge enabled.
 
@@ -90,7 +90,7 @@ When a CI run fails on an EC2 instance, it calls `merge_train_failure_slack_noti
 | `.github/workflows/merge-train-auto-merge.yml` | Hourly cron to auto-merge inactive trains |
 | `.github/workflows/merge-train-next-to-branches.yml` | Syncs `next` into all train branches; defines active branches |
 | `.github/workflows/merge-train-recreate.yml` | Recreates branch after merge |
-| `.github/workflows/merge-train-update-pr-body.yml` | Updates PR body with commit list |
+| `.github/workflows/merge-train-update-pr-body.yml` | Updates PR body with commit list (merge-train and backport branches) |
 | `.github/workflows/merge-queue-dequeue-notify.yml` | Slack notification on merge-queue dequeue |
 | `.github/workflows/squashed-pr-check.yml` | Squash enforcement (skipped for `ci-no-squash`) |
 
@@ -103,6 +103,7 @@ When a CI run fails on an EC2 instance, it calls `merge_train_failure_slack_noti
 | `scripts/merge-train/update-pr-body.sh` | Updates PR body with meaningful commits |
 | `scripts/merge-train/squash-pr.sh` | Squashes PR commits (used by `ci-squash-and-merge` label) |
 | `scripts/merge-train/wakeup-prs.sh` | Adds `ci-wakeup-pr-after-merge` label to qualifying PRs after branch recreation |
+| `scripts/backport_to_staging.sh` | Cherry-picks a merged PR to a backport staging branch; creates/updates the backport PR |
 
 ### CI Configuration
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -71,10 +71,12 @@ jobs:
         run: |
           TARGET_BRANCH="${{ steps.extract-branch.outputs.target_branch }}"
           STAGING_BRANCH="backport-to-${TARGET_BRANCH}-staging"
-          COMMIT_COUNT=$(gh pr view "${{ github.event.pull_request.number }}" --json commits --jq '.commits | length')
+          STAGING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$STAGING_BRANCH" --json number,url --jq '.[0]')
+          STAGING_PR_NUMBER=$(echo "$STAGING_PR" | jq -r '.number')
+          STAGING_PR_URL=$(echo "$STAGING_PR" | jq -r '.url')
 
           gh pr comment "${{ github.event.pull_request.number }}" --body \
-            "✅ Successfully cherry-picked $COMMIT_COUNT commit(s) to backport staging branch \`$STAGING_BRANCH\`."
+            "✅ Successfully backported to [$STAGING_BRANCH #$STAGING_PR_NUMBER]($STAGING_PR_URL)."
 
       - name: Comment on original PR (failure)
         if: steps.backport.outcome == 'failure'

--- a/.github/workflows/merge-train-update-pr-body.yml
+++ b/.github/workflows/merge-train-update-pr-body.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'merge-train/**'
+      - 'backport-to-*-staging'
 
 jobs:
   update-pr-body:

--- a/scripts/backport_to_staging.sh
+++ b/scripts/backport_to_staging.sh
@@ -101,7 +101,7 @@ echo "Author: $PR_AUTHOR"
 echo "Author Email: $PR_AUTHOR_EMAIL"
 
 if [[ "$PR_STATE" != "MERGED" ]]; then
-  echo "Error: PR #$PR_NUMBER is not merged yet (state: $PR_MERGED_AT)" >&2
+  echo "Error: PR #$PR_NUMBER is not merged yet (state: $PR_STATE)" >&2
   exit 1
 fi
 
@@ -144,8 +144,14 @@ echo "Diff applied successfully! Committing changes..."
 git config user.name "$PR_AUTHOR"
 git config user.email "$PR_AUTHOR_EMAIL"
 
+# Ensure commit subject contains PR reference for get_meaningful_commits
+COMMIT_SUBJECT="$PR_TITLE"
+if ! echo "$COMMIT_SUBJECT" | grep -qE '\(#[0-9]+\)'; then
+  COMMIT_SUBJECT="$COMMIT_SUBJECT (#$PR_NUMBER)"
+fi
+
 git add -A
-git commit -m "$PR_TITLE
+git commit -m "$COMMIT_SUBJECT
 
 $PR_BODY"
 
@@ -162,27 +168,18 @@ EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$STAGING_BRANCH" --json
 
 if [[ -z "$EXISTING_PR" ]]; then
   echo "Creating new PR..."
-  TRAIN_PR_BODY="This PR accumulates backport commits throughout the day and will be auto-merged overnight.
-
-Latest backport: #$PR_NUMBER - $PR_TITLE
-
-🤖 This PR is managed automatically by the backport workflow."
-
   do_or_dryrun gh pr create \
     --base "$TARGET_BRANCH" \
     --head "$STAGING_BRANCH" \
     --title "chore: Accumulated backports to $TARGET_BRANCH" \
-    --body "$TRAIN_PR_BODY"
-
-  do_or_dryrun echo "✅ Created new backport PR"
+    --body "Backport staging PR. Body will be updated with commit list."
+  do_or_dryrun echo "Created new backport PR"
 else
-  echo "PR already exists (#$EXISTING_PR), updating description..."
-  CURRENT_BODY=$(gh pr view "$EXISTING_PR" --json body --jq '.body')
-  NEW_BODY="${CURRENT_BODY}
-- #$PR_NUMBER - $PR_TITLE"
-
-  do_or_dryrun gh pr edit "$EXISTING_PR" --body "$NEW_BODY"
-  do_or_dryrun echo "✅ Updated existing backport PR #$EXISTING_PR"
+  echo "PR already exists (#$EXISTING_PR)"
 fi
 
-do_or_dryrun echo "✅ Successfully backported PR #$PR_NUMBER to $STAGING_BRANCH"
+# Update PR body with commit override markers (same mechanism as merge-trains)
+echo "Updating PR body with commit list..."
+do_or_dryrun "$root/scripts/merge-train/update-pr-body.sh" "$STAGING_BRANCH"
+
+do_or_dryrun echo "Successfully backported PR #$PR_NUMBER to $STAGING_BRANCH"


### PR DESCRIPTION
## Summary
- Backport staging PRs now use `BEGIN_COMMIT_OVERRIDE`/`END_COMMIT_OVERRIDE` markers (same as merge-trains) instead of ad-hoc text appending
- Backport commits ensure `(#PR)` references in the subject line so `update-pr-body.sh` picks them up
- The PR body update workflow now also triggers on `backport-to-*-staging` branches as a safety net

## Test plan
- [x] Run `./scripts/backport_to_staging.sh --dry-run <pr> v2` and verify it calls `update-pr-body.sh` instead of manually appending to the body
- [ ] Verify workflow YAML triggers on both `merge-train/**` and `backport-to-*-staging` patterns
- [ ] Test with a real backport to confirm the PR body contains `BEGIN_COMMIT_OVERRIDE` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fix A-570