### PR TITLE
fix: include validation reason in PXE simulate error

### DIFF
--- a/yarn-project/end-to-end/src/e2e_expiration_timestamp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_expiration_timestamp.test.ts
@@ -114,14 +114,6 @@ describe('e2e_expiration_timestamp', () => {
             .send({ from: defaultAccountAddress }),
         ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
       });
-
-      it('simulation includes validation reason in error', async () => {
-        await expect(
-          contract.methods
-            .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
-            .simulate({ from: defaultAccountAddress }),
-        ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
-      });
     });
 
     describe('with an enqueued public call', () => {
@@ -141,14 +133,6 @@ describe('e2e_expiration_timestamp', () => {
           contract.methods
             .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
             .send({ from: defaultAccountAddress }),
-        ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
-      });
-
-      it('simulation includes validation reason in error', async () => {
-        await expect(
-          contract.methods
-            .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
-            .simulate({ from: defaultAccountAddress }),
         ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
       });
     });

--- a/yarn-project/end-to-end/src/e2e_expiration_timestamp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_expiration_timestamp.test.ts
@@ -114,6 +114,14 @@ describe('e2e_expiration_timestamp', () => {
             .send({ from: defaultAccountAddress }),
         ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
       });
+
+      it('simulation includes validation reason in error', async () => {
+        await expect(
+          contract.methods
+            .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
+            .simulate({ from: defaultAccountAddress }),
+        ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
+      });
     });
 
     describe('with an enqueued public call', () => {
@@ -133,6 +141,14 @@ describe('e2e_expiration_timestamp', () => {
           contract.methods
             .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
             .send({ from: defaultAccountAddress }),
+        ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
+      });
+
+      it('simulation includes validation reason in error', async () => {
+        await expect(
+          contract.methods
+            .set_expiration_timestamp(expirationTimestamp, enqueuePublicCall)
+            .simulate({ from: defaultAccountAddress }),
         ).rejects.toThrow(TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
       });
     });

--- a/yarn-project/end-to-end/src/e2e_pxe.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pxe.test.ts
@@ -1,0 +1,37 @@
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import { Fr } from '@aztec/aztec.js/fields';
+import { TestContract } from '@aztec/noir-test-contracts.js/Test';
+import { TX_ERROR_EXISTING_NULLIFIER } from '@aztec/stdlib/tx';
+
+import { setup } from './fixtures/utils.js';
+import type { TestWallet } from './test-wallet/test_wallet.js';
+
+// TODO: Ideally these would be unit tests for PXE, but some functions like simulateTx, proveTx, etc require
+// more complex setup
+describe('e2e_pxe', () => {
+  let wallet: TestWallet;
+  let defaultAccountAddress: AztecAddress;
+  let teardown: () => Promise<void>;
+
+  let contract: TestContract;
+
+  beforeAll(async () => {
+    ({
+      teardown,
+      wallet,
+      accounts: [defaultAccountAddress],
+    } = await setup());
+    contract = await TestContract.deploy(wallet).send({ from: defaultAccountAddress });
+  });
+
+  afterAll(() => teardown());
+
+  it('simulate includes validation reason in error', async () => {
+    const nullifier = Fr.random();
+    await contract.methods.emit_nullifier(nullifier).send({ from: defaultAccountAddress });
+
+    await expect(contract.methods.emit_nullifier(nullifier).simulate({ from: defaultAccountAddress })).rejects.toThrow(
+      TX_ERROR_EXISTING_NULLIFIER,
+    );
+  });
+});

--- a/yarn-project/pxe/src/pxe.ts
+++ b/yarn-project/pxe/src/pxe.ts
@@ -958,7 +958,8 @@ export class PXE {
           const validationResult = await this.node.isValidTx(simulatedTx, { isSimulation: true, skipFeeEnforcement });
           validationTime = validationTimer.ms();
           if (validationResult.result === 'invalid') {
-            throw new Error('The simulated transaction is unable to be added to state and is invalid.');
+            const reason = validationResult.reason.length > 0 ? ` Reason: ${validationResult.reason.join(', ')}` : '';
+            throw new Error(`The simulated transaction is unable to be added to state and is invalid.${reason}`);
           }
         }
 


### PR DESCRIPTION
## Summary

- PXE `.simulate()` now includes the validation reason in the error message when a transaction is invalid, matching the behavior of `.send()`.
- Adds e2e tests verifying that the simulation error includes the validation reason.

Closes F-82 and https://github.com/AztecProtocol/aztec-packages/issues/17787