### PR TITLE
refactor: Add buffer and hash caching to Tx serialization path

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -22,7 +22,7 @@ import { EmptyL1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { L2LogsSource, MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { MerkleTreeId, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import {
   BlockHeader,
@@ -35,6 +35,8 @@ import {
   TX_ERROR_INVALID_EXPIRATION_TIMESTAMP,
   TX_ERROR_SIZE_ABOVE_LIMIT,
   Tx,
+  TxConstantData,
+  TxContext,
 } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 import type { ValidatorClient } from '@aztec/validator-client';
@@ -231,22 +233,46 @@ describe('aztec node', () => {
     });
 
     it('tests that the node correctly validates chain id', async () => {
-      const tx = await mockTxForRollup(0x10000);
+      let tx = await mockTxForRollup(0x10000);
       expect(await node.isValidTx(tx)).toEqual({ result: 'valid' });
 
       // We make the chain id on the tx not equal to the configured chain id
-      tx.data.constants.txContext.chainId = new Fr(1n + chainId.toBigInt());
+      const newChainId = new Fr(1n + chainId.toBigInt());
+      const newTxContext = new TxContext(
+        newChainId,
+        tx.data.constants.txContext.version,
+        tx.data.constants.txContext.gasSettings,
+      );
+      const newConstants = new TxConstantData(
+        tx.data.constants.anchorBlockHeader,
+        newTxContext,
+        tx.data.constants.vkTreeRoot,
+        tx.data.constants.protocolContractsHash,
+      );
+      tx = txWithDataOverrides(tx, { constants: newConstants });
       await tx.recomputeHash();
 
       expect(await node.isValidTx(tx)).toEqual({ result: 'invalid', reason: [TX_ERROR_INCORRECT_L1_CHAIN_ID] });
     });
 
     it('tests that the node correctly validates rollup version', async () => {
-      const tx = await mockTxForRollup(0x10000);
+      let tx = await mockTxForRollup(0x10000);
       expect(await node.isValidTx(tx)).toEqual({ result: 'valid' });
 
-      // We make the chain id on the tx not equal to the configured chain id
-      tx.data.constants.txContext.version = new Fr(1n + rollupVersion.toBigInt());
+      // We make the version on the tx not equal to the configured rollup version
+      const newVersion = new Fr(1n + rollupVersion.toBigInt());
+      const newTxContext = new TxContext(
+        tx.data.constants.txContext.chainId,
+        newVersion,
+        tx.data.constants.txContext.gasSettings,
+      );
+      const newConstants = new TxConstantData(
+        tx.data.constants.anchorBlockHeader,
+        newTxContext,
+        tx.data.constants.vkTreeRoot,
+        tx.data.constants.protocolContractsHash,
+      );
+      tx = txWithDataOverrides(tx, { constants: newConstants });
       await tx.recomputeHash();
 
       expect(await node.isValidTx(tx)).toEqual({ result: 'invalid', reason: [TX_ERROR_INCORRECT_ROLLUP_VERSION] });
@@ -271,13 +297,17 @@ describe('aztec node', () => {
 
     it('tests that the node correctly validates expiration timestamps', async () => {
       const txs = await Promise.all([mockTxForRollup(0x10000), mockTxForRollup(0x20000)]);
-      const invalidExpirationTimestampMetadata = txs[0];
-      const validExpirationTimestampMetadata = txs[1];
+      let invalidExpirationTimestampMetadata = txs[0];
+      let validExpirationTimestampMetadata = txs[1];
 
-      invalidExpirationTimestampMetadata.data.expirationTimestamp = BigInt(NOW_S);
+      invalidExpirationTimestampMetadata = txWithDataOverrides(invalidExpirationTimestampMetadata, {
+        expirationTimestamp: BigInt(NOW_S),
+      });
       await invalidExpirationTimestampMetadata.recomputeHash();
 
-      validExpirationTimestampMetadata.data.expirationTimestamp = BigInt(NOW_S + 1);
+      validExpirationTimestampMetadata = txWithDataOverrides(validExpirationTimestampMetadata, {
+        expirationTimestamp: BigInt(NOW_S + 1),
+      });
       await validExpirationTimestampMetadata.recomputeHash();
 
       // We need to set the last block number to get this working properly because if it was set to 0, it would mean

--- a/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
+++ b/yarn-project/aztec.js/src/contract/get_gas_limits.test.ts
@@ -1,6 +1,6 @@
 import { MAX_PROCESSABLE_L2_GAS } from '@aztec/constants';
 import { Gas } from '@aztec/stdlib/gas';
-import { mockSimulatedTx, mockTxForRollup } from '@aztec/stdlib/testing';
+import { mockSimulatedTx, mockTxForRollup, txWithDataOverrides } from '@aztec/stdlib/testing';
 import type { TxSimulationResult } from '@aztec/stdlib/tx';
 
 import { getGasLimits } from './get_gas_limits.js';
@@ -11,8 +11,8 @@ describe('getGasLimits', () => {
   beforeEach(async () => {
     txSimulationResult = await mockSimulatedTx();
 
-    const tx = await mockTxForRollup();
-    tx.data.gasUsed = Gas.from({ daGas: 100, l2Gas: 200 });
+    let tx = await mockTxForRollup();
+    tx = txWithDataOverrides(tx, { gasUsed: Gas.from({ daGas: 100, l2Gas: 200 }) });
     txSimulationResult.publicInputs = tx.data;
 
     txSimulationResult.publicOutput!.gasUsed = {

--- a/yarn-project/foundation/src/serialize/buffer_reader.ts
+++ b/yarn-project/foundation/src/serialize/buffer_reader.ts
@@ -52,6 +52,16 @@ export class BufferReader {
     return this.index === this.buffer.length;
   }
 
+  /** Returns the current read position in the buffer. */
+  public get currentPosition(): number {
+    return this.index;
+  }
+
+  /** Returns a subarray view of the underlying buffer from start to the current position. */
+  public getSlice(start: number): Buffer {
+    return this.buffer.subarray(start, this.index);
+  }
+
   /**
    * Reads a 32-bit unsigned integer from the buffer at the current index position.
    * Updates the index position by 4 bytes after reading the number.

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -6,7 +6,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import {
   MerkleTreeId,
   NullifierLeaf,
@@ -14,7 +14,7 @@ import {
   PublicDataTreeLeaf,
   PublicDataTreeLeafPreimage,
 } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, TxHash } from '@aztec/stdlib/tx';
+import { BlockHeader, GlobalVariables, TxConstantData, TxHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -273,13 +273,13 @@ describe('KV TX pool', () => {
   });
 
   it('Evicts txs with an insufficient fee payer balance after a block is mined', async () => {
-    const tx1 = await mockTx(1);
+    let tx1 = await mockTx(1);
     const tx2 = await mockTx(2);
     const tx3 = await mockTx(3);
     const tx4 = await mockTx(4);
 
     // modify tx1 to have the same fee payer as the mined tx and an insufficient fee payer balance
-    tx1.data.feePayer = tx4.data.feePayer;
+    tx1 = txWithDataOverrides(tx1, { feePayer: tx4.data.feePayer });
     const prev = db.getLeafPreimage.getMockImplementation()!;
     const expectedSlot = await computeFeePayerBalanceLeafSlot(tx1.data.feePayer);
     db.getLeafPreimage.mockImplementation((tree, index) => {
@@ -302,12 +302,12 @@ describe('KV TX pool', () => {
   });
 
   it('Evicts txs with an expiration timestamp lower than or equal to the timestamp of the mined block', async () => {
-    const tx1 = await mockTx(1);
-    tx1.data.expirationTimestamp = 0n;
-    const tx2 = await mockTx(2);
-    tx2.data.expirationTimestamp = 32n;
-    const tx3 = await mockTx(3);
-    tx3.data.expirationTimestamp = 64n;
+    let tx1 = await mockTx(1);
+    tx1 = txWithDataOverrides(tx1, { expirationTimestamp: 0n });
+    let tx2 = await mockTx(2);
+    tx2 = txWithDataOverrides(tx2, { expirationTimestamp: 32n });
+    let tx3 = await mockTx(3);
+    tx3 = txWithDataOverrides(tx3, { expirationTimestamp: 64n });
 
     await txPool.addTxs([tx1, tx2, tx3]);
     await txPool.markAsMined([tx1.getTxHash()], block2Header);
@@ -315,12 +315,21 @@ describe('KV TX pool', () => {
   });
 
   it('Evicts txs with invalid archive roots after a reorg', async () => {
-    const tx1 = await mockTx(1);
+    let tx1 = await mockTx(1);
     const tx2 = await mockTx(2);
     const tx3 = await mockTx(3);
 
     // modify tx1 to return no archive indices
-    tx1.data.constants.anchorBlockHeader.globalVariables.blockNumber = BlockNumber(1);
+    const newAnchorBlockHeader = BlockHeader.empty({
+      globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(1) }),
+    });
+    const newConstants = new TxConstantData(
+      newAnchorBlockHeader,
+      tx1.data.constants.txContext,
+      tx1.data.constants.vkTreeRoot,
+      tx1.data.constants.protocolContractsHash,
+    );
+    tx1 = txWithDataOverrides(tx1, { constants: newConstants });
     const tx1HeaderHash = await tx1.data.constants.anchorBlockHeader.hash();
     const tx1HeaderHashFr = tx1HeaderHash;
     db.findLeafIndices.mockImplementation((tree, leaves) => {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/fee_payer_balance_eviction_rule.test.ts
@@ -2,7 +2,7 @@ import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { BlockHeader, type Tx, type TxHash } from '@aztec/stdlib/tx';
 
@@ -190,11 +190,11 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('evicts low priority txs when fee payer balance cannot cover total fee limit', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      const tx3 = await mockTx(3);
+      let tx2 = await mockTx(2);
+      let tx3 = await mockTx(3);
 
-      tx2.data.feePayer = tx1.data.feePayer;
-      tx3.data.feePayer = tx1.data.feePayer;
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
+      tx3 = txWithDataOverrides(tx3, { feePayer: tx1.data.feePayer });
 
       mockTxLookup(tx1, tx2, tx3);
 
@@ -281,8 +281,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('keeps txs when fee payer claims enough balance during setup', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       mockTxLookup(tx1, tx2);
 
@@ -312,8 +312,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('does not fund later txs with claims from evicted txs', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(tx1), 20n, { claimAmount: 10n, priority: 2n }),
@@ -340,11 +340,11 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('keeps multiple lower-priority txs funded by higher-priority claims', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      const tx3 = await mockTx(3);
+      let tx2 = await mockTx(2);
+      let tx3 = await mockTx(3);
 
-      tx2.data.feePayer = tx1.data.feePayer;
-      tx3.data.feePayer = tx1.data.feePayer;
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
+      tx3 = txWithDataOverrides(tx3, { feePayer: tx1.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(tx1), 1n, { claimAmount: 100n, priority: 3n }),
@@ -372,8 +372,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('handles equal priority ties deterministically', async () => {
       const txClaim = await mockTx(1);
-      const txSpend = await mockTx(2);
-      txSpend.data.feePayer = txClaim.data.feePayer;
+      let txSpend = await mockTx(2);
+      txSpend = txWithDataOverrides(txSpend, { feePayer: txClaim.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(txClaim), 10n, { claimAmount: 100n, priority: 1n }),
@@ -408,11 +408,11 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('evicts all txs when balance is too low', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      const tx3 = await mockTx(3);
+      let tx2 = await mockTx(2);
+      let tx3 = await mockTx(3);
 
-      tx2.data.feePayer = tx1.data.feePayer;
-      tx3.data.feePayer = tx1.data.feePayer;
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
+      tx3 = txWithDataOverrides(tx3, { feePayer: tx1.data.feePayer });
 
       const feeLimit = 50n;
       mockBalanceEntries(buildBalanceEntries(txHashes(tx1, tx2, tx3), feeLimit, { priority: [3n, 2n, 1n] }));
@@ -437,8 +437,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('evicts later txs when balance is exactly exhausted', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(tx1), 10n, { priority: 2n }),
@@ -464,8 +464,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('keeps non-evictable txs even when over balance', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(tx1), 10n, { isEvictable: false, priority: 2n }),
@@ -492,8 +492,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('evicts only evictable txs when the top tx is non-evictable and unfunded', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       mockBalanceEntries([
         ...buildBalanceEntries(txHashes(tx1), 10n, { isEvictable: false, priority: 2n }),
@@ -519,8 +519,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('respects non-evictable txs when fee payer balance is exceeded', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       const feeLimit = 100n;
       mockBalanceEntries([
@@ -547,8 +547,8 @@ describe('FeePayerBalanceEvictionRule', () => {
 
     it('evicts higher-priority spends that rely on lower-priority claims', async () => {
       const tx1 = await mockTx(1);
-      const tx2 = await mockTx(2);
-      tx2.data.feePayer = tx1.data.feePayer;
+      let tx2 = await mockTx(2);
+      tx2 = txWithDataOverrides(tx2, { feePayer: tx1.data.feePayer });
 
       const feeLimit = 100n;
       mockBalanceEntries([

--- a/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_mining_rule.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/eviction/invalid_txs_after_mining_rule.test.ts
@@ -1,6 +1,6 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -113,17 +113,17 @@ describe('InvalidTxsAfterMiningRule', () => {
         const tx1 = TxHash.random();
         const tx2 = TxHash.random();
 
-        const mockTx1 = await mockTx(1, {
+        let mockTx1 = await mockTx(1, {
           numberOfNonRevertiblePublicCallRequests: 0,
           numberOfRevertiblePublicCallRequests: 0,
         });
-        const mockTx2 = await mockTx(2, {
+        let mockTx2 = await mockTx(2, {
           numberOfNonRevertiblePublicCallRequests: 0,
           numberOfRevertiblePublicCallRequests: 0,
         });
 
-        mockTx1.data.expirationTimestamp = 500n;
-        mockTx2.data.expirationTimestamp = 1500n;
+        mockTx1 = txWithDataOverrides(mockTx1, { expirationTimestamp: 500n });
+        mockTx2 = txWithDataOverrides(mockTx2, { expirationTimestamp: 1500n });
 
         const pendingTxs: PendingTxInfo[] = [
           { blockHash: Fr.ZERO, txHash: tx1, isEvictable: true },

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
@@ -14,7 +14,7 @@ import { RevertCode } from '@aztec/stdlib/avm';
 import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import {
   AppendOnlyTreeSnapshot,
   MerkleTreeId,
@@ -23,7 +23,15 @@ import {
   PublicDataTreeLeaf,
   PublicDataTreeLeafPreimage,
 } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+import {
+  BlockHeader,
+  GlobalVariables,
+  type Tx,
+  TxConstantData,
+  TxEffect,
+  TxHash,
+  type TxValidator,
+} from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -545,13 +553,13 @@ describe('TxPoolV2 Compatibility Tests', () => {
   });
 
   it('Evicts txs with an insufficient fee payer balance after a block is mined', async () => {
-    const tx1 = await mockTx(1);
+    let tx1 = await mockTx(1);
     const tx2 = await mockTx(2);
     const tx3 = await mockTx(3);
     const tx4 = await mockTx(4);
 
     // modify tx1 to have the same fee payer as the mined tx and an insufficient fee payer balance
-    tx1.data.feePayer = tx4.data.feePayer;
+    tx1 = txWithDataOverrides(tx1, { feePayer: tx4.data.feePayer });
     const prev = db.getLeafPreimage.getMockImplementation()!;
     const expectedSlot = await computeFeePayerBalanceLeafSlot(tx1.data.feePayer);
     db.getLeafPreimage.mockImplementation((tree, index) => {
@@ -574,12 +582,21 @@ describe('TxPoolV2 Compatibility Tests', () => {
   });
 
   it('Evicts txs with invalid archive roots after a reorg', async () => {
-    const tx1 = await mockTx(1);
+    let tx1 = await mockTx(1);
     const tx2 = await mockTx(2);
     const tx3 = await mockTx(3);
 
     // modify tx1 to return no archive indices
-    tx1.data.constants.anchorBlockHeader.globalVariables.blockNumber = BlockNumber(1);
+    const newAnchorBlockHeader = BlockHeader.empty({
+      globalVariables: GlobalVariables.empty({ blockNumber: BlockNumber(1) }),
+    });
+    const newConstants = new TxConstantData(
+      newAnchorBlockHeader,
+      tx1.data.constants.txContext,
+      tx1.data.constants.vkTreeRoot,
+      tx1.data.constants.protocolContractsHash,
+    );
+    tx1 = txWithDataOverrides(tx1, { constants: newConstants });
     const tx1HeaderHash = await tx1.data.constants.anchorBlockHeader.hash();
     db.findLeafIndices.mockImplementation((tree, leaves) => {
       if (tree === MerkleTreeId.ARCHIVE) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -16,14 +16,23 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import {
   AppendOnlyTreeSnapshot,
   MerkleTreeId,
   PublicDataTreeLeaf,
   PublicDataTreeLeafPreimage,
 } from '@aztec/stdlib/trees';
-import { BlockHeader, GlobalVariables, type Tx, TxEffect, TxHash, type TxValidator } from '@aztec/stdlib/tx';
+import {
+  BlockHeader,
+  GlobalVariables,
+  type Tx,
+  TxConstantData,
+  TxContext,
+  TxEffect,
+  TxHash,
+  type TxValidator,
+} from '@aztec/stdlib/tx';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -665,25 +674,46 @@ describe('TxPoolV2', () => {
       await gasArchiveStore.delete();
     });
 
+    const withGasSettings = (t: MockTx, newGasSettings: GasSettings): MockTx => {
+      const newTxContext = new TxContext(
+        t.data.constants.txContext.chainId,
+        t.data.constants.txContext.version,
+        newGasSettings,
+      );
+      const newConstants = new TxConstantData(
+        t.data.constants.anchorBlockHeader,
+        newTxContext,
+        t.data.constants.vkTreeRoot,
+        t.data.constants.protocolContractsHash,
+      );
+      return txWithDataOverrides(t, { constants: newConstants });
+    };
+
     const makePublicTxWithGas = async (seed: number, gasLimits: Gas) => {
-      const tx = await mockTx(seed, { numberOfNonRevertiblePublicCallRequests: 1 });
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits,
-        maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
-      });
+      let tx = await mockTx(seed, { numberOfNonRevertiblePublicCallRequests: 1 });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits,
+          maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
+        }),
+      );
       return tx;
     };
 
     const makePrivateTxWithGas = async (seed: number, gasLimits: Gas) => {
-      const tx = await mockTx(seed, {
+      let tx = await mockTx(seed, {
         numberOfNonRevertiblePublicCallRequests: 0,
         numberOfRevertiblePublicCallRequests: 0,
         hasPublicTeardownCallRequest: false,
       });
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits,
-        maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits,
+          maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
+        }),
+      );
       return tx;
     };
 
@@ -730,24 +760,30 @@ describe('TxPoolV2', () => {
     });
 
     it('rejects public tx if L2 gas limit is too high', async () => {
-      const tx = await makePublicTxWithGas(1, new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1));
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
-        maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
-        teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
-      });
+      let tx = await makePublicTxWithGas(1, new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1));
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
+          maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
+          teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
+        }),
+      );
       const result = await gasPool.addPendingTxs([tx]);
       expect(result.accepted).toHaveLength(0);
       expect(toStrings(result.rejected)).toContain(hashOf(tx));
     });
 
     it('rejects private tx if L2 gas limit is too high', async () => {
-      const tx = await makePrivateTxWithGas(1, new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1));
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
-        maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
-        teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
-      });
+      let tx = await makePrivateTxWithGas(1, new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1));
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
+          maxFeesPerGas: DEFAULT_MAX_FEES_PER_GAS,
+          teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
+        }),
+      );
       const result = await gasPool.addPendingTxs([tx]);
       expect(result.accepted).toHaveLength(0);
       expect(toStrings(result.rejected)).toContain(hashOf(tx));
@@ -3294,14 +3330,21 @@ describe('TxPoolV2', () => {
 
     it('handles mixed valid/invalid anchor blocks in batch', async () => {
       const txValid = await mockTx(1);
-      const txInvalid = await mockTx(2);
+      let txInvalid = await mockTx(2);
 
       // Give txInvalid a different anchor block header
-      txInvalid.data.constants.anchorBlockHeader = BlockHeader.empty({
+      const newAnchor = BlockHeader.empty({
         globalVariables: GlobalVariables.empty({
           blockNumber: BlockNumber(999),
         }),
       });
+      const newConstants = new TxConstantData(
+        newAnchor,
+        txInvalid.data.constants.txContext,
+        txInvalid.data.constants.vkTreeRoot,
+        txInvalid.data.constants.protocolContractsHash,
+      );
+      txInvalid = txWithDataOverrides(txInvalid, { constants: newConstants });
 
       await pool.addPendingTxs([txValid, txInvalid]);
       await pool.handleMinedBlock(makeBlock([txValid, txInvalid], slot1Header));
@@ -4064,10 +4107,22 @@ describe('TxPoolV2', () => {
       // Create a tx with very high maxFeesPerGas so fee limit exceeds 1e18 balance
       // Fee limit = gasLimits.l2 * maxFees.l2 + gasLimits.da * maxFees.da
       // Default gas limits are ~1e7 each, so with maxFees of 1e12 we get ~1e19 fee limit
-      const highFeeTx = await mockTx(4, { numberOfNonRevertiblePublicCallRequests: 1 });
-      highFeeTx.data.constants.txContext.gasSettings = GasSettings.default({
+      let highFeeTx = await mockTx(4, { numberOfNonRevertiblePublicCallRequests: 1 });
+      const highFeeGasSettings = GasSettings.default({
         maxFeesPerGas: new GasFees(1e12, 1e12),
       });
+      const highFeeTxContext = new TxContext(
+        highFeeTx.data.constants.txContext.chainId,
+        highFeeTx.data.constants.txContext.version,
+        highFeeGasSettings,
+      );
+      const highFeeConstants = new TxConstantData(
+        highFeeTx.data.constants.anchorBlockHeader,
+        highFeeTxContext,
+        highFeeTx.data.constants.vkTreeRoot,
+        highFeeTx.data.constants.protocolContractsHash,
+      );
+      highFeeTx = txWithDataOverrides(highFeeTx, { constants: highFeeConstants });
 
       // Give conflictingTx a nullifier conflict with existingTx
       setNullifier(conflictingTx, 0, getNullifier(existingTx, 0));

--- a/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.test.ts
@@ -13,7 +13,7 @@ import { computeFeePayerBalanceStorageSlot } from '@aztec/protocol-contracts/fee
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
-import { mockTx } from '@aztec/stdlib/testing';
+import { mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import type { PublicStateSource } from '@aztec/stdlib/trees';
 import {
   TX_ERROR_GAS_LIMIT_TOO_HIGH,
@@ -21,6 +21,8 @@ import {
   TX_ERROR_INSUFFICIENT_FEE_PER_GAS,
   TX_ERROR_INSUFFICIENT_GAS_LIMIT,
   type Tx,
+  TxConstantData,
+  TxContext,
 } from '@aztec/stdlib/tx';
 
 import assert from 'assert';
@@ -40,6 +42,21 @@ describe('GasTxValidator', () => {
   let expectedBalanceSlot: Fr;
   let feeLimit: bigint;
 
+  const withGasSettings = (t: Tx, newGasSettings: GasSettings): Tx => {
+    const newTxContext = new TxContext(
+      t.data.constants.txContext.chainId,
+      t.data.constants.txContext.version,
+      newGasSettings,
+    );
+    const newConstants = new TxConstantData(
+      t.data.constants.anchorBlockHeader,
+      newTxContext,
+      t.data.constants.vkTreeRoot,
+      t.data.constants.protocolContractsHash,
+    );
+    return txWithDataOverrides(t, { constants: newConstants });
+  };
+
   beforeEach(async () => {
     publicStateSource = mock<PublicStateSource>({
       storageRead: mockFn().mockImplementation((_address: AztecAddress, _slot: Fr) => Fr.ZERO),
@@ -47,9 +64,11 @@ describe('GasTxValidator', () => {
     feeJuiceAddress = ProtocolContractAddress.FeeJuice;
     gasFees = new GasFees(11, 22);
 
+    const newPayer = await AztecAddress.random();
+    const newGasSettings = GasSettings.default({ maxFeesPerGas: gasFees.clone() });
     tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 2 });
-    tx.data.feePayer = await AztecAddress.random();
-    tx.data.constants.txContext.gasSettings = GasSettings.default({ maxFeesPerGas: gasFees.clone() });
+    tx = txWithDataOverrides(tx, { feePayer: newPayer });
+    tx = withGasSettings(tx, newGasSettings);
     payer = tx.data.feePayer;
     expectedBalanceSlot = await computeFeePayerBalanceStorageSlot(payer);
     feeLimit = tx.data.constants.txContext.gasSettings.getFeeLimit().toBigInt();
@@ -114,98 +133,125 @@ describe('GasTxValidator', () => {
   });
 
   const makePrivateTx = async () => {
-    const privateTx = await mockTx(1, {
+    let privateTx = await mockTx(1, {
       numberOfNonRevertiblePublicCallRequests: 0,
       numberOfRevertiblePublicCallRequests: 0,
       hasPublicTeardownCallRequest: false,
     });
     assert(!privateTx.data.forPublic);
-    privateTx.data.feePayer = payer;
-    privateTx.data.constants.txContext.gasSettings = GasSettings.default({ maxFeesPerGas: gasFees.clone() });
+    privateTx = txWithDataOverrides(privateTx, { feePayer: payer });
+    privateTx = withGasSettings(privateTx, GasSettings.default({ maxFeesPerGas: gasFees.clone() }));
     return privateTx;
   };
 
   describe('gas limits', () => {
     it('accepts public tx at exactly the minimum gas limits', async () => {
       assert(!!tx.data.forPublic);
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PUBLIC_TX_L2_GAS_OVERHEAD),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PUBLIC_TX_L2_GAS_OVERHEAD),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       mockBalance(tx.data.constants.txContext.gasSettings.getFeeLimit().toBigInt());
       await expectValid(tx);
     });
 
     it('accepts private tx at exactly the minimum gas limits', async () => {
-      const privateTx = await makePrivateTx();
-      privateTx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      let privateTx = await makePrivateTx();
+      privateTx = withGasSettings(
+        privateTx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       mockBalance(privateTx.data.constants.txContext.gasSettings.getFeeLimit().toBigInt());
       await expectValid(privateTx);
     });
 
     it('rejects public tx below the public L2 gas minimum', async () => {
       assert(!!tx.data.forPublic);
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PUBLIC_TX_L2_GAS_OVERHEAD - 1),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PUBLIC_TX_L2_GAS_OVERHEAD - 1),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       await expectInvalid(tx, TX_ERROR_INSUFFICIENT_GAS_LIMIT);
     });
 
     it('rejects private tx below the private L2 gas minimum', async () => {
-      const privateTx = await makePrivateTx();
-      privateTx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD - 1),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      let privateTx = await makePrivateTx();
+      privateTx = withGasSettings(
+        privateTx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD - 1),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       await expectInvalid(privateTx, TX_ERROR_INSUFFICIENT_GAS_LIMIT);
     });
 
     it('rejects public tx at private L2 gas minimum (between the two thresholds)', async () => {
       assert(!!tx.data.forPublic);
       // PRIVATE_TX_L2_GAS_OVERHEAD is enough for a private tx but not for a public tx.
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD, PRIVATE_TX_L2_GAS_OVERHEAD),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       await expectInvalid(tx, TX_ERROR_INSUFFICIENT_GAS_LIMIT);
     });
 
     it('rejects tx below DA gas minimum', async () => {
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(TX_DA_GAS_OVERHEAD - 1, PUBLIC_TX_L2_GAS_OVERHEAD),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(TX_DA_GAS_OVERHEAD - 1, PUBLIC_TX_L2_GAS_OVERHEAD),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       await expectInvalid(tx, TX_ERROR_INSUFFICIENT_GAS_LIMIT);
     });
 
     it('rejects tx below both DA and L2 gas minimums', async () => {
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(1, 1),
-        maxFeesPerGas: gasFees.clone(),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(1, 1),
+          maxFeesPerGas: gasFees.clone(),
+        }),
+      );
       await expectInvalid(tx, TX_ERROR_INSUFFICIENT_GAS_LIMIT);
     });
 
     it('rejects public tx if L2 gas limit is too high', async () => {
-      tx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
-        maxFeesPerGas: gasFees.clone(),
-        teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
-      });
+      tx = withGasSettings(
+        tx,
+        GasSettings.default({
+          gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
+          maxFeesPerGas: gasFees.clone(),
+          teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
+        }),
+      );
       await expectInvalid(tx, TX_ERROR_GAS_LIMIT_TOO_HIGH);
     });
 
     it('rejects private tx if L2 gas limit is too high', async () => {
-      const privateTx = await makePrivateTx();
-      privateTx.data.constants.txContext.gasSettings = GasSettings.default({
-        gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
-        maxFeesPerGas: gasFees.clone(),
-        teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
-      });
+      let privateTx = await makePrivateTx();
+      privateTx = withGasSettings(
+        privateTx,
+        GasSettings.default({
+          gasLimits: new Gas(DEFAULT_DA_GAS_LIMIT, MAX_PROCESSABLE_L2_GAS + 1),
+          maxFeesPerGas: gasFees.clone(),
+          teardownGasLimits: new Gas(DEFAULT_TEARDOWN_DA_GAS_LIMIT, 1),
+        }),
+      );
       await expectInvalid(privateTx, TX_ERROR_GAS_LIMIT_TOO_HIGH);
     });
   });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
@@ -1,11 +1,13 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
-import { mockTx, mockTxForRollup } from '@aztec/stdlib/testing';
+import { mockTx, mockTxForRollup, txWithDataOverrides } from '@aztec/stdlib/testing';
 import type { AnyTx, Tx } from '@aztec/stdlib/tx';
 import {
   TX_ERROR_INCORRECT_L1_CHAIN_ID,
   TX_ERROR_INCORRECT_PROTOCOL_CONTRACTS_HASH,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
   TX_ERROR_INCORRECT_VK_TREE_ROOT,
+  TxConstantData,
+  TxContext,
 } from '@aztec/stdlib/tx';
 
 import { MetadataTxValidator } from './metadata_validator.js';
@@ -55,10 +57,22 @@ describe('MetadataTxValidator', () => {
 
   it('allows only transactions for the right chain', async () => {
     const goodTxs = await makeTxs();
-    const badTxs = await makeTxs();
+    let badTxs = await makeTxs();
 
-    badTxs.forEach(tx => {
-      tx.data.constants.txContext.chainId = chainId.add(new Fr(1));
+    badTxs = badTxs.map(tx => {
+      const wrongChainId = chainId.add(new Fr(1));
+      const newTxContext = new TxContext(
+        wrongChainId,
+        tx.data.constants.txContext.version,
+        tx.data.constants.txContext.gasSettings,
+      );
+      const newConstants = new TxConstantData(
+        tx.data.constants.anchorBlockHeader,
+        newTxContext,
+        tx.data.constants.vkTreeRoot,
+        tx.data.constants.protocolContractsHash,
+      );
+      return txWithDataOverrides(tx, { constants: newConstants });
     });
 
     await expectValid(goodTxs[0]);
@@ -69,10 +83,22 @@ describe('MetadataTxValidator', () => {
 
   it('allows only transactions for the right rollup', async () => {
     const goodTxs = await makeTxs();
-    const badTxs = await makeTxs();
+    let badTxs = await makeTxs();
 
-    badTxs.forEach(tx => {
-      tx.data.constants.txContext.version = rollupVersion.add(Fr.ONE);
+    badTxs = badTxs.map(tx => {
+      const wrongVersion = rollupVersion.add(Fr.ONE);
+      const newTxContext = new TxContext(
+        tx.data.constants.txContext.chainId,
+        wrongVersion,
+        tx.data.constants.txContext.gasSettings,
+      );
+      const newConstants = new TxConstantData(
+        tx.data.constants.anchorBlockHeader,
+        newTxContext,
+        tx.data.constants.vkTreeRoot,
+        tx.data.constants.protocolContractsHash,
+      );
+      return txWithDataOverrides(tx, { constants: newConstants });
     });
 
     await expectValid(goodTxs[0]);
@@ -85,8 +111,23 @@ describe('MetadataTxValidator', () => {
     const goodTxs = await makeTxs();
     const badTxs = await makeTxs();
 
-    badTxs[0].data.constants.vkTreeRoot = vkTreeRoot.add(new Fr(1));
-    badTxs[1].data.constants.protocolContractsHash = protocolContractsHash.add(new Fr(1));
+    const wrongVkTreeRoot = vkTreeRoot.add(new Fr(1));
+    const newConstants0 = new TxConstantData(
+      badTxs[0].data.constants.anchorBlockHeader,
+      badTxs[0].data.constants.txContext,
+      wrongVkTreeRoot,
+      badTxs[0].data.constants.protocolContractsHash,
+    );
+    badTxs[0] = txWithDataOverrides(badTxs[0], { constants: newConstants0 });
+
+    const wrongProtocolContractsHash = protocolContractsHash.add(new Fr(1));
+    const newConstants1 = new TxConstantData(
+      badTxs[1].data.constants.anchorBlockHeader,
+      badTxs[1].data.constants.txContext,
+      badTxs[1].data.constants.vkTreeRoot,
+      wrongProtocolContractsHash,
+    );
+    badTxs[1] = txWithDataOverrides(badTxs[1], { constants: newConstants1 });
 
     await expectValid(goodTxs[0]);
     await expectValid(goodTxs[1]);

--- a/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/timestamp_validator.test.ts
@@ -1,5 +1,5 @@
 import { BlockNumber } from '@aztec/foundation/branded-types';
-import { mockTx, mockTxForRollup } from '@aztec/stdlib/testing';
+import { mockTx, mockTxForRollup, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { TX_ERROR_INVALID_EXPIRATION_TIMESTAMP, type Tx } from '@aztec/stdlib/tx';
 
 import { TimestampTxValidator } from './timestamp_validator.js';
@@ -38,24 +38,24 @@ describe('TimestampTxValidator', () => {
   };
 
   it.each([10n, 11n])('allows txs with valid expiration timestamp', async expirationTimestamp => {
-    const [goodTx] = await makeTxs();
-    goodTx.data.expirationTimestamp = expirationTimestamp;
+    let [goodTx] = await makeTxs();
+    goodTx = txWithDataOverrides(goodTx, { expirationTimestamp });
 
     await expectValid(goodTx);
   });
 
   it('allows txs with equal or greater expiration timestamp', async () => {
-    const [goodTx1, goodTx2] = await makeTxs();
-    goodTx1.data.expirationTimestamp = timestamp;
-    goodTx2.data.expirationTimestamp = timestamp + 1n;
+    let [goodTx1, goodTx2] = await makeTxs();
+    goodTx1 = txWithDataOverrides(goodTx1, { expirationTimestamp: timestamp });
+    goodTx2 = txWithDataOverrides(goodTx2, { expirationTimestamp: timestamp + 1n });
 
     await expectValid(goodTx1);
     await expectValid(goodTx2);
   });
 
   it('rejects txs with lower expiration timestamp', async () => {
-    const [badTx] = await makeTxs();
-    badTx.data.expirationTimestamp = timestamp - 1n;
+    let [badTx] = await makeTxs();
+    badTx = txWithDataOverrides(badTx, { expirationTimestamp: timestamp - 1n });
 
     await expectInvalid(badTx, TX_ERROR_INVALID_EXPIRATION_TIMESTAMP);
   });
@@ -67,8 +67,8 @@ describe('TimestampTxValidator', () => {
     // `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
     setValidatorAtBlock(BlockNumber(1));
 
-    const [badTx] = await makeTxs();
-    badTx.data.expirationTimestamp = timestamp - 1n;
+    let [badTx] = await makeTxs();
+    badTx = txWithDataOverrides(badTx, { expirationTimestamp: timestamp - 1n });
 
     await expectValid(badTx);
   });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_validator_bench.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_validator_bench.test.ts
@@ -11,9 +11,9 @@ import { GasFees } from '@aztec/stdlib/gas';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { LogHash } from '@aztec/stdlib/kernel';
 import { ContractClassLogFields } from '@aztec/stdlib/logs';
-import { makeSelector, mockTx, mockTxForRollup } from '@aztec/stdlib/testing';
+import { makeSelector, mockTx, mockTxForRollup, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { DatabasePublicStateSource, MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
-import type { Tx } from '@aztec/stdlib/tx';
+import { type Tx, TxConstantData } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
@@ -124,7 +124,9 @@ describe('TxValidator: Benchmarks', () => {
 
     // TimestampTxValidator
     timestampTx = await mockTx(5);
-    timestampTx.data.expirationTimestamp = BigInt(Math.floor(Date.now() / 1000)) + 3600n;
+    timestampTx = txWithDataOverrides(timestampTx, {
+      expirationTimestamp: BigInt(Math.floor(Date.now() / 1000)) + 3600n,
+    });
     timestampValidator = new TimestampTxValidator({
       timestamp: BigInt(Math.floor(Date.now() / 1000)),
       blockNumber: BlockNumber(3),
@@ -187,7 +189,13 @@ describe('TxValidator: Benchmarks', () => {
 
     // BlockHeaderTxValidator
     blockHeaderTx = await mockTx(12);
-    blockHeaderTx.data.constants.anchorBlockHeader = worldStateService.getInitialHeader();
+    const newBhConstants = new TxConstantData(
+      worldStateService.getInitialHeader(),
+      blockHeaderTx.data.constants.txContext,
+      blockHeaderTx.data.constants.vkTreeRoot,
+      blockHeaderTx.data.constants.protocolContractsHash,
+    );
+    blockHeaderTx = txWithDataOverrides(blockHeaderTx, { constants: newBhConstants });
     await blockHeaderTx.recomputeHash();
     blockHeaderValidator = new BlockHeaderTxValidator(new ArchiveCache(merkleTree));
 
@@ -399,7 +407,13 @@ describe('TxValidator: Benchmarks', () => {
 
       // BlockHeaderTx needs anchorBlockHeader matching the inner world state's initial header
       localBlockHeaderTx = await mockTx(1000 + dbSize);
-      localBlockHeaderTx.data.constants.anchorBlockHeader = localWs.getInitialHeader();
+      const localBhConstants = new TxConstantData(
+        localWs.getInitialHeader(),
+        localBlockHeaderTx.data.constants.txContext,
+        localBlockHeaderTx.data.constants.vkTreeRoot,
+        localBlockHeaderTx.data.constants.protocolContractsHash,
+      );
+      localBlockHeaderTx = txWithDataOverrides(localBlockHeaderTx, { constants: localBhConstants });
       await localBlockHeaderTx.recomputeHash();
     });
 

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -21,7 +21,13 @@ import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { type BlockProposal, P2PClientType, P2PMessage } from '@aztec/stdlib/p2p';
 import { ChonkProof } from '@aztec/stdlib/proofs';
-import { makeAztecAddress, makeBlockHeader, makeBlockProposal, mockTx } from '@aztec/stdlib/testing';
+import {
+  makeAztecAddress,
+  makeBlockHeader,
+  makeBlockProposal,
+  mockTx,
+  txWithDataOverrides,
+} from '@aztec/stdlib/testing';
 import { Tx, TxHash, type TxValidationResult } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -179,9 +185,9 @@ async function generateDeterministicTxs(txCount: number, seed: number, config: P
       hasPublicTeardownCallRequest: false,
       publicCalldataSize: 0,
     });
-    tx.data.expirationTimestamp = expirationTimestampBase + BigInt(i);
-    await tx.recomputeHash();
-    cached.push(tx);
+    const txWithExpiration = txWithDataOverrides(tx, { expirationTimestamp: expirationTimestampBase + BigInt(i) });
+    await txWithExpiration.recomputeHash();
+    cached.push(txWithExpiration);
   }
 
   txCache.set(seed, cached);

--- a/yarn-project/sequencer-client/src/test/utils.ts
+++ b/yarn-project/sequencer-client/src/test/utils.ts
@@ -10,8 +10,15 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { CommitteeAttestation, L2Block } from '@aztec/stdlib/block';
 import { BlockProposal, CheckpointAttestation, CheckpointProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
 import { CheckpointHeader } from '@aztec/stdlib/rollup';
-import { makeAppendOnlyTreeSnapshot, mockTxForRollup } from '@aztec/stdlib/testing';
-import { BlockHeader, GlobalVariables, type Tx, makeProcessedTxFromPrivateOnlyTx } from '@aztec/stdlib/tx';
+import { makeAppendOnlyTreeSnapshot, mockTxForRollup, txWithDataOverrides } from '@aztec/stdlib/testing';
+import {
+  BlockHeader,
+  GlobalVariables,
+  type Tx,
+  TxConstantData,
+  TxContext,
+  makeProcessedTxFromPrivateOnlyTx,
+} from '@aztec/stdlib/tx';
 
 import type { MockProxy } from 'jest-mock-extended';
 
@@ -22,9 +29,20 @@ export { MockCheckpointBuilder, MockCheckpointsBuilder } from './mock_checkpoint
  * Creates a mock transaction with a specific seed for deterministic testing
  */
 export async function makeTx(seed?: number, chainId?: Fr): Promise<Tx> {
-  const tx = await mockTxForRollup(seed);
+  let tx = await mockTxForRollup(seed);
   if (chainId) {
-    tx.data.constants.txContext.chainId = chainId;
+    const newTxContext = new TxContext(
+      chainId,
+      tx.data.constants.txContext.version,
+      tx.data.constants.txContext.gasSettings,
+    );
+    const newConstants = new TxConstantData(
+      tx.data.constants.anchorBlockHeader,
+      newTxContext,
+      tx.data.constants.vkTreeRoot,
+      tx.data.constants.protocolContractsHash,
+    );
+    tx = txWithDataOverrides(tx, { constants: newConstants });
   }
   return tx;
 }

--- a/yarn-project/simulator/src/public/fixtures/utils.ts
+++ b/yarn-project/simulator/src/public/fixtures/utils.ts
@@ -21,6 +21,8 @@ import {
   PartialPrivateTailPublicInputsForPublic,
   PartialPrivateTailPublicInputsForRollup,
   PrivateKernelTailCircuitPublicInputs,
+  PrivateToPublicAccumulatedData,
+  PublicCallRequest,
   countAccumulatedItems,
 } from '@aztec/stdlib/kernel';
 import { ContractClassLogFields, PrivateLog } from '@aztec/stdlib/logs';
@@ -70,7 +72,9 @@ export async function createTxForPublicCalls(
   // use max limits
   const gasLimits = new Gas(DEFAULT_DA_GAS_LIMIT, DEFAULT_L2_GAS_LIMIT);
 
-  const forPublic = PartialPrivateTailPublicInputsForPublic.empty();
+  // Build accumulated data objects (their array elements are still mutable).
+  const nonRevertibleAccumulatedData = PrivateToPublicAccumulatedData.empty();
+  const revertibleAccumulatedData = PrivateToPublicAccumulatedData.empty();
 
   // Non revertible private insertions
   if (!privateInsertions.nonRevertible?.nullifiers?.length) {
@@ -78,19 +82,19 @@ export async function createTxForPublicCalls(
   }
 
   for (let i = 0; i < privateInsertions.nonRevertible.nullifiers.length; i++) {
-    assert(i < forPublic.nonRevertibleAccumulatedData.nullifiers.length, 'Nullifier index out of bounds');
-    forPublic.nonRevertibleAccumulatedData.nullifiers[i] = privateInsertions.nonRevertible.nullifiers[i];
+    assert(i < nonRevertibleAccumulatedData.nullifiers.length, 'Nullifier index out of bounds');
+    nonRevertibleAccumulatedData.nullifiers[i] = privateInsertions.nonRevertible.nullifiers[i];
   }
   if (privateInsertions.nonRevertible.noteHashes) {
     for (let i = 0; i < privateInsertions.nonRevertible.noteHashes.length; i++) {
-      assert(i < forPublic.nonRevertibleAccumulatedData.noteHashes.length, 'Note hash index out of bounds');
-      forPublic.nonRevertibleAccumulatedData.noteHashes[i] = privateInsertions.nonRevertible.noteHashes[i];
+      assert(i < nonRevertibleAccumulatedData.noteHashes.length, 'Note hash index out of bounds');
+      nonRevertibleAccumulatedData.noteHashes[i] = privateInsertions.nonRevertible.noteHashes[i];
     }
   }
   if (privateInsertions.nonRevertible.l2ToL1Msgs) {
     for (let i = 0; i < privateInsertions.nonRevertible.l2ToL1Msgs.length; i++) {
-      assert(i < forPublic.nonRevertibleAccumulatedData.l2ToL1Msgs.length, 'L2 to L1 message index out of bounds');
-      forPublic.nonRevertibleAccumulatedData.l2ToL1Msgs[i] = privateInsertions.nonRevertible.l2ToL1Msgs[i];
+      assert(i < nonRevertibleAccumulatedData.l2ToL1Msgs.length, 'L2 to L1 message index out of bounds');
+      nonRevertibleAccumulatedData.l2ToL1Msgs[i] = privateInsertions.nonRevertible.l2ToL1Msgs[i];
     }
   }
 
@@ -98,33 +102,36 @@ export async function createTxForPublicCalls(
   if (privateInsertions.revertible) {
     if (privateInsertions.revertible.noteHashes) {
       for (let i = 0; i < privateInsertions.revertible.noteHashes.length; i++) {
-        assert(i < forPublic.revertibleAccumulatedData.noteHashes.length, 'Note hash index out of bounds');
-        forPublic.revertibleAccumulatedData.noteHashes[i] = privateInsertions.revertible.noteHashes[i];
+        assert(i < revertibleAccumulatedData.noteHashes.length, 'Note hash index out of bounds');
+        revertibleAccumulatedData.noteHashes[i] = privateInsertions.revertible.noteHashes[i];
       }
     }
     if (privateInsertions.revertible.nullifiers) {
       for (let i = 0; i < privateInsertions.revertible.nullifiers.length; i++) {
-        assert(i < forPublic.revertibleAccumulatedData.nullifiers.length, 'Nullifier index out of bounds');
-        forPublic.revertibleAccumulatedData.nullifiers[i] = privateInsertions.revertible.nullifiers[i];
+        assert(i < revertibleAccumulatedData.nullifiers.length, 'Nullifier index out of bounds');
+        revertibleAccumulatedData.nullifiers[i] = privateInsertions.revertible.nullifiers[i];
       }
     }
     if (privateInsertions.revertible.l2ToL1Msgs) {
       for (let i = 0; i < privateInsertions.revertible.l2ToL1Msgs.length; i++) {
-        assert(i < forPublic.revertibleAccumulatedData.l2ToL1Msgs.length, 'L2 to L1 message index out of bounds');
-        forPublic.revertibleAccumulatedData.l2ToL1Msgs[i] = privateInsertions.revertible.l2ToL1Msgs[i];
+        assert(i < revertibleAccumulatedData.l2ToL1Msgs.length, 'L2 to L1 message index out of bounds');
+        revertibleAccumulatedData.l2ToL1Msgs[i] = privateInsertions.revertible.l2ToL1Msgs[i];
       }
     }
   }
 
   for (let i = 0; i < setupCallRequests.length; i++) {
-    forPublic.nonRevertibleAccumulatedData.publicCallRequests[i] = setupCallRequests[i].request;
+    nonRevertibleAccumulatedData.publicCallRequests[i] = setupCallRequests[i].request;
   }
   for (let i = 0; i < appCallRequests.length; i++) {
-    forPublic.revertibleAccumulatedData.publicCallRequests[i] = appCallRequests[i].request;
+    revertibleAccumulatedData.publicCallRequests[i] = appCallRequests[i].request;
   }
-  if (teardownCallRequest) {
-    forPublic.publicTeardownCallRequest = teardownCallRequest.request;
-  }
+
+  const forPublic = new PartialPrivateTailPublicInputsForPublic(
+    nonRevertibleAccumulatedData,
+    revertibleAccumulatedData,
+    teardownCallRequest?.request ?? PublicCallRequest.empty(),
+  );
 
   const maxFeesPerGas = feePayer.isZero() ? GasFees.empty() : new GasFees(10, 10);
   const teardownGasLimits = teardownCallRequest

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -12,7 +12,7 @@ import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
 import { LogHash } from '@aztec/stdlib/kernel';
 import { ContractClassLogFields } from '@aztec/stdlib/logs';
-import { makeContractClassPublic, mockTx } from '@aztec/stdlib/testing';
+import { makeContractClassPublic, mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { type MerkleTreeWriteOperations, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { GlobalVariables, StateReference, Tx, type TxValidator } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
@@ -262,12 +262,12 @@ describe('public_processor', () => {
     });
 
     it('injects balance update with no public calls', async function () {
-      const tx = await mockPrivateOnlyTx({
+      let tx = await mockPrivateOnlyTx({
         feePayer,
       });
 
       const privateGasUsed = new Gas(12, 34);
-      tx.data.gasUsed = privateGasUsed;
+      tx = txWithDataOverrides(tx, { gasUsed: privateGasUsed });
 
       const txFee = privateGasUsed.computeFee(globalVariables.gasFees);
 
@@ -284,7 +284,7 @@ describe('public_processor', () => {
     });
 
     it('rejects tx if fee payer has not enough balance', async function () {
-      const tx = await mockPrivateOnlyTx({
+      let tx = await mockPrivateOnlyTx({
         feePayer,
       });
 
@@ -292,7 +292,7 @@ describe('public_processor', () => {
       if (privateGasUsed.computeFee(gasFees) < initialBalance) {
         throw new Error('Test setup error: gas fees are too low');
       }
-      tx.data.gasUsed = privateGasUsed;
+      tx = txWithDataOverrides(tx, { gasUsed: privateGasUsed });
 
       const [processed, failed] = await processor.process([tx]);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -19,9 +19,9 @@ import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { countAccumulatedItems } from '@aztec/stdlib/kernel';
 import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
-import { fr, mockTx } from '@aztec/stdlib/testing';
+import { fr, mockTx, txWithDataOverrides } from '@aztec/stdlib/testing';
 import { MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
-import { GlobalVariables } from '@aztec/stdlib/tx';
+import { GlobalVariables, TxConstantData, TxContext } from '@aztec/stdlib/tx';
 import { NativeWorldStateService } from '@aztec/world-state';
 
 import { jest } from '@jest/globals';
@@ -85,17 +85,28 @@ describe('public_tx_simulator', () => {
     feePayer?: AztecAddress;
   }) => {
     // seed with min nullifier to prevent insertion of a nullifier < min
-    const tx = await mockTx(/*seed=*/ MIN_NULLIFIER, {
+    let tx = await mockTx(/*seed=*/ MIN_NULLIFIER, {
       numberOfNonRevertiblePublicCallRequests: numberOfSetupCalls,
       numberOfRevertiblePublicCallRequests: numberOfAppLogicCalls,
       hasPublicTeardownCallRequest: hasPublicTeardownCall,
     });
-    tx.data.constants.txContext.gasSettings = GasSettings.from({
+    const newGasSettings = GasSettings.from({
       gasLimits,
       teardownGasLimits,
       maxFeesPerGas,
       maxPriorityFeesPerGas,
     });
+    const newTxContext = new TxContext(
+      tx.data.constants.txContext.chainId,
+      tx.data.constants.txContext.version,
+      newGasSettings,
+    );
+    const newConstants = new TxConstantData(
+      tx.data.constants.anchorBlockHeader,
+      newTxContext,
+      tx.data.constants.vkTreeRoot,
+      tx.data.constants.protocolContractsHash,
+    );
 
     tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] = new Fr(0x7777);
     tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[1] = new Fr(0x8888);
@@ -117,12 +128,12 @@ describe('public_tx_simulator', () => {
       AztecAddress.fromField(new Fr(0x8888)),
     );
 
-    tx.data.gasUsed = privateGasUsed;
+    let gasUsed = privateGasUsed;
     if (hasPublicTeardownCall) {
-      tx.data.gasUsed = tx.data.gasUsed.add(teardownGasLimits);
+      gasUsed = gasUsed.add(teardownGasLimits);
     }
 
-    tx.data.feePayer = feePayer;
+    tx = txWithDataOverrides(tx, { constants: newConstants, gasUsed, feePayer });
 
     return tx;
   };

--- a/yarn-project/stdlib/src/kernel/private_kernel_tail_circuit_public_inputs.ts
+++ b/yarn-project/stdlib/src/kernel/private_kernel_tail_circuit_public_inputs.ts
@@ -20,15 +20,15 @@ export class PartialPrivateTailPublicInputsForPublic {
     /**
      * Accumulated side effects and enqueued calls that are not revertible.
      */
-    public nonRevertibleAccumulatedData: PrivateToPublicAccumulatedData,
+    public readonly nonRevertibleAccumulatedData: PrivateToPublicAccumulatedData,
     /**
      * Data accumulated from both public and private circuits.
      */
-    public revertibleAccumulatedData: PrivateToPublicAccumulatedData,
+    public readonly revertibleAccumulatedData: PrivateToPublicAccumulatedData,
     /**
      * Call request for the public teardown function.
      */
-    public publicTeardownCallRequest: PublicCallRequest,
+    public readonly publicTeardownCallRequest: PublicCallRequest,
   ) {}
 
   getSize() {
@@ -99,27 +99,31 @@ export class PartialPrivateTailPublicInputsForRollup {
 }
 
 export class PrivateKernelTailCircuitPublicInputs {
+  #cachedBuf: Buffer | undefined;
+  #cachedPublicInputs: PrivateToPublicKernelCircuitPublicInputs | undefined;
+  #cachedRollupInputs: PrivateToRollupKernelCircuitPublicInputs | undefined;
+
   constructor(
     /**
      * Data which is not modified by the circuits.
      */
-    public constants: TxConstantData,
+    public readonly constants: TxConstantData,
     /**
      * The accumulated gas used after private execution.
      * If the tx has a teardown call request, the teardown gas limits will also be included.
      */
-    public gasUsed: Gas,
+    public readonly gasUsed: Gas,
     /**
      * The address of the fee payer for the transaction.
      */
-    public feePayer: AztecAddress,
+    public readonly feePayer: AztecAddress,
     /**
      * The timestamp by which the transaction must be included in a block.
      */
-    public expirationTimestamp: UInt64,
+    public readonly expirationTimestamp: UInt64,
 
-    public forPublic?: PartialPrivateTailPublicInputsForPublic,
-    public forRollup?: PartialPrivateTailPublicInputsForRollup,
+    public readonly forPublic?: PartialPrivateTailPublicInputsForPublic,
+    public readonly forRollup?: PartialPrivateTailPublicInputsForRollup,
   ) {
     if (!forPublic && !forRollup) {
       throw new Error('Missing partial public inputs for private tail circuit.');
@@ -151,37 +155,37 @@ export class PrivateKernelTailCircuitPublicInputs {
   }
 
   toPrivateToPublicKernelCircuitPublicInputs() {
-    if (!this.forPublic) {
-      throw new Error('Private tail public inputs is not for public circuit.');
+    if (!this.#cachedPublicInputs) {
+      if (!this.forPublic) {
+        throw new Error('Private tail public inputs is not for public circuit.');
+      }
+      this.#cachedPublicInputs = new PrivateToPublicKernelCircuitPublicInputs(
+        this.constants,
+        this.forPublic.nonRevertibleAccumulatedData,
+        this.forPublic.revertibleAccumulatedData,
+        this.forPublic.publicTeardownCallRequest,
+        this.gasUsed,
+        this.feePayer,
+        this.expirationTimestamp,
+      );
     }
-    return new PrivateToPublicKernelCircuitPublicInputs(
-      this.constants,
-      this.forPublic.nonRevertibleAccumulatedData,
-      this.forPublic.revertibleAccumulatedData,
-      this.forPublic.publicTeardownCallRequest,
-      this.gasUsed,
-      this.feePayer,
-      this.expirationTimestamp,
-    );
+    return this.#cachedPublicInputs;
   }
 
   toPrivateToRollupKernelCircuitPublicInputs() {
-    if (!this.forRollup) {
-      throw new Error('Private tail public inputs is not for rollup circuit.');
+    if (!this.#cachedRollupInputs) {
+      if (!this.forRollup) {
+        throw new Error('Private tail public inputs is not for rollup circuit.');
+      }
+      this.#cachedRollupInputs = new PrivateToRollupKernelCircuitPublicInputs(
+        this.constants,
+        this.forRollup.end,
+        this.gasUsed,
+        this.feePayer,
+        this.expirationTimestamp,
+      );
     }
-    const constants = new TxConstantData(
-      this.constants.anchorBlockHeader,
-      this.constants.txContext,
-      this.constants.vkTreeRoot,
-      this.constants.protocolContractsHash,
-    );
-    return new PrivateToRollupKernelCircuitPublicInputs(
-      constants,
-      this.forRollup.end,
-      this.gasUsed,
-      this.feePayer,
-      this.expirationTimestamp,
-    );
+    return this.#cachedRollupInputs;
   }
 
   publicInputs(): PrivateToPublicKernelCircuitPublicInputs | PrivateToRollupKernelCircuitPublicInputs {
@@ -280,8 +284,9 @@ export class PrivateKernelTailCircuitPublicInputs {
 
   static fromBuffer(buffer: Buffer | BufferReader): PrivateKernelTailCircuitPublicInputs {
     const reader = BufferReader.asReader(buffer);
+    const startPos = reader.currentPosition;
     const isForPublic = reader.readBoolean();
-    return new PrivateKernelTailCircuitPublicInputs(
+    const result = new PrivateKernelTailCircuitPublicInputs(
       reader.readObject(TxConstantData),
       reader.readObject(Gas),
       reader.readObject(AztecAddress),
@@ -289,18 +294,23 @@ export class PrivateKernelTailCircuitPublicInputs {
       isForPublic ? reader.readObject(PartialPrivateTailPublicInputsForPublic) : undefined,
       !isForPublic ? reader.readObject(PartialPrivateTailPublicInputsForRollup) : undefined,
     );
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   toBuffer() {
-    const isForPublic = !!this.forPublic;
-    return serializeToBuffer(
-      isForPublic,
-      this.constants,
-      this.gasUsed,
-      this.feePayer,
-      bigintToUInt64BE(this.expirationTimestamp),
-      isForPublic ? this.forPublic!.toBuffer() : this.forRollup!.toBuffer(),
-    );
+    if (!this.#cachedBuf) {
+      const isForPublic = !!this.forPublic;
+      this.#cachedBuf = serializeToBuffer(
+        isForPublic,
+        this.constants,
+        this.gasUsed,
+        this.feePayer,
+        bigintToUInt64BE(this.expirationTimestamp),
+        isForPublic ? this.forPublic!.toBuffer() : this.forRollup!.toBuffer(),
+      );
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 
   static empty() {

--- a/yarn-project/stdlib/src/kernel/private_to_public_kernel_circuit_public_inputs.ts
+++ b/yarn-project/stdlib/src/kernel/private_to_public_kernel_circuit_public_inputs.ts
@@ -14,14 +14,16 @@ import { PrivateToPublicAccumulatedData } from './private_to_public_accumulated_
 import { PublicCallRequest } from './public_call_request.js';
 
 export class PrivateToPublicKernelCircuitPublicInputs {
+  #cachedHash: Promise<Fr> | undefined;
+
   constructor(
-    public constants: TxConstantData,
-    public nonRevertibleAccumulatedData: PrivateToPublicAccumulatedData,
-    public revertibleAccumulatedData: PrivateToPublicAccumulatedData,
-    public publicTeardownCallRequest: PublicCallRequest,
-    public gasUsed: Gas,
-    public feePayer: AztecAddress,
-    public expirationTimestamp: UInt64,
+    public readonly constants: TxConstantData,
+    public readonly nonRevertibleAccumulatedData: PrivateToPublicAccumulatedData,
+    public readonly revertibleAccumulatedData: PrivateToPublicAccumulatedData,
+    public readonly publicTeardownCallRequest: PublicCallRequest,
+    public readonly gasUsed: Gas,
+    public readonly feePayer: AztecAddress,
+    public readonly expirationTimestamp: UInt64,
   ) {}
 
   toBuffer() {
@@ -91,8 +93,11 @@ export class PrivateToPublicKernelCircuitPublicInputs {
     return fields;
   }
 
-  hash() {
-    return poseidon2HashWithSeparator(this.toFields(), DomainSeparator.PUBLIC_TX_HASH);
+  hash(): Promise<Fr> {
+    if (!this.#cachedHash) {
+      this.#cachedHash = poseidon2HashWithSeparator(this.toFields(), DomainSeparator.PUBLIC_TX_HASH);
+    }
+    return this.#cachedHash;
   }
 
   toJSON() {

--- a/yarn-project/stdlib/src/kernel/private_to_rollup_kernel_circuit_public_inputs.ts
+++ b/yarn-project/stdlib/src/kernel/private_to_rollup_kernel_circuit_public_inputs.ts
@@ -17,27 +17,29 @@ import { PrivateToRollupAccumulatedData } from './private_to_rollup_accumulated_
  * All Public kernels use this shape for outputs.
  */
 export class PrivateToRollupKernelCircuitPublicInputs {
+  #cachedHash: Promise<Fr> | undefined;
+
   constructor(
     /**
      * Data which is not modified by the circuits.
      */
-    public constants: TxConstantData,
+    public readonly constants: TxConstantData,
     /**
      * Data accumulated from both public and private circuits.
      */
-    public end: PrivateToRollupAccumulatedData,
+    public readonly end: PrivateToRollupAccumulatedData,
     /**
      * Gas used during this transaction
      */
-    public gasUsed: Gas,
+    public readonly gasUsed: Gas,
     /**
      * The address of the fee payer for the transaction.
      */
-    public feePayer: AztecAddress,
+    public readonly feePayer: AztecAddress,
     /**
      * The timestamp by which the transaction must be included in a block.
      */
-    public expirationTimestamp: UInt64,
+    public readonly expirationTimestamp: UInt64,
   ) {}
 
   getNonEmptyNullifiers() {
@@ -112,7 +114,10 @@ export class PrivateToRollupKernelCircuitPublicInputs {
     return fields;
   }
 
-  hash() {
-    return poseidon2HashWithSeparator(this.toFields(), DomainSeparator.PRIVATE_TX_HASH);
+  hash(): Promise<Fr> {
+    if (!this.#cachedHash) {
+      this.#cachedHash = poseidon2HashWithSeparator(this.toFields(), DomainSeparator.PRIVATE_TX_HASH);
+    }
+    return this.#cachedHash;
   }
 }

--- a/yarn-project/stdlib/src/logs/contract_class_log.ts
+++ b/yarn-project/stdlib/src/logs/contract_class_log.ts
@@ -11,9 +11,11 @@ import { z } from 'zod';
 import { AztecAddress } from '../aztec-address/index.js';
 
 export class ContractClassLogFields {
+  #cachedBuf: Buffer | undefined;
+
   // Below line gives error 'Type instantiation is excessively deep and possibly infinite. ts(2589)'
   // public fields: Tuple<Fr, typeof CONTRACT_CLASS_LOG_SIZE_IN_FIELDS>
-  constructor(public fields: Fr[]) {
+  constructor(public readonly fields: Fr[]) {
     if (fields.length !== CONTRACT_CLASS_LOG_SIZE_IN_FIELDS) {
       throw new Error(
         `Invalid number of fields for ContractClassLog. Expected ${CONTRACT_CLASS_LOG_SIZE_IN_FIELDS}, got ${fields.length}`,
@@ -57,16 +59,22 @@ export class ContractClassLogFields {
   }
 
   toBuffer() {
-    return serializeToBuffer(this.fields);
+    if (!this.#cachedBuf) {
+      this.#cachedBuf = serializeToBuffer(this.fields);
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 
   static fromBuffer(buffer: Buffer | BufferReader) {
     const reader = BufferReader.asReader(buffer);
+    const startPos = reader.currentPosition;
     // Below line gives error 'Type instantiation is excessively deep and possibly infinite. ts(2589)'
     // reader.readArray(CONTRACT_CLASS_LOG_SIZE_IN_FIELDS, Fr)
-    return new ContractClassLogFields(
+    const result = new ContractClassLogFields(
       Array.from({ length: CONTRACT_CLASS_LOG_SIZE_IN_FIELDS }, () => reader.readObject(Fr)),
     );
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   equals(other: ContractClassLogFields) {

--- a/yarn-project/stdlib/src/proofs/chonk_proof.ts
+++ b/yarn-project/stdlib/src/proofs/chonk_proof.ts
@@ -7,11 +7,13 @@ import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 // CHONK: "Client Honk" - An UltraHonk variant with incremental folding and delayed non-native arithmetic.
 export class ChonkProof {
+  #cachedBuf: Buffer | undefined;
+
   constructor(
     // The proof fields.
     // For native verification, attach public inputs via `attachPublicInputs(publicInputs)`.
     // Not using Tuple here due to the length being too high.
-    public fields: Fr[],
+    public readonly fields: Fr[],
   ) {
     if (fields.length !== CHONK_PROOF_LENGTH) {
       throw new Error(`Invalid ChonkProof length: ${fields.length}`);
@@ -55,21 +57,29 @@ export class ChonkProof {
 
   static fromBuffer(buffer: Buffer | BufferReader): ChonkProof {
     const reader = BufferReader.asReader(buffer);
+    const startPos = reader.currentPosition;
     const proofLength = reader.readNumber();
     const proof = reader.readArray(proofLength, Fr);
-    return new ChonkProof(proof);
+    const result = new ChonkProof(proof);
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   public toBuffer() {
-    return serializeToBuffer(this.fields.length, this.fields);
+    if (!this.#cachedBuf) {
+      this.#cachedBuf = serializeToBuffer(this.fields.length, this.fields);
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 }
 
 export class ChonkProofWithPublicInputs {
+  #cachedBuf: Buffer | undefined;
+
   constructor(
     // The proof fields with public inputs.
     // For recursive verification, use without public inputs via `removePublicInputs()`.
-    public fieldsWithPublicInputs: Fr[],
+    public readonly fieldsWithPublicInputs: Fr[],
   ) {
     if (fieldsWithPublicInputs.length < CHONK_PROOF_LENGTH) {
       throw new Error(`Invalid ChonkProofWithPublicInputs length: ${fieldsWithPublicInputs.length}`);
@@ -105,13 +115,19 @@ export class ChonkProofWithPublicInputs {
 
   static fromBuffer(buffer: Buffer | BufferReader): ChonkProofWithPublicInputs {
     const reader = BufferReader.asReader(buffer);
+    const startPos = reader.currentPosition;
     const proofLength = reader.readNumber();
     const proof = reader.readArray(proofLength, Fr);
-    return new ChonkProofWithPublicInputs(proof);
+    const result = new ChonkProofWithPublicInputs(proof);
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   public toBuffer() {
-    return serializeToBuffer(this.fieldsWithPublicInputs.length, this.fieldsWithPublicInputs);
+    if (!this.#cachedBuf) {
+      this.#cachedBuf = serializeToBuffer(this.fieldsWithPublicInputs.length, this.fieldsWithPublicInputs);
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 
   // Called when constructing from bb proving results.

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -41,11 +41,13 @@ import { Nullifier } from '../kernel/nullifier.js';
 import { PrivateCircuitPublicInputs } from '../kernel/private_circuit_public_inputs.js';
 import {
   PartialPrivateTailPublicInputsForPublic,
+  PartialPrivateTailPublicInputsForRollup,
   PrivateKernelTailCircuitPublicInputs,
 } from '../kernel/private_kernel_tail_circuit_public_inputs.js';
 import { PrivateToAvmAccumulatedData } from '../kernel/private_to_avm_accumulated_data.js';
 import { PrivateToPublicAccumulatedDataBuilder } from '../kernel/private_to_public_accumulated_data_builder.js';
-import { PublicCallRequestArrayLengths } from '../kernel/public_call_request.js';
+import { PrivateToRollupAccumulatedData } from '../kernel/private_to_rollup_accumulated_data.js';
+import { PublicCallRequest, PublicCallRequestArrayLengths } from '../kernel/public_call_request.js';
 import { computeInHashFromL1ToL2Messages } from '../messaging/in_hash.js';
 import { BlockProposal } from '../p2p/block_proposal.js';
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
@@ -65,6 +67,7 @@ import {
   ProtocolContracts,
   Tx,
   TxConstantData,
+  TxContext,
   makeProcessedTxFromPrivateOnlyTx,
   makeProcessedTxFromTxWithPublicCalls,
 } from '../tx/index.js';
@@ -88,6 +91,32 @@ import {
 
 export const randomTxHash = (): TxHash => TxHash.random();
 
+/** Creates a copy of the tx with overridden data fields. For testing only. */
+export function txWithDataOverrides(
+  tx: Tx,
+  overrides: Partial<
+    Pick<
+      {
+        constants: TxConstantData;
+        gasUsed: Gas;
+        feePayer: AztecAddress;
+        expirationTimestamp: bigint;
+      },
+      'feePayer' | 'gasUsed' | 'expirationTimestamp' | 'constants'
+    >
+  >,
+): Tx {
+  const data = new PrivateKernelTailCircuitPublicInputs(
+    overrides.constants ?? tx.data.constants,
+    overrides.gasUsed ?? tx.data.gasUsed,
+    overrides.feePayer ?? tx.data.feePayer,
+    overrides.expirationTimestamp ?? tx.data.expirationTimestamp,
+    tx.data.forPublic,
+    tx.data.forRollup,
+  );
+  return new Tx(tx.txHash, data, tx.chonkProof, tx.contractClassLogFields, tx.publicFunctionCalldata);
+}
+
 export const mockTx = async (
   seed = 1,
   {
@@ -98,6 +127,7 @@ export const mockTx = async (
     publicCalldataSize = 2,
     feePayer,
     chonkProof = ChonkProof.random(),
+    gasSettings,
     maxFeesPerGas = new GasFees(10, 10),
     maxPriorityFeesPerGas,
     gasUsed = Gas.empty(),
@@ -114,6 +144,7 @@ export const mockTx = async (
     publicCalldataSize?: number;
     feePayer?: AztecAddress;
     chonkProof?: ChonkProof;
+    gasSettings?: GasSettings;
     maxFeesPerGas?: GasFees;
     maxPriorityFeesPerGas?: GasFees;
     gasUsed?: Gas;
@@ -129,27 +160,24 @@ export const mockTx = async (
     numberOfRevertiblePublicCallRequests +
     (hasPublicTeardownCallRequest ? 1 : 0);
   const isForPublic = totalPublicCallRequests > 0;
-  const data = PrivateKernelTailCircuitPublicInputs.empty();
   const firstNullifier = new Nullifier(new Fr(seed + 1), Fr.ZERO, 0);
-  data.constants.anchorBlockHeader = anchorBlockHeader;
-  data.constants.txContext.gasSettings = GasSettings.default({ maxFeesPerGas, maxPriorityFeesPerGas });
-  data.feePayer = feePayer ?? (await AztecAddress.random());
-  data.gasUsed = gasUsed;
-  data.constants.txContext.chainId = chainId;
-  data.constants.txContext.version = version;
-  data.constants.vkTreeRoot = vkTreeRoot;
-  data.constants.protocolContractsHash = protocolContractsHash;
 
-  // Set expirationTimestamp to the maximum allowed duration from the current time.
-  data.expirationTimestamp = BigInt(Math.floor(Date.now() / 1000) + MAX_TX_LIFETIME);
+  // Build constants bottom-up (all properties are readonly).
+  const actualGasSettings = gasSettings ?? GasSettings.default({ maxFeesPerGas, maxPriorityFeesPerGas });
+  const txContext = new TxContext(chainId, version, actualGasSettings);
+  const constants = new TxConstantData(anchorBlockHeader, txContext, vkTreeRoot, protocolContractsHash);
+  const actualFeePayer = feePayer ?? (await AztecAddress.random());
+  const expirationTimestamp = BigInt(Math.floor(Date.now() / 1000) + MAX_TX_LIFETIME);
 
   const publicFunctionCalldata: HashedValues[] = [];
-  if (!isForPublic) {
-    data.forRollup!.end.nullifiers[0] = firstNullifier.value;
-  } else {
-    data.forRollup = undefined;
-    data.forPublic = PartialPrivateTailPublicInputsForPublic.empty();
+  let forPublic: PartialPrivateTailPublicInputsForPublic | undefined;
+  let forRollup: PartialPrivateTailPublicInputsForRollup | undefined;
 
+  if (!isForPublic) {
+    const rollupData = PrivateToRollupAccumulatedData.empty();
+    rollupData.nullifiers[0] = firstNullifier.value;
+    forRollup = new PartialPrivateTailPublicInputsForRollup(rollupData);
+  } else {
     const revertibleBuilder = new PrivateToPublicAccumulatedDataBuilder();
     const nonRevertibleBuilder = new PrivateToPublicAccumulatedDataBuilder();
 
@@ -161,11 +189,11 @@ export const mockTx = async (
       publicCallRequests[i].calldataHash = hashedCalldata.hash;
     }
 
-    if (hasPublicTeardownCallRequest) {
-      data.forPublic.publicTeardownCallRequest = publicCallRequests.pop()!;
-    }
+    const publicTeardownCallRequest = hasPublicTeardownCallRequest
+      ? publicCallRequests.pop()!
+      : PublicCallRequest.empty();
 
-    data.forPublic.nonRevertibleAccumulatedData = nonRevertibleBuilder
+    const nonRevertibleAccumulatedData = nonRevertibleBuilder
       .pushNullifier(firstNullifier.value)
       .withPublicCallRequests(publicCallRequests.slice(numberOfRevertiblePublicCallRequests))
       .build();
@@ -175,10 +203,25 @@ export const mockTx = async (
       revertibleBuilder.pushNullifier(revertibleNullifier.value);
     }
 
-    data.forPublic.revertibleAccumulatedData = revertibleBuilder
+    const revertibleAccumulatedData = revertibleBuilder
       .withPublicCallRequests(publicCallRequests.slice(0, numberOfRevertiblePublicCallRequests))
       .build();
+
+    forPublic = new PartialPrivateTailPublicInputsForPublic(
+      nonRevertibleAccumulatedData,
+      revertibleAccumulatedData,
+      publicTeardownCallRequest,
+    );
   }
+
+  const data = new PrivateKernelTailCircuitPublicInputs(
+    constants,
+    gasUsed,
+    actualFeePayer,
+    expirationTimestamp,
+    forPublic,
+    forRollup,
+  );
 
   return await Tx.create({
     data,
@@ -230,43 +273,77 @@ export async function mockProcessedTx({
   feePayer ??= makeAztecAddress(seed + 0x100);
   feePaymentPublicDataWrite ??= makePublicDataWrite(seed + 0x200);
 
-  const txConstantData = TxConstantData.empty();
-  txConstantData.anchorBlockHeader = anchorBlockHeader;
-  txConstantData.txContext.chainId = chainId;
-  txConstantData.txContext.version = version;
-  txConstantData.txContext.gasSettings = gasSettings;
-  txConstantData.vkTreeRoot = vkTreeRoot;
-  txConstantData.protocolContractsHash = await protocolContracts.hash();
+  const protocolContractsHashValue = await protocolContracts.hash();
 
-  const tx = !privateOnly
-    ? await mockTx(seed, { feePayer, gasUsed, ...mockTxOpts })
+  let tx = !privateOnly
+    ? await mockTx(seed, {
+        ...mockTxOpts,
+        feePayer,
+        gasUsed,
+        anchorBlockHeader,
+        chainId,
+        version,
+        vkTreeRoot,
+        protocolContractsHash: protocolContractsHashValue,
+        gasSettings,
+      })
     : await mockTx(seed, {
         numberOfNonRevertiblePublicCallRequests: 0,
         numberOfRevertiblePublicCallRequests: 0,
+        ...mockTxOpts,
         feePayer,
         gasUsed,
-        ...mockTxOpts,
+        anchorBlockHeader,
+        chainId,
+        version,
+        vkTreeRoot,
+        protocolContractsHash: protocolContractsHashValue,
+        gasSettings,
       });
-  tx.data.constants = txConstantData;
 
   const transactionFee = tx.data.gasUsed.computeFee(globalVariables.gasFees);
 
   if (privateOnly) {
-    const data = makePrivateToRollupAccumulatedData(seed + 0x1000, { numContractClassLogs: 0 });
+    const rollupEndData = makePrivateToRollupAccumulatedData(seed + 0x1000, { numContractClassLogs: 0 });
 
-    tx.data.forRollup!.end = data;
+    // Reconstruct forRollup with new end data (avoids stale caches on PrivateKernelTailCircuitPublicInputs).
+    const newForRollup = new PartialPrivateTailPublicInputsForRollup(rollupEndData);
+    const newData = new PrivateKernelTailCircuitPublicInputs(
+      tx.data.constants,
+      tx.data.gasUsed,
+      tx.data.feePayer,
+      tx.data.expirationTimestamp,
+      undefined,
+      newForRollup,
+    );
+    tx = new Tx(tx.txHash, newData, tx.chonkProof, tx.contractClassLogFields, tx.publicFunctionCalldata);
 
     await tx.recomputeHash();
     return makeProcessedTxFromPrivateOnlyTx(tx, transactionFee, feePaymentPublicDataWrite, globalVariables);
   } else {
-    const dataFromPrivate = tx.data.forPublic!;
+    const oldForPublic = tx.data.forPublic!;
 
-    const nonRevertibleData = dataFromPrivate.nonRevertibleAccumulatedData;
+    const nonRevertibleData = oldForPublic.nonRevertibleAccumulatedData;
 
     // Create revertible data.
     const revertibleData = makePrivateToPublicAccumulatedData(seed + 0x1000, { numContractClassLogs: 0 });
     revertibleData.nullifiers[MAX_NULLIFIERS_PER_TX - 1] = Fr.ZERO; // Leave one space for the tx hash nullifier in nonRevertibleAccumulatedData.
-    dataFromPrivate.revertibleAccumulatedData = revertibleData;
+
+    // Reconstruct forPublic with new revertible data (readonly properties).
+    const newForPublic = new PartialPrivateTailPublicInputsForPublic(
+      nonRevertibleData,
+      revertibleData,
+      oldForPublic.publicTeardownCallRequest,
+    );
+    const newData = new PrivateKernelTailCircuitPublicInputs(
+      tx.data.constants,
+      tx.data.gasUsed,
+      tx.data.feePayer,
+      tx.data.expirationTimestamp,
+      newForPublic,
+    );
+    tx = new Tx(tx.txHash, newData, tx.chonkProof, tx.contractClassLogFields, tx.publicFunctionCalldata);
+    const dataFromPrivate = tx.data.forPublic!;
 
     // Create avm output.
     const avmOutput = AvmCircuitPublicInputs.empty();

--- a/yarn-project/stdlib/src/tx/hashed_values.ts
+++ b/yarn-project/stdlib/src/tx/hashed_values.ts
@@ -12,6 +12,8 @@ import { Vector } from '../types/index.js';
  * A container for storing a list of values and their hash.
  */
 export class HashedValues {
+  #cachedBuf: Buffer | undefined;
+
   constructor(
     /**
      *  Raw values.
@@ -49,12 +51,18 @@ export class HashedValues {
   }
 
   toBuffer() {
-    return serializeToBuffer(new Vector(this.values), this.hash);
+    if (!this.#cachedBuf) {
+      this.#cachedBuf = serializeToBuffer(new Vector(this.values), this.hash);
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 
   static fromBuffer(buffer: Buffer | BufferReader): HashedValues {
     const reader = BufferReader.asReader(buffer);
-    return new HashedValues(reader.readVector(Fr), Fr.fromBuffer(reader));
+    const startPos = reader.currentPosition;
+    const result = new HashedValues(reader.readVector(Fr), Fr.fromBuffer(reader));
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   // Computes the hash of input arguments or return values for private functions, or for authwit creation.

--- a/yarn-project/stdlib/src/tx/tx.test.ts
+++ b/yarn-project/stdlib/src/tx/tx.test.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from '@aztec/foundation/crypto/random';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 
+import { PrivateKernelTailCircuitPublicInputs } from '../kernel/private_kernel_tail_circuit_public_inputs.js';
+import { ChonkProof } from '../proofs/chonk_proof.js';
 import { mockTx } from '../tests/mocks.js';
 import { Tx, TxArray } from './tx.js';
 
@@ -15,6 +17,79 @@ describe('Tx', () => {
     const tx = await mockTx();
     const json = jsonStringify(tx);
     expect(await Tx.schema.parseAsync(JSON.parse(json))).toEqual(tx);
+  });
+
+  it('toBuffer round-trip produces byte-identical buffers', async () => {
+    const tx = await mockTx();
+    const buf1 = tx.toBuffer();
+    const tx2 = Tx.fromBuffer(buf1);
+    const buf2 = tx2.toBuffer();
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+
+  it('computeTxHash is identical with and without buffer cache', async () => {
+    const tx = Tx.random();
+    const hashWithoutCache = await Tx.computeTxHash(tx);
+    const buf = tx.toBuffer();
+    const txFromBuf = Tx.fromBuffer(buf);
+    const hashWithCache = await Tx.computeTxHash(txFromBuf);
+    expect(hashWithoutCache).toEqual(hashWithCache);
+  });
+
+  it('getSize uses cached buffer length', async () => {
+    const tx = await mockTx();
+    const buf = tx.toBuffer();
+    const txFromBuf = Tx.fromBuffer(buf);
+    expect(txFromBuf.getSize()).toBe(buf.length);
+  });
+
+  it('clone produces byte-identical buffer', async () => {
+    const tx = await mockTx();
+    const buf = tx.toBuffer();
+    const txFromBuf = Tx.fromBuffer(buf);
+    const cloned = Tx.clone(txFromBuf);
+    expect(cloned.toBuffer().equals(buf)).toBe(true);
+  });
+});
+
+describe('ChonkProof buffer caching', () => {
+  it('round-trip produces byte-identical buffers', () => {
+    const proof = ChonkProof.random();
+    const buf1 = proof.toBuffer();
+    const proof2 = ChonkProof.fromBuffer(buf1);
+    const buf2 = proof2.toBuffer();
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+});
+
+describe('PrivateKernelTailCircuitPublicInputs buffer caching', () => {
+  it('round-trip produces byte-identical buffers', async () => {
+    const tx = await mockTx();
+    const data = tx.data;
+    const buf1 = data.toBuffer();
+    const data2 = PrivateKernelTailCircuitPublicInputs.fromBuffer(buf1);
+    const buf2 = data2.toBuffer();
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+});
+
+describe('hash caching', () => {
+  it('PrivateToPublicKernelCircuitPublicInputs.hash returns same value on repeated calls', async () => {
+    const tx = await mockTx();
+    const publicInputs = tx.data.toPrivateToPublicKernelCircuitPublicInputs();
+    const hash1 = await publicInputs.hash();
+    const hash2 = await publicInputs.hash();
+    expect(hash1).toEqual(hash2);
+  });
+
+  it('cached intermediate objects return consistent hashes', async () => {
+    const tx = await mockTx();
+    const pi1 = tx.data.toPrivateToPublicKernelCircuitPublicInputs();
+    const pi2 = tx.data.toPrivateToPublicKernelCircuitPublicInputs();
+    expect(pi1).toBe(pi2); // same reference due to caching
+    const hash1 = await pi1.hash();
+    const hash2 = await pi2.hash();
+    expect(hash1).toEqual(hash2);
   });
 });
 

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -27,6 +27,7 @@ import { TxHash } from './tx_hash.js';
 export class Tx extends Gossipable {
   static override p2pTopic = TopicType.tx;
 
+  #cachedBuf: Buffer | undefined;
   private calldataMap: Map<string, Fr[]> | undefined;
 
   constructor(
@@ -113,13 +114,16 @@ export class Tx extends Gossipable {
    */
   static fromBuffer(buffer: Buffer | BufferReader): Tx {
     const reader = BufferReader.asReader(buffer);
-    return new Tx(
+    const startPos = reader.currentPosition;
+    const result = new Tx(
       reader.readObject(TxHash),
       reader.readObject(PrivateKernelTailCircuitPublicInputs),
       reader.readObject(ChonkProof),
       reader.readVectorUint8Prefix(ContractClassLogFields),
       reader.readVectorUint8Prefix(HashedValues),
     );
+    result.#cachedBuf = reader.getSlice(startPos);
+    return result;
   }
 
   /**
@@ -127,13 +131,16 @@ export class Tx extends Gossipable {
    * @returns Buffer representation of the Tx object.
    */
   toBuffer() {
-    return serializeToBuffer([
-      this.txHash,
-      this.data,
-      this.chonkProof,
-      serializeArrayOfBufferableToVector(this.contractClassLogFields, 1),
-      serializeArrayOfBufferableToVector(this.publicFunctionCalldata, 1),
-    ]);
+    if (!this.#cachedBuf) {
+      this.#cachedBuf = serializeToBuffer([
+        this.txHash,
+        this.data,
+        this.chonkProof,
+        serializeArrayOfBufferableToVector(this.contractClassLogFields, 1),
+        serializeArrayOfBufferableToVector(this.publicFunctionCalldata, 1),
+      ]);
+    }
+    return Buffer.from(this.#cachedBuf);
   }
 
   static get schema(): ZodFor<Tx> {
@@ -254,13 +261,11 @@ export class Tx extends Gossipable {
     };
   }
 
-  private sizeCache: number | undefined;
-
   getSize(): number {
-    if (this.sizeCache == undefined) {
-      this.sizeCache = this.toBuffer().length;
+    if (this.#cachedBuf) {
+      return this.#cachedBuf.length;
     }
-    return this.sizeCache;
+    return this.toBuffer().length;
   }
 
   /**

--- a/yarn-project/stdlib/src/tx/tx_constant_data.ts
+++ b/yarn-project/stdlib/src/tx/tx_constant_data.ts
@@ -13,10 +13,10 @@ import { TxContext } from './tx_context.js';
  */
 export class TxConstantData {
   constructor(
-    public anchorBlockHeader: BlockHeader,
-    public txContext: TxContext,
-    public vkTreeRoot: Fr,
-    public protocolContractsHash: Fr,
+    public readonly anchorBlockHeader: BlockHeader,
+    public readonly txContext: TxContext,
+    public readonly vkTreeRoot: Fr,
+    public readonly protocolContractsHash: Fr,
   ) {}
 
   static from(fields: FieldsOf<TxConstantData>) {

--- a/yarn-project/stdlib/src/tx/tx_context.ts
+++ b/yarn-project/stdlib/src/tx/tx_context.ts
@@ -12,8 +12,8 @@ import { GasSettings } from '../gas/gas_settings.js';
  * Transaction context.
  */
 export class TxContext {
-  public chainId: Fr;
-  public version: Fr;
+  public readonly chainId: Fr;
+  public readonly version: Fr;
 
   constructor(
     /** Chain ID of the transaction. Here for replay protection. */
@@ -21,7 +21,7 @@ export class TxContext {
     /** Version of the transaction. Here for replay protection. */
     version: Fr | number | bigint,
     /** Gas limits for this transaction. */
-    public gasSettings: GasSettings,
+    public readonly gasSettings: GasSettings,
   ) {
     this.chainId = new Fr(chainId);
     this.version = new Fr(version);

--- a/yarn-project/wallet-sdk/src/base-wallet/utils.ts
+++ b/yarn-project/wallet-sdk/src/base-wallet/utils.ts
@@ -14,6 +14,7 @@ import {
   ClaimedLengthArray,
   CountedPublicCallRequest,
   PrivateCircuitPublicInputs,
+  PrivateKernelTailCircuitPublicInputs,
   PublicCallRequest,
 } from '@aztec/stdlib/kernel';
 import { ChonkProof } from '@aztec/stdlib/proofs';
@@ -133,10 +134,17 @@ async function simulateBatchViaNode(
     1, // minRevertibleSideEffectCounter
   );
 
-  provingResult.publicInputs.feePayer = from;
+  const dataWithFeePayer = new PrivateKernelTailCircuitPublicInputs(
+    provingResult.publicInputs.constants,
+    provingResult.publicInputs.gasUsed,
+    from,
+    provingResult.publicInputs.expirationTimestamp,
+    provingResult.publicInputs.forPublic,
+    provingResult.publicInputs.forRollup,
+  );
 
   const tx = await Tx.create({
-    data: provingResult.publicInputs,
+    data: dataWithFeePayer,
     chonkProof: ChonkProof.empty(),
     contractClassLogFields: [],
     publicFunctionCalldata: publicFunctionCalldata,


### PR DESCRIPTION
## Summary

- Cache serialized buffers (`#cachedBuf`) on `Tx`, `ChonkProof`, `ContractClassLogFields`, `HashedValues`, and `PrivateKernelTailCircuitPublicInputs` to skip redundant re-serialization during validation, forwarding, and size computation
- Cache computed hashes (`#cachedHash`) on `PrivateToPublicKernelCircuitPublicInputs` and `PrivateToRollupKernelCircuitPublicInputs` to avoid repeated poseidon2 hashing
- Cache intermediate objects (`#cachedPublicInputs`, `#cachedRollupInputs`) on `PrivateKernelTailCircuitPublicInputs` to avoid recreating them on each `computeTxHash` call
- Make constructor properties `readonly` on all cached classes to prevent silent cache invalidation
- Add `currentPosition` and `getSlice` to `BufferReader` for efficient buffer slice capture during deserialization
- Refactor test mocks to construct objects bottom-up instead of mutating readonly properties

## Test plan

- [x] `yarn build` compiles cleanly
- [x] `yarn workspace @aztec/stdlib test src/tx/tx.test.ts` — new caching tests pass (buffer round-trips, hash identity, getSize, clone, hash caching)
- [x] `prover-client/src/orchestrator/orchestrator_rollup_structure.test.ts` — passes (caught and fixed a stale-cache bug in mockProcessedTx's private-only path)
- [ ] CI passes for all affected packages (p2p, simulator, aztec-node, aztec.js, prover-client, sequencer-client, wallet-sdk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)