### PR TITLE
docs: document RevertCodeEnum phases and add 120-char line width rule

### DIFF
--- a/yarn-project/CLAUDE.md
+++ b/yarn-project/CLAUDE.md
@@ -110,6 +110,10 @@ LOG_LEVEL='info; debug:sequencer,archiver' yarn workspace @aztec/<package-name> 
 
 **IMPORTANT**: These commands are run from the root of `yarn-project`, NOT the git root.
 
+### Style
+
+- **Line width**: 120 characters (`printWidth: 120` in `.prettierrc.json`). Wrap comments and code at 120, not 80.
+
 ### Format
 
 ```bash

--- a/yarn-project/stdlib/src/avm/revert_code.ts
+++ b/yarn-project/stdlib/src/avm/revert_code.ts
@@ -5,10 +5,25 @@ import { BufferReader, FieldReader } from '@aztec/foundation/serialize';
 import { inspect } from 'util';
 import { z } from 'zod';
 
+/**
+ * Tracks which revertible phases of a transaction's public execution reverted.
+ *
+ * A transaction executes in three sequential phases:
+ *   1. SETUP     – non-revertible; if this fails the entire transaction is rejected.
+ *   2. APP_LOGIC – revertible; its state changes are rolled back on failure.
+ *   3. TEARDOWN  – revertible; always runs (even after app-logic revert) so the fee-payment contract can clean up.
+ *
+ * Only APP_LOGIC and TEARDOWN can produce a revert code. SETUP failures throw instead and discard the transaction
+ * entirely.
+ */
 export enum RevertCodeEnum {
+  /** All phases completed successfully; no state was rolled back. */
   OK = 0,
+  /** APP_LOGIC reverted; its state changes were discarded. TEARDOWN still ran and succeeded. */
   APP_LOGIC_REVERTED = 1,
+  /** TEARDOWN reverted; its state changes were discarded. APP_LOGIC succeeded. */
   TEARDOWN_REVERTED = 2,
+  /** Both APP_LOGIC and TEARDOWN reverted; only SETUP effects are kept. */
   BOTH_REVERTED = 3,
 }
 

--- a/yarn-project/stdlib/src/avm/revert_code.ts
+++ b/yarn-project/stdlib/src/avm/revert_code.ts
@@ -19,7 +19,7 @@ import { z } from 'zod';
 export enum RevertCodeEnum {
   /** All phases completed successfully; no state was rolled back. */
   OK = 0,
-  /** APP_LOGIC reverted; its state changes were discarded. TEARDOWN still ran and succeeded. */
+  /** APP_LOGIC reverted; its state changes were discarded. If present, TEARDOWN still ran and succeeded. */
   APP_LOGIC_REVERTED = 1,
   /** TEARDOWN reverted; its state changes were discarded. APP_LOGIC succeeded. */
   TEARDOWN_REVERTED = 2,


### PR DESCRIPTION
I wanted to confirm the exact meaning of different revert codes and found the code documentation was missing so I had Claude  do this PR. This is not my sphere of knowledge so please be thorough in reviewing the docs. Also added a formatting fix to CLAUDE.md as Claude was generating comments wrapped and 80 chars instead of 120.

## Summary

- Adds JSDoc to `RevertCodeEnum` explaining the three transaction execution phases (SETUP, APP_LOGIC, TEARDOWN) and what each revert code value means
- Adds a Style section to `yarn-project/CLAUDE.md` documenting the 120-character line width rule (`printWidth: 120` from `.prettierrc.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Note**: The CI failure is unrelated and for this reason I've already sent it for a review.