### PR TITLE
feat(cli): auto-recompiling when aztec test is run

### DIFF
--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -61,6 +61,7 @@
     "@aztec/validator-ha-signer": "workspace:^",
     "@aztec/wallets": "workspace:^",
     "@aztec/world-state": "workspace:^",
+    "@iarna/toml": "^2.2.5",
     "@types/chalk": "^2.2.0",
     "abitype": "^0.8.11",
     "chalk": "^5.3.0",

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -20,6 +20,68 @@ function aztec {
 
 case $cmd in
   test)
+    # Auto-recompile if sources changed since last compile.
+    #
+    # We check *.nr and Nargo.toml files not only in the current project but also in any path-based dependencies (e.g.
+    # path = "../aztec-nr/aztec"), resolved recursively. Git-based deps are pinned by tag/rev so they only change when
+    # Nargo.toml itself is modified -- no need to walk into them.
+
+    # Track which directories we already visited so we don't loop forever if two packages depend on each other.
+    _visited=""
+
+    # Given a directory, print its absolute path and then recurse into every path-based dependency found in any
+    # Nargo.toml under that directory.
+    collect_dep_dirs() {
+      # `local dir` declares a function-scoped variable.
+      local dir
+      # Resolve the argument to an absolute path. `cd "$1" && pwd` is a portable way to do this. `2>/dev/null`
+      # suppresses errors if the dir doesn't exist, and `|| return` exits the function early in that case.
+      dir=$(cd "$1" && pwd) 2>/dev/null || return
+
+      # If we already visited this directory, skip it (cycle detection). The pattern `,/abs/path,` is checked inside
+      # the comma-delimited _visited string so partial path matches don't give false positives.
+      case ",$_visited," in *",$dir,"*) return ;; esac
+      # Mark this directory as visited.
+      _visited="$_visited,$dir"
+
+      # Output this directory -- callers capture this via `mapfile` below.
+      echo "$dir"
+
+      # Find every Nargo.toml under this directory (skipping target/ build dirs). `< <(...)` is process substitution
+      # -- the while loop reads from the output of the find command line by line.
+      while IFS= read -r toml; do
+        local toml_dir
+        # Get the directory containing this Nargo.toml so we can resolve relative paths declared inside it.
+        toml_dir=$(dirname "$toml")
+
+        # Extract the value of every `path = "..."` entry in the toml file. sed -n with the s///p flag prints only
+        # matching lines, capturing the quoted path value. Example: `aztec = { path = "../foo" }` -> `../foo`
+        while IFS= read -r dep_path; do
+          # If the resolved path is an existing directory, recurse into it.
+          [ -d "$toml_dir/$dep_path" ] && collect_dep_dirs "$toml_dir/$dep_path"
+        done < <(sed -n 's/.*path *= *"\([^"]*\)".*/\1/p' "$toml")
+      done < <(find "$dir" -path '*/target' -prune -o -name 'Nargo.toml' -print 2>/dev/null)
+    }
+
+    # Build the array of all directories whose source files should be checked. `mapfile -t` reads lines from stdin
+    # into a bash array (source_dirs). The input comes from collect_dep_dirs which prints one directory per line.
+    mapfile -t source_dirs < <(collect_dep_dirs .)
+
+    # Find the most recently modified artifact in target/. `ls -t` sorts by modification time (newest first),
+    # `head -1` takes the first.
+    newest_artifact=$(ls -t target/*.json 2>/dev/null | head -1)
+
+    # Recompile if either:
+    #   1. there is no artifact at all (first build), OR
+    #   2. any *.nr or Nargo.toml in any of the source_dirs is newer than that artifact.
+    # `"${source_dirs[@]}"` expands the array into separate arguments so `find` searches all directories at once.
+    # `-newer` tests if a file was modified after the reference file. `head -1` short-circuits after the first match.
+    if [ -z "$newest_artifact" ] || \
+       [ -n "$(find "${source_dirs[@]}" \( -path '*/target' -prune \) -o \( -name '*.nr' -o -name 'Nargo.toml' \) -newer "$newest_artifact" -print 2>/dev/null | head -1)" ]; then
+      echo "Recompiling contracts..."
+      node --no-warnings "$script_dir/../dest/bin/index.js" compile
+    fi
+
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract_log"}"
     aztec start --txe --port 8081 &
     server_pid=$!

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -20,6 +20,7 @@ function aztec {
 
 case $cmd in
   test)
+    # Attempt to compile, no-op if there are no changes
     node --no-warnings "$script_dir/../dest/bin/index.js" compile
 
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract_log"}"

--- a/yarn-project/aztec/scripts/aztec.sh
+++ b/yarn-project/aztec/scripts/aztec.sh
@@ -20,67 +20,7 @@ function aztec {
 
 case $cmd in
   test)
-    # Auto-recompile if sources changed since last compile.
-    #
-    # We check *.nr and Nargo.toml files not only in the current project but also in any path-based dependencies (e.g.
-    # path = "../aztec-nr/aztec"), resolved recursively. Git-based deps are pinned by tag/rev so they only change when
-    # Nargo.toml itself is modified -- no need to walk into them.
-
-    # Track which directories we already visited so we don't loop forever if two packages depend on each other.
-    _visited=""
-
-    # Given a directory, print its absolute path and then recurse into every path-based dependency found in any
-    # Nargo.toml under that directory.
-    collect_dep_dirs() {
-      # `local dir` declares a function-scoped variable.
-      local dir
-      # Resolve the argument to an absolute path. `cd "$1" && pwd` is a portable way to do this. `2>/dev/null`
-      # suppresses errors if the dir doesn't exist, and `|| return` exits the function early in that case.
-      dir=$(cd "$1" && pwd) 2>/dev/null || return
-
-      # If we already visited this directory, skip it (cycle detection). The pattern `,/abs/path,` is checked inside
-      # the comma-delimited _visited string so partial path matches don't give false positives.
-      case ",$_visited," in *",$dir,"*) return ;; esac
-      # Mark this directory as visited.
-      _visited="$_visited,$dir"
-
-      # Output this directory -- callers capture this via `mapfile` below.
-      echo "$dir"
-
-      # Find every Nargo.toml under this directory (skipping target/ build dirs). `< <(...)` is process substitution
-      # -- the while loop reads from the output of the find command line by line.
-      while IFS= read -r toml; do
-        local toml_dir
-        # Get the directory containing this Nargo.toml so we can resolve relative paths declared inside it.
-        toml_dir=$(dirname "$toml")
-
-        # Extract the value of every `path = "..."` entry in the toml file. sed -n with the s///p flag prints only
-        # matching lines, capturing the quoted path value. Example: `aztec = { path = "../foo" }` -> `../foo`
-        while IFS= read -r dep_path; do
-          # If the resolved path is an existing directory, recurse into it.
-          [ -d "$toml_dir/$dep_path" ] && collect_dep_dirs "$toml_dir/$dep_path"
-        done < <(sed -n 's/.*path *= *"\([^"]*\)".*/\1/p' "$toml")
-      done < <(find "$dir" -path '*/target' -prune -o -name 'Nargo.toml' -print 2>/dev/null)
-    }
-
-    # Build the array of all directories whose source files should be checked. `mapfile -t` reads lines from stdin
-    # into a bash array (source_dirs). The input comes from collect_dep_dirs which prints one directory per line.
-    mapfile -t source_dirs < <(collect_dep_dirs .)
-
-    # Find the most recently modified artifact in target/. `ls -t` sorts by modification time (newest first),
-    # `head -1` takes the first.
-    newest_artifact=$(ls -t target/*.json 2>/dev/null | head -1)
-
-    # Recompile if either:
-    #   1. there is no artifact at all (first build), OR
-    #   2. any *.nr or Nargo.toml in any of the source_dirs is newer than that artifact.
-    # `"${source_dirs[@]}"` expands the array into separate arguments so `find` searches all directories at once.
-    # `-newer` tests if a file was modified after the reference file. `head -1` short-circuits after the first match.
-    if [ -z "$newest_artifact" ] || \
-       [ -n "$(find "${source_dirs[@]}" \( -path '*/target' -prune \) -o \( -name '*.nr' -o -name 'Nargo.toml' \) -newer "$newest_artifact" -print 2>/dev/null | head -1)" ]; then
-      echo "Recompiling contracts..."
-      node --no-warnings "$script_dir/../dest/bin/index.js" compile
-    fi
+    node --no-warnings "$script_dir/../dest/bin/index.js" compile
 
     export LOG_LEVEL="${LOG_LEVEL:-"error;trace:contract_log"}"
     aztec start --txe --port 8081 &

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -6,6 +6,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
 import { readArtifactFiles } from './utils/artifacts.js';
+import { needsRecompile } from './utils/needs_recompile.js';
 import { run } from './utils/spawn.js';
 
 /** Returns paths to contract artifacts in the target directory. */
@@ -137,6 +138,11 @@ async function checkNoTestsInContracts(nargo: string, log: LogFn): Promise<void>
 
 /** Compiles Aztec Noir contracts and postprocesses artifacts. */
 async function compileAztecContract(nargoArgs: string[], log: LogFn): Promise<void> {
+  if (!(await needsRecompile())) {
+    log('No source changes detected, skipping compilation.');
+    return;
+  }
+
   const nargo = process.env.NARGO ?? 'nargo';
   const bb = process.env.BB ?? 'bb';
 

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdir, rm, utimes, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { needsRecompile } from './needs_recompile.js';
+
+/** Create a file and backdate it to the given timestamp (seconds since epoch). */
+async function touch(filePath: string, timeSec: number) {
+  await writeFile(filePath, '');
+  await utimes(filePath, timeSec, timeSec);
+}
+
+/** Create a directory (recursively). */
+async function mkdirp(dir: string) {
+  await mkdir(dir, { recursive: true });
+}
+
+describe('needsRecompile', () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    // Create a unique temp directory and chdir into it so needsRecompile()
+    // resolves its relative paths ('target', '.') against our test fixtures.
+    tempDir = join(tmpdir(), `needs-recompile-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdirp(tempDir);
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns true when target directory does not exist', async () => {
+    // No target/ at all — always needs recompile.
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns true when target directory is empty (no .json artifacts)', async () => {
+    await mkdirp('target');
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns true when target has only non-json files', async () => {
+    await mkdirp('target');
+    await touch(join('target', 'something.txt'), 1000);
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns false when artifacts are newer than all sources', async () => {
+    // Source files at t=1000, artifact at t=2000.
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    expect(await needsRecompile()).toBe(false);
+  });
+
+  it('returns true when a .nr source file is newer than the newest artifact', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('target', 'artifact.json'), 2000);
+    await touch(join('src', 'main.nr'), 3000);
+
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns true when Nargo.toml is newer than the newest artifact', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 3000, 3000);
+
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('follows path-based dependencies and detects newer sources in them', async () => {
+    // Main project depends on a local library via path.
+    const libDir = join(tempDir, 'lib', 'my_dep');
+    await mkdirp(join(libDir, 'src'));
+    await mkdirp('src');
+    await mkdirp('target');
+
+    // Main project Nargo.toml with a path dependency.
+    const mainToml = `[package]
+name = "test"
+type = "contract"
+
+[dependencies]
+my_dep = { path = "lib/my_dep" }
+`;
+    await writeFile('Nargo.toml', mainToml);
+    await utimes('Nargo.toml', 1000, 1000);
+
+    // Dependency Nargo.toml
+    await writeFile(join(libDir, 'Nargo.toml'), '[package]\nname = "my_dep"\ntype = "lib"\n');
+    await utimes(join(libDir, 'Nargo.toml'), 1000, 1000);
+
+    // Source files — all old.
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join(libDir, 'src', 'lib.nr'), 1000);
+
+    // Artifact is newer than all sources.
+    await touch(join('target', 'artifact.json'), 2000);
+
+    expect(await needsRecompile()).toBe(false);
+
+    // Now update a source file in the dependency.
+    await utimes(join(libDir, 'src', 'lib.nr'), 3000, 3000);
+
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('ignores git-based dependencies (no path field)', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    // Nargo.toml with a git dependency only.
+    const toml = `[package]
+name = "test"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/example/repo", tag = "v1.0" }
+`;
+    await writeFile('Nargo.toml', toml);
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    // Should return false and not error out because of invalid links — git deps are not searched through since they
+    // are fixed to a tag in Nargo.toml (and if Nargo.toml got modified we would detect it).
+    expect(await needsRecompile()).toBe(false);
+  });
+
+  it('skips target/ directories when scanning for source files', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    // Place a newer .nr file inside a nested target/ directory.
+    // This should be ignored.
+    await mkdirp(join('src', 'target'));
+    await touch(join('src', 'target', 'cached.nr'), 5000);
+
+    expect(await needsRecompile()).toBe(false);
+  });
+
+  it('compares against the oldest artifact when multiple exist', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 2500);
+    // Two artifacts: one old, one very new.
+    await touch(join('target', 'old_artifact.json'), 2000);
+    await touch(join('target', 'new_artifact.json'), 3000);
+
+    // Source (2500) is newer than the oldest artifact (2000), so recompile.
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns true when source is newer than the oldest but older than newest artifact', async () => {
+    // The comparison is against the oldest artifact so that a source change
+    // between the oldest and newest compilation still triggers a recompile.
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('target', 'old_artifact.json'), 1500);
+    await touch(join('target', 'new_artifact.json'), 3000);
+    await touch(join('src', 'main.nr'), 2000);
+
+    // Source (2000) > oldest artifact (1500), so recompile needed.
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('returns false when all sources are older than the oldest artifact', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'old_artifact.json'), 2000);
+    await touch(join('target', 'new_artifact.json'), 3000);
+
+    // Source (1000) < oldest artifact (2000), no recompile.
+    expect(await needsRecompile()).toBe(false);
+  });
+
+  it('handles deeply nested .nr source files', async () => {
+    await mkdirp('src/nested/deep');
+    await mkdirp('target');
+
+    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'nested', 'deep', 'module.nr'), 3000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    expect(await needsRecompile()).toBe(true);
+  });
+
+  it('does not follow circular path dependencies', async () => {
+    // Two projects that depend on each other via path.
+    const libDir = join(tempDir, 'lib');
+    await mkdirp(join(libDir, 'src'));
+    await mkdirp('src');
+    await mkdirp('target');
+
+    const mainToml = `[package]
+name = "main"
+type = "contract"
+
+[dependencies]
+lib = { path = "lib" }
+`;
+    await writeFile('Nargo.toml', mainToml);
+    await utimes('Nargo.toml', 1000, 1000);
+
+    // lib depends back on the main project.
+    const libToml = `[package]
+name = "lib"
+type = "lib"
+
+[dependencies]
+main = { path = ".." }
+`;
+    await writeFile(join(libDir, 'Nargo.toml'), libToml);
+    await utimes(join(libDir, 'Nargo.toml'), 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join(libDir, 'src', 'lib.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    // Should not infinite-loop; should return false since all sources are old.
+    expect(await needsRecompile()).toBe(false);
+  });
+});

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
@@ -188,8 +188,8 @@ aztec = { git = "https://github.com/example/repo", tag = "v1.0" }
   });
 
   it('returns true when source is newer than the oldest but older than newest artifact', async () => {
-    // The comparison is against the oldest artifact so that a source change
-    // between the oldest and newest compilation still triggers a recompile.
+    // The comparison is against the oldest artifact so that a source change between the oldest and newest compilation
+    // still triggers a recompile.
     await mkdirp('src');
     await mkdirp('target');
 
@@ -230,6 +230,29 @@ aztec = { git = "https://github.com/example/repo", tag = "v1.0" }
     await touch(join('target', 'artifact.json'), 2000);
 
     expect(await needsRecompile()).toBe(true);
+  });
+
+  it('throws when a path dependency resolves to a file instead of a directory', async () => {
+    await mkdirp('src');
+    await mkdirp('target');
+
+    // Create a file where the dependency path points.
+    await writeFile('not_a_dir', 'I am a file');
+
+    const mainToml = `[package]
+name = "test"
+type = "contract"
+
+[dependencies]
+bad_dep = { path = "not_a_dir" }
+`;
+    await writeFile('Nargo.toml', mainToml);
+    await utimes('Nargo.toml', 1000, 1000);
+
+    await touch(join('src', 'main.nr'), 1000);
+    await touch(join('target', 'artifact.json'), 2000);
+
+    await expect(needsRecompile()).rejects.toThrow('which is not a directory');
   });
 
   it('does not follow circular path dependencies', async () => {

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
@@ -5,9 +5,11 @@ import { join } from 'path';
 
 import { needsRecompile } from './needs_recompile.js';
 
-/** Create a file and backdate it to the given timestamp (seconds since epoch). */
+/** Create a file (if needed) and set its timestamp to the given value (seconds since epoch). */
 async function touch(filePath: string, timeSec: number) {
-  await writeFile(filePath, '');
+  // we apply the 'a' flag to mimic the behavior of touch command that does not change contents of a file if it already
+  // exist
+  await writeFile(filePath, '', { flag: 'a' });
   await utimes(filePath, timeSec, timeSec);
 }
 

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.test.ts
@@ -189,23 +189,6 @@ aztec = { git = "https://github.com/example/repo", tag = "v1.0" }
     expect(await needsRecompile()).toBe(true);
   });
 
-  it('returns true when source is newer than the oldest but older than newest artifact', async () => {
-    // The comparison is against the oldest artifact so that a source change between the oldest and newest compilation
-    // still triggers a recompile.
-    await mkdirp('src');
-    await mkdirp('target');
-
-    await writeFile('Nargo.toml', '[package]\nname = "test"\ntype = "contract"\n');
-    await utimes('Nargo.toml', 1000, 1000);
-
-    await touch(join('target', 'old_artifact.json'), 1500);
-    await touch(join('target', 'new_artifact.json'), 3000);
-    await touch(join('src', 'main.nr'), 2000);
-
-    // Source (2000) > oldest artifact (1500), so recompile needed.
-    expect(await needsRecompile()).toBe(true);
-  });
-
   it('returns false when all sources are older than the oldest artifact', async () => {
     await mkdirp('src');
     await mkdirp('target');

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -51,20 +51,20 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
     const content = await readFile(tomlPath, 'utf-8').catch(() => {
       throw new Error(`Incorrectly defined dependency. Nargo.toml not found in ${absDir}`);
     });
-    const parsed = TOML.parse(content) as Record<string, any>;
 
+    // We parse and iterate over the dependencies
+    const parsed = TOML.parse(content) as Record<string, any>;
     const deps = (parsed.dependencies as Record<string, any>) ?? {};
     for (const dep of Object.values(deps)) {
       if (dep && typeof dep === 'object' && typeof dep.path === 'string') {
         const depPath = resolve(absDir, dep.path);
-        try {
-          const s = await stat(depPath);
-          if (s.isDirectory()) {
-            await visit(depPath);
-          }
-        } catch {
-          // Dependency directory doesn't exist; skip.
+        const s = await stat(depPath);
+        if (!s.isDirectory()) {
+          throw new Error(
+            `Dependency path "${dep.path}" in ${tomlPath} resolves to ${depPath} which is not a directory`,
+          );
         }
+        await visit(depPath);
       }
     }
   }
@@ -77,6 +77,7 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
  * Walks sourceDirs looking for .nr and Nargo.toml files newer than thresholdMs. Short-circuits on the first match.
  */
 async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Promise<boolean> {
+  // Returns true if it find a new file than thresholdMs, false otherwise
   async function walkForNewer(dir: string): Promise<boolean> {
     let entries;
     try {
@@ -85,9 +86,11 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
       return false;
     }
 
+    // We iterate over the entries in the dir
     for (const entry of entries) {
       const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {
+        // If the entry is a dir and it's not called `target` we recursively enter it
         if (entry.name === 'target') {
           continue;
         }
@@ -95,6 +98,7 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
           return true;
         }
       } else if (entry.name === 'Nargo.toml' || entry.name.endsWith('.nr')) {
+        // The entry is a Nargo.toml file or *.nr file so we check the timestamp
         const s = await stat(fullPath);
         if (s.mtimeMs > thresholdMs) {
           return true;
@@ -104,6 +108,7 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
     return false;
   }
 
+  // We search through the source dirs
   for (const dir of sourceDirs) {
     if (await walkForNewer(dir)) {
       return true;

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -11,7 +11,7 @@ import { join, resolve } from 'path';
  * Note: The above implies that if there is a random json file in the target dir we would be always recompiling.
  */
 export async function needsRecompile(): Promise<boolean> {
-  const oldestArtifactMs = await getOldestArtifactMtimeMs('target');
+  const oldestArtifactMs = await getOldestArtifactModificationTime('target');
   if (oldestArtifactMs === undefined) {
     return true;
   }
@@ -20,8 +20,11 @@ export async function needsRecompile(): Promise<boolean> {
   return hasNewerSourceFile(crateDirs, oldestArtifactMs);
 }
 
-/** Returns the mtime (in ms) of the oldest .json artifact in targetDir, or undefined if none exist. */
-async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | undefined> {
+/**
+ * Returns the last modification time (timestamp in ms) of the oldest .json artifact in targetDir, or undefined if
+ * none exist.
+ */
+async function getOldestArtifactModificationTime(targetDir: string): Promise<number | undefined> {
   let entries: string[];
   try {
     entries = (await readdir(targetDir)).filter(f => f.endsWith('.json'));

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -37,16 +37,13 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
   // We have a set of visited dirs we check against when entering a new dir because we could stumble upon a directory
   // multiple times in case multiple deps shared a dep (e.g. dep A and dep B both sharing dep C).
   const visited = new Set<string>();
-  const result: string[] = [];
 
   async function visit(dir: string): Promise<void> {
     const absDir = resolve(dir);
     if (visited.has(absDir)) {
-      // We already visited this dir so we stop searching.
       return;
     }
     visited.add(absDir);
-    result.push(absDir);
 
     const tomlPath = join(absDir, 'Nargo.toml');
     const content = await readFile(tomlPath, 'utf-8').catch(() => {
@@ -71,7 +68,7 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
   }
 
   await visit(startDir);
-  return result;
+  return [...visited];
 }
 
 /**

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -1,0 +1,168 @@
+import TOML from '@iarna/toml';
+import { readFile, readdir, stat } from 'fs/promises';
+import { dirname, join, resolve } from 'path';
+
+/** Returns the mtime (in ms) of the oldest .json artifact in targetDir, or undefined if none exist. */
+async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | undefined> {
+  let entries: string[];
+  try {
+    entries = (await readdir(targetDir)).filter(f => f.endsWith('.json'));
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  let oldest = Infinity;
+  for (const entry of entries) {
+    const s = await stat(join(targetDir, entry));
+    if (s.mtimeMs < oldest) {
+      oldest = s.mtimeMs;
+    }
+  }
+  return oldest;
+}
+
+/** Recursively finds all Nargo.toml files under dir, skipping target/ directories. */
+async function findNargoTomls(dir: string): Promise<string[]> {
+  const results: string[] = [];
+
+  async function walk(d: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (entry.name === 'target') {
+          continue;
+        }
+        await walk(join(d, entry.name));
+      } else if (entry.name === 'Nargo.toml') {
+        results.push(join(d, entry.name));
+      }
+    }
+  }
+
+  await walk(dir);
+  return results;
+}
+
+/**
+ * Recursively collects source directories starting from startDir by following path-based
+ * dependencies declared in Nargo.toml files. Git-based deps are ignored (they only change
+ * when Nargo.toml itself is modified).
+ */
+async function collectSourceDirs(startDir: string): Promise<string[]> {
+  const visited = new Set<string>();
+  const result: string[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    const absDir = resolve(dir);
+    if (visited.has(absDir)) {
+      return;
+    }
+    visited.add(absDir);
+    result.push(absDir);
+
+    const tomlPaths = await findNargoTomls(absDir);
+
+    for (const tomlPath of tomlPaths) {
+      let content: string;
+      try {
+        content = await readFile(tomlPath, 'utf-8');
+      } catch {
+        continue;
+      }
+
+      let parsed: Record<string, any>;
+      try {
+        parsed = TOML.parse(content) as Record<string, any>;
+      } catch {
+        continue;
+      }
+
+      const deps = (parsed.dependencies as Record<string, any>) ?? {};
+      for (const dep of Object.values(deps)) {
+        if (dep && typeof dep === 'object' && typeof dep.path === 'string') {
+          const depPath = resolve(dirname(tomlPath), dep.path);
+          try {
+            const s = await stat(depPath);
+            if (s.isDirectory()) {
+              await visit(depPath);
+            }
+          } catch {
+            // Dependency directory doesn't exist; skip.
+          }
+        }
+      }
+    }
+  }
+
+  await visit(startDir);
+  return result;
+}
+
+/**
+ * Walks sourceDirs looking for .nr and Nargo.toml files newer than thresholdMs.
+ * Short-circuits on the first match.
+ */
+async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Promise<boolean> {
+  async function walkForNewer(dir: string): Promise<boolean> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'target') {
+          continue;
+        }
+        if (await walkForNewer(fullPath)) {
+          return true;
+        }
+      } else if (entry.name === 'Nargo.toml' || entry.name.endsWith('.nr')) {
+        const s = await stat(fullPath);
+        if (s.mtimeMs > thresholdMs) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  for (const dir of sourceDirs) {
+    if (await walkForNewer(dir)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or
+ * Nargo.toml source file (including path-based dependencies) is newer than the oldest artifact.
+ * We compare against the oldest artifact so that a source change between the oldest and newest
+ * compilation (e.g. in a multi-contract workspace) still triggers a recompile.
+ */
+export async function needsRecompile(): Promise<boolean> {
+  const oldestArtifactMs = await getOldestArtifactMtimeMs('target');
+  if (oldestArtifactMs === undefined) {
+    return true;
+  }
+
+  const sourceDirs = await collectSourceDirs('.');
+  return hasNewerSourceFile(sourceDirs, oldestArtifactMs);
+}

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -70,7 +70,7 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
   async function visit(dir: string): Promise<void> {
     const absDir = resolve(dir);
     if (visited.has(absDir)) {
-      // We already visited this dir so we stop searching in this recursion.
+      // We already visited this dir so we stop searching.
       return;
     }
     visited.add(absDir);

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -57,9 +57,9 @@ async function findNargoTomls(dir: string): Promise<string[]> {
 }
 
 /**
- * Recursively collects source directories starting from startDir by following path-based
- * dependencies declared in Nargo.toml files. Git-based deps are ignored (they only change
- * when Nargo.toml itself is modified).
+ * Recursively collects source directories starting from startDir by following path-based dependencies declared in
+ * Nargo.toml files. Git-based deps are ignored (they only change when Nargo.toml itself is modified since the deps are
+ * tagged).
  */
 async function collectSourceDirs(startDir: string): Promise<string[]> {
   const visited = new Set<string>();
@@ -112,8 +112,7 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
 }
 
 /**
- * Walks sourceDirs looking for .nr and Nargo.toml files newer than thresholdMs.
- * Short-circuits on the first match.
+ * Walks sourceDirs looking for .nr and Nargo.toml files newer than thresholdMs. Short-circuits on the first match.
  */
 async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Promise<boolean> {
   async function walkForNewer(dir: string): Promise<boolean> {
@@ -152,10 +151,13 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
 }
 
 /**
- * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or
- * Nargo.toml source file (including path-based dependencies) is newer than the oldest artifact.
- * We compare against the oldest artifact so that a source change between the oldest and newest
- * compilation (e.g. in a multi-contract workspace) still triggers a recompile.
+ * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or Nargo.toml source file
+ * (including path-based dependencies) is newer than the oldest artifact. We compare against the oldest artifact so
+ * that a source change between the oldest and newest compilation (e.g. in a multi-contract workspace) still triggers
+ * a recompile.
+ *
+ * Note: The above implies that if there is a random json file in the target dir we would be always recompiling.
+ * TODO: Is this ^ ok?
  */
 export async function needsRecompile(): Promise<boolean> {
   const oldestArtifactMs = await getOldestArtifactMtimeMs('target');

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -1,6 +1,6 @@
 import TOML from '@iarna/toml';
 import { readFile, readdir, stat } from 'fs/promises';
-import { dirname, join, resolve } from 'path';
+import { join, resolve } from 'path';
 
 /** Returns the mtime (in ms) of the oldest .json artifact in targetDir, or undefined if none exist. */
 async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | undefined> {
@@ -28,34 +28,6 @@ async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | und
   return oldest;
 }
 
-/** Recursively finds all Nargo.toml files under dir, skipping target/ directories. */
-async function findNargoTomls(dir: string): Promise<string[]> {
-  const results: string[] = [];
-
-  async function walk(d: string): Promise<void> {
-    let entries;
-    try {
-      entries = await readdir(d, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (entry.name === 'target') {
-          continue;
-        }
-        await walk(join(d, entry.name));
-      } else if (entry.name === 'Nargo.toml') {
-        results.push(join(d, entry.name));
-      }
-    }
-  }
-
-  await walk(dir);
-  return results;
-}
-
 /**
  * Recursively collects source directories starting from startDir by following path-based dependencies declared in
  * Nargo.toml files. Git-based deps are ignored (they only change when Nargo.toml itself is modified since the deps are
@@ -76,35 +48,23 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
     visited.add(absDir);
     result.push(absDir);
 
-    const tomlPaths = await findNargoTomls(absDir);
+    const tomlPath = join(absDir, 'Nargo.toml');
+    const content = await readFile(tomlPath, 'utf-8').catch(() => {
+      throw new Error(`Nargo.toml not found in ${absDir}`);
+    });
+    const parsed = TOML.parse(content) as Record<string, any>;
 
-    for (const tomlPath of tomlPaths) {
-      let content: string;
-      try {
-        content = await readFile(tomlPath, 'utf-8');
-      } catch {
-        continue;
-      }
-
-      let parsed: Record<string, any>;
-      try {
-        parsed = TOML.parse(content) as Record<string, any>;
-      } catch {
-        continue;
-      }
-
-      const deps = (parsed.dependencies as Record<string, any>) ?? {};
-      for (const dep of Object.values(deps)) {
-        if (dep && typeof dep === 'object' && typeof dep.path === 'string') {
-          const depPath = resolve(dirname(tomlPath), dep.path);
-          try {
-            const s = await stat(depPath);
-            if (s.isDirectory()) {
-              await visit(depPath);
-            }
-          } catch {
-            // Dependency directory doesn't exist; skip.
+    const deps = (parsed.dependencies as Record<string, any>) ?? {};
+    for (const dep of Object.values(deps)) {
+      if (dep && typeof dep === 'object' && typeof dep.path === 'string') {
+        const depPath = resolve(absDir, dep.path);
+        try {
+          const s = await stat(depPath);
+          if (s.isDirectory()) {
+            await visit(depPath);
           }
+        } catch {
+          // Dependency directory doesn't exist; skip.
         }
       }
     }

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -2,6 +2,24 @@ import TOML from '@iarna/toml';
 import { readFile, readdir, stat } from 'fs/promises';
 import { join, resolve } from 'path';
 
+/**
+ * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or Nargo.toml source file
+ * (including path-based dependencies) is newer than the oldest artifact. We compare against the oldest artifact so
+ * that a source change between the oldest and newest compilation (e.g. in a multi-contract workspace) still triggers
+ * a recompile.
+ *
+ * Note: The above implies that if there is a random json file in the target dir we would be always recompiling.
+ */
+export async function needsRecompile(): Promise<boolean> {
+  const oldestArtifactMs = await getOldestArtifactMtimeMs('target');
+  if (oldestArtifactMs === undefined) {
+    return true;
+  }
+
+  const sourceDirs = await collectSourceDirs('.');
+  return hasNewerSourceFile(sourceDirs, oldestArtifactMs);
+}
+
 /** Returns the mtime (in ms) of the oldest .json artifact in targetDir, or undefined if none exist. */
 async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | undefined> {
   let entries: string[];
@@ -115,22 +133,4 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
     }
   }
   return false;
-}
-
-/**
- * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or Nargo.toml source file
- * (including path-based dependencies) is newer than the oldest artifact. We compare against the oldest artifact so
- * that a source change between the oldest and newest compilation (e.g. in a multi-contract workspace) still triggers
- * a recompile.
- *
- * Note: The above implies that if there is a random json file in the target dir we would be always recompiling.
- */
-export async function needsRecompile(): Promise<boolean> {
-  const oldestArtifactMs = await getOldestArtifactMtimeMs('target');
-  if (oldestArtifactMs === undefined) {
-    return true;
-  }
-
-  const sourceDirs = await collectSourceDirs('.');
-  return hasNewerSourceFile(sourceDirs, oldestArtifactMs);
 }

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -62,12 +62,15 @@ async function findNargoTomls(dir: string): Promise<string[]> {
  * tagged).
  */
 async function collectSourceDirs(startDir: string): Promise<string[]> {
+  // We have a set of visited dirs we check against when entering a new dir because we could stumble upon a directory
+  // multiple times in case multiple deps shared a dep (e.g. dep A and dep B both sharing dep C).
   const visited = new Set<string>();
   const result: string[] = [];
 
   async function visit(dir: string): Promise<void> {
     const absDir = resolve(dir);
     if (visited.has(absDir)) {
+      // We already visited this dir so we stop searching in this recursion.
       return;
     }
     visited.add(absDir);
@@ -157,7 +160,6 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
  * a recompile.
  *
  * Note: The above implies that if there is a random json file in the target dir we would be always recompiling.
- * TODO: Is this ^ ok?
  */
 export async function needsRecompile(): Promise<boolean> {
   const oldestArtifactMs = await getOldestArtifactMtimeMs('target');

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -45,9 +45,11 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
     }
     visited.add(absDir);
 
+    // Every dep is its own crate and every crate needs to have Nargo.toml defined in the root so we try to load it and
+    // error out if it's not the case.
     const tomlPath = join(absDir, 'Nargo.toml');
     const content = await readFile(tomlPath, 'utf-8').catch(() => {
-      throw new Error(`Nargo.toml not found in ${absDir}`);
+      throw new Error(`Incorrectly defined dependency. Nargo.toml not found in ${absDir}`);
     });
     const parsed = TOML.parse(content) as Record<string, any>;
 

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -16,8 +16,8 @@ export async function needsRecompile(): Promise<boolean> {
     return true;
   }
 
-  const sourceDirs = await collectSourceDirs('.');
-  return hasNewerSourceFile(sourceDirs, oldestArtifactMs);
+  const crateDirs = await collectCrateDirs('.');
+  return hasNewerSourceFile(crateDirs, oldestArtifactMs);
 }
 
 /** Returns the mtime (in ms) of the oldest .json artifact in targetDir, or undefined if none exist. */
@@ -47,17 +47,17 @@ async function getOldestArtifactMtimeMs(targetDir: string): Promise<number | und
 }
 
 /**
- * Recursively collects source directories starting from startDir by following path-based dependencies declared in
+ * Recursively collects crate directories starting from startCrateDir by following path-based dependencies declared in
  * Nargo.toml files. Git-based deps are ignored (they only change when Nargo.toml itself is modified since the deps are
  * tagged).
  */
-async function collectSourceDirs(startDir: string): Promise<string[]> {
+async function collectCrateDirs(startCrateDir: string): Promise<string[]> {
   // We have a set of visited dirs we check against when entering a new dir because we could stumble upon a directory
   // multiple times in case multiple deps shared a dep (e.g. dep A and dep B both sharing dep C).
   const visited = new Set<string>();
 
-  async function visit(dir: string): Promise<void> {
-    const absDir = resolve(dir);
+  async function visit(crateDir: string): Promise<void> {
+    const absDir = resolve(crateDir);
     if (visited.has(absDir)) {
       return;
     }
@@ -87,14 +87,14 @@ async function collectSourceDirs(startDir: string): Promise<string[]> {
     }
   }
 
-  await visit(startDir);
+  await visit(startCrateDir);
   return [...visited];
 }
 
 /**
- * Walks sourceDirs looking for .nr and Nargo.toml files newer than thresholdMs. Short-circuits on the first match.
+ * Walks crate dirs looking for .nr and Nargo.toml files newer than thresholdMs. Short-circuits on the first match.
  */
-async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Promise<boolean> {
+async function hasNewerSourceFile(crateDirs: string[], thresholdMs: number): Promise<boolean> {
   // Returns true if it find a new file than thresholdMs, false otherwise
   async function walkForNewer(dir: string): Promise<boolean> {
     let entries;
@@ -126,8 +126,8 @@ async function hasNewerSourceFile(sourceDirs: string[], thresholdMs: number): Pr
     return false;
   }
 
-  // We search through the source dirs
-  for (const dir of sourceDirs) {
+  // We search through the crate dirs
+  for (const dir of crateDirs) {
     if (await walkForNewer(dir)) {
       return true;
     }

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -933,6 +933,7 @@ __metadata:
     "@aztec/validator-ha-signer": "workspace:^"
     "@aztec/wallets": "workspace:^"
     "@aztec/world-state": "workspace:^"
+    "@iarna/toml": "npm:^2.2.5"
     "@jest/globals": "npm:^30.0.0"
     "@types/chalk": "npm:^2.2.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
In this PR I ensure that contracts get automatically recompiled when `aztec test` is run. To avoid unnecessary compilations I use `make` command inspired approach of checking timestamp of source files (*.toml and *.nr files) against the timestamp of the oldest artifact in the `/target` dir (as artifact I consider any `*.json` file). 

**Note:** By using the oldest timestamp we would get constant recompilation on each run in case the dev placed there some random `*.json` file.

**Question**: Does the reviewer think this ^ is fine? Alternatively I could nuke the `target` dir whenever a recompilation is being run. This feels a bit dangerous though. Another approach would be to predict the artifact name of individual crates and just check against those. This would be the most efficient but it introduces complexity and brittleness in case `nargo` artifact names change. I think I would keep it as it is for now and come up with solution if someone complains about constant recompilations.

I initially thought I will implement this in the `aztec test` command but that command is fully implemented in bash. When I had AI implement this the resulting bash was impossible to comprehend so I told it to rewrite in typescript. Given that the `aztec test` command is calling `aztec compile` that is implemented in typescript it made sense for this PR to modify only that command. This has the added advantage that it will make bugs in this code way more visible because when a dev runs `aztec compile` they will either see that the code is getting re-compiled or they will get "No source changes detected, skipping compilation." log. If they modify a contract, run `aztec compile` and see that nothing got compiled it will be obvious that the thing is broken.

Closes https://linear.app/aztec-labs/issue/F-197/auto-recompile-contracts-on-tests
