### PR TITLE
fix: (A-592) p2p client proposal tx collector test

### DIFF
--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -483,7 +483,8 @@ class WorkerClientManager {
     };
 
     this.processes[0].send(aggregatorCmd);
-    const result = await this.waitForBenchResult(0, config.timeoutMs + 30000);
+    const aggregatorBudgetMs = config.timeoutMs + BENCHMARK_CONSTANTS.MAX_PEER_WAIT_MS + 30000;
+    const result = await this.waitForBenchResult(0, aggregatorBudgetMs);
 
     this.logger.info(
       `Benchmark complete: fetched=${result.fetchedCount}/${config.txCount}, duration=${result.durationMs.toFixed(0)}ms, success=${result.success}`,


### PR DESCRIPTION
The aggregator worker may wait up to MAX_PEER_WAIT_MS for peer connections before starting collection, so we must give it at least that much additional headroom beyond the collection timeout.