### PR TITLE
feat: use warn_log_format for discarded messages

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -11,7 +11,7 @@ use crate::messages::{
     processing::MessageContext,
 };
 
-use crate::protocol::{address::AztecAddress, logging::{debug_log, debug_log_format}};
+use crate::protocol::{address::AztecAddress, logging::{debug_log, warn_log_format}};
 
 /// Processes a message that can contain notes, partial notes, or events.
 ///
@@ -43,7 +43,7 @@ pub unconstrained fn process_message_ciphertext<ComputeNoteHashAndNullifierEnv, 
             message_context,
         );
     } else {
-        debug_log_format(
+        warn_log_format(
             "Could not decrypt message ciphertext from tx {0}, ignoring",
             [message_context.tx_hash],
         );
@@ -99,7 +99,7 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
         // The message type ID falls in the range reserved for aztec.nr built-in types but wasn't matched above. This
         // most likely means the message is malformed or a custom message was incorrectly assigned a reserved ID.
         // Custom message types must use IDs allocated via `custom_msg_type_id`.
-        debug_log_format(
+        warn_log_format(
             "Message type ID {0} is in the reserved range but is not recognized, ignoring. See https://docs.aztec.network/errors/3",
             [msg_type_id as Field],
         );
@@ -114,7 +114,7 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
     } else {
         // A custom message was received but no handler is configured. This likely means the contract emits custom
         // messages but forgot to register a handler via `AztecConfig::custom_message_handler`.
-        debug_log_format(
+        warn_log_format(
             "Received custom message with type id {0} but no handler is configured, ignoring. See https://docs.aztec.network/errors/2",
             [msg_type_id as Field],
         );


### PR DESCRIPTION
## Summary
- Replace `debug_log_format` with `warn_log_format` for messages that are discarded during processing (undecryptable ciphertext, unrecognized reserved message type IDs, custom messages with no handler configured).
- These are situations users should be aware of, so warn-level logging is more appropriate than debug.

Fixes F-360