### PR TITLE
fix: Fix static linker order error in debug build

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/chonk_bench/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/benchmark/chonk_bench/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(chonk_bench vm2_stub dsl chonk stdlib_honk_verifier stdlib_sha256 stdlib_primitives)
+barretenberg_module(chonk_bench vm2_stub chonk stdlib_honk_verifier stdlib_sha256 stdlib_primitives)


### PR DESCRIPTION
There was a static linker order error (dsl coming before chonk) that was caught in the debug build. This PR fixes it (we remove dsl as it is already linked by chonk)