### PR TITLE
refactor(aztec-node): skip unnecessary subsystems in prover-only mode and remove P2PClientType enum

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -79,7 +79,6 @@ import {
 import type { DebugLogStore, LogFilter, SiloedTag, Tag, TxScopedL2Log } from '@aztec/stdlib/logs';
 import { InMemoryDebugLogStore, NullDebugLogStore } from '@aztec/stdlib/logs';
 import { InboxLeaf, type L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { P2PClientType } from '@aztec/stdlib/p2p';
 import type { Offense, SlashPayloadRound } from '@aztec/stdlib/slashing';
 import type { NullifierLeafPreimage, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { MerkleTreeId, NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
@@ -194,7 +193,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       logger?: Logger;
       publisher?: SequencerPublisher;
       dateProvider?: DateProvider;
-      p2pClientDeps?: P2PClientDeps<P2PClientType.Full>;
+      p2pClientDeps?: P2PClientDeps;
       proverNodeDeps?: Partial<ProverNodeDeps>;
     } = {},
     options: {
@@ -325,9 +324,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
     const proofVerifier = new QueuedIVCVerifier(config, circuitVerifier);
 
+    const proverOnly = config.enableProverNode && config.disableValidator;
+    if (proverOnly) {
+      log.info('Starting in prover-only mode: skipping validator, sequencer, sentinel, and slasher subsystems');
+    }
+
     // create the tx pool and the p2p client, which will need the l2 block source
     const p2pClient = await createP2PClient(
-      P2PClientType.Full,
       config,
       archiver,
       proofVerifier,
@@ -342,7 +345,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // We should really not be modifying the config object
     config.txPublicSetupAllowList = config.txPublicSetupAllowList ?? (await getDefaultAllowedSetupFunctions());
 
-    // Create FullNodeCheckpointsBuilder for validator and non-validator block proposal handling
+    // We'll accumulate sentinel watchers here
+    const watchers: Watcher[] = [];
+
+    // Create FullNodeCheckpointsBuilder for block proposal handling and tx validation
     const validatorCheckpointsBuilder = new FullNodeCheckpointsBuilder(
       { ...config, l1GenesisTime, slotDuration: Number(slotDuration) },
       worldStateSynchronizer,
@@ -351,47 +357,48 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       telemetry,
     );
 
-    // We'll accumulate sentinel watchers here
-    const watchers: Watcher[] = [];
+    let validatorClient: ValidatorClient | undefined;
 
-    // Create validator client if required
-    const validatorClient = await createValidatorClient(config, {
-      checkpointsBuilder: validatorCheckpointsBuilder,
-      worldState: worldStateSynchronizer,
-      p2pClient,
-      telemetry,
-      dateProvider,
-      epochCache,
-      blockSource: archiver,
-      l1ToL2MessageSource: archiver,
-      keyStoreManager,
-      blobClient,
-    });
-
-    // If we have a validator client, register it as a source of offenses for the slasher,
-    // and have it register callbacks on the p2p client *before* we start it, otherwise messages
-    // like attestations or auths will fail.
-    if (validatorClient) {
-      watchers.push(validatorClient);
-      if (!options.dontStartSequencer) {
-        await validatorClient.registerHandlers();
-      }
-    }
-
-    // If there's no validator client but alwaysReexecuteBlockProposals is enabled,
-    // create a BlockProposalHandler to reexecute block proposals for monitoring
-    if (!validatorClient && config.alwaysReexecuteBlockProposals) {
-      log.info('Setting up block proposal reexecution for monitoring');
-      createBlockProposalHandler(config, {
+    if (!proverOnly) {
+      // Create validator client if required
+      validatorClient = await createValidatorClient(config, {
         checkpointsBuilder: validatorCheckpointsBuilder,
         worldState: worldStateSynchronizer,
+        p2pClient,
+        telemetry,
+        dateProvider,
         epochCache,
         blockSource: archiver,
         l1ToL2MessageSource: archiver,
-        p2pClient,
-        dateProvider,
-        telemetry,
-      }).registerForReexecution(p2pClient);
+        keyStoreManager,
+        blobClient,
+      });
+
+      // If we have a validator client, register it as a source of offenses for the slasher,
+      // and have it register callbacks on the p2p client *before* we start it, otherwise messages
+      // like attestations or auths will fail.
+      if (validatorClient) {
+        watchers.push(validatorClient);
+        if (!options.dontStartSequencer) {
+          await validatorClient.registerHandlers();
+        }
+      }
+
+      // If there's no validator client but alwaysReexecuteBlockProposals is enabled,
+      // create a BlockProposalHandler to reexecute block proposals for monitoring
+      if (!validatorClient && config.alwaysReexecuteBlockProposals) {
+        log.info('Setting up block proposal reexecution for monitoring');
+        createBlockProposalHandler(config, {
+          checkpointsBuilder: validatorCheckpointsBuilder,
+          worldState: worldStateSynchronizer,
+          epochCache,
+          blockSource: archiver,
+          l1ToL2MessageSource: archiver,
+          p2pClient,
+          dateProvider,
+          telemetry,
+        }).registerForReexecution(p2pClient);
+      }
     }
 
     // Start world state and wait for it to sync to the archiver.
@@ -400,29 +407,33 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     // Start p2p. Note that it depends on world state to be running.
     await p2pClient.start();
 
-    const validatorsSentinel = await createSentinel(epochCache, archiver, p2pClient, config);
-    if (validatorsSentinel && config.slashInactivityPenalty > 0n) {
-      watchers.push(validatorsSentinel);
-    }
-
+    let validatorsSentinel: Awaited<ReturnType<typeof createSentinel>> | undefined;
     let epochPruneWatcher: EpochPruneWatcher | undefined;
-    if (config.slashPrunePenalty > 0n || config.slashDataWithholdingPenalty > 0n) {
-      epochPruneWatcher = new EpochPruneWatcher(
-        archiver,
-        archiver,
-        epochCache,
-        p2pClient.getTxProvider(),
-        validatorCheckpointsBuilder,
-        config,
-      );
-      watchers.push(epochPruneWatcher);
-    }
-
-    // We assume we want to slash for invalid attestations unless all max penalties are set to 0
     let attestationsBlockWatcher: AttestationsBlockWatcher | undefined;
-    if (config.slashProposeInvalidAttestationsPenalty > 0n || config.slashAttestDescendantOfInvalidPenalty > 0n) {
-      attestationsBlockWatcher = new AttestationsBlockWatcher(archiver, epochCache, config);
-      watchers.push(attestationsBlockWatcher);
+
+    if (!proverOnly) {
+      validatorsSentinel = await createSentinel(epochCache, archiver, p2pClient, config);
+      if (validatorsSentinel && config.slashInactivityPenalty > 0n) {
+        watchers.push(validatorsSentinel);
+      }
+
+      if (config.slashPrunePenalty > 0n || config.slashDataWithholdingPenalty > 0n) {
+        epochPruneWatcher = new EpochPruneWatcher(
+          archiver,
+          archiver,
+          epochCache,
+          p2pClient.getTxProvider(),
+          validatorCheckpointsBuilder,
+          config,
+        );
+        watchers.push(epochPruneWatcher);
+      }
+
+      // We assume we want to slash for invalid attestations unless all max penalties are set to 0
+      if (config.slashProposeInvalidAttestationsPenalty > 0n || config.slashAttestDescendantOfInvalidPenalty > 0n) {
+        attestationsBlockWatcher = new AttestationsBlockWatcher(archiver, epochCache, config);
+        watchers.push(attestationsBlockWatcher);
+      }
     }
 
     // Start p2p-related services once the archiver has completed sync

--- a/yarn-project/end-to-end/src/fixtures/setup.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup.ts
@@ -49,7 +49,6 @@ import type { SequencerClient } from '@aztec/sequencer-client';
 import { type ContractInstanceWithAddress, getContractInstanceFromInstantiationParams } from '@aztec/stdlib/contract';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
-import type { P2PClientType } from '@aztec/stdlib/p2p';
 import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import {
   type TelemetryClient,
@@ -456,7 +455,7 @@ export async function setup(
     }
 
     let mockGossipSubNetwork: MockGossipSubNetwork | undefined;
-    let p2pClientDeps: P2PClientDeps<P2PClientType.Full> | undefined = undefined;
+    let p2pClientDeps: P2PClientDeps | undefined = undefined;
 
     if (opts.mockGossipSubNetwork) {
       mockGossipSubNetwork = new MockGossipSubNetwork();
@@ -503,7 +502,7 @@ export async function setup(
       const proverNodePrivateKeyHex: Hex = `0x${proverNodePrivateKey!.toString('hex')}`;
       const proverNodeDataDirectory = path.join(directoryToCleanup, randomBytes(8).toString('hex'));
 
-      const p2pClientDeps: Partial<P2PClientDeps<P2PClientType.Full>> = {
+      const p2pClientDeps: Partial<P2PClientDeps> = {
         p2pServiceFactory: mockGossipSubNetwork && getMockPubSubP2PServiceFactory(mockGossipSubNetwork!),
         rpcTxProviders: [aztecNodeService],
       };
@@ -719,7 +718,7 @@ export function createAndSyncProverNode(
   deps: {
     telemetry?: TelemetryClient;
     dateProvider: DateProvider;
-    p2pClientDeps?: P2PClientDeps<P2PClientType.Full>;
+    p2pClientDeps?: P2PClientDeps;
   },
   options: { prefilledPublicData: PublicDataTreeLeaf[]; dontStart?: boolean },
 ): Promise<{ proverNode: AztecNodeService }> {

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -9,7 +9,6 @@ import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ChainConfig } from '@aztec/stdlib/config';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { AztecNode, ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { P2PClientType } from '@aztec/stdlib/p2p';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import { P2PClient } from '../client/p2p_client.js';
@@ -27,14 +26,14 @@ import { NodeRpcTxSource, type TxSource, createNodeRpcTxSources } from '../servi
 import { TxFileStore } from '../services/tx_file_store/tx_file_store.js';
 import { configureP2PClientAddresses, createLibP2PPeerIdFromPrivateKey, getPeerIdPrivateKey } from '../util.js';
 
-export type P2PClientDeps<T extends P2PClientType> = {
+export type P2PClientDeps = {
   txPool?: TxPoolV2;
   store?: AztecAsyncKVStore;
   attestationPool?: AttestationPoolApi;
   logger?: Logger;
   txCollectionNodeSources?: TxSource[];
   rpcTxProviders?: AztecNode[];
-  p2pServiceFactory?: (...args: Parameters<(typeof LibP2PService)['new']>) => Promise<LibP2PService<T>>;
+  p2pServiceFactory?: (...args: Parameters<(typeof LibP2PService)['new']>) => Promise<LibP2PService>;
 };
 
 export const P2P_STORE_NAME = 'p2p';
@@ -42,8 +41,7 @@ export const P2P_ARCHIVE_STORE_NAME = 'p2p-archive';
 export const P2P_PEER_STORE_NAME = 'p2p-peers';
 export const P2P_ATTESTATION_STORE_NAME = 'p2p-attestation';
 
-export async function createP2PClient<T extends P2PClientType>(
-  clientType: T,
+export async function createP2PClient(
   inputConfig: P2PConfig & DataStoreConfig & ChainConfig,
   archiver: L2BlockSource & ContractDataSource,
   proofVerifier: ClientProtocolCircuitVerifier,
@@ -52,7 +50,7 @@ export async function createP2PClient<T extends P2PClientType>(
   packageVersion: string,
   dateProvider: DateProvider = new DateProvider(),
   telemetry: TelemetryClient = getTelemetryClient(),
-  deps: P2PClientDeps<T> = {},
+  deps: P2PClientDeps = {},
 ) {
   const config = await configureP2PClientAddresses({
     ...inputConfig,
@@ -111,9 +109,8 @@ export async function createP2PClient<T extends P2PClientType>(
     attestationPool: deps.attestationPool ?? new AttestationPool(attestationStore, telemetry),
   };
 
-  const p2pService = await createP2PService<T>(
+  const p2pService = await createP2PService(
     config,
-    clientType,
     archiver,
     proofVerifier,
     worldStateSynchronizer,
@@ -171,7 +168,6 @@ export async function createP2PClient<T extends P2PClientType>(
   );
 
   return new P2PClient(
-    clientType,
     store,
     archiver,
     mempools,
@@ -185,9 +181,8 @@ export async function createP2PClient<T extends P2PClientType>(
   );
 }
 
-async function createP2PService<T extends P2PClientType>(
+async function createP2PService(
   config: P2PConfig & DataStoreConfig,
-  clientType: T,
   archiver: L2BlockSource & ContractDataSource,
   proofVerifier: ClientProtocolCircuitVerifier,
   worldStateSynchronizer: WorldStateSynchronizer,
@@ -195,7 +190,7 @@ async function createP2PService<T extends P2PClientType>(
   store: AztecAsyncKVStore,
   peerStore: AztecLMDBStoreV2,
   mempools: MemPools,
-  p2pServiceFactory: P2PClientDeps<T>['p2pServiceFactory'],
+  p2pServiceFactory: P2PClientDeps['p2pServiceFactory'],
   packageVersion: string,
   logger: Logger,
   telemetry: TelemetryClient,
@@ -211,7 +206,7 @@ async function createP2PService<T extends P2PClientType>(
   const peerIdPrivateKey = await getPeerIdPrivateKey(config, store, logger);
   const peerId = await createLibP2PPeerIdFromPrivateKey(peerIdPrivateKey.getValue());
 
-  const p2pService = await (p2pServiceFactory ?? LibP2PService.new<T>)(clientType, config, peerId, {
+  const p2pService = await (p2pServiceFactory ?? LibP2PService.new)(config, peerId, {
     packageVersion,
     mempools,
     l2BlockSource: archiver,

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -1,13 +1,7 @@
 import type { SlotNumber } from '@aztec/foundation/branded-types';
 import type { EthAddress, L2BlockId } from '@aztec/stdlib/block';
-import type { ITxProvider, P2PApiFull } from '@aztec/stdlib/interfaces/server';
-import type {
-  BlockProposal,
-  CheckpointAttestation,
-  CheckpointProposal,
-  P2PClientType,
-  TopicType,
-} from '@aztec/stdlib/p2p';
+import type { ITxProvider, P2PClient } from '@aztec/stdlib/interfaces/server';
+import type { BlockProposal, CheckpointAttestation, CheckpointProposal, TopicType } from '@aztec/stdlib/p2p';
 import type { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
@@ -54,7 +48,7 @@ export interface P2PSyncState {
 /**
  * Interface of a P2P client.
  **/
-export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApiFull<T> & {
+export type P2P = P2PClient & {
   /**
    * Broadcasts a block proposal to other peers.
    *

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -7,7 +7,6 @@ import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2Block } from '@aztec/stdlib/block';
 import { EmptyL1RollupConstants, type L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
-import { P2PClientType } from '@aztec/stdlib/p2p';
 import { mockTx } from '@aztec/stdlib/testing';
 import { TxHash } from '@aztec/stdlib/tx';
 
@@ -62,17 +61,7 @@ describe('P2P Client', () => {
   });
 
   const createClient = (config: Partial<P2PConfig> = {}) =>
-    new P2PClient(
-      P2PClientType.Full,
-      kvStore,
-      blockSource,
-      mempools,
-      p2pService,
-      txCollection,
-      undefined,
-      epochCache,
-      config,
-    );
+    new P2PClient(kvStore, blockSource, mempools, p2pService, txCollection, undefined, epochCache, config);
 
   const advanceToProvenBlock = async (blockNumber: BlockNumber) => {
     blockSource.setProvenBlockNumber(blockNumber);

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -20,13 +20,7 @@ import {
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import { type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
-import {
-  type BlockProposal,
-  CheckpointAttestation,
-  type CheckpointProposal,
-  type P2PClientType,
-  type TopicType,
-} from '@aztec/stdlib/p2p';
+import { type BlockProposal, CheckpointAttestation, type CheckpointProposal, type TopicType } from '@aztec/stdlib/p2p';
 import type { BlockHeader, Tx, TxHash } from '@aztec/stdlib/tx';
 import { Attributes, type TelemetryClient, WithTracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 
@@ -59,10 +53,7 @@ import { type P2P, P2PClientState, type P2PSyncState } from './interface.js';
 /**
  * The P2P client implementation.
  */
-export class P2PClient<T extends P2PClientType = P2PClientType.Full>
-  extends WithTracer
-  implements P2P, P2P<P2PClientType.Prover>
-{
+export class P2PClient extends WithTracer implements P2P {
   /** The JS promise that will be running to keep the client's data in sync. Can be interrupted if the client is stopped. */
   private runningPromise!: Promise<void>;
 
@@ -94,7 +85,6 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   private slotMonitor: RunningPromise | undefined;
 
   constructor(
-    _clientType: T,
     private store: AztecAsyncKVStore,
     private l2BlockSource: L2BlockSource & ContractDataSource,
     mempools: MemPools,

--- a/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
+++ b/yarn-project/p2p/src/client/test/tx_proposal_collector/proposal_tx_collector_worker.ts
@@ -8,7 +8,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
-import { P2PClientType, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import type { Tx, TxValidationResult } from '@aztec/stdlib/tx';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -114,7 +114,6 @@ async function startClient(config: P2PConfig, clientIndex: number) {
   };
 
   client = await createP2PClient(
-    P2PClientType.Full,
     config as P2PConfig & DataStoreConfig,
     l2BlockSource as L2BlockSource & ContractDataSource,
     proofVerifier as ClientProtocolCircuitVerifier,

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.test.ts
@@ -9,7 +9,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb';
 import { L2Block, type L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier } from '@aztec/stdlib/interfaces/server';
-import { BlockProposal, P2PClientType, PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { BlockProposal, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import {
   makeBlockHeader,
   makeBlockProposal,
@@ -1118,7 +1118,6 @@ class TestLibP2PService extends LibP2PService {
     });
 
     super(
-      P2PClientType.Full,
       mockConfig,
       node,
       mockPeerDiscoveryService,

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -16,13 +16,12 @@ import {
   CheckpointProposal,
   type CheckpointProposalCore,
   type Gossipable,
-  P2PClientType,
   P2PMessage,
   type ValidationResult as P2PValidationResult,
   PeerErrorSeverity,
   TopicType,
   createTopicString,
-  getTopicsForClientAndConfig,
+  getTopicsForConfig,
   metricsTopicStrToLabels,
 } from '@aztec/stdlib/p2p';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
@@ -135,7 +134,7 @@ type ReceivedMessageValidationResult<T, M = undefined> =
 /**
  * Lib P2P implementation of the P2PService interface.
  */
-export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends WithTracer implements P2PService {
+export class LibP2PService extends WithTracer implements P2PService {
   private discoveryRunningPromise?: RunningPromise;
   private msgIdSeenValidators: Record<TopicType, MessageSeenValidator> = {} as Record<TopicType, MessageSeenValidator>;
 
@@ -182,7 +181,6 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   protected logger: Logger;
 
   constructor(
-    private clientType: T,
     private config: P2PConfig,
     protected node: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
@@ -262,8 +260,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
    * @param txPool - The transaction pool to be accessed by the service.
    * @returns The new service.
    */
-  public static async new<T extends P2PClientType>(
-    clientType: T,
+  public static async new(
     config: P2PConfig,
     peerId: PeerId,
     deps: {
@@ -475,7 +472,6 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       peerManager.shouldDisableP2PGossip(peerId) ? -Infinity : peerManager.getPeerScore(peerId);
 
     return new LibP2PService(
-      clientType,
       config,
       node,
       peerDiscoveryService,
@@ -549,7 +545,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     await this.node.start();
 
     // Subscribe to standard GossipSub topics by default
-    for (const topic of getTopicsForClientAndConfig(this.clientType, this.config.disableTransactions)) {
+    for (const topic of getTopicsForConfig(this.config.disableTransactions)) {
       this.subscribeToTopic(this.topicStrings[topic]);
     }
 
@@ -818,9 +814,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       if (msg.topic === this.topicStrings[TopicType.tx]) {
         await this.handleGossipedTx(p2pMessage.payload, msgId, source);
       } else if (msg.topic === this.topicStrings[TopicType.checkpoint_attestation]) {
-        if (this.clientType === P2PClientType.Full) {
-          await this.processCheckpointAttestationFromPeer(p2pMessage.payload, msgId, source);
-        }
+        await this.processCheckpointAttestationFromPeer(p2pMessage.payload, msgId, source);
       } else if (msg.topic === this.topicStrings[TopicType.block_proposal]) {
         await this.processBlockFromPeer(p2pMessage.payload, msgId, source);
       } else if (msg.topic === this.topicStrings[TopicType.checkpoint_proposal]) {

--- a/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
+++ b/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
@@ -7,7 +7,6 @@ import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { P2PClientType } from '@aztec/stdlib/p2p';
 
 import { createP2PClient } from '../client/index.js';
 import type { P2PClient } from '../client/p2p_client.js';
@@ -98,7 +97,6 @@ export async function makeTestP2PClient(
   const kvStore = await openTmpStore('test');
 
   const client = await createP2PClient(
-    P2PClientType.Full,
     config,
     l2BlockSource,
     proofVerifier,

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -4,7 +4,6 @@ import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { P2PClientType } from '@aztec/stdlib/p2p';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
 import type { GossipsubEvents, GossipsubMessage } from '@chainsafe/libp2p-gossipsub';
@@ -42,11 +41,10 @@ type GossipSubService = PubSubLibp2p['services']['pubsub'];
  * Given a mock gossip sub network, returns a factory function that creates an instance LibP2PService connected to it.
  * Designed to be used in tests in P2PClientDeps.p2pServiceFactory.
  */
-export function getMockPubSubP2PServiceFactory<T extends P2PClientType>(
+export function getMockPubSubP2PServiceFactory(
   network: MockGossipSubNetwork,
-): (...args: Parameters<(typeof LibP2PService<T>)['new']>) => Promise<LibP2PService<T>> {
+): (...args: Parameters<(typeof LibP2PService)['new']>) => Promise<LibP2PService> {
   return (
-    clientType: P2PClientType,
     config: P2PConfig,
     peerId: PeerId,
     deps: {
@@ -66,8 +64,7 @@ export function getMockPubSubP2PServiceFactory<T extends P2PClientType>(
     const peerManager = new DummyPeerManager(peerId, network);
     const reqresp: ReqRespInterface = new MockReqResp(peerId, network);
     const peerDiscoveryService = new DummyPeerDiscoveryService();
-    const service = new LibP2PService<T>(
-      clientType as T,
+    const service = new LibP2PService(
       config,
       libp2p,
       peerDiscoveryService,

--- a/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
+++ b/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
@@ -12,7 +12,6 @@ import type {
   IVCProofVerificationResult,
   WorldStateSynchronizer,
 } from '@aztec/stdlib/interfaces/server';
-import type { P2PClientType } from '@aztec/stdlib/p2p';
 import type { Tx } from '@aztec/stdlib/tx';
 import { compressComponentVersions } from '@aztec/stdlib/versioning';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
@@ -107,8 +106,7 @@ export async function createLibp2pNode(
  *
  *
  */
-export async function createTestLibP2PService<T extends P2PClientType>(
-  clientType: T,
+export async function createTestLibP2PService(
   boostrapAddrs: string[] = [],
   archiver: L2BlockSource & ContractDataSource,
   worldStateSynchronizer: WorldStateSynchronizer,
@@ -159,8 +157,7 @@ export async function createTestLibP2PService<T extends P2PClientType>(
   p2pNode.services.pubsub.score.params.appSpecificScore = (peerId: string) =>
     peerManager.shouldDisableP2PGossip(peerId) ? -Infinity : peerManager.getPeerScore(peerId);
 
-  return new LibP2PService<T>(
-    clientType,
+  return new LibP2PService(
     config,
     p2pNode as PubSubLibp2p,
     discoveryService,

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -19,7 +19,7 @@ import { protocolContractsHash } from '@aztec/protocol-contracts';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
-import { type BlockProposal, P2PClientType, P2PMessage } from '@aztec/stdlib/p2p';
+import { type BlockProposal, P2PMessage } from '@aztec/stdlib/p2p';
 import { ChonkProof } from '@aztec/stdlib/proofs';
 import { makeAztecAddress, makeBlockHeader, makeBlockProposal, mockTx } from '@aztec/stdlib/testing';
 import { Tx, TxHash, type TxValidationResult } from '@aztec/stdlib/tx';
@@ -86,12 +86,11 @@ export interface BenchReadyMessage {
 }
 const txCache = new Map<number, Tx[]>();
 
-class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends LibP2PService<T> {
+class TestLibP2PService extends LibP2PService {
   private disableTxValidation: boolean;
   private gossipMessageCount = 0;
 
   constructor(
-    clientType: T,
     config: P2PConfig,
     node: PubSubLibp2p,
     peerDiscoveryService: PeerDiscoveryService,
@@ -107,7 +106,6 @@ class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends Li
     disableTxValidation = true,
   ) {
     super(
-      clientType,
       config,
       node,
       peerDiscoveryService,
@@ -365,7 +363,6 @@ process.on('message', async msg => {
       };
 
       const client = await createP2PClient(
-        P2PClientType.Full,
         config as P2PConfig & DataStoreConfig,
         l2BlockSource,
         proofVerifier as ClientProtocolCircuitVerifier,
@@ -378,7 +375,6 @@ process.on('message', async msg => {
       );
 
       const testService = new TestLibP2PService(
-        P2PClientType.Full,
         config,
         (client as any).p2pService.node,
         (client as any).p2pService.peerDiscoveryService,

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -3,7 +3,6 @@ import type { SlotNumber } from '@aztec/foundation/branded-types';
 import { z } from 'zod';
 
 import { CheckpointAttestation } from '../p2p/checkpoint_attestation.js';
-import type { P2PClientType } from '../p2p/client_type.js';
 import { type ApiSchemaFor, optional, schemas } from '../schemas/index.js';
 import { Tx } from '../tx/tx.js';
 import { TxHash } from '../tx/tx_hash.js';
@@ -27,7 +26,7 @@ const PeerInfoSchema = z.discriminatedUnion('status', [
 ]);
 
 /** Exposed API to the P2P module. */
-export interface P2PApiWithoutAttestations {
+export interface P2PApi {
   /**
    * Returns all pending transactions in the transaction pool.
    * @param limit - The number of items to returns
@@ -48,9 +47,7 @@ export interface P2PApiWithoutAttestations {
    * Returns info for all connected, dialing, and cached peers.
    */
   getPeers(includePending?: boolean): Promise<PeerInfo[]>;
-}
 
-export interface P2PApiWithAttestations extends P2PApiWithoutAttestations {
   /**
    * Queries the Attestation pool for checkpoint attestations for the given slot
    *
@@ -61,18 +58,10 @@ export interface P2PApiWithAttestations extends P2PApiWithoutAttestations {
   getCheckpointAttestationsForSlot(slot: SlotNumber, proposalId?: string): Promise<CheckpointAttestation[]>;
 }
 
-export interface P2PClient extends P2PApiWithAttestations {
+export interface P2PClient extends P2PApi {
   /** Manually adds checkpoint attestations to the p2p client attestation pool. */
   addOwnCheckpointAttestations(attestations: CheckpointAttestation[]): Promise<void>;
 }
-
-export type P2PApi<T extends P2PClientType = P2PClientType.Full> = T extends P2PClientType.Full
-  ? P2PApiWithAttestations
-  : P2PApiWithoutAttestations;
-
-export type P2PApiFull<T extends P2PClientType = P2PClientType.Full> = T extends P2PClientType.Full
-  ? P2PApiWithAttestations & P2PClient
-  : P2PApiWithoutAttestations;
 
 export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
   getCheckpointAttestationsForSlot: z

--- a/yarn-project/stdlib/src/p2p/client_type.ts
+++ b/yarn-project/stdlib/src/p2p/client_type.ts
@@ -1,6 +1,0 @@
-export enum P2PClientType {
-  // Full p2p clients will subscribe to all gossip topics
-  Full,
-  // Prove p2p clients will only subscribe to transaction and proving topics
-  Prover,
-}

--- a/yarn-project/stdlib/src/p2p/index.ts
+++ b/yarn-project/stdlib/src/p2p/index.ts
@@ -8,7 +8,6 @@ export * from './interface.js';
 export * from './signature_utils.js';
 export * from './signed_txs.js';
 export * from './topic_type.js';
-export * from './client_type.js';
 export * from './message_validator.js';
 export * from './peer_error.js';
 export * from './constants.js';

--- a/yarn-project/stdlib/src/p2p/topic_type.ts
+++ b/yarn-project/stdlib/src/p2p/topic_type.ts
@@ -1,5 +1,3 @@
-import { P2PClientType } from './client_type.js';
-
 /**
  * Creates the topic channel identifier string from a given topic type
  */
@@ -27,19 +25,14 @@ export enum TopicType {
   checkpoint_attestation = 'checkpoint_attestation',
 }
 
-export function getTopicTypeForClientType(clientType: P2PClientType) {
-  if (clientType === P2PClientType.Full) {
-    return [TopicType.tx, TopicType.block_proposal, TopicType.checkpoint_proposal, TopicType.checkpoint_attestation];
-  } else if (clientType === P2PClientType.Prover) {
-    return [TopicType.tx, TopicType.block_proposal, TopicType.checkpoint_proposal];
-  } else {
-    const _: never = clientType;
-    return [TopicType.tx];
-  }
-}
-
-export function getTopicsForClientAndConfig(clientType: P2PClientType, disableTransactions: boolean) {
-  const topics = getTopicTypeForClientType(clientType);
+/** Returns all gossip topics, optionally filtering out transactions. */
+export function getTopicsForConfig(disableTransactions: boolean) {
+  const topics = [
+    TopicType.tx,
+    TopicType.block_proposal,
+    TopicType.checkpoint_proposal,
+    TopicType.checkpoint_attestation,
+  ];
   if (disableTransactions) {
     return topics.filter(topic => topic !== TopicType.tx);
   }

--- a/yarn-project/stdlib/src/p2p/topics.test.ts
+++ b/yarn-project/stdlib/src/p2p/topics.test.ts
@@ -1,16 +1,13 @@
-import { P2PClientType } from './client_type.js';
-import { TopicType, getTopicFromString, getTopicsForClientAndConfig } from './topic_type.js';
+import { TopicType, getTopicFromString, getTopicsForConfig } from './topic_type.js';
 
 describe('Gossip topic retrieval', () => {
   it.each([
-    [P2PClientType.Full, ['tx', 'block_proposal', 'checkpoint_proposal', 'checkpoint_attestation'], true],
-    [P2PClientType.Prover, ['tx', 'block_proposal', 'checkpoint_proposal'], true],
-    [P2PClientType.Full, ['block_proposal', 'checkpoint_proposal', 'checkpoint_attestation'], false],
-    [P2PClientType.Prover, ['block_proposal', 'checkpoint_proposal'], false],
+    [['tx', 'block_proposal', 'checkpoint_proposal', 'checkpoint_attestation'], true],
+    [['block_proposal', 'checkpoint_proposal', 'checkpoint_attestation'], false],
   ])(
-    'Node type %s subscribes to topics %s with transactions enabled: %s',
-    (clientType: P2PClientType, expectedTopics: string[], transactionsEnabled: boolean) => {
-      expect(getTopicsForClientAndConfig(clientType, !transactionsEnabled)).toEqual(expectedTopics);
+    'subscribes to topics %s with transactions enabled: %s',
+    (expectedTopics: string[], transactionsEnabled: boolean) => {
+      expect(getTopicsForConfig(!transactionsEnabled)).toEqual(expectedTopics);
     },
   );
 });


### PR DESCRIPTION
## Summary

- When the node starts with `--prover` (without `--sequencer`), skip creating validator, sentinel, watchers, sequencer, slasher, and block-proposal-handler subsystems. The prover only needs archiver, world-state, p2p, epoch cache, blob client, and the prover node itself.
- Remove the unused `P2PClientType.Prover` enum variant and all associated generic type parameters (`<T extends P2PClientType>`) from P2P classes, simplifying the type surface across 18 files (-192 lines net).

The `proverOnly` flag is `enableProverNode && disableValidator`, so combined modes like `--node --prover-node --sequencer` still create all subsystems as before.

## Test plan

- [x] `yarn build` compiles cleanly
- [x] `yarn format` and `yarn lint` pass
- [x] `yarn workspace @aztec/stdlib test src/p2p/topics.test.ts` — 23/23 pass
- [x] `yarn workspace @aztec/p2p test src/client/p2p_client.test.ts` — 18/18 pass
- [x] `yarn workspace @aztec/aztec-node test` — 83/83 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fix A-550