### PR TITLE
fix: create fork release tag via Releases API

### DIFF
--- a/.github/workflows/private-fork-release.yml
+++ b/.github/workflows/private-fork-release.yml
@@ -1,8 +1,9 @@
 # Accepts a release dispatch from the private fork.
 # Checks out the fork's code and runs the standard release pipeline
 # using this (public) repo's secrets and publishing identity.
-# The tag is pushed using GITHUB_TOKEN (not a PAT) so it does not trigger ci3.yml.
-# See: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+# The tag and release are created via the Releases API (not git push) so they
+# don't trigger ci3.yml. The API creates the tag as a side-effect of the release,
+# avoiding the tag protection ruleset that blocks GITHUB_TOKEN git pushes.
 name: Release (Fork)
 on:
   workflow_dispatch:
@@ -18,9 +19,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: master
-    # contents: write is needed for GITHUB_TOKEN to push tags.
-    permissions:
-      contents: write
     steps:
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -31,18 +29,29 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      # Uses GITHUB_TOKEN (not a PAT) so this push does NOT trigger other workflows.
-      # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
-      - name: Push tag
+      # Create the GitHub release (and tag) via the Releases API.
+      # This uses AZTEC_BOT_GITHUB_TOKEN (which has tag-creation bypass permission).
+      # The Releases API creates the tag as a side-effect, which does not trigger
+      # push-based workflows like ci3.yml.
+      - name: Create tag and release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
-          git config user.name "AztecBot"
-          git config user.email "tech@aztecprotocol.com"
-          git remote add public "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git fetch public next --depth=1
-          git tag -a "${{ inputs.tag }}" public/next -m "${{ inputs.tag }}"
-          git push public "refs/tags/${{ inputs.tag }}" || echo "Tag already exists, continuing."
+          # Get the tip of the public repo's next branch to tag
+          PUBLIC_NEXT_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/next --jq '.object.sha')
+          echo "Tagging public/next at $PUBLIC_NEXT_SHA"
+
+          if gh release view "${{ inputs.tag }}" --repo ${{ github.repository }} &>/dev/null; then
+            echo "Release ${{ inputs.tag }} already exists, skipping."
+          else
+            gh release create "${{ inputs.tag }}" \
+              --repo ${{ github.repository }} \
+              --target "$PUBLIC_NEXT_SHA" \
+              --title "${{ inputs.tag }}" \
+              --prerelease \
+              --notes "Private fork release from ${{ inputs.commit }}"
+            echo "Created release ${{ inputs.tag }}"
+          fi
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary
- Replace git tag push with `gh release create` in the fork release workflow
- The tag-creation ruleset blocks `GITHUB_TOKEN` from pushing tags via git
- Using `AZTEC_BOT_GITHUB_TOKEN` for git push triggers ci3.yml (race condition)
- The Releases API creates the tag as a side-effect, bypassing both issues

## Test plan
- [ ] Dispatch fork release and verify tag + release are created
- [ ] Verify ci3.yml is NOT triggered by the release creation
- [ ] Verify bb cpp binaries are uploaded to the release