### PR TITLE
feat: make clang20 preset use zig with glibc 2.35

### DIFF
--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -35,55 +35,46 @@
     },
     {
       "name": "clang20",
-      "displayName": "Build with Clang-20",
-      "description": "Build with globally installed Clang-20",
+      "displayName": "Build with Zig (glibc 2.35)",
+      "description": "Build with Zig-wrapped Clang targeting glibc 2.35 (Ubuntu 22.04+)",
       "inherits": "default",
       "binaryDir": "build",
       "environment": {
-        "CC": "clang-20",
-        "CXX": "clang++-20"
+        "CC": "zig cc -target native-linux-gnu.2.35",
+        "CXX": "zig c++ -target native-linux-gnu.2.35"
       },
       "cacheVariables": {
+        "CMAKE_AR": "${sourceDir}/scripts/zig-ar.sh",
+        "CMAKE_RANLIB": "${sourceDir}/scripts/zig-ranlib.sh",
         "AVM_TRANSPILER_LIB": "${sourceDir}/../../avm-transpiler/target/release/libavm_transpiler.a"
       }
     },
     {
       "name": "clang20-no-avm",
-      "displayName": "Build with Clang-20 plus AVM",
-      "description": "Build with globally installed Clang-20 plus AVM",
+      "displayName": "Build with Zig (no AVM, glibc 2.35)",
+      "description": "Build with Zig-wrapped Clang targeting glibc 2.35, AVM disabled",
       "inherits": "clang20",
       "binaryDir": "build",
-      "environment": {
-        "CC": "clang-20",
-        "CXX": "clang++-20"
-      },
       "cacheVariables": {
-        "AVM": "OFF",
-        "AVM_TRANSPILER_LIB": "${sourceDir}/../../avm-transpiler/target/release/libavm_transpiler.a"
+        "AVM": "OFF"
       }
     },
     {
       "name": "clang20-assert",
-      "displayName": "Build with Clang-20",
-      "description": "Build with globally installed Clang-20",
-      "inherits": "default",
+      "displayName": "Build with Zig (assertions, glibc 2.35)",
+      "description": "Build with Zig-wrapped Clang targeting glibc 2.35, assertions enabled",
+      "inherits": "clang20",
       "binaryDir": "build",
-      "environment": {
-        "CC": "clang-20",
-        "CXX": "clang++-20"
-      },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithAssert"
       }
     },
     {
       "name": "clang20-no-exceptions",
-      "displayName": "Build with Clang-20",
-      "description": "Build with globally installed Clang-20",
-      "inherits": "default",
+      "displayName": "Build with Zig (no exceptions, glibc 2.35)",
+      "description": "Build with Zig-wrapped Clang targeting glibc 2.35, exceptions disabled",
+      "inherits": "clang20",
       "environment": {
-        "CC": "clang-20",
-        "CXX": "clang++-20",
         "CMAKE_CXX_FLAGS": "-DBB_NO_EXCEPTIONS"
       }
     },
@@ -476,8 +467,8 @@
       "displayName": "Build for linux amd64 with Zig",
       "inherits": "zig-base",
       "environment": {
-        "CC": "zig cc -target x86_64-linux-gnu",
-        "CXX": "zig c++ -target x86_64-linux-gnu",
+        "CC": "zig cc -target x86_64-linux-gnu.2.35",
+        "CXX": "zig c++ -target x86_64-linux-gnu.2.35",
         "LDFLAGS": "-s"
       },
       "cacheVariables": {
@@ -490,8 +481,8 @@
       "name": "zig-arm64-linux",
       "inherits": "zig-base",
       "environment": {
-        "CC": "zig cc -target aarch64-linux-gnu",
-        "CXX": "zig c++ -target aarch64-linux-gnu",
+        "CC": "zig cc -target aarch64-linux-gnu.2.35",
+        "CXX": "zig c++ -target aarch64-linux-gnu.2.35",
         "LDFLAGS": "-s"
       },
       "cacheVariables": {

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -214,9 +214,13 @@
     {
       "name": "fuzzing",
       "displayName": "Build with fuzzing",
-      "description": "Build default preset but with fuzzing enabled",
-      "inherits": "clang20",
+      "description": "Build default preset but with fuzzing enabled. Uses clang-20 directly (zig does not provide libFuzzer/libclang_rt.fuzzer).",
+      "inherits": "default",
       "binaryDir": "build-fuzzing",
+      "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20"
+      },
       "cacheVariables": {
         "FUZZING": "ON",
         "AVM": "OFF",
@@ -229,15 +233,10 @@
       "name": "fuzzing-noasm",
       "displayName": "Build with fuzzing and ASM disabled",
       "description": "Build default preset but with fuzzing enabled and ASM disabled",
-      "inherits": "clang20",
+      "inherits": "fuzzing",
       "binaryDir": "build-fuzzing-noasm",
       "cacheVariables": {
-        "FUZZING": "ON",
-        "AVM": "OFF",
-        "AVM_TRANSPILER_LIB": "",
-        "DISABLE_ASM": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithAssert",
-        "MULTITHREADING": "OFF"
+        "DISABLE_ASM": "ON"
       }
     },
     {
@@ -261,17 +260,14 @@
       "name": "fuzzing-coverage",
       "displayName": "Build with coverage flags",
       "description": "Build default preset but with fuzzing and coverage enabled",
-      "inherits": "clang20",
+      "inherits": "fuzzing",
       "binaryDir": "build-fuzzing-cov",
       "cacheVariables": {
-        "FUZZING": "ON",
-        "AVM": "OFF",
-        "DISABLE_ASM": "ON",
-        "AVM_TRANSPILER_LIB": "",
-        "CMAKE_BUILD_TYPE": "RelWithAssert",
-        "MULTITHREADING": "OFF"
+        "DISABLE_ASM": "ON"
       },
       "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20",
         "CXXFLAGS": "-fprofile-instr-generate -fcoverage-mapping"
       }
     },
@@ -281,13 +277,19 @@
       "description": "Build default preset but with fuzzing and AVM enabled",
       "inherits": "clang20",
       "binaryDir": "build-fuzzing-avm",
+      "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20"
+      },
       "cacheVariables": {
         "FUZZING": "ON",
         "DISABLE_ASM": "OFF",
         "AVM_TRANSPILER_LIB": "",
         "FUZZING_AVM": "ON",
         "CMAKE_BUILD_TYPE": "RelWithAssert",
-        "MULTITHREADING": "ON"
+        "MULTITHREADING": "ON",
+        "CMAKE_AR": null,
+        "CMAKE_RANLIB": null
       }
     },
     {

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -306,8 +306,12 @@
       "name": "smt-verification",
       "displayName": "Build with smt verification",
       "description": "Build default preset but with smt library included",
-      "inherits": "clang20",
+      "inherits": "default",
       "binaryDir": "build-smt",
+      "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20"
+      },
       "cacheVariables": {
         "AVM_TRANSPILER_LIB": "",
         "SMT": "ON"

--- a/barretenberg/cpp/CMakePresets.json
+++ b/barretenberg/cpp/CMakePresets.json
@@ -82,14 +82,17 @@
       "name": "debug",
       "displayName": "Debugging build with Clang-20",
       "description": "Build with globally installed Clang-20 in debug mode",
-      "inherits": "clang20",
+      "inherits": "default",
       "binaryDir": "build-debug",
       "environment": {
+        "CC": "clang-20",
+        "CXX": "clang++-20",
         "CFLAGS": "-gdwarf-4",
         "CXXFLAGS": "-gdwarf-4",
         "LDFLAGS": "-gdwarf-4"
       },
       "cacheVariables": {
+        "AVM_TRANSPILER_LIB": "${sourceDir}/../../avm-transpiler/target/release/libavm_transpiler.a",
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_ASAN": "OFF",
         "DISABLE_ASM": "OFF",
@@ -305,14 +308,16 @@
     {
       "name": "smt-verification",
       "displayName": "Build with smt verification",
-      "description": "Build default preset but with smt library included",
-      "inherits": "default",
+      "description": "Build clang20 preset but with smt library included, using clang-20 directly (cvc5 ExternalProject needs a plain compiler path)",
+      "inherits": "clang20",
       "binaryDir": "build-smt",
       "environment": {
         "CC": "clang-20",
         "CXX": "clang++-20"
       },
       "cacheVariables": {
+        "CMAKE_AR": null,
+        "CMAKE_RANLIB": null,
         "AVM_TRANSPILER_LIB": "",
         "SMT": "ON"
       }

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field.fuzzer.hpp
@@ -966,9 +966,9 @@ template <typename Field> struct FieldVM {
                         assert(product == Field::one());
 
                         // Verify uint arithmetic consistency
-                        auto uint_product = (static_cast<uint512_t>(original_uint_elements[i]) *
-                                             static_cast<uint512_t>(uint_internal_state[idx])) %
-                                            static_cast<uint512_t>(Field::modulus);
+                        [[maybe_unused]] auto uint_product = (static_cast<uint512_t>(original_uint_elements[i]) *
+                                                              static_cast<uint512_t>(uint_internal_state[idx])) %
+                                                             static_cast<uint512_t>(Field::modulus);
                         assert(uint_product == static_cast<uint512_t>(1));
                     } else {
                         // Zero elements should remain zero

--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field.fuzzer.hpp
@@ -962,7 +962,7 @@ template <typename Field> struct FieldVM {
                         assert(uint_internal_state[idx] == individual_uint_inverses[i]);
 
                         // Verify the inverse property: a * a^(-1) = 1
-                        Field product = original_elements[i] * field_internal_state[idx];
+                        [[maybe_unused]] Field product = original_elements[i] * field_internal_state[idx];
                         assert(product == Field::one());
 
                         // Verify uint arithmetic consistency

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.fuzzer.cpp
@@ -76,7 +76,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
 
     // Compare outputs
     for (size_t i = 0; i < 8; i++) {
-        uint32_t circuit_val = static_cast<uint32_t>(uint256_t(circuit_output[i].get_value()));
+        [[maybe_unused]] uint32_t circuit_val = static_cast<uint32_t>(uint256_t(circuit_output[i].get_value()));
         assert(circuit_val == expected_output[i]);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/hash/sha256/sha256.fuzzer.cpp
@@ -52,7 +52,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
     }
 
     // Compute native result
-    auto expected_output = crypto::sha256_block(h_init_native, block_native);
+    [[maybe_unused]] auto expected_output = crypto::sha256_block(h_init_native, block_native);
 
     // Build circuit with compression
     UltraCircuitBuilder builder;


### PR DESCRIPTION
## Summary
- Change the \`clang20\` preset (and variants) to use \`zig cc/c++ -target native-linux-gnu.2.35\` instead of plain \`clang-20\`. This ensures every build — dev and release — produces binaries compatible with Ubuntu 22.04+ (glibc 2.35).
- Pin cross-compile zig presets (\`zig-amd64-linux\`, \`zig-arm64-linux\`) to glibc 2.35.
- The \`native\` zig target auto-detects host architecture — no hardcoded \`x86_64\`/\`aarch64\`.
- \`debug\` preset inherits from \`default\` with explicit \`CC=clang-20\` so all sanitizer presets (ASAN/TSAN/UBSAN/MSAN) use plain clang-20. Zig does not provide the sanitizer runtimes (\`libclang_rt.asan\` etc.).
- \`smt-verification\` inherits from \`clang20\` but overrides to \`CC=clang-20\` with \`CMAKE_AR=null\`, since cvc5's ExternalProject receives \`CMAKE_C_COMPILER\` and needs a plain binary path.
- Remove \`bb-cpp-cross-amd64-linux\` Makefile target — native \`clang20\` build now covers amd64-linux.
- Remove release-preset switching in \`bootstrap.sh\` — \`clang20\`'s \`build/\` dir is already glibc 2.35 compatible.

## Test plan
- [x] Built \`bb\` with \`cmake --preset clang20\`, confirmed max glibc requirement is 2.34 via \`readelf -V\`
- [x] Ran \`bb --version\` inside \`ubuntu:22.04\` Docker container — succeeded
- [x] Fuzz presets configure/build correctly (fixed \`[[maybe_unused]]\` for \`-Wunused-variable\` under \`-Wfatal-errors\`)
- [x] \`asan-fast\` preset configures with \`clang-20\` compiler (not zig) — \`CMAKE_C_COMPILER=/usr/bin/clang-20\`
- [x] \`smt-verification\` preset configures with \`clang-20\` — \`CMAKE_C_COMPILER=/usr/bin/clang-20\`