### PR TITLE
fix: add GITHUB_REPOSITORY and drop source_repo input

### DIFF
--- a/.github/workflows/private-fork-release.yml
+++ b/.github/workflows/private-fork-release.yml
@@ -13,22 +13,12 @@ on:
       commit:
         description: "Commit SHA from the source repo"
         required: true
-      source_repo:
-        description: "Source repository (must be AztecProtocol/aztec-packages-private)"
-        required: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
     environment: master
     steps:
-      - name: Validate source repo
-        run: |
-          if [[ "${{ inputs.source_repo }}" != "AztecProtocol/aztec-packages-private" ]]; then
-            echo "::error::source_repo must be AztecProtocol/aztec-packages-private, got '${{ inputs.source_repo }}'"
-            exit 1
-          fi
-
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -58,6 +48,7 @@ jobs:
           REF_NAME: ${{ inputs.tag }}
           RUN_ID: ${{ github.run_id }}
           SOURCE_REPOSITORY: AztecProtocol/aztec-packages-private
+          GITHUB_REPOSITORY: AztecProtocol/aztec-packages-private
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Set `GITHUB_REPOSITORY` env var to `AztecProtocol/aztec-packages-private` so `gh` CLI targets the correct repo for releases
- Remove `source_repo` input (hardcoded everywhere)
- Remove validation step (no longer needed)

## Test plan
- [ ] Dispatch fork release without `source_repo` field
- [ ] `gh release create` targets the private repo (when enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)