### PR TITLE
fix(aztec-up): install noir-profiler alongside nargo

### DIFF
--- a/aztec-up/bin/0.0.1/aztec-install
+++ b/aztec-up/bin/0.0.1/aztec-install
@@ -51,11 +51,12 @@ function title {
   echo -e "Installing version: ${bold}${g}$VERSION${r}"
   echo
   echo -e "This install script will install the following and update your PATH if necessary:"
-  echo -e "  ${bold}${g}nargo${r}        - the version of the noir programming language compatible with this version of aztec."
-  echo -e "  ${bold}${g}bb${r}           - the version of the barretenberg proving backend compatible with this version of aztec."
-  echo -e "  ${bold}${g}aztec${r}        - a collection of tools to compile and test contracts, to launch subsystems and interact with the aztec network."
-  echo -e "  ${bold}${g}aztec-up${r}     - a tool to install and manage aztec toolchain versions."
-  echo -e "  ${bold}${g}aztec-wallet${r} - our minimalistic CLI wallet"
+  echo -e "  ${bold}${g}nargo${r}          - the version of the noir programming language compatible with this version of aztec."
+  echo -e "  ${bold}${g}noir-profiler${r}  - a sampling profiler for analyzing and visualizing Noir programs."
+  echo -e "  ${bold}${g}bb${r}             - the version of the barretenberg proving backend compatible with this version of aztec."
+  echo -e "  ${bold}${g}aztec${r}          - a collection of tools to compile and test contracts, to launch subsystems and interact with the aztec network."
+  echo -e "  ${bold}${g}aztec-up${r}       - a tool to install and manage aztec toolchain versions."
+  echo -e "  ${bold}${g}aztec-wallet${r}   - our minimalistic CLI wallet"
   echo
   read -p "Do you wish to continue? (y/n) " -n 1 -r
   echo

--- a/aztec-up/bin/0.0.1/install
+++ b/aztec-up/bin/0.0.1/install
@@ -153,6 +153,8 @@ function install_noir {
 
     # Move the nargo binary to our version bin directory
     mv "$temp_nargo_home/bin/nargo" "$version_bin_path/nargo"
+    # Also move noir-profiler, needed by `aztec profile flamegraph`
+    mv "$temp_nargo_home/bin/noir-profiler" "$version_bin_path/noir-profiler"
 
     # Cleanup temp directory
     rm -rf "$temp_nargo_home"


### PR DESCRIPTION
## Summary

- Adds `noir-profiler` binary to the `install_noir` function in `aztec-up`, so it gets installed alongside `nargo`.
- Without this, `aztec profile flamegraph` fails with `spawn noir-profiler ENOENT`.
- Updates the install banner to list `noir-profiler` as an installed tool.