### PR TITLE
chore: avoid use of size_t in bbapi to be safe

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_chonk.cpp
@@ -58,7 +58,7 @@ void ChonkAPI::prove(const Flags& flags,
     request.vk_policy = bbapi::parse_vk_policy(flags.vk_policy);
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);
 
-    bbapi::ChonkStart{ .num_circuits = raw_steps.size() }.execute(request);
+    bbapi::ChonkStart{ .num_circuits = static_cast<uint32_t>(raw_steps.size()) }.execute(request);
     info("Chonk: starting with ", raw_steps.size(), " circuits");
     for (const auto& step : raw_steps) {
         bbapi::ChonkLoad{

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_chonk.hpp
@@ -35,7 +35,7 @@ struct ChonkStart {
         bool operator==(const Response&) const = default;
     };
     // Number of circuits to be accumulated.
-    size_t num_circuits;
+    uint32_t num_circuits;
     Response execute(BBApiRequest& request) &&;
     MSGPACK_FIELDS(num_circuits);
     bool operator==(const ChonkStart&) const = default;

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.cpp
@@ -179,7 +179,8 @@ CircuitStats::Response _stats(std::vector<uint8_t>&& bytecode, bool include_gate
     response.num_gates = static_cast<uint32_t>(builder.get_finalized_total_circuit_size());
     response.num_gates_dyadic = static_cast<uint32_t>(builder.get_circuit_subgroup_size(response.num_gates));
     // note: will be empty if collect_gates_per_opcode is false
-    response.gates_per_opcode = std::move(program.constraints.gates_per_opcode);
+    response.gates_per_opcode =
+        std::vector<uint32_t>(program.constraints.gates_per_opcode.begin(), program.constraints.gates_per_opcode.end());
 
     return response;
 }

--- a/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.hpp
+++ b/barretenberg/cpp/src/barretenberg/bbapi/bbapi_ultra_honk.hpp
@@ -84,7 +84,7 @@ struct CircuitStats {
         uint32_t num_gates{};
         uint32_t num_gates_dyadic{};
         uint32_t num_acir_opcodes{};
-        std::vector<size_t> gates_per_opcode;
+        std::vector<uint32_t> gates_per_opcode;
         MSGPACK_FIELDS(num_gates, num_gates_dyadic, num_acir_opcodes, gates_per_opcode);
         bool operator==(const Response&) const = default;
     };


### PR DESCRIPTION
Use uint32_t in bbapi (as was already done in most places) to avoid any platform dependent shenanigans. 