### PR TITLE
chore: update auto convert to an assert

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -109,11 +109,9 @@ cycle_group<Builder>::cycle_group(const field_t& x, const field_t& y, bool_t is_
         }
     }
 
-    // If both coordinates are constant, enforce that is_infinity is also constant.
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1584): make this an assertion when possible
-    if (_x.is_constant() && _y.is_constant() && !_is_infinity.is_constant()) {
-        _is_infinity = bool_t(_is_infinity.get_value());
-    }
+    // If both coordinates are constant, is_infinity must also be constant.
+    BB_ASSERT(!(_x.is_constant() && _y.is_constant() && !_is_infinity.is_constant()),
+              "cycle_group: constant coordinates with non-constant infinity flag");
 
     // Elements are always expected to be on the curve but may or may not be constrained as such.
     BB_ASSERT(get_value().on_curve(), "cycle_group: Point is not on curve");


### PR DESCRIPTION
Prior to this change, if we encountered a `cycle_group` element whose coords were constant, we would ensure it's infinity flag agreed - if not, we would simply overwrite it with a constant. Such a case was only ever possible from Noir. Recently, we made a change that causes the inf flag from acir to be ignored and it is instead computed based on the coordinates. This makes const coords + witness inf impossible so I'm simply updating this protection to be a sanity checking ASSERT.