### PR TITLE
fix: allow v{major}-devnet-{iteration} in --network

### DIFF
--- a/yarn-project/cli/src/config/chain_l2_config.ts
+++ b/yarn-project/cli/src/config/chain_l2_config.ts
@@ -45,7 +45,9 @@ export function enrichEnvironmentWithChainName(networkName: NetworkNames) {
   }
 
   // Apply generated network config from defaults.yml
-  const generatedConfig = NetworkConfigs[networkName];
+  // For devnet iterations (v4-devnet-1, etc.), use the base devnet config
+  const configKey = /^v\d+-devnet-\d+$/.test(networkName) ? 'devnet' : networkName;
+  const generatedConfig = NetworkConfigs[configKey];
   if (generatedConfig) {
     enrichEnvironmentWithNetworkConfig(generatedConfig);
   }

--- a/yarn-project/foundation/src/config/network_name.ts
+++ b/yarn-project/foundation/src/config/network_name.ts
@@ -5,7 +5,8 @@ export type NetworkNames =
   | 'testnet'
   | 'mainnet'
   | 'next-net'
-  | 'devnet';
+  | 'devnet'
+  | `v${number}-devnet-${number}`;
 
 export function getActiveNetworkName(name?: string): NetworkNames {
   const network = name || process.env.NETWORK;
@@ -23,6 +24,8 @@ export function getActiveNetworkName(name?: string): NetworkNames {
     return 'next-net';
   } else if (network === 'devnet') {
     return 'devnet';
+  } else if (/^v\d+-devnet-\d+$/.test(network)) {
+    return network as `v${number}-devnet-${number}`;
   }
   throw new Error(`Unknown network: ${network}`);
 }


### PR DESCRIPTION
I thought we allowed anything in `--network` now that we have AztecProtocol/networks but that's not the case.

This will have to be backported to v4-devnet-2