### PR TITLE
chore: web3signer refreshes keystore

### DIFF
--- a/spartan/terraform/modules/web3signer/values/web3signer.yaml
+++ b/spartan/terraform/modules/web3signer/values/web3signer.yaml
@@ -10,7 +10,15 @@ customCommand:
   - /bin/bash
   - -c
   - |
-    /opt/web3signer/bin/web3signer --config-file /data/config.yaml eth1 
+    trap 'kill $(jobs -p) 2>/dev/null' EXIT
+    (
+      sleep 30 # initial delay to let web3signer start
+      while true; do
+        curl -s -X POST http://localhost:9000/reload > /dev/null 2>&1 || true
+        sleep 60
+      done
+    ) &
+    /opt/web3signer/bin/web3signer --config-file /data/config.yaml eth1
 
 extraEnv:
   - name: K8S_NAMESPACE_NAME


### PR DESCRIPTION
When redeploying testnet, validators refused to come up because the attester count was changed and the new keys weren't loaded into web3signer's state even though they keystores were updated.