### PR TITLE
fix(avm)!: bitwise pre-audit

### DIFF
--- a/barretenberg/cpp/pil/vm2/bitwise.pil
+++ b/barretenberg/cpp/pil/vm2/bitwise.pil
@@ -2,6 +2,62 @@ include "precomputed.pil";
 include "constants_gen.pil";
 
 /**
+ * The bitwise trace performs AND/OR/XOR operations on non-FF types. It does
+ * this by decomposing the inputs into 8-bit chunks and looks up the resulting
+ * chunk of the operation in the precomputed bitwise table. The final output is
+ * the accumulation of these result chunks.
+ * The precomputed bitwise table contains the results of all combinations of
+ * bitwise operations for 8-bit values. These values are stored as a tuple of
+ * <input_a, input_b, output_and, output_or, output_xor>.
+ * ERROR HANDLING:
+ * The possible errors for this subtrace relate to the AVM memory tag:
+ * 1) Either of the inputs tags is of type FF
+ * 2) The inputs do not have the same tag.
+ * In either case, we do not attempt to perform the bitwise operation.
+ *
+ * N.B The "controlling" selector that drives the computation of the bitwise operation
+ * is NOT the `sel` column but in fact the `start` column, which is in turn driven by `ctr` !=0.
+ * For error handling, err = 1, we do the following:
+ * (1) Set last = 1, this turns off the propagation / decrementing of values to subsequent rows
+ * (2) Set ctr = 0, this turns off `sel` which turns off most constraints including the lookups
+ *
+ * N.B for (2), ctr is constrained to be either 0 or 1 on error rows (although 0 is optimal
+ * for the prover). If ctr != 0, then #[BITW_SEL_CTR_NON_ZERO] forces sel = 1, and combined
+ * with last = 1 (from err), #[BITW_LAST_FOR_CTR_ONE] forces ctr = 1. Setting ctr = 1 would
+ * needlessly activate the #[BYTE_OPERATIONS] lookup, but the prover cannot prevent the
+ * propagation of the error flag to execution. Therefore, any additional work incurred
+ * (by not setting ctr to 0) is wasted since the result will be discarded by the execution trace.
+ *
+ * Trace example for a AND b == c of type u32
+ * a = 0x52488425
+ * b = 0xC684486C
+ * c = 0x42000024
+ * +-----+-----+-------+------+------------+------------+------------+---------+---------+---------+
+ * | ctr | sel | start | last |   acc_ia   |   acc_ib   |   acc_ic   | ia_byte | ib_byte | ic_byte |
+ * +-----+-----+-------+------+------------+------------+------------+---------+---------+---------+
+ * |   4 |   1 |     1 |    0 | 0x52488425 | 0xC684486C | 0x42000024 |    0x25 |    0x6C |    0x24 |
+ * |   3 |   1 |     0 |    0 |   0x524884 |   0xC68448 |   0x420000 |    0x84 |    0x48 |    0x00 |
+ * |   2 |   1 |     0 |    0 |     0x5248 |     0xC684 |     0x4200 |    0x48 |    0x84 |    0x00 |
+ * |   1 |   1 |     0 |    1 |       0x52 |       0xC6 |       0x42 |    0x52 |    0xC6 |    0x42 |
+ * +-----+-----+-------+------+------------+------------+------------+---------+---------+---------+
+ *
+ * Trace example for an ERROR case (tag mismatch: a is U16, b is U32)
+ * The error case generates a single row with start=1, last=1, sel=0, err=1.
+ * Since sel=0, the byte operations lookup and counter decrement are disabled.
+ * The accumulator init constraint (last=1) still applies, requiring acc_* = *_byte.
+ * +-----+-----+-------+------+-----+----------------------+--------+-------+-------+-------+
+ * | ctr | sel | start | last | err | sel_tag_mismatch_err | acc_ia | tag_a | tag_b | tag_c |
+ * +-----+-----+-------+------+-----+----------------------+--------+-------+-------+-------+
+ * |  0  |  0  |   1   |  1   |  1  |          1           | a_val  |   3   |   4   | 0(FF) |
+ * +-----+-----+-------+------+-----+----------------------+--------+-------+-------+-------+
+ *
+ * IMPORTANT: Row 0 sentinel
+ * When the trace is non-empty, tracegen sets last=1 at row 0 (with all other columns as 0).
+ * This is critical because constraints like #[BITW_OP_ID_REL] and #[BITW_ACC_REL_*] use
+ * (1 - last) as a guard. At row 0, shifted columns reference row 1. Without last=1 at row 0,
+ * these constraints would force op_id_0 = op_id_1 and acc_ia_1 = 0, breaking the first
+ * event's trace.
+ *
  * ==============================
  * INVOCATION WITH ERROR HANDLING
  * ==============================
@@ -39,45 +95,9 @@ include "constants_gen.pil";
  * Note that the order of the tuple columns might differ though. As long as the correct columns
  * are passed, the usage is sound.
  *
- *
- * The bitwise trace performs AND/OR/XOR operations on non-FF types. It does
- * this by decomposing the inputs into 8-bit chunks and looks up the resulting
- * chunk of the operation in the precomputed bitwise table. The final output is
- * the accumulation of these result chunks.
- * The precomputed bitwise table contains the results of all combinations of
- * bitwise operations for 8-bit values. These values are stored as a tuple of
- * <id, input_a, input_b, output_c>  where id is either AND/OR/XOR.
- * ERROR HANDLING:
- * The possible errors for this subtrace relate to the AVM memory tag:
- * 1) Either of the inputs tags is of type FF
- * 2) The inputs do not have the same tag.
- * In either case, we do not attempt to perform the bitwise operation.
- *
- * N.B The "controlling" selector that drives the computation of the bitwise operation
- * is NOT the `sel` column but in fact the `start` column, which is in turn driven by `ctr` !=0.
- * For error handling, err = 1, we do the following:
- * (1) Set last = 1, this turns off the propagation / decrementing of values to subsequent rows
- * (2) Set ctr = 0, this turns off `sel` which turns off most constraints including the lookups
- *
- * N.B for (2), ctr is technically left unconstrained (although 0 is optimal for the prover).
- * Since it is unconstrained, a prover is free to set ctr to any value, but
- * they cannot prevent the propagation of the error flag to execution. Therefore,
- * any additional work incurred (by not setting ctr to 0) is wasted since the result
- * will be discarded by the execution trace.
  */
 
 namespace bitwise;
-
-// Trace example for a AND b == c of type u32
-// a = 0x52488425
-// b = 0xC684486C (We omit acc_ib and ic_byte as it follows the very same behavior as for a and c)
-// c = 0x42000024
-//
-//   ctr   sel   start   last       acc_ia     acc_ic     ia_byte     ic_byte
-//    4     1      1      0       0x52488425  0x42000024    0x25        0x24
-//    3     1      0      0       0x524884    0x420000      0x84        0x00
-//    2     1      0      0       0x5248      0x4200        0x48        0x00
-//    1     1      0      1       0x52        0x42          0x52        0x42
 
 // Selector for Bitwise Operation
 pol commit sel; // @boolean
@@ -87,8 +107,28 @@ sel * (1 - sel) = 0;
 #[skippable_if]
 sel + last = 0;
 
-pol commit start; // @boolean Identifies when we want to capture the output to the main trace.
-// Must be constrained as a boolean as any selector used in a lookup/permutation.
+// NOTE on trace continuity:
+// Unlike gadgets following the standard multi-row recipe (e.g., emit_public_log.pil which uses
+// an explicit TRACE_CONTINUITY constraint), this subtrace enforces block integrity implicitly
+// via the counter logic:
+// - #[BITW_SEL_CTR_NON_ZERO]: sel <=> ctr != 0 (sel stays active while ctr > 0)
+// - #[BITW_CTR_DECREMENT]: ctr decrements by exactly 1 each row (within active blocks)
+// - #[BITW_LAST_FOR_CTR_ONE]: last <=> ctr == 1 (block terminates when ctr reaches 1)
+// Together, once a block starts (ctr = TAG_LEN), it MUST complete its full counter sequence.
+// A prover cannot "turn off" sel mid-block without violating one of these constraints.
+//
+// NOTE on start selector:
+// Unlike emit_public_log.pil's #[START_AFTER_LATCH], there is no constraint preventing
+// start=1 on non-first rows within a block. This is safe because:
+// (1) The execution dispatch is a lookup INTO bitwise using bitwise.start as the destination
+//     selector. Extra start=1 rows are just unclaimed destinations -- harmless.
+// (2) Keccak/sha256 use separate selectors (start_keccak/start_sha256) protected by
+//     #[BITW_START_ONLY_WHEN_SEL].
+// (3) Setting start=1 on a middle row triggers #[INTEGRAL_TAG_LENGTH] lookup, which would fail
+//     because ctr at that row would not match the tag's byte length.
+
+// The start of the computation, used as a selector by a caller.
+pol commit start; // @boolean
 start * (1 - start) = 0;
 
 // This is used to decouple generation of inverses of lookups into this trace.
@@ -111,7 +151,7 @@ start_sha256 * (1 - start_sha256) = 0;
 // This decrementing counter goes from [TAG_LEN, 0] where TAG_LEN is the number of bytes in the
 // corresponding integer. i.e. TAG_LEN is between 1 (U1/U8) and 16 (U128).
 // Consistency can be achieved with a lookup table between the tag and precomputed.tag_byte_length
-pol commit ctr;
+pol commit ctr; // when err=1, last=1 forces ctr in {0,1} via BITW_LAST_FOR_CTR_ONE; 0 is optimal
 
 // The error flags for this subtrace
 pol commit sel_tag_ff_err; // @boolean
@@ -128,14 +168,17 @@ last * (1 - last) = 0;
 #[LAST_ON_ERROR] // last = 1 if err = 1
 err * (last - 1) = 0;
 
-/////////////////////////////////
+////////////////////////////////////////////////
 // Tag Checking / Error Handling
-/////////////////////////////////
+////////////////////////////////////////////////
 // The checks that need to be performed are: (1) the tags are not FF, and (2) that the input tags are the same.
 // We can simplify (1) by just checking that tag_a != FF. It can be observed
 // that we don't need to also check that tag_b != FF since it follows from the the tag check of (2)
 
-// These are the tags {1,2,3,4,5,6} of the inputs (restricted to not be a field)
+// These are the tags {1,2,3,4,5,6} of the inputs (restricted to not be a field).
+// @unconstrained-on-non-start: tag_a, tag_b, tag_c are only constrained when start=1
+// (via tag checking relations and the execution dispatch lookup). On non-start rows,
+// these columns are free. Tracegen sets them to 0 on non-start rows.
 pol commit tag_a;
 pol commit tag_b;
 pol commit tag_c; // This is the tag of the result
@@ -159,30 +202,33 @@ pol commit tag_ab_diff_inv;
 #[INPUT_TAGS_SHOULD_MATCH]
 start * (TAG_AB_DIFF * ((1 - sel_tag_mismatch_err) * (1 - tag_ab_diff_inv) + tag_ab_diff_inv) - sel_tag_mismatch_err) = 0;
 
-/////////////////////////////////
+////////////////////////////////////////////////
 // Begin Executing Bitwise ops
-/////////////////////////////////
+////////////////////////////////////////////////
 // Byte recomposition column, the value in these columns are part of the equivalence
-// check to main wherever Start is set to 1.
+// check to main wherever start is set to 1.
 pol commit acc_ia;
 pol commit acc_ib;
 pol commit acc_ic;
 
 // Little Endian bitwise decomposition of accumulators (which are processed top-down),
-// constrained to be U8 given by the lookup to the byte_lookup
+// constrained to be U8 via the #[BYTE_OPERATIONS] lookup (gated by sel).
+// @unconstrained-on-error: when sel=0 (error rows), these columns are not range-checked to U8.
+// This is safe because the byte lookup is disabled and the values only appear in
+// #[BITW_INIT_*] (gated by last) to set acc_* values.
 pol commit ia_byte;
 pol commit ib_byte;
 pol commit ic_byte;
 
 // Selectors for bitwise operations, constrained from subtrace_operation_id from execution trace
-// Op Id is restricted to be the same during the same computation (i.e. between Starts)
 pol commit op_id;
 
-#[BITW_OP_ID_REL]
+// Op Id is restricted to be the same during the same computation (i.e. between starts)
+#[BITW_OP_ID_REL_CONTINUITY]
 (op_id' - op_id) * (1 - last) = 0;
 
-#[BITW_CTR_DECREMENT]
 // Note: sel factor is required for an empty row to satisfy this relation
+#[BITW_CTR_DECREMENT]
 sel * (ctr' - ctr + 1) * (1 - last) = 0;
 
 // sel is set to 1 if and only if ctr != 0. (and sel == 0 <==> ctr == 0)
@@ -199,7 +245,7 @@ pol commit ctr_min_one_inv;
 #[BITW_LAST_FOR_CTR_ONE]
 sel * ((ctr - 1) * (last * (1 - ctr_min_one_inv) + ctr_min_one_inv) + last - 1) = 0;
 
-// Forces accumulator to initialize with ia_byte, ib_byte, and ic_byte
+// Forces accumulator to initialize with ia_byte, ib_byte, and ic_byte (the MSB)
 #[BITW_INIT_A]
 last * (acc_ia - ia_byte) = 0;
 #[BITW_INIT_B]
@@ -215,10 +261,11 @@ last * (acc_ic - ic_byte) = 0;
 (acc_ic - ic_byte - 256 * acc_ic') * (1 - last) = 0;
 
 // If we encounter an error, we do not want to perform a lookup to retrieve ctr.
-// In the case of an error, ctr is unconstrained (ideally set to 0).
 pol commit sel_get_ctr; // @boolean
 sel_get_ctr = start * (1 - err);
 
+// Lookup to verify that ctr matches the expected byte length for the given tag.
+// Only active on non-error start rows
 #[INTEGRAL_TAG_LENGTH]
 sel_get_ctr { tag_a, ctr }
 in
@@ -230,16 +277,24 @@ pol commit sel_xor;
 sel_and * (1 - sel_and) = 0;
 sel_or * (1 - sel_or) = 0;
 sel_xor * (1 - sel_xor) = 0;
-// op_id dispatch for byte operations
+
+// op_id dispatch for byte operations.
+// Note: there is no explicit constraint sel_and + sel_or + sel_xor = 1 when sel=1.
+// Exclusivity is implicit because the constants {1, 2, 4} are distinct powers of 2,
+// and sel_and, sel_or, sel_xor are booleans. Any multi-selector activation gives an op_id
+// in {3, 5, 6, 7}, which cannot match the valid execution dispatch op_ids {1, 2, 4}.
 sel * op_id = sel_and * constants.AVM_BITWISE_AND_OP_ID
             + sel_or * constants.AVM_BITWISE_OR_OP_ID
             + sel_xor * constants.AVM_BITWISE_XOR_OP_ID;
 
+// @unconstrained-on-error: when sel=0 (error rows), these columns are not range-checked.
 pol commit output_and;
 pol commit output_or;
 pol commit output_xor;
 
 // We fetch all the byte operations in one lookup for efficiency purposes.
+// This lookup constrains ia_byte, ib_byte to be U8 and output_and/or/xor to be the correct
+// byte-level results for the given inputs. Only active when sel=1 (computation rows).
 #[BYTE_OPERATIONS]
 sel {
      ia_byte, ib_byte,
@@ -252,48 +307,3 @@ sel {
 // Dispatch the relevant output value to the output.
 ic_byte = sel_and * output_and + sel_or * output_or + sel_xor * output_xor;
 
-// Potential improvements: See the following paragraphs
-
-// ################################################
-// Alternative implementation as potential speed-up
-// ################################################
-//
-// In vm1, we had an approach which requires one extra row per bitwise operation but
-// had 2 less columns and #[BITW_CTR_DECREMENT] would have degree 0 and the degree 4 relation
-// #[BITW_LAST_FOR_CTR_ONE] is not present.
-// The main difference is that we decrement ctr down to zero (extra line) and impose an initialization
-// condition for acc_ia, acc_ib, acc_ic to be zero on this last row.
-// Column last can be removed and sel is used instead of (1 - last).
-// Note that sel == 0 on last row of each operation, but the skippable condition
-// remains valid as the last row will be empty with our witness generator.
-//
-// It might be worth to measure the difference among both approaches.
-
-// ################################################
-// Recycling of bitwise operations of prefixes
-// ################################################
-//
-// Observation: If two inputs are prefixes of other inputs which are already present in the
-//              trace, then we could retrieve the result as a truncated trace of the larger.
-//
-// For instance, re-using example at the top, we consider the U16 and computation over
-// a = 0x5248
-// b = 0xC684
-// c = 0x4200
-// Then, we should activate the start selector where ctr == 2, and the following rows
-// represent a valid trace for this computation.
-// It is not clear if this would lead to some speed-up in practice.
-
-// ################################################
-// Tight counter
-// ################################################
-//
-// The counter is currently set to TAG_LEN, which is the maximum number of bytes of the two inputs.
-// This is not tight, and we can reduce the counter to the effective number of bytes of the largest
-// input. For instance, a == 0x23 and b == 0x123 with tag U64 can be computed with ctr == 2.
-// We can relax the lookup #[INTEGRAL_TAG_LENGTH] and have ctr being chosen "freely" in the
-// interval [1, 31]. Namely, if ctr is non-zero, the computation is triggered and if ctr is too short,
-// a relation will fail. If ctr is too large, then some rows are wasted. However, it is crucial that
-// ctr != 0, otherwise it is underconstrained and the bitwise operation can be completely faked (no lookup to precomputed.bitwise).
-// In addition, requesting a max value of 31 prevents the acc_ia, acc_ib, acc_ic values to overflow the field
-// which represents a potential attack vector.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
@@ -371,9 +371,10 @@ TEST(BitwiseConstrainingTest, NegativeChangeOpIDBeforeEnd)
         },
     });
 
-    check_relation<bitwise>(trace, bitwise::SR_BITW_OP_ID_REL);
+    check_relation<bitwise>(trace, bitwise::SR_BITW_OP_ID_REL_CONTINUITY);
     trace.set(C::bitwise_op_id, 1, static_cast<uint8_t>(BitwiseOperation::AND)); // Mutate to wrong value
-    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_BITW_OP_ID_REL), "BITW_OP_ID_REL");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_BITW_OP_ID_REL_CONTINUITY),
+                              "BITW_OP_ID_REL_CONTINUITY");
 }
 
 TEST(BitwiseConstrainingTest, NegativeWrongAccumulation)
@@ -404,6 +405,111 @@ TEST(BitwiseConstrainingTest, NegativeWrongAccumulation)
     EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_BITW_ACC_REL_A), "BITW_ACC_REL_A");
     EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_BITW_ACC_REL_B), "BITW_ACC_REL_B");
     EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_BITW_ACC_REL_C), "BITW_ACC_REL_C");
+}
+
+// Verify that #[INPUT_TAG_CANNOT_BE_FF] catches a prover who hides an FF tag error.
+// A malicious prover might set sel_tag_ff_err=0 when tag_a is actually FF (tag 0),
+// trying to bypass the error handling.
+TEST(BitwiseConstrainingTest, NegativeInputTagCannotBeFF)
+{
+    // Build a valid error trace with tag_a = FF
+    TestTraceContainer trace;
+    BitwiseTraceBuilder builder;
+    std::vector<simulation::BitwiseEvent> events = {
+        { .operation = BitwiseOperation::XOR,
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .res = 0 },
+    };
+    builder.process(events, trace);
+
+    // Verify valid trace passes
+    check_relation<bitwise>(trace, bitwise::SR_INPUT_TAG_CANNOT_BE_FF);
+
+    // Mutate: hide the FF error by setting sel_tag_ff_err = 0
+    // Row 1 is the error row (row 0 is sentinel)
+    trace.set(C::bitwise_sel_tag_ff_err, 1, 0);
+    // Also need to fix err to be consistent (err = ff_err OR mismatch_err)
+    trace.set(C::bitwise_err, 1, 0);
+
+    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_INPUT_TAG_CANNOT_BE_FF),
+                              "INPUT_TAG_CANNOT_BE_FF");
+}
+
+// Verify that #[INPUT_TAGS_SHOULD_MATCH] catches a prover who hides a tag mismatch.
+// A malicious prover might set sel_tag_mismatch_err=0 when tag_a != tag_b,
+// trying to proceed with the computation on mismatched tags.
+TEST(BitwiseConstrainingTest, NegativeInputTagsShouldMatch)
+{
+    // Build a valid error trace with mismatched tags
+    TestTraceContainer trace;
+    BitwiseTraceBuilder builder;
+    std::vector<simulation::BitwiseEvent> events = {
+        { .operation = BitwiseOperation::AND,
+          .a = MemoryValue::from_tag(MemoryTag::U8, 1),
+          .b = MemoryValue::from_tag(MemoryTag::U16, 1),
+          .res = 0 },
+    };
+    builder.process(events, trace);
+
+    // Verify valid trace passes
+    check_relation<bitwise>(trace, bitwise::SR_INPUT_TAGS_SHOULD_MATCH);
+
+    // Mutate: hide the mismatch error
+    trace.set(C::bitwise_sel_tag_mismatch_err, 1, 0);
+    trace.set(C::bitwise_err, 1, 0);
+
+    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_INPUT_TAGS_SHOULD_MATCH),
+                              "INPUT_TAGS_SHOULD_MATCH");
+}
+
+// Verify that #[RES_TAG_SHOULD_MATCH_INPUT] catches tag_c != tag_a on a non-error start row.
+TEST(BitwiseConstrainingTest, NegativeResTagShouldMatchInput)
+{
+    // Build a valid trace with a U8 AND operation
+    TestTraceContainer trace;
+    BitwiseTraceBuilder builder;
+    std::vector<simulation::BitwiseEvent> events = {
+        { .operation = BitwiseOperation::AND,
+          .a = MemoryValue::from<uint8_t>(85),
+          .b = MemoryValue::from<uint8_t>(175),
+          .res = 5 },
+    };
+    builder.process(events, trace);
+
+    // Verify valid trace passes
+    check_relation<bitwise>(trace, bitwise::SR_RES_TAG_SHOULD_MATCH_INPUT);
+
+    // Row 1 is the start row (and also the last row for U8, since only 1 byte).
+    // Mutate: set tag_c to a different value than tag_a.
+    trace.set(C::bitwise_tag_c, 1, static_cast<uint8_t>(MemoryTag::U32));
+
+    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_RES_TAG_SHOULD_MATCH_INPUT),
+                              "RES_TAG_SHOULD_MATCH_INPUT");
+}
+
+// Verify that #[LAST_ON_ERROR] catches last=0 when err=1.
+// A malicious prover might try to continue computation after an error.
+TEST(BitwiseConstrainingTest, NegativeLastOnError)
+{
+    // Build a valid error trace
+    TestTraceContainer trace;
+    BitwiseTraceBuilder builder;
+    std::vector<simulation::BitwiseEvent> events = {
+        { .operation = BitwiseOperation::XOR,
+          .a = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .b = MemoryValue::from_tag(MemoryTag::FF, 1),
+          .res = 0 },
+    };
+    builder.process(events, trace);
+
+    // Verify valid trace passes
+    check_relation<bitwise>(trace, bitwise::SR_LAST_ON_ERROR);
+
+    // Mutate: set last=0 on the error row (row 1)
+    trace.set(C::bitwise_last, 1, 0);
+
+    EXPECT_THROW_WITH_MESSAGE(check_relation<bitwise>(trace, bitwise::SR_LAST_ON_ERROR), "LAST_ON_ERROR");
 }
 
 TEST(BitwiseConstrainingTest, MixedOperationsInteractions)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
@@ -42,7 +42,7 @@ template <typename FF> class bitwise : public Relation<bitwiseImpl<FF>> {
     static constexpr size_t SR_RES_TAG_SHOULD_MATCH_INPUT = 11;
     static constexpr size_t SR_INPUT_TAG_CANNOT_BE_FF = 12;
     static constexpr size_t SR_INPUT_TAGS_SHOULD_MATCH = 13;
-    static constexpr size_t SR_BITW_OP_ID_REL = 14;
+    static constexpr size_t SR_BITW_OP_ID_REL_CONTINUITY = 14;
     static constexpr size_t SR_BITW_CTR_DECREMENT = 15;
     static constexpr size_t SR_BITW_SEL_CTR_NON_ZERO = 16;
     static constexpr size_t SR_BITW_LAST_FOR_CTR_ONE = 17;
@@ -66,8 +66,8 @@ template <typename FF> class bitwise : public Relation<bitwiseImpl<FF>> {
             return "INPUT_TAG_CANNOT_BE_FF";
         case SR_INPUT_TAGS_SHOULD_MATCH:
             return "INPUT_TAGS_SHOULD_MATCH";
-        case SR_BITW_OP_ID_REL:
-            return "BITW_OP_ID_REL";
+        case SR_BITW_OP_ID_REL_CONTINUITY:
+            return "BITW_OP_ID_REL_CONTINUITY";
         case SR_BITW_CTR_DECREMENT:
             return "BITW_CTR_DECREMENT";
         case SR_BITW_SEL_CTR_NON_ZERO:

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise_impl.hpp
@@ -112,7 +112,7 @@ void bitwiseImpl<FF_>::accumulate(ContainerOverSubrelations& evals,
                     static_cast<View>(in.get(C::bitwise_sel_tag_mismatch_err)));
         std::get<13>(evals) += (tmp * scaling_factor);
     }
-    { // BITW_OP_ID_REL
+    { // BITW_OP_ID_REL_CONTINUITY
         using View = typename std::tuple_element_t<14, ContainerOverSubrelations>::View;
         auto tmp = (static_cast<View>(in.get(C::bitwise_op_id_shift)) - static_cast<View>(in.get(C::bitwise_op_id))) *
                    (FF(1) - static_cast<View>(in.get(C::bitwise_last)));

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/bitwise_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/bitwise_event.hpp
@@ -7,13 +7,20 @@
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Event emitted during bitwise operation simulation for trace generation.
+ *
+ * Captures the inputs, operation type, and result of a bitwise AND/OR/XOR operation.
+ * Emitted on both success and error paths (on error, res defaults to 0).
+ * Consumed by BitwiseTraceBuilder::process() to populate the bitwise subtrace.
+ */
 struct BitwiseEvent {
-    BitwiseOperation operation;
-    MemoryValue a;
-    MemoryValue b;
-    uint128_t res = 0;
+    BitwiseOperation operation;                              ///< The bitwise operation (AND, OR, or XOR).
+    MemoryValue a = MemoryValue::from_tag(MemoryTag::FF, 0); ///< Left operand (tagged memory value).
+    MemoryValue b = MemoryValue::from_tag(MemoryTag::FF, 0); ///< Right operand (tagged memory value).
+    uint128_t res = 0; ///< Result of the operation. Defaults to 0 (used on error paths).
 
-    // To be used with deduplicating event emitters.
+    /// @brief Key type for deduplication (operation, input_a, input_b).
     using Key = std::tuple<BitwiseOperation, MemoryValue, MemoryValue>;
     Key get_key() const { return { operation, a, b }; }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.cpp
@@ -1,13 +1,22 @@
 #include "barretenberg/vm2/simulation/gadgets/bitwise.hpp"
 
 #include <cstdint>
-#include <stdexcept>
 
-#include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/common/tagged_value.hpp"
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Perform bitwise AND on two tagged memory values.
+ *
+ * On success, emits a BitwiseEvent with the computed result and returns it.
+ * On error (FF tag or tag mismatch), emits the event with res=0, then throws.
+ *
+ * @param a Left operand.
+ * @param b Right operand.
+ * @return The AND result with the same tag as the inputs.
+ * @throws BitwiseException If either tag is FF or tags don't match.
+ */
 MemoryValue Bitwise::and_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
@@ -15,12 +24,22 @@ MemoryValue Bitwise::and_op(const MemoryValue& a, const MemoryValue& b)
         events.emit({ .operation = BitwiseOperation::AND, .a = a, .b = b, .res = static_cast<uint128_t>(c.as_ff()) });
         return c;
     } catch (const TaggedValueException& e) {
-        // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::AND, .a = a, .b = b, .res = 0 });
         throw BitwiseException("AND, " + std::string(e.what()));
     }
 }
 
+/**
+ * @brief Perform bitwise OR on two tagged memory values.
+ *
+ * On success, emits a BitwiseEvent with the computed result and returns it.
+ * On error (FF tag or tag mismatch), emits the event with res=0, then throws.
+ *
+ * @param a Left operand.
+ * @param b Right operand.
+ * @return The OR result with the same tag as the inputs.
+ * @throws BitwiseException If either tag is FF or tags don't match.
+ */
 MemoryValue Bitwise::or_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
@@ -28,12 +47,22 @@ MemoryValue Bitwise::or_op(const MemoryValue& a, const MemoryValue& b)
         events.emit({ .operation = BitwiseOperation::OR, .a = a, .b = b, .res = static_cast<uint128_t>(c.as_ff()) });
         return c;
     } catch (const TaggedValueException& e) {
-        // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::OR, .a = a, .b = b, .res = 0 });
         throw BitwiseException("OR, " + std::string(e.what()));
     }
 }
 
+/**
+ * @brief Perform bitwise XOR on two tagged memory values.
+ *
+ * On success, emits a BitwiseEvent with the computed result and returns it.
+ * On error (FF tag or tag mismatch), emits the event with res=0, then throws.
+ *
+ * @param a Left operand.
+ * @param b Right operand.
+ * @return The XOR result with the same tag as the inputs.
+ * @throws BitwiseException If either tag is FF or tags don't match.
+ */
 MemoryValue Bitwise::xor_op(const MemoryValue& a, const MemoryValue& b)
 {
     try {
@@ -46,7 +75,6 @@ MemoryValue Bitwise::xor_op(const MemoryValue& a, const MemoryValue& b)
         });
         return c;
     } catch (const TaggedValueException& e) {
-        // We emit an event if we fail, but default the result to 0.
         events.emit({ .operation = BitwiseOperation::XOR, .a = a, .b = b, .res = 0 });
         throw BitwiseException("XOR, " + std::string(e.what()));
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/bitwise.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/simulation/events/bitwise_event.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
@@ -9,8 +7,14 @@
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Witness-generating implementation of bitwise AND/OR/XOR operations.
+ */
 class Bitwise : public BitwiseInterface {
   public:
+    /**
+     * @param event_emitter Destination for BitwiseEvent emissions consumed by tracegen.
+     */
     Bitwise(EventEmitterInterface<BitwiseEvent>& event_emitter)
         : events(event_emitter)
     {}
@@ -20,8 +24,6 @@ class Bitwise : public BitwiseInterface {
     MemoryValue xor_op(const MemoryValue& a, const MemoryValue& b) override;
 
   private:
-    // TODO: Use deduplicating events + consider (see bottom paragraph of bitwise.pil) a further deduplication
-    // when some inputs are prefixes of another ones (with a bigger tag).
     EventEmitterInterface<BitwiseEvent>& events;
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.cpp
@@ -1,16 +1,9 @@
 #include "barretenberg/vm2/tracegen/bitwise_trace.hpp"
 
-#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <ranges>
-#include <stdexcept>
 
 #include "barretenberg/vm2/common/memory_types.hpp"
 #include "barretenberg/vm2/generated/relations/lookups_bitwise.hpp"
-#include "barretenberg/vm2/simulation/events/bitwise_event.hpp"
-#include "barretenberg/vm2/simulation/events/event_emitter.hpp"
-#include "barretenberg/vm2/tracegen/lib/interaction_def.hpp"
 
 namespace bb::avm2::tracegen {
 
@@ -18,17 +11,26 @@ void BitwiseTraceBuilder::process(const simulation::EventEmitterInterface<simula
                                   TraceContainer& trace)
 {
     using C = Column;
-    // Important to not set last to 1 in the first row if there are no events. Otherwise, the skippable condition
-    // would be skipped wrongly as the sub-relation last * (1 - last) = 0 cannot be satisified (after the
-    // randomization process happening in the sumcheck protocol).
+    // When the trace is non-empty, we set last=1 at row 0 as a sentinel. This serves two purposes:
+    // 1) Skippable condition: ensures `sel + last = 0` does NOT hold, preventing the sub-relation
+    //    `last * (1 - last) = 0` from being skipped (which would fail after sumcheck randomization).
+    // 2) Boundary breaking: constraints like #[BITW_OP_ID_REL] and #[BITW_ACC_REL_*] use `(1 - last)`
+    //    as a guard. At row 0, the shifted columns reference row 1. Without last=1 here, these
+    //    constraints would force op_id_0 = op_id_1 and acc_ia_1 = 0, breaking the first event's trace.
+    // When there are no events, we must NOT set last=1.
     if (!events.empty()) {
-        // We activate last selector in the first row.
         trace.set(C::bitwise_last, 0, 1);
     }
 
     // Precomputed inverses ranges from 0 to 16. (for columns bitwise_ctr_inv, bitwise_ctr_min_one_inv)
-    std::array<FF, 17> precomputed_inverses = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-    FF::batch_invert(precomputed_inverses);
+    static constexpr std::array<FF, 17> precomputed_inverses = [] {
+        std::array<FF, 17> inverses{ 0, 1 };
+        // skip 0 since it's not invertible, inverse(1) = 1 so we can skip it as well
+        for (size_t i = 2; i <= 16; i++) {
+            inverses[i] = FF(i).invert();
+        }
+        return inverses;
+    }();
 
     // Lambda to map the column selector of the op_id.
     const auto get_op_id_column_selector = [](BitwiseOperation op_id) {
@@ -108,7 +110,7 @@ void BitwiseTraceBuilder::process(const simulation::EventEmitterInterface<simula
         // Note that for tag U1, we take only one bit. This is correctly
         // captured below since input_a/b and output_c are each a single bit
         // and the byte mask correctly extracts it.
-        const uint128_t mask_low_byte = (1 << 8) - 1;
+        constexpr uint128_t mask_low_byte = (1 << 8) - 1;
         const auto start_ctr = get_tag_bytes(tag);
 
         for (int ctr = start_ctr; ctr > 0; ctr--) {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/simulation/events/bitwise_event.hpp"
 #include "barretenberg/vm2/simulation/events/event_emitter.hpp"
@@ -10,11 +8,21 @@
 
 namespace bb::avm2::tracegen {
 
+/**
+ * @brief Trace builder for the bitwise subtrace (AND/OR/XOR operations).
+ */
 class BitwiseTraceBuilder final {
   public:
+    /**
+     * @brief Populate the bitwise trace columns from simulation events.
+     *
+     * @param events Container of BitwiseEvent from simulation (success and error events).
+     * @param trace The trace container to populate with bitwise columns.
+     */
     void process(const simulation::EventEmitterInterface<simulation::BitwiseEvent>::Container& events,
                  TraceContainer& trace);
 
+    /// @brief Interaction definitions for outbound lookups (BYTE_OPERATIONS, INTEGRAL_TAG_LENGTH).
     static const InteractionDefinition interactions;
 };
 


### PR DESCRIPTION
Pre-audit for bitwise trace. Pretty much entirely documentation.

A pr on top of this will standardise the multi-row constraints

