### PR TITLE
feat: early circuit block deallocation after trace populate

### DIFF
--- a/barretenberg/cpp/scripts/rss_transitions.py
+++ b/barretenberg/cpp/scripts/rss_transitions.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Extract RSS transitions from bb log output.
+
+bb logs include "(mem: X.XX MiB)" on every log line (peak RSS via getrusage).
+This script filters to only the lines where the RSS value changes, giving a
+compact timeline of memory growth.
+
+Usage:
+    bb prove ... 2>&1 | python3 scripts/rss_transitions.py
+    python3 scripts/rss_transitions.py < logfile.log
+"""
+import sys
+
+prev = None
+for line in sys.stdin:
+    line = line.strip()
+    parts = line.split('mem: ')
+    if len(parts) >= 2:
+        val = parts[1].split(' MiB')[0]
+        if val != prev:
+            msg = parts[0].strip().rstrip('(').strip()
+            if len(msg) > 80:
+                msg = msg[:80]
+            print(f'  {val} MiB  {msg}')
+            prev = val

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -422,6 +422,14 @@ void Chonk::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVerific
 
     QUEUE_TYPE queue_type = get_queue_type();
 
+    // Free circuit block memory (wires and selectors) now that they've been copied to prover polynomials.
+    // Skip for MEGA (hiding kernel) since it constructs a second ProverInstance from the same circuit.
+    if (queue_type != QUEUE_TYPE::MEGA) {
+        for (auto& block : circuit.blocks.get()) {
+            block.free_data();
+        }
+    }
+
     FoldingProver prover(prover_accumulation_transcript);
     HonkProof proof;
     switch (queue_type) {

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -532,6 +532,11 @@ HonkProof Chonk::construct_honk_proof_for_hiding_kernel(ClientCircuit& circuit,
 {
     auto hiding_prover_inst = std::make_shared<DeciderZKProvingKey>(circuit);
 
+    // Free circuit block memory now that trace data has been copied to prover polynomials
+    for (auto& block : circuit.blocks.get()) {
+        block.free_data();
+    }
+
     // Hiding kernel is proven by a MegaZKProver
     MegaZKProver prover(hiding_prover_inst, verification_key, transcript);
     HonkProof proof = prover.construct_proof();

--- a/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/chonk/chonk.cpp
@@ -395,8 +395,28 @@ void Chonk::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVerific
 
     BB_ASSERT(precomputed_vk != nullptr, "Chonk::accumulate - VK expected for the provided circuit");
 
+    QUEUE_TYPE queue_type = get_queue_type();
+
+    // For the hiding kernel (MEGA), skip straight to the ZK prover — no non-ZK ProverInstance needed.
+    if (queue_type == QUEUE_TYPE::MEGA) {
+        vinfo("Generating proof for hiding kernel");
+#ifndef NDEBUG
+        debug_incoming_circuit(circuit, std::make_shared<ProverInstance>(circuit), precomputed_vk);
+#endif
+        HonkProof proof = construct_honk_proof_for_hiding_kernel(circuit, precomputed_vk);
+        VerifierInputs queue_entry{ std::move(proof), precomputed_vk, queue_type, /*is_kernel=*/true };
+        verification_queue.push_back(queue_entry);
+        num_circuits_accumulated++;
+        return;
+    }
+
     // Construct the prover instance for circuit
     std::shared_ptr<ProverInstance> prover_instance = std::make_shared<ProverInstance>(circuit);
+
+    // Free circuit block memory (wires and selectors) now that they've been copied to prover polynomials
+    for (auto& block : circuit.blocks.get()) {
+        block.free_data();
+    }
 
 #ifndef NDEBUG
     debug_incoming_circuit(circuit, prover_instance, precomputed_vk);
@@ -419,16 +439,6 @@ void Chonk::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVerific
     auto verifier_transcript =
         Transcript::convert_prover_transcript_to_verifier_transcript(prover_accumulation_transcript);
 #endif
-
-    QUEUE_TYPE queue_type = get_queue_type();
-
-    // Free circuit block memory (wires and selectors) now that they've been copied to prover polynomials.
-    // Skip for MEGA (hiding kernel) since it constructs a second ProverInstance from the same circuit.
-    if (queue_type != QUEUE_TYPE::MEGA) {
-        for (auto& block : circuit.blocks.get()) {
-            block.free_data();
-        }
-    }
 
     FoldingProver prover(prover_accumulation_transcript);
     HonkProof proof;
@@ -457,28 +467,19 @@ void Chonk::accumulate(ClientCircuit& circuit, const std::shared_ptr<MegaVerific
         decider_proof = decider.construct_proof(prover_accumulator);
         break;
     }
-    case QUEUE_TYPE::MEGA:
-        vinfo("Generating proof for hiding kernel");
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1555): Method for constructing hiding kernel proof
-        // constructs a new ProverInstance (with ZK Flavor). For now just do a hacky shared ptr deallocation to avoid
-        // double memory for storing two instances.
-        prover_instance.reset();
-        proof = construct_honk_proof_for_hiding_kernel(circuit, precomputed_vk);
+    default:
+        BB_ASSERT(false, "Unexpected queue type");
         break;
     }
 
     VerifierInputs queue_entry{ std::move(proof), precomputed_vk, queue_type, is_kernel };
     verification_queue.push_back(queue_entry);
 
-    // Construct merge proof (excluded for hiding kernel since accumulation terminates with
-    // tail kernel and hiding merge proof is constructed as part of goblin proving)
-    if (queue_entry.type != QUEUE_TYPE::MEGA) {
+    // Construct merge proof (MEGA/hiding kernel is handled in the early return above)
 #ifndef NDEBUG
-        // In debugging builds update native verifier accumulator
-        update_native_verifier_accumulator(queue_entry, verifier_transcript);
+    update_native_verifier_accumulator(queue_entry, verifier_transcript);
 #endif
-        goblin.prove_merge(prover_accumulation_transcript);
-    }
+    goblin.prove_merge(prover_accumulation_transcript);
 
     num_circuits_accumulated++;
 }

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -120,6 +120,11 @@ template <typename FF> class Selector {
      * @param value Field element.
      */
     virtual void set(size_t idx, const FF& value) = 0;
+
+    /**
+     * @brief Release all memory held by this selector.
+     */
+    virtual void free_memory() {}
 };
 
 /**
@@ -179,6 +184,8 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
 
     bool empty() const override { return size_ == 0; }
 
+    void free_memory() override { size_ = 0; }
+
   private:
     static constexpr FF zero = 0;
     size_t size_ = 0;
@@ -208,6 +215,12 @@ template <typename FF> class SlabVectorSelector : public Selector<FF> {
 
     size_t size() const override { return data.size(); }
     bool empty() const override { return data.empty(); }
+
+    void free_memory() override
+    {
+        data.clear();
+        data.shrink_to_fit();
+    }
 
   private:
     std::vector<FF> data;
@@ -253,6 +266,8 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
     }
 
     Wires wires;                                                   // vectors of indices into a witness variables array
+    size_t cached_size_ = 0;                                       // set by free_data() so size() works after freeing
+    bool data_freed_ = false;                                      // true after free_data() has been called
     uint32_t trace_offset_ = std::numeric_limits<uint32_t>::max(); // where this block starts in the trace
 
     uint32_t trace_offset() const
@@ -263,7 +278,7 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
 
     bool operator==(const ExecutionTraceBlock& other) const = default;
 
-    size_t size() const { return std::get<0>(this->wires).size(); }
+    size_t size() const { return data_freed_ ? cached_size_ : std::get<0>(this->wires).size(); }
 
     void reserve(size_t size_hint)
     {
@@ -292,6 +307,23 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
 #endif
 
     virtual RefVector<Selector<FF>> get_selectors() = 0;
+
+    /**
+     * @brief Release wire and selector memory. Caches block size so size() still works.
+     * @details Called after trace data has been copied to prover polynomials.
+     */
+    void free_data()
+    {
+        cached_size_ = std::get<0>(wires).size();
+        data_freed_ = true;
+        for (auto& wire : wires) {
+            wire.clear();
+            wire.shrink_to_fit();
+        }
+        for (auto& sel : get_selectors()) {
+            sel.free_memory();
+        }
+    }
 
     void populate_wires(const uint32_t& idx_1, const uint32_t& idx_2, const uint32_t& idx_3, const uint32_t& idx_4)
     {


### PR DESCRIPTION
## Summary

- Free circuit block wire and selector memory immediately after `TraceToPolynomials::populate()` copies them to prover polynomials in the Chonk IVC accumulation loop
- Block size is cached before freeing so `block.size()` and `block.trace_offset()` continue to work for subsequent code that needs block metadata
- Refactors the hiding kernel (MEGA) path to early-return at the top of `Chonk::accumulate()`, skipping the unnecessary non-ZK ProverInstance construction. This eliminates the double ProverInstance construction that [barretenberg#1555](https://github.com/AztecProtocol/barretenberg/issues/1555) flagged, and allows unconditional circuit block deallocation for all other circuit types
- Adds a small utility script for extracting RSS transitions from bb log output

## RSS Measurements (AMM flow: `ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc`)

| Stage | Before (MiB) | After (MiB) | Delta |
|---|---|---|---|
| Startup | 7.55 | 7.61 | — |
| CRS loaded | 128.86 | 126.61 | -2 |
| EcdsaRAccount accumulate | 163.36 | 162.61 | -1 |
| After first large circuit | 356.86 | 329.13 | **-27.7** |
| After Token:transfer (1st) | 651.96 | 555.73 | **-96.2** |
| **Peak RSS** | **668.28** | **573.91** | **-94.4** |

**Peak RSS reduction: 94.4 MiB (14.1%)**

Commands used:
```
# baseline (merge-train/barretenberg)
bb prove -o /tmp/amm-output-base \
  --ivc_inputs_path .../ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc/ivc-inputs.msgpack \
  --scheme chonk 2>&1 | python3 scripts/rss_transitions.py

# feature branch
bb prove -o /tmp/amm-output-feature \
  --ivc_inputs_path .../ecdsar1+amm_add_liquidity_1_recursions+sponsored_fpc/ivc-inputs.msgpack \
  --scheme chonk 2>&1 | python3 scripts/rss_transitions.py
```

Resolves https://github.com/AztecProtocol/barretenberg/issues/1500
Partial fix for https://github.com/AztecProtocol/barretenberg/issues/1555