### PR TITLE
chore: deflake epoch invalidate block test

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
+++ b/yarn-project/sequencer-client/src/sequencer/checkpoint_proposal_job.ts
@@ -808,11 +808,20 @@ export class CheckpointProposalJob implements Traceable {
       this.log.warn(`Shuffling attestation ordering in checkpoint for slot ${slotNumber} (proposer #${proposerIndex})`);
 
       const shuffled = [...attestations];
-      const [i, j] = [(proposerIndex + 1) % shuffled.length, (proposerIndex + 2) % shuffled.length];
-      const valueI = shuffled[i];
-      const valueJ = shuffled[j];
-      shuffled[i] = valueJ;
-      shuffled[j] = valueI;
+
+      // Find two non-proposer positions that both have non-empty signatures to swap.
+      // This ensures the bitmap doesn't change, so the MaliciousCommitteeAttestationsAndSigners
+      // signers array stays correctly aligned with L1's committee reconstruction.
+      const swappable: number[] = [];
+      for (let k = 0; k < shuffled.length; k++) {
+        if (!shuffled[k].signature.isEmpty() && k !== proposerIndex) {
+          swappable.push(k);
+        }
+      }
+      if (swappable.length >= 2) {
+        const [i, j] = [swappable[0], swappable[1]];
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      }
 
       const signers = new CommitteeAttestationsAndSigners(attestations).getSigners();
       return new MaliciousCommitteeAttestationsAndSigners(shuffled, signers);


### PR DESCRIPTION
## Summary

- Fix flaky "proposer invalidates previous block with shuffled attestations" e2e test that fails with `ValidatorSelection__InvalidCommitteeCommitment`
- Only swap two signed attestation positions in `manipulateAttestations`, preserving the bitmap so `MaliciousCommitteeAttestationsAndSigners` signers stay aligned with L1's `reconstructCommitteeFromSigners`

## Root cause

`trimAttestations` reduces signed attestations to the minimum required (4 of 5), leaving one position with only an address (no signature). The old swap formula `(proposerIndex+1)%N, (proposerIndex+2)%N` could swap a signed position with an unsigned one, changing the bitmap pattern. `MaliciousCommitteeAttestationsAndSigners` provides the `_signers` array in the original bitmap order, but L1's `reconstructCommitteeFromSigners` maps signers to the new bitmap positions, producing a mismatched committee commitment hash. Whether the swap crosses a signed/unsigned boundary depends on the proposer index and which attestation was trimmed, explaining the flakiness.

## Test plan

- Confirmed the bug reproduces deterministically by forcing a signed/unsigned swap (test times out with 15 `InvalidCommitteeCommitment` reverts)
- After fix, test passes cleanly with zero committee commitment errors

Fixes A-590