### PR TITLE
feat: call syncImmediate without block number during chain prune

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.test.ts
@@ -376,7 +376,7 @@ describe('FeePayerBalanceEvictionRule', () => {
 
         await rule.evict(context, pool);
 
-        expect(mockWorldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(3));
+        expect(mockWorldState.syncImmediate).toHaveBeenCalledWith();
         expect(mockWorldState.getSnapshot).toHaveBeenCalledWith(BlockNumber(3));
       });
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/fee_payer_balance_eviction_rule.ts
@@ -34,7 +34,7 @@ export class FeePayerBalanceEvictionRule implements EvictionRule {
       }
 
       if (context.event === EvictionEvent.CHAIN_PRUNED) {
-        await this.worldState.syncImmediate(context.blockNumber);
+        await this.worldState.syncImmediate();
         const feePayers = pool.getPendingFeePayers();
         return await this.evictForFeePayers(feePayers, this.worldState.getSnapshot(context.blockNumber), pool);
       }

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.test.ts
@@ -137,7 +137,7 @@ describe('InvalidTxsAfterReorgRule', () => {
         expect(result.txsEvicted).toContain('0x1111');
         expect(result.txsEvicted).toContain('0x2222');
         // Ensure syncImmediate is called before accessing the world state snapshot
-        expect(worldState.syncImmediate).toHaveBeenCalledWith(BlockNumber(1));
+        expect(worldState.syncImmediate).toHaveBeenCalledWith();
       });
 
       it('handles large number of transactions efficiently', async () => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/eviction/invalid_txs_after_reorg_rule.ts
@@ -45,8 +45,8 @@ export class InvalidTxsAfterReorgRule implements EvictionRule {
         txsByBlockHash.get(blockHashStr)!.push(meta.txHash);
       }
 
-      // Ensure world state is synced to this block before accessing the snapshot
-      await this.worldState.syncImmediate(context.blockNumber);
+      // Sync without a block number to ensure the world state processes the prune event.
+      await this.worldState.syncImmediate();
       const db = this.worldState.getSnapshot(context.blockNumber);
 
       // Check which blocks exist in the archive


### PR DESCRIPTION
## Summary

- Update `syncImmediate` calls in `FeePayerBalanceEvictionRule` and `InvalidTxsAfterReorgRule` to call without a block number during `CHAIN_PRUNED` events
- `syncImmediate(blockNumber)` returns early when the world state is already at or past the target, skipping `blockStream.sync()` — calling without args ensures the prune event is always processed

Note: despite the original issue description (A-545) suggesting that validations may produce incorrect results, the eviction rules were already correct. Both rules use `getSnapshot(blockNumber)` which serves historical data via the native content-addressed store's root hash, regardless of whether `unwindBlocks` has run. Additionally, `#revalidateMetadata` (step 5 in `handlePrunedBlocks`) already calls `syncImmediate()` without args through `createPoolTxValidator`, so the world state processes the prune before the eviction rules run. This change makes the eviction rules' intent explicit rather than relying on the earlier sync.

Fixes A-545
