### PR TITLE
fix: pass CARGO_REGISTRY_TOKEN to CI release environment

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -79,6 +79,7 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # For automatic documentation updates via Claude Code
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -520,8 +520,17 @@ function release {
     )
   fi
 
+  # Non-fatal projects: failure logs a warning but doesn't block the release.
+  local non_fatal_projects=(barretenberg/rust)
+
   for project in "${projects[@]}"; do
-    $project/bootstrap.sh release
+    if [[ " ${non_fatal_projects[*]} " == *" $project "* ]]; then
+      if ! $project/bootstrap.sh release; then
+        echo "WARNING: $project release failed (non-fatal, continuing)"
+      fi
+    else
+      $project/bootstrap.sh release
+    fi
   done
 }
 

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -318,6 +318,7 @@ function run {
         -e NETLIFY_SITE_ID=${NETLIFY_SITE_ID:-} \
         -e NETLIFY_AUTH_TOKEN=${NETLIFY_AUTH_TOKEN:-} \
         -e NPM_TOKEN=${NPM_TOKEN:-} \
+        -e CARGO_REGISTRY_TOKEN=${CARGO_REGISTRY_TOKEN:-} \
         -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-} \
         -e AWS_TOKEN=\$aws_token \
         -e NAMESPACE=${NAMESPACE:-} \


### PR DESCRIPTION
## Summary
- Add `CARGO_REGISTRY_TOKEN` secret to the ci3.yml workflow "Run" step env block
- Forward `CARGO_REGISTRY_TOKEN` through `bootstrap_ec2` into the Docker container
- Make `barretenberg/rust` release non-fatal so a cargo publish failure doesn't block the entire release (npm, docker, etc. still ship)

The barretenberg-rs crate publish (`cargo publish -p barretenberg-rs`) was failing with "no token found" because the crates.io token wasn't being passed through the CI pipeline, even though the secret was configured in GitHub.

Fixes the `ci-release-pr` flow for barretenberg-rs.