### PR TITLE
feat: dont publish ci-full bench on main page

### DIFF
--- a/.github/ci3_labels_to_env.sh
+++ b/.github/ci3_labels_to_env.sh
@@ -86,6 +86,19 @@ function main {
     echo "SHOULD_UPLOAD_BENCHMARKS=1" >> $GITHUB_ENV
   fi
 
+  # Determine the branch label for benchmark publishing.
+  # Only merge-queue runs targeting "next" publish under "next" since those represent code about to land.
+  # Everything else (ci-full PRs, merge queues for other branches) publishes under "prs"
+  # to avoid polluting the main benchmark graphs.
+  local bench_branch
+  if [[ ("$ci_mode" == "merge-queue" || "$ci_mode" == "merge-queue-heavy") && "$target_branch" == "next" ]]; then
+    bench_branch="$target_branch"
+  else
+    bench_branch="prs"
+  fi
+  echo "BENCH_BRANCH=$bench_branch" >> $GITHUB_ENV
+  echo "Bench branch: $bench_branch"
+
   # Handle no-cache label
   if has_label "no-cache"; then
     echo "NO_CACHE=1" >> $GITHUB_ENV

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -117,7 +117,7 @@ jobs:
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with: &ci_benchmark_args
           name: Aztec Benchmarks
-          benchmark-data-dir-path: "bench/${{ env.TARGET_BRANCH }}"
+          benchmark-data-dir-path: "bench/${{ env.BENCH_BRANCH }}"
           tool: "customSmallerIsBetter"
           output-file-path: ./bench-out/bench.json
           gh-repository: github.com/AztecProtocol/benchmark-page-data


### PR DESCRIPTION
Everything else goes to a 'prs' page.