### PR TITLE
fix: Use async poseidon

### DIFF
--- a/yarn-project/foundation/src/crypto/poseidon/index.test.ts
+++ b/yarn-project/foundation/src/crypto/poseidon/index.test.ts
@@ -1,11 +1,11 @@
-import { BarretenbergSync } from '@aztec/bb.js';
+import { Barretenberg } from '@aztec/bb.js';
 
 import { Fr } from '../../curves/bn254/field.js';
 import { poseidon2Permutation } from './index.js';
 
 describe('poseidon2Permutation', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton({ threads: 1 });
+    await Barretenberg.initSingleton({ threads: 1 });
   });
 
   it('test vectors from cpp should match', async () => {

--- a/yarn-project/foundation/src/crypto/poseidon/index.ts
+++ b/yarn-project/foundation/src/crypto/poseidon/index.ts
@@ -1,4 +1,4 @@
-import { BarretenbergSync } from '@aztec/bb.js';
+import { Barretenberg } from '@aztec/bb.js';
 
 import { Fr } from '../../curves/bn254/field.js';
 import { type Fieldable, serializeToFields } from '../../serialize/serialize.js';
@@ -10,9 +10,9 @@ import { type Fieldable, serializeToFields } from '../../serialize/serialize.js'
  */
 export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  await BarretenbergSync.initSingleton();
-  const api = BarretenbergSync.getSingleton();
-  const response = api.poseidon2Hash({
+  await Barretenberg.initSingleton();
+  const api = Barretenberg.getSingleton();
+  const response = await api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),
   });
   return Fr.fromBuffer(Buffer.from(response.hash));
@@ -27,9 +27,9 @@ export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
 export async function poseidon2HashWithSeparator(input: Fieldable[], separator: number): Promise<Fr> {
   const inputFields = serializeToFields(input);
   inputFields.unshift(new Fr(separator));
-  await BarretenbergSync.initSingleton();
-  const api = BarretenbergSync.getSingleton();
-  const response = api.poseidon2Hash({
+  await Barretenberg.initSingleton();
+  const api = Barretenberg.getSingleton();
+  const response = await api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),
   });
   return Fr.fromBuffer(Buffer.from(response.hash));
@@ -44,9 +44,9 @@ export async function poseidon2Permutation(input: Fieldable[]): Promise<Fr[]> {
   const inputFields = serializeToFields(input);
   // We'd like this assertion but it's not possible to use it in the browser.
   // assert(input.length === 4, 'Input state must be of size 4');
-  await BarretenbergSync.initSingleton();
-  const api = BarretenbergSync.getSingleton();
-  const response = api.poseidon2Permutation({
+  await Barretenberg.initSingleton();
+  const api = Barretenberg.getSingleton();
+  const response = await api.poseidon2Permutation({
     inputs: inputFields.map(i => i.toBuffer()),
   });
   // We'd like this assertion but it's not possible to use it in the browser.
@@ -65,9 +65,9 @@ export async function poseidon2HashBytes(input: Buffer): Promise<Fr> {
     inputFields.push(Fr.fromBuffer(fieldBytes));
   }
 
-  await BarretenbergSync.initSingleton();
-  const api = BarretenbergSync.getSingleton();
-  const response = api.poseidon2Hash({
+  await Barretenberg.initSingleton();
+  const api = Barretenberg.getSingleton();
+  const response = await api.poseidon2Hash({
     inputs: inputFields.map(i => i.toBuffer()),
   });
 


### PR DESCRIPTION
This PR switches the poseidon hashing function to use the async barretenberg api. Profiling shows that generating a transaction hash takes ~22ms meaning the node needs to delegate this asynchronously to barretenberg.
