### PR TITLE
chore: deflake epochs mbps test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_mbps.parallel.test.ts
@@ -145,6 +145,20 @@ describe('e2e_epochs/epochs_mbps', () => {
 
   /** Retrieves all checkpoints from the archiver, checks that one has the target block count, and returns its number. */
   async function assertMultipleBlocksPerSlot(targetBlockCount: number, logger: Logger): Promise<CheckpointNumber> {
+    // Wait for the first validator's archiver to index a checkpoint with the target block count.
+    // waitForTx polls the initial setup node, but this archiver belongs to nodes[0] (the first
+    // validator). They sync L1 independently, so there's a race window of ~200-400ms.
+    const waitTimeout = test.L2_SLOT_DURATION_IN_S * 3;
+    await retryUntil(
+      async () => {
+        const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
+        return checkpoints.some(pc => pc.checkpoint.blocks.length >= targetBlockCount) || undefined;
+      },
+      `checkpoint with at least ${targetBlockCount} blocks`,
+      waitTimeout,
+      0.5,
+    );
+
     const checkpoints = await archiver.getCheckpoints(CheckpointNumber(1), 50);
     logger.warn(`Retrieved ${checkpoints.length} checkpoints from archiver`, {
       checkpoints: checkpoints.map(pc => pc.checkpoint.getStats()),


### PR DESCRIPTION
## Summary

- Fixes flaky `epochs_mbps.parallel` test by adding a `retryUntil` poll to `assertMultipleBlocksPerSlot`, closing a race condition between two independently-syncing archivers

## Details

The `epochs_mbps.parallel` test has been flaking in CI (9 recent failures across PRs 20562-20868) on the "checkpointed block" test case. The root cause is a race condition:

1. `waitForTx` polls the **initial setup node's** archiver and returns when it sees the tx as `CHECKPOINTED`.
2. `assertMultipleBlocksPerSlot` then queries the **first validator node's** (`nodes[0]`) archiver via `archiver.getCheckpoints()`.
3. These are different nodes with independent L1 polling cycles (~50ms interval each).
4. The first validator's archiver may not have indexed the latest checkpoint yet (~200-400ms race window).

CI logs confirm: the checkpoint with the expected block count is always produced and published to L1, but the first validator's archiver hasn't indexed it when the assertion runs.

### Fix

Added a `retryUntil` poll at the start of `assertMultipleBlocksPerSlot` that waits (up to `L2_SLOT_DURATION_IN_S * 3` = 108s, polling every 0.5s) for `nodes[0]`'s archiver to index a checkpoint with at least `targetBlockCount` blocks. Once found, the existing validation logic runs as before.

Fixes A-594