### PR TITLE
fix: cross-compile avm-transpiler for arm64-linux in release builds

### DIFF
--- a/avm-transpiler/bootstrap.sh
+++ b/avm-transpiler/bootstrap.sh
@@ -39,6 +39,9 @@ function build_cross {
     # Determine rust target outside of subshell
     local rust_target
     case "$target" in
+      arm64-linux)
+        rust_target=aarch64-unknown-linux-gnu
+        ;;
       amd64-macos)
         rust_target=x86_64-apple-darwin
         ;;
@@ -75,6 +78,7 @@ function build {
   if [ "$CI_FULL" -eq 1 ]; then
     build_cross amd64-macos
     build_cross arm64-macos
+    build_cross arm64-linux
   fi
 }
 

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -496,7 +496,8 @@
       },
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Linux",
-        "TARGET_ARCH": "generic"
+        "TARGET_ARCH": "generic",
+        "AVM_TRANSPILER_LIB": "${sourceDir}/../../avm-transpiler/target/aarch64-unknown-linux-gnu/release/libavm_transpiler.a"
       }
     },
     {


### PR DESCRIPTION
## Summary

- `zig-arm64-linux` CMake preset was missing `AVM_TRANSPILER_LIB`
- `avm-transpiler/bootstrap.sh` had no `arm64-linux` case in `build_cross`

This adds `arm64-linux` cross-compilation to avm-transpiler (triggered on release via `semver check`) and wires up the `zig-arm64-linux` preset to the resulting library.