### PR TITLE
refactor: auto-inject contract address into scopes for account deploys

### DIFF
--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -14,7 +14,7 @@ import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 
 import { publishContractClass } from '../deployment/publish_class.js';
 import { publishInstance } from '../deployment/publish_instance.js';
-import type { SendOptions, Wallet } from '../wallet/wallet.js';
+import type { ProfileOptions, SendOptions, SimulateOptions, Wallet } from '../wallet/wallet.js';
 import { BaseContractInteraction } from './base_contract_interaction.js';
 import type { ContractBase } from './contract_base.js';
 import { ContractFunctionInteraction } from './contract_function_interaction.js';
@@ -207,7 +207,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * @param options - Deploy options with wait parameter
    * @returns Send options with wait parameter
    */
-  private convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
+  protected convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
     options: DeployOptions<W>,
     // eslint-disable-next-line jsdoc/require-jsdoc
   ): SendOptions<W extends { returnReceipt: true } ? WaitOpts : W> {
@@ -217,6 +217,24 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
         wait: options.wait as any,
       }),
     } as any;
+  }
+
+  /**
+   * Converts deploy simulation options into wallet-level simulate options.
+   * @param options - The deploy simulation options to convert.
+   */
+  protected convertDeployOptionsToSimulateOptions(options: SimulateDeployOptions): SimulateOptions {
+    return toSimulateOptions(options);
+  }
+
+  /**
+   * Converts deploy profile options into wallet-level profile options.
+   * @param options - The deploy profile options to convert.
+   */
+  protected convertDeployOptionsToProfileOptions(
+    options: DeployOptionsWithoutWait & ProfileInteractionOptions,
+  ): ProfileOptions {
+    return toProfileOptions(options);
   }
 
   /**
@@ -368,7 +386,10 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    */
   public async simulate(options: SimulateDeployOptions): Promise<SimulationReturn<true>> {
     const executionPayload = await this.request(this.convertDeployOptionsToRequestOptions(options));
-    const simulatedTx = await this.wallet.simulateTx(executionPayload, toSimulateOptions(options));
+    const simulatedTx = await this.wallet.simulateTx(
+      executionPayload,
+      this.convertDeployOptionsToSimulateOptions(options),
+    );
 
     const { gasLimits, teardownGasLimits } = getGasLimits(simulatedTx, options.fee?.estimatedGasPadding);
     this.log.verbose(
@@ -390,11 +411,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    */
   public async profile(options: DeployOptionsWithoutWait & ProfileInteractionOptions): Promise<TxProfileResult> {
     const executionPayload = await this.request(this.convertDeployOptionsToRequestOptions(options));
-    return await this.wallet.profileTx(executionPayload, {
-      ...toProfileOptions(options),
-      profileMode: options.profileMode,
-      skipProofGeneration: options.skipProofGeneration,
-    });
+    return await this.wallet.profileTx(executionPayload, this.convertDeployOptionsToProfileOptions(options));
   }
 
   /** Return this deployment address. */

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -159,32 +159,29 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
     options: DeployOptions<W>,
     // eslint-disable-next-line jsdoc/require-jsdoc
   ): SendOptions<W extends { returnReceipt: true } ? WaitOpts : W> {
-    return super.convertDeployOptionsToSendOptions(this.addContractToScopes(options) as DeployOptions<W>);
+    return super.convertDeployOptionsToSendOptions(this.injectContractAddressIntoScopes(options));
   }
 
   protected override convertDeployOptionsToSimulateOptions(options: SimulateDeployOptions): SimulateOptions {
-    return super.convertDeployOptionsToSimulateOptions(this.addContractToScopes(options));
+    return super.convertDeployOptionsToSimulateOptions(this.injectContractAddressIntoScopes(options));
   }
 
   protected override convertDeployOptionsToProfileOptions(
     options: DeployOptionsWithoutWait & ProfileInteractionOptions,
   ): ProfileOptions {
-    const withScope = this.addContractToScopes(options as SimulateDeployOptions);
-    return super.convertDeployOptionsToProfileOptions(
-      withScope as DeployOptionsWithoutWait & ProfileInteractionOptions,
-    );
+    return super.convertDeployOptionsToProfileOptions(this.injectContractAddressIntoScopes(options));
   }
 
-  /** Injects the contract's own address into scopes so the constructor can access its own keys. */
-  private addContractToScopes(
-    options: DeployOptions<DeployInteractionWaitOptions>,
-  ): DeployOptions<DeployInteractionWaitOptions>;
-  private addContractToScopes(options: SimulateDeployOptions): SimulateDeployOptions;
-  private addContractToScopes(options: Record<string, unknown>): Record<string, unknown> {
+  /**
+   * Injects the contract's own address into scopes so the constructor can access its own keys.
+   * @param options - The deploy options to augment with the contract address.
+   */
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  private injectContractAddressIntoScopes<T extends { additionalScopes?: AztecAddress[] }>(options: T): T {
     if (!this.address) {
       throw new Error('Instance not yet constructed. This is a bug!');
     }
-    const existing = (options.additionalScopes as AztecAddress[] | undefined) ?? [];
+    const existing = options.additionalScopes ?? [];
     return { ...options, additionalScopes: [...existing, this.address] };
   }
 }

--- a/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
+++ b/yarn-project/aztec.js/src/wallet/deploy_account_method.ts
@@ -9,15 +9,22 @@ import type { Account } from '../account/account.js';
 import type { Contract } from '../contract/contract.js';
 import type { ContractBase } from '../contract/contract_base.js';
 import {
+  type DeployInteractionWaitOptions,
   DeployMethod,
+  type DeployOptions,
   type DeployOptionsWithoutWait,
   type RequestDeployOptions,
   type SimulateDeployOptions,
 } from '../contract/deploy_method.js';
-import type { FeePaymentMethodOption, InteractionWaitOptions } from '../contract/interaction_options.js';
+import type {
+  FeePaymentMethodOption,
+  InteractionWaitOptions,
+  ProfileInteractionOptions,
+} from '../contract/interaction_options.js';
+import type { WaitOpts } from '../contract/wait_opts.js';
 import type { FeePaymentMethod } from '../fee/fee_payment_method.js';
 import { AccountEntrypointMetaPaymentMethod } from './account_entrypoint_meta_payment_method.js';
-import type { Wallet } from './index.js';
+import type { ProfileOptions, SendOptions, SimulateOptions, Wallet } from './index.js';
 
 /**
  * Extended fee payment method option for account deployments that includes entrypoint wrapping options
@@ -146,5 +153,38 @@ export class DeployAccountMethod<TContract extends ContractBase = Contract> exte
       // The fee payment method one way or another
       deployer: options.from,
     };
+  }
+
+  protected override convertDeployOptionsToSendOptions<W extends DeployInteractionWaitOptions>(
+    options: DeployOptions<W>,
+    // eslint-disable-next-line jsdoc/require-jsdoc
+  ): SendOptions<W extends { returnReceipt: true } ? WaitOpts : W> {
+    return super.convertDeployOptionsToSendOptions(this.addContractToScopes(options) as DeployOptions<W>);
+  }
+
+  protected override convertDeployOptionsToSimulateOptions(options: SimulateDeployOptions): SimulateOptions {
+    return super.convertDeployOptionsToSimulateOptions(this.addContractToScopes(options));
+  }
+
+  protected override convertDeployOptionsToProfileOptions(
+    options: DeployOptionsWithoutWait & ProfileInteractionOptions,
+  ): ProfileOptions {
+    const withScope = this.addContractToScopes(options as SimulateDeployOptions);
+    return super.convertDeployOptionsToProfileOptions(
+      withScope as DeployOptionsWithoutWait & ProfileInteractionOptions,
+    );
+  }
+
+  /** Injects the contract's own address into scopes so the constructor can access its own keys. */
+  private addContractToScopes(
+    options: DeployOptions<DeployInteractionWaitOptions>,
+  ): DeployOptions<DeployInteractionWaitOptions>;
+  private addContractToScopes(options: SimulateDeployOptions): SimulateDeployOptions;
+  private addContractToScopes(options: Record<string, unknown>): Record<string, unknown> {
+    if (!this.address) {
+      throw new Error('Instance not yet constructed. This is a bug!');
+    }
+    const existing = (options.additionalScopes as AztecAddress[] | undefined) ?? [];
+    return { ...options, additionalScopes: [...existing, this.address] };
   }
 }

--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -79,8 +79,6 @@ export async function createAccount(
       skipInstancePublication: !publicDeploy,
       skipInitialization,
       from,
-      // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-      additionalScopes: [address],
       fee: { paymentMethod, gasSettings },
     };
 

--- a/yarn-project/end-to-end/src/composed/docs_examples.test.ts
+++ b/yarn-project/end-to-end/src/composed/docs_examples.test.ts
@@ -32,8 +32,6 @@ describe('docs_examples', () => {
     const newAccountDeployMethod = await newAccountManager.getDeployMethod();
     await newAccountDeployMethod.send({
       from: prefundedAccount.address,
-      // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-      additionalScopes: [newAccountManager.address],
     });
     const newAccountAddress = newAccountManager.address;
     const defaultAccountAddress = prefundedAccount.address;

--- a/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_local_network_example.test.ts
@@ -145,8 +145,7 @@ describe('e2e_local_network_example', () => {
       return await Promise.all(
         accountManagers.map(async x => {
           const deployMethod = await x.getDeployMethod();
-          // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-          await deployMethod.send({ from: fundedAccount, additionalScopes: [x.address] });
+          await deployMethod.send({ from: fundedAccount });
           return x;
         }),
       );

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -91,8 +91,6 @@ describe('e2e_fees account_init', () => {
 
       const tx = await bobsDeployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [bobsAddress],
         wait: { returnReceipt: true },
       });
 
@@ -105,8 +103,6 @@ describe('e2e_fees account_init', () => {
       const paymentMethod = new FeeJuicePaymentMethodWithClaim(bobsAddress, claim);
       const tx = await bobsDeployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [bobsAddress],
         fee: { paymentMethod },
         wait: { returnReceipt: true },
       });
@@ -127,8 +123,6 @@ describe('e2e_fees account_init', () => {
       const paymentMethod = new PrivateFeePaymentMethod(bananaFPC.address, bobsAddress, wallet, gasSettings);
       const tx = await bobsDeployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [bobsAddress],
         fee: { paymentMethod },
         wait: { returnReceipt: true },
       });
@@ -158,8 +152,6 @@ describe('e2e_fees account_init', () => {
       const paymentMethod = new PublicFeePaymentMethod(bananaFPC.address, bobsAddress, wallet, gasSettings);
       const tx = await bobsDeployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [bobsAddress],
         skipInstancePublication: false,
         fee: { paymentMethod },
         wait: { returnReceipt: true },

--- a/yarn-project/end-to-end/src/e2e_fees/fee_juice_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_juice_payments.test.ts
@@ -34,8 +34,7 @@ describe('e2e_fees Fee Juice payments', () => {
     // Alice pays for Bob's account contract deployment.
     const bobsDeployMethod = await bobsAccountManager.getDeployMethod();
     bobAddress = bobsAccountManager.address;
-    // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-    await bobsDeployMethod.send({ from: aliceAddress, additionalScopes: [bobAddress] });
+    await bobsDeployMethod.send({ from: aliceAddress });
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -841,8 +841,6 @@ export const deployAccounts =
       const deployMethod = await accountManager.getDeployMethod();
       await deployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [accountManager.address],
         skipClassPublication: i !== 0, // Publish the contract class at most once.
       });
     }

--- a/yarn-project/end-to-end/src/shared/submit-transactions.ts
+++ b/yarn-project/end-to-end/src/shared/submit-transactions.ts
@@ -21,8 +21,6 @@ export const submitTxsTo = async (
       const deployMethod = await accountManager.getDeployMethod();
       const txHash = await deployMethod.send({
         from: submitter,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [accountManager.address],
         wait: NO_WAIT,
       });
 

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -90,8 +90,6 @@ export async function deploySponsoredTestAccountsWithTokens(
   const recipientDeployMethod = await recipientAccount.getDeployMethod();
   await recipientDeployMethod.send({
     from: AztecAddress.ZERO,
-    // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-    additionalScopes: [recipientAccount.address],
     fee: { paymentMethod },
     wait: { timeout: 2400 },
   });
@@ -100,8 +98,6 @@ export async function deploySponsoredTestAccountsWithTokens(
       const deployMethod = await a.getDeployMethod();
       await deployMethod.send({
         from: AztecAddress.ZERO,
-        // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-        additionalScopes: [a.address],
         fee: { paymentMethod },
         wait: { timeout: 2400 },
       }); // increase timeout on purpose in order to account for two empty epochs
@@ -144,8 +140,6 @@ async function deployAccountWithDiagnostics(
   try {
     txHash = await deployMethod.send({
       from: AztecAddress.ZERO,
-      // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-      additionalScopes: [account.address],
       fee: { paymentMethod },
       wait: NO_WAIT,
     });
@@ -240,8 +234,7 @@ export async function deployTestAccountsWithTokens(
     fundedAccounts.map(async (a, i) => {
       const paymentMethod = new FeeJuicePaymentMethodWithClaim(a.address, claims[i]);
       const deployMethod = await a.getDeployMethod();
-      // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-      await deployMethod.send({ from: AztecAddress.ZERO, additionalScopes: [a.address], fee: { paymentMethod } });
+      await deployMethod.send({ from: AztecAddress.ZERO, fee: { paymentMethod } });
       logger.info(`Account deployed at ${a.address}`);
     }),
   );

--- a/yarn-project/wallets/src/testing.ts
+++ b/yarn-project/wallets/src/testing.ts
@@ -22,8 +22,6 @@ export async function deployFundedSchnorrAccounts(
     const deployMethod = await accountManager.getDeployMethod();
     await deployMethod.send({
       from: AztecAddress.ZERO,
-      // The account constructor initializes storage vars that need the contract's own nullifier key, so we need to add it to scopes.
-      additionalScopes: [accountManager.address],
       skipClassPublication: i !== 0,
       wait: waitOptions,
     });


### PR DESCRIPTION
## Summary
- `DeployAccountMethod` now automatically injects the contract's own address into `additionalScopes`, so callers no longer need to manually pass `additionalScopes: [accountManager.address]` on every account deploy call.