### PR TITLE
feat: Validate num txs in block proposals

### DIFF
--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -464,11 +464,6 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
     description: 'Minimum age (ms) a transaction must have been in the pool before it is eligible for block building.',
     ...numberConfigHelper(2_000),
   },
-  maxTxsPerBlock: {
-    env: 'SEQ_MAX_TX_PER_BLOCK',
-    description: 'The maximum number of txs to include in a block. Used for validating proposals from peers.',
-    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
-  },
   ...sharedSequencerConfigMappings,
   ...p2pReqRespConfigMappings,
   ...batchTxRequesterConfigMappings,

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -38,7 +38,7 @@ export interface P2PConfig
     ChainConfig,
     TxCollectionConfig,
     TxFileStoreConfig,
-    Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot'> {
+    Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot' | 'maxTxsPerBlock'> {
   /** A flag dictating whether the P2P subsystem should be enabled. */
   p2pEnabled: boolean;
 
@@ -463,6 +463,11 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
     env: 'P2P_MIN_TX_POOL_AGE_MS',
     description: 'Minimum age (ms) a transaction must have been in the pool before it is eligible for block building.',
     ...numberConfigHelper(2_000),
+  },
+  maxTxsPerBlock: {
+    env: 'SEQ_MAX_TX_PER_BLOCK',
+    description: 'The maximum number of txs to include in a block. Used for validating proposals from peers.',
+    parseEnv: (val: string) => (val ? parseInt(val, 10) : undefined),
   },
   ...sharedSequencerConfigMappings,
   ...p2pReqRespConfigMappings,

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/block_proposal_validator.ts
@@ -4,7 +4,7 @@ import type { BlockProposal, P2PValidator } from '@aztec/stdlib/p2p';
 import { ProposalValidator } from '../proposal_validator/proposal_validator.js';
 
 export class BlockProposalValidator extends ProposalValidator<BlockProposal> implements P2PValidator<BlockProposal> {
-  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean }) {
+  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean; maxTxsPerBlock?: number }) {
     super(epochCache, opts, 'p2p:block_proposal_validator');
   }
 }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/checkpoint_proposal_validator.ts
@@ -7,7 +7,7 @@ export class CheckpointProposalValidator
   extends ProposalValidator<CheckpointProposal>
   implements P2PValidator<CheckpointProposal>
 {
-  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean }) {
+  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean; maxTxsPerBlock?: number }) {
     super(epochCache, opts, 'p2p:checkpoint_proposal_validator');
   }
 }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator.ts
@@ -9,10 +9,16 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
   protected epochCache: EpochCacheInterface;
   protected logger: Logger;
   protected txsPermitted: boolean;
+  protected maxTxsPerBlock?: number;
 
-  constructor(epochCache: EpochCacheInterface, opts: { txsPermitted: boolean }, loggerName: string) {
+  constructor(
+    epochCache: EpochCacheInterface,
+    opts: { txsPermitted: boolean; maxTxsPerBlock?: number },
+    loggerName: string,
+  ) {
     this.epochCache = epochCache;
     this.txsPermitted = opts.txsPermitted;
+    this.maxTxsPerBlock = opts.maxTxsPerBlock;
     this.logger = createLogger(loggerName);
   }
 
@@ -43,6 +49,14 @@ export abstract class ProposalValidator<TProposal extends BlockProposal | Checkp
       if (!this.txsPermitted && (proposal.txHashes.length > 0 || embeddedTxCount > 0)) {
         this.logger.warn(
           `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when transactions are not permitted`,
+        );
+        return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
+      }
+
+      // Max txs per block check
+      if (this.maxTxsPerBlock !== undefined && proposal.txHashes.length > this.maxTxsPerBlock) {
+        this.logger.warn(
+          `Penalizing peer for proposal with ${proposal.txHashes.length} transaction(s) when max is ${this.maxTxsPerBlock}`,
         );
         return { result: 'reject', severity: PeerErrorSeverity.MidToleranceError };
       }

--- a/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator_test_suite.ts
+++ b/yarn-project/p2p/src/msg_validators/proposal_validator/proposal_validator_test_suite.ts
@@ -1,4 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { NoCommitteeError } from '@aztec/ethereum/contracts';
 import type { Secp256k1Signer } from '@aztec/foundation/crypto/secp256k1-signer';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import {
@@ -9,12 +10,13 @@ import {
 } from '@aztec/stdlib/p2p';
 import type { TxHash } from '@aztec/stdlib/tx';
 
+import { jest } from '@jest/globals';
 import type { MockProxy } from 'jest-mock-extended';
 
 export interface ProposalValidatorTestParams<TProposal extends BlockProposal | CheckpointProposal> {
   validatorFactory: (
     epochCache: EpochCacheInterface,
-    opts: { txsPermitted: boolean },
+    opts: { txsPermitted: boolean; maxTxsPerBlock?: number },
   ) => { validate: (proposal: TProposal) => Promise<ValidationResult> };
   makeProposal: (options?: any) => Promise<TProposal>;
   makeHeader: (epochNumber: number | bigint, slotNumber: number | bigint, blockNumber: number | bigint) => any;
@@ -105,6 +107,26 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
       expect(result).toEqual({ result: 'ignore' });
     });
 
+    it('returns mid tolerance error if proposal has invalid signature', async () => {
+      const currentProposer = getSigner();
+      const header = makeHeader(1, 100, 100);
+      const mockProposal = await makeProposal({
+        blockHeader: header,
+        lastBlockHeader: header,
+        signer: currentProposer,
+      });
+
+      // Override getSender to return undefined (invalid signature)
+      jest.spyOn(mockProposal as any, 'getSender').mockReturnValue(undefined);
+
+      mockGetProposer(getAddress(currentProposer), getAddress());
+      const result = await validator.validate(mockProposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+
+      // Should not try to resolve proposer if signature is invalid
+      expect(epochCache.getProposerAttesterAddressInSlot).not.toHaveBeenCalled();
+    });
+
     it('returns mid tolerance error if proposer is not current proposer for current slot', async () => {
       const currentProposer = getSigner();
       const nextProposer = getSigner();
@@ -150,6 +172,34 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
       mockGetProposer(getAddress(currentProposer), getAddress(nextProposer));
       const result = await validator.validate(mockProposal);
       expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+    });
+
+    it('accepts proposal when proposer is undefined (open committee)', async () => {
+      const currentProposer = getSigner();
+      const header = makeHeader(1, 100, 100);
+      const mockProposal = await makeProposal({
+        blockHeader: header,
+        lastBlockHeader: header,
+        signer: currentProposer,
+      });
+
+      epochCache.getProposerAttesterAddressInSlot.mockResolvedValue(undefined);
+      const result = await validator.validate(mockProposal);
+      expect(result).toEqual({ result: 'accept' });
+    });
+
+    it('returns low tolerance error when getProposerAttesterAddressInSlot throws NoCommitteeError', async () => {
+      const currentProposer = getSigner();
+      const header = makeHeader(1, 100, 100);
+      const mockProposal = await makeProposal({
+        blockHeader: header,
+        lastBlockHeader: header,
+        signer: currentProposer,
+      });
+
+      epochCache.getProposerAttesterAddressInSlot.mockRejectedValue(new NoCommitteeError());
+      const result = await validator.validate(mockProposal);
+      expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
     });
 
     it('returns undefined if proposal is valid for current slot and proposer', async () => {
@@ -219,6 +269,99 @@ export function sharedProposalValidatorTests<TProposal extends BlockProposal | C
           lastBlockHeader: header,
           signer: currentProposer,
           txHashes: getTxHashes(2),
+        });
+
+        mockGetProposer(getAddress(currentProposer), getAddress());
+        const result = await validator.validate(mockProposal);
+        expect(result).toEqual({ result: 'accept' });
+      });
+    });
+
+    describe('embedded tx validation', () => {
+      it('returns mid tolerance error if embedded txs are not listed in txHashes', async () => {
+        const currentProposer = getSigner();
+        const txHashes = getTxHashes(2);
+        const header = makeHeader(1, 100, 100);
+        const mockProposal = await makeProposal({
+          blockHeader: header,
+          lastBlockHeader: header,
+          signer: currentProposer,
+          txHashes,
+        });
+
+        // Create a fake tx whose hash is NOT in txHashes
+        const fakeTxHash = getTxHashes(1)[0];
+        const fakeTx = { getTxHash: () => fakeTxHash, validateTxHash: () => Promise.resolve(true) };
+        Object.defineProperty(mockProposal, 'txs', { get: () => [fakeTx], configurable: true });
+
+        mockGetProposer(getAddress(currentProposer), getAddress());
+        const result = await validator.validate(mockProposal);
+        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      });
+
+      it('returns low tolerance error if embedded tx has invalid tx hash', async () => {
+        const currentProposer = getSigner();
+        const txHashes = getTxHashes(2);
+        const header = makeHeader(1, 100, 100);
+        const mockProposal = await makeProposal({
+          blockHeader: header,
+          lastBlockHeader: header,
+          signer: currentProposer,
+          txHashes,
+        });
+
+        // Create a fake tx whose hash IS in txHashes but validateTxHash returns false
+        const fakeTx = { getTxHash: () => txHashes[0], validateTxHash: () => Promise.resolve(false) };
+        Object.defineProperty(mockProposal, 'txs', { get: () => [fakeTx], configurable: true });
+
+        mockGetProposer(getAddress(currentProposer), getAddress());
+        const result = await validator.validate(mockProposal);
+        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.LowToleranceError });
+      });
+    });
+
+    describe('maxTxsPerBlock validation', () => {
+      it('rejects proposal when txHashes exceed maxTxsPerBlock', async () => {
+        const validatorWithMaxTxs = validatorFactory(epochCache, { txsPermitted: true, maxTxsPerBlock: 2 });
+        const currentProposer = getSigner();
+        const header = makeHeader(1, 100, 100);
+        const mockProposal = await makeProposal({
+          blockHeader: header,
+          lastBlockHeader: header,
+          signer: currentProposer,
+          txHashes: getTxHashes(3),
+        });
+
+        mockGetProposer(getAddress(currentProposer), getAddress());
+        const result = await validatorWithMaxTxs.validate(mockProposal);
+        expect(result).toEqual({ result: 'reject', severity: PeerErrorSeverity.MidToleranceError });
+      });
+
+      it('accepts proposal when txHashes count equals maxTxsPerBlock', async () => {
+        const validatorWithMaxTxs = validatorFactory(epochCache, { txsPermitted: true, maxTxsPerBlock: 2 });
+        const currentProposer = getSigner();
+        const header = makeHeader(1, 100, 100);
+        const mockProposal = await makeProposal({
+          blockHeader: header,
+          lastBlockHeader: header,
+          signer: currentProposer,
+          txHashes: getTxHashes(2),
+        });
+
+        mockGetProposer(getAddress(currentProposer), getAddress());
+        const result = await validatorWithMaxTxs.validate(mockProposal);
+        expect(result).toEqual({ result: 'accept' });
+      });
+
+      it('accepts proposal when maxTxsPerBlock is not set (unlimited)', async () => {
+        // Default validator has no maxTxsPerBlock
+        const currentProposer = getSigner();
+        const header = makeHeader(1, 100, 100);
+        const mockProposal = await makeProposal({
+          blockHeader: header,
+          lastBlockHeader: header,
+          signer: currentProposer,
+          txHashes: getTxHashes(10),
         });
 
         mockGetProposer(getAddress(currentProposer), getAddress());

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -224,9 +224,13 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       this.protocolVersion,
     );
 
-    this.blockProposalValidator = new BlockProposalValidator(epochCache, { txsPermitted: !config.disableTransactions });
+    this.blockProposalValidator = new BlockProposalValidator(epochCache, {
+      txsPermitted: !config.disableTransactions,
+      maxTxsPerBlock: config.maxTxsPerBlock,
+    });
     this.checkpointProposalValidator = new CheckpointProposalValidator(epochCache, {
       txsPermitted: !config.disableTransactions,
+      maxTxsPerBlock: config.maxTxsPerBlock,
     });
     this.checkpointAttestationValidator = config.fishermanMode
       ? new FishermanAttestationValidator(epochCache, mempools.attestationPool, telemetry)

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -13,6 +13,7 @@ import { type P2PConfig, p2pConfigMappings } from '@aztec/p2p/config';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
   type ChainConfig,
+  DEFAULT_MAX_TXS_PER_BLOCK,
   type SequencerConfig,
   chainConfigMappings,
   sharedSequencerConfigMappings,
@@ -37,7 +38,7 @@ export type { SequencerConfig };
  */
 export const DefaultSequencerConfig: ResolvedSequencerConfig = {
   sequencerPollingIntervalMS: 500,
-  maxTxsPerBlock: 32,
+  maxTxsPerBlock: DEFAULT_MAX_TXS_PER_BLOCK,
   minTxsPerBlock: 1,
   buildCheckpointIfEmpty: false,
   publishTxsWithProposals: false,

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -77,11 +77,6 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
     description: 'The number of ms to wait between polling for checking to build on the next slot.',
     ...numberConfigHelper(DefaultSequencerConfig.sequencerPollingIntervalMS),
   },
-  maxTxsPerBlock: {
-    env: 'SEQ_MAX_TX_PER_BLOCK',
-    description: 'The maximum number of txs to include in a block.',
-    ...numberConfigHelper(DefaultSequencerConfig.maxTxsPerBlock),
-  },
   minTxsPerBlock: {
     env: 'SEQ_MIN_TX_PER_BLOCK',
     description: 'The minimum number of txs to include in a block.',

--- a/yarn-project/stdlib/src/config/sequencer-config.ts
+++ b/yarn-project/stdlib/src/config/sequencer-config.ts
@@ -1,4 +1,4 @@
-import type { ConfigMappingsType } from '@aztec/foundation/config';
+import { type ConfigMappingsType, numberConfigHelper } from '@aztec/foundation/config';
 
 import type { SequencerConfig } from '../interfaces/configs.js';
 
@@ -9,7 +9,7 @@ import type { SequencerConfig } from '../interfaces/configs.js';
  * to avoid duplication.
  */
 export const sharedSequencerConfigMappings: ConfigMappingsType<
-  Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot'>
+  Pick<SequencerConfig, 'blockDurationMs' | 'expectedBlockProposalsPerSlot' | 'maxTxsPerBlock'>
 > = {
   blockDurationMs: {
     env: 'SEQ_BLOCK_DURATION_MS',
@@ -25,5 +25,10 @@ export const sharedSequencerConfigMappings: ConfigMappingsType<
       '0 (default) disables block proposal scoring. Set to a positive value to enable.',
     parseEnv: (val: string) => (val ? parseInt(val, 10) : 0),
     defaultValue: 0,
+  },
+  maxTxsPerBlock: {
+    env: 'SEQ_MAX_TX_PER_BLOCK',
+    description: 'The maximum number of txs to include in a block.',
+    ...numberConfigHelper(32),
   },
 };

--- a/yarn-project/stdlib/src/config/sequencer-config.ts
+++ b/yarn-project/stdlib/src/config/sequencer-config.ts
@@ -2,6 +2,9 @@ import { type ConfigMappingsType, numberConfigHelper } from '@aztec/foundation/c
 
 import type { SequencerConfig } from '../interfaces/configs.js';
 
+/** Default maximum number of transactions per block. */
+export const DEFAULT_MAX_TXS_PER_BLOCK = 32;
+
 /**
  * Partial sequencer config mappings for fields that need to be shared across packages.
  * The full sequencer config mappings remain in sequencer-client, but shared fields
@@ -29,6 +32,6 @@ export const sharedSequencerConfigMappings: ConfigMappingsType<
   maxTxsPerBlock: {
     env: 'SEQ_MAX_TX_PER_BLOCK',
     description: 'The maximum number of txs to include in a block.',
-    ...numberConfigHelper(32),
+    ...numberConfigHelper(DEFAULT_MAX_TXS_PER_BLOCK),
   },
 };

--- a/yarn-project/stdlib/src/interfaces/validator.ts
+++ b/yarn-project/stdlib/src/interfaces/validator.ts
@@ -62,7 +62,7 @@ export type ValidatorClientConfig = ValidatorHASignerConfig & {
 };
 
 export type ValidatorClientFullConfig = ValidatorClientConfig &
-  Pick<SequencerConfig, 'txPublicSetupAllowList' | 'broadcastInvalidBlockProposal'> &
+  Pick<SequencerConfig, 'txPublicSetupAllowList' | 'broadcastInvalidBlockProposal' | 'maxTxsPerBlock'> &
   Pick<
     SlasherConfig,
     'slashBroadcastedInvalidBlockPenalty' | 'slashDuplicateProposalPenalty' | 'slashDuplicateAttestationPenalty'
@@ -93,6 +93,7 @@ export const ValidatorClientFullConfigSchema = zodFor<Omit<ValidatorClientFullCo
   ValidatorClientConfigSchema.extend({
     txPublicSetupAllowList: z.array(AllowedElementSchema).optional(),
     broadcastInvalidBlockProposal: z.boolean().optional(),
+    maxTxsPerBlock: z.number().optional(),
     slashBroadcastedInvalidBlockPenalty: schemas.BigInt,
     slashDuplicateProposalPenalty: schemas.BigInt,
     slashDuplicateAttestationPenalty: schemas.BigInt,

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -29,6 +29,7 @@ export function createBlockProposalHandler(
   const metrics = new ValidatorMetrics(deps.telemetry);
   const blockProposalValidator = new BlockProposalValidator(deps.epochCache, {
     txsPermitted: !config.disableTransactions,
+    maxTxsPerBlock: config.maxTxsPerBlock,
   });
   return new BlockProposalHandler(
     deps.checkpointsBuilder,

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -197,6 +197,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     const metrics = new ValidatorMetrics(telemetry);
     const blockProposalValidator = new BlockProposalValidator(epochCache, {
       txsPermitted: !config.disableTransactions,
+      maxTxsPerBlock: config.maxTxsPerBlock,
     });
     const blockProposalHandler = new BlockProposalHandler(
       checkpointsBuilder,


### PR DESCRIPTION
This PR introduces additional block/checkpoint proposal validation to ensure `SEQ_MAX_TX_PER_BLOCK` is not breached. Also adds additional tests for existing validation criteria.
