### PR TITLE
fix: ECDSA tests in acir_tests don't fail anymore

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -113,12 +113,6 @@ function build {
     rm -rf acir_tests/{regression_5045,regression_7744}
     # The following test fails because it uses CallData/ReturnData with UltraBuilder, which is not supported
     rm -rf acir_tests/{regression_7612,regression_7143,databus_composite_calldata,databus_two_calldata_simple,databus_two_calldata,databus}
-    # Mark tests that are expected to fail with a failing_ prefix.
-    # bb_prove.sh will expect these to fail and error if they suddenly pass.
-    for t in ecdsa_secp256k1_invalid_inputs; do
-      mv acir_tests/$t acir_tests/failing_$t
-      sed -i "s/^name = \"$t\"/name = \"failing_$t\"/" acir_tests/failing_$t/Nargo.toml
-    done
     # Merge the internal test programs with the acir tests.
     cp -R ./internal_test_programs/* acir_tests
 


### PR DESCRIPTION
Previously some configuration of witnesses would make ecdsa circuits fail, this is not true anymore, so the acir_tests are not supposed to fail anymore.