### PR TITLE
fix: move EC2 shutdown timers from bootstrap_ec2 to ci.sh

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -72,9 +72,15 @@ case "$cmd" in
   dash)
     watch_ci -s next,prs --user --watch
     ;;
-  fast|full|full-no-test-cache|full-no-test-cache-makefile|docs|barretenberg|barretenberg-full)
+  fast|docs|barretenberg|barretenberg-full)
     export CI_DASHBOARD="prs"
     export JOB_ID="x-$cmd"
+    bootstrap_ec2 "./bootstrap.sh ci-$cmd"
+    ;;
+  full|full-no-test-cache|full-no-test-cache-makefile)
+    export CI_DASHBOARD="prs"
+    export JOB_ID="x-$cmd"
+    export AWS_SHUTDOWN_TIME=75
     bootstrap_ec2 "./bootstrap.sh ci-$cmd"
     ;;
   barretenberg-debug)
@@ -107,6 +113,8 @@ case "$cmd" in
     else
       export CI_DASHBOARD="prs"
     fi
+    export AWS_SHUTDOWN_TIME=75
+    export AWS_SHUTDOWN_TIME_ARM=90
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
@@ -128,6 +136,8 @@ case "$cmd" in
     else
       export CI_DASHBOARD="prs"
     fi
+    export AWS_SHUTDOWN_TIME=75
+    export AWS_SHUTDOWN_TIME_ARM=90
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {
@@ -267,6 +277,7 @@ case "$cmd" in
   release)
     # Spin up ec2 instance and run the release flow.
     export CI_DASHBOARD="releases"
+    export AWS_SHUTDOWN_TIME=75
     export DENOISE=1
     export DENOISE_WIDTH=32
     run() {

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -12,16 +12,13 @@ export CI=1
 # Set to 0 in ci3-external.yml for external contributors who don't have SSH access.
 export CI_USE_BUILD_INSTANCE_KEY=${CI_USE_BUILD_INSTANCE_KEY:-1}
 
+export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-60}
+
 if [ "$arch" == "arm64" ]; then
   cores=64
-  # Allow for 90 minutes as ARM has less cores.
-  export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-90}
+  export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME_ARM:-$AWS_SHUTDOWN_TIME}
 else
   cores=192,128,64
-  if [ "$CI_FULL" -eq 1 ]; then
-    # Allow for 75 minutes as ci-full time has crept up.
-    export AWS_SHUTDOWN_TIME=${AWS_SHUTDOWN_TIME:-75}
-  fi
 fi
 
 # Allow override.


### PR DESCRIPTION
Fixes ci-full variants not allowing for > 60 minute runs.