### PR TITLE
fix: hodgepodge of small things

### DIFF
--- a/playground/src/utils/networks.ts
+++ b/playground/src/utils/networks.ts
@@ -19,14 +19,14 @@ export type Network = {
 
 export const NETWORKS: Network[] = [
   {
-    nodeURL: 'https://next.devnet.aztec-labs.com',
+    nodeURL: 'https://v4-devnet-2.aztec-labs.com/',
     name: 'Aztec Devnet',
     description: 'Public development network',
     chainId: 11155111,
-    version: 1647720761,
+    version: 615022430,
     hasTestAccounts: false,
     hasSponsoredFPC: true,
-    nodeVersion: '3.0.0-devnet',
+    nodeVersion: '4.0.0-devnet.2-patch.1',
   },
   {
     nodeURL: 'http://localhost:8080',

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -9,7 +9,14 @@ import {
   getContractInstanceFromInstantiationParams,
 } from '@aztec/stdlib/contract';
 import type { PublicKeys } from '@aztec/stdlib/keys';
-import { type Capsule, TxHash, type TxProfileResult, type TxReceipt, collectOffchainEffects } from '@aztec/stdlib/tx';
+import {
+  type Capsule,
+  HashedValues,
+  TxHash,
+  type TxProfileResult,
+  type TxReceipt,
+  collectOffchainEffects,
+} from '@aztec/stdlib/tx';
 import { ExecutionPayload, mergeExecutionPayloads } from '@aztec/stdlib/tx';
 
 import { publishContractClass } from '../deployment/publish_class.js';
@@ -164,6 +171,7 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
     constructorNameOrArtifact?: string | FunctionArtifact,
     authWitnesses: AuthWitness[] = [],
     capsules: Capsule[] = [],
+    private extraHashedArgs: HashedValues[] = [],
   ) {
     super(wallet, authWitnesses, capsules);
     this.constructorArtifact = getInitializer(artifact, constructorNameOrArtifact);
@@ -174,20 +182,29 @@ export class DeployMethod<TContract extends ContractBase = ContractBase> extends
    * @param options - Configuration options.
    * @returns The execution payload for this operation
    */
-  public async request(options?: RequestDeployOptions): Promise<ExecutionPayload> {
+  public async request(options: RequestDeployOptions = {}): Promise<ExecutionPayload> {
     const publication = await this.getPublicationExecutionPayload(options);
 
     if (!options?.skipRegistration) {
       await this.wallet.registerContract(await this.getInstance(options), this.artifact);
     }
+    const { authWitnesses, capsules } = options;
 
+    // Propagates the included authwitnesses, capsules, and extraHashedArgs
+    // potentially baked into the interaction
+    const initialExecutionPayload = new ExecutionPayload(
+      [],
+      this.authWitnesses.concat(authWitnesses ?? []),
+      this.capsules.concat(capsules ?? []),
+      this.extraHashedArgs,
+    );
     const initialization = await this.getInitializationExecutionPayload(options);
     const feeExecutionPayload = options?.fee?.paymentMethod
       ? await options.fee.paymentMethod.getExecutionPayload()
       : undefined;
     const finalExecutionPayload = feeExecutionPayload
-      ? mergeExecutionPayloads([feeExecutionPayload, publication, initialization])
-      : mergeExecutionPayloads([publication, initialization]);
+      ? mergeExecutionPayloads([initialExecutionPayload, feeExecutionPayload, publication, initialization])
+      : mergeExecutionPayloads([initialExecutionPayload, publication, initialization]);
     if (!finalExecutionPayload.calls.length) {
       throw new Error(`No transactions are needed to publish or initialize contract ${this.artifact.name}`);
     }

--- a/yarn-project/protocol-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/protocol-contracts/src/scripts/generate_data.ts
@@ -1,3 +1,7 @@
+// Reads compiled Noir artifacts for each protocol contract and derives their addresses, class IDs,
+// bytecode commitments, and other deployment data, emitting everything as precomputed constants into
+// `protocol_contract_data.ts`. This avoids clients repeating the expensive hashing at runtime and
+// ensures a single source of truth for the protocol contracts hash enforced by circuits, P2P, and L1.
 import {
   CANONICAL_AUTH_REGISTRY_ADDRESS,
   CONTRACT_CLASS_REGISTRY_CONTRACT_ADDRESS,

--- a/yarn-project/wallets/src/embedded/embedded_wallet.ts
+++ b/yarn-project/wallets/src/embedded/embedded_wallet.ts
@@ -180,10 +180,15 @@ export class EmbeddedWallet extends BaseWallet {
     const accountManager = await AccountManager.create(this, secret, contract, salt);
 
     const instance = accountManager.getInstance();
-    const artifact = await accountManager.getAccountContract().getContractArtifact();
-
-    await this.registerContract(instance, artifact, accountManager.getSecretKey());
-
+    const existingInstance = await this.pxe.getContractInstance(instance.address);
+    if (!existingInstance) {
+      const existingArtifact = await this.pxe.getContractArtifact(instance.currentContractClassId);
+      await this.registerContract(
+        instance,
+        !existingArtifact ? await accountManager.getAccountContract().getContractArtifact() : undefined,
+        accountManager.getSecretKey(),
+      );
+    }
     return accountManager;
   }
 


### PR DESCRIPTION
Stuff I don't want hanging over my head while I'm out. Potentially (read: recommended) portable to current devnet.

* Comment about the protocol contracts `generate_data` script requested by @nchamo 
* Fix for Niall's issue with deployments that require authwitnesses: https://linear.app/aztec-labs/issue/F-302/authwits-are-not-being-forwarded-to-the-executionpayload-in
* Update playground's devnet URL
* Avoid reregistering accounts on every operation in `EmbeddedWallet`