### PR TITLE
fix: deflake e2e HA full test

### DIFF
--- a/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
+++ b/yarn-project/end-to-end/src/composed/ha/e2e_ha_full.test.ts
@@ -416,9 +416,9 @@ describe('HA Full Setup', () => {
     const round = await governanceProposer.computeRound(blockSlot);
     logger.info(`Block slot ${blockSlot}, governance round ${round}`);
 
-    // Poll L1 for governance votes
+    // Poll L1 until at least one governance vote appears
     logger.info('Polling L1 for governance votes...');
-    const l1VoteCount = await retryUntil(
+    await retryUntil(
       async () => {
         const voteCount = Number(
           await governanceProposer.getPayloadSignals(
@@ -433,11 +433,6 @@ describe('HA Full Setup', () => {
       6, // timeout in seconds (30 attempts * 200ms)
       0.2, // interval in seconds (200ms)
     );
-    logger.info(`Found ${l1VoteCount} governance vote(s) on L1 for payload ${mockGovernancePayload.toString()}`);
-
-    // Verify votes were actually sent to L1
-    expect(l1VoteCount).toBeGreaterThan(0);
-    logger.info(`Verified ${l1VoteCount} governance vote(s) successfully sent to L1`);
 
     // Get L1 round info to determine which slots have actually landed on L1.
     // We anchor the comparison on L1's lastSignalSlot since:
@@ -448,6 +443,17 @@ describe('HA Full Setup', () => {
       round,
     );
     const lastSignalSlot = Number(roundInfo.lastSignalSlot);
+
+    // Re-query L1 vote count after getting lastSignalSlot in case more votes landed between the poll and getRoundInfo:
+    // the retryUntil may return a stale count if more votes land between the poll and getRoundInfo
+    const l1VoteCount = Number(
+      await governanceProposer.getPayloadSignals(
+        deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
+        round,
+        mockGovernancePayload.toString(),
+      ),
+    );
+    expect(l1VoteCount).toBeGreaterThan(0);
     logger.info(
       `L1 round ${round} info: lastSignalSlot=${lastSignalSlot}, l1VoteCount=${l1VoteCount}, payloadWithMostSignals=${roundInfo.payloadWithMostSignals}`,
     );


### PR DESCRIPTION
Deflake attempt for `e2e_ha_full.test.ts`
Re-query L1 for votes in case more landed after checking DB