### PR TITLE
fix(docs): build bb.js in nightly docs workflow

### DIFF
--- a/.github/workflows/nightly-docs-release.yml
+++ b/.github/workflows/nightly-docs-release.yml
@@ -139,6 +139,17 @@ jobs:
           chmod +x /tmp/bb-bin/bb
           echo "BB_PATH=/tmp/bb-bin" >> $GITHUB_ENV
 
+      - name: Build bb.js TypeScript package
+        working-directory: ./barretenberg/ts
+        run: |
+          # Symlink the downloaded bb binary to where generate expects it
+          mkdir -p ../cpp/build/bin
+          ln -sf /tmp/bb-bin/bb ../cpp/build/bin/bb
+          # Install deps, generate bindings, and build ESM output
+          yarn install
+          yarn generate
+          yarn build:esm
+
       - name: Build noir packages
         run: |
           # Initialize noir submodule (required for yarn-project portal dependencies)
@@ -180,8 +191,8 @@ jobs:
           EOF
           chmod +x /tmp/cli-bin/aztec
 
-          # Copy aztec-up from repo (it's a standalone bash script)
-          cp "$GITHUB_WORKSPACE/aztec-up/bin/aztec-up" /tmp/cli-bin/aztec-up
+          # Copy aztec-up from repo (source is under bin/<version>/aztec-up)
+          cp "$GITHUB_WORKSPACE"/aztec-up/bin/*/aztec-up /tmp/cli-bin/aztec-up
           chmod +x /tmp/cli-bin/aztec-up
 
           export PATH="/tmp/cli-bin:${PATH}"

--- a/yarn-project/wallets/package.json
+++ b/yarn-project/wallets/package.json
@@ -44,6 +44,14 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   },
+  "typedocOptions": {
+    "entryPoints": [
+      "./src/embedded/entrypoints/node.ts",
+      "./src/testing.ts"
+    ],
+    "name": "Wallets",
+    "tsconfig": "./tsconfig.json"
+  },
   "files": [
     "dest",
     "src",


### PR DESCRIPTION
## Summary
- Adds a step to build `barretenberg/ts` (bb.js) in the nightly docs workflow before `yarn-project/bootstrap.sh` runs. This ensures `@aztec/bb.js`'s portal dependency resolves correctly so TypeDoc can generate docs for `foundation`, `pxe`, and other packages that depend on it.
- Fixes the `aztec-up` copy path (was `bin/aztec-up`, corrected to `bin/*/aztec-up` to match repo layout).
- Adds `typedocOptions` to the `wallets` package so it gets included in TypeScript API doc generation.

## Details
The nightly docs workflow downloads the native `bb` binary but never builds the `@aztec/bb.js` TypeScript package. Since `yarn-project/foundation` (and others) depend on `@aztec/bb.js` via `portal:../../barretenberg/ts`, TypeDoc fails when it tries to resolve `@aztec/bb.js/dest/node/index.js` — the file doesn't exist.

The fix adds a step between "Download bb" and "Build noir packages" that:
1. Symlinks the downloaded `bb` binary to where `generate` expects it
2. Runs `yarn install` + `yarn generate` + `yarn build:esm` to produce `dest/node/`

Verified locally: all 9/9 TypeScript API packages and 3/3 CLI docs generate successfully.

## Test plan
- [ ] Trigger workflow manually and verify TypeDoc generates docs for all packages (especially foundation and pxe)
- [ ] Verify CLI docs generate (aztec, aztec-up, aztec-wallet)