### PR TITLE
fix: identify L2-to-L1 messages by position to handle duplicates

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -710,6 +710,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return (await this.blockSource.getCheckpointedBlocks(from, limit)) ?? [];
   }
 
+  public async getCheckpointedBlocksForEpoch(epoch: EpochNumber) {
+    return this.blockSource.getCheckpointedBlocksForEpoch(epoch);
+  }
+
   /**
    * Method to fetch the current min L2 fees.
    * @returns The current min L2 fees.

--- a/yarn-project/aztec/src/testing/epoch_test_settler.ts
+++ b/yarn-project/aztec/src/testing/epoch_test_settler.ts
@@ -4,7 +4,7 @@ import { type EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import type { Logger } from '@aztec/foundation/log';
 import { EpochMonitor } from '@aztec/prover-node';
 import type { EthAddress, L2BlockSource } from '@aztec/stdlib/block';
-import { computeL2ToL1MembershipWitnessFromMessagesInEpoch } from '@aztec/stdlib/messaging';
+import { computeEpochOutHash } from '@aztec/stdlib/messaging';
 
 export class EpochTestSettler {
   private rollupCheatCodes: RollupCheatCodes;
@@ -51,9 +51,8 @@ export class EpochTestSettler {
       messagesInEpoch[checkpointIndex].push(block.body.txEffects.map(txEffect => txEffect.l2ToL1Msgs));
     }
 
-    const [firstMessage] = messagesInEpoch.flat(3);
-    if (firstMessage) {
-      const { root: outHash } = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, firstMessage);
+    if (messagesInEpoch.flat(3).length > 0) {
+      const outHash = computeEpochOutHash(messagesInEpoch);
       await this.rollupCheatCodes.insertOutbox(epoch, outHash.toBigInt());
     } else {
       this.log.info(`No L2 to L1 messages in epoch ${epoch}`);

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -200,12 +200,6 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     // docs:end:setup-withdrawal
 
     // docs:start:l2-withdraw
-    const l2ToL1Message = await l1PortalManager.getL2ToL1MessageLeaf(
-      withdrawAmount,
-      EthAddress.fromString(ownerEthAddress),
-      l2BridgeContract.address,
-      EthAddress.ZERO,
-    );
     const l2TxReceipt = await l2BridgeContract.methods
       .exit_to_l1_public(EthAddress.fromString(ownerEthAddress), withdrawAmount, EthAddress.ZERO, authwitNonce)
       .send({ from: ownerAztecAddress });
@@ -222,7 +216,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     const block = await node.getBlock(l2TxReceipt.blockNumber!);
     const epoch = await rollup.getEpochNumberForCheckpoint(block!.checkpointNumber);
 
-    const result = await computeL2ToL1MembershipWitness(node, epoch, l2ToL1Message);
+    const result = await computeL2ToL1MembershipWitness(node, epoch, l2TxReceipt.txHash, 0);
     if (!result) {
       throw new Error('L2 to L1 message not found');
     }

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/l2_to_l1.test.ts
@@ -1,6 +1,7 @@
 import { AztecAddress, EthAddress } from '@aztec/aztec.js/addresses';
 import { BatchCall } from '@aztec/aztec.js/contracts';
 import { Fr } from '@aztec/aztec.js/fields';
+import type { TxHash } from '@aztec/aztec.js/tx';
 import type { Wallet } from '@aztec/aztec.js/wallet';
 import { OutboxContract, RollupContract, type ViemL2ToL1Msg } from '@aztec/ethereum/contracts';
 import { EpochNumber } from '@aztec/foundation/branded-types';
@@ -76,9 +77,9 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     expect(l2ToL1Messages).toStrictEqual([computeMessageLeaf(messages[0]), computeMessageLeaf(messages[1])]);
 
     // Consume messages[0].
-    await expectConsumeMessageToSucceed(epoch, messages[0]);
+    await expectConsumeMessageToSucceed(epoch, messages[0], txReceipt.txHash, 0);
     // Consume messages[1].
-    await expectConsumeMessageToSucceed(epoch, messages[1]);
+    await expectConsumeMessageToSucceed(epoch, messages[1], txReceipt.txHash, 1);
   });
 
   // When the block contains a tx with no messages, the zero txOutHash is skipped and won't be included in the top tree.
@@ -106,7 +107,7 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     const epoch = await t.advanceToEpochProven(withMessageReceipt);
 
     // Consume the message.
-    await expectConsumeMessageToSucceed(epoch, message);
+    await expectConsumeMessageToSucceed(epoch, message, withMessageReceipt.txHash, 0);
   });
 
   it('2 txs (balanced), one with 3 messages (unbalanced), one with 4 messages (balanced)', async () => {
@@ -144,20 +145,17 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     // Consume messages in tx0.
     {
       // Consume messages[0], which is in the subtree of height 2.
-      const msg = tx0.messages[0];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx0.messages[0], l2TxReceipt0.txHash, 0);
     }
     {
       // Consume messages[2], which is in the subtree of height 1.
-      const msg = tx0.messages[2];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx0.messages[2], l2TxReceipt0.txHash, 2);
     }
 
     // Consume messages in tx1.
     {
-      // Consume messages[2], which is in the subtree of height 2.
-      const msg = tx1.messages[0];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      // Consume messages[0], which is in the subtree of height 2.
+      await expectConsumeMessageToSucceed(epoch, tx1.messages[0], l2TxReceipt1.txHash, 0);
     }
   });
 
@@ -190,27 +188,23 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     // Consume messages in tx0.
     {
       // Consume messages[0], which is in the subtree of height 2.
-      const msg = tx0.messages[0];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx0.messages[0], l2TxReceipt0.txHash, 0);
     }
     {
       // Consume messages[2], which is in the subtree of height 1.
-      const msg = tx0.messages[2];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx0.messages[2], l2TxReceipt0.txHash, 2);
     }
 
     // Consume messages in tx1.
     {
       // Consume messages[0], which is the tx subtree root.
-      const msg = tx1.messages[0];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx1.messages[0], l2TxReceipt1.txHash, 0);
     }
 
     // Consume messages in tx2.
     {
       // Consume messages[1], which is in the subtree of height 1.
-      const msg = tx2.messages[1];
-      await expectConsumeMessageToSucceed(epoch, msg);
+      await expectConsumeMessageToSucceed(epoch, tx2.messages[1], l2TxReceipt2.txHash, 1);
     }
   });
 
@@ -252,12 +246,17 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     return { recipients, contents, messages };
   }
 
-  async function expectConsumeMessageToSucceed(epoch: EpochNumber, msg: ReturnType<typeof makeL2ToL1Message>) {
+  async function expectConsumeMessageToSucceed(
+    epoch: EpochNumber,
+    msg: ReturnType<typeof makeL2ToL1Message>,
+    txHash: TxHash,
+    messageIndexInTx: number,
+  ) {
     const msgLeaf = computeMessageLeaf(msg);
-    const witness = (await computeL2ToL1MembershipWitness(aztecNode, epoch, msgLeaf))!;
+    const witness = (await computeL2ToL1MembershipWitness(aztecNode, epoch, txHash, messageIndexInTx))!;
     const leafId = getL2ToL1MessageLeafId(witness);
 
-    const txHash = await outbox.consume(
+    const l1TxHash = await outbox.consume(
       msg,
       epoch,
       witness.leafIndex,
@@ -265,7 +264,7 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
     );
 
     const l1Receipt = await t.deployL1ContractsValues.l1Client.waitForTransactionReceipt({
-      hash: txHash,
+      hash: l1TxHash,
     });
 
     // Consume call goes through.
@@ -301,12 +300,8 @@ describe('e2e_cross_chain_messaging l2_to_l1', () => {
   async function expectConsumeMessageToFail(
     epoch: EpochNumber,
     msg: ReturnType<typeof makeL2ToL1Message>,
-    witness?: L2ToL1MembershipWitness,
+    witness: L2ToL1MembershipWitness,
   ) {
-    if (!witness) {
-      const msgLeaf = computeMessageLeaf(msg);
-      witness = (await computeL2ToL1MembershipWitness(aztecNode, epoch, msgLeaf))!;
-    }
     await expect(
       outbox.consume(
         msg,

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
@@ -64,7 +64,6 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     });
 
     // 5. Withdraw owner's funds from L2 to L1
-    const l2ToL1Message = await crossChainTestHarness.getL2ToL1MessageLeaf(withdrawAmount);
     const l2TxReceipt = await crossChainTestHarness.withdrawPrivateFromAztecToL1(
       withdrawAmount,
       authwitNonce,
@@ -75,7 +74,7 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     const epoch = await t.advanceToEpochProven(l2TxReceipt);
 
-    const l2ToL1MessageResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, l2ToL1Message);
+    const l2ToL1MessageResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, l2TxReceipt.txHash, 0);
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
@@ -1,4 +1,3 @@
-import { Fr } from '@aztec/aztec.js/fields';
 import { computeL2ToL1MembershipWitness } from '@aztec/stdlib/messaging';
 
 import { NO_L1_TO_L2_MSG_ERROR } from '../fixtures/fixtures.js';
@@ -75,14 +74,13 @@ describe('e2e_cross_chain_messaging token_bridge_public', () => {
 
     // 5. Withdraw owner's funds from L2 to L1
     logger.verbose('5. Withdraw owner funds from L2 to L1');
-    const l2ToL1Message = await crossChainTestHarness.getL2ToL1MessageLeaf(withdrawAmount);
     const l2TxReceipt = await crossChainTestHarness.withdrawPublicFromAztecToL1(withdrawAmount, authwitNonce);
     await crossChainTestHarness.expectPublicBalanceOnL2(ownerAddress, afterBalance - withdrawAmount);
 
     // Advance the epoch until the tx is proven since the messages are inserted to the outbox when the epoch is proven.
     const epoch = await t.advanceToEpochProven(l2TxReceipt);
 
-    const l2ToL1MessageResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, l2ToL1Message);
+    const l2ToL1MessageResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, l2TxReceipt.txHash, 0);
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -351,7 +351,7 @@ describe('e2e_p2p_add_rollup', () => {
         const block = await node.getBlock(l2OutgoingReceipt.blockNumber!);
         const epoch = await rollup.getEpochNumberForCheckpoint(block!.checkpointNumber);
 
-        const l2ToL1MessageResult = (await computeL2ToL1MembershipWitness(node, epoch, leaf))!;
+        const l2ToL1MessageResult = (await computeL2ToL1MembershipWitness(node, epoch, l2OutgoingReceipt.txHash, 0))!;
         const leafId = getL2ToL1MessageLeafId(l2ToL1MessageResult);
 
         // We need to advance to the next epoch so that the out hash will be set to outbox when the epoch is proven.

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -260,8 +260,22 @@ export const uniswapL1L2TestSuite = (
       const daiL1BalanceOfPortalBeforeSwap = await daiCrossChainHarness.getL1BalanceOf(
         daiCrossChainHarness.tokenPortalAddress,
       );
-      const swapResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, swapPrivateLeaf);
-      const withdrawResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, withdrawLeaf);
+      // Resolve per-tx message indices so we can use the txHash-based lookup.
+      const uniswapTxEffect = (await aztecNode.getTxEffect(l2UniswapInteractionReceipt.txHash))!;
+      const swapPrivateIndex = uniswapTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(swapPrivateLeaf));
+      const withdrawIndex = uniswapTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(withdrawLeaf));
+      const swapResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        l2UniswapInteractionReceipt.txHash,
+        swapPrivateIndex,
+      );
+      const withdrawResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        l2UniswapInteractionReceipt.txHash,
+        withdrawIndex,
+      );
 
       const swapPrivateL2MessageIndex = swapResult!.leafIndex;
       const swapPrivateSiblingPath = swapResult!.siblingPath;
@@ -840,8 +854,22 @@ export const uniswapL1L2TestSuite = (
 
       const block = await aztecNode.getBlock(withdrawReceipt.blockNumber!);
       const epoch = await rollup.getEpochNumberForCheckpoint(block!.checkpointNumber);
-      const swapResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, swapPrivateLeaf);
-      const withdrawResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, withdrawLeaf);
+      // Resolve per-tx message indices so we can use the txHash-based lookup.
+      const withdrawTxEffect = (await aztecNode.getTxEffect(withdrawReceipt.txHash))!;
+      const swapPrivateIndex2 = withdrawTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(swapPrivateLeaf));
+      const withdrawIndex2 = withdrawTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(withdrawLeaf));
+      const swapResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        withdrawReceipt.txHash,
+        swapPrivateIndex2,
+      );
+      const withdrawResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        withdrawReceipt.txHash,
+        withdrawIndex2,
+      );
 
       const swapPrivateL2MessageIndex = swapResult!.leafIndex;
       const swapPrivateSiblingPath = swapResult!.siblingPath;
@@ -973,8 +1001,22 @@ export const uniswapL1L2TestSuite = (
 
       const block = await aztecNode.getBlock(withdrawReceipt.blockNumber!);
       const epoch = await rollup.getEpochNumberForCheckpoint(block!.checkpointNumber);
-      const swapResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, swapPublicLeaf);
-      const withdrawResult = await computeL2ToL1MembershipWitness(aztecNode, epoch, withdrawLeaf);
+      // Resolve per-tx message indices so we can use the txHash-based lookup.
+      const swapPublicTxEffect = (await aztecNode.getTxEffect(withdrawReceipt.txHash))!;
+      const swapPublicIndex = swapPublicTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(swapPublicLeaf));
+      const withdrawIndex3 = swapPublicTxEffect.data.l2ToL1Msgs.findIndex(m => m.equals(withdrawLeaf));
+      const swapResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        withdrawReceipt.txHash,
+        swapPublicIndex,
+      );
+      const withdrawResult = await computeL2ToL1MembershipWitness(
+        aztecNode,
+        epoch,
+        withdrawReceipt.txHash,
+        withdrawIndex3,
+      );
 
       const swapPublicL2MessageIndex = swapResult!.leafIndex;
       const swapPublicSiblingPath = swapResult!.siblingPath;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_rollup_structure.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_rollup_structure.test.ts
@@ -7,7 +7,7 @@ import { Fr } from '@aztec/foundation/curves/bn254';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
-import { ScopedL2ToL1Message, computeL2ToL1MembershipWitnessFromMessagesInEpoch } from '@aztec/stdlib/messaging';
+import { ScopedL2ToL1Message, computeEpochOutHash } from '@aztec/stdlib/messaging';
 import { FeeRecipient } from '@aztec/stdlib/rollup';
 import type { ServerCircuitName } from '@aztec/stdlib/stats';
 import { makeScopedL2ToL1Message } from '@aztec/stdlib/testing';
@@ -150,11 +150,7 @@ describe('prover/orchestrator/rollup-structure', () => {
       const epochEndArchive = await getTreeSnapshot(MerkleTreeId.ARCHIVE, await context.worldState.fork());
       expect(result.publicInputs.endArchiveRoot).toEqual(epochEndArchive.root);
 
-      const firstMessage = l1ToL2MessagesInEpoch.flat(4)[0];
-      const { root: epochOutHash } = computeL2ToL1MembershipWitnessFromMessagesInEpoch(
-        l1ToL2MessagesInEpoch,
-        firstMessage,
-      );
+      const epochOutHash = computeEpochOutHash(l1ToL2MessagesInEpoch);
       expect(result.publicInputs.outHash).toEqual(epochOutHash);
 
       const expectedCheckpointHeaderHashes = checkpoints.map(c => c.header.hash());

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -249,6 +249,11 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toEqual([]);
   });
 
+  it('getCheckpointedBlocksForEpoch', async () => {
+    const response = await context.client.getCheckpointedBlocksForEpoch(EpochNumber(1));
+    expect(response).toEqual([]);
+  });
+
   it('getNodeVersion', async () => {
     const response = await context.client.getNodeVersion();
     expect(response).toBe('1.0.0');
@@ -529,6 +534,10 @@ class MockAztecNode implements AztecNode {
   }
 
   getCheckpointedBlocks(_from: BlockNumber, _limit: number) {
+    return Promise.resolve([]);
+  }
+
+  getCheckpointedBlocksForEpoch(_epoch: EpochNumber) {
     return Promise.resolve([]);
   }
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -192,6 +192,13 @@ export interface AztecNode
   getL2ToL1Messages(epoch: EpochNumber): Promise<Fr[][][][]>;
 
   /**
+   * Returns all checkpointed blocks for a given epoch, ordered by slot then ascending block number.
+   * @param epoch - The epoch number.
+   * @returns The checkpointed blocks in the epoch.
+   */
+  getCheckpointedBlocksForEpoch(epoch: EpochNumber): Promise<CheckpointedL2Block[]>;
+
+  /**
    * Get a block specified by its block number or 'latest'.
    * @param blockParameter - The block parameter (block number, block hash, or 'latest').
    * @returns The requested block.
@@ -556,6 +563,8 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
     .function()
     .args(BlockNumberPositiveSchema, z.number().gt(0).lte(MAX_RPC_BLOCKS_LEN))
     .returns(z.array(CheckpointedL2Block.schema)),
+
+  getCheckpointedBlocksForEpoch: z.function().args(EpochNumberSchema).returns(z.array(CheckpointedL2Block.schema)),
 
   getCurrentMinFees: z.function().returns(GasFees.schema),
 

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_membership.test.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_membership.test.ts
@@ -37,22 +37,30 @@ describe('L2 to L1 membership', () => {
 
   const verifyMembershipForMessagesInEpoch = (messagesInEpoch: Fr[][][][]): L2ToL1MembershipWitness[] => {
     let root = Fr.ZERO;
-    const messages = messagesInEpoch.flat(3);
-    const witnesses = messages.map((msg, i) => {
-      const witness = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, msg);
-      const leafId = getL2ToL1MessageLeafId(witness);
-      expect(foundLeafIds.has(leafId)).toBe(false);
-      foundLeafIds.add(leafId);
-      verifyMembership(msg, witness);
+    const witnesses: L2ToL1MembershipWitness[] = [];
 
-      if (i === 0) {
-        root = witness.root;
-      } else {
-        expect(witness.root).toEqual(root);
+    for (let ci = 0; ci < messagesInEpoch.length; ci++) {
+      for (let bi = 0; bi < messagesInEpoch[ci].length; bi++) {
+        for (let ti = 0; ti < messagesInEpoch[ci][bi].length; ti++) {
+          for (let mi = 0; mi < messagesInEpoch[ci][bi][ti].length; mi++) {
+            const msg = messagesInEpoch[ci][bi][ti][mi];
+            const witness = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, ci, bi, ti, mi);
+            const leafId = getL2ToL1MessageLeafId(witness);
+            expect(foundLeafIds.has(leafId)).toBe(false);
+            foundLeafIds.add(leafId);
+            verifyMembership(msg, witness);
+
+            if (witnesses.length === 0) {
+              root = witness.root;
+            } else {
+              expect(witness.root).toEqual(root);
+            }
+
+            witnesses.push(witness);
+          }
+        }
       }
-
-      return witness;
-    });
+    }
 
     const computedRoot = computeEpochOutHash(messagesInEpoch);
     expect(root).toEqual(computedRoot);
@@ -65,12 +73,15 @@ describe('L2 to L1 membership', () => {
   });
 
   describe('one block in one checkpoint in the epoch', () => {
-    it('throws if the message is not found', () => {
-      const messagesInEpoch = [[[msgHashes(3), msgHashes(1)]]];
-      const targetMsg = Fr.random();
-      expect(() => computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, targetMsg)).toThrow(
-        'The L2ToL1Message you are trying to prove inclusion of does not exist',
-      );
+    it('correctly finds a message when duplicates exist', () => {
+      // Both txs emit the same message value. With value-based search this would always return the first,
+      // but coordinate-based search correctly finds each one at its own position.
+      const duplicateMsg = Fr.random();
+      const messagesInEpoch = [[[msgHashes(1).concat([duplicateMsg]), [duplicateMsg]]]];
+      const witness0 = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, 0, 0, 0, 1);
+      const witness1 = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, 0, 0, 1, 0);
+      // Both witnesses prove the same message leaf but have different positions.
+      expect(getL2ToL1MessageLeafId(witness0)).not.toBe(getL2ToL1MessageLeafId(witness1));
     });
 
     it('a single tx with 1 message', () => {
@@ -802,7 +813,8 @@ describe('L2 to L1 membership', () => {
         [[[], []]],
         [[[], []], [[]], [[], [], []], [[], []]],
       ];
-      const witness = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, msg);
+      // msg is in checkpoint 2, block 2 (first two blocks are empty), tx 0, message 0.
+      const witness = computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, 2, 2, 0, 0);
       expect(witness.leafIndex).toBe(2n); // The message is the root of the second checkpoint.
       expect(witness.siblingPath.pathSize).toBe(epochTopTreeDepth);
     });

--- a/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
+++ b/yarn-project/stdlib/src/messaging/l2_to_l1_membership.ts
@@ -1,7 +1,11 @@
 import { OUT_HASH_TREE_LEAF_COUNT } from '@aztec/constants';
-import type { EpochNumber } from '@aztec/foundation/branded-types';
+import type { EpochNumber, SlotNumber } from '@aztec/foundation/branded-types';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { SiblingPath, UnbalancedMerkleTreeCalculator, computeUnbalancedShaRoot } from '@aztec/foundation/trees';
+
+import type { CheckpointedL2Block } from '../block/checkpointed_l2_block.js';
+import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
+import type { TxHash } from '../tx/tx_hash.js';
 
 /**
  * # L2-to-L1 Message Tree Structure and Leaf IDs
@@ -92,8 +96,12 @@ export function getL2ToL1MessageLeafId(
   return 2n ** BigInt(membershipWitness.siblingPath.pathSize) + membershipWitness.leafIndex;
 }
 
+/** Interface for looking up L2-to-L1 messages by transaction hash. */
 export interface MessageRetrieval {
-  getL2ToL1Messages(epoch: EpochNumber): Promise<Fr[][][][]>;
+  /** Returns the indexed tx effect for the given tx hash (block number, tx index in block, and tx data). */
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
+  /** Returns all checkpointed blocks for the given epoch, ordered by slot then ascending block number. */
+  getCheckpointedBlocksForEpoch(epoch: EpochNumber): Promise<CheckpointedL2Block[]>;
 }
 
 export type L2ToL1MembershipWitness = {
@@ -102,46 +110,94 @@ export type L2ToL1MembershipWitness = {
   siblingPath: SiblingPath<number>;
 };
 
+/**
+ * Computes the L2-to-L1 message membership witness for a specific message in a transaction.
+ *
+ * Uniquely identifies the message by its transaction hash and its index within that transaction,
+ * which correctly handles the case where multiple messages in an epoch share the same value.
+ *
+ * @param messageRetriever - Source for tx effects and checkpointed blocks.
+ * @param epoch - The epoch in which the message was emitted.
+ * @param txHash - The hash of the transaction that emitted the message.
+ * @param messageIndexInTx - The index of the message within the transaction's L2-to-L1 message array.
+ * @returns The membership witness, or undefined if the tx or epoch is not found.
+ */
 export async function computeL2ToL1MembershipWitness(
   messageRetriever: MessageRetrieval,
   epoch: EpochNumber,
-  message: Fr,
+  txHash: TxHash,
+  messageIndexInTx: number,
 ): Promise<L2ToL1MembershipWitness | undefined> {
-  const messagesInEpoch = await messageRetriever.getL2ToL1Messages(epoch);
-  if (messagesInEpoch.length === 0) {
+  const txEffect = await messageRetriever.getTxEffect(txHash);
+  if (!txEffect) {
     return undefined;
   }
 
-  return computeL2ToL1MembershipWitnessFromMessagesInEpoch(messagesInEpoch, message);
-}
+  const { l2BlockNumber, txIndexInBlock } = txEffect;
+  const l2ToL1Msgs = txEffect.data.l2ToL1Msgs;
 
-// TODO: Allow to specify the message to consume by its index or by an offset, in case there are multiple messages with
-// the same value.
-export function computeL2ToL1MembershipWitnessFromMessagesInEpoch(
-  messagesInEpoch: Fr[][][][],
-  message: Fr,
-): L2ToL1MembershipWitness {
-  // Find the index of the message in the tx, index of the tx in the block, and index of the block in the epoch.
-  let messageIndexInTx = -1;
-  let txIndex = -1;
-  let blockIndex = -1;
-  const checkpointIndex = messagesInEpoch.findIndex(messagesInCheckpoint => {
-    blockIndex = messagesInCheckpoint.findIndex(messagesInBlock => {
-      txIndex = messagesInBlock.findIndex(messagesInTx => {
-        messageIndexInTx = messagesInTx.findIndex(msg => msg.equals(message));
-        return messageIndexInTx !== -1;
-      });
-      return txIndex !== -1;
-    });
-    return blockIndex !== -1;
-  });
-
-  if (checkpointIndex === -1) {
-    throw new Error('The L2ToL1Message you are trying to prove inclusion of does not exist');
+  if (messageIndexInTx >= l2ToL1Msgs.length) {
+    throw new Error(
+      `Message index ${messageIndexInTx} is out of bounds: tx has ${l2ToL1Msgs.length} L2-to-L1 messages`,
+    );
   }
 
-  // Build the tx tree.
+  // Get all checkpointed blocks for this epoch, ordered by slot then block number.
+  const checkpointedBlocks = await messageRetriever.getCheckpointedBlocksForEpoch(epoch);
+  if (checkpointedBlocks.length === 0) {
+    return undefined;
+  }
+
+  // Group blocks by slot (same slot = same checkpoint), matching the tree structure in getL2ToL1Messages.
+  const checkpoints = groupCheckpointedBlocksBySlot(checkpointedBlocks);
+
+  // Build the 4D messages array while finding the exact position of our block.
+  let checkpointIndex = -1;
+  let blockIndex = -1;
+
+  const messagesInEpoch: Fr[][][][] = checkpoints.map((checkpointBlocks, ci) =>
+    checkpointBlocks.map((checkpointedBlock, bi) => {
+      if (checkpointedBlock.block.number === l2BlockNumber) {
+        checkpointIndex = ci;
+        blockIndex = bi;
+      }
+      return checkpointedBlock.block.body.txEffects.map(tx => tx.l2ToL1Msgs);
+    }),
+  );
+
+  if (checkpointIndex === -1) {
+    // The tx's block was not found among the epoch's checkpointed blocks.
+    return undefined;
+  }
+
+  return computeL2ToL1MembershipWitnessFromMessagesInEpoch(
+    messagesInEpoch,
+    checkpointIndex,
+    blockIndex,
+    txIndexInBlock,
+    messageIndexInTx,
+  );
+}
+
+/**
+ * Computes the L2-to-L1 membership witness given the full epoch message structure and the exact
+ * coordinates of the target message within that structure.
+ *
+ * @param messagesInEpoch - 4D array of messages organized as [checkpoint][block][tx][message].
+ * @param checkpointIndex - Index of the checkpoint within the epoch.
+ * @param blockIndex - Index of the block within the checkpoint.
+ * @param txIndex - Index of the transaction within the block.
+ * @param messageIndexInTx - Index of the message within the transaction.
+ */
+export function computeL2ToL1MembershipWitnessFromMessagesInEpoch(
+  messagesInEpoch: Fr[][][][],
+  checkpointIndex: number,
+  blockIndex: number,
+  txIndex: number,
+  messageIndexInTx: number,
+): L2ToL1MembershipWitness {
   const messagesInTx = messagesInEpoch[checkpointIndex][blockIndex][txIndex];
+  // Build the tx tree.
   const txTree = UnbalancedMerkleTreeCalculator.create(messagesInTx.map(msg => msg.toBuffer()));
   // Get the sibling path of the target message in the tx tree.
   const pathToMessageInTxSubtree = txTree.getSiblingPathByLeafIndex(messageIndexInTx);
@@ -205,6 +261,25 @@ export function computeL2ToL1MembershipWitnessFromMessagesInEpoch(
     leafIndex: BigInt(combinedIndex),
     siblingPath: new SiblingPath(combinedPath.length, combinedPath),
   };
+}
+
+/**
+ * Groups an ordered list of checkpointed blocks into per-checkpoint arrays.
+ * Blocks that share the same slot number belong to the same checkpoint.
+ * Assumes the input is already ordered by ascending block number (and therefore slot number).
+ */
+function groupCheckpointedBlocksBySlot(checkpointedBlocks: CheckpointedL2Block[]): CheckpointedL2Block[][] {
+  const checkpoints: CheckpointedL2Block[][] = [];
+  let previousSlotNumber: SlotNumber | undefined = undefined;
+  for (const checkpointedBlock of checkpointedBlocks) {
+    const slotNumber = checkpointedBlock.block.header.globalVariables.slotNumber;
+    if (slotNumber !== previousSlotNumber) {
+      checkpoints.push([]);
+      previousSlotNumber = slotNumber;
+    }
+    checkpoints[checkpoints.length - 1].push(checkpointedBlock);
+  }
+  return checkpoints;
 }
 
 function buildCheckpointTree(messagesInCheckpoint: Fr[][][]) {


### PR DESCRIPTION
## Summary

- Fixes the long-standing TODO in `computeL2ToL1MembershipWitnessFromMessagesInEpoch` where value-based search always returned the first occurrence of a duplicate message
- Replaces `computeL2ToL1MembershipWitness(retriever, epoch, message: Fr)` with `computeL2ToL1MembershipWitness(retriever, epoch, txHash, messageIndexInTx)` — uniquely identifies any message including duplicates
- Adds `getCheckpointedBlocksForEpoch` to the `AztecNode` interface and exposes it via RPC
- Extracts `groupCheckpointedBlocksBySlot` helper to avoid duplicating the slot-grouping logic
- Updates all callers (e2e tests, prover tests, testing utilities)

## Test plan

- Unit test added: `'correctly finds a message when duplicates exist'` in `l2_to_l1_membership.test.ts` — verifies that two txs emitting the same message value get distinct leaf IDs
- Existing unit tests updated to use coordinate-based iteration (same coverage, no value-based search)
- E2e tests updated: `l2_to_l1`, `token_bridge_private`, `token_bridge_public`, `uniswap_l1_l2`, `add_rollup`, tutorial test
- TypeScript type-check (`tsgo --noEmit`) passes with zero errors in changed files

Closes #<!-- issue number if known -->