### PR TITLE
fix: Deflake the gossip test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -30,6 +30,8 @@ const CHECK_ALERTS = process.env.CHECK_ALERTS === 'true';
 const NUM_VALIDATORS = 4;
 const NUM_TXS_PER_NODE = 2;
 const BOOT_NODE_UDP_PORT = 4500;
+const AZTEC_SLOT_DURATION = 36;
+const AZTEC_EPOCH_DURATION = 4;
 
 const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'gossip-'));
 
@@ -61,8 +63,8 @@ describe('e2e_p2p_network', () => {
       startProverNode: false, // we'll start our own using p2p
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES,
-        aztecSlotDuration: 36,
-        aztecEpochDuration: 4,
+        aztecSlotDuration: AZTEC_SLOT_DURATION,
+        aztecEpochDuration: AZTEC_EPOCH_DURATION,
         slashingRoundSizeInEpochs: 2,
         slashingQuorum: 5,
         listenAddress: '127.0.0.1',
@@ -211,7 +213,7 @@ describe('e2e_p2p_network', () => {
         return provenBlock > 0;
       },
       'proven block',
-      120,
+      SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES.aztecProofSubmissionWindow * AZTEC_EPOCH_DURATION * AZTEC_SLOT_DURATION,
     );
   });
 });


### PR DESCRIPTION
Fixes the timout duration for waiting for a proven block
