### PR TITLE
test: intentionally stale VK to test VK-UPDATE flow

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -16,7 +16,7 @@ cd ..
 pinned_short_hash="189f0026"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
-script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 function update_pinned_hash_in_script {
     local new_hash=$1
@@ -229,7 +229,14 @@ else
       echo "No VK changes detected. Short hash is: ${pinned_short_hash}"
     elif [[ $exit_code -eq 1 ]]; then
       # All flows had VK changes
-      echo "VK changes detected. Please re-run the script with --update_inputs"
+      echo ""
+      echo "VK changes detected!"
+      echo "To acknowledge and auto-regenerate, add a commit to your PR:"
+      echo '  git commit --allow-empty -m "VK-UPDATE: <explanation of why VKs changed>"'
+      echo ""
+      echo "CI will automatically regenerate and commit the updated VKs on the next ci-fast/ci-full run."
+      echo "If running ci-barretenberg, add the ci-full label to trigger a full CI run."
+      echo "To update locally instead, re-run with --update_inputs."
       exit 1
     else
       # At least one real error

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="db8f42e3"
+pinned_short_hash="c68ca31e"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -13,7 +13,7 @@ cd ..
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="189f0026"
+pinned_short_hash="db8f42e3"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -570,14 +570,18 @@ case "$cmd" in
     export USE_TEST_CACHE=1
     export CI_FULL=0
     build
-    test
+    if ! test; then
+      scripts/ci_vk_update.sh
+    fi
     ;;
   "ci-full")
     export CI=1
     export USE_TEST_CACHE=1
     export CI_FULL=1
     build
-    test
+    if ! test; then
+      scripts/ci_vk_update.sh
+    fi
     bench
     ;;
   "ci-full-no-test-cache")

--- a/scripts/ci_vk_update.sh
+++ b/scripts/ci_vk_update.sh
@@ -56,7 +56,7 @@ function main {
   git commit -m "chore: regenerate chonk VKs
 
 VK-UPDATE acknowledged: ${explanation}"
-  git push
+  git push origin HEAD
 
   echo "VK update completed. A new CI run will be triggered."
 }

--- a/scripts/ci_vk_update.sh
+++ b/scripts/ci_vk_update.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Handles automatic VK regeneration when CI fails and the author has acknowledged
+# the VK change via a VK-UPDATE commit message.
+#
+# Flow:
+# 1. CI fails (potentially due to VK staleness)
+# 2. This step checks if any commit in the PR contains "VK-UPDATE: <explanation>"
+# 3. If found, regenerates VKs, commits the update, and pushes
+# 4. The subsequent CI run should pass with updated VKs
+#
+# If no VK-UPDATE commit is found, this step is a no-op (the CI failure stands).
+set -euo pipefail
+
+NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
+
+function main {
+  echo_header "VK Update Check"
+
+  # Scan PR commit messages for VK-UPDATE acknowledgment.
+  local vk_update_message
+  vk_update_message=$(git log --format=%B -n "${PR_COMMITS:-50}" HEAD | grep -m1 "^VK-UPDATE:" || true)
+
+  if [ -z "$vk_update_message" ]; then
+    echo "No VK-UPDATE commit found. If VKs need updating, add a commit with:"
+    echo '  git commit --allow-empty -m "VK-UPDATE: <explanation of why VKs changed>"'
+    echo "CI failure stands."
+    return
+  fi
+
+  local explanation="${vk_update_message#VK-UPDATE:}"
+  explanation="${explanation# }" # trim leading space
+
+  if [ -z "$explanation" ]; then
+    echo "Found VK-UPDATE commit but no explanation provided."
+    echo "Please include an explanation:"
+    echo '  git commit --allow-empty -m "VK-UPDATE: changed public inputs in rollup circuit"'
+    echo "CI failure stands."
+    return
+  fi
+
+  echo "Found VK-UPDATE acknowledgment: $explanation"
+  echo "Proceeding with VK regeneration..."
+
+  local github_repository
+  github_repository=$(git remote get-url origin | sed -E 's|.*github\.com[/:]([^/]+/[^/]+)(\.git)?$|\1|')
+
+  # Reauth the git repo with our GITHUB_TOKEN
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${github_repository}"
+
+  # Generate fresh IVC inputs, upload to S3, and verify VKs
+  # Run from barretenberg/cpp in a subshell so script_path resolves correctly
+  (cd barretenberg/cpp && scripts/test_chonk_standalone_vks_havent_changed.sh --update_inputs)
+
+  # Commit and push the updated pinned hash
+  git add barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+  git commit -m "chore: regenerate chonk VKs
+
+VK-UPDATE acknowledged: ${explanation}"
+  git push
+
+  echo "VK update completed. A new CI run will be triggered."
+}
+
+main


### PR DESCRIPTION
## Test PR — do not merge

Testing the VK-UPDATE commit message flow:
1. This PR intentionally breaks the ECCVM VK hash
2. CI should fail on the VK test
3. Then we'll add a `VK-UPDATE:` commit to trigger auto-regeneration
4. Verify the mechanism works end-to-end

Related: #20158