### PR TITLE
chore: better parallelisation of translator wire instantiation 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.fuzzer.cpp
@@ -14,7 +14,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
 {
     // Parse the queue and challenges
-    // FS, so we have to do that, too
     auto parsing_result = parse_and_construct_opqueue(data, size);
     if (!parsing_result.has_value()) {
         return 0;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.fuzzer.cpp
@@ -14,7 +14,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
 {
     // Parse the queue and challenges
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/869): composer generates the initial challenge through
     // FS, so we have to do that, too
     auto parsing_result = parse_and_construct_opqueue(data, size);
     if (!parsing_result.has_value()) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -54,20 +54,18 @@ class TranslatorProvingKey {
 
         proving_key = std::make_shared<ProvingKey>();
         auto wires = proving_key->polynomials.get_wires();
-        for (auto [wire_poly_, wire_] : zip_view(wires, circuit.wires)) {
-            auto& wire_poly = wire_poly_;
-            const auto& wire = wire_;
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1383)
-            parallel_for_range(circuit.num_gates(), [&](size_t start, size_t end) {
-                for (size_t i = start; i < end; i++) {
-                    if (i >= wire_poly.start_index() && i < wire_poly.end_index()) {
-                        wire_poly.at(i) = circuit.get_variable(wire[i]);
-                    } else {
-                        BB_ASSERT_EQ(circuit.get_variable(wire[i]), 0);
-                    }
+        // Distribute wires across threads (one task per wire) rather than multithreading within each wire.
+        parallel_for(wires.size(), [&](size_t wire_idx) {
+            auto& wire_poly = wires[wire_idx];
+            const auto& wire = circuit.wires[wire_idx];
+            for (size_t i = 0; i < circuit.num_gates(); i++) {
+                if (i >= wire_poly.start_index() && i < wire_poly.end_index()) {
+                    wire_poly.at(i) = circuit.get_variable(wire[i]);
+                } else {
+                    BB_ASSERT_EQ(circuit.get_variable(wire[i]), 0);
                 }
-            });
-        }
+            }
+        });
 
         // Iterate over all circuit wire polynomials, except the ones representing the op queue, and add random values
         // at the end.

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -10,7 +10,6 @@
 #include "barretenberg/common/assert.hpp"
 #include "barretenberg/translator_vm/translator_flavor.hpp"
 namespace bb {
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1317)
 class TranslatorProvingKey {
   public:
     using Flavor = TranslatorFlavor;


### PR DESCRIPTION
resolves https://github.com/AztecProtocol/barretenberg/issues/1383

While filling the wire polynomials in translator, we currently process wires sequentially (and parallelise filling an individual wire). However, since there's only $2^{13}$ values to be filled, it didn't make sense to parallelise for a given wire.

Instead, we parallelise across wires: thread $i$ will process wire $i$. This makes the proving key construction faster by ~30% (but overall translator proving only improves by a mere ~2% because proving key construction forms a small part of total proving.)