### PR TITLE
fix: Fix script for testing vks haven't changed

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -3,9 +3,10 @@ source $(git rev-parse --show-toplevel)/ci3/source
 
 # export bb as it is needed when using exported functions
 export bb="$root/barretenberg/cpp/$(./native-preset-build-dir)/bin/bb"
-script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-cd ..
+# script path to auto update short hash
+script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh"
+
 
 # NOTE: We pin the captured IVC inputs to a known master commit, exploiting that there won't be frequent changes.
 # This allows us to compare the generated VKs here with ones we compute freshly, detecting breaking protocol changes.
@@ -139,7 +140,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 EOF
   exit 0
 elif [[ "${1:-}" == "--update_inputs" ]]; then
-    export inputs_dir="../../yarn-project/end-to-end/example-app-ivc-inputs-out"
+    export inputs_dir="$root/yarn-project/end-to-end/example-app-ivc-inputs-out"
 
     # For easily rerunning the inputs generation
     set -eu

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -3,6 +3,8 @@ source $(git rev-parse --show-toplevel)/ci3/source
 
 # export bb as it is needed when using exported functions
 export bb="$root/barretenberg/cpp/$(./native-preset-build-dir)/bin/bb"
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
 cd ..
 
 # NOTE: We pin the captured IVC inputs to a known master commit, exploiting that there won't be frequent changes.
@@ -15,8 +17,6 @@ cd ..
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
 pinned_short_hash="189f0026"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
-
-script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/scripts" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 function update_pinned_hash_in_script {
     local new_hash=$1

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -80,12 +80,12 @@ export -f check_circuit_vks
 function prove_and_verify_inputs {
   set -eu
   local flow_folder="$inputs_dir/$1"
-  local proof_exit_code=0
+  local prove_exit_code=0
 
   echo "Running proof test for $1..."
-  $bb prove --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" > /dev/null 2>&1 || proof_exit_code=$?
+  $bb prove --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" > /dev/null 2>&1 || prove_exit_code=$?
 
-  if [[ $proof_exit_code -ne 0 ]]; then
+  if [[ $prove_exit_code -ne 0 ]]; then
     echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."
 
     cp "$flow_folder/ivc-inputs.msgpack" "$root/yarn-project/end-to-end/example-app-ivc-inputs-out/$1/ivc-inputs.msgpack"

--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -83,7 +83,7 @@ function prove_and_verify_inputs {
   local proof_exit_code=0
 
   echo "Running proof test for $1..."
-  $bb prove --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" > /dev/null 2>&1 || prove_exit_code=$?
+  $bb prove --scheme chonk --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" > /dev/null 2>&1 || proof_exit_code=$?
 
   if [[ $proof_exit_code -ne 0 ]]; then
     echo "Proof test failed for flow $1. Please re-run the script with flag --update_inputs."


### PR DESCRIPTION
When verifying the inputs can be proven, we were extracting the exit code of `bb prove` to a variable that was never used. This meant that the script would always pass, even though the inputs were wrong.