### PR TITLE
chore: (A-554) bump reth version 1.6.0 -> 1.11.1 for eth devnet

### DIFF
--- a/spartan/eth-devnet/values.yaml
+++ b/spartan/eth-devnet/values.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 images:
   reth:
-    image: ghcr.io/paradigmxyz/reth:v1.6.0
+    image: ghcr.io/paradigmxyz/reth:v1.11.1
     pullPolicy: IfNotPresent
   geth:
     image: ethereum/client-go:v1.15.5

--- a/spartan/terraform/deploy-eth-devnet/values/eth-devnet.yaml
+++ b/spartan/terraform/deploy-eth-devnet/values/eth-devnet.yaml
@@ -3,7 +3,7 @@ fullnameOverride: ""
 
 images:
   reth:
-    image: ghcr.io/paradigmxyz/reth:v1.6.0
+    image: ghcr.io/paradigmxyz/reth:v1.11.1
     pullPolicy: IfNotPresent
   geth:
     image: ethereum/client-go:v1.15.5

--- a/spartan/terraform/deploy-ethereum-nodes/variables.tf
+++ b/spartan/terraform/deploy-ethereum-nodes/variables.tf
@@ -48,7 +48,7 @@ variable "lighthouse_p2p_port" {
 variable "reth_image" {
   description = "Reth Docker image"
   type        = string
-  default     = "ghcr.io/paradigmxyz/reth:v1.9.3"
+  default     = "ghcr.io/paradigmxyz/reth:v1.11.1"
 }
 
 variable "reth_chart_version" {


### PR DESCRIPTION
This PR prevents A-554 from happening to services interacting with eth devnets. A-554 has been fixed. 