### PR TITLE
chore: exclude auto-generated dirs from VS Code search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -148,11 +148,53 @@
   },
   "solidity.formatter": "forge",
   "search.exclude": {
+    // Package managers / dependencies
     "**/.yarn": true,
     "**/.yalc": true,
     "**/node_modules": true,
     "**/.pnp.*": true,
-    "**/msgpack-c/**": true
+    "**/l1-contracts/lib/**": true,
+    "**/barretenberg/sol/lib/**": true,
+    "**/msgpack-c/**": true,
+
+    // Build outputs
+    "**/dest/**": true,
+    "**/dist/**": true,
+    "**/target/**": true,
+    "**/build/**": true,
+    "**/out/**": true,
+    "**/artifacts/**": true,
+    "**/generated/**": true,
+
+    // Caches
+    "**/.cache/**": true,
+    "**/.cache-loader/**": true,
+    "**/.docusaurus/**": true,
+    "**/.tsbuildinfo": true,
+    "**/tsconfig.tsbuildinfo": true,
+    "**/.eslintcache": true,
+
+    // Docs: versioned/generated content
+    "**/docs/developer_versioned_docs/**": true,
+    "**/docs/network_versioned_docs/**": true,
+    "**/docs/network_versioned_sidebars/**": true,
+    "**/docs/processed-docs/**": true,
+    "**/docs/processed-docs-cache/**": true,
+    "**/docs/static/**": true,
+    "**/docs/build/**": true,
+    "**/barretenberg/docs/versioned_docs/**": true,
+    "**/barretenberg/docs/versioned_sidebars/**": true,
+    "**/barretenberg/docs/static/**": true,
+    "**/barretenberg/docs/build/**": true,
+    "**/noir/noir-repo/docs/versioned_docs/**": true,
+    "**/noir/noir-repo/docs/versioned_sidebars/**": true,
+
+    // C++/Rust build
+    "**/barretenberg/cpp/build*/**": true,
+    "**/barretenberg/cpp/src/wasi-sdk*/**": true,
+    "**/cmake-build-*/**": true,
+    "**/bench-out/**": true,
+    "**/coverage/**": true
   },
   "[terraform]": {
     "editor.defaultFormatter": "hashicorp.terraform"


### PR DESCRIPTION
## Summary
- Adds auto-generated directories to `.vscode/settings.json` `search.exclude` so they don't pollute VS Code search results
- Covers build outputs (`dest`, `dist`, `target`, `build`, `out`, `artifacts`, `generated`), caches (`.cache`, `.docusaurus`, `.tsbuildinfo`), versioned/generated docs, and vendored Solidity libs

## Test plan
- Open VS Code search and verify excluded directories no longer appear in results
- Verify source code files are still searchable


🤖 Generated with [Claude Code](https://claude.com/claude-code)