### PR TITLE
fix(docs): remove aggressive word-break CSS that splits words mid-syllable

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -538,37 +538,18 @@ html[data-theme="dark"] .sidebar-divider {
    Table Wrapping Styles for Long Content
    ============================================ */
 
-/* Force table layout and wrap long content like addresses */
+/* Allow long content like addresses to wrap in table cells */
 .markdown table {
-  table-layout: fixed;
   width: 100%;
-  word-break: break-word;
 }
 
-/* Allow content in table cells to wrap */
 .markdown td, .markdown th {
-  word-wrap: break-word;
-  word-break: break-all;
   overflow-wrap: break-word;
   white-space: normal;
 }
 
-/* Optional: Adjust column widths for specific tables */
-/* Contract address tables - give more space to address columns */
-.markdown table td:nth-child(n+2),
-.markdown table th:nth-child(n+2) {
-  min-width: 200px;
-}
-
-/* First column (contract names) can be narrower */
-.markdown table td:first-child,
-.markdown table th:first-child {
-  min-width: 150px;
-  max-width: 200px;
-}
-
 /* Make code blocks in tables wrap */
 .markdown table code {
-  word-break: break-all;
+  overflow-wrap: break-word;
   white-space: normal;
 }


### PR DESCRIPTION
## Summary
- Removes `word-break: break-all` from table cells which was breaking words at arbitrary characters (e.g., "to-kens", "sequenc-er", "del-egated")
- Removes `table-layout: fixed` and arbitrary `min-width`/`max-width` column constraints that forced narrow columns
- Keeps `overflow-wrap: break-word` which only breaks words that are genuinely too long (like hex addresses)

## Test plan
- [ ] Verify the governance "Quick Summary for Token Holders" table no longer breaks words mid-syllable
- [ ] Check tables with long content (e.g., contract addresses) still wrap correctly
- [ ] Verify no horizontal overflow on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)