### PR TITLE
feat: use native crypto to compute p2p message ID

### DIFF
--- a/yarn-project/p2p/src/services/encoding.bench.test.ts
+++ b/yarn-project/p2p/src/services/encoding.bench.test.ts
@@ -1,0 +1,129 @@
+import { asyncPool } from '@aztec/foundation/async-pool';
+import { randomBytes } from '@aztec/foundation/crypto/random';
+import { sha256 } from '@aztec/foundation/crypto/sha256';
+import { MAX_L2_BLOCK_SIZE_KB, MAX_MESSAGE_SIZE_KB, MAX_TX_SIZE_KB } from '@aztec/stdlib/p2p';
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { type RecordableHistogram, createHistogram } from 'node:perf_hooks';
+
+const HASH_COUNT = 20;
+const TOPIC = '/aztec/tx/0.1.0';
+
+const MESSAGE_SIZES_KB = [1, 64, MAX_TX_SIZE_KB, MAX_L2_BLOCK_SIZE_KB, MAX_MESSAGE_SIZE_KB] as const;
+
+type SizeKb = (typeof MESSAGE_SIZES_KB)[number];
+
+const CONCURRENCY_LEVELS = [1, 4] as const;
+type CaseKey = `${SizeKb}-${(typeof CONCURRENCY_LEVELS)[number]}`;
+
+const NS_PER_MS = 1e6;
+
+const CASES = MESSAGE_SIZES_KB.flatMap(s => CONCURRENCY_LEVELS.map(c => [s, c] as const));
+
+describe('P2P Message ID: Benchmarks', () => {
+  let hashJsHistograms: Record<CaseKey, { h: RecordableHistogram; total: number }>;
+  let nodeCryptoHistograms: Record<CaseKey, { h: RecordableHistogram; total: number }>;
+  let subtleHistograms: Record<CaseKey, { h: RecordableHistogram; total: number }>;
+
+  let messageData: Record<SizeKb, Uint8Array>;
+
+  beforeAll(() => {
+    const allKeys = CASES.map(([s, c]) => `${s}-${c}` as CaseKey);
+    hashJsHistograms = Object.fromEntries(allKeys.map(k => [k, { h: createHistogram(), total: 0 }])) as any;
+    nodeCryptoHistograms = Object.fromEntries(allKeys.map(k => [k, { h: createHistogram(), total: 0 }])) as any;
+    subtleHistograms = Object.fromEntries(allKeys.map(k => [k, { h: createHistogram(), total: 0 }])) as any;
+
+    messageData = Object.fromEntries(MESSAGE_SIZES_KB.map(sizeKb => [sizeKb, randomBytes(sizeKb * 1024)])) as any;
+  });
+
+  afterAll(async () => {
+    const implementations = [
+      { key: 'hash.js', label: 'hashJs.sha256 x' + HASH_COUNT, histograms: hashJsHistograms },
+      { key: 'node-crypto', label: 'crypto.createHash x' + HASH_COUNT, histograms: nodeCryptoHistograms },
+      { key: 'web-crypto', label: 'globalThis.crypto.subtle.digest x' + HASH_COUNT, histograms: subtleHistograms },
+    ];
+
+    const data: { name: string; value: number; unit: string }[] = [];
+    for (const [sizeKb, concurrency] of CASES) {
+      const key: CaseKey = `${sizeKb}-${concurrency}`;
+      for (const impl of implementations) {
+        const { h, total } = impl.histograms[key];
+        data.push({ name: `MsgId/${impl.key}/x${concurrency}/${sizeKb}kb/avg`, value: h.mean, unit: 'ms' });
+        data.push({ name: `MsgId/${impl.key}/x${concurrency}/${sizeKb}kb/p50`, value: h.percentile(50), unit: 'ms' });
+        data.push({ name: `MsgId/${impl.key}/x${concurrency}/${sizeKb}kb/p99`, value: h.percentile(99), unit: 'ms' });
+        data.push({ name: `MsgId/${impl.key}/x${concurrency}/${sizeKb}kb/sum`, value: total, unit: 'ms' });
+      }
+    }
+
+    if (process.env.BENCH_OUTPUT) {
+      await fs.mkdir(path.dirname(process.env.BENCH_OUTPUT), { recursive: true });
+      await fs.writeFile(process.env.BENCH_OUTPUT, JSON.stringify(data, null, 2));
+    } else if (process.env.BENCH_OUTPUT_MD) {
+      await fs.mkdir(path.dirname(process.env.BENCH_OUTPUT_MD), { recursive: true });
+      await using f = await fs.open(process.env.BENCH_OUTPUT_MD, 'w');
+      await f.write('| Function | CONCURRENCY | Size (KB) | Avg (ms) | P50 (ms) | P99 (ms) | TOTAL (ms) |\n');
+      await f.write('|----------|---|-----------|----------|----------|----------|------------|\n');
+      for (const [sizeKb, concurrency] of CASES) {
+        const key: CaseKey = `${sizeKb}-${concurrency}`;
+        for (const impl of implementations) {
+          const { h, total } = impl.histograms[key];
+          await f.write(
+            `| ${impl.label} | ${concurrency} | ${sizeKb} | ${h.mean} | ${h.percentile(50)} | ${h.percentile(99)} | ${total} |\n`,
+          );
+        }
+      }
+    }
+  });
+
+  it.each(CASES)('hash.js sha256: %d KB x%d', async (sizeKb, concurrency) => {
+    const data = messageData[sizeKb as SizeKb];
+    const key: CaseKey = `${sizeKb}-${concurrency}`;
+    const res = hashJsHistograms[key];
+
+    const testStart = process.hrtime.bigint();
+    await asyncPool(concurrency, Array(HASH_COUNT), () => {
+      const start = process.hrtime.bigint();
+      sha256(Buffer.concat([Buffer.from(TOPIC), data])).subarray(0, 20);
+      const elapsed = Number(process.hrtime.bigint() - start) / NS_PER_MS;
+      res.h.record(Math.trunc(Math.max(1, elapsed)));
+      return Promise.resolve();
+    });
+    res.total = Number(process.hrtime.bigint() - testStart) / NS_PER_MS;
+  });
+
+  it.each(CASES)('node:crypto createHash: %d KB x%d', async (sizeKb, concurrency) => {
+    const data = messageData[sizeKb as SizeKb];
+    const key: CaseKey = `${sizeKb}-${concurrency}`;
+    const res = nodeCryptoHistograms[key];
+
+    const testStart = process.hrtime.bigint();
+    await asyncPool(concurrency, Array(HASH_COUNT), () => {
+      const start = process.hrtime.bigint();
+      createHash('sha256').update(TOPIC).update(data).digest().subarray(0, 20);
+      const elapsed = Number(process.hrtime.bigint() - start) / NS_PER_MS;
+      res.h.record(Math.trunc(Math.max(1, elapsed)));
+      return Promise.resolve();
+    });
+    res.total = Number(process.hrtime.bigint() - testStart) / NS_PER_MS;
+  });
+
+  it.each(CASES)('crypto.subtle.digest parallel: %d KB x%d', async (sizeKb, concurrency) => {
+    const data = messageData[sizeKb as SizeKb];
+    const concat = Buffer.concat([Buffer.from(TOPIC), data]);
+    const key: CaseKey = `${sizeKb}-${concurrency}`;
+    const res = subtleHistograms[key];
+
+    const testStart = process.hrtime.bigint();
+
+    await asyncPool(concurrency, Array(HASH_COUNT), async () => {
+      const start = process.hrtime.bigint();
+      await crypto.subtle.digest('SHA-256', concat).then(buf => Buffer.from(buf).subarray(0, 20));
+      const elapsed = Number(process.hrtime.bigint() - start) / NS_PER_MS;
+      res.h.record(Math.trunc(Math.max(1, elapsed)));
+    });
+
+    res.total = Number(process.hrtime.bigint() - testStart) / NS_PER_MS;
+  });
+});

--- a/yarn-project/p2p/src/services/encoding.ts
+++ b/yarn-project/p2p/src/services/encoding.ts
@@ -1,11 +1,11 @@
 // Taken from lodestar: https://github.com/ChainSafe/lodestar
-import { sha256 } from '@aztec/foundation/crypto/sha256';
 import { createLogger } from '@aztec/foundation/log';
 import { MAX_TX_SIZE_KB, TopicType, getTopicFromString } from '@aztec/stdlib/p2p';
 
 import type { RPC } from '@chainsafe/libp2p-gossipsub/message';
 import type { DataTransform } from '@chainsafe/libp2p-gossipsub/types';
 import type { Message } from '@libp2p/interface';
+import { webcrypto } from 'node:crypto';
 import { compressSync, uncompressSync } from 'snappy';
 import xxhashFactory from 'xxhash-wasm';
 
@@ -44,11 +44,10 @@ export function msgIdToStrFn(msgId: Uint8Array): string {
  * @param message - The libp2p message
  * @returns The message identifier
  */
-export function getMsgIdFn(message: Message) {
-  const { topic } = message;
-
-  const vec = [Buffer.from(topic), message.data];
-  return sha256(Buffer.concat(vec)).subarray(0, 20);
+export async function getMsgIdFn({ topic, data }: Message): Promise<Uint8Array> {
+  const buffer = Buffer.concat([Buffer.from(topic), data]);
+  const hash = await webcrypto.subtle.digest('SHA-256', buffer);
+  return Buffer.from(hash.slice(0, 20));
 }
 
 const DefaultMaxSizesKb: Record<TopicType, number> = {


### PR DESCRIPTION
Replace aztec/foundation for native sha256. The native sha256 implementations are orders of magnitude faster than hash.js (which is not surprising). I have used the web-crypto subtle.digest since it's async.

Fix A-583

<details>
  <summary> Benchmark run on mainframe</summary>

| Function | CONCURRENCY | Size (KB) | Avg (ms) | P50 (ms) | P99 (ms) | TOTAL (ms) |
|----------|---|-----------|----------|----------|----------|------------|
| hashJs.sha256 x20 | 1 | 1 | 2.65 | 1 | 34 | 39.544517 |
| crypto.createHash x20 | 1 | 1 | 1 | 1 | 1 | 0.520618 |
| globalThis.crypto.subtle.digest x20 | 1 | 1 | 1.75 | 1 | 16 | 18.246695 |
| hashJs.sha256 x20 | 4 | 1 | 1 | 1 | 1 | 1.176059 |
| crypto.createHash x20 | 4 | 1 | 1 | 1 | 1 | 0.261084 |
| globalThis.crypto.subtle.digest x20 | 4 | 1 | 1 | 1 | 1 | 0.734331 |
| hashJs.sha256 x20 | 1 | 64 | 2.25 | 2 | 3 | 56.111665 |
| crypto.createHash x20 | 1 | 64 | 1 | 1 | 1 | 0.982696 |
| globalThis.crypto.subtle.digest x20 | 1 | 64 | 1 | 1 | 1 | 1.911511 |
| hashJs.sha256 x20 | 4 | 64 | 2.25 | 2 | 7 | 58.449153 |
| crypto.createHash x20 | 4 | 64 | 1 | 1 | 1 | 1.031626 |
| globalThis.crypto.subtle.digest x20 | 4 | 64 | 1 | 1 | 1 | 0.994706 |
| hashJs.sha256 x20 | 1 | 512 | 22.7 | 21 | 27 | 464.974449 |
| crypto.createHash x20 | 1 | 512 | 1 | 1 | 1 | 6.18104 |
| globalThis.crypto.subtle.digest x20 | 1 | 512 | 1 | 1 | 1 | 7.551702 |
| hashJs.sha256 x20 | 4 | 512 | 22.5 | 21 | 34 | 462.867755 |
| crypto.createHash x20 | 4 | 512 | 1 | 1 | 1 | 6.185 |
| globalThis.crypto.subtle.digest x20 | 4 | 512 | 1 | 1 | 1 | 3.335444 |
| hashJs.sha256 x20 | 1 | 3072 | 162.55 | 153 | 254 | 3262.797195 |
| crypto.createHash x20 | 1 | 3072 | 1.05 | 1 | 2 | 37.506365 |
| globalThis.crypto.subtle.digest x20 | 1 | 3072 | 2.05 | 2 | 3 | 45.949082 |
| hashJs.sha256 x20 | 4 | 3072 | 158.65 | 153 | 255 | 3182.793907 |
| crypto.createHash x20 | 4 | 3072 | 1 | 1 | 1 | 35.97431 |
| globalThis.crypto.subtle.digest x20 | 4 | 3072 | 3.1 | 2 | 8 | 22.177998 |
| hashJs.sha256 x20 | 1 | 10240 | 581.35 | 561 | 684 | 11641.084243 |
| crypto.createHash x20 | 1 | 10240 | 5.15 | 5 | 6 | 119.489467 |
| globalThis.crypto.subtle.digest x20 | 1 | 10240 | 7.55 | 7 | 13 | 161.12074 |
| hashJs.sha256 x20 | 4 | 10240 | 578.5 | 561 | 655 | 11581.108637 |
| crypto.createHash x20 | 4 | 10240 | 5.1 | 5 | 6 | 119.847924 |
| globalThis.crypto.subtle.digest x20 | 4 | 10240 | 13.15 | 11 | 27 | 85.079143 |

</details>