### PR TITLE
fix: some mac install fixes

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -182,9 +182,11 @@ function main {
   mkdir -p "$shared_bin_path"
 
   # Install jq
-  echo -n "Installing jq... "
-  install_jq
-  echo_green "done."
+  if ! command -v jq >/dev/null 2>&1; then
+    echo -n "Installing jq... "
+    install_jq
+    echo_green "done."
+  fi
 
   # Install aztec-up (version manager)
   echo -n "Installing aztec-up... "

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -5,10 +5,11 @@
 set -euo pipefail
 
 # Colors
+r="\033[31m" # Red
 g="\033[32m" # Green
 y="\033[33m" # Yellow
 b="\033[34m" # Blue
-r="\033[0m"  # Reset
+reset="\033[0m"
 
 # Helper function to safely read version from versions file
 function get_version {
@@ -36,11 +37,11 @@ version_bin_path="$version_path/bin"
 os="$(uname -s)"
 
 function echo_green {
-  echo -e "${g}$1${r}"
+  echo -e "${g}$1${reset}"
 }
 
 function echo_yellow {
-  echo -e "${y}$1${r}"
+  echo -e "${y}$1${reset}"
 }
 
 function timeout {
@@ -70,8 +71,8 @@ function dump_fail {
   if [ "$status" -ne 0 ] && [ "$status" -ne 143 ]; then
     {
       echo
-      echo -e "${y}command failed${r}: $@ (exit: $status)"
-      echo -e "${b}--- output ---${r}"
+      echo -e "${r}command failed${reset}: $@ (exit: $status)"
+      echo -e "${b}--- output ---${reset}"
       cat $output
     } >&2
   fi
@@ -104,43 +105,21 @@ function install_node {
   node_installed_version=$(node --version 2>/dev/null | cut -d 'v' -f 2 || echo "none")
 
   # Check if current version is sufficient
-  if [[ "$(printf '%s\n' "$node_min_version" "$node_installed_version" | sort -V | head -n1)" = "$node_min_version" ]]; then
+  if [ "$node_installed_version" != "none" ] && \
+     [[ "$(printf '%s\n' "$node_min_version" "$node_installed_version" | sort -V | head -n1)" = "$node_min_version" ]]; then
     return 0
   fi
 
   # Need to install - check if nvm is available
-  if [ -z "${NVM_DIR:-}" ] || [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  if [ ! -f "$HOME/.nvm/nvm.sh" ]; then
     echo "Minimum Node.js version $node_min_version not found (got $node_installed_version)."
     echo "Installation: nvm install --lts && nvm alias default lts/*"
     exit 1
   fi
 
-  # Source nvm and install
-  . "$NVM_DIR/nvm.sh"
+  . "$HOME/.nvm/nvm.sh"
   nvm install --lts
   nvm alias default lts/*
-}
-
-function install_python {
-  set -euo pipefail
-  # Only needed on macOS for node-gyp
-  if [ "$os" != "Darwin" ]; then
-    return 0
-  fi
-
-  # Check if brew is available
-  if ! command -v brew &>/dev/null; then
-    echo "Installation of python requires Homebrew."
-    echo "Install it from https://brew.sh"
-    exit 1
-  fi
-
-  # Check if python 3.11 is already installed
-  if [ -f "$(brew --prefix)/opt/python@3.11/bin/python3.11" ]; then
-    return 0
-  fi
-
-  brew install python@3.11
 }
 
 function install_versions_file {
@@ -212,11 +191,6 @@ function install_foundry {
 function install_aztec_packages {
   set -euo pipefail
 
-  if [ "$os" = "Darwin" ]; then
-    # Ensure python 3.11 is used for node-gyp on macOS.
-    export npm_config_python="$(brew --prefix)/opt/python@3.11/bin/python3.11"
-  fi
-
   # Install npm packages to the version directory using --prefix
   npm install @aztec/aztec@$VERSION @aztec/cli-wallet@$VERSION @aztec/bb.js@$VERSION --prefix "$version_path"
 }
@@ -235,12 +209,8 @@ function main {
   dump_fail install_node
   echo_green "done."
 
-  # Install python if needed (macOS only)
-  if [ "$os" = "Darwin" ]; then
-    echo -n "Installing python... "
-    dump_fail install_python
-    echo_green "done."
-  fi
+  # Source nvm to ensure node is in PATH.
+  . "$HOME/.nvm/nvm.sh"
 
   # Install noir
   echo -n "Installing nargo... "

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -131,6 +131,124 @@ function release_aztec_up {
     do_or_dryrun aws s3 cp bin/aliases/index "s3://install.aztec.network/aliases/index"
 }
 
+function prep_test_mac {
+  local verdaccio_port=4873
+  local http_port=4874
+
+  # Ensure we've cross-compiled bb for macos. Normally this is only done on releases.
+  ../barretenberg/cpp/bootstrap.sh build_cross amd64-macos true
+  ../barretenberg/ts/bootstrap.sh cross_copy amd64-macos
+
+  # Ensure build artifacts exist.
+  if [ ! -f ./bin/0.0.1/versions ] || [ ! -d ./verdaccio-storage ]; then
+    echo "Build artifacts missing. Running build first..."
+    build
+  fi
+
+  # Cleanup background processes on exit.
+  local pids=()
+  trap 'kill "${pids[@]}" &>/dev/null || true' EXIT
+
+  # Start Verdaccio in offline mode (no uplinks), bound to all interfaces.
+  cat > /tmp/verdaccio-mac-test.yaml <<EOF
+storage: $PWD/verdaccio-storage
+max_body_size: 1000mb
+
+packages:
+  "@*/*":
+    access: \$all
+    publish: \$all
+    unpublish: \$all
+
+  "**":
+    access: \$all
+    publish: \$all
+    unpublish: \$all
+
+logs: { type: stdout, format: pretty, level: warn }
+EOF
+
+  verdaccio --config /tmp/verdaccio-mac-test.yaml --listen 0.0.0.0:$verdaccio_port &>/dev/null &
+  pids+=($!)
+  while ! nc -z localhost $verdaccio_port &>/dev/null; do sleep 1; done
+  echo "Verdaccio running on 0.0.0.0:$verdaccio_port"
+
+  # Serve bin/ directory over HTTP to mimic S3-hosted install scripts.
+  python3 -m http.server $http_port --directory ./bin --bind 0.0.0.0 &>/dev/null &
+  pids+=($!)
+  while ! nc -z localhost $http_port &>/dev/null; do sleep 1; done
+  echo "HTTP server running on 0.0.0.0:$http_port (serving ./bin/)"
+}
+
+function install_on_mac_vm {
+  local mac_name="${1:?Mac vm name (e.g. 14)}"
+  local host_ip="${HOST_IP:-172.20.0.1}"
+  local verdaccio_port=4873
+  local http_port=4874
+
+  # Run install on the Mac VM via SSH.
+  echo "Running install on Mac VM ($mac_name)..."
+  /mnt/user-data/macos/ssh.sh $mac_name zsh -l <<REMOTE_EOF
+    set -euo pipefail
+
+    # Clean previous install.
+    rm -rf ~/.aztec
+
+    # Point npm at local Verdaccio and scripts at local HTTP server.
+    export npm_config_registry=http://$host_ip:$verdaccio_port
+    export INSTALL_URI=http://$host_ip:$http_port
+    export NO_NEW_SHELL=1
+    export NON_INTERACTIVE=1
+
+    touch \$HOME/.zshrc
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
+    . "\$HOME/.nvm/nvm.sh"
+
+    echo
+    echo "Running aztec install script..."
+    VERSION=0.0.1 bash <(curl -sL \$INSTALL_URI/0.0.1/aztec-install)
+
+    # Fake fresh shell.
+    export PATH="\$HOME/.aztec/current/bin:\$HOME/.aztec/current/node_modules/.bin:\$HOME/.aztec/bin:\$PATH"
+    . "\$HOME/.nvm/nvm.sh"
+
+    # Verify installation.
+    nargo --version
+    bb --version
+    aztec --version
+REMOTE_EOF
+}
+
+function launch_and_install_on_mac_vm {
+  set -euo pipefail
+  local version="$1"
+  local name="aztec-up-test-$version"
+  /mnt/user-data/macos/launch_vm.sh $version "" $name
+  local ip=$(docker inspect -f '{{ .NetworkSettings.Networks.bridge.IPAddress }}' macos-$name)
+  echo "Waiting for Mac VM ($name) to be accessible at $ip..."
+  while ! nc -z $ip 22 &>/dev/null; do sleep 0.5; done
+  install_on_mac_vm $name
+  docker stop macos-$name
+}
+
+export -f install_on_mac_vm launch_and_install_on_mac_vm
+
+# Assumes a macos vm is already running.
+# Starts services, and runs install script on the mac vm via ssh.
+function test_mac {
+  echo_header "aztec-up test_mac"
+  local mac_name="${1:?Mac vm name (e.g. 14)}"
+  prep_test_mac
+  install_on_mac_vm $mac_name
+}
+
+# Starts services, launches a mac vm for each version and runs install script via ssh.
+function test_macs {
+  echo_header "aztec-up test_macs"
+  prep_test_mac
+  LIVE_LOGGING=1 PASS_LOG=1 parallelize < <(for mac in 14 15 26; do echo "fake_hash launch_and_install_on_mac_vm $mac"; done) | cat
+}
+
 case "$cmd" in
   "")
     build

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -68,7 +68,7 @@ function release {
 }
 
 function cross_copy {
-  ./scripts/copy_cross.sh
+  ./scripts/copy_cross.sh "$@"
 }
 
 case "$cmd" in

--- a/barretenberg/ts/scripts/copy_cross.sh
+++ b/barretenberg/ts/scripts/copy_cross.sh
@@ -5,7 +5,12 @@ NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
 cd $(dirname $0)/..
 
-if semver check "${REF_NAME:-}" && [[ "$(arch)" == "amd64" ]]; then
+if [ -n "${1:-}" ]; then
+  arch="$1"
+  mkdir -p ./build/$arch
+  cp ../cpp/build-zig-$arch/bin/bb ./build/$arch
+  cp ../cpp/build-zig-$arch/lib/nodejs_module.node ./build/$arch
+elif semver check "${REF_NAME:-}" && [[ "$(arch)" == "amd64" ]]; then
   # We're building a release.
   # We take host build for amd64-linux.
   mkdir -p ./build/amd64-linux

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -203,6 +203,7 @@ RUN apt update && \
         neovim \
         psmisc \
         python3-blessed \
+        qemu-utils \
         redis-tools \
         rsync \
         software-properties-common \
@@ -264,7 +265,7 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 # It can be used independently:
 # - The user should use the ./run.sh script to launch.
 # - A persistent volume will be mounted to /home/aztec-dev.
-# - It provides docker via the hosts docker instance, mounted at /var/lib/docker.sock.
+# - It provides docker-in-docker.
 # - It uses an entrypoint script at runtime to perform uid/gid alignment with the host and drop into user account.
 FROM basebox AS devbox
 

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-shopt -s inherit_errexit
 
 # Re-execute using correct version if we have an .aztecrc file.
 if [ "${AZTEC_VERSIONED:-0}" -eq 0 ] && [ -f .aztecrc ] && command -v aztec-up &>/dev/null; then


### PR DESCRIPTION
* jq install only needed on macos 14.
* python check/install not needed. guess my machine was in a weird state.
* remove inheriterr setting from aztec.sh for mac on bash 3.
* added `test_macs` cmd to aztec-up bootstrap. Launches 14/15/26 macos in parallel and installs on each.
* add `qemu-utils` to devbox.