### PR TITLE
chore(avm): Class ID Derivation pre-audit docs

### DIFF
--- a/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
@@ -2,33 +2,109 @@ include "../constants_gen.pil";
 include "../poseidon2_hash.pil";
 include "../precomputed.pil";
 
+/**
+ * This subtrace constrains the derivation of the contract class ID from the class members. It is
+ * used during bytecode retrieval (bc_retrieval.pil) in our execution flow.
+ * The class ID is defined as:
+ *   Poseidon2(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, bytecode_id (= public_bytecode_commitment))
+ *
+ * See the 'Hash Computation" and 'INTERACTIONS' sections for details on how we enforce the hash.
+ *
+ * PRECONDITIONS: The correctness of the class members themselves is not constrained here and must be
+ *               enforced by the calling circuits.
+ *               - bytecode_id (= public_bytecode_commitment) is constrained externally in bc_hashing.pil,
+ *                 which is propagated to the bc_retrieval.pil lookup into this trace (see interaction map below).
+ *               - artifact_hash is hinted in all circuits (public and private) since its correctness is not
+ *                 enforced by the protocol. It's used by clients to verify that an offchain fetched artifact
+ *                 matches a registered class.
+ *               - private_functions_root is hinted in public since it is calculated and constrained in the
+ *                 private kernel. The kernel additionally recalculates the class ID from this root, so if the
+ *                 hint here is wrong there will be an address mismatch.
+ *
+ * USAGE: To enforce that a contract class ID matches the hash of its members (adapted from #[CLASS_ID_DERIVATION]
+ *        in bc_retrieval.pil):
+ *
+ *   sel { class_id, artifact_hash, private_functions_root, bytecode_id }
+ *   in class_id_derivation.sel {
+ *     class_id_derivation.class_id,
+ *     class_id_derivation.artifact_hash,
+ *     class_id_derivation.private_functions_root,
+ *     class_id_derivation.public_bytecode_commitment
+ *   };
+ *
+ * TRACE SHAPE: 1 row per contract class ID. Note that simulation deduplicates class IDs that have
+ *             already been processed i.e. when two contract instances share a class and both their IDs are
+ *             derived, only one event is emitted.
+ *
+ * INTERACTIONS:                                                  --> precomputed.pil
+ *  execution.pil --> instr_fetching.pil --> bc_decomposition.pil <-> bc_hashing.pil
+ *                --> bc_retrieval.pil --> class_id_derivation.pil --> poseidon2_hash.pil
+ *
+ * This subtrace is looked up by:
+ * - bc_retrieval.pil: To verify the stored class ID against the derived hash (#[CLASS_ID_DERIVATION]).
+ *                     Note: only looks up if there are no error cases.
+ *
+ * This subtrace looks up:
+ * - poseidon2_hash.pil: To constrain the Poseidon2 hash across 2 rounds (#[CLASS_ID_POSEIDON2_0] and
+ *                       #[CLASS_ID_POSEIDON2_1]). They are linked by the shared poseidon2_hash.output
+ *                       (= class_id) value which is propagated at each row of the poseidon trace,
+ *                       so (under hash collision resistance) both lookups must reference the same
+ *                       computation.
+ *                       Since we lookup by poseidon2_hash.start with input_len = 4, we enforce that
+ *                       we have two rounds only (see poseidon2_hash.num_perm_rounds_rem), so no
+ *                       intermediate rows can be maliciously added.
+ *                       The second lookup is by poseidon2_hash.end, constraining the final round and
+ *                       correctness of the padding values (= zero).
+ */
 namespace class_id_derivation;
+
+    ///////////////////////////////
+    // Set Up Columns
+    ///////////////////////////////
 
     pol commit sel; // @boolean
     sel * (1 - sel) = 0;
-
+    // No relations will be checked if this identity is satisfied.
     #[skippable_if]
     sel = 0;
 
-    // Members of Contract Class Id, looked up with bc_retrieval
+    // Contract class members (See barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp).
     pol commit artifact_hash;
     pol commit private_functions_root;
-    pol commit public_bytecode_commitment; // This is constrained via executions's lookup to instr_fetching, which looks up bc_decomposition <-> bc_hashing
-    // The result of
-    // H(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment)
+    // The public bytecode commitment (= bytecode_id).
+    // Note: This is constrained in bc_hashing <-> bc_decomposition <- instr_fetching (#[BYTES_FROM_BC_DEC]).
+    pol commit public_bytecode_commitment;
+    // The derived class ID: H(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment).
     pol commit class_id;
 
-    // TODO: We need these temporarily while we dont allow for aliases in the lookup tuple.
+    ///////////////////////////////
+    // Hash Computation
+    ///////////////////////////////
+    //
+    // To constrain the hash result we require:
+    //  poseidon2_hash.output == class_id == Poseidon2([...poseidon2_hash.input_i])
+    // Where the inputs array (input_i, i = 0..3) is given by:
+    //  [DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment]
+    //
+    //  Since Poseidon2 processes inputs in chunks of 3, we need 2 permutation rounds to cover our 4 inputs:
+    //   Round 1 (start, input_len=4): (DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root)
+    //   Round 2 (end):                (public_bytecode_commitment, 0, 0)
+    //
+
+    // Needs to be committed because it's used in the #[CLASS_ID_POSEIDON2_0] lookup
     pol commit gen_index_contract_class_id;
     sel * (gen_index_contract_class_id - constants.DOM_SEP__CONTRACT_CLASS_ID) = 0;
+    // Needs to be committed because it's used in the #[CLASS_ID_POSEIDON2_0] lookup
     pol commit const_four;
     sel * (const_four - 4) = 0;
 
-    // Since the inputs to poseidon2 have to be chunks of 3, we need two lookups if we want to do this in a single row
+    // Enforces the first poseidon round. Note that we must lookup const_four == poseidon2_hash.input_len
+    // here since it is constrained in the poseidon trace on the start row.
     #[CLASS_ID_POSEIDON2_0]
     sel { gen_index_contract_class_id, artifact_hash, private_functions_root, class_id, const_four }
     in poseidon2_hash.start { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output, poseidon2_hash.input_len };
 
+    // Enforces the second and final poseidon round. Note that we must enforce the padded values are zero here.
     #[CLASS_ID_POSEIDON2_1]
     sel { public_bytecode_commitment, precomputed.zero, precomputed.zero, class_id }
     in poseidon2_hash.end { poseidon2_hash.input_0, poseidon2_hash.input_1, poseidon2_hash.input_2, poseidon2_hash.output };

--- a/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
@@ -68,14 +68,15 @@ namespace class_id_derivation;
     #[skippable_if]
     sel = 0;
 
+    // The derived class ID: H(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment).
+    pol commit class_id;
+
     // Contract class members (See barretenberg/cpp/src/barretenberg/vm2/common/aztec_types.hpp).
     pol commit artifact_hash;
     pol commit private_functions_root;
     // The public bytecode commitment (= bytecode_id).
     // Note: This is constrained in bc_hashing <-> bc_decomposition <- instr_fetching (#[BYTES_FROM_BC_DEC]).
     pol commit public_bytecode_commitment;
-    // The derived class ID: H(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment).
-    pol commit class_id;
 
     ///////////////////////////////
     // Hash Computation

--- a/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
+++ b/barretenberg/cpp/pil/vm2/bytecode/class_id_derivation.pil
@@ -36,9 +36,10 @@ include "../precomputed.pil";
  *             already been processed i.e. when two contract instances share a class and both their IDs are
  *             derived, only one event is emitted.
  *
- * INTERACTIONS:                                                  --> precomputed.pil
- *  execution.pil --> instr_fetching.pil --> bc_decomposition.pil <-> bc_hashing.pil
- *                --> bc_retrieval.pil --> class_id_derivation.pil --> poseidon2_hash.pil
+ * INTERACTIONS:
+ *  execution.pil --> bc_retrieval.pil --> class_id_derivation.pil --> poseidon2_hash.pil
+ *                --> instr_fetching.pil --> bc_decomposition.pil <-> bc_hashing.pil
+ *                                                                --> precomputed.pil
  *
  * This subtrace is looked up by:
  * - bc_retrieval.pil: To verify the stored class ID against the derived hash (#[CLASS_ID_DERIVATION]).
@@ -75,7 +76,10 @@ namespace class_id_derivation;
     pol commit artifact_hash;
     pol commit private_functions_root;
     // The public bytecode commitment (= bytecode_id).
-    // Note: This is constrained in bc_hashing <-> bc_decomposition <- instr_fetching (#[BYTES_FROM_BC_DEC]).
+    // Note: This is constrained by the interactions: bc_hashing <-> bc_decomposition <- instr_fetching (#[BYTES_FROM_BC_DEC]).
+    //  bc_hashing enforces that the bytes corresponding to some bytecode_id (=public_bytecode_commitment) indeed commit to that value.
+    //  bc_decomposition contains the bytes accessed by bc_hashing, and is itself accessed by instr_fetching.
+    //  execution ensures that the bytecode_id above is the same value used in bc_retrieval and hence here.
     pol commit public_bytecode_commitment;
 
     ///////////////////////////////

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_retrieval.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_retrieval.test.cpp
@@ -344,6 +344,7 @@ TEST_F(BytecodeRetrievalConstrainingTestFewerMocks, SuccessfulRetrievalFewerMock
     FF class_id = poseidon2.hash(
         { DOM_SEP__CONTRACT_CLASS_ID, klass.artifact_hash, klass.private_functions_root, bytecode_commitment });
     instance.current_contract_class_id = class_id;
+    klass.id = class_id;
     contract_instance_retrieval_builder.process({ {
                                                     .address = instance.deployer,
                                                     .contract_instance = { instance },
@@ -353,14 +354,11 @@ TEST_F(BytecodeRetrievalConstrainingTestFewerMocks, SuccessfulRetrievalFewerMock
                                                 } },
                                                 trace);
 
-    ContractClassWithCommitment klass_with_commitment = {
-        .id = instance.current_contract_class_id,
-        .artifact_hash = klass.artifact_hash,
-        .private_functions_root = klass.private_functions_root,
-        .packed_bytecode = klass.packed_bytecode,
-        .public_bytecode_commitment = bytecode_commitment,
-    };
-    class_id_builder.process({ { .klass = klass_with_commitment } }, trace);
+    class_id_builder.process({ { .class_id = klass.id,
+                                 .artifact_hash = klass.artifact_hash,
+                                 .private_functions_root = klass.private_functions_root,
+                                 .public_bytecode_commitment = bytecode_commitment } },
+                             trace);
 
     AppendOnlyTreeSnapshot snapshot_before = retrieved_bytecodes_tree_check.get_snapshot();
 
@@ -431,6 +429,7 @@ TEST_F(BytecodeRetrievalConstrainingTestFewerMocks, SuccessfulRepeatedRetrievalF
     FF class_id = poseidon2.hash(
         { DOM_SEP__CONTRACT_CLASS_ID, klass.artifact_hash, klass.private_functions_root, bytecode_commitment });
     instance.current_contract_class_id = class_id;
+    klass.id = class_id;
     contract_instance_retrieval_builder.process({ {
                                                     .address = instance.deployer,
                                                     .contract_instance = { instance },
@@ -439,14 +438,11 @@ TEST_F(BytecodeRetrievalConstrainingTestFewerMocks, SuccessfulRepeatedRetrievalF
                                                     .exists = true,
                                                 } },
                                                 trace);
-    ContractClassWithCommitment klass_with_commitment = {
-        .id = instance.current_contract_class_id,
-        .artifact_hash = klass.artifact_hash,
-        .private_functions_root = klass.private_functions_root,
-        .packed_bytecode = klass.packed_bytecode,
-        .public_bytecode_commitment = bytecode_commitment,
-    };
-    class_id_builder.process({ { .klass = klass_with_commitment } }, trace);
+    class_id_builder.process({ { .class_id = klass.id,
+                                 .artifact_hash = klass.artifact_hash,
+                                 .private_functions_root = klass.private_functions_root,
+                                 .public_bytecode_commitment = bytecode_commitment } },
+                             trace);
 
     AppendOnlyTreeSnapshot snapshot_before = retrieved_bytecodes_tree_check.get_snapshot();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_retrieval.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_retrieval.test.cpp
@@ -126,14 +126,11 @@ TEST_F(BytecodeRetrievalConstrainingTest, SuccessfulRetrieval)
                                                     .exists = true,
                                                 } },
                                                 trace);
-    ContractClassWithCommitment klass_with_commitment = {
-        .id = instance.current_contract_class_id,
-        .artifact_hash = klass.artifact_hash,
-        .private_functions_root = klass.private_functions_root,
-        .packed_bytecode = klass.packed_bytecode,
-        .public_bytecode_commitment = bytecode_commitment,
-    };
-    class_id_builder.process({ { .klass = klass_with_commitment } }, trace);
+    class_id_builder.process({ { .class_id = instance.current_contract_class_id,
+                                 .artifact_hash = klass.artifact_hash,
+                                 .private_functions_root = klass.private_functions_root,
+                                 .public_bytecode_commitment = bytecode_commitment } },
+                             trace);
 
     AppendOnlyTreeSnapshot snapshot_before = AppendOnlyTreeSnapshot{
         .root = FF(AVM_RETRIEVED_BYTECODES_TREE_INITIAL_ROOT),

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/class_id_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/class_id_derivation.test.cpp
@@ -70,9 +70,12 @@ TEST(ClassIdDerivationConstrainingTest, Basic)
     auto klass = generate_contract_class();
     FF class_id =
         compute_contract_class_id(klass.artifact_hash, klass.private_functions_root, klass.public_bytecode_commitment);
-    klass.id = class_id;
 
-    builder.process({ { .klass = klass } }, trace);
+    builder.process({ { .class_id = class_id,
+                        .artifact_hash = klass.artifact_hash,
+                        .private_functions_root = klass.private_functions_root,
+                        .public_bytecode_commitment = klass.public_bytecode_commitment } },
+                    trace);
 
     check_relation<class_id_derivation_relation>(trace);
 }
@@ -105,7 +108,11 @@ TEST(ClassIdDerivationPoseidonTest, WithHashInteraction)
     class_id_derivation.assert_derivation(klass);
 
     poseidon2_builder.process_hash(hash_event_emitter.dump_events(), trace);
-    builder.process({ { .klass = klass } }, trace);
+    builder.process({ { .class_id = klass.id,
+                        .artifact_hash = klass.artifact_hash,
+                        .private_functions_root = klass.private_functions_root,
+                        .public_bytecode_commitment = klass.public_bytecode_commitment } },
+                    trace);
 
     check_interaction<ClassIdDerivationTraceBuilder,
                       lookup_class_id_derivation_class_id_poseidon2_0_settings,

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/class_id_derivation_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/class_id_derivation_event.hpp
@@ -7,6 +7,7 @@ namespace bb::avm2::simulation {
 struct ClassIdDerivationEvent {
     // Uses ContractClassWithCommitment which includes id and bytecode_commitment
     // WARNING: this class has the whole bytecode. Create a new class.
+    // TODO(MW): Do this ^ as part of preaudit?
     ContractClassWithCommitment klass;
 };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/class_id_derivation_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/class_id_derivation_event.hpp
@@ -5,10 +5,10 @@
 namespace bb::avm2::simulation {
 
 struct ClassIdDerivationEvent {
-    // Uses ContractClassWithCommitment which includes id and bytecode_commitment
-    // WARNING: this class has the whole bytecode. Create a new class.
-    // TODO(MW): Do this ^ as part of preaudit?
-    ContractClassWithCommitment klass;
+    ContractClassId class_id = 0;
+    FF artifact_hash = 0;
+    FF private_functions_root = 0;
+    BytecodeId public_bytecode_commitment = 0;
 };
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
@@ -45,7 +45,10 @@ void ClassIdDerivation::assert_derivation(const ContractClassWithCommitment& kla
     cached_derivations.insert(klass.id);
 
     // Emits ClassIdDerivationEvent.
-    events.emit({ .klass = klass });
+    events.emit({ .class_id = klass.id,
+                  .artifact_hash = klass.artifact_hash,
+                  .private_functions_root = klass.private_functions_root,
+                  .public_bytecode_commitment = klass.public_bytecode_commitment });
 }
 
 } // namespace bb::avm2::simulation

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.cpp
@@ -4,29 +4,47 @@
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
 #include "barretenberg/vm2/simulation/gadgets/poseidon2.hpp"
-#include "barretenberg/vm2/simulation/lib/contract_crypto.hpp"
 
 namespace bb::avm2::simulation {
 
+/**
+ * @brief Computes the contract class ID and emits a ClassIdDerivationEvent. Corresponds to
+ * the subtrace class_id_derivation.pil.
+ *
+ * If the class ID has already been derived, an event has already been emitted and we skip
+ * repeating the computation and emission. Otherwise, we call the poseidon trace to perform
+ * the hash defining the class ID, given as:
+ *  Poseidon2(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment)
+ * and we add the output to the local cache.
+ *
+ * @throws Unexpected exception if
+ *        - the calculated class ID does not match that stored in the @p klass itself.
+ *
+ * @param klass The contract class.
+ */
 void ClassIdDerivation::assert_derivation(const ContractClassWithCommitment& klass)
 {
-    // Check if we've already derived this class_id
+    // Check if we've already derived this class_id.
     if (cached_derivations.contains(klass.id)) {
-        // Already processed this class_id - cache hit, don't emit event
+        // Already processed this class_id - cache hit, don't emit event.
         return;
     }
 
-    // First time seeing this class_id - do the actual derivation
+    // First time seeing this class_id - do the actual derivation.
+    // Emits Poseidon2HashEvent and Poseidon2PermutationEvents, see #[CLASS_ID_POSEIDON2_i]
+    // lookups in class_id_derivation.pil.
     FF computed_class_id = poseidon2.hash({ DOM_SEP__CONTRACT_CLASS_ID,
                                             klass.artifact_hash,
                                             klass.private_functions_root,
                                             klass.public_bytecode_commitment });
-    // This will throw an unexpected exception if it fails.
+    // This will throw an unexpected exception if it fails. If we have reached this point,
+    // the contract class registry should have enforced this.
     BB_ASSERT_EQ(computed_class_id, klass.id, "Computed class ID mismatch");
 
-    // Cache this derivation so we don't repeat it
+    // Cache this derivation so we don't repeat it.
     cached_derivations.insert(klass.id);
 
+    // Emits ClassIdDerivationEvent.
     events.emit({ .klass = klass });
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/class_id_derivation.test.cpp
@@ -46,8 +46,8 @@ TEST(AvmSimulationClassIdDerivationTest, Positive)
 
     auto events = class_id_derivation_event_emitter.dump_events();
     EXPECT_THAT(events, SizeIs(1));
-    EXPECT_EQ(events[0].klass.id, expected_class_id);
-    EXPECT_EQ(events[0].klass.artifact_hash, klass.artifact_hash);
+    EXPECT_EQ(events[0].class_id, expected_class_id);
+    EXPECT_EQ(events[0].artifact_hash, klass.artifact_hash);
 
     // Second derivation for the same class ID should be a cache hit and should not emit an event
     class_id_derivation.assert_derivation(klass);

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/gadgets/concrete_dbs.cpp
@@ -44,6 +44,8 @@ std::optional<ContractClass> ContractDB::get_contract_class(const ContractClassI
     BB_ASSERT(maybe_bytecode_commitment.has_value(), "Bytecode commitment not found");
 
     // Perform class ID derivation to verify the class ID is correctly derived from the class data.
+    // Emits ClassIdDerivationEvent (and corresponding Poseidon2HashEvent and Poseidon2PermutationEvents) if
+    // we have yet to derive this class ID.
     class_id_derivation.assert_derivation(maybe_klass->with_commitment(maybe_bytecode_commitment.value()));
 
     return maybe_klass;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
@@ -34,11 +34,11 @@ void ClassIdDerivationTraceBuilder::process(
                   { {
                       { C::class_id_derivation_sel, 1 },
                       // Class ID.
-                      { C::class_id_derivation_class_id, event.klass.id },
+                      { C::class_id_derivation_class_id, event.class_id },
                       // Class members.
-                      { C::class_id_derivation_artifact_hash, event.klass.artifact_hash },
-                      { C::class_id_derivation_private_functions_root, event.klass.private_functions_root },
-                      { C::class_id_derivation_public_bytecode_commitment, event.klass.public_bytecode_commitment },
+                      { C::class_id_derivation_artifact_hash, event.artifact_hash },
+                      { C::class_id_derivation_private_functions_root, event.private_functions_root },
+                      { C::class_id_derivation_public_bytecode_commitment, event.public_bytecode_commitment },
                       // Constant columns (this is temp because aliasing is not allowed in lookups).
                       { C::class_id_derivation_gen_index_contract_class_id, DOM_SEP__CONTRACT_CLASS_ID },
                       { C::class_id_derivation_const_four, 4 },

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
@@ -19,7 +19,7 @@ namespace bb::avm2::tracegen {
  *  to constrain correctness of the class id, given as:
  *      Poseidon2(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment)
  *
- * @param events The container of class id derivation events events to process.
+ * @param events The container of class id derivation events to process.
  * @param trace The trace container.
  */
 void ClassIdDerivationTraceBuilder::process(

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.cpp
@@ -11,6 +11,17 @@
 
 namespace bb::avm2::tracegen {
 
+/**
+ * @brief Process class id derivation events and populate the relevant columns in the trace.
+ *  Corresponds to the subtrace class_id_derivation.pil.
+ *
+ *  This trace is non memory-aware and does not handle any errors. It relies on the poseidon trace
+ *  to constrain correctness of the class id, given as:
+ *      Poseidon2(DOM_SEP__CONTRACT_CLASS_ID, artifact_hash, private_functions_root, public_bytecode_commitment)
+ *
+ * @param events The container of class id derivation events events to process.
+ * @param trace The trace container.
+ */
 void ClassIdDerivationTraceBuilder::process(
     const simulation::EventEmitterInterface<simulation::ClassIdDerivationEvent>::Container& events,
     TraceContainer& trace)
@@ -22,12 +33,13 @@ void ClassIdDerivationTraceBuilder::process(
         trace.set(row,
                   { {
                       { C::class_id_derivation_sel, 1 },
+                      // Class ID.
                       { C::class_id_derivation_class_id, event.klass.id },
+                      // Class members.
                       { C::class_id_derivation_artifact_hash, event.klass.artifact_hash },
                       { C::class_id_derivation_private_functions_root, event.klass.private_functions_root },
                       { C::class_id_derivation_public_bytecode_commitment, event.klass.public_bytecode_commitment },
-
-                      // This is temp because aliasing is not allowed in lookups
+                      // Constant columns (this is temp because aliasing is not allowed in lookups).
                       { C::class_id_derivation_gen_index_contract_class_id, DOM_SEP__CONTRACT_CLASS_ID },
                       { C::class_id_derivation_const_four, 4 },
                   } });

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
@@ -22,14 +22,13 @@ TEST(ClassIdDerivationTraceGenTest, TraceGeneration)
     TestTraceContainer trace;
     ClassIdDerivationTraceBuilder builder;
 
-    ContractClassWithCommitment klass{
-        .id = FF(0xdeadbeef),
+    simulation::ClassIdDerivationEvent class_event{
+        .class_id = FF(0xdeadbeef),
         .artifact_hash = FF(12),
         .private_functions_root = FF(23),
-        .packed_bytecode = {},
         .public_bytecode_commitment = FF(45),
     };
-    builder.process({ { .klass = klass } }, trace);
+    builder.process({ { class_event } }, trace);
 
     EXPECT_THAT(trace.as_rows(),
                 ElementsAre(


### PR DESCRIPTION
Class ID  pre-audit PR including:

- New comments/documentation
- Rearranging code

This is just a small 'destination' subtrace which computes a hash, so no significant findings!
Closes [AVM-56](https://linear.app/aztec-labs/issue/AVM-56/bytecode-class-id-deriv)

TODOs/Notes: ~Only TODO is to remove bytecode from the event (unused)~ None!
