### PR TITLE
feat(aztec): node enters standby mode on genesis root mismatch

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -4,10 +4,14 @@ import { Fr } from '@aztec/aztec.js/fields';
 import { getSponsoredFPCAddress } from '@aztec/cli/cli-utils';
 import { getL1Config } from '@aztec/cli/config';
 import { getPublicClient } from '@aztec/ethereum/client';
+import { RegistryContract, RollupContract } from '@aztec/ethereum/contracts';
 import { SecretValue } from '@aztec/foundation/config';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import type { NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
+import { startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
 import { Agent, makeUndiciFetch } from '@aztec/foundation/json-rpc/undici';
 import type { LogFn } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 import { ProvingJobConsumerSchema, createProvingJobBrokerClient } from '@aztec/prover-client/broker';
 import { type CliPXEOptions, type PXEConfig, allPxeConfigMappings } from '@aztec/pxe/config';
 import { AztecNodeAdminApiSchema, AztecNodeApiSchema } from '@aztec/stdlib/interfaces/client';
@@ -21,6 +25,8 @@ import {
 import { EmbeddedWallet } from '@aztec/wallets/embedded';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
+import Koa from 'koa';
+
 import { createAztecNode } from '../../local-network/index.js';
 import {
   extractNamespacedOptions,
@@ -30,6 +36,72 @@ import {
 } from '../util.js';
 import { getVersions } from '../versioning.js';
 import { startProverBroker } from './start_prover_broker.js';
+
+const ROLLUP_POLL_INTERVAL_MS = 600_000;
+
+/**
+ * Waits until the canonical rollup's genesis archive root matches the expected local genesis root.
+ * If the rollup is not yet compatible (e.g. during L1 contract upgrades), enters standby mode:
+ * starts a lightweight HTTP server for K8s liveness probes and polls until a compatible rollup appears.
+ */
+async function waitForCompatibleRollup(
+  publicClient: ReturnType<typeof getPublicClient>,
+  registryAddress: EthAddress,
+  rollupVersion: number | 'canonical',
+  expectedGenesisRoot: Fr,
+  port: number | undefined,
+  userLog: LogFn,
+): Promise<void> {
+  const registry = new RegistryContract(publicClient, registryAddress);
+  const rollupAddress = await registry.getRollupAddress(rollupVersion);
+  const rollup = new RollupContract(publicClient, rollupAddress.toString());
+
+  let l1GenesisRoot: Fr;
+  try {
+    l1GenesisRoot = await rollup.getGenesisArchiveTreeRoot();
+  } catch (err: any) {
+    throw new Error(
+      `Could not retrieve genesis archive root from canonical rollup at ${rollupAddress}: ${err.message}`,
+    );
+  }
+
+  if (l1GenesisRoot.equals(expectedGenesisRoot)) {
+    return;
+  }
+
+  userLog(
+    `Genesis root mismatch: expected ${expectedGenesisRoot}, got ${l1GenesisRoot} from rollup at ${rollupAddress}. ` +
+      `Entering standby mode. Will poll every ${ROLLUP_POLL_INTERVAL_MS / 1000}s for a compatible rollup...`,
+  );
+
+  const standbyServer = await startHttpRpcServer({ getApp: () => new Koa(), isHealthy: () => true }, { port });
+  userLog(`Standby status server listening on port ${standbyServer.port}`);
+
+  try {
+    while (true) {
+      await sleep(ROLLUP_POLL_INTERVAL_MS);
+
+      const currentRollupAddress = await registry.getRollupAddress(rollupVersion);
+      const currentRollup = new RollupContract(publicClient, currentRollupAddress.toString());
+
+      try {
+        l1GenesisRoot = await currentRollup.getGenesisArchiveTreeRoot();
+      } catch {
+        userLog(`Failed to fetch genesis root from rollup at ${currentRollupAddress}. Retrying...`);
+        continue;
+      }
+
+      if (l1GenesisRoot.equals(expectedGenesisRoot)) {
+        userLog(`Compatible rollup found at ${currentRollupAddress}. Exiting standby mode.`);
+        return;
+      }
+
+      userLog(`Still waiting. Rollup at ${currentRollupAddress} has genesis root ${l1GenesisRoot}.`);
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) => standbyServer.close(err => (err ? reject(err) : resolve())));
+  }
+}
 
 export async function startNode(
   options: any,
@@ -96,6 +168,20 @@ export async function startNode(
   if (!nodeConfig.l1Contracts.registryAddress || nodeConfig.l1Contracts.registryAddress.isZero()) {
     throw new Error('L1 registry address is required to start Aztec Node');
   }
+
+  // Wait for a compatible rollup before proceeding with full L1 config fetch.
+  // This prevents crashes when the canonical rollup hasn't been upgraded yet.
+  const publicClient = getPublicClient(nodeConfig);
+  const rollupVersion: number | 'canonical' = nodeConfig.rollupVersion ?? 'canonical';
+  await waitForCompatibleRollup(
+    publicClient,
+    nodeConfig.l1Contracts.registryAddress,
+    rollupVersion,
+    genesisArchiveRoot,
+    options.port,
+    userLog,
+  );
+
   const { addresses, config } = await getL1Config(
     nodeConfig.l1Contracts.registryAddress,
     nodeConfig.l1RpcUrls,


### PR DESCRIPTION
Closes A-547

Forward-port of #20937.

## Summary

- Before calling `getL1Config()`, the node now compares its local genesis archive root against the canonical rollup's via `archiveAt(0)`.
- If the roots don't match (e.g. during L1 contract upgrades where the old rollup ABI is incompatible), the node enters **standby mode** instead of crashing.
- In standby mode, a lightweight HTTP server is started for K8s liveness probes, and the node polls every 10 minutes until a compatible rollup becomes canonical.
- When `rollupVersion` is not explicitly configured (`undefined`), it now falls back to `'canonical'` instead of passing `0` to the registry.

### Tested against testnet (incompatible rollup):

```
Genesis archive root: 0x2727683df35594b1f073a681532520056ca8a775398c8b5a94574c67ef1ce6de
Genesis root mismatch: expected 0x2727683df35594b1f073a681532520056ca8a775398c8b5a94574c67ef1ce6de, got 0x0ae6138310f7b877b6c68856451eddec0873fb63f9033931cedcdc46815729e1 from rollup at 0x66a41cb55f9a1e38a45a2ac8685f12a61fbfab77. Entering standby mode. Will poll every 10s for a compatible rollup...
Standby status server listening on port 8080
Still waiting. Rollup at 0x66a41cb55f9a1e38a45a2ac8685f12a61fbfab77 has genesis root 0x0ae6138310f7b877b6c68856451eddec0873fb63f9033931cedcdc46815729e1.
```

```
$ curl http://localhost:8080/status
OK
```

## Test plan

- Run `aztec start --node --archiver --network testnet` against an incompatible rollup: verify standby mode with health check responding OK
- Run against a compatible network: verify normal startup without entering standby
- Ctrl+C during standby: verify clean exit