### PR TITLE
chore: fix yaml encoding of consensus API keys

### DIFF
--- a/spartan/aztec-node/templates/_pod-template.yaml
+++ b/spartan/aztec-node/templates/_pod-template.yaml
@@ -287,9 +287,9 @@ spec:
         - name: L1_CONSENSUS_HOST_URLS
           value: {{ join "," .Values.global.l1ConsensusUrls | quote }}
         - name: L1_CONSENSUS_HOST_API_KEYS
-          value: {{ join "," .Values.global.l1ConsensusHostApiKeys | quote }}
+          value: {{ .Values.global.l1ConsensusHostApiKeys | quote }}
         - name: L1_CONSENSUS_HOST_API_KEY_HEADERS
-          value: {{ join "," .Values.global.l1ConsensusHostApiKeyHeaders | quote }}
+          value: {{ .Values.global.l1ConsensusHostApiKeyHeaders | quote }}
         {{- end }}
         - name: DATA_DIRECTORY
           value: "{{ .Values.node.storage.dataDirectory }}/data"

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -29,9 +29,9 @@ global:
   l1ConsensusUrls: []
   ## Only when api key is required via header, otherwise just provide in l1ConsensusHostUrls
   ## Example: "1234abcd"
-  l1ConsensusHostApiKeys: []
+  l1ConsensusHostApiKeys: ""
   ## Example: "X-API-KEY"
-  l1ConsensusHostApiKeyHeaders: []
+  l1ConsensusHostApiKeyHeaders: ""
 
   aztecImage:
     repository: aztecprotocol/aztec

--- a/spartan/aztec-prover-stack/values.yaml
+++ b/spartan/aztec-prover-stack/values.yaml
@@ -6,8 +6,8 @@ global:
 
   l1ExecutionUrls: []
   l1ConsensusUrls: []
-  l1ConsensusHostApiKeys: []
-  l1ConsensusHostApiKeyHeaders: []
+  l1ConsensusHostApiKeys: ""
+  l1ConsensusHostApiKeyHeaders: ""
 
 node:
   nodeType: "prover-node"

--- a/spartan/aztec-validator/values.yaml
+++ b/spartan/aztec-validator/values.yaml
@@ -6,8 +6,8 @@ global:
 
   l1ExecutionUrls: []
   l1ConsensusUrls: []
-  l1ConsensusHostApiKeys: []
-  l1ConsensusHostApiKeyHeaders: []
+  l1ConsensusHostApiKeys: ""
+  l1ConsensusHostApiKeyHeaders: ""
 
 validator:
   nodeType: "sequencer-node"

--- a/spartan/terraform/deploy-aztec-infra/main.tf
+++ b/spartan/terraform/deploy-aztec-infra/main.tf
@@ -111,13 +111,13 @@ locals {
     "global.otelCollectorEndpoint"                             = var.OTEL_COLLECTOR_ENDPOINT
     "global.sponsoredFPC"                                      = var.SPONSORED_FPC
     "global.testAccounts"                                      = var.TEST_ACCOUNTS
+    "global.l1ConsensusHostApiKeys"                            = length(var.L1_CONSENSUS_HOST_API_KEYS) > 0 ? join(",", var.L1_CONSENSUS_HOST_API_KEYS) : null
+    "global.l1ConsensusHostApiKeyHeaders"                      = length(var.L1_CONSENSUS_HOST_API_KEY_HEADERS) > 0 ? join(",", var.L1_CONSENSUS_HOST_API_KEY_HEADERS) : null
   }
 
   common_list_settings = {
-    "global.l1ExecutionUrls"              = var.L1_RPC_URLS
-    "global.l1ConsensusUrls"              = var.L1_CONSENSUS_HOST_URLS
-    "global.l1ConsensusHostApiKeys"       = var.L1_CONSENSUS_HOST_API_KEYS
-    "global.l1ConsensusHostApiKeyHeaders" = var.L1_CONSENSUS_HOST_API_KEY_HEADERS
+    "global.l1ExecutionUrls" = var.L1_RPC_URLS
+    "global.l1ConsensusUrls" = var.L1_CONSENSUS_HOST_URLS
   }
 
   # Generate a set of _external_ host ports to use for P2P
@@ -205,7 +205,7 @@ locals {
     "validator.node.env.SEQ_MAX_TX_PER_BLOCK"                  = var.SEQ_MAX_TX_PER_BLOCK
     "validator.node.env.SEQ_BLOCK_DURATION_MS"                 = var.SEQ_BLOCK_DURATION_MS
     "validator.node.env.SEQ_BUILD_CHECKPOINT_IF_EMPTY"         = var.SEQ_BUILD_CHECKPOINT_IF_EMPTY
-    "validator.node.env.SEQ_ENFORCE_TIME_TABLE"               = var.SEQ_ENFORCE_TIME_TABLE
+    "validator.node.env.SEQ_ENFORCE_TIME_TABLE"                = var.SEQ_ENFORCE_TIME_TABLE
     "validator.node.env.P2P_TX_POOL_DELETE_TXS_AFTER_REORG"    = var.P2P_TX_POOL_DELETE_TXS_AFTER_REORG
     "validator.node.env.L1_PRIORITY_FEE_BUMP_PERCENTAGE"       = var.VALIDATOR_L1_PRIORITY_FEE_BUMP_PERCENTAGE
     "validator.node.env.L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE" = var.VALIDATOR_L1_PRIORITY_FEE_RETRY_BUMP_PERCENTAGE
@@ -424,7 +424,7 @@ locals {
             type    = local.is_kind ? "ClusterIP" : "LoadBalancer"
           }
         }
-      })], var.FISHERMAN_MODE ? [yamlencode({
+        })], var.FISHERMAN_MODE ? [yamlencode({
         node = {
           logLevel = var.FISHERMAN_LOG_LEVEL
         }


### PR DESCRIPTION
The empty API keys would get dropped which would break the alignment between API hosts and API keys.