### PR TITLE
fix(e2e): fix off-by-one in block building timetable test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -137,7 +137,7 @@ describe('e2e_block_building', () => {
       const receipts = await Promise.all(txHashes.map(txHash => waitForTx(aztecNode, txHash)));
       const blockNumbers = receipts.map(r => r.blockNumber!).sort((a, b) => a - b);
       logger.info(`Txs mined on blocks: ${unique(blockNumbers)}`);
-      expect(blockNumbers.at(-1)! - blockNumbers[0]).toBeGreaterThan(EXPECTED_BLOCKS - 1);
+      expect(blockNumbers.at(-1)! - blockNumbers[0]).toBeGreaterThanOrEqual(EXPECTED_BLOCKS - 1);
     });
 
     it('assembles a block with multiple txs', async () => {


### PR DESCRIPTION
## Summary
- Fixes flaky `processes txs until hitting timetable` test in `e2e_block_building`
- The test sends 11 txs with a fake delay allowing 5 per block, yielding exactly 3 blocks (span of 2). The assertion used `toBeGreaterThan(2)` instead of `toBeGreaterThanOrEqual(2)`, causing intermittent failures when the block span was exactly the expected minimum.
- Off-by-one introduced in #19252

## Test plan
- The fix is a single assertion change (`toBeGreaterThan` -> `toBeGreaterThanOrEqual`), no build impact
- CI run of `e2e_block_building` should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)