### PR TITLE
fix: prioritize Android over Linux in build.rs target detection

### DIFF
--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -50,6 +50,9 @@ fn get_lib_dir() -> PathBuf {
 fn download_lib(out_dir: &PathBuf) {
     let target = std::env::var("TARGET").unwrap();
     let arch = match target.as_str() {
+        // Android (must check before linux since android targets contain "linux")
+        t if t.contains("aarch64") && t.contains("android") => "arm64-android",
+        t if t.contains("x86_64") && t.contains("android") => "x86_64-android",
         // Linux
         t if t.contains("x86_64") && t.contains("linux") => "amd64-linux",
         t if t.contains("aarch64") && t.contains("linux") => "arm64-linux",
@@ -62,9 +65,6 @@ fn download_lib(out_dir: &PathBuf) {
         }
         // iOS device
         t if t.contains("aarch64") && t.contains("apple") && t.contains("ios") => "arm64-ios",
-        // Android
-        t if t.contains("aarch64") && t.contains("android") => "arm64-android",
-        t if t.contains("x86_64") && t.contains("android") => "x86_64-android",
         _ => panic!(
             "Unsupported target for FFI backend: {}. \
              Supported: x86_64-linux, aarch64-linux, x86_64-apple-darwin, aarch64-apple-darwin, \


### PR DESCRIPTION
## Summary
- Android Rust targets (e.g. `aarch64-linux-android`, `x86_64-linux-android`) contain the `linux` keyword, causing them to incorrectly match the Linux match arms in `build.rs` before reaching the Android ones
- Moves Android match arms above Linux ones so they take precedence

## Test plan
- [x] `cargo check -p barretenberg-rs --target aarch64-linux-android` with `BB_LIB_DIR` pointing to Android libs — passes
- [x] `cargo check -p barretenberg-rs --target aarch64-linux-android` with `BARRETENBERG_VERSION=4.0.0-rc.5` — successfully downloads `barretenberg-static-arm64-android.tar.gz` (not `arm64-linux`)