### PR TITLE
chore: use free witness for offset generator in `batch_mul`

### DIFF
--- a/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_changed.sh
@@ -16,7 +16,7 @@ script_path="$root/barretenberg/cpp/scripts/test_chonk_standalone_vks_havent_cha
 # - Generate a hash for versioning: sha256sum bb-chonk-inputs.tar.gz
 # - Upload the compressed results: aws s3 cp bb-chonk-inputs.tar.gz s3://aztec-ci-artifacts/protocol/bb-chonk-inputs-[hash(0:8)].tar.gz
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
-pinned_short_hash="189f0026"
+pinned_short_hash="b99f5b94"
 pinned_chonk_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-chonk-inputs-${pinned_short_hash}.tar.gz"
 
 function update_pinned_hash_in_script {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -61,10 +61,6 @@ template <typename Curve_> class KZG {
         // future we might need to adjust this to use the incoming alternative to work queue (i.e. variation of
         // pthreads) or even the work queue itself
         prover_trancript->send_to_verifier("KZG:W", quotient_commitment);
-
-        // Masking challenge is used in the recursive setting to perform batch_mul. This is not used
-        // by the prover directly, we just need it for consistent transcript state with the verifier.
-        prover_trancript->template get_challenge<Fr>("KZG:masking_challenge");
     };
 
     /**
@@ -133,13 +129,10 @@ template <typename Curve_> class KZG {
     {
         auto quotient_commitment = transcript->template receive_from_prover<Commitment>("KZG:W");
 
-        // This challenge is used to compute offset generators in the batch_mul call below
-        const Fr masking_challenge = transcript->template get_challenge<Fr>("KZG:masking_challenge");
-
         // OriginTag false positive: The quotient commitment is PCS-bound - the prover cannot
         // choose it freely because it must satisfy the batched opening equation.
         if constexpr (Curve::is_stdlib_type) {
-            const auto challenge_tag = masking_challenge.get_origin_tag();
+            const auto challenge_tag = batch_opening_claim.evaluation_point.get_origin_tag();
             quotient_commitment.set_origin_tag(challenge_tag);
         }
 
@@ -160,8 +153,7 @@ template <typename Curve_> class KZG {
         P_0 = GroupElement::batch_mul(batch_opening_claim.commitments,
                                       batch_opening_claim.scalars,
                                       /*max_num_bits=*/0,
-                                      /*with_edgecases=*/true,
-                                      /*masking_scalar=*/masking_challenge);
+                                      /*with_edgecases=*/true);
         auto P_1 = -quotient_commitment;
 
         return PairingPointsType(P_0, P_1);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -129,8 +129,13 @@ template <typename Curve_> class KZG {
     {
         auto quotient_commitment = transcript->template receive_from_prover<Commitment>("KZG:W");
 
-        // OriginTag false positive: The quotient commitment is PCS-bound - the prover cannot
-        // choose it freely because it must satisfy the batched opening equation.
+        // OriginTag suppression: The tag system flags patterns like A*α + B where A, B are
+        // prover-supplied and α is a challenge derived without hashing them. The quotient commitment
+        // W is prover-supplied and scaled by z in C + W·z, so it triggers this pattern.
+        // This is a false positive: the pairing check e(C + W·z, [1]₂) · e(−W, [x]₂) = 1 forces W
+        // to be the honest quotient commitment, so the prover cannot tamper with it.
+        // We assign W the tag of z (evaluation_point): the challenge it is scaled by,
+        // so the tag system does not flag the multiplication.
         if constexpr (Curve::is_stdlib_type) {
             const auto challenge_tag = batch_opening_claim.evaluation_point.get_origin_tag();
             quotient_commitment.set_origin_tag(challenge_tag);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -100,7 +100,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
         if (mode != PredicateTestCase::ConstantTrue) {
             bb::assert_failure("Unhandled mode in MegaZKRecursiveFlavor.");
         }
-        return std::make_tuple(819381, 0);
+        return std::make_tuple(786730, 0);
     } else {
         bb::assert_failure("Unhandled recursive flavor.");
     }
@@ -113,7 +113,7 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
 // ========================================
 
 // Gate count for Chonk recursive verification (Ultra with RollupIO)
-inline constexpr size_t CHONK_RECURSION_GATES = 1685112;
+inline constexpr size_t CHONK_RECURSION_GATES = 1587459;
 
 // ========================================
 // Hypernova Recursion Constants
@@ -123,22 +123,22 @@ inline constexpr size_t CHONK_RECURSION_GATES = 1685112;
 inline constexpr size_t MSM_ROWS_OFFSET = 2;
 
 // Init kernel gate counts (verifies OINK proof)
-inline constexpr size_t INIT_KERNEL_GATE_COUNT = 24226;
+inline constexpr size_t INIT_KERNEL_GATE_COUNT = 24047;
 inline constexpr size_t INIT_KERNEL_ECC_ROWS = 848 + MSM_ROWS_OFFSET;
 inline constexpr size_t INIT_KERNEL_ULTRA_OPS = 89;
 
 // Inner kernel gate counts (verifies HN proof for previous kernel + HN for app)
-inline constexpr size_t INNER_KERNEL_GATE_COUNT_HN = 57418;
+inline constexpr size_t INNER_KERNEL_GATE_COUNT_HN = 57138;
 inline constexpr size_t INNER_KERNEL_ECC_ROWS = 1700 + MSM_ROWS_OFFSET;
 inline constexpr size_t INNER_KERNEL_ULTRA_OPS = 179;
 
 // Tail kernel gate counts (verifies HN_TAIL proof)
-inline constexpr size_t TAIL_KERNEL_GATE_COUNT = 31295;
+inline constexpr size_t TAIL_KERNEL_GATE_COUNT = 31117;
 inline constexpr size_t TAIL_KERNEL_ECC_ROWS = 914 + MSM_ROWS_OFFSET;
 inline constexpr size_t TAIL_KERNEL_ULTRA_OPS = 96;
 
 // Hiding kernel gate counts (verifies HN_FINAL proof)
-inline constexpr size_t HIDING_KERNEL_GATE_COUNT = 34339;
+inline constexpr size_t HIDING_KERNEL_GATE_COUNT = 34132;
 inline constexpr size_t HIDING_KERNEL_ECC_ROWS = 1341 + MSM_ROWS_OFFSET;
 inline constexpr size_t HIDING_KERNEL_ULTRA_OPS = 124;
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/gate_count_constants.hpp
@@ -55,7 +55,7 @@ template <typename Builder> inline constexpr size_t ASSERT_EQUALITY = ZERO_GATE 
 // Honk Recursion Constants
 // ========================================
 
-inline constexpr size_t ROOT_ROLLUP_GATE_COUNT = 12998771;
+inline constexpr size_t ROOT_ROLLUP_GATE_COUNT = 12933470;
 
 template <typename RecursiveFlavor>
 constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
@@ -67,34 +67,34 @@ constexpr std::tuple<size_t, size_t> HONK_RECURSION_CONSTANTS(
     if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(728641, 0);
+            return std::make_tuple(695991, 0);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(729776, 0);
+            return std::make_tuple(697126, 0);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraZKRecursiveFlavor_<UltraCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(772418, 0);
+            return std::make_tuple(739768, 0);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(773655, 0);
+            return std::make_tuple(741005, 0);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraRecursiveFlavor_<MegaCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(22449, 76);
+            return std::make_tuple(22271, 76);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(23584, 76);
+            return std::make_tuple(23406, 76);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::UltraZKRecursiveFlavor_<MegaCircuitBuilder>>) {
         switch (mode) {
         case PredicateTestCase::ConstantTrue:
-            return std::make_tuple(27301, 80);
+            return std::make_tuple(27122, 80);
         case PredicateTestCase::WitnessTrue:
         case PredicateTestCase::WitnessFalse:
-            return std::make_tuple(28538, 80);
+            return std::make_tuple(28359, 80);
         }
     } else if constexpr (std::is_same_v<RecursiveFlavor, bb::MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
         if (mode != PredicateTestCase::ConstantTrue) {

--- a/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/merge.test.cpp
@@ -576,9 +576,8 @@ class MergeTranscriptTests : public ::testing::Test {
         manifest_expected.add_entry(round, "REVERSED_BATCHED_LEFT_TABLES_EVAL", frs_per_Fr);
         manifest_expected.add_entry(round, "SHPLONK_BATCHED_QUOTIENT", frs_per_G);
 
-        // Round 3: KZG masking challenge, then send W commitment
+        // Round 3: KZG:W commitment
         round++;
-        manifest_expected.add_challenge(round, "KZG:masking_challenge");
         manifest_expected.add_entry(round, "KZG:W", frs_per_G);
 
         return manifest_expected;

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_verifier.test.cpp
@@ -57,7 +57,7 @@ class HypernovaDeciderVerifierTests : public ::testing::Test {
      * - Round 48: Gemini FOLD commitments -> Gemini:r challenge
      * - Round 49: Gemini evaluations -> Shplonk:nu challenge
      * - Round 50: Shplonk:Q commitment -> Shplonk:z challenge
-     * - Round 51: KZG:W commitment -> KZG:masking_challenge
+     * - Round 51: KZG:W commitment
      */
     static TranscriptManifest build_expected_decider_manifest()
     {
@@ -88,9 +88,8 @@ class HypernovaDeciderVerifierTests : public ::testing::Test {
         manifest.add_entry(LAST_FOLDING_ROUND + 3, "Shplonk:Q", frs_per_G);
         manifest.add_challenge(LAST_FOLDING_ROUND + 3, "Shplonk:z");
 
-        // Round 51: KZG:W -> KZG:masking_challenge
+        // Round 51: KZG:W
         manifest.add_entry(LAST_FOLDING_ROUND + 4, "KZG:W", frs_per_G);
-        manifest.add_challenge(LAST_FOLDING_ROUND + 4, "KZG:masking_challenge");
 
         return manifest;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -358,8 +358,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     static element batch_mul(const std::vector<element>& points,
                              const std::vector<Fr>& scalars,
                              const size_t max_num_bits = 0,
-                             const bool with_edgecases = false,
-                             const Fr& masking_scalar = Fr(1));
+                             const bool with_edgecases = false);
 
     template <typename X = NativeGroup, typename = typename std::enable_if_t<std::is_same<X, secp256k1::g1>::value>>
     static element secp256k1_ecdsa_mul(const element& pubkey, const Fr& u1, const Fr& u2);
@@ -464,8 +463,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
     static element batch_mul_internal(const std::vector<element>& points,
                                       const std::vector<Fr>& scalars,
                                       const size_t max_num_bits = 0,
-                                      const bool with_edgecases = false,
-                                      const Fr& masking_scalar = Fr(1));
+                                      const bool with_edgecases = false);
 
     /**
      * @brief Compute both add and subtract (a + b, a - b) results simultaneously
@@ -477,14 +475,12 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class element {
      * @brief Mask points for batch multiplication to handle edge cases
      * @param _points The points to be masked
      * @param _scalars The corresponding scalars
-     * @param masking_scalar The masking scalar used to randomise the points
      * @return A pair of vectors containing the masked points and scalars
      *
      * @details Only used internally in biggroup_edgecase_handling.hpp
      */
     static std::pair<std::vector<element>, std::vector<Fr>> mask_points(const std::vector<element>& _points,
-                                                                        const std::vector<Fr>& _scalars,
-                                                                        const Fr& masking_scalar);
+                                                                        const std::vector<Fr>& _scalars);
 
     /**
      * @brief Handle points at infinity in batch operations, replaces (∞, scalar) pairs by (G, 0)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1383,21 +1383,11 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
         }
 
         // If with_edgecases = true, should handle linearly dependent points correctly
-        // Define masking scalar (128 bits)
-        const auto get_128_bit_scalar = []() {
-            uint256_t scalar_u256(0, 0, 0, 0);
-            scalar_u256.data[0] = engine.get_random_uint64();
-            scalar_u256.data[1] = engine.get_random_uint64();
-            fr scalar(scalar_u256);
-            return scalar;
-        };
-        fr masking_scalar = get_128_bit_scalar();
-        scalar_ct masking_scalar_ct = scalar_ct::from_witness(&builder, masking_scalar);
+        // (offset generator is now a free witness sampled inside batch_mul)
         element_ct c = element_ct::batch_mul(points,
                                              scalars,
                                              /*max_num_bits*/ 128,
-                                             /*with_edgecases*/ true,
-                                             /*masking_scalar*/ masking_scalar_ct);
+                                             /*with_edgecases*/ true);
         element input_e = (element(input_P_a) * scalar_a);
         element input_f = (element(input_P_b) * scalar_b);
         element input_g = (element(input_P_c) * scalar_c);
@@ -1511,20 +1501,8 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
             circuit_points.push_back(P);
         }
 
-        // Define masking scalar (128 bits) if with_edgecases is true
-        const auto get_128_bit_scalar = []() {
-            uint256_t scalar_u256(0, 0, 0, 0);
-            scalar_u256.data[0] = engine.get_random_uint64();
-            scalar_u256.data[1] = engine.get_random_uint64();
-            fr scalar(scalar_u256);
-            return scalar;
-        };
-        fr masking_scalar = with_edgecases ? get_128_bit_scalar() : fr(1);
-        scalar_ct masking_scalar_ct =
-            with_edgecases ? scalar_ct::from_witness(&builder, masking_scalar) : scalar_ct(&builder, fr(1));
-
-        element_ct result_point = element_ct::batch_mul(
-            circuit_points, circuit_scalars, /*max_num_bits=*/0, with_edgecases, masking_scalar_ct);
+        element_ct result_point =
+            element_ct::batch_mul(circuit_points, circuit_scalars, /*max_num_bits=*/0, with_edgecases);
 
         element expected_point = g1::one;
         expected_point.self_set_infinity();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_edgecase_handling.hpp
@@ -35,33 +35,32 @@ typename G::affine_element element<C, Fq, Fr, G>::compute_table_offset_generator
  * @brief Given two lists of points that need to be multiplied by scalars, create a new list of length +1 with original
  * points masked, but the same scalar product sum
  *
- * @details Add (δ)G, (2δ)G, (4δ)G etc to the original points and adds a new point (2ⁿ)⋅G and scalar x to the lists.
- * By doubling the point every time, we ensure that no +-1 combination of 6 sequential elements run into edgecases.
- * Since the challenge δ not known to the prover ahead of time, it is not possible to create points that cancel out
- * the offset generators.
+ * @details Add G, 2G, 4G etc to the original points and adds a new point (2ⁿ)⋅G and scalar x to the lists, where G
+ * is a random curve point (free witness) chosen by the prover at proof-generation time. By doubling the point
+ * every time, we ensure that no +-1 combination of 6 sequential elements run into edgecases for an honest prover.
+ *
+ * Security argument: An honest prover samples a uniformly random G, so any ROM table entry is at infinity with
+ * negligible probability. A malicious prover who picks a degenerate G cannot produce a valid proof: the circuit's
+ * algebraic constraints propagate the intermediate values end-to-end, and a wrong intermediate result (from hitting
+ * a special case) would cause the final MSM output to be wrong, failing the verifier's checks.
  */
 template <typename C, class Fq, class Fr, class G>
 std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr, G>::mask_points(
-    const std::vector<element>& _points, const std::vector<Fr>& _scalars, const Fr& masking_scalar)
+    const std::vector<element>& _points, const std::vector<Fr>& _scalars)
 {
     std::vector<element> points;
     std::vector<Fr> scalars;
     BB_ASSERT_EQ(_points.size(), _scalars.size());
 
-    BB_ASSERT_LTE(uint256_t(masking_scalar.get_value()).get_msb() + 1ULL,
-                  128ULL,
-                  "biggroup mask_points: masking_scalar must ≤ 128 bits");
-
-    // Get the offset generator G_offset in native and in-circuit form
-    const typename G::affine_element native_offset_generator = element::compute_table_offset_generator();
+    // Sample a random curve point as the offset generator (free witness).
+    // The prover provides this point: the circuit only constrains it to lie on the curve.
     C* builder = validate_context<C>(validate_context<C>(_points), validate_context<C>(_scalars));
+    const typename G::affine_element native_offset_generator = typename G::affine_element(G::element::random_element());
     const element offset_generator_element = element::from_witness(builder, native_offset_generator);
     auto empty_tag = OriginTag::constant(); // Disable origin checking during intermediate operations
     offset_generator_element.set_origin_tag(empty_tag);
 
-    // Compute initial point to be added: (δ)⋅G_offset
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1585): do we really need to multiply by δ here?
-    element running_point = offset_generator_element.scalar_mul(masking_scalar, 128);
+    element running_point = offset_generator_element;
 
     // Start the running scalar at 1
     Fr running_scalar = Fr(1);
@@ -71,7 +70,7 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
     for (size_t i = 0; i < _points.size(); i++) {
         scalars.push_back(_scalars[i]);
 
-        // Convert point into point + (2ⁱ)⋅(δG_offset)
+        // Convert point into point + (2ⁱ)⋅G_offset
         points.push_back(_points[i].add_internal(running_point));
 
         // Add 2ⁱ⋅scalar_i to the last scalar
@@ -82,7 +81,7 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
         running_point = running_point.dbl_internal();
     }
 
-    // Add a scalar -(<δ(1, 2, 2²,...,2ⁿ⁻¹),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
+    // Add a scalar -(<(1, 2, 2²,...,2ⁿ⁻¹),(scalar₀,...,scalarₙ₋₁)> / 2ⁿ)
     const uint32_t n = static_cast<uint32_t>(_points.size());
     const Fr two_power_n = Fr(2).pow(n);
     const Fr two_power_n_inverse = two_power_n.invert();
@@ -91,7 +90,7 @@ std::pair<std::vector<element<C, Fq, Fr, G>>, std::vector<Fr>> element<C, Fq, Fr
     if constexpr (Fr::is_composite) {
         scalars.back().self_reduce();
     }
-    // Add in-circuit 2ⁿ.(δ.G_offset) to points
+    // Add in-circuit 2ⁿ·G_offset to points
     points.push_back(running_point);
 
     return { points, scalars };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -281,8 +281,7 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
     static goblin_element batch_mul(const std::vector<goblin_element>& points,
                                     const std::vector<Fr>& scalars,
                                     const size_t max_num_bits = 0,
-                                    const bool handle_edge_cases = false,
-                                    const Fr& masking_scalar = Fr(1));
+                                    const bool handle_edge_cases = false);
 
     // we use this data structure to add together a sequence of points.
     // By tracking the previous values of x_1, y_1, \lambda, we can avoid

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin_impl.hpp
@@ -39,8 +39,7 @@ template <typename C, class Fq, class Fr, class G>
 goblin_element<C, Fq, Fr, G> goblin_element<C, Fq, Fr, G>::batch_mul(const std::vector<goblin_element>& points,
                                                                      const std::vector<Fr>& scalars,
                                                                      [[maybe_unused]] const size_t max_num_bits,
-                                                                     [[maybe_unused]] const bool handle_edge_cases,
-                                                                     [[maybe_unused]] const Fr& masking_scalar)
+                                                                     [[maybe_unused]] const bool handle_edge_cases)
 {
     auto builder = validate_context<C>(validate_context<C>(points), validate_context<C>(scalars));
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_impl.hpp
@@ -948,8 +948,7 @@ template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul_internal(const std::vector<element>& _points,
                                                                 const std::vector<Fr>& _scalars,
                                                                 const size_t max_num_bits,
-                                                                const bool with_edgecases,
-                                                                const Fr& masking_scalar)
+                                                                const bool with_edgecases)
 {
     // Sanity check input sizes
     BB_ASSERT_GT(_points.size(), 0ULL, "biggroup batch_mul: no points provided for batch multiplication");
@@ -1001,19 +1000,11 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul_internal(const std::vecto
     points = new_points;
     scalars = new_scalars;
 
-    // If with_edgecases is false, masking_scalar must be constant and equal to 1 (as it is unused).
-    if (!with_edgecases) {
-        BB_ASSERT_EQ(
-            masking_scalar.is_constant() && masking_scalar.get_value() == 1,
-            true,
-            "biggroup batch_mul: masking_scalar must be constant (and equal to 1) when with_edgecases is false");
-    }
-
     if (with_edgecases && !points.empty()) {
-        // If points are linearly dependent, we randomise them using a masking scalar.
+        // If points are linearly dependent, we randomise them using a free-witness offset generator.
         // We do this to ensure that the x-coordinates of the points are all distinct. This is required
         // while creating the ROM lookup table with the points.
-        std::tie(points, scalars) = mask_points(points, scalars, masking_scalar);
+        std::tie(points, scalars) = mask_points(points, scalars);
     }
 
     BB_ASSERT_EQ(
@@ -1115,10 +1106,9 @@ template <typename C, class Fq, class Fr, class G>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::batch_mul(const std::vector<element>& points,
                                                        const std::vector<Fr>& scalars,
                                                        const size_t max_num_bits,
-                                                       const bool with_edgecases,
-                                                       const Fr& masking_scalar)
+                                                       const bool with_edgecases)
 {
-    element result = batch_mul_internal(points, scalars, max_num_bits, with_edgecases, masking_scalar);
+    element result = batch_mul_internal(points, scalars, max_num_bits, with_edgecases);
     return result.get_standard_form();
 }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
@@ -65,7 +65,7 @@ class TranslatorTests : public ::testing::Test {
      * - Round 21: Gemini fold commitments -> Gemini:r
      * - Round 22: Gemini evaluations + Libra evals -> Shplonk:nu
      * - Round 23: Shplonk:Q -> Shplonk:z
-     * - Round 24: KZG:W -> KZG:masking_challenge
+     * - Round 24: KZG:W
      */
     static TranscriptManifest build_expected_translator_manifest()
     {
@@ -158,10 +158,9 @@ class TranslatorTests : public ::testing::Test {
         manifest.add_entry(shplonk_round, "Shplonk:Q", frs_per_G);
         manifest.add_challenge(shplonk_round, "Shplonk:z");
 
-        // KZG:W -> KZG:masking_challenge
+        // KZG:W
         const size_t kzg_round = shplonk_round + 1;
         manifest.add_entry(kzg_round, "KZG:W", frs_per_G);
-        manifest.add_challenge(kzg_round, "KZG:masking_challenge");
 
         return manifest;
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/honk_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/honk_transcript.test.cpp
@@ -189,7 +189,6 @@ template <typename Flavor> class HonkTranscriptTests : public ::testing::Test {
 
         round++;
         manifest_expected.add_entry(round, "KZG:W", data_types_per_G);
-        manifest_expected.add_challenge(round, "KZG:masking_challenge");
 
         return manifest_expected;
     }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -172,9 +172,6 @@ class AvmRecursiveFlavor {
 
             [[maybe_unused]] auto _kzg_w = transcript->template receive_from_prover<StdlibCommitment>("KZG:W");
 
-            [[maybe_unused]] const FF _masking_challenge =
-                transcript->template get_challenge<FF>("KZG:masking_challenge");
-
             return transcript;
         };
 


### PR DESCRIPTION
resolves https://github.com/AztecProtocol/barretenberg/issues/1585

tldr: we make the offset generator a free witness while performing `batch_mul`

### Current Way of Masking Points

While performing `batch_mul` we create ROM tables of linear combinations of the group elements. If we have an MSM of the form $[(s_1, s_2, \dots, s_n), (G_1, G_2, \dots, G_n)]$ then the ROM tables are of the form:

| Index | Element |
| --- | --- |
| 0 | $G_1 + G_2 + \dots + G_5 + G_6$ |
| 1 | $G_1 + G_2 + \dots + G_5 - G_6$ |
| 2 | $G_1 + G_2 + \dots - G_5 - G_6$ |
| $\vdots$ | $\vdots$ | 
| $2^6 - 1$ | $- G_1 - G_2 - \dots - G_5 - G_6$ |

To avoid any entries of the ROM table to be a point at infinity, we add a multiple of an offset generator:

$G'_i := G_i + 2^{i-1}\delta \cdot G\_{\textsf{offset}} \quad \forall i \in [0, 6).$ 

and then we create a ROM table with $(G'_1, G'_2, \dots, G'_6)$. Here, $\delta$ is a verifier-sent challenge so the prover cannot know it beforehand. 

### Proposed Masking of Points

Instead of sampling a challenge $\delta$, we make the offset generator $G\_{\textsf{offset}}$ a free witness in the circuit, so the masked generators become:

$G'_i := G_i + 2^{i-1}\cdot G\_{\textsf{offset}} \quad \forall i \in [0, 6).$

We only constrain $G\_{\textsf{offset}}$ to be a valid point on the curve. This approach should also be safe because if a malicious prover tries to exploit the fact that he can freely choose $G\_{\textsf{offset}}$ the circuit will be unsatisfiable. An honest prover must choose a random point on the curve as $G\_{\textsf{offset}}$. 
