### PR TITLE
fix(cli): expand scientific notation in network config generator

### DIFF
--- a/yarn-project/cli/scripts/generate.sh
+++ b/yarn-project/cli/scripts/generate.sh
@@ -21,11 +21,44 @@ HEADER
 # Get all network keys from the networks section
 networks=$(yq -o json '.networks | keys' spartan/environments/network-defaults.yml | jq -r '.[]')
 
+# format_value: Converts a YAML value string to a TypeScript literal.
+# Handles scientific notation like "200000e18" by expanding to full integer,
+# since BigInt() cannot parse scientific notation strings.
+format_value() {
+  local val="$1"
+  # Expand integer scientific notation (e.g., 200000e18 -> 200000000000000000000000)
+  if [[ "$val" =~ ^[0-9]+e[0-9]+$ ]]; then
+    python3 -c "
+import re, sys
+m = re.match(r'^(\d+)e(\d+)$', sys.argv[1])
+print(int(m.group(1)) * (10 ** int(m.group(2))))
+" "$val"
+  else
+    echo "$val"
+  fi
+}
+
 for network in $networks; do
   echo "export const ${network}Config = {" >> yarn-project/cli/src/config/generated/networks.ts
-  yq -o json "explode(.) | .networks.$network // {}" spartan/environments/network-defaults.yml | \
-    jq -r "to_entries | .[] | \"  \\(.key): \\(.value | if type == \"string\" then \"'\\(.)'\" else . end),\"" \
-    >> yarn-project/cli/src/config/generated/networks.ts
+
+  # Use yq to iterate entries, converting values to strings to preserve
+  # the original YAML text (avoids float64 precision loss for large numbers).
+  while IFS= read -r line; do
+    key=$(echo "$line" | cut -d':' -f1 | xargs)
+    raw_value=$(echo "$line" | cut -d':' -f2- | xargs)
+
+    formatted=$(format_value "$raw_value")
+
+    # Determine TypeScript formatting: strings get quotes, booleans/numbers are bare
+    if [[ "$formatted" == "true" || "$formatted" == "false" ]]; then
+      echo "  $key: $formatted," >> yarn-project/cli/src/config/generated/networks.ts
+    elif [[ "$formatted" =~ ^-?[0-9]*\.?[0-9]+$ ]]; then
+      echo "  $key: $formatted," >> yarn-project/cli/src/config/generated/networks.ts
+    else
+      echo "  $key: '$formatted'," >> yarn-project/cli/src/config/generated/networks.ts
+    fi
+  done < <(yq "explode(.) | .networks.$network | to_entries | .[] | .key + \": \" + (.value | . tag = \"!!str\")" spartan/environments/network-defaults.yml)
+
   echo "} as const;" >> yarn-project/cli/src/config/generated/networks.ts
   echo "" >> yarn-project/cli/src/config/generated/networks.ts
 done


### PR DESCRIPTION
## Summary

- Fixes `generate.sh` to correctly handle large numbers (like `200000e18`) from `network-defaults.yml` by expanding them to full decimal integers instead of letting `yq -o json | jq` convert them to float64 scientific notation (`2E+23`)
- This prevents `BigInt("2e+23")` crashes when starting a node with `--network testnet` or `--network mainnet`
- Uses yq's string tagging to preserve original YAML text, then Python integer math to expand `XeY` notation losslessly

## Context

The bug was introduced in e76efa286f ("refactor: centralize network defaults in YAML with bash generation scripts", Jan 12 2026). Before that refactor, values were hand-written as TypeScript BigInt expressions (`200_000n * 10n ** 18n`).

The old `yq -o json | jq` pipeline converts `200000e18` to float64, which outputs `2E+23`. This gets written into `networks.ts` as a JS number literal. At runtime, the config system calls `String(2E+23)` → `"2e+23"` → `BigInt("2e+23")` which throws `SyntaxError: Cannot convert 2e+23 to a BigInt`.

Devnet config was unaffected because its values (e.g., `100e18` = `1e20`) are small enough to stay as full integers in float64. Testnet and mainnet values (`200000e18` = `2e23`) exceed this threshold.

## Repro

```bash
aztec-up install 4.0.1
aztec start --node --archiver --network testnet
# Crashes: SyntaxError: Cannot convert 2e+23 to a BigInt
```

## Test plan

- Run `cd yarn-project/cli && yarn generate` and verify no `E+` notation in `src/config/generated/networks.ts`
- Verify the generated values match expected: `200000e18` → `200000000000000000000000`
- Build and run `aztec start --node --archiver --network testnet` without BigInt crash