### PR TITLE
revert: rollback 2nd nightly image (#20646)

### DIFF
--- a/yarn-project/aztec/src/cli/admin_api_key_store.test.ts
+++ b/yarn-project/aztec/src/cli/admin_api_key_store.test.ts
@@ -22,9 +22,9 @@ describe('resolveAdminApiKey', () => {
     }
   });
 
-  describe('opt-out (noAdminApiKey = true)', () => {
+  describe('opt-out (disableAdminApiKey = true)', () => {
     it('returns undefined when auth is disabled', async () => {
-      const result = await resolveAdminApiKey({ noAdminApiKey: true }, log);
+      const result = await resolveAdminApiKey({ disableAdminApiKey: true }, log);
       expect(result).toBeUndefined();
     });
   });

--- a/yarn-project/aztec/src/cli/admin_api_key_store.ts
+++ b/yarn-project/aztec/src/cli/admin_api_key_store.ts
@@ -28,7 +28,7 @@ export interface ResolveAdminApiKeyOptions {
   /** SHA-256 hex hash of a pre-generated API key. When set, the node uses this hash directly. */
   adminApiKeyHash?: string;
   /** If true, disable admin API key auth entirely. */
-  noAdminApiKey?: boolean;
+  disableAdminApiKey?: boolean;
   /** If true, force-generate a new key even if one is already persisted. */
   resetAdminApiKey?: boolean;
   /** Root data directory for persistent storage. */
@@ -39,7 +39,7 @@ export interface ResolveAdminApiKeyOptions {
  * Resolves the admin API key for the admin RPC endpoint.
  *
  * Strategy:
- * 1. If opt-out flag is set (`noAdminApiKey`), return undefined (no auth).
+ * 1. If opt-out flag is set (`disableAdminApiKey`), return undefined (no auth).
  * 2. If a pre-generated hash is provided (`adminApiKeyHash`), use it directly.
  * 3. If a data directory exists, look for a persisted hash file
  *    at `<dataDirectory>/admin/api_key_hash`:
@@ -58,8 +58,8 @@ export async function resolveAdminApiKey(
   log: Logger,
 ): Promise<AdminApiKeyResolution | undefined> {
   // Operator explicitly opted out of admin auth
-  if (options.noAdminApiKey) {
-    log.warn('Admin API key authentication is DISABLED (--no-admin-api-key / AZTEC_NO_ADMIN_API_KEY)');
+  if (options.disableAdminApiKey) {
+    log.warn('Admin API key authentication is DISABLED (--disable-admin-api-key / AZTEC_NO_ADMIN_API_KEY)');
     return undefined;
   }
 

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -109,7 +109,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
     const apiKeyResolution = await resolveAdminApiKey(
       {
         adminApiKeyHash: options.adminApiKeyHash,
-        noAdminApiKey: options.noAdminApiKey,
+        disableAdminApiKey: options.disableAdminApiKey,
         resetAdminApiKey: options.resetAdminApiKey,
         dataDirectory: options.dataDirectory,
       },
@@ -148,7 +148,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
         userLog('  The key hash has been persisted — on next restart, the same key will be used.');
       }
       userLog('');
-      userLog('  To disable admin auth: --no-admin-api-key or AZTEC_NO_ADMIN_API_KEY=true');
+      userLog('  To disable admin auth: --disable-admin-api-key or AZTEC_NO_ADMIN_API_KEY=true');
       userLog(separator);
       userLog('');
     }

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -150,7 +150,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       env: 'AZTEC_ADMIN_API_KEY_HASH',
     },
     {
-      flag: '--no-admin-api-key',
+      flag: '--disable-admin-api-key',
       description:
         'Disable API key authentication on the admin RPC endpoint. By default, a key is auto-generated, displayed once, and its hash is persisted.',
       defaultValue: false,


### PR DESCRIPTION
Commander interprets flags that start with `no-` in a special way. This PR renames `--no-admin-api-key` to avoid (since there's no 'enable' flag because it's on by default I chose to rename it)