### PR TITLE
refactor: cleaning up construction of SiloedTag

### DIFF
--- a/yarn-project/pxe/src/logs/log_service.ts
+++ b/yarn-project/pxe/src/logs/log_service.ts
@@ -47,7 +47,7 @@ export class LogService {
       logRetrievalRequests.map(async request => {
         const [publicLog, privateLog] = await Promise.all([
           this.#getPublicLogByTag(request.tag, request.contractAddress),
-          this.#getPrivateLogByTag(await SiloedTag.compute(request.tag, request.contractAddress)),
+          this.#getPrivateLogByTag(await SiloedTag.computeFromTagAndApp(request.tag, request.contractAddress)),
         ]);
 
         if (publicLog !== null && privateLog !== null) {

--- a/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
+++ b/yarn-project/pxe/src/tagging/get_all_logs_by_tags.test.ts
@@ -21,7 +21,7 @@ describe('getAllPrivateLogsByTags', () => {
 
   beforeAll(async () => {
     tags = await Promise.all(
-      [1, 2, 3].map(async () => SiloedTag.compute(new Tag(Fr.random()), await AztecAddress.random())),
+      [1, 2, 3].map(async () => SiloedTag.computeFromTagAndApp(new Tag(Fr.random()), await AztecAddress.random())),
     );
   });
 

--- a/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/load_private_logs_for_sender_recipient_pair.test.ts
@@ -4,7 +4,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { type ExtendedDirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
+import { type ExtendedDirectionalAppTaggingSecret, SiloedTag } from '@aztec/stdlib/logs';
 import {
   makeBlockHeader,
   makeL2Tips,
@@ -31,9 +31,8 @@ describe('loadPrivateLogsForSenderRecipientPair', () => {
 
   const currentTimestamp = BigInt(Math.floor(Date.now() / 1000));
 
-  async function computeSiloedTagForIndex(index: number) {
-    const tag = await Tag.compute({ extendedSecret: secret, index });
-    return SiloedTag.compute(tag, secret.app);
+  function computeSiloedTagForIndex(index: number) {
+    return SiloedTag.compute({ extendedSecret: secret, index });
   }
 
   function makeLog(blockNumber: number, blockTimestamp: bigint, tag: Fr) {

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.test.ts
@@ -1,7 +1,7 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { type ExtendedDirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
+import { type ExtendedDirectionalAppTaggingSecret, SiloedTag } from '@aztec/stdlib/logs';
 import { randomExtendedDirectionalAppTaggingSecret, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 import { TxHash } from '@aztec/stdlib/tx';
 
@@ -20,9 +20,8 @@ describe('loadLogsForRange', () => {
 
   let aztecNode: MockProxy<AztecNode>;
 
-  async function computeSiloedTagForIndex(index: number) {
-    const tag = await Tag.compute({ extendedSecret: secret, index });
-    return SiloedTag.compute(tag, secret.app);
+  function computeSiloedTagForIndex(index: number) {
+    return SiloedTag.compute({ extendedSecret: secret, index });
   }
 
   function makeLog(txHash: TxHash, blockNumber: number, blockTimestamp: bigint, tag: SiloedTag) {

--- a/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
+++ b/yarn-project/pxe/src/tagging/recipient_sync/utils/load_logs_for_range.ts
@@ -1,8 +1,8 @@
 import type { BlockNumber } from '@aztec/foundation/branded-types';
 import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
-import type { ExtendedDirectionalAppTaggingSecret, PreTag, TxScopedL2Log } from '@aztec/stdlib/logs';
-import { SiloedTag, Tag } from '@aztec/stdlib/logs';
+import type { ExtendedDirectionalAppTaggingSecret, TxScopedL2Log } from '@aztec/stdlib/logs';
+import { SiloedTag } from '@aztec/stdlib/logs';
 
 import { getAllPrivateLogsByTags } from '../../get_all_logs_by_tags.js';
 
@@ -19,12 +19,9 @@ export async function loadLogsForRange(
   anchorBlockNumber: BlockNumber,
   anchorBlockHash: BlockHash,
 ): Promise<Array<{ log: TxScopedL2Log; taggingIndex: number }>> {
-  // Derive tags for the window
-  const preTags: PreTag[] = Array(end - start)
-    .fill(0)
-    .map((_, i) => ({ extendedSecret, index: start + i }));
-  const siloedTags = await Promise.all(preTags.map(preTag => Tag.compute(preTag))).then(tags =>
-    Promise.all(tags.map(tag => SiloedTag.compute(tag, extendedSecret.app))),
+  // Derive siloed tags for the window
+  const siloedTags = await Promise.all(
+    Array.from({ length: end - start }, (_, i) => SiloedTag.compute({ extendedSecret, index: start + i })),
   );
 
   // We use the utility function below to retrieve all logs for the tags across all pages, so we don't need to handle
@@ -35,7 +32,7 @@ export async function loadLogsForRange(
   const logsWithIndexes: Array<{ log: TxScopedL2Log; taggingIndex: number }> = [];
   for (let i = 0; i < logs.length; i++) {
     const logsForTag = logs[i];
-    const taggingIndex = preTags[i].index;
+    const taggingIndex = start + i;
     for (const log of logsForTag) {
       if (log.blockNumber <= anchorBlockNumber) {
         logsWithIndexes.push({ log, taggingIndex });

--- a/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/sync_sender_tagging_indexes.test.ts
@@ -12,7 +12,6 @@ import { SenderTaggingStore } from '../../storage/tagging_store/sender_tagging_s
 import {
   type ExtendedDirectionalAppTaggingSecret,
   SiloedTag,
-  Tag,
   UNFINALIZED_TAGGING_INDEXES_WINDOW_LEN,
 } from '../index.js';
 import { syncSenderTaggingIndexes } from './sync_sender_tagging_indexes.js';
@@ -26,9 +25,8 @@ describe('syncSenderTaggingIndexes', () => {
   let aztecNode: MockProxy<AztecNode>;
   let taggingStore: SenderTaggingStore;
 
-  async function computeSiloedTagForIndex(index: number) {
-    const tag = await Tag.compute({ extendedSecret: secret, index });
-    return SiloedTag.compute(tag, secret.app);
+  function computeSiloedTagForIndex(index: number) {
+    return SiloedTag.compute({ extendedSecret: secret, index });
   }
 
   function makeLog(txHash: TxHash, tag: Fr) {

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.test.ts
@@ -2,7 +2,7 @@ import type { Fr } from '@aztec/foundation/curves/bn254';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import { type ExtendedDirectionalAppTaggingSecret, SiloedTag, Tag } from '@aztec/stdlib/logs';
+import { type ExtendedDirectionalAppTaggingSecret, SiloedTag } from '@aztec/stdlib/logs';
 import { randomExtendedDirectionalAppTaggingSecret, randomTxScopedPrivateL2Log } from '@aztec/stdlib/testing';
 import { TxHash } from '@aztec/stdlib/tx';
 
@@ -20,9 +20,8 @@ describe('loadAndStoreNewTaggingIndexes', () => {
   let aztecNode: MockProxy<AztecNode>;
   let taggingStore: SenderTaggingStore;
 
-  async function computeSiloedTagForIndex(index: number) {
-    const tag = await Tag.compute({ extendedSecret: secret, index });
-    return SiloedTag.compute(tag, secret.app);
+  function computeSiloedTagForIndex(index: number) {
+    return SiloedTag.compute({ extendedSecret: secret, index });
   }
 
   function makeLog(txHash: TxHash, tag: Fr) {

--- a/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
+++ b/yarn-project/pxe/src/tagging/sender_sync/utils/load_and_store_new_tagging_indexes.ts
@@ -1,7 +1,7 @@
 import type { BlockHash } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/server';
-import type { ExtendedDirectionalAppTaggingSecret, PreTag } from '@aztec/stdlib/logs';
-import { SiloedTag, Tag } from '@aztec/stdlib/logs';
+import type { ExtendedDirectionalAppTaggingSecret } from '@aztec/stdlib/logs';
+import { SiloedTag } from '@aztec/stdlib/logs';
 import { TxHash } from '@aztec/stdlib/tx';
 
 import type { SenderTaggingStore } from '../../../storage/tagging_store/sender_tagging_store.js';
@@ -29,15 +29,12 @@ export async function loadAndStoreNewTaggingIndexes(
   jobId: string,
 ) {
   // We compute the tags for the current window of indexes
-  const preTagsForWindow: PreTag[] = Array(end - start)
-    .fill(0)
-    .map((_, i) => ({ extendedSecret, index: start + i }));
   const siloedTagsForWindow = await Promise.all(
-    preTagsForWindow.map(async preTag => SiloedTag.compute(await Tag.compute(preTag), extendedSecret.app)),
+    Array.from({ length: end - start }, (_, i) => SiloedTag.compute({ extendedSecret, index: start + i })),
   );
 
   const txsForTags = await getTxsContainingTags(siloedTagsForWindow, aztecNode, anchorBlockHash);
-  const highestIndexMap = getTxHighestIndexMap(txsForTags, preTagsForWindow);
+  const highestIndexMap = getTxHighestIndexMap(txsForTags, start, siloedTagsForWindow.length);
 
   // Now we iterate over the map, reconstruct the preTags and tx hash and store them in the db.
   for (const [txHashStr, highestIndex] of highestIndexMap.entries()) {
@@ -60,16 +57,14 @@ async function getTxsContainingTags(
 }
 
 // Returns a map of txHash to the highest index for that txHash.
-function getTxHighestIndexMap(txHashesForTags: TxHash[][], preTagsForWindow: PreTag[]): Map<string, number> {
-  if (txHashesForTags.length !== preTagsForWindow.length) {
-    throw new Error(
-      `Number of tx hashes arrays does not match number of pre-tags. ${txHashesForTags.length} !== ${preTagsForWindow.length}`,
-    );
+function getTxHighestIndexMap(txHashesForTags: TxHash[][], start: number, count: number): Map<string, number> {
+  if (txHashesForTags.length !== count) {
+    throw new Error(`Number of tx hashes arrays does not match number of tags. ${txHashesForTags.length} !== ${count}`);
   }
 
   const highestIndexMap = new Map<string, number>();
   for (let i = 0; i < txHashesForTags.length; i++) {
-    const taggingIndex = preTagsForWindow[i].index;
+    const taggingIndex = start + i;
     const txHashesForTag = txHashesForTags[i];
     for (const txHash of txHashesForTag) {
       const key = txHash.toString();

--- a/yarn-project/stdlib/src/logs/siloed_tag.ts
+++ b/yarn-project/stdlib/src/logs/siloed_tag.ts
@@ -4,7 +4,8 @@ import type { ZodFor } from '@aztec/foundation/schemas';
 import type { AztecAddress } from '../aztec-address/index.js';
 import { computeSiloedPrivateLogFirstField } from '../hash/hash.js';
 import { schemas } from '../schemas/schemas.js';
-import type { Tag } from './tag.js';
+import type { PreTag } from './pre_tag.js';
+import { Tag } from './tag.js';
 
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 
@@ -21,7 +22,12 @@ export interface SiloedTag {
 export class SiloedTag {
   constructor(public readonly value: Fr) {}
 
-  static async compute(tag: Tag, app: AztecAddress): Promise<SiloedTag> {
+  static async compute(preTag: PreTag): Promise<SiloedTag> {
+    const tag = await Tag.compute(preTag);
+    return SiloedTag.computeFromTagAndApp(tag, preTag.extendedSecret.app);
+  }
+
+  static async computeFromTagAndApp(tag: Tag, app: AztecAddress): Promise<SiloedTag> {
     const siloedTag = await computeSiloedPrivateLogFirstField(app, tag.value);
     return new SiloedTag(siloedTag);
   }


### PR DESCRIPTION
Constructor funcs of `SiloedTag` didn't reflect how we most commonly wanted to construct the thing - in most cases we wanted to build it from PreTag but we only accepted `Tag` and `app` on the input. For this reason I created a new function that accepts the `PreTag`. Note that this PR became possible with the PR down the stack as before that we didn't have access to the `app` address in the `PreTag`.