### PR TITLE
chore: add build_bench to ci-barretenberg-full

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -758,6 +758,7 @@ case "$cmd" in
     pull_submodules
     noir/bootstrap.sh build_native  # Build nargo for acir_tests
     barretenberg/bootstrap.sh ci
+    barretenberg/cpp/bootstrap.sh build_bench
     ;;
 
   #######################


### PR DESCRIPTION
## Summary
- Adds `barretenberg/cpp/bootstrap.sh build_bench` to the `ci-barretenberg-full` CI target
- This ensures benchmark binary compilation failures are caught early in the barretenberg merge train, rather than only surfacing later during full CI bench runs
- Motivated by failures like http://ci.aztec-labs.com/e0b887a5e8eb4376