### PR TITLE
feat: add `aztec profile` command with gate count profiling

### DIFF
--- a/yarn-project/aztec/bootstrap.sh
+++ b/yarn-project/aztec/bootstrap.sh
@@ -8,7 +8,9 @@ export BB=${BB:-$repo_root/barretenberg/cpp/build/bin/bb}
 hash=$(../bootstrap.sh hash)
 
 function test_cmds {
-  echo "$hash:ISOLATE=1:NAME=aztec/src/cli/cmds/compile.test.ts NARGO=$NARGO BB=$BB yarn-project/scripts/run_test.sh aztec/src/cli/cmds/compile.test.ts"
+  for test in src/cli/**/*.test.ts; do
+    echo "$hash:ISOLATE=1:NAME=aztec/$test NARGO=$NARGO BB=$BB yarn-project/scripts/run_test.sh aztec/$test"
+  done
 }
 
 case "$cmd" in

--- a/yarn-project/aztec/src/bin/index.ts
+++ b/yarn-project/aztec/src/bin/index.ts
@@ -16,6 +16,7 @@ import { Command } from 'commander';
 
 import { injectCompileCommand } from '../cli/cmds/compile.js';
 import { injectMigrateCommand } from '../cli/cmds/migrate_ha_db.js';
+import { injectProfileCommand } from '../cli/cmds/profile.js';
 import { injectAztecCommands } from '../cli/index.js';
 import { getCliVersion } from '../cli/release_version.js';
 
@@ -58,6 +59,7 @@ async function main() {
   program = injectMiscCommands(program, userLog);
   program = injectValidatorKeysCommands(program, userLog);
   program = injectCompileCommand(program, userLog);
+  program = injectProfileCommand(program, userLog);
   program = injectMigrateCommand(program, userLog);
 
   await program.parseAsync(process.argv);

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -26,8 +26,11 @@ async function collectContractArtifacts(): Promise<string[]> {
   let files;
   try {
     files = await readArtifactFiles('target');
-  } catch {
-    return [];
+  } catch (err: any) {
+    if (err?.message?.includes('does not exist')) {
+      return [];
+    }
+    throw err;
   }
   return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
 }

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -2,8 +2,9 @@ import type { LogFn } from '@aztec/foundation/log';
 
 import { execFileSync, spawn } from 'child_process';
 import type { Command } from 'commander';
-import { readFile, readdir, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+
+import { readArtifactFiles } from './utils/artifacts.js';
 
 /** Spawns a command with inherited stdio and rejects on non-zero exit. */
 function run(cmd: string, args: string[]): Promise<void> {
@@ -20,32 +21,15 @@ function run(cmd: string, args: string[]): Promise<void> {
   });
 }
 
-/** Returns paths to contract artifacts in the target directory.
- *  Contract artifacts are identified by having a `functions` array in the JSON.
- */
+/** Returns paths to contract artifacts in the target directory. */
 async function collectContractArtifacts(): Promise<string[]> {
-  let files: string[];
+  let files;
   try {
-    files = await readdir('target');
-  } catch (err: any) {
-    if (err?.code === 'ENOENT') {
-      return [];
-    }
-    throw new Error(`Failed to read target directory: ${err.message}`);
+    files = await readArtifactFiles('target');
+  } catch {
+    return [];
   }
-
-  const artifacts: string[] = [];
-  for (const file of files) {
-    if (!file.endsWith('.json')) {
-      continue;
-    }
-    const filePath = join('target', file);
-    const content = JSON.parse(await readFile(filePath, 'utf-8'));
-    if (Array.isArray(content.functions)) {
-      artifacts.push(filePath);
-    }
-  }
-  return artifacts;
+  return files.filter(f => Array.isArray(f.content.functions)).map(f => f.filePath);
 }
 
 /** Strips the `__aztec_nr_internals__` prefix from function names in contract artifacts. */

--- a/yarn-project/aztec/src/cli/cmds/profile.ts
+++ b/yarn-project/aztec/src/cli/cmds/profile.ts
@@ -1,0 +1,17 @@
+import type { LogFn } from '@aztec/foundation/log';
+
+import type { Command } from 'commander';
+
+import { profileGates } from './profile_gates.js';
+
+export function injectProfileCommand(program: Command, log: LogFn): Command {
+  const profile = program.command('profile').description('Profile compiled Aztec artifacts.');
+
+  profile
+    .command('gates')
+    .argument('[target-dir]', 'Path to the compiled artifacts directory', './target')
+    .description('Display gate counts for all compiled Aztec artifacts in a target directory.')
+    .action((targetDir: string) => profileGates(targetDir, log));
+
+  return program;
+}

--- a/yarn-project/aztec/src/cli/cmds/profile_gates.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/profile_gates.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { execFileSync } from 'child_process';
+import { rmSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const CLI = join(PACKAGE_ROOT, 'dest/bin/index.js');
+const WORKSPACE = join(PACKAGE_ROOT, 'test/mixed-workspace');
+const TARGET = join(WORKSPACE, 'target');
+
+describe('aztec profile gates', () => {
+  let gatesOutput: string;
+
+  beforeAll(() => {
+    rmSync(TARGET, { recursive: true, force: true });
+    runCompile();
+    gatesOutput = runProfile('gates');
+  }, 300_000);
+
+  afterAll(() => {
+    rmSync(TARGET, { recursive: true, force: true });
+  });
+
+  it('prints gate counts for both contract functions', () => {
+    expect(gatesOutput).toContain('simple_contract-SimpleContract::private_function');
+    expect(gatesOutput).toContain('simple_contract-SimpleContract::another_private_function');
+  });
+
+  it('prints gate counts for both plain circuits', () => {
+    expect(gatesOutput).toContain('simple_circuit');
+    expect(gatesOutput).toContain('simple_circuit_2');
+  });
+
+  it('gate counts are positive integers', () => {
+    const counts = [...gatesOutput.matchAll(/(\d[\d,]*)\s*$/gm)].map(m => parseInt(m[1].replace(/,/g, ''), 10));
+    expect(counts.length).toBeGreaterThanOrEqual(4);
+    for (const count of counts) {
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+});
+
+function runCompile() {
+  try {
+    execFileSync('node', [CLI, 'compile'], { cwd: WORKSPACE, stdio: 'pipe' });
+  } catch (e: any) {
+    throw new Error(`compile failed:\n${e.stderr?.toString() ?? e.message}`);
+  }
+}
+
+function runProfile(subcommand: string) {
+  try {
+    return execFileSync('node', [CLI, 'profile', subcommand, TARGET], { encoding: 'utf-8', stdio: 'pipe' });
+  } catch (e: any) {
+    throw new Error(`profile ${subcommand} failed:\n${e.stderr?.toString() ?? e.message}`);
+  }
+}

--- a/yarn-project/aztec/src/cli/cmds/profile_gates.ts
+++ b/yarn-project/aztec/src/cli/cmds/profile_gates.ts
@@ -1,0 +1,67 @@
+import { asyncPool } from '@aztec/foundation/async-pool';
+import type { LogFn } from '@aztec/foundation/log';
+
+import { execFile as execFileCb } from 'child_process';
+import { rm } from 'fs/promises';
+import { promisify } from 'util';
+
+import { MAX_CONCURRENT, discoverArtifacts } from './profile_utils.js';
+
+const execFile = promisify(execFileCb);
+
+interface GateCountResult {
+  name: string;
+  gateCount: number;
+}
+
+/** Parses circuit_size from bb gates JSON output: { "functions": [{ "circuit_size": N }] } */
+function parseGateCount(stdout: string): number {
+  const parsed = JSON.parse(stdout);
+  const size = parsed?.functions?.[0]?.circuit_size;
+  if (typeof size !== 'number') {
+    throw new Error('Failed to parse circuit_size from bb gates output');
+  }
+  return size;
+}
+
+/** Runs bb gates on a single artifact file and returns the gate count. */
+async function getGateCount(bb: string, artifactPath: string): Promise<number> {
+  const { stdout } = await execFile(bb, ['gates', '--scheme', 'chonk', '-b', artifactPath]);
+  return parseGateCount(stdout);
+}
+
+/** Profiles all compiled artifacts in a target directory and prints gate counts. */
+export async function profileGates(targetDir: string, log: LogFn): Promise<void> {
+  const bb = process.env.BB ?? 'bb';
+  const { artifacts, tmpDir } = await discoverArtifacts(targetDir);
+
+  if (artifacts.length === 0) {
+    log('No artifacts found in target directory.');
+    return;
+  }
+
+  try {
+    const results: GateCountResult[] = await asyncPool(MAX_CONCURRENT, artifacts, async artifact => ({
+      name: artifact.name,
+      gateCount: await getGateCount(bb, artifact.filePath),
+    }));
+    results.sort((a, b) => a.name.localeCompare(b.name));
+
+    if (results.length === 0) {
+      log('No constrained circuits found.');
+      return;
+    }
+
+    const maxNameLen = Math.max(...results.map(r => r.name.length));
+    log('');
+    log('Gate counts:');
+    log('-'.repeat(maxNameLen + 16));
+    for (const { name, gateCount } of results) {
+      log(`${name.padEnd(maxNameLen)}  ${gateCount.toLocaleString().padStart(12)}`);
+    }
+    log('-'.repeat(maxNameLen + 16));
+    log(`Total: ${results.length} circuit(s)`);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/yarn-project/aztec/src/cli/cmds/profile_utils.ts
+++ b/yarn-project/aztec/src/cli/cmds/profile_utils.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { ContractArtifact, ContractFunction } from './utils/artifacts.js';
+import { readArtifactFiles } from './utils/artifacts.js';
+
+export type { ContractArtifact, ContractFunction };
+
+export const MAX_CONCURRENT = 4;
+
+export interface DiscoveredArtifact {
+  name: string;
+  filePath: string;
+  type: 'contract-function' | 'program';
+}
+
+/**
+ * Reads a target directory and returns a list of discovered artifacts with temp files
+ * created for contract functions. Caller must clean up tmpDir when done.
+ */
+export async function discoverArtifacts(
+  targetDir: string,
+): Promise<{ artifacts: DiscoveredArtifact[]; tmpDir: string }> {
+  const files = await readArtifactFiles(targetDir);
+  const tmpDir = await mkdtemp(join(tmpdir(), 'aztec-profile-'));
+  const artifacts: DiscoveredArtifact[] = [];
+
+  for (const file of files) {
+    if (Array.isArray(file.content.functions)) {
+      for (const func of file.content.functions) {
+        if (!func.bytecode || func.is_unconstrained) {
+          continue;
+        }
+        const name = `${file.name}::${func.name}`;
+        const tmpPath = join(tmpDir, `${file.name}-${func.name}.json`);
+        await writeFile(tmpPath, makeFunctionArtifact(file.content, func));
+        artifacts.push({ name, filePath: tmpPath, type: 'contract-function' });
+      }
+    } else if (file.content.bytecode) {
+      artifacts.push({ name: file.name, filePath: file.filePath, type: 'program' });
+    }
+  }
+
+  return { artifacts, tmpDir };
+}
+
+/** Extracts a contract function as a standalone program artifact JSON string. */
+function makeFunctionArtifact(contractArtifact: ContractArtifact, func: ContractFunction) {
+  /* eslint-disable camelcase */
+  return JSON.stringify({
+    noir_version: contractArtifact.noir_version,
+    hash: 0,
+    abi: func.abi,
+    bytecode: func.bytecode,
+    debug_symbols: func.debug_symbols,
+    file_map: contractArtifact.file_map,
+    expression_width: { Bounded: { width: 4 } },
+  });
+  /* eslint-enable camelcase */
+}

--- a/yarn-project/aztec/src/cli/cmds/profile_utils.ts
+++ b/yarn-project/aztec/src/cli/cmds/profile_utils.ts
@@ -2,10 +2,8 @@ import { mkdtemp, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import type { ContractArtifact, ContractFunction } from './utils/artifacts.js';
+import type { CompiledArtifact, ContractFunction } from './utils/artifacts.js';
 import { readArtifactFiles } from './utils/artifacts.js';
-
-export type { ContractArtifact, ContractFunction };
 
 export const MAX_CONCURRENT = 4;
 
@@ -46,16 +44,15 @@ export async function discoverArtifacts(
 }
 
 /** Extracts a contract function as a standalone program artifact JSON string. */
-function makeFunctionArtifact(contractArtifact: ContractArtifact, func: ContractFunction) {
+function makeFunctionArtifact(artifact: CompiledArtifact, func: ContractFunction) {
   /* eslint-disable camelcase */
   return JSON.stringify({
-    noir_version: contractArtifact.noir_version,
+    noir_version: artifact.noir_version,
     hash: 0,
     abi: func.abi,
     bytecode: func.bytecode,
     debug_symbols: func.debug_symbols,
-    file_map: contractArtifact.file_map,
-    expression_width: { Bounded: { width: 4 } },
+    file_map: artifact.file_map,
   });
   /* eslint-enable camelcase */
 }

--- a/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
 
-export interface ContractArtifact {
+export interface CompiledArtifact {
   noir_version: string;
   file_map: unknown;
   functions: ContractFunction[];
@@ -19,7 +19,7 @@ export interface ContractFunction {
 export interface ArtifactFile {
   name: string;
   filePath: string;
-  content: ContractArtifact;
+  content: CompiledArtifact;
 }
 
 /** Reads all JSON artifact files from a target directory and returns their parsed contents. */
@@ -37,7 +37,7 @@ export async function readArtifactFiles(targetDir: string): Promise<ArtifactFile
   const artifacts: ArtifactFile[] = [];
   for (const file of entries) {
     const filePath = join(targetDir, file);
-    const content = JSON.parse(await readFile(filePath, 'utf-8')) as ContractArtifact;
+    const content = JSON.parse(await readFile(filePath, 'utf-8')) as CompiledArtifact;
     artifacts.push({ name: file.replace('.json', ''), filePath, content });
   }
   return artifacts;

--- a/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/artifacts.ts
@@ -1,0 +1,44 @@
+import { readFile, readdir } from 'fs/promises';
+import { join } from 'path';
+
+export interface ContractArtifact {
+  noir_version: string;
+  file_map: unknown;
+  functions: ContractFunction[];
+  bytecode?: string;
+}
+
+export interface ContractFunction {
+  name: string;
+  abi: unknown;
+  bytecode: string;
+  debug_symbols: unknown;
+  is_unconstrained?: boolean;
+}
+
+export interface ArtifactFile {
+  name: string;
+  filePath: string;
+  content: ContractArtifact;
+}
+
+/** Reads all JSON artifact files from a target directory and returns their parsed contents. */
+export async function readArtifactFiles(targetDir: string): Promise<ArtifactFile[]> {
+  let entries: string[];
+  try {
+    entries = (await readdir(targetDir)).filter(f => f.endsWith('.json'));
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      throw new Error(`Target directory '${targetDir}' does not exist. Compile first with 'aztec compile'.`);
+    }
+    throw err;
+  }
+
+  const artifacts: ArtifactFile[] = [];
+  for (const file of entries) {
+    const filePath = join(targetDir, file);
+    const content = JSON.parse(await readFile(filePath, 'utf-8')) as ContractArtifact;
+    artifacts.push({ name: file.replace('.json', ''), filePath, content });
+  }
+  return artifacts;
+}

--- a/yarn-project/aztec/test/mixed-workspace/Nargo.toml
+++ b/yarn-project/aztec/test/mixed-workspace/Nargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["simple_contract", "simple_circuit"]
+members = ["simple_contract", "simple_circuit", "simple_circuit_2"]

--- a/yarn-project/aztec/test/mixed-workspace/simple_circuit_2/Nargo.toml
+++ b/yarn-project/aztec/test/mixed-workspace/simple_circuit_2/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "simple_circuit_2"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "bin"
+
+[dependencies]

--- a/yarn-project/aztec/test/mixed-workspace/simple_circuit_2/src/main.nr
+++ b/yarn-project/aztec/test/mixed-workspace/simple_circuit_2/src/main.nr
@@ -1,0 +1,3 @@
+fn main(x: Field, y: Field) {
+    assert(x != y);
+}

--- a/yarn-project/aztec/test/mixed-workspace/simple_contract/src/main.nr
+++ b/yarn-project/aztec/test/mixed-workspace/simple_contract/src/main.nr
@@ -8,4 +8,9 @@ pub contract SimpleContract {
     fn private_function() -> Field {
         0
     }
+
+    #[external("private")]
+    fn another_private_function(x: Field) -> Field {
+        x
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new `aztec profile` command that profiles compiled Aztec artifacts. The first subcommand, `aztec profile gates`, displays gate counts for all compiled contracts and circuits in a target directory.

This is the beginning of a profiling suite for Aztec developers. The `flamegraph` command will be added as a subcommand under `aztec profile` next, consolidating all profiling tools in one place. Running bare `aztec profile` shows help listing available subcommands.

**Sample output** (on the test workspace with a simple contract and two circuits):

```
Gate counts:
------------------------------------------------------------------------
simple_circuit                                                      45
simple_circuit_2                                                    46
simple_contract-SimpleContract::another_private_function         5,616
simple_contract-SimpleContract::private_function                 5,540
------------------------------------------------------------------------
Total: 4 circuit(s)
```


Addresses https://github.com/AztecProtocol/aztec-packages/issues/20323