### PR TITLE
fix: make fd_tell and path_filestat_get WASI stubs abort instead of silently returning success

### DIFF
--- a/barretenberg/cpp/src/barretenberg/wasi/wasi_stubs.cpp
+++ b/barretenberg/cpp/src/barretenberg/wasi/wasi_stubs.cpp
@@ -165,7 +165,8 @@ int32_t __imported_wasi_snapshot_preview1_fd_renumber(int32_t, int32_t)
 
 int32_t __imported_wasi_snapshot_preview1_fd_tell(int32_t, uint64_t*)
 {
-    info("fd_tell stubbed.");
+    info("fd_tell not implemented.");
+    abort();
     return 0;
 }
 
@@ -200,6 +201,8 @@ int32_t __imported_wasi_snapshot_preview1_fd_prestat_dir_name(int32_t, int32_t, 
 
 int32_t __imported_wasi_snapshot_preview1_path_filestat_get(int32_t, int32_t, int32_t, int32_t, int32_t)
 {
+    info("path_filestat_get not implemented.");
+    abort();
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Two WASI stubs in `wasi_stubs.cpp` were silently returning success (0) without doing the right thing. This is the same class of issue as the `environ_sizes_get` fix in #20902.

- **`fd_tell`**: was returning success without writing to the output pointer. Since barretenberg never calls `ftell()`, it now aborts like the other unimplemented stubs.
- **`path_filestat_get`**: was silently returning success without writing the `filestat` output struct. Since barretenberg has no filesystem support, it now aborts like the other unimplemented filesystem stubs (`path_filestat_set_times`, `path_link`, etc.).

Closes https://github.com/AztecProtocol/barretenberg/issues/1648