### PR TITLE
chore(e2e): fix e2e bot L1 tx nonce reuse

### DIFF
--- a/yarn-project/end-to-end/src/e2e_bot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_bot.test.ts
@@ -52,6 +52,9 @@ describe('e2e_bot', () => {
 
   afterAll(() => teardown());
 
+  let privateKeyIndex = 10;
+  const getPrivateKey = () => new SecretValue(bufferToHex(getPrivateKeyFromIndex(privateKeyIndex++)!));
+
   describe('transaction-bot', () => {
     let bot: Bot;
     beforeAll(async () => {
@@ -131,8 +134,7 @@ describe('e2e_bot', () => {
 
         l1RpcUrls,
         feePaymentMethod: 'fee_juice',
-        // TODO: this should be taken from the `setup` call above
-        l1Mnemonic: new SecretValue('test test test test test test test test test test test junk'),
+        l1PrivateKey: getPrivateKey(),
         flushSetupTransactions: true,
         // Increase fee headroom to handle fee volatility from rapid block building in tests.
         // Fees can escalate >10x due to blocks built by earlier tests and bridge operations.
@@ -172,8 +174,7 @@ describe('e2e_bot', () => {
 
         l1RpcUrls,
         feePaymentMethod: 'fee_juice',
-        // TODO: this should be taken from the `setup` call above
-        l1Mnemonic: new SecretValue('test test test test test test test test test test test junk'),
+        l1PrivateKey: getPrivateKey(),
         flushSetupTransactions: true,
         // Increase fee headroom to handle fee volatility from rapid block building in tests.
         // This test is especially susceptible because changing salt triggers a new bridge claim,
@@ -238,7 +239,7 @@ describe('e2e_bot', () => {
         followChain: 'PROPOSED',
         botMode: 'transfer',
         senderPrivateKey: new SecretValue(Fr.random()),
-        l1PrivateKey: new SecretValue(bufferToHex(getPrivateKeyFromIndex(8)!)),
+        l1PrivateKey: getPrivateKey(),
         l1RpcUrls,
         flushSetupTransactions: true,
       };
@@ -261,7 +262,7 @@ describe('e2e_bot', () => {
         followChain: 'PROPOSED',
         botMode: 'crosschain',
         l1RpcUrls,
-        l1PrivateKey: new SecretValue(bufferToHex(getPrivateKeyFromIndex(9)!)),
+        l1PrivateKey: getPrivateKey(),
         flushSetupTransactions: true,
         l1ToL2SeedCount: 2,
       };


### PR DESCRIPTION
Fixes the following error caused by reusing the same L1 private key across multiple bots, without waiting for the txs from the previous bots to be done.

```
13:06:39   ● e2e_bot › bridge resume › does not reuse prior bridge claims if recipient address changes
13:06:39
13:06:39     expect(received).rejects.toThrow(expected)
13:06:39
13:06:39     Expected substring: "test error"
13:06:39     Received message:   "Transaction creation failed.·
13:06:39     URL: http://127.0.0.1:8545
13:06:39     Request body: {\"method\":\"eth_sendRawTransaction\",\"params\":[\"0x02f8b1827a6935843b9aca00843c028b4a82b54194a513e6e4b8f2a923d98304ec87f64353c4d5c85380b844095ea7b3000000000000000000000000846005fdb8e3f125749df47d36b2c826029e536400000000000000000000000000000000000000000000003635c9adc5dea00000c080a019eb199d74619635cc3f88492e1818ae26ece48c5dc102091b03be9a4cbc2df7a0047b03d47e4f034a239c639c6610d472e36a35b01c070f6b9072c1b67df6b9c4\"]}··
13:06:39     Request Arguments:
13:06:39       from:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
13:06:39       to:    0xa513e6e4b8f2a923d98304ec87f64353c4d5c853
13:06:39       data:  0x095ea7b3000000000000000000000000846005fdb8e3f125749df47d36b2c826029e536400000000000000000000000000000000000000000000003635c9adc5dea00000··
13:06:39     Contract Call:
13:06:39       address:   0xa513e6e4b8f2a923d98304ec87f64353c4d5c853
13:06:39       function:  approve(address spender, uint256 value)
13:06:39       args:             (0x846005fdb8e3f125749df47d36b2c826029e5364, 1000000000000000000000)
13:06:39       sender:    0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266·
13:06:39     Docs: https://viem.sh/docs/contract/writeContract
13:06:39     Details: replacement transaction underpriced
13:06:39     Version: viem@2.38.2"
13:06:39
13:06:39           87 |         this.logger.info(`Approving ${amount} tokens for ${stringifyEthAddress(address, addressName)}`);
13:06:39           88 |         await this.extendedClient.waitForTransactionReceipt({
13:06:39         > 89 |             hash: await this.contract.write.approve([
13:06:39              |                   ^
13:06:39           90 |                 address,
13:06:39           91 |                 amount
13:06:39           92 |             ])
13:06:39
13:06:39           at getContractError (../node_modules/viem/utils/errors/getContractError.ts:78:10)
13:06:39           at writeContract.internal (../node_modules/viem/actions/wallet/writeContract.ts:242:13)
13:06:39           at L1TokenManager.approve (../aztec.js/dest/ethereum/portal_manager.js:89:19)
13:06:39           at L1FeeJuicePortalManager.bridgeTokensPublic (../aztec.js/dest/ethereum/portal_manager.js:129:9)
13:06:39           at BotFactory.bridgeL1FeeJuice (../bot/dest/factory.js:450:23)
13:06:39           at BotFactory.getOrCreateBridgeClaim (../bot/dest/factory.js:432:23)
13:06:39           at BotFactory.setupAccountWithPrivateKey (../bot/dest/factory.js:170:27)
13:06:39           at BotFactory.setupAccount (../bot/dest/factory.js:149:20)
13:06:39           at BotFactory.setup (../bot/dest/factory.js:49:39)
13:06:39           at Bot.create (../bot/dest/bot.js:14:61)
13:06:39           at Object.<anonymous> (src/e2e_bot.test.ts:189:9)
```

Fix is to use different L1 private key per test.
