### PR TITLE
chore: builders audit response 0

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -185,6 +185,9 @@ bool UltraCircuitChecker::check_block(Builder& builder,
             if (!result) {
                 return report_fail("Failed databus read at row idx = ", idx);
             }
+            // Note: EccOpQueueRelation is not checked here because it simply establishes that the ecc_op_wire
+            // polynomials contain copies of the conventional wire data in the ecc_op region (and are zero elsewhere) so
+            // there is nothing to check at the level of the builder.
         }
         if (!result) {
             return report_fail("Failed at row idx = ", idx);

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -109,12 +109,6 @@ template <typename FF> class Selector {
     virtual void set(size_t idx, int value) = 0;
 
     /**
-     * @brief Set the last value using integer.
-     * @param value Integer value.
-     */
-    virtual void set_back(int value) = 0;
-
-    /**
      * @brief Set the value at index using a field element.
      * @param idx Index.
      * @param value Field element.
@@ -144,24 +138,8 @@ template <typename FF> class ZeroSelector : public Selector<FF> {
         size_++;
     }
 
-    void set_back(int value) override
-    {
-        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set_back with a non zero value.");
-        BB_ASSERT_GT(size_, 0U);
-    }
-
-    void set(size_t idx, int value) override
-    {
-        BB_ASSERT_DEBUG(idx < size_);
-        BB_ASSERT_EQ(value, 0, "Calling ZeroSelector::set with a non zero value.");
-    }
-
-    void set(size_t idx, const FF& value) override
-    {
-        BB_ASSERT_DEBUG(idx < size_);
-        BB_ASSERT(value.is_zero());
-        size_++;
-    }
+    void set(size_t, int) override { BB_ASSERT(false, "ZeroSelector::set should not be called"); }
+    void set(size_t, const FF&) override { BB_ASSERT(false, "ZeroSelector::set should not be called"); }
 
     void resize(size_t new_size) override { size_ = new_size; }
 
@@ -196,7 +174,6 @@ template <typename FF> class SlabVectorSelector : public Selector<FF> {
 
     void emplace_back(int i) override { data.emplace_back(i); }
     void push_back(const FF& value) override { data.push_back(value); }
-    void set_back(int value) override { data.back() = value; }
     void set(size_t idx, int i) override { data[idx] = i; }
     void set(size_t idx, const FF& value) override { data[idx] = value; }
     void resize(size_t new_size) override { data.resize(new_size); }

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -242,19 +242,6 @@ template <typename FF, size_t NUM_WIRES_> class ExecutionTraceBlock {
 
     size_t size() const { return std::get<0>(this->wires).size(); }
 
-    void reserve(size_t size_hint)
-    {
-        for (auto& w : wires) {
-            w.reserve(size_hint);
-        }
-        for (auto& p : get_selectors()) {
-            p.reserve(size_hint);
-        }
-#ifdef CHECK_CIRCUIT_STACKTRACES
-        stack_traces.stack_traces.reserve(size_hint);
-#endif
-    }
-
 #ifdef TRACY_HACK_GATES_AS_MEMORY
     ~ExecutionTraceBlock()
     {

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -25,7 +25,7 @@ namespace bb {
  * Subrelation 0 (x-coordinate):
  *   Formula: x3 = lambda^2 - x1 - x2, where lambda = (q_sign * y2 - y1) / (x2 - x1)
  *   Constraint (via cancellation of denominator and assumption that q_sign^2 = 1):
- *      (x3 + x1 + x2)(x2 - x1)^2 - (y2^2 - y1^2 + 2*q_sign*y2*y1) = 0
+ *      (x3 + x1 + x2)(x2 - x1)^2 - (y2^2 + y1^2 - 2*q_sign*y2*y1) = 0
  *
  * Subrelation 1 (y-coordinate):
  *   Formula: y3 = lambda * (x1 - x3) - y1
@@ -42,7 +42,7 @@ namespace bb {
  * Subrelation 1 (y-coordinate):
  *   Formula: y3 = lambda * (x1 - x3) - y1
  *   Constraint:
- *      (y3 + y1)(x2 - x1) + (q_sign*y2 - y1)(x3 - x1) = 0
+ *      (y3 + y1)(2*y1) - (3*x1^2)(x1 - x3) = 0
  *
  * @warning On-curve assumption: The doubling constraint uses the substitution x1^3 = y1^2 - b (the curve equation) to
  * reduce constraint degree. Therefore care must be taken to ensure that points involved in such gates are

--- a/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/memory_relation.hpp
@@ -106,12 +106,12 @@ template <typename FF_> class MemoryRelationImpl {
          *  * i: `index` of memory cell being accessed
          *  * v: `value1` of memory cell being accessed (ROM tables can store up to 2 values per index)
          *  * v2:`value2` of memory cell being accessed (ROM tables can store up to 2 values per index)
-         *  * r: `record` of memory cell. record = index * eta + value2 * η₂ + value1 * η₃
+         *  * r: `record` of memory cell. record = index * eta + value1 * η₂ + value2 * η₃
          *
          *  When performing a read/write access, the values of i, t, v, v2, a, r are stored in the following wires +
          * selectors, depending on whether the gate is a RAM read/write or a ROM read
          *
-         *  | gate type | i  | v2/t  |  v | a  | r  |
+         *  | gate type | i  | v/t   | v2 | a  | r  |
          *  | --------- | -- | ----- | -- | -- | -- |
          *  | ROM       | w1 | w2    | w3 | -- | w4 |
          *  | RAM       | w1 | w2    | w3 | qc | w4 |
@@ -185,7 +185,7 @@ template <typename FF_> class MemoryRelationImpl {
          * RAM Consistency Check
          *
          * The 'access' type of the record is extracted with the expression `w_4 - partial_record_check`
-         * (i.e. for an honest Prover `w1 * η + w2 * η₂ + w3 * η₃ - w4 = access`.
+         * (i.e. for an honest Prover `w1 * η + w2 * η₂ + w3 * η₃ - w4 = -access`.
          * This is validated by requiring `access` to be boolean
          *
          * For two adjacent entries in the sorted list if _both_

--- a/barretenberg/cpp/src/barretenberg/relations/non_native_field_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/non_native_field_relation.hpp
@@ -92,7 +92,7 @@ template <typename FF_> class NonNativeFieldRelationImpl {
 
         // Bigfield Product Gate 2 (selected by q_2 * q_4):
         // Computes cross-term contributions in limb multiplication.
-        // Formula: (w_1 * w_2') + (w_1' * w_2) + (w_1 * w_4 + w_2 * w_3 - w_3') * 2^14 - w_3 - w_4' = 0
+        // Formula: (w_1 * w_2') + (w_1' * w_2) + (w_1 * w_4 + w_2 * w_3 - w_3') * 2^68 - w_3 - w_4' = 0
         // where primed values (') denote shifted wires from the next row.
         auto limb_subproduct = w_1_m * w_2_shift_m + w_1_shift_m * w_2_m;
         auto non_native_field_gate_2_m = (w_1_m * w_4_m + w_2_m * w_3_m - w_3_shift_m);

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
@@ -39,10 +39,10 @@ namespace bb {
  * `GateSeparatorPolynomial`. These contributions are added to the corresponding univariate accumulator \f$ A_i
  * \f$:
  * \f{align}{
- *   A_1 &\;\mathrel{+}=  \text{q_poseidon2_internal}\cdot \big(v_1 - w_{1,\text{shift}}\big) \cdot \hat{g} \\
- *   A_2 &\;\mathrel{+}=  \text{q_poseidon2_internal}\cdot \big(v_1 - w_{1,\text{shift}}\big) \cdot \hat{g} \\
- *   A_3 &\;\mathrel{+}=  \text{q_poseidon2_internal}\cdot \big(v_3 - w_{3,\text{shift}}\big) \cdot \hat{g} \\
- *   A_4 &\;\mathrel{+}=  \text{q_poseidon2_internal}\cdot \big(v_4 - w_{4,\text{shift}}\big) \cdot \hat{g}
+ *   A_1 &\;\mathrel{+}=  \text{q_poseidon2_external}\cdot \big(v_1 - w_{1,\text{shift}}\big) \cdot \hat{g} \\
+ *   A_2 &\;\mathrel{+}=  \text{q_poseidon2_external}\cdot \big(v_2 - w_{2,\text{shift}}\big) \cdot \hat{g} \\
+ *   A_3 &\;\mathrel{+}=  \text{q_poseidon2_external}\cdot \big(v_3 - w_{3,\text{shift}}\big) \cdot \hat{g} \\
+ *   A_4 &\;\mathrel{+}=  \text{q_poseidon2_external}\cdot \big(v_4 - w_{4,\text{shift}}\big) \cdot \hat{g}
  * \f}
  * At the end of each Sumcheck Round, the subrelation accumulators are aggregated with independent challenges
  * \f$\alpha_{i} = \alpha_{i, \text{Poseidon2Ext}}\f$ taken from the array of `SubrelationSeparators`

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -122,6 +122,8 @@ template <typename FF_> class CircuitBuilderBase {
     std::vector<uint32_t> real_variable_tags;
     uint32_t current_tag = DEFAULT_TAG;
 
+    bool circuit_finalized = false;
+
     CircuitBuilderBase(bool is_write_vk_mode = false);
 
     CircuitBuilderBase(const CircuitBuilderBase& other) = default;
@@ -139,7 +141,11 @@ template <typename FF_> class CircuitBuilderBase {
     size_t num_gates() const { return _num_gates; }
 
     // Increment the gate count by the specified amount
-    void increment_num_gates(size_t count = 1) { _num_gates += count; }
+    void increment_num_gates(size_t count = 1)
+    {
+        BB_ASSERT_DEBUG(!circuit_finalized, "Cannot add gates after circuit is finalized");
+        _num_gates += count;
+    }
 
     // Get the permutation on variable tags
     const std::unordered_map<uint32_t, uint32_t>& tau() const { return _tau; }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -257,12 +257,6 @@ template <typename FF_> class CircuitBuilderBase {
      */
     virtual void set_variable_name(uint32_t index, const std::string& name);
 
-    /**
-     * @brief Export the existing circuit as msgpack compatible buffer
-     * @return msgpack compatible buffer
-     */
-    virtual msgpack::sbuffer export_circuit();
-
     bool failed() const;
     const std::string& err() const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -76,12 +76,6 @@ template <typename FF_> size_t CircuitBuilderBase<FF_>::get_circuit_subgroup_siz
     return 1UL << log2_n;
 }
 
-template <typename FF_> msgpack::sbuffer CircuitBuilderBase<FF_>::export_circuit()
-{
-    info("not implemented");
-    return { 0 };
-}
-
 template <typename FF_> uint32_t CircuitBuilderBase<FF_>::add_public_variable(const FF& in)
 {
     const uint32_t index = add_variable(in);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -92,6 +92,7 @@ template <typename FF_> uint32_t CircuitBuilderBase<FF_>::add_public_variable(co
 
 template <typename FF_> uint32_t CircuitBuilderBase<FF_>::set_public_input(const uint32_t witness_index)
 {
+    BB_ASSERT_LT(witness_index, get_num_variables(), "set_public_input: witness_index out of range");
     for (const uint32_t public_input : public_inputs()) {
         if (public_input == witness_index) {
             if (!failed()) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/plookup_tables/keccak/keccak_rho.hpp
@@ -269,7 +269,10 @@ template <size_t TABLE_BITS = 0, size_t LANE_INDEX = 0> class Rho {
             }
 
             table.slice_sizes.push_back(scaled_base);
-            table.get_table_values.emplace_back(&get_rho_renormalization_values);
+            // N.B. must use Rho<bit_slice> (not the unqualified get_rho_renormalization_values) so that
+            // the function pointer's MSB divisor (11^(bit_slice-1)) matches this sub-table's actual size.
+            // The enclosing class's version uses 11^(TABLE_BITS-1) which is wrong when bit_slice != TABLE_BITS.
+            table.get_table_values.emplace_back(&Rho<bit_slice>::get_rho_renormalization_values);
             table.basic_table_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
         });
 
@@ -289,7 +292,8 @@ template <size_t TABLE_BITS = 0, size_t LANE_INDEX = 0> class Rho {
             }
 
             table.slice_sizes.push_back(scaled_base);
-            table.get_table_values.emplace_back(&get_rho_renormalization_values);
+            // See right-slice comment above re: Rho<bit_slice>.
+            table.get_table_values.emplace_back(&Rho<bit_slice>::get_rho_renormalization_values);
             table.basic_table_ids.push_back((BasicTableId)((size_t)KECCAK_RHO_1 + (bit_slice - 1)));
         });
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -51,7 +51,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::finalize_circuit(const bool ensure_no
      * Therefore, we introduce a boolean flag `circuit_finalized` here. Once we add the rom and range gates,
      * our circuit is finalized, and we must not to execute these functions again.
      */
-    if (!circuit_finalized) {
+    if (!this->circuit_finalized) {
         if (ensure_nonzero) {
             add_gates_to_ensure_all_polys_are_non_zero();
         }
@@ -62,7 +62,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::finalize_circuit(const bool ensure_no
         process_range_lists();
 #endif
         populate_public_inputs_block();
-        circuit_finalized = true;
+        this->circuit_finalized = true;
     } else {
         // Gates added after first call to finalize will not be processed since finalization is only performed once
         info("WARNING: Redundant call to finalize_circuit(). Is this intentional?");

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -677,7 +677,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     // ========================================================================================
 
-    msgpack::sbuffer export_circuit() override;
+    msgpack::sbuffer export_circuit();
 };
 using UltraCircuitBuilder = UltraCircuitBuilder_<UltraExecutionTraceBlocks>;
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -211,8 +211,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     std::vector<cached_partial_non_native_field_multiplication> cached_partial_non_native_field_multiplications;
 
-    bool circuit_finalized = false;
-
     std::vector<fr> ipa_proof;
 
     void populate_public_inputs_block();
@@ -364,7 +362,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      */
     size_t get_num_finalized_gates() const override
     {
-        BB_ASSERT(circuit_finalized);
+        BB_ASSERT(this->circuit_finalized);
         return this->num_gates();
     }
 
@@ -407,7 +405,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      */
     size_t get_finalized_total_circuit_size() const
     {
-        BB_ASSERT(circuit_finalized);
+        BB_ASSERT(this->circuit_finalized);
         auto num_filled_gates = get_num_finalized_gates() + this->num_public_inputs();
         return std::max(get_tables_size(), num_filled_gates);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -207,7 +207,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     std::vector<uint32_t> memory_read_records;
     // Stores gate index of RAM writes (required by proving key)
     std::vector<uint32_t> memory_write_records;
-    std::map<uint64_t, RangeList> range_lists; // DOCTODO: explain this.
+    // Range constraints to be batched, keyed by target_range. See create_small_range_constraint() for details.
+    std::map<uint64_t, RangeList> range_lists;
 
     std::vector<cached_partial_non_native_field_multiplication> cached_partial_non_native_field_multiplications;
 
@@ -307,7 +308,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     /**
      * @brief Range-constraints for small ranges, where the upper bound (`target_range`) need not be dyadic. Max
      * possible value is 2^16 - 1. Adds variable to a RangeList for batched processing.
-     * @details Constrains variable to [0, target_range], where `target_range < 2^14`. The constraint is deferred:
+     * @details Constrains variable to [0, target_range], where `target_range <= MAX_SMALL_RANGE_CONSTRAINT_VAL`
+     * (2^16 - 1). The constraint is deferred:
      * variables are collected into RangeLists (grouped by target_range), then processed together in
      * `process_range_lists()` which creates the actual delta-range gates. This batching is efficient because multiple
      * variables sharing the same range can share the "staircase" of multiples-of-3 values.


### PR DESCRIPTION
Response to ultra/mega builder ext audit:

Issue 1: CircuitChecker does not check EccOpQueueRelation
- Resolution: Intentional. Added explanatory comment

Issue 2: Disabled asserts in wasm allow invalid circuit construction
- No updates at this time

Issue 3: set_public_input allows out-of-bounds access
- Resolution: Added protective assert

Issue 4: No guard against post-finalization gate addition
- Resolution: added protective assert in key gate creation method `increment_num_gates`

Issue 5: bug in ZeroSelector::set()
- Resolution: Method was deleted (unused)

Issue 6: export_circuit returns empty buffer
- Resolution: Root cause was unnecessary inheritance structure. Removed that structure so this problem goes away

Issue 7: bug in ExecutionTraceBlock::reserve()
- Resolution: Method was deleted (unused)

Issue 8: bad function pointer in Keccak rho multitable
- Resolution: Corrected function pointer (but continues to be unused code)

Note: also addresses several comment correctness issues raised during the audit (particularly in relations) 