### PR TITLE
revert: rollback 2nd nightly image

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -138,9 +138,10 @@ jobs:
       fail-fast: false
       matrix:
         test_set: ["1", "2"]
-    # We run after a spartan release (from merge-train/spartan), or when the ci-network-scenario label is present in a PR.
+    # We either run after a release (tag starting with v), or when the ci-network-scenario label is present in a PR.
+    # We exclude ci-release-pr test tags (v0.0.1-commit.*) which are only for testing the release process.
     needs: ci
-    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && ((startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-spartan.')) || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
+    if: github.event.pull_request.head.repo.fork != true && github.event.pull_request.draft == false && ((startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-commit.')) || contains(github.event.pull_request.labels.*.name, 'ci-network-scenario'))
     steps:
       - name: Remove label (one-time use)
         if: github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'ci-network-scenario')
@@ -187,8 +188,8 @@ jobs:
           ./.github/ci3.sh network-scenarios next-scenario "$namespace" "$docker_image" "${{ matrix.test_set }}"
 
       - name: Cleanup network resources
-        # Clean up if this is a CI label or spartan.
-        if: always() && (!startsWith(github.ref, 'refs/tags/v') || contains(github.ref_name, '-spartan.'))
+        # Clean up if this is a CI label or nightly.
+        if: always() && (!startsWith(github.ref, 'refs/tags/v') || contains(github.ref_name, '-nightly.'))
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -1,6 +1,6 @@
-# Deploy next-net environment from merge-train/spartan
+# Deploy next-net environment
 # This workflow deploys the next-net environment with a specified version
-# Runs nightly with the latest spartan nightly tag, or can be manually triggered with any image
+# Runs nightly with the latest nightly tag, or can be manually triggered with any image
 name: Deploy Next Net
 
 on:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Docker image tag (e.g., 2.3.4, 3.0.0-spartan.20251004-amd64, or leave empty for latest spartan nightly)'
+        description: 'Docker image tag (e.g., 2.3.4, 3.0.0-nightly.20251004-amd64, or leave empty for latest nightly)'
         required: false
         type: string
 
@@ -27,8 +27,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          ref: merge-train/spartan
 
       - name: Determine image tag
         id: determine_tag
@@ -38,22 +36,22 @@ jobs:
             TAG="${{ inputs.image_tag }}"
             echo "Using manually specified tag: $TAG"
 
-            # Extract semver (remove -amd64 suffix if present, remove -spartan.YYYYMMDD if present)
-            SEMVER=$(echo "$TAG" | sed 's/-amd64$//' | sed 's/-spartan\.[0-9]\{8\}//')
+            # Extract semver (remove -amd64 suffix if present, remove -nightly.YYYYMMDD if present)
+            SEMVER=$(echo "$TAG" | sed 's/-amd64$//' | sed 's/-nightly\.[0-9]\{8\}//')
           else
-            # Scheduled nightly run - get latest spartan nightly tag
+            # Scheduled nightly run - get latest nightly tag
             current_version=$(jq -r '."."' .release-please-manifest.json)
             echo "Current version: $current_version"
 
-            # Format the tag as: <current_version>-spartan.<YYYYMMDD>-amd64
-            nightly_tag="${current_version}-spartan.$(date -u +%Y%m%d)-amd64"
+            # Format the tag as: <current_version>-nightly.<YYYYMMDD>-amd64
+            nightly_tag="${current_version}-nightly.$(date -u +%Y%m%d)-amd64"
 
             # Check if the tag exists on docker hub
             TAGS=$(curl -s https://registry.hub.docker.com/v2/repositories/aztecprotocol/aztec/tags/$nightly_tag)
             if [[ "$TAGS" != *"not found"* ]]; then
               TAG="$nightly_tag"
               SEMVER="$current_version"
-              echo "Using spartan nightly tag: $TAG"
+              echo "Using nightly tag: $TAG"
             else
               echo "Error: Tag $nightly_tag not published to docker hub"
               exit 1
@@ -70,5 +68,5 @@ jobs:
       network: next-net
       semver: ${{ needs.get-image-tag.outputs.semver }}
       docker_image_tag: ${{ needs.get-image-tag.outputs.tag }}
-      ref: merge-train/spartan
+      ref: ${{ github.ref }}
     secrets: inherit

--- a/.github/workflows/nightly-release-tag.yml
+++ b/.github/workflows/nightly-release-tag.yml
@@ -33,23 +33,3 @@ jobs:
           # Tag and push.
           git tag -a "$nightly_tag" -m "$nightly_tag"
           git push origin "$nightly_tag"
-
-  nightly-release-tag-spartan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          ref: merge-train/spartan
-          token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-
-      - name: Create Spartan Nightly Tag
-        run: |
-          git config --global user.email "tech@aztecprotocol.com"
-          git config --global user.name "AztecBot"
-          current_version=$(jq -r '."."' .release-please-manifest.json)
-          echo "Current version: $current_version"
-          nightly_tag="v${current_version}-spartan.$(date -u +%Y%m%d)"
-          echo "Spartan nightly tag: $nightly_tag"
-          # Tag and push.
-          git tag -a "$nightly_tag" -m "$nightly_tag"
-          git push origin "$nightly_tag"


### PR DESCRIPTION
Reverts two commits that changed next-net to a separate nightly that worked off of merge-train/spartan. Caused too much confusion.