### PR TITLE
fix: add contents:write to fork release workflow

### DIFF
--- a/.github/workflows/private-fork-release.yml
+++ b/.github/workflows/private-fork-release.yml
@@ -18,6 +18,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: master
+    # contents: write is needed for GITHUB_TOKEN to push tags.
+    permissions:
+      contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -48,7 +51,6 @@ jobs:
           REF_NAME: ${{ inputs.tag }}
           RUN_ID: ${{ github.run_id }}
           SOURCE_REPOSITORY: AztecProtocol/aztec-packages-private
-          GITHUB_REPOSITORY: AztecProtocol/aztec-packages-private
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `permissions.contents: write` so the built-in `GITHUB_TOKEN` can push tags (was silently failing)
- Remove the non-functional `GITHUB_REPOSITORY` env override (it's a read-only GitHub Actions default variable)

## Context
The Push tag step uses `GITHUB_TOKEN` (not a PAT) to prevent ci3.yml from triggering on tag push. But without `contents: write` permission, the tag push was silently failing (masked by `|| echo "Tag already exists"`).