### PR TITLE
feat: prefix aztec-nr contract logs with `[aztec-nr] `

### DIFF
--- a/noir-projects/aztec-nr/CLAUDE.md
+++ b/noir-projects/aztec-nr/CLAUDE.md
@@ -33,3 +33,8 @@ Follow the Rust stdlib style roughly. See `PublicImmutable` in `state_vars/publi
 - **Be precise with terminology.** For example, messages sent onchain are "messages that use logs", not "logs" themselves.
 - **Show practical patterns in examples.** Don't just show the API call — show it in context (e.g. inside a `#[external("public")]` function with realistic variable names).
 - **Document cost for methods.** When relevant, note which AVM opcodes are invoked and how many times (e.g. "`SLOAD` is invoked a number of times equal to `T`'s packed length").
+
+## Logging
+
+- **Always use the prefixed logging functions** from `crate::logging` (e.g. `logging::aztecnr_debug_log!`, `logging::aztecnr_debug_log_format!`). These automatically prepend `[aztec-nr] ` to all messages at compile time.
+- **Never use `crate::protocol::logging` directly** — those functions have no prefix, making logs harder to filter and identify.

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -17,6 +17,7 @@ use crate::{
         nullifiers::notify_created_nullifier,
     },
 };
+use crate::logging::aztecnr_trace_log_format;
 use crate::protocol::{
     abis::{
         block_header::BlockHeader,
@@ -527,7 +528,7 @@ impl PrivateContext {
     /// balance (>= the gas limits specified in the TxContext) by the time we reach the public setup phase of the tx.
     ///
     pub fn set_as_fee_payer(&mut self) {
-        crate::protocol::logging::debug_log_format("Setting {0} as fee payer", [self.this_address().to_field()]);
+        aztecnr_trace_log_format!("Setting {0} as fee payer")([self.this_address().to_field()]);
         self.is_fee_payer = true;
     }
 
@@ -576,10 +577,7 @@ impl PrivateContext {
         // Incrementing the side effect counter when ending setup ensures non ambiguity for the counter where we change
         // phases.
         self.side_effect_counter += 1;
-        // crate::protocol::logging::debug_log_format(
-        //     "Ending setup at counter {0}",
-        //     [self.side_effect_counter as Field]
-        // );
+        aztecnr_trace_log_format!("Ending setup at counter {0}")([self.side_effect_counter as Field]);
         self.min_revertible_side_effect_counter = self.next_counter();
         notify_set_min_revertible_side_effect_counter(self.min_revertible_side_effect_counter);
     }

--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -42,6 +42,7 @@ pub mod capsules;
 pub mod event;
 pub mod messages;
 pub use protocol_types as protocol;
+pub(crate) mod logging;
 pub mod utils;
 pub mod authwit;
 pub mod macros;

--- a/noir-projects/aztec-nr/aztec/src/logging.nr
+++ b/noir-projects/aztec-nr/aztec/src/logging.nr
@@ -1,0 +1,96 @@
+// Not all log levels are currently used, but we provide the full set so that new call sites can use any level. Because
+// of that we tag all with `#[allow(dead_code)]` to prevent warnings.
+
+use std::meta::ctstring::AsCtString;
+
+comptime fn log_prefix<let N: u32>(msg: str<N>) -> CtString {
+    "[aztec-nr] ".as_ctstring().append_str(msg)
+}
+
+// --- No-args variants (direct call) ---
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_fatal_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::fatal_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_error_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::error_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_warn_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::warn_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_info_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::info_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_verbose_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::verbose_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_debug_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::debug_log($msg) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_trace_log<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { crate::protocol::logging::trace_log($msg) }
+}
+
+// --- Format variants (return lambda for runtime args) ---
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_fatal_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::fatal_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_error_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::error_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_warn_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::warn_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_info_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::info_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_verbose_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::verbose_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_debug_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::debug_log_format($msg, args)) }
+}
+
+#[allow(dead_code)]
+pub(crate) comptime fn aztecnr_trace_log_format<let N: u32>(msg: str<N>) -> Quoted {
+    let msg = log_prefix(msg);
+    quote { (|args| crate::protocol::logging::trace_log_format($msg, args)) }
+}

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -1,4 +1,5 @@
-use crate::protocol::{address::AztecAddress, logging::{debug_log, debug_log_format}};
+use crate::logging::{aztecnr_debug_log, aztecnr_debug_log_format};
+use crate::protocol::address::AztecAddress;
 
 pub(crate) mod nonce_discovery;
 pub(crate) mod partial_notes;
@@ -107,16 +108,13 @@ pub unconstrained fn do_sync_state<ComputeNoteHashAndNullifierEnv, CustomMessage
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<ComputeNoteHashAndNullifierEnv>,
     process_custom_message: Option<CustomMessageHandler<CustomMessageHandlerEnv>>,
 ) {
-    debug_log("Performing state synchronization");
+    aztecnr_debug_log!("Performing state synchronization");
 
     // First we process all private logs, which can contain different kinds of messages e.g. private notes, partial
     // notes, private events, etc.
     let logs = get_private_logs(contract_address);
     logs.for_each(|i, pending_tagged_log: PendingTaggedLog| {
-        debug_log_format(
-            "Processing log with tag {0}",
-            [pending_tagged_log.log.get(0)],
-        );
+        aztecnr_debug_log_format!("Processing log with tag {0}")([pending_tagged_log.log.get(0)]);
 
         // We remove the tag from the pending tagged log and process the message ciphertext contained in it.
         let message_ciphertext = array::subbvec(pending_tagged_log.log, 1);

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/nonce_discovery.nr
@@ -1,10 +1,10 @@
 use crate::messages::{discovery::ComputeNoteHashAndNullifier, logs::note::MAX_NOTE_PACKED_LEN};
 
+use crate::logging::aztecnr_debug_log_format;
 use crate::protocol::{
     address::AztecAddress,
     constants::MAX_NOTE_HASHES_PER_TX,
     hash::{compute_note_hash_nonce, compute_siloed_note_hash, compute_unique_note_hash},
-    logging::debug_log_format,
     traits::ToField,
 };
 
@@ -36,8 +36,9 @@ pub(crate) unconstrained fn attempt_note_nonce_discovery<Env>(
 ) -> BoundedVec<DiscoveredNoteInfo, MAX_NOTE_HASHES_PER_TX> {
     let discovered_notes = &mut BoundedVec::new();
 
-    debug_log_format(
+    aztecnr_debug_log_format!(
         "Attempting nonce discovery on {0} potential notes on contract {1} for storage slot {2}",
+    )(
         [unique_note_hashes_in_tx.len() as Field, contract_address.to_field(), storage_slot],
     );
 
@@ -90,10 +91,7 @@ pub(crate) unconstrained fn attempt_note_nonce_discovery<Env>(
         }
     });
 
-    debug_log_format(
-        "Found valid nonces for a total of {0} notes",
-        [discovered_notes.len() as Field],
-    );
+    aztecnr_debug_log_format!("Found valid nonces for a total of {0} notes")([discovered_notes.len() as Field]);
 
     *discovered_notes
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -12,12 +12,8 @@ use crate::{
     utils::array,
 };
 
-use crate::protocol::{
-    address::AztecAddress,
-    hash::sha256_to_field,
-    logging::debug_log_format,
-    traits::{Deserialize, Serialize},
-};
+use crate::logging::aztecnr_debug_log_format;
+use crate::protocol::{address::AztecAddress, hash::sha256_to_field, traits::{Deserialize, Serialize}};
 
 /// The slot in the PXE capsules where we store a `CapsuleArray` of `DeliveredPendingPartialNote`.
 pub(crate) global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sha256_to_field(
@@ -76,10 +72,7 @@ pub(crate) unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
         DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT,
     );
 
-    debug_log_format(
-        "{} pending partial notes",
-        [pending_partial_notes.len() as Field],
-    );
+    aztecnr_debug_log_format!("{} pending partial notes")([pending_partial_notes.len() as Field]);
 
     // Each of the pending partial notes might get completed by a log containing its public values. For performance
     // reasons, we fetch all of these logs concurrently and then process them one by one, minimizing the amount of time
@@ -99,8 +92,7 @@ pub(crate) unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
         let pending_partial_note = pending_partial_notes.get(i);
 
         if maybe_log.is_none() {
-            debug_log_format(
-                "Found no completion logs for partial note with tag {}",
+            aztecnr_debug_log_format!("Found no completion logs for partial note with tag {}")(
                 [pending_partial_note.note_completion_log_tag],
             );
 
@@ -108,10 +100,9 @@ pub(crate) unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
             // searching for this tagged log when performing message discovery in the future until we either find it or
             // the entry is somehow removed from the array.
         } else {
-            debug_log_format(
-                "Completion log found for partial note with tag {}",
-                [pending_partial_note.note_completion_log_tag],
-            );
+            aztecnr_debug_log_format!("Completion log found for partial note with tag {}")([
+                pending_partial_note.note_completion_log_tag,
+            ]);
             let log = maybe_log.unwrap();
 
             // Public fields are assumed to all be placed at the end of the packed representation, so we combine the
@@ -142,10 +133,10 @@ pub(crate) unconstrained fn fetch_and_process_partial_note_completion_logs<Env>(
                 );
             }
 
-            debug_log_format(
-                "Discovered {0} notes for partial note with tag {1}",
-                [discovered_notes.len() as Field, pending_partial_note.note_completion_log_tag],
-            );
+            aztecnr_debug_log_format!("Discovered {0} notes for partial note with tag {1}")([
+                discovered_notes.len() as Field,
+                pending_partial_note.note_completion_log_tag,
+            ]);
 
             discovered_notes.for_each(|discovered_note| {
                 enqueue_note_for_validation(

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_notes.nr
@@ -1,10 +1,11 @@
+use crate::logging::aztecnr_debug_log_format;
 use crate::messages::{
     discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
     encoding::MAX_MESSAGE_CONTENT_LEN,
     logs::note::{decode_private_note_message, MAX_NOTE_PACKED_LEN},
     processing::enqueue_note_for_validation,
 };
-use crate::protocol::{address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX, logging::debug_log_format};
+use crate::protocol::{address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX};
 
 pub(crate) unconstrained fn process_private_note_msg<Env>(
     contract_address: AztecAddress,
@@ -61,10 +62,7 @@ pub unconstrained fn attempt_note_discovery<Env>(
         packed_note,
     );
 
-    debug_log_format(
-        "Discovered {0} notes from a private message",
-        [discovered_notes.len() as Field],
-    );
+    aztecnr_debug_log_format!("Discovered {0} notes from a private message")([discovered_notes.len() as Field]);
 
     discovered_notes.for_each(|discovered_note| {
         enqueue_note_for_validation(

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/process_message.nr
@@ -11,7 +11,8 @@ use crate::messages::{
     processing::MessageContext,
 };
 
-use crate::protocol::{address::AztecAddress, logging::{debug_log, warn_log_format}};
+use crate::logging::{aztecnr_debug_log, aztecnr_warn_log_format};
+use crate::protocol::address::AztecAddress;
 
 /// Processes a message that can contain notes, partial notes, or events.
 ///
@@ -43,10 +44,7 @@ pub unconstrained fn process_message_ciphertext<ComputeNoteHashAndNullifierEnv, 
             message_context,
         );
     } else {
-        warn_log_format(
-            "Could not decrypt message ciphertext from tx {0}, ignoring",
-            [message_context.tx_hash],
-        );
+        aztecnr_warn_log_format!("Could not decrypt message ciphertext from tx {0}, ignoring")([message_context.tx_hash]);
     }
 }
 
@@ -64,7 +62,7 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
     let (msg_type_id, msg_metadata, msg_content) = decode_message(message_plaintext);
 
     if msg_type_id == PRIVATE_NOTE_MSG_TYPE_ID {
-        debug_log("Processing private note msg");
+        aztecnr_debug_log!("Processing private note msg");
 
         process_private_note_msg(
             contract_address,
@@ -77,7 +75,7 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
             msg_content,
         );
     } else if msg_type_id == PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID {
-        debug_log("Processing partial note private msg");
+        aztecnr_debug_log!("Processing partial note private msg");
 
         process_partial_note_private_msg(
             contract_address,
@@ -86,7 +84,7 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
             msg_content,
         );
     } else if msg_type_id == PRIVATE_EVENT_MSG_TYPE_ID {
-        debug_log("Processing private event msg");
+        aztecnr_debug_log!("Processing private event msg");
 
         process_private_event_msg(
             contract_address,
@@ -99,8 +97,9 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
         // The message type ID falls in the range reserved for aztec.nr built-in types but wasn't matched above. This
         // most likely means the message is malformed or a custom message was incorrectly assigned a reserved ID.
         // Custom message types must use IDs allocated via `custom_msg_type_id`.
-        warn_log_format(
+        aztecnr_warn_log_format!(
             "Message type ID {0} is in the reserved range but is not recognized, ignoring. See https://docs.aztec.network/errors/3",
+        )(
             [msg_type_id as Field],
         );
     } else if process_custom_message.is_some() {
@@ -114,8 +113,9 @@ pub(crate) unconstrained fn process_message_plaintext<ComputeNoteHashAndNullifie
     } else {
         // A custom message was received but no handler is configured. This likely means the contract emits custom
         // messages but forgot to register a handler via `AztecConfig::custom_message_handler`.
-        warn_log_format(
+        aztecnr_warn_log_format!(
             "Received custom message with type id {0} but no handler is configured, ignoring. See https://docs.aztec.network/errors/2",
+        )(
             [msg_type_id as Field],
         );
     }


### PR DESCRIPTION
We now prefix all logs that aztecnr emits with `[aztec-nr] `, so that these are identifiable from user messages. It unfortunately requires some comtpime magic but nothing too crazy.

I put these in a new `logging` mod that for now is not made public. In the future we'll likely move `debug_log` and friends there. We'll never use those from aztecnr, they're just for users.