### PR TITLE
chore: trigger typesense docs indexer on next branch

### DIFF
--- a/.github/workflows/docs-typesense.yml
+++ b/.github/workflows/docs-typesense.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 5 * * *"
   push:
     branches:
-      - master
+      - next
     paths:
       - docs/**
 


### PR DESCRIPTION
## Summary
- Updates the `docs-typesense.yml` workflow to trigger on pushes to `next` instead of `master`, so the search index is refreshed whenever docs changes are merged.

## Test plan
- [ ] Verify the workflow triggers on next branch pushes to `docs/`