### PR TITLE
chore: monitor ELU in E2E tests

### DIFF
--- a/ci3/docker_isolate
+++ b/ci3/docker_isolate
@@ -77,6 +77,7 @@ cid=$(docker run -d \
   -e TMPFS_SIZE \
   -e USE_HOME_TMP \
   -e AVM \
+  -e ELU_MONITOR_FILE \
   "${arg_env_vars[@]}" \
   aztecprotocol/build:3.0 \
   /bin/bash -c "$cmd")

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -54,4 +54,10 @@ fi
 code=$?
 set -e
 
+# Upload ELU data if present (written by e2e tests, absent for C++/Rust/Noir).
+if [ -s "$HOME/.elu_monitor.log" ]; then
+  cat "$HOME/.elu_monitor.log" | cache_log elufile
+  rm -f "$HOME/.elu_monitor.log"
+fi
+
 exit $code

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -43,6 +43,9 @@ EOF
 # If the test has a verbose mode, we want it enabled.
 export VERBOSE=1
 
+# ELU monitor file path (e2e tests write event loop data here, uploaded after test finishes).
+export ELU_MONITOR_FILE=$HOME/.elu_monitor_$$.log
+
 # Run the test with timestamps via process substitution (preserves exit code)
 set +e
 if [ "${ISOLATE:-0}" -eq 1 ]; then
@@ -55,8 +58,10 @@ code=$?
 set -e
 
 # Upload ELU data if present (written by e2e tests, absent for C++/Rust/Noir).
-for f in "$HOME"/.elu_monitor_*.log; do
-  [ -s "$f" ] && cat "$f" | cache_log "elufile:${NAME:-unknown}" && rm -f "$f"
-done
+if [ -s "$ELU_MONITOR_FILE" ]; then
+  echo "ELU file: $ELU_MONITOR_FILE ($(wc -l < "$ELU_MONITOR_FILE") lines, $(wc -c < "$ELU_MONITOR_FILE") bytes)"
+  cat "$ELU_MONITOR_FILE" | cache_log "elufile:${NAME:-unknown}"
+  rm -f "$ELU_MONITOR_FILE"
+fi
 
 exit $code

--- a/ci3/exec_test
+++ b/ci3/exec_test
@@ -55,9 +55,8 @@ code=$?
 set -e
 
 # Upload ELU data if present (written by e2e tests, absent for C++/Rust/Noir).
-if [ -s "$HOME/.elu_monitor.log" ]; then
-  cat "$HOME/.elu_monitor.log" | cache_log elufile
-  rm -f "$HOME/.elu_monitor.log"
-fi
+for f in "$HOME"/.elu_monitor_*.log; do
+  [ -s "$f" ] && cat "$f" | cache_log "elufile:${NAME:-unknown}" && rm -f "$f"
+done
 
 exit $code

--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -21,6 +21,14 @@ export LOG_LEVEL=${LOG_LEVEL:-verbose}
 export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
 
+# Capture per-test event loop utilization in CI.
+if command -v cache_log &>/dev/null; then
+  export ELU_MONITOR_FILE=/tmp/elu_monitor_$$.log
+  touch $ELU_MONITOR_FILE
+  tail -f $ELU_MONITOR_FILE > >(cache_log elufile) 2>/dev/null &
+  elu_pid=$!
+fi
+
 test_file=$1
 test_name=${2:-}
 
@@ -40,3 +48,6 @@ else
   "${test_name_arg[@]}" \
   --runInBand "$1"
 fi
+
+# Kill ELU monitor tail if started.
+[ -n "${elu_pid:-}" ] && kill $elu_pid 2>/dev/null || true

--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -22,7 +22,7 @@ export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
 
 # Capture per-test event loop utilization (uploaded by exec_test after test finishes).
-export ELU_MONITOR_FILE=$HOME/.elu_monitor.log
+export ELU_MONITOR_FILE=$HOME/.elu_monitor_$$.log
 
 test_file=$1
 test_name=${2:-}

--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -21,13 +21,8 @@ export LOG_LEVEL=${LOG_LEVEL:-verbose}
 export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
 
-# Capture per-test event loop utilization in CI.
-if command -v cache_log &>/dev/null; then
-  export ELU_MONITOR_FILE=/tmp/elu_monitor_$$.log
-  touch $ELU_MONITOR_FILE
-  tail -f $ELU_MONITOR_FILE > >(cache_log elufile) 2>/dev/null &
-  elu_pid=$!
-fi
+# Capture per-test event loop utilization (uploaded by exec_test after test finishes).
+export ELU_MONITOR_FILE=$HOME/.elu_monitor.log
 
 test_file=$1
 test_name=${2:-}
@@ -48,6 +43,3 @@ else
   "${test_name_arg[@]}" \
   --runInBand "$1"
 fi
-
-# Kill ELU monitor tail if started.
-[ -n "${elu_pid:-}" ] && kill $elu_pid 2>/dev/null || true

--- a/yarn-project/end-to-end/scripts/test_simple.sh
+++ b/yarn-project/end-to-end/scripts/test_simple.sh
@@ -21,9 +21,6 @@ export LOG_LEVEL=${LOG_LEVEL:-verbose}
 export NODE_NO_WARNINGS=1
 export FORCE_COLOR=1
 
-# Capture per-test event loop utilization (uploaded by exec_test after test finishes).
-export ELU_MONITOR_FILE=$HOME/.elu_monitor_$$.log
-
 test_file=$1
 test_name=${2:-}
 

--- a/yarn-project/end-to-end/src/fixtures/elu_monitor.ts
+++ b/yarn-project/end-to-end/src/fixtures/elu_monitor.ts
@@ -1,0 +1,126 @@
+import { appendFileSync } from 'node:fs';
+import { type EventLoopUtilization, type IntervalHistogram, monitorEventLoopDelay, performance } from 'node:perf_hooks';
+
+const NANOS_PER_MS = 1_000_000;
+
+/** Samples event-loop utilization, delay histogram, and heap usage per test, writing columnar text to a file. */
+export class EluMonitor {
+  private filePath: string;
+  private intervalMs: number;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private lastELU: EventLoopUtilization | undefined;
+  private histogram: IntervalHistogram;
+  private testName: string | undefined;
+  private testStart: number | undefined;
+  private eluSamples: number[] = [];
+
+  constructor(filePath: string, intervalMs?: number) {
+    this.filePath = filePath;
+    this.intervalMs = intervalMs ?? 2000;
+    this.histogram = monitorEventLoopDelay({ resolution: 20 });
+  }
+
+  /** Begin sampling for a test. Writes a header line and starts the periodic sampler. */
+  startTest(testName: string): void {
+    this.stopTest();
+
+    this.testName = testName;
+    this.testStart = performance.now();
+    this.eluSamples = [];
+
+    appendFileSync(this.filePath, `\n=== Test: ${testName} ===\n`);
+    appendFileSync(
+      this.filePath,
+      padColumns('TIME', 'ELU', 'EL_DLY_P50', 'EL_DLY_P99', 'EL_DLY_MAX', 'HEAP_MB') + '\n',
+    );
+
+    this.lastELU = performance.eventLoopUtilization();
+    this.histogram.enable();
+
+    this.timer = setInterval(() => this.sample(), this.intervalMs);
+    // Allow the process to exit even if the timer is still running.
+    this.timer.unref();
+  }
+
+  /** Stop sampling and write a summary line. */
+  stopTest(): void {
+    if (!this.timer) {
+      return;
+    }
+
+    // Take a final sample before stopping.
+    this.sample();
+
+    clearInterval(this.timer);
+    this.timer = undefined;
+    this.histogram.disable();
+    this.histogram.reset();
+
+    this.writeSummary();
+
+    this.lastELU = undefined;
+    this.testName = undefined;
+    this.testStart = undefined;
+    this.eluSamples = [];
+  }
+
+  /** Alias for stopTest — call on process exit to flush any remaining data. */
+  stop(): void {
+    this.stopTest();
+  }
+
+  private sample(): void {
+    const newELU = performance.eventLoopUtilization();
+    const delta = performance.eventLoopUtilization(newELU, this.lastELU);
+    this.lastELU = newELU;
+
+    const elu = delta.utilization;
+    this.eluSamples.push(elu);
+
+    const p50 = this.histogram.percentile(50) / NANOS_PER_MS;
+    const p99 = this.histogram.percentile(99) / NANOS_PER_MS;
+    const max = this.histogram.max / NANOS_PER_MS;
+    const heapMb = Math.round(process.memoryUsage().heapUsed / (1024 * 1024));
+
+    const now = new Date();
+    const time = [now.getHours(), now.getMinutes(), now.getSeconds()].map(n => String(n).padStart(2, '0')).join(':');
+
+    const line = padColumns(
+      time,
+      elu.toFixed(2),
+      `${p50.toFixed(1)}ms`,
+      `${p99.toFixed(1)}ms`,
+      `${max.toFixed(1)}ms`,
+      String(heapMb),
+    );
+    appendFileSync(this.filePath, line + '\n');
+
+    // Reset histogram so next sample only reflects the new interval.
+    this.histogram.reset();
+  }
+
+  private writeSummary(): void {
+    if (this.eluSamples.length === 0 || this.testStart === undefined) {
+      return;
+    }
+
+    const mean = this.eluSamples.reduce((a, b) => a + b, 0) / this.eluSamples.length;
+    const maxElu = Math.max(...this.eluSamples);
+    const sorted = [...this.eluSamples].sort((a, b) => a - b);
+    const p90Elu = sorted[Math.floor(sorted.length * 0.9)] ?? maxElu;
+    const durationS = ((performance.now() - this.testStart) / 1000).toFixed(1);
+
+    let summary = `--- Summary: mean_elu=${mean.toFixed(2)} max_elu=${maxElu.toFixed(2)} p90_elu=${p90Elu.toFixed(2)} duration=${durationS}s`;
+    if (maxElu > 0.85) {
+      summary += ' WARNING:ELU>0.85';
+    }
+    summary += ' ---\n';
+
+    appendFileSync(this.filePath, summary);
+  }
+}
+
+function padColumns(...cols: string[]): string {
+  const widths = [11, 7, 12, 12, 12, 8];
+  return cols.map((col, i) => col.padEnd(widths[i] ?? 10)).join('');
+}

--- a/yarn-project/end-to-end/src/shared/jest_setup.ts
+++ b/yarn-project/end-to-end/src/shared/jest_setup.ts
@@ -1,7 +1,17 @@
 import { createLogger } from '@aztec/aztec.js/log';
 
-import { beforeEach, expect } from '@jest/globals';
+import { afterEach, beforeEach, expect } from '@jest/globals';
 import { basename } from 'path';
+
+import { EluMonitor } from '../fixtures/elu_monitor.js';
+
+const eluMonitor = process.env.ELU_MONITOR_FILE
+  ? new EluMonitor(process.env.ELU_MONITOR_FILE, Number(process.env.ELU_MONITOR_INTERVAL_MS) || undefined)
+  : undefined;
+
+if (eluMonitor) {
+  process.on('exit', () => eluMonitor.stop());
+}
 
 beforeEach(() => {
   const { testPath, currentTestName } = expect.getState();
@@ -10,4 +20,9 @@ beforeEach(() => {
   }
   const logger = createLogger(`e2e:${basename(testPath).replace('.test.ts', '')}`);
   logger.info(`Running test: ${currentTestName}`);
+  eluMonitor?.startTest(currentTestName);
+});
+
+afterEach(() => {
+  eluMonitor?.stopTest();
 });


### PR DESCRIPTION
Adds an event-loop-utilisation monitor that logs to a file for each test in CI.

Related to A-530