### PR TITLE
fix: merge-train/fairies should merge from v4 not next

### DIFF
--- a/.claude/skills/merge-train-infra/SKILL.md
+++ b/.claude/skills/merge-train-infra/SKILL.md
@@ -11,15 +11,15 @@ This skill covers the automation internals of the merge-train system. For contri
 
 The merge-train system is fully automated via GitHub Actions in `.github/workflows/merge-train-*.yml`:
 
-1. **PR Creation** (`merge-train-create-pr.yml`): Triggered on push to `merge-train/*` branches. Creates a PR targeting `next` with the `ci-no-squash` label (and `ci-full-no-test-cache` for spartan). Skips merge commits and commits already in `next`.
+1. **PR Creation** (`merge-train-create-pr.yml`): Triggered on push to `merge-train/*` branches. Creates a PR targeting `next` with the `ci-no-squash` label (and `ci-full-no-test-cache` for spartan). Exception: `merge-train/fairies` targets `v4` instead of `next`. Skips merge commits and commits already in the target base branch.
 
 2. **Body Updates** (`merge-train-update-pr-body.yml`): Triggered on push to `merge-train/**` and `backport-to-*-staging` branches. Updates the PR body with meaningful commits (those containing PR references like `(#1234)`). The body uses `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` markers for release-please. Backport staging PRs also call `update-pr-body.sh` inline from `scripts/backport_to_staging.sh` to handle the first-push case (where the PR doesn't exist yet when the workflow fires).
 
-3. **Next Integration** (`merge-train-next-to-branches.yml`): Triggered on push to `next`. Merges `next` into each active merge-train branch via `scripts/merge-train/merge-next.sh`. Uses `continue-on-error: true` so a conflict in one branch does not block others. Skips branches whose PR already has auto-merge enabled.
+3. **Next Integration** (`merge-train-next-to-branches.yml`): Triggered on push to `next`. Merges `next` into each active merge-train branch via `scripts/merge-train/merge-next.sh`. Uses `continue-on-error: true` so a conflict in one branch does not block others. Skips branches whose PR already has auto-merge enabled. Exception: `merge-train/fairies` is synced from `v4` instead, via `merge-train-v4-to-branches.yml`.
 
 4. **Auto-Merge** (`merge-train-auto-merge.yml`): Runs hourly via cron (`0 * * * *`). Calls `scripts/merge-train/auto-merge.sh` for both merge-train (4-hour inactivity) and backport-train (8-hour inactivity) branches. Uses separate GitHub tokens: `AZTEC_BOT_GITHUB_TOKEN` for API calls and `MERGE_TRAIN_GITHUB_TOKEN` for approvals. Will not auto-merge if the last merge-queue CI run failed or was cancelled.
 
-5. **Recreation & Wakeup** (`merge-train-recreate.yml`): Triggered when a PR is closed (merged). If the merged PR's head branch starts with `merge-train/`, recreates the branch from the base branch (usually `next`). Then runs `scripts/merge-train/wakeup-prs.sh` to add the `ci-wakeup-pr-after-merge` label to all open PRs targeting the branch that have passed CI and have automerge enabled. This triggers a CI re-run (typically a no-op via tree-hash cache) so those PRs can proceed through the merge queue. The label is immediately removed by a step in `ci3.yml` so it can be re-applied on subsequent merges.
+5. **Recreation & Wakeup** (`merge-train-recreate.yml`): Triggered when a PR is closed (merged). If the merged PR's head branch starts with `merge-train/`, recreates the branch from the PR's base branch (usually `next`; `v4` for `merge-train/fairies`). Then runs `scripts/merge-train/wakeup-prs.sh` to add the `ci-wakeup-pr-after-merge` label to all open PRs targeting the branch that have passed CI and have automerge enabled. This triggers a CI re-run (typically a no-op via tree-hash cache) so those PRs can proceed through the merge queue. The label is immediately removed by a step in `ci3.yml` so it can be re-applied on subsequent merges.
 
 6. **Failure Notification** (`merge-queue-dequeue-notify.yml`): Triggered when a PR is dequeued from the merge queue. If the PR's head branch starts with `merge-train/` and the PR was NOT merged, sends a Slack notification via `ci3/merge_train_failure_slack_notify`.
 
@@ -73,8 +73,10 @@ When a CI run fails on an EC2 instance, it calls `merge_train_failure_slack_noti
 
 ## Creating a New Merge Train
 
-1. Create a branch from `next` with naming pattern `merge-train/{team}`
-2. Add the branch to the matrix in `.github/workflows/merge-train-next-to-branches.yml`
+1. Create a branch from the appropriate source branch with naming pattern `merge-train/{team}`
+2. Add the branch to the matrix in the appropriate sync workflow:
+   - Targeting `next`: add to `.github/workflows/merge-train-next-to-branches.yml`
+   - Targeting another branch (e.g. `v4`): add to the corresponding `merge-train-<source>-to-branches.yml` (create it if it doesn't exist), and add a branch-name override in `.github/workflows/merge-train-create-pr.yml`
 3. Add the branch-to-Slack-channel mapping in `ci3/merge_train_failure_slack_notify`
 4. Optionally add CI mode overrides in `.github/ci3_labels_to_env.sh` and `bootstrap.sh`
 5. Push code to the branch -- automation handles PR creation from there
@@ -88,7 +90,8 @@ When a CI run fails on an EC2 instance, it calls `merge_train_failure_slack_noti
 | `.github/workflows/merge-train-readme.md` | User-facing documentation |
 | `.github/workflows/merge-train-create-pr.yml` | Auto-creates PRs for train branches |
 | `.github/workflows/merge-train-auto-merge.yml` | Hourly cron to auto-merge inactive trains |
-| `.github/workflows/merge-train-next-to-branches.yml` | Syncs `next` into all train branches; defines active branches |
+| `.github/workflows/merge-train-next-to-branches.yml` | Syncs `next` into train branches targeting `next`; defines active branches |
+| `.github/workflows/merge-train-v4-to-branches.yml` | Syncs `v4` into train branches targeting `v4` (currently `merge-train/fairies`) |
 | `.github/workflows/merge-train-recreate.yml` | Recreates branch after merge |
 | `.github/workflows/merge-train-update-pr-body.yml` | Updates PR body with commit list (merge-train and backport branches) |
 | `.github/workflows/merge-queue-dequeue-notify.yml` | Slack notification on merge-queue dequeue |
@@ -99,7 +102,7 @@ When a CI run fails on an EC2 instance, it calls `merge_train_failure_slack_noti
 | File | Purpose |
 |---|---|
 | `scripts/merge-train/auto-merge.sh` | Auto-merge logic -- checks inactivity, last CI status, approves and merges |
-| `scripts/merge-train/merge-next.sh` | Merges `next` into a train branch, handles conflicts, cancels stale CI runs |
+| `scripts/merge-train/merge-next.sh` | Merges a source branch (default: `next`) into a train branch, handles conflicts, cancels stale CI runs |
 | `scripts/merge-train/update-pr-body.sh` | Updates PR body with meaningful commits |
 | `scripts/merge-train/squash-pr.sh` | Squashes PR commits (used by `ci-squash-and-merge` label) |
 | `scripts/merge-train/wakeup-prs.sh` | Adds `ci-wakeup-pr-after-merge` label to qualifying PRs after branch recreation |

--- a/.claude/skills/merge-trains/SKILL.md
+++ b/.claude/skills/merge-trains/SKILL.md
@@ -7,18 +7,18 @@ description: Guide for working with merge-train branches -- creating PRs, choosi
 
 ## What Is a Merge Train?
 
-A merge train is an automated batching system (inspired by [Rust rollups](https://forge.rust-lang.org/release/rollups.html)) that groups multiple PRs together for coordinated integration into the `next` branch. Instead of each PR going through the merge queue individually, teams push their PRs into a shared `merge-train/*` branch. Periodically, that branch is merged as a single unit into `next`.
+A merge train is an automated batching system (inspired by [Rust rollups](https://forge.rust-lang.org/release/rollups.html)) that groups multiple PRs together for coordinated integration into a target branch (usually `next`). Instead of each PR going through the merge queue individually, teams push their PRs into a shared `merge-train/*` branch. Periodically, that branch is merged as a single unit into its target branch.
 
 ## Active Merge-Train Branches
 
-| Branch | Team / Domain | Slack Channel |
-|---|---|---|
-| `merge-train/avm` | AVM, barretenberg vm2 folder | `#team-bonobos` |
-| `merge-train/barretenberg` | Barretenberg folder, but not vm2 folder | `#honk-team` |
-| `merge-train/ci` | CI infrastructure / ci3 | `#help-ci` |
-| `merge-train/docs` | Documentation | `#dev-rels` |
-| `merge-train/fairies` | aztec-nr | `#team-fairies` |
-| `merge-train/spartan` | Spartan / infra / yarn-project sequencer and prover orchestration | `#team-alpha` |
+| Branch | Team / Domain | Slack Channel | Targets |
+|---|---|---|---|
+| `merge-train/avm` | AVM, barretenberg vm2 folder | `#team-bonobos` | `next` |
+| `merge-train/barretenberg` | Barretenberg folder, but not vm2 folder | `#honk-team` | `next` |
+| `merge-train/ci` | CI infrastructure / ci3 | `#help-ci` | `next` |
+| `merge-train/docs` | Documentation | `#dev-rels` | `next` |
+| `merge-train/fairies` | aztec-nr | `#team-fairies` | `v4` |
+| `merge-train/spartan` | Spartan / infra / yarn-project sequencer and prover orchestration | `#team-alpha` | `next` |
 
 ## How to Use a Merge Train
 
@@ -27,13 +27,13 @@ A merge train is an automated batching system (inspired by [Rust rollups](https:
 1. Create your feature branch **off the appropriate merge-train branch** (not our default branch `next`).
 2. Open your PR targeting that merge-train branch (e.g., base: `merge-train/barretenberg`).
 3. When your PR is approved and merged, it gets squashed into the merge-train branch.
-4. The merge-train PR (which targets `next`) automatically accumulates your commit.
+4. The merge-train PR (which targets `next`, or `v4` for `merge-train/fairies`) automatically accumulates your commit.
 
 ### Key Rules for Contributors
 
 - **Base branch matters**: Always branch from the branch specified in the CI_BASE_BRANCH environment variable. If it is not set, then ask the user their intent and offer to set CI_BASE_BRANCH in their shell's RC file. 
 - **Your PR is squashed into the train**: Individual PRs targeting a merge-train branch are squash-merged as usual. You should not use the merge commit merge method, but the squash method.
-- **The train itself is NOT squashed**: The merge-train PR (e.g., `merge-train/barretenberg` -> `next`) is merged with a **merge commit**, preserving the individual squashed commits. This is why the `ci-no-squash` label is automatically applied.
+- **The train itself is NOT squashed**: The merge-train PR (e.g., `merge-train/barretenberg` -> `next`, or `merge-train/fairies` -> `v4`) is merged with a **merge commit**, preserving the individual squashed commits. This is why the `ci-no-squash` label is automatically applied.
 - **You generally don't need to worry about the train PR itself** -- it is fully automated (creation, body updates, approval, merge, and recreation). You only need to pay attention to it if an alert is sent to your team channel.
 
 ## CI Behavior for Merge Trains
@@ -51,17 +51,17 @@ Two options from the [merge-train-readme.md](https://github.com/AztecProtocol/az
 
 **Option 1: Direct Fix** -- Push a fix directly to the merge-train branch. Use bypass merge to expedite (all users have this permission). You can use the ci-skip label to no-op CI if really necessary.
 
-**Option 2: Fix in Next** -- Merge a revert or workaround into `next`. The fix will auto-propagate to the merge-train via the `merge-train-next-to-branches` workflow. Best when the root cause is in `next` or multiple trains are affected.
+**Option 2: Fix in the source branch** -- Merge a revert or workaround into the train's source branch (`next` for most trains, `v4` for `merge-train/fairies`). The fix will auto-propagate to the merge-train via the appropriate `merge-train-*-to-branches` workflow. Best when the root cause is in the source branch or multiple trains are affected.
 
 ### When Auto-Merge Is Blocked
 
 The auto-merge script will **not** enable auto-merge if the last merge-queue CI run for the PR concluded with `failure` or `cancelled`. Someone needs to either fix the issue and push, or force-merge.
 
-### Merge Conflicts from Next
+### Merge Conflicts from the Source Branch
 
-When merging `next` into a train branch causes conflicts, the `merge-next.sh` script:
+When merging the source branch (`next` or `v4`) into a train branch causes conflicts, the `merge-next.sh` script:
 - Aborts the merge
-- Posts a comment on the latest `next` commit listing the conflicted files
+- Posts a comment on the latest commit of the source branch listing the conflicted files
 - The team must manually resolve conflicts on their train branch
 
 ## Bypassing Checks / Force-Merging

--- a/.github/workflows/merge-train-create-pr.yml
+++ b/.github/workflows/merge-train-create-pr.yml
@@ -30,9 +30,17 @@ jobs:
               exit 0
             fi
 
-            # Skip if this commit is already in the next branch
-            if git merge-base --is-ancestor "${{ github.sha }}" origin/next; then
-              echo "Skipping: This commit is already in the next branch"
+            # Determine base branch (default to next)
+            base_branch="next"
+            if [[ "$branch" == "merge-train/fairies" ]]; then
+              base_branch="v4"
+            fi
+
+            git fetch origin "$base_branch"
+
+            # Skip if this commit is already in the base branch
+            if git merge-base --is-ancestor "${{ github.sha }}" "origin/$base_branch"; then
+              echo "Skipping: This commit is already in the $base_branch branch"
               exit 0
             fi
 
@@ -42,9 +50,6 @@ jobs:
             if [[ -z "$existing_pr" ]]; then
               echo "No PR exists for $branch, creating one"
 
-              # Determine base branch (default to next)
-              base_branch="next"
-
               # Create PR with ci-no-squash label
               labels="ci-no-squash"
               if [[ "$branch" == "merge-train/spartan" ]]; then
@@ -52,7 +57,7 @@ jobs:
               fi
               gh pr create --base "$base_branch" --head "$branch" \
                 --title "feat: $branch" \
-                --body "$(echo -e "See [merge-train-readme.md](https://github.com/${{ github.repository }}/blob/next/.github/workflows/merge-train-readme.md).\nThis is a merge-train.")" \
+                --body "$(echo -e "See [merge-train-readme.md](https://github.com/${{ github.repository }}/blob/${base_branch}/.github/workflows/merge-train-readme.md).\nThis is a merge-train.")" \
                 --label "$labels"
 
               echo "Created PR for $branch"

--- a/.github/workflows/merge-train-v4-to-branches.yml
+++ b/.github/workflows/merge-train-v4-to-branches.yml
@@ -1,22 +1,18 @@
-name: Merge Train Auto-Pull
+name: Merge Train Auto-Pull (v4)
 
 on:
   push:
     branches:
-      - next
+      - v4
 
 jobs:
   merge-to-train:
-    name: Merge next to ${{ matrix.train-branch }}
+    name: Merge v4 to ${{ matrix.train-branch }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         train-branch:
-          - merge-train/avm
-          - merge-train/barretenberg
-          - merge-train/ci
-          - merge-train/docs
-          - merge-train/spartan
+          - merge-train/fairies
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -29,8 +25,7 @@ jobs:
           git config --global user.name AztecBot
           git config --global user.email tech@aztecprotocol.com
 
-      - name: Run merge-next script
+      - name: Merge v4 into train branch
         continue-on-error: true
         run: |
-          GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} ./scripts/merge-train/merge-next.sh "${{ matrix.train-branch }}"
-
+          GH_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} ./scripts/merge-train/merge-next.sh "${{ matrix.train-branch }}" v4

--- a/scripts/merge-train/merge-next.sh
+++ b/scripts/merge-train/merge-next.sh
@@ -62,20 +62,22 @@ function get_meaningful_commits {
     --pretty=format:"%s" | grep -v "^\[empty\]" || true
 }
 
-# Usage: merge-next.sh <train-branch>
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <train-branch>"
+# Usage: merge-next.sh <train-branch> [source-branch]
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <train-branch> [source-branch]"
   echo "Example: $0 merge-train/docs"
+  echo "Example: $0 merge-train/fairies v4"
   exit 1
 fi
 
 TRAIN_BRANCH="$1"
+SOURCE_BRANCH="${2:-next}"
 
 # Check if PR has auto-merge enabled
 pr_info=$(get_pr_for_branch "$TRAIN_BRANCH")
 pr_number=$(echo "$pr_info" | jq -r '.number // empty')
 if [[ -n "$pr_number" ]] && pr_has_auto_merge "$pr_number"; then
-  echo "PR #$pr_number has auto-merge enabled, skipping merge from next"
+  echo "PR #$pr_number has auto-merge enabled, skipping merge from $SOURCE_BRANCH"
   exit 0
 fi
 
@@ -87,23 +89,23 @@ fi
 
 # Fetch and checkout the merge-train branch
 git fetch origin "$TRAIN_BRANCH" || exit 1
-git fetch origin next || exit 1
+git fetch origin "$SOURCE_BRANCH" || exit 1
 git checkout "$TRAIN_BRANCH" || exit 1
 
-# Check if there are meaningful commits in next that aren't in the train branch
-meaningful_commits=$(get_meaningful_commits "$TRAIN_BRANCH" "origin/next")
+# Check if there are meaningful commits in the source branch that aren't in the train branch
+meaningful_commits=$(get_meaningful_commits "$TRAIN_BRANCH" "origin/$SOURCE_BRANCH")
 
 if [[ -z "$meaningful_commits" ]]; then
-  echo "No meaningful commits found in next that aren't already in $TRAIN_BRANCH, skipping merge"
+  echo "No meaningful commits found in $SOURCE_BRANCH that aren't already in $TRAIN_BRANCH, skipping merge"
   exit 0
 fi
 
 echo "Found meaningful commits to merge:"
 echo "$meaningful_commits"
 
-# Attempt to merge next
-if git merge "origin/next" --no-edit -m "Merge branch 'next' into $TRAIN_BRANCH"; then
-  echo "Successfully merged next into $TRAIN_BRANCH"
+# Attempt to merge source branch
+if git merge "origin/$SOURCE_BRANCH" --no-edit -m "Merge branch '$SOURCE_BRANCH' into $TRAIN_BRANCH"; then
+  echo "Successfully merged $SOURCE_BRANCH into $TRAIN_BRANCH"
 
   # Try to push
   if git push origin "$TRAIN_BRANCH"; then
@@ -136,7 +138,7 @@ else
   # Create conflict comment
   conflict_comment="## ⚠️ Auto-merge to ${TRAIN_BRANCH} failed
 
-Merge conflicts detected when merging \`next\` into \`${TRAIN_BRANCH}\`.
+Merge conflicts detected when merging \`${SOURCE_BRANCH}\` into \`${TRAIN_BRANCH}\`.
 
 **Conflicted files:**
 \`\`\`
@@ -145,8 +147,8 @@ ${conflicts}
 
 Please resolve the conflicts manually."
 
-  # Post comment on the most recent commit on next
-  latest_commit=$(gh api repos/{owner}/{repo}/commits/next --jq '.sha')
+  # Post comment on the most recent commit on source branch
+  latest_commit=$(gh api "repos/{owner}/{repo}/commits/${SOURCE_BRANCH}" --jq '.sha')
   gh api "repos/{owner}/{repo}/commits/${latest_commit}/comments" \
     -f body="$conflict_comment"
 


### PR DESCRIPTION
Configures merge-train/fairies to target and merge from the v4 branch instead of next. This ensures the correct base branch is used for this specific merge train and prevents incorrect merges to the next branch. The change aligns merge behavior with v4 release requirements.