### PR TITLE
fix: avoid PGID race in bootstrap test engine cleanup

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@ function cleanup {
   set +e
   if [ -n "${test_engine_pid:-}" ]; then
     echo "Sending SIGTERM to test engine process group..."
-    kill -SIGTERM -- -$test_engine_pgid &>/dev/null
+    kill -SIGTERM -- -$test_engine_pid &>/dev/null
     wait $test_engine_pid
     test_engine_pid=
   fi
@@ -277,9 +277,9 @@ function build_and_test {
   touch $test_cmds_file
   # put it in it's own process group, we can terminate on cleanup.
   setsid color_prefix "test-engine" "denoise \"test_engine $test_cmds_file\"" &
+  # setsid makes the child the session leader, so its PID is its PGID.
   test_engine_pid=$!
-  test_engine_pgid=$(ps -o pgid= -p $test_engine_pid | tr -d ' ')
-  echo "Started test engine with $test_engine_pid in PGID $test_engine_pgid."
+  echo "Started test engine with PGID $test_engine_pid."
 
   # Start the build.
   make $1 &


### PR DESCRIPTION
## Summary
- Fix rare container bug where `ps -o pgid=` could return PGID `1`, causing `kill -SIGTERM -- -1` to nuke the entire container
- Since `setsid` makes the child the session leader, its PID **is** its PGID — use it directly instead of querying `ps`
- Remove the now-unnecessary `test_engine_pgid` variable
