### PR TITLE
fix!: undo bad fix

### DIFF
--- a/l1-contracts/src/core/slashing/TallySlashingProposer.sol
+++ b/l1-contracts/src/core/slashing/TallySlashingProposer.sol
@@ -903,14 +903,6 @@ contract TallySlashingProposer is EIP712 {
         if (escapeHatchEpochs[epochIndex]) {
           continue;
         }
-
-        // Skip validators for epochs without a valid committee (e.g. early epochs
-        // before the validator set was sampled). Without this check, indexing into
-        // an empty committee array would revert and block execution of the round.
-        if (_committees[epochIndex].length != COMMITTEE_SIZE) {
-          continue;
-        }
-
         uint256 packedVotes = tallyMatrix[i];
 
         // Skip if no votes for this validator

--- a/l1-contracts/test/slashing/TallySlashingProposer.t.sol
+++ b/l1-contracts/test/slashing/TallySlashingProposer.t.sol
@@ -991,9 +991,9 @@ contract TallySlashingProposerTest is TestBase {
     // Round FIRST_SLASH_ROUND targets epochs 0 and 1, which have no committees
     // because they precede the validator set sampling lag.
     //
-    // Before the fix, casting votes that reach quorum for validator slots in these
-    // committee-less epochs would cause executeRound (and getTally) to revert with
-    // an array out-of-bounds access when indexing _committees[epochIndex][validatorIndex].
+    // Casting votes that reach quorum for validator slots in these committee-less epochs cause
+    // executeRound (and getTally) to revert with an array out-of-bounds access when
+    // indexing _committees[epochIndex][validatorIndex].
     _jumpToSlashRound(FIRST_SLASH_ROUND);
     SlashRound targetRound = slashingProposer.getCurrentRound();
 
@@ -1020,16 +1020,18 @@ contract TallySlashingProposerTest is TestBase {
     assertEq(committees[0].length, 0, "Epoch 0 should have empty committee");
     assertEq(committees[1].length, 0, "Epoch 1 should have empty committee");
 
-    // getTally should not revert and should return 0 actions
+    // getTally should revert because of out of bounds
+    vm.expectRevert();
     TallySlashingProposer.SlashAction[] memory actions = slashingProposer.getTally(targetRound, committees);
-    assertEq(actions.length, 0, "Should have no slash actions for empty committees");
+    assertEq(actions.length, 0, "Should have no slash actions since reverted");
 
-    // executeRound should also succeed
+    // Reverts because of out of bounds
+    vm.expectRevert();
     slashingProposer.executeRound(targetRound, committees);
 
-    // Verify round is marked as executed
+    // Verify round is not marked as executed
     (bool isExecuted,) = slashingProposer.getRound(targetRound);
-    assertTrue(isExecuted, "Round should be marked as executed");
+    assertFalse(isExecuted, "Round should not be marked as executed");
   }
 
   function test_revertWhenSlashAmountIsZero() public {


### PR DESCRIPTION
In https://github.com/AztecProtocol/aztec-packages/commit/b7605403131 a fix was applied to avoid a revert when slashing quorum was reached for empty committees. This was something that was quite unlikely, but as the fix seemed easy we applied it. In doing so, we did not validate the new use of input values properly (missing input validation anyone?). Anyway, then r0bert from Spearbit had a look because he was reviewing some faintly related code, and realized that the new part could be used to bypass a slash by convincing the execution that it was empty.

To avoid this issue, we are essentially undoing the fix (no longer skip), but keep the test slightly altered to showcase that this is now intended behaviour.

The code is current not deployed anywhere