### PR TITLE
feat: add public bytecode sizes to benchmarks dashboard

### DIFF
--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -161,6 +161,8 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     }
     const avmResult = await this.simulator.simulate(tx, fullTxLabel);
 
+    await this.#recordBytecodeSizes(fullTxLabel, [...setupCalls, ...appCalls, ...(teardownCall ? [teardownCall] : [])]);
+
     // Something like this is often useful for debugging:
     //if (avmResult.revertReason) {
     //  // resolve / enrich revert reason
@@ -276,6 +278,27 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     const request = await PublicCallRequest.fromCalldata(sender, address, isStaticCall, calldata);
 
     return new PublicCallRequestWithCalldata(request, calldata);
+  }
+
+  // WARNING: Deduplicates by artifact name, so two different artifacts with the same name
+  // in a single tx would only record the first one's bytecode size.
+  async #recordBytecodeSizes(txLabel: string, calls: TestEnqueuedCall[]) {
+    const seenArtifactNames = new Set<string>();
+    for (const call of calls) {
+      const artifact = await this.contractDataSource.getContractArtifact(call.address);
+      if (!artifact || seenArtifactNames.has(artifact.name)) {
+        continue;
+      }
+      seenArtifactNames.add(artifact.name);
+      const instance = await this.contractDataSource.getContract(call.address);
+      if (!instance) {
+        continue;
+      }
+      const contractClass = await this.contractDataSource.getContractClass(instance.currentContractClassId);
+      if (contractClass) {
+        this.metrics.recordBytecodeSize(txLabel, artifact.name, contractClass.packedBytecode.length);
+      }
+    }
   }
 }
 

--- a/yarn-project/simulator/src/public/test_executor_metrics.ts
+++ b/yarn-project/simulator/src/public/test_executor_metrics.ts
@@ -21,6 +21,7 @@ export interface PublicTxMetrics {
   totalDurationMs: number;
   manaUsed: number | undefined;
   totalInstructionsExecuted: number;
+  bytecodeSizes: { contractName: string; sizeBytes: number }[];
   nonRevertiblePrivateInsertionsUs: number | undefined;
   revertiblePrivateInsertionsUs: number | undefined;
   enqueuedCalls: PublicEnqueuedCallMetrics[];
@@ -62,6 +63,7 @@ function createEmptyTxMetrics(): PublicTxMetrics {
     totalDurationMs: 0,
     manaUsed: 0,
     totalInstructionsExecuted: 0,
+    bytecodeSizes: [],
     nonRevertiblePrivateInsertionsUs: undefined,
     revertiblePrivateInsertionsUs: undefined,
     enqueuedCalls: [],
@@ -172,6 +174,12 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
     }
   }
 
+  recordBytecodeSize(txLabel: string, contractName: string, sizeBytes: number) {
+    const txMetrics = this.txMetrics.get(txLabel);
+    assert(txMetrics, `Cannot record bytecode size for unknown tx label: ${txLabel}`);
+    txMetrics.bytecodeSizes.push({ contractName, sizeBytes });
+  }
+
   recordProverMetrics(txLabel: string, metrics: Partial<PublicTxMetrics>) {
     if (!this.txMetrics.has(txLabel)) {
       this.txMetrics.set(txLabel, createEmptyTxMetrics());
@@ -215,6 +223,15 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
         filter === PublicTxMetricsFilter.ALL
       ) {
         pretty += `${INDENT0}Total instructions executed: ${fmtNum(txMetrics.totalInstructionsExecuted)}\n`;
+      }
+      if (
+        (filter === PublicTxMetricsFilter.TOTALS || filter === PublicTxMetricsFilter.ALL) &&
+        txMetrics.bytecodeSizes.length > 0
+      ) {
+        pretty += `${INDENT0}Bytecode sizes:\n`;
+        for (const { contractName, sizeBytes } of txMetrics.bytecodeSizes) {
+          pretty += `${INDENT1}${contractName}: ${fmtNum(sizeBytes, 'bytes')}\n`;
+        }
       }
       if (filter === PublicTxMetricsFilter.DURATIONS || filter === PublicTxMetricsFilter.ALL) {
         pretty += `${INDENT0}Private insertions:\n`;
@@ -386,6 +403,13 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
             unit: metricsInfo[key as keyof typeof metricsInfo].unit,
           });
         }
+      }
+      for (const { contractName, sizeBytes } of txMetrics.bytecodeSizes) {
+        data.push({
+          name: `${txLabel}/bytecodeSizeBytes/${contractName}`,
+          value: sizeBytes,
+          unit: 'bytes',
+        });
       }
     }
     return JSON.stringify(data, null, indent);


### PR DESCRIPTION
In the benchmarks dashboard, each tx will show sizes for all bytecodes it interacts with. This will be another nested subgroup under each tx in the dashboard.

The size is `packedBytecode.length` which is what is deployed and hashed to produce bytecode commitment, which is in turn in the preimage of classId.

Example in the markdown format for viewing in console:

## TX Label: AMM contract tests/AMM/add_liquidity/5
- Total duration: `281.073 ms`
- Total mana used: `366,757`
- Mana per second: `1,304,844`
- Total instructions executed: `4,636`
- Bytecode sizes:
    - Token: `27,196 bytes`
    - AMM: `10,027 bytes`
- Private insertions:
    - Non-revertible: `4.197 ms`
    - Revertible: `0.038 ms`
- Enqueued public calls:
    - **Fn: Token._increase_public_balance**
        - Duration: `24.537 ms`
        - Mana used: `47,531`
        - Mana per second: `1,937,098`
        - Instructions executed: `513`
    - **Fn: Token._increase_public_balance**
        - Duration: `21.584 ms`
        - Mana used: `47,531`
        - Mana per second: `2,202,119`
        - Instructions executed: `513`
    - **Fn: AMM._add_liquidity**
        - Duration: `170.29 ms`
        - Mana used: `271,695`
        - Mana per second: `1,595,484`
        - Instructions executed: `3,610`

And for avm test contract:

## TX Label: AvmTest contract tests/AvmTest/bulk_testing/0
- Total duration: `1,023.971 ms`
- Total mana used: `1,913,343`
- Mana per second: `1,868,552`
- Total instructions executed: `72,382`
- Bytecode sizes:
    - AvmTest: `54,963 bytes`
- Private insertions:
    - Non-revertible: `15.939 ms`
    - Revertible: `6.066 ms`
- Enqueued public calls:
...