### PR TITLE
chore: remove final instances of unneeded +1 in SRS construction

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -91,7 +91,7 @@ AvmFlavor::ProverPolynomials::ProverPolynomials(const ProverPolynomials& full_po
 }
 
 AvmFlavor::ProvingKey::ProvingKey()
-    : commitment_key(circuit_size + 1) {
+    : commitment_key(circuit_size) {
         // The proving key's polynomials are not allocated here because they are later overwritten
         // AvmComposer::compute_witness(). We should probably refactor this flow.
     };

--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -72,8 +72,8 @@ export class Barretenberg extends AsyncApi {
 
   async initSRSChonk(srsSize = this.getDefaultSrsSize()): Promise<void> {
     // crsPath can be undefined
-    const crs = await Crs.new(srsSize + 1, this.options.crsPath, this.options.logger);
-    const grumpkinCrs = await GrumpkinCrs.new(2 ** 16 + 1, this.options.crsPath, this.options.logger);
+    const crs = await Crs.new(srsSize, this.options.crsPath, this.options.logger);
+    const grumpkinCrs = await GrumpkinCrs.new(2 ** 16, this.options.crsPath, this.options.logger);
 
     // Load CRS into wasm global CRS state.
     // TODO: Make RawBuffer be default behavior, and have a specific Vector type for when wanting length prefixed.

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -271,7 +271,7 @@ export async function preloadCrsDataForVerifying(
 ): Promise<void> {
   if (realProofs) {
     const { Crs, GrumpkinCrs } = await import('@aztec/bb.js');
-    await Promise.all([Crs.new(2 ** 1, undefined, log), GrumpkinCrs.new(2 ** 16 + 1, undefined, log)]);
+    await Promise.all([Crs.new(2 ** 1, undefined, log), GrumpkinCrs.new(2 ** 16, undefined, log)]);
   }
 }
 
@@ -286,7 +286,7 @@ export async function preloadCrsDataForServerSideProving(
 ): Promise<void> {
   if (realProofs) {
     const { Crs, GrumpkinCrs } = await import('@aztec/bb.js');
-    await Promise.all([Crs.new(2 ** 25 + 1, undefined, log), GrumpkinCrs.new(2 ** 18 + 1, undefined, log)]);
+    await Promise.all([Crs.new(2 ** 25, undefined, log), GrumpkinCrs.new(2 ** 18, undefined, log)]);
   }
 }
 


### PR DESCRIPTION
We used to need dyadic_size + 1 SRS elements for Plonk due to a quirk. We never needed this for Honk but it got propagated around anyway. This removes the final instances of that.