### PR TITLE
fix: Inject version to correct binary

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -71,13 +71,10 @@ function build_native {
     cache_upload barretenberg-$native_preset-$hash.zst build/{bin,lib}
   fi
   # Always inject version (even for cached binaries) to ensure correct version on release
-  if [ "${NATIVE_PRESET:-clang20}" == "clang20" ]; then
-    inject_version build/bin/bb
-  elif [ "${NATIVE_PRESET}" == "debug" ]; then
-    inject_version build-debug/bin/bb
-  fi
-  if [ -f build/bin/bb-avm ]; then
-    inject_version build/bin/bb-avm
+  inject_version $(scripts/native-preset-build-dir)/bin/bb
+
+  if [ -f $(scripts/native-preset-build-dir)/bin/bb-avm ]; then
+    inject_version $(scripts/native-preset-build-dir)/bin/bb-avm
   fi
 }
 

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -71,7 +71,11 @@ function build_native {
     cache_upload barretenberg-$native_preset-$hash.zst build/{bin,lib}
   fi
   # Always inject version (even for cached binaries) to ensure correct version on release
-  inject_version build/bin/bb
+  if [ "${NATIVE_PRESET:-clang20}" == "clang20" ]; then
+    inject_version build/bin/bb
+  elif [ "${NATIVE_PRESET}" == "debug" ]; then
+    inject_version build-debug/bin/bb
+  fi
   if [ -f build/bin/bb-avm ]; then
     inject_version build/bin/bb-avm
   fi


### PR DESCRIPTION
In `bootstrap.sh` we always inject the version to `build/bb`. This raises an error when running the debug build in nightly. This PR fixes it by injecting the version to the correct binary.