### PR TITLE
chore: remove unused prover-node dep

### DIFF
--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -19,7 +19,6 @@ import {
   getPublisherConfigFromProverConfig,
 } from '@aztec/sequencer-client';
 import type {
-  AztecNode,
   ITxProvider,
   ProverConfig,
   ProvingJobBroker,
@@ -38,7 +37,6 @@ import { ProverPublisherFactory } from './prover-publisher-factory.js';
 export type ProverNodeDeps = {
   telemetry?: TelemetryClient;
   log?: Logger;
-  aztecNodeTxProvider?: Pick<AztecNode, 'getTxsByHash'>;
   archiver: Archiver;
   publisherFactory?: ProverPublisherFactory;
   broker?: ProvingJobBroker;
@@ -127,9 +125,6 @@ export async function createProverNode(
       publisherManager: new PublisherManager(l1TxUtils, getPublisherConfigFromProverConfig(config), log.getBindings()),
       telemetry,
     });
-
-  // TODO(#20393): Check that the tx collection node sources are properly injected
-  // See aztecNodeTxProvider
 
   const proverNodeConfig = {
     ...pick(

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -207,6 +207,15 @@ describe('prover-node', () => {
     expect(proverNode.totalJobCount).toEqual(0);
   });
 
+  it('gathers txs via the p2p client tx provider', async () => {
+    await proverNode.handleEpochReadyToProve(EpochNumber.fromBigInt(10n));
+    // The prover node must route tx gathering through the shared p2p client's tx provider
+    expect(p2p.getTxProvider).toHaveBeenCalled();
+    // One call per block across all checkpoints in the epoch
+    const totalBlocks = checkpoints.flatMap(c => c.blocks).length;
+    expect(txProvider.getTxsForBlock).toHaveBeenCalledTimes(totalBlocks);
+  });
+
   it('does not start a proof if there is a tx missing from coordinator', async () => {
     txProvider.getTxsForBlock.mockResolvedValue({ missingTxs: [TxHash.random()], txs: [] });
     await proverNode.handleEpochReadyToProve(EpochNumber.fromBigInt(10n));


### PR DESCRIPTION
Fixes [A-564](https://linear.app/aztec-labs/issue/A-564/ensure-node-sources-are-correctly-injected-into-the-prover-node)