### PR TITLE
feat: add support for signed integers on contract functions

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -35,6 +35,7 @@ members = [
     "contracts/protocol_interface/contract_instance_registry_interface",
     "contracts/protocol_interface/fee_juice_interface",
     "contracts/test/generic_proxy_contract",
+    "contracts/test/abi_types_contract",
     "contracts/test/auth_wit_test_contract",
     "contracts/test/avm_gadgets_test_contract",
     "contracts/test/avm_initializer_test_contract",

--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "abi_types_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
@@ -1,0 +1,41 @@
+// A contract used for testing that different types are supported as types on external function functions (both public
+// and private).
+
+mod test;
+
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract AbiTypes {
+    use aztec::{macros::functions::external, protocol::traits::{Deserialize, Serialize}};
+
+    #[derive(Serialize, Deserialize, Eq)]
+    pub struct CustomStruct {
+        pub w: Field,
+        pub x: bool,
+        pub y: u64,
+        pub z: i64,
+    }
+
+    #[external("public")]
+    fn return_public_parameters(
+        a: bool,
+        b: Field,
+        c: u64,
+        d: i64,
+        e: CustomStruct,
+    ) -> (bool, Field, u64, i64, CustomStruct) {
+        (a, b, c, d, e)
+    }
+
+    #[external("private")]
+    fn return_private_parameters(
+        a: bool,
+        b: Field,
+        c: u64,
+        d: i64,
+        e: CustomStruct,
+    ) -> (bool, Field, u64, i64, CustomStruct) {
+        (a, b, c, d, e)
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/main.nr
@@ -1,5 +1,5 @@
-// A contract used for testing that different types are supported as types on external function functions (both public
-// and private).
+// A contract used for testing that different types are supported as types on external functions (both public, private
+// and utility).
 
 mod test;
 
@@ -30,6 +30,17 @@ pub contract AbiTypes {
 
     #[external("private")]
     fn return_private_parameters(
+        a: bool,
+        b: Field,
+        c: u64,
+        d: i64,
+        e: CustomStruct,
+    ) -> (bool, Field, u64, i64, CustomStruct) {
+        (a, b, c, d, e)
+    }
+
+    #[external("utility")]
+    unconstrained fn return_utility_parameters(
         a: bool,
         b: Field,
         c: u64,

--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/test.nr
@@ -88,3 +88,37 @@ unconstrained fn pass_private_parameters() {
         ),
     );
 }
+
+#[test]
+unconstrained fn pass_utility_parameters() {
+    let mut env = TestEnvironment::new();
+
+    let abi_types = AbiTypes::at(env.deploy("AbiTypes").without_initializer());
+
+    let min_range_return_values = env.execute_utility(abi_types.return_utility_parameters(
+        false,
+        0,
+        0,
+        I64_MIN,
+        CustomStruct { w: 0, x: false, y: 0, z: I64_MIN },
+    ));
+    assert_eq(
+        min_range_return_values,
+        (false, 0, 0, I64_MIN, CustomStruct { w: 0, x: false, y: 0, z: I64_MIN }),
+    );
+
+    let max_range_return_values = env.execute_utility(abi_types.return_utility_parameters(
+        true,
+        MAX_FIELD_VALUE,
+        U64_MAX,
+        I64_MAX,
+        CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+    ));
+    assert_eq(
+        max_range_return_values,
+        (
+            true, MAX_FIELD_VALUE, U64_MAX, I64_MAX,
+            CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+        ),
+    );
+}

--- a/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/abi_types_contract/src/test.nr
@@ -1,0 +1,90 @@
+use crate::AbiTypes;
+use crate::AbiTypes::CustomStruct;
+use aztec::{protocol::constants::MAX_FIELD_VALUE, test::helpers::test_environment::TestEnvironment};
+
+global U64_MAX: u64 = (2.pow_32(64) - 1) as u64;
+
+global I64_MAX: i64 = (2.pow_32(63) - 1) as i64;
+global I64_MIN: i64 = -I64_MAX - 1;
+
+#[test]
+unconstrained fn pass_public_parameters() {
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+
+    let abi_types = AbiTypes::at(env.deploy("AbiTypes").without_initializer());
+
+    let min_range_return_values = env.call_public(
+        sender,
+        abi_types.return_public_parameters(
+            false,
+            0,
+            0,
+            I64_MIN,
+            CustomStruct { w: 0, x: false, y: 0, z: I64_MIN },
+        ),
+    );
+    assert_eq(
+        min_range_return_values,
+        (false, 0, 0, I64_MIN, CustomStruct { w: 0, x: false, y: 0, z: I64_MIN }),
+    );
+
+    let max_range_return_values = env.call_public(
+        sender,
+        abi_types.return_public_parameters(
+            true,
+            MAX_FIELD_VALUE,
+            U64_MAX,
+            I64_MAX,
+            CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+        ),
+    );
+    assert_eq(
+        max_range_return_values,
+        (
+            true, MAX_FIELD_VALUE, U64_MAX, I64_MAX,
+            CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+        ),
+    );
+}
+
+#[test]
+unconstrained fn pass_private_parameters() {
+    let mut env = TestEnvironment::new();
+    let sender = env.create_light_account();
+
+    let abi_types = AbiTypes::at(env.deploy("AbiTypes").without_initializer());
+
+    let min_range_return_values = env.call_private(
+        sender,
+        abi_types.return_private_parameters(
+            false,
+            0,
+            0,
+            I64_MIN,
+            CustomStruct { w: 0, x: false, y: 0, z: I64_MIN },
+        ),
+    );
+    assert_eq(
+        min_range_return_values,
+        (false, 0, 0, I64_MIN, CustomStruct { w: 0, x: false, y: 0, z: I64_MIN }),
+    );
+
+    let max_range_return_values = env.call_private(
+        sender,
+        abi_types.return_private_parameters(
+            true,
+            MAX_FIELD_VALUE,
+            U64_MAX,
+            I64_MAX,
+            CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+        ),
+    );
+    assert_eq(
+        max_range_return_values,
+        (
+            true, MAX_FIELD_VALUE, U64_MAX, I64_MAX,
+            CustomStruct { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+        ),
+    );
+}

--- a/yarn-project/end-to-end/src/e2e_abi_types.test.ts
+++ b/yarn-project/end-to-end/src/e2e_abi_types.test.ts
@@ -83,4 +83,29 @@ describe('AbiTypes', () => {
       { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
     ]);
   });
+
+  it('passes utility parameters', async () => {
+    const minResult = await abiTypesContract.methods
+      .return_utility_parameters(false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(minResult).toEqual([false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN }]);
+
+    const maxResult = await abiTypesContract.methods
+      .return_utility_parameters(true, MAX_FIELD_VALUE, U64_MAX, I64_MAX, {
+        w: MAX_FIELD_VALUE,
+        x: true,
+        y: U64_MAX,
+        z: I64_MAX,
+      })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(maxResult).toEqual([
+      true,
+      MAX_FIELD_VALUE,
+      U64_MAX,
+      I64_MAX,
+      { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+    ]);
+  });
 });

--- a/yarn-project/end-to-end/src/e2e_abi_types.test.ts
+++ b/yarn-project/end-to-end/src/e2e_abi_types.test.ts
@@ -1,0 +1,86 @@
+import { AztecAddress } from '@aztec/aztec.js/addresses';
+import type { Wallet } from '@aztec/aztec.js/wallet';
+import { MAX_FIELD_VALUE } from '@aztec/constants';
+import { AbiTypesContract } from '@aztec/noir-test-contracts.js/AbiTypes';
+
+import { jest } from '@jest/globals';
+
+import { setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+const U64_MAX = 2n ** 64n - 1n;
+const I64_MAX = 2n ** 63n - 1n;
+const I64_MIN = -(2n ** 63n);
+
+// Tests that different types are supported to be passed to contract functions and received as return values. This
+// mirrors the Noir tests for the AbiTypes contract to make sure that these values can also be passed from TS.
+describe('AbiTypes', () => {
+  let abiTypesContract: AbiTypesContract;
+  jest.setTimeout(TIMEOUT);
+
+  let wallet: Wallet;
+  let defaultAccountAddress: AztecAddress;
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({
+      teardown,
+      wallet,
+      accounts: [defaultAccountAddress],
+    } = await setup(1));
+    abiTypesContract = await AbiTypesContract.deploy(wallet).send({ from: defaultAccountAddress });
+  });
+
+  afterAll(() => teardown());
+
+  it('passes public parameters', async () => {
+    const minResult = await abiTypesContract.methods
+      .return_public_parameters(false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(minResult).toEqual([false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN }]);
+
+    const maxResult = await abiTypesContract.methods
+      .return_public_parameters(true, MAX_FIELD_VALUE, U64_MAX, I64_MAX, {
+        w: MAX_FIELD_VALUE,
+        x: true,
+        y: U64_MAX,
+        z: I64_MAX,
+      })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(maxResult).toEqual([
+      true,
+      MAX_FIELD_VALUE,
+      U64_MAX,
+      I64_MAX,
+      { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+    ]);
+  });
+
+  it('passes private parameters', async () => {
+    const minResult = await abiTypesContract.methods
+      .return_private_parameters(false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(minResult).toEqual([false, 0n, 0n, I64_MIN, { w: 0n, x: false, y: 0n, z: I64_MIN }]);
+
+    const maxResult = await abiTypesContract.methods
+      .return_private_parameters(true, MAX_FIELD_VALUE, U64_MAX, I64_MAX, {
+        w: MAX_FIELD_VALUE,
+        x: true,
+        y: U64_MAX,
+        z: I64_MAX,
+      })
+      .simulate({ from: defaultAccountAddress });
+
+    expect(maxResult).toEqual([
+      true,
+      MAX_FIELD_VALUE,
+      U64_MAX,
+      I64_MAX,
+      { w: MAX_FIELD_VALUE, x: true, y: U64_MAX, z: I64_MAX },
+    ]);
+  });
+});

--- a/yarn-project/stdlib/src/abi/decoder.ts
+++ b/yarn-project/stdlib/src/abi/decoder.ts
@@ -135,10 +135,7 @@ export class FunctionSignatureDecoder {
       case 'field':
         return 'Field';
       case 'integer':
-        if (param.sign === 'signed') {
-          throw new Error('Unsupported type: signed integer');
-        }
-        return `u${param.width}`;
+        return param.sign === 'signed' ? `i${param.width}` : `u${param.width}`;
       case 'boolean':
         return 'bool';
       case 'array':

--- a/yarn-project/stdlib/src/abi/encoder.test.ts
+++ b/yarn-project/stdlib/src/abi/encoder.test.ts
@@ -209,6 +209,33 @@ describe('abi/encoder', () => {
     expect(() => encodeArguments(testFunctionAbi, args)).toThrow(`Cannot convert garbage to a BigInt`);
   });
 
+  it("encodes negative signed integers as two's complement", () => {
+    const testFunctionAbi: FunctionAbi = {
+      name: 'test',
+      functionType: FunctionType.PRIVATE,
+      isOnlySelf: false,
+      isInitializer: false,
+      isStatic: false,
+      parameters: [
+        {
+          name: 'value',
+          type: { kind: 'integer', sign: 'signed', width: 8 },
+          visibility: 'private',
+        },
+      ],
+      returnTypes: [],
+      errorTypes: {},
+    };
+
+    expect(encodeArguments(testFunctionAbi, [0])).toEqual([new Fr(0n)]);
+    expect(encodeArguments(testFunctionAbi, [-128])).toEqual([new Fr(128n)]);
+    expect(encodeArguments(testFunctionAbi, [127])).toEqual([new Fr(127n)]);
+    expect(encodeArguments(testFunctionAbi, [-1])).toEqual([new Fr(255n)]);
+
+    // Also check strings are properly encoded
+    expect(encodeArguments(testFunctionAbi, ['-1'])).toEqual([new Fr(255n)]);
+  });
+
   it('throws when passing object argument as field', () => {
     const testFunctionAbi: FunctionAbi = {
       name: 'constructor',

--- a/yarn-project/stdlib/src/abi/encoder.ts
+++ b/yarn-project/stdlib/src/abi/encoder.ts
@@ -123,14 +123,17 @@ class ArgumentEncoder {
         }
         break;
       }
-      case 'integer':
-        if (typeof arg === 'string') {
-          const value = BigInt(arg);
-          this.flattened.push(new Fr(value));
+      case 'integer': {
+        const value = BigInt(arg);
+        if (abiType.sign === 'signed' && value < 0n) {
+          // Convert negative values to two's complement representation
+          const twosComplement = value + (1n << BigInt(abiType.width));
+          this.flattened.push(new Fr(twosComplement));
         } else {
-          this.flattened.push(new Fr(arg));
+          this.flattened.push(new Fr(value));
         }
         break;
+      }
       default:
         throw new Error(`Unsupported type: ${abiType.kind}`);
     }


### PR DESCRIPTION
Closes #20746.

I added both Noir and TS tests to make sure this works as expected. The TS tests are currently failing because we cannot create an `Fr` for a negative number, but I don't know enough about how the encoding works to fix it myself. @sirasistant?

I only added tests for `i64` as `i128` it not yet supported by Noir (https://github.com/noir-lang/noir/issues/7591).