### PR TITLE
chore(docs): generate missing wallets.md for devnet TypeScript API docs

### DIFF
--- a/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/aztec-js/typescript_api_reference.mdx
+++ b/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/aztec-js/typescript_api_reference.mdx
@@ -131,7 +131,7 @@ Packages for building Aztec applications:
 | **@aztec/accounts**          | Sample account contract implementations including ECDSA and Schnorr accounts.                                         |
 | **@aztec/pxe**               | Private eXecution Environment client library for orchestrating private transaction execution and proving.             |
 | **@aztec/wallet-sdk**        | Wallet SDK for browser and extension integrations.                                                                    |
-| **@aztec/test-wallet**       | Test wallet for development and e2e testing with in-memory account management.                                        |
+| **@aztec/wallets**           | Embedded wallet for browser and Node.js environments.                                                                 |
 | **@aztec/entrypoints**       | Transaction entrypoint implementations for account abstraction.                                                       |
 
 ### Core Libraries
@@ -166,7 +166,7 @@ The following markdown files are available for LLM context inclusion at <ApiPath
 | <ApiFile path="accounts.md" />          | Account implementations (ECDSA, Schnorr)        |
 | <ApiFile path="pxe.md" />               | Private execution environment client            |
 | <ApiFile path="wallet-sdk.md" />        | Browser/extension wallet integration            |
-| <ApiFile path="test-wallet.md" />       | Test wallet for development and e2e testing     |
+| <ApiFile path="wallets.md" />           | Embedded wallet for browser and Node.js         |
 | <ApiFile path="entrypoints.md" />       | Transaction entrypoints for account abstraction |
 | <ApiFile path="stdlib.md" />            | Protocol types (transactions, blocks, proofs)   |
 | <ApiFile path="foundation.md" />        | Low-level utilities (crypto, serialization)     |

--- a/docs/docs-developers/docs/aztec-js/typescript_api_reference.mdx
+++ b/docs/docs-developers/docs/aztec-js/typescript_api_reference.mdx
@@ -131,7 +131,7 @@ Packages for building Aztec applications:
 | **@aztec/accounts**          | Sample account contract implementations including ECDSA and Schnorr accounts.                                         |
 | **@aztec/pxe**               | Private eXecution Environment client library for orchestrating private transaction execution and proving.             |
 | **@aztec/wallet-sdk**        | Wallet SDK for browser and extension integrations.                                                                    |
-| **@aztec/test-wallet**       | Test wallet for development and e2e testing with in-memory account management.                                        |
+| **@aztec/wallets**           | Embedded wallet for browser and Node.js environments.                                                                 |
 | **@aztec/entrypoints**       | Transaction entrypoint implementations for account abstraction.                                                       |
 
 ### Core Libraries
@@ -166,7 +166,7 @@ The following markdown files are available for LLM context inclusion at <ApiPath
 | <ApiFile path="accounts.md" />          | Account implementations (ECDSA, Schnorr)        |
 | <ApiFile path="pxe.md" />               | Private execution environment client            |
 | <ApiFile path="wallet-sdk.md" />        | Browser/extension wallet integration            |
-| <ApiFile path="test-wallet.md" />       | Test wallet for development and e2e testing     |
+| <ApiFile path="wallets.md" />           | Embedded wallet for browser and Node.js         |
 | <ApiFile path="entrypoints.md" />       | Transaction entrypoints for account abstraction |
 | <ApiFile path="stdlib.md" />            | Protocol types (transactions, blocks, proofs)   |
 | <ApiFile path="foundation.md" />        | Low-level utilities (crypto, serialization)     |

--- a/docs/scripts/validate_api_ref_links.sh
+++ b/docs/scripts/validate_api_ref_links.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# validate_api_ref_links - Validate that markdown links to aztec-nr API reference resolve to actual files
+# validate_api_ref_links - Validate that API reference links resolve to actual files
 #
-# Scans processed-docs/ (current build content) and developer_versioned_docs/ (pinned snapshots)
-# for pathname:///aztec-nr-api/ links (and JSX href variants) and checks that the target files
-# exist in static/aztec-nr-api/. Uses case-insensitive matching since Netlify's CDN is
-# case-insensitive, but warns about case mismatches.
+# Validates two types of API reference links:
+#   - Aztec.nr API: pathname:///aztec-nr-api/ links and JSX href variants → static/aztec-nr-api/
+#   - TypeScript API: <ApiFile path="..."/> and <ApiLink path="..."/> JSX components,
+#     plus pathname:///typescript-api/ links and JSX href variants → static/typescript-api/
+#
+# Scans processed-docs/ (current build content), developer_versioned_docs/ (pinned snapshots),
+# and docs-developers/ (source files, for TypeScript API JSX components only).
 #
 # Checks performed:
 #   1. Broken links - target file does not exist at all
@@ -20,9 +23,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCS_ROOT="$(dirname "$SCRIPT_DIR")"
 STATIC_API_DIR="$DOCS_ROOT/static/aztec-nr-api"
+TS_STATIC_API_DIR="$DOCS_ROOT/static/typescript-api"
 
-if [[ ! -d "$STATIC_API_DIR" ]]; then
-  echo "WARNING: static/aztec-nr-api/ directory not found. Skipping API ref link validation."
+if [[ ! -d "$STATIC_API_DIR" ]] && [[ ! -d "$TS_STATIC_API_DIR" ]]; then
+  echo "WARNING: Neither static/aztec-nr-api/ nor static/typescript-api/ found. Skipping API ref link validation."
   exit 0
 fi
 
@@ -31,7 +35,9 @@ echo "Validating API reference links..."
 # Collect directories to scan.
 # 1. processed-docs/ — current docs with macros resolved (available during build after preprocess:move)
 # 2. developer_versioned_docs/ — pinned version snapshots (macros already resolved at version time)
-# We skip docs-developers/ source files because they contain unresolved #api_ref_version macros.
+# 3. docs-developers/ — source files (for TypeScript API JSX components that don't use macros)
+# We skip docs-developers/ for aztec-nr-api links because they contain unresolved #api_ref_version macros,
+# but we DO scan it for TypeScript API links (ApiFile/ApiLink) which use runtime version resolution.
 SEARCH_DIRS=()
 
 # Processed docs (current build content — most important for catching regressions)
@@ -43,6 +49,11 @@ fi
 for dir in "$DOCS_ROOT"/developer_versioned_docs/version-*; do
   [[ -d "$dir" ]] && SEARCH_DIRS+=("$dir")
 done
+
+# Source docs (for TypeScript API JSX component validation only)
+if [[ -d "$DOCS_ROOT/docs-developers" ]]; then
+  SEARCH_DIRS+=("$DOCS_ROOT/docs-developers")
+fi
 
 if [[ ${#SEARCH_DIRS[@]} -eq 0 ]]; then
   echo "No docs directories found (no processed-docs/ or versioned docs). Skipping."
@@ -249,7 +260,7 @@ send_alert() {
     done
   fi
 
-  message+=$'\n'"*Action required:* Run \`yarn generate:aztec-nr-api\` to regenerate the API docs."
+  message+=$'\n'"*Action required:* Run \`yarn generate:aztec-nr-api\` and/or \`yarn generate:typescript-api\` to regenerate the API docs."
 
   if send_slack_message "$message"; then
     echo "Slack notification sent to #devrel-docs-updates."
@@ -326,9 +337,61 @@ process_link() {
   fi
 }
 
+# Get the expected TypeScript API version from a docs directory path.
+# Args: $1 = search directory path
+# Outputs: "nightly", "devnet", or "next" — the folder name under static/typescript-api/
+get_expected_ts_api_version() {
+  local search_dir="$1"
+  local dirname
+  dirname=$(basename "$search_dir")
+
+  if [[ "$dirname" =~ devnet ]]; then
+    echo "devnet"
+  elif [[ "$dirname" =~ nightly ]]; then
+    echo "nightly"
+  else
+    # processed-docs maps to "next"
+    echo "next"
+  fi
+}
+
+# Process a TypeScript API link found via ApiFile/ApiLink JSX props.
+# These reference files under static/typescript-api/{version}/.
+# Args: $1 = source file, $2 = line number, $3 = file path (e.g., "wallets.md"),
+#        $4 = expected TS API version
+process_ts_api_link() {
+  local source_file="$1"
+  local line_num="$2"
+  local file_path="$3"
+  local expected_version="${4:-nightly}"
+
+  TOTAL_COUNT=$((TOTAL_COUNT + 1))
+
+  local rel_source="${source_file#$DOCS_ROOT/}"
+
+  # Check if the file exists under static/typescript-api/{version}/
+  local full_path="$TS_STATIC_API_DIR/$expected_version/$file_path"
+  if [[ ! -f "$full_path" ]]; then
+    # Also try "nightly" as fallback since that's the only generated output currently
+    if [[ "$expected_version" != "nightly" ]] && [[ -f "$TS_STATIC_API_DIR/nightly/$file_path" ]]; then
+      return
+    fi
+    BROKEN_COUNT=$((BROKEN_COUNT + 1))
+    BROKEN_DETAILS+=("$rel_source:$line_num -> typescript-api/$expected_version/$file_path")
+    echo "  BROKEN: $rel_source:$line_num"
+    echo "    TypeScript API file not found: typescript-api/$expected_version/$file_path"
+  fi
+}
+
 # Regex patterns stored in variables to avoid bash parsing issues with special chars
 MD_LINK_PATTERN='][(]pathname:///aztec-nr-api/([^)]*)[)]'
 JSX_HREF_PATTERN='href="/aztec-nr-api/([^"]*)"'
+# TypeScript API patterns: <ApiFile path="..." /> and <ApiLink path="..." />
+TS_APIFILE_PATTERN='ApiFile path="([^"]*)"'
+TS_APILINK_PATTERN='ApiLink path="([^"]*)"'
+# TypeScript API markdown and JSX href links
+TS_MD_LINK_PATTERN='][(]pathname:///typescript-api/([^)]*)[)]'
+TS_JSX_HREF_PATTERN='href="/typescript-api/([^"]*)"'
 
 # Scan files for links
 for search_dir in "${SEARCH_DIRS[@]}"; do
@@ -339,6 +402,8 @@ for search_dir in "${SEARCH_DIRS[@]}"; do
   else
     echo "  $rel_search_dir"
   fi
+
+  expected_ts_version=$(get_expected_ts_api_version "$search_dir")
 
   # Find all .md and .mdx files
   while IFS= read -r -d '' file; do
@@ -364,6 +429,46 @@ for search_dir in "${SEARCH_DIRS[@]}"; do
         remaining="${remaining#*"$full_match"}"
       done
 
+      # Match TypeScript API JSX components: <ApiFile path="..." /> and <ApiLink path="..." />
+      remaining="$line"
+      while [[ "$remaining" =~ $TS_APIFILE_PATTERN ]]; do
+        ts_file_path="${BASH_REMATCH[1]}"
+        full_match="${BASH_REMATCH[0]}"
+        process_ts_api_link "$file" "$local_line_num" "$ts_file_path" "$expected_ts_version"
+        remaining="${remaining#*"$full_match"}"
+      done
+
+      remaining="$line"
+      while [[ "$remaining" =~ $TS_APILINK_PATTERN ]]; do
+        ts_file_path="${BASH_REMATCH[1]}"
+        full_match="${BASH_REMATCH[0]}"
+        process_ts_api_link "$file" "$local_line_num" "$ts_file_path" "$expected_ts_version"
+        remaining="${remaining#*"$full_match"}"
+      done
+
+      # Match markdown links: ](pathname:///typescript-api/...)
+      remaining="$line"
+      while [[ "$remaining" =~ $TS_MD_LINK_PATTERN ]]; do
+        ts_link="${BASH_REMATCH[1]}"
+        full_match="${BASH_REMATCH[0]}"
+        # Extract version and file path from e.g. "nightly/wallets.md"
+        if [[ "$ts_link" =~ ^([^/]+)/(.+)$ ]]; then
+          process_ts_api_link "$file" "$local_line_num" "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
+        fi
+        remaining="${remaining#*"$full_match"}"
+      done
+
+      # Match JSX href attributes: href="/typescript-api/..."
+      remaining="$line"
+      while [[ "$remaining" =~ $TS_JSX_HREF_PATTERN ]]; do
+        ts_link="${BASH_REMATCH[1]}"
+        full_match="${BASH_REMATCH[0]}"
+        if [[ "$ts_link" =~ ^([^/]+)/(.+)$ ]]; then
+          process_ts_api_link "$file" "$local_line_num" "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
+        fi
+        remaining="${remaining#*"$full_match"}"
+      done
+
     done < "$file"
   done < <(find "$search_dir" -type f \( -name "*.md" -o -name "*.mdx" \) -print0)
 done
@@ -377,8 +482,8 @@ echo "  - Version mismatches: $VERSION_MISMATCH_COUNT"
 if [[ $BROKEN_COUNT -gt 0 ]]; then
   echo ""
   echo "WARNING: $BROKEN_COUNT broken API reference link(s) found."
-  echo "These links point to files that don't exist in static/aztec-nr-api/."
-  echo "Run 'yarn generate:aztec-nr-api' to regenerate the API docs."
+  echo "These links point to files that don't exist in static/aztec-nr-api/ or static/typescript-api/."
+  echo "Run 'yarn generate:aztec-nr-api' or 'yarn generate:typescript-api' to regenerate the API docs."
 fi
 
 if [[ $VERSION_MISMATCH_COUNT -gt 0 ]]; then

--- a/docs/static/typescript-api/devnet/llm-summary.txt
+++ b/docs/static/typescript-api/devnet/llm-summary.txt
@@ -44,6 +44,8 @@ Exports: 6 classes, 31 interfaces, 10 functions, 8 types
   - EmbeddedWallet with browser and Node.js flavors
   - Account creation and management
   - Transaction simulation and proving
+Exports: 2 classes, 2 functions, 2 types
+Key: NodeEmbeddedWallet, WalletDB
 
 ### Core Libraries
 
@@ -111,5 +113,6 @@ entrypoints → foundation, stdlib
 pxe → aztec.js, foundation, kv-store, stdlib
 stdlib → blob-lib, constants, ethereum, foundation
 wallet-sdk → aztec.js, entrypoints, foundation, pxe, stdlib
+wallets → accounts, aztec.js, entrypoints, foundation, kv-store, pxe, stdlib, wallet-sdk
 
 For detailed API documentation, see the individual package files.

--- a/docs/static/typescript-api/devnet/wallets.md
+++ b/docs/static/typescript-api/devnet/wallets.md
@@ -1,0 +1,131 @@
+# @aztec/wallets
+
+Version: v4.0.0-devnet.2-patch.1
+
+## Quick Import Reference
+
+```typescript
+import {
+  NodeEmbeddedWallet,
+  WalletDB,
+  deployFundedSchnorrAccounts,
+  registerInitialLocalNetworkAccountsInWallet,
+  AccountType,
+  // ... and more
+} from '@aztec/wallets';
+```
+
+## Classes
+
+### NodeEmbeddedWallet
+
+Extends: `EmbeddedWallet`
+
+**Constructor**
+```typescript
+new NodeEmbeddedWallet(pxe: PXE, aztecNode: AztecNode, walletDB: WalletDB, accountContracts: AccountContractsProvider, log?: Logger)
+```
+
+**Properties**
+- `accountContracts: AccountContractsProvider`
+- `readonly aztecNode: AztecNode`
+- `cancellableTransactions: boolean`
+- `log: Logger`
+- `minFeePadding: number`
+- `readonly pxe: PXE`
+- `walletDB: WalletDB`
+
+**Methods**
+- `batch<T extends readonly BatchedMethod[]>(methods: T) => Promise<BatchResults<T>>`
+- `completeFeeOptions(from: AztecAddress, feePayer?: AztecAddress, gasSettings?: Partial<FieldsOf<GasSettings>>) => Promise<FeeOptions>` - Completes partial user-provided fee options with wallet defaults.
+- `completeFeeOptionsForEstimation(from: AztecAddress, feePayer?: AztecAddress, gasSettings?: Partial<FieldsOf<GasSettings>>) => Promise<{ accountFeePaymentMethodOptions: AccountFeePaymentMethodOptions; gasSettings: GasSettings; walletFeePaymentMethod?: FeePaymentMethod }>` - Completes partial user-provided fee options with unreasonably high gas limits for gas estimation. Uses the same logic as completeFeeOptions but sets high limits to avoid running out of gas during estimation.
+- `contextualizeError(err: Error, ...context: string[]) => Error`
+- `static create<T extends NodeEmbeddedWallet>(this: (pxe: PXE, aztecNode: AztecNode, walletDB: WalletDB, accountContracts: AccountContractsProvider, log?: Logger) => T, nodeOrUrl: string | AztecNode, options: EmbeddedWalletOptions) => Promise<T>`
+- `createAccountInternal(type: "schnorr" | "ecdsasecp256r1" | "ecdsasecp256k1", secret: Fr, salt: Fr, signingKey: Buffer) => Promise<AccountManager>`
+- `createAndStoreAccount(alias: string, type: "schnorr" | "ecdsasecp256r1" | "ecdsasecp256k1", secret: Fr, salt: Fr, signingKey: Buffer) => Promise<AccountManager>`
+- `createAuthWit(from: AztecAddress, messageHashOrIntent: IntentInnerHash | CallIntent) => Promise<AuthWitness>`
+- `createECDSAKAccount(secret: Fr, salt: Fr, signingKey: Buffer, alias?: string) => Promise<AccountManager>`
+- `createECDSARAccount(secret: Fr, salt: Fr, signingKey: Buffer, alias?: string) => Promise<AccountManager>`
+- `createSchnorrAccount(secret: Fr, salt: Fr, signingKey?: Fq, alias?: string) => Promise<AccountManager>`
+- `createTxExecutionRequestFromPayloadAndFee(executionPayload: ExecutionPayload, from: AztecAddress, feeOptions: FeeOptions) => Promise<TxExecutionRequest>`
+- `getAccountFromAddress(address: AztecAddress) => Promise<Account>`
+- `getAccounts() => Promise<Aliased<AztecAddress>[]>`
+- `getAddressBook() => Promise<Aliased<AztecAddress>[]>` - Returns the list of aliased contacts associated with the wallet. This base implementation directly returns PXE's senders, but note that in general contacts are a superset of senders. - Senders: Addresses we check during synching in case they sent us notes, - Contacts: more general concept akin to a phone's contact list.
+- `getChainInfo() => Promise<ChainInfo>`
+- `getContractClassMetadata(id: Fr) => Promise<{ isArtifactRegistered: boolean; isContractClassPubliclyRegistered: boolean }>`
+- `getContractMetadata(address: AztecAddress) => Promise<{ instance: ContractInstanceWithAddress | undefined; isContractInitialized: boolean; ... }>`
+- `getPrivateEvents<T>(eventDef: EventMetadataDefinition, eventFilter: PrivateEventFilter) => Promise<PrivateEvent<T>[]>`
+- `profileTx(executionPayload: ExecutionPayload, opts: ProfileOptions) => Promise<TxProfileResult>`
+- `registerContract(instance: ContractInstanceWithAddress, artifact?: ContractArtifact, secretKey?: Fr) => Promise<ContractInstanceWithAddress>`
+- `registerSender(address: AztecAddress, alias: string) => Promise<AztecAddress>`
+- `requestCapabilities(_manifest: AppCapabilities) => Promise<WalletCapabilities>` - Request capabilities from the wallet. This method is wallet-implementation-dependent and must be provided by classes extending BaseWallet. Embedded wallets typically don't support capability-based authorization (no user authorization flow), while external wallets (browser extensions, hardware wallets) implement this to reduce authorization friction by allowing apps to request permissions upfront. Consider making it abstract so implementing it is a conscious decision. Leaving it as-is while the feature stabilizes.
+- `scopesFor(from: AztecAddress) => AztecAddress[]`
+- `sendTx<W extends InteractionWaitOptions>(executionPayload: ExecutionPayload, opts: SendOptions<W>) => Promise<SendReturn<W>>`
+- `setMinFeePadding(value?: number) => void`
+- `simulateTx(executionPayload: ExecutionPayload, opts: SimulateOptions) => Promise<TxSimulationResult>` - Simulates a transaction, optimizing leading public static calls by running them directly on the node while sending the remaining calls through the standard PXE path. Return values from both paths are merged back in original call order.
+- `simulateUtility(call: FunctionCall, opts: SimulateUtilityOptions) => Promise<UtilitySimulationResult>`
+- `simulateViaEntrypoint(executionPayload: ExecutionPayload, from: AztecAddress, feeOptions: FeeOptions, scopes: AccessScopes, _skipTxValidation?: boolean, _skipFeeEnforcement?: boolean) => Promise<TxSimulationResult>` - Simulates calls via a stub account entrypoint, bypassing real account authorization. This allows kernelless simulation with contract overrides, skipping expensive private kernel circuit execution.
+- `stop() => Promise<void>`
+
+### WalletDB
+
+**Methods**
+- `deleteAccount(address: AztecAddress) => Promise<void>`
+- `static init(store: AztecAsyncKVStore, userLog: LogFn) => WalletDB`
+- `listAccounts() => Promise<Aliased<AztecAddress>[]>`
+- `listSenders() => Promise<Aliased<AztecAddress>[]>`
+- `retrieveAccount(address: string | AztecAddress) => Promise<{ address: string | AztecAddress; salt: Fr; ... }>`
+- `storeAccount(address: AztecAddress, __namedParameters: { alias: string | undefined; salt: Fr; ... }, log: LogFn) => Promise<void>`
+- `storeSender(address: AztecAddress, alias: string, log: LogFn) => Promise<void>`
+
+## Functions
+
+### deployFundedSchnorrAccounts
+```typescript
+function deployFundedSchnorrAccounts(wallet: WalletWithSchnorrAccounts, accountsData: InitialAccountData[], waitOptions?: WaitOpts) => Promise<AccountManager[]>
+```
+
+### registerInitialLocalNetworkAccountsInWallet
+```typescript
+function registerInitialLocalNetworkAccountsInWallet(wallet: WalletWithSchnorrAccounts) => Promise<AztecAddress[]>
+```
+
+## Types
+
+### AccountType
+```typescript
+type AccountType = typeof AccountTypes[number]
+```
+
+### EmbeddedWalletOptions
+```typescript
+type EmbeddedWalletOptions = unknown
+```
+
+## Cross-Package References
+
+This package references types from other Aztec packages:
+
+**@aztec/accounts**
+- `InitialAccountData`
+
+**@aztec/aztec.js**
+- `Account`, `AccountManager`, `Aliased`, `AppCapabilities`, `BatchResults`, `BatchedMethod`, `CallIntent`, `FeePaymentMethod`, `IntentInnerHash`, `InteractionWaitOptions`, `PrivateEvent`, `PrivateEventFilter`, `ProfileOptions`, `SendOptions`, `SendReturn`, `SimulateOptions`, `SimulateUtilityOptions`, `WaitOpts`, `WalletCapabilities`
+
+**@aztec/entrypoints**
+- `AccountFeePaymentMethodOptions`, `ChainInfo`
+
+**@aztec/foundation**
+- `FieldsOf`, `Fq`, `Fr`, `LogFn`, `Logger`
+
+**@aztec/kv-store**
+- `AztecAsyncKVStore`
+
+**@aztec/pxe**
+- `AccessScopes`, `PXE`
+
+**@aztec/stdlib**
+- `AuthWitness`, `AztecAddress`, `AztecNode`, `ContractArtifact`, `ContractInstanceWithAddress`, `EventMetadataDefinition`, `ExecutionPayload`, `FunctionCall`, `GasSettings`, `TxExecutionRequest`, `TxProfileResult`, `TxSimulationResult`, `UtilitySimulationResult`
+
+**@aztec/wallet-sdk**
+- `FeeOptions`, `W`


### PR DESCRIPTION
## Summary

- Generated the missing `wallets.md` for the devnet TypeScript API docs (`docs/static/typescript-api/devnet/`)
- Updated `llm-summary.txt` with export counts and dependency info for `@aztec/wallets`

The `@aztec/wallets@4.0.0-devnet.2-patch.1` package was skipped during the original devnet doc generation because that version didn't have `typedocOptions` in its `package.json`. Generated by installing the npm package, running TypeDoc against its shipped source files, and transforming with the existing `transform_for_llm.ts` script.

## Test plan

- [x] `wallets.md` has 2 classes, 2 functions, 2 types matching the package's public API
- [x] Content structure matches the nightly `wallets.md` format
- [x] `validate_api_ref_links.sh` reports 0 broken links for devnet versioned docs
- [x] `llm-summary.txt` includes wallets export counts and dependency line