### PR TITLE
feat(aztec.js): add additionalScopes to ContractFunctionPattern in capabilities

### DIFF
--- a/yarn-project/aztec.js/src/wallet/capabilities.ts
+++ b/yarn-project/aztec.js/src/wallet/capabilities.ts
@@ -32,6 +32,15 @@ export interface ContractFunctionPattern {
 
   /** Function name or '*' for any function */
   function: string;
+
+  /**
+   * Additional addresses whose private state and keys are accessible
+   * when calling this function, beyond the sender's.
+   * - undefined: No additional scopes allowed
+   * - AztecAddress[]: Only these specific addresses allowed as additional scopes
+   * - '*': All known address allowed as an additional scope
+   */
+  additionalScopes?: AztecAddress[] | '*';
 }
 
 /**

--- a/yarn-project/aztec.js/src/wallet/wallet.test.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.test.ts
@@ -226,6 +226,8 @@ describe('WalletSchema', () => {
   });
 
   it('requestCapabilities', async () => {
+    const someAddress = await AztecAddress.random();
+    const anotherAddress = await AztecAddress.random();
     const manifest: AppCapabilities = {
       version: '1.0',
       metadata: {
@@ -238,6 +240,14 @@ describe('WalletSchema', () => {
           type: 'accounts',
           canGet: true,
           canCreateAuthWit: true,
+        },
+        {
+          type: 'transaction',
+          scope: [
+            { contract: someAddress, function: 'withdraw', additionalScopes: [anotherAddress] },
+            { contract: someAddress, function: 'transfer' },
+            { contract: someAddress, function: 'deposit', additionalScopes: '*' },
+          ],
         },
       ],
     };

--- a/yarn-project/aztec.js/src/wallet/wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/wallet.ts
@@ -381,6 +381,7 @@ export const ContractClassMetadataSchema = z.object({
 export const ContractFunctionPatternSchema = z.object({
   contract: z.union([schemas.AztecAddress, z.literal('*')]),
   function: z.union([z.string(), z.literal('*')]),
+  additionalScopes: optional(z.union([z.array(schemas.AztecAddress), z.literal('*')])),
 });
 
 export const AccountsCapabilitySchema = z.object({


### PR DESCRIPTION
## Summary
- Adds `additionalScopes?: AztecAddress[] | '*'` to `ContractFunctionPattern` interface, allowing wallets to control which additional addresses' private state and keys an app can request per function call
- Adds matching schema validation in `ContractFunctionPatternSchema`