### PR TITLE
chore(docs): update aztec MCP server package name to @aztec/mcp-server

### DIFF
--- a/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/ai_tooling.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/ai_tooling.md
@@ -31,7 +31,7 @@ Install the Aztec and Noir plugins from the marketplace. These include the MCP s
 Or add the MCP servers directly:
 
 ```bash
-claude mcp add aztec -- npx aztec-mcp-server@latest
+claude mcp add aztec -- npx @aztec/mcp-server@latest
 claude mcp add noir -- npx noir-mcp-server@latest
 ```
 
@@ -44,7 +44,7 @@ Add the servers to your MCP configuration JSON:
   "mcpServers": {
     "aztec": {
       "command": "npx",
-      "args": ["-y", "aztec-mcp-server@latest"]
+      "args": ["-y", "@aztec/mcp-server@latest"]
     },
     "noir": {
       "command": "npx",
@@ -56,7 +56,7 @@ Add the servers to your MCP configuration JSON:
 
 ### OpenAI Codex
 
-Use the same MCP configuration format, pointing at `aztec-mcp-server` and `noir-mcp-server`.
+Use the same MCP configuration format, pointing at `@aztec/mcp-server` and `noir-mcp-server`.
 
 ## For learning and exploration
 
@@ -85,7 +85,7 @@ These resources help you understand Aztec concepts, read docs, or provide additi
 | Tool                                                                        | Works with                                            | Description                                                                            |
 | --------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [aztec-claude-plugin](https://github.com/critesjosh/aztec-claude-plugin)    | Claude Code                                           | Skills, commands, agents, and MCP server for Aztec contract and TypeScript development |
-| [aztec-mcp-server](https://github.com/critesjosh/aztec-mcp-server)          | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
+| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
 | [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                       |
 | [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples       |
 | [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing              |

--- a/docs/docs-developers/ai_tooling.md
+++ b/docs/docs-developers/ai_tooling.md
@@ -31,7 +31,7 @@ Install the Aztec and Noir plugins from the marketplace. These include the MCP s
 Or add the MCP servers directly:
 
 ```bash
-claude mcp add aztec -- npx aztec-mcp-server@latest
+claude mcp add aztec -- npx @aztec/mcp-server@latest
 claude mcp add noir -- npx noir-mcp-server@latest
 ```
 
@@ -44,7 +44,7 @@ Add the servers to your MCP configuration JSON:
   "mcpServers": {
     "aztec": {
       "command": "npx",
-      "args": ["-y", "aztec-mcp-server@latest"]
+      "args": ["-y", "@aztec/mcp-server@latest"]
     },
     "noir": {
       "command": "npx",
@@ -56,7 +56,7 @@ Add the servers to your MCP configuration JSON:
 
 ### OpenAI Codex
 
-Use the same MCP configuration format, pointing at `aztec-mcp-server` and `noir-mcp-server`.
+Use the same MCP configuration format, pointing at `@aztec/mcp-server` and `noir-mcp-server`.
 
 ## For learning and exploration
 
@@ -85,7 +85,7 @@ These resources help you understand Aztec concepts, read docs, or provide additi
 | Tool                                                                        | Works with                                            | Description                                                                            |
 | --------------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [aztec-claude-plugin](https://github.com/critesjosh/aztec-claude-plugin)    | Claude Code                                           | Skills, commands, agents, and MCP server for Aztec contract and TypeScript development |
-| [aztec-mcp-server](https://github.com/critesjosh/aztec-mcp-server)          | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
+| [@aztec/mcp-server](https://github.com/AztecProtocol/mcp-server)            | Any MCP client (Claude Code, Cursor, Windsurf, Codex) | Clones Aztec repos locally, provides code search, doc search, and example discovery    |
 | [noir-claude-plugin](https://github.com/critesjosh/noir-claude-plugin)      | Claude Code                                           | Skills and commands for Noir circuit development                                       |
 | [noir-mcp-server](https://github.com/critesjosh/noir-mcp-server)            | Any MCP client                                        | Clones Noir repos, stdlib, and community libraries; provides search and examples       |
 | [aztec-skills](https://github.com/NethermindEth/aztec-skills)               | Claude Code, Codex                                    | Installable skills for Aztec contracts, deployment, Aztec.js, and testing              |


### PR DESCRIPTION
## Summary
- Updates all references from the old `aztec-mcp-server` npm package to the scoped `@aztec/mcp-server` package
- Updates the GitHub URL from `critesjosh/aztec-mcp-server` to `AztecProtocol/mcp-server`
- Applied to both the source docs and the devnet versioned copy

## Changed files
- `docs/docs-developers/ai_tooling.md`
- `docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/ai_tooling.md`

## Test plan
- [ ] Verify links resolve correctly on the built docs site
- [ ] Confirm `npx @aztec/mcp-server@latest` works as documented