### PR TITLE
feat: improve oracle name prefixes

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -538,38 +538,38 @@ fn handle_foreign_call(
     inputs: &[ValueOrArray],
 ) {
     match function {
-        "avmOpcodeCall" => handle_external_call(avm_instrs, destinations, inputs, AvmOpcode::CALL),
-        "avmOpcodeStaticCall" => {
+        "aztec_avm_call" => handle_external_call(avm_instrs, destinations, inputs, AvmOpcode::CALL),
+        "aztec_avm_staticCall" => {
             handle_external_call(avm_instrs, destinations, inputs, AvmOpcode::STATICCALL);
         }
-        "avmOpcodeEmitPublicLog" => {
+        "aztec_avm_emitPublicLog" => {
             handle_emit_public_log(avm_instrs, destinations, inputs);
         }
-        "avmOpcodeNoteHashExists" => handle_note_hash_exists(avm_instrs, destinations, inputs),
-        "avmOpcodeEmitNoteHash" | "avmOpcodeEmitNullifier" => handle_emit_note_hash_or_nullifier(
-            function == "avmOpcodeEmitNullifier",
+        "aztec_avm_noteHashExists" => handle_note_hash_exists(avm_instrs, destinations, inputs),
+        "aztec_avm_emitNoteHash" | "aztec_avm_emitNullifier" => handle_emit_note_hash_or_nullifier(
+            function == "aztec_avm_emitNullifier",
             avm_instrs,
             destinations,
             inputs,
         ),
-        "avmOpcodeNullifierExists" => handle_nullifier_exists(avm_instrs, destinations, inputs),
-        "avmOpcodeL1ToL2MsgExists" => handle_l1_to_l2_msg_exists(avm_instrs, destinations, inputs),
-        "avmOpcodeSendL2ToL1Msg" => handle_send_l2_to_l1_msg(avm_instrs, destinations, inputs),
-        "avmOpcodeCalldataCopy" => handle_calldata_copy(avm_instrs, destinations, inputs),
-        "avmOpcodeSuccessCopy" => handle_success_copy(avm_instrs, destinations, inputs),
-        "avmOpcodeReturndataSize" => handle_returndata_size(avm_instrs, destinations, inputs),
-        "avmOpcodeReturndataCopy" => handle_returndata_copy(avm_instrs, destinations, inputs),
-        "avmOpcodeReturn" => handle_return(avm_instrs, destinations, inputs),
-        "avmOpcodeRevert" => handle_revert(avm_instrs, destinations, inputs),
-        "avmOpcodeStorageRead" => handle_storage_read(avm_instrs, destinations, inputs),
-        "avmOpcodeStorageWrite" => handle_storage_write(avm_instrs, destinations, inputs),
-        "utilityLog" => handle_debug_log(avm_instrs, destinations, inputs),
+        "aztec_avm_nullifierExists" => handle_nullifier_exists(avm_instrs, destinations, inputs),
+        "aztec_avm_l1ToL2MsgExists" => handle_l1_to_l2_msg_exists(avm_instrs, destinations, inputs),
+        "aztec_avm_sendL2ToL1Msg" => handle_send_l2_to_l1_msg(avm_instrs, destinations, inputs),
+        "aztec_avm_calldataCopy" => handle_calldata_copy(avm_instrs, destinations, inputs),
+        "aztec_avm_successCopy" => handle_success_copy(avm_instrs, destinations, inputs),
+        "aztec_avm_returndataSize" => handle_returndata_size(avm_instrs, destinations, inputs),
+        "aztec_avm_returndataCopy" => handle_returndata_copy(avm_instrs, destinations, inputs),
+        "aztec_avm_return" => handle_return(avm_instrs, destinations, inputs),
+        "aztec_avm_revert" => handle_revert(avm_instrs, destinations, inputs),
+        "aztec_avm_storageRead" => handle_storage_read(avm_instrs, destinations, inputs),
+        "aztec_avm_storageWrite" => handle_storage_write(avm_instrs, destinations, inputs),
+        "aztec_utl_log" => handle_debug_log(avm_instrs, destinations, inputs),
         // Getters.
         _ if inputs.is_empty() && destinations.len() == 1 => {
             handle_getter_instruction(avm_instrs, function, destinations, inputs);
         }
         // Get contract instance variations.
-        _ if function.starts_with("avmOpcodeGetContractInstance") => {
+        _ if function.starts_with("aztec_avm_getContractInstance") => {
             handle_get_contract_instance(avm_instrs, function, destinations, inputs);
         }
         // Anything else.
@@ -580,7 +580,7 @@ fn handle_foreign_call(
 /// Handle an AVM CALL
 /// (an external 'call' brillig foreign call was encountered)
 /// Adds the new instruction to the avm instructions list.
-// #[oracle(avmOpcodeCall)]
+// #[oracle(aztec_avm_call)]
 // unconstrained fn call_opcode<let N: u32>(
 //     l2_gas_allocation: u32,
 //     da_gas_allocation: u32,
@@ -947,18 +947,18 @@ fn handle_getter_instruction(
     };
 
     let var_idx = match function {
-        "avmOpcodeAddress" => EnvironmentVariable::ADDRESS,
-        "avmOpcodeSender" => EnvironmentVariable::SENDER,
-        "avmOpcodeMinFeePerL2Gas" => EnvironmentVariable::MINFEEPERL2GAS,
-        "avmOpcodeMinFeePerDaGas" => EnvironmentVariable::MINFEEPERDAGAS,
-        "avmOpcodeTransactionFee" => EnvironmentVariable::TRANSACTIONFEE,
-        "avmOpcodeChainId" => EnvironmentVariable::CHAINID,
-        "avmOpcodeVersion" => EnvironmentVariable::VERSION,
-        "avmOpcodeBlockNumber" => EnvironmentVariable::BLOCKNUMBER,
-        "avmOpcodeTimestamp" => EnvironmentVariable::TIMESTAMP,
-        "avmOpcodeL2GasLeft" => EnvironmentVariable::L2GASLEFT,
-        "avmOpcodeDaGasLeft" => EnvironmentVariable::DAGASLEFT,
-        "avmOpcodeIsStaticCall" => EnvironmentVariable::ISSTATICCALL,
+        "aztec_avm_address" => EnvironmentVariable::ADDRESS,
+        "aztec_avm_sender" => EnvironmentVariable::SENDER,
+        "aztec_avm_minFeePerL2Gas" => EnvironmentVariable::MINFEEPERL2GAS,
+        "aztec_avm_minFeePerDaGas" => EnvironmentVariable::MINFEEPERDAGAS,
+        "aztec_avm_transactionFee" => EnvironmentVariable::TRANSACTIONFEE,
+        "aztec_avm_chainId" => EnvironmentVariable::CHAINID,
+        "aztec_avm_version" => EnvironmentVariable::VERSION,
+        "aztec_avm_blockNumber" => EnvironmentVariable::BLOCKNUMBER,
+        "aztec_avm_timestamp" => EnvironmentVariable::TIMESTAMP,
+        "aztec_avm_l2GasLeft" => EnvironmentVariable::L2GASLEFT,
+        "aztec_avm_daGasLeft" => EnvironmentVariable::DAGASLEFT,
+        "aztec_avm_isStaticCall" => EnvironmentVariable::ISSTATICCALL,
         _ => panic!("Transpiler doesn't know how to process getter {:?}", function),
     };
 
@@ -1348,7 +1348,7 @@ fn handle_debug_log(
 ) {
     // We need to handle two flavors here:
     //
-    // #[oracle(utilityLog)]
+    // #[oracle(aztec_utl_log)]
     // unconstrained fn log_oracle<let M: u32, let N: u32>(
     //     log_level: u8,
     //     msg: str<M>,
@@ -1358,7 +1358,7 @@ fn handle_debug_log(
     //
     // and
     //
-    //#[oracle(utilityLog)]
+    //#[oracle(aztec_utl_log)]
     // unconstrained fn log_slice_oracle<let M: u32>(log_level: u8, msg: str<M>, args: [Field]) {}
     //
     // Luckily, these two flavors have both 4 arguments, since noir inserts a length field for slices before the slice.
@@ -1420,7 +1420,7 @@ fn handle_debug_log(
     });
 }
 
-// #[oracle(avmOpcodeCalldataCopy)]
+// #[oracle(aztec_avm_calldataCopy)]
 // unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: Field) -> [Field; N] {}
 fn handle_calldata_copy(
     avm_instrs: &mut Vec<AvmInstruction>,
@@ -1463,7 +1463,7 @@ fn handle_calldata_copy(
     });
 }
 
-// #[oracle(avmOpcodeReturndataSize)]
+// #[oracle(aztec_avm_returndataSize)]
 // unconstrained fn returndata_size_opcode() -> u32 {}
 fn handle_returndata_size(
     avm_instrs: &mut Vec<AvmInstruction>,
@@ -1488,7 +1488,7 @@ fn handle_returndata_size(
     });
 }
 
-// #[oracle(avmOpcodeReturndataCopy)]
+// #[oracle(aztec_avm_returndataCopy)]
 // unconstrained fn returndata_copy_opcode(rdoffset: u32, copy_size: u32) -> [Field] {}
 fn handle_returndata_copy(
     avm_instrs: &mut Vec<AvmInstruction>,
@@ -1546,7 +1546,7 @@ fn handle_returndata_copy(
     ]);
 }
 
-// #[oracle(avmOpcodeReturn)]
+// #[oracle(aztec_avm_return)]
 // unconstrained fn return_opcode<let N: u32>(returndata: [Field; N]) {}
 fn handle_return(
     avm_instrs: &mut Vec<AvmInstruction>,
@@ -1565,7 +1565,7 @@ fn handle_return(
     generate_return_instruction(avm_instrs, &return_data_offset, &return_data_size);
 }
 
-// #[oracle(avmOpcodeRevert)]
+// #[oracle(aztec_avm_revert)]
 // unconstrained fn revert_opcode(revertdata: [Field]) {}
 fn handle_revert(
     avm_instrs: &mut Vec<AvmInstruction>,
@@ -1640,9 +1640,9 @@ fn handle_get_contract_instance(
     assert_eq!(destinations.len(), 1);
 
     let member_idx = match function {
-        "avmOpcodeGetContractInstanceDeployer" => ContractInstanceMember::DEPLOYER,
-        "avmOpcodeGetContractInstanceClassId" => ContractInstanceMember::CLASS_ID,
-        "avmOpcodeGetContractInstanceInitializationHash" => ContractInstanceMember::INIT_HASH,
+        "aztec_avm_getContractInstanceDeployer" => ContractInstanceMember::DEPLOYER,
+        "aztec_avm_getContractInstanceClassId" => ContractInstanceMember::CLASS_ID,
+        "aztec_avm_getContractInstanceInitializationHash" => ContractInstanceMember::INIT_HASH,
         _ => panic!("Transpiler doesn't know how to process function {:?}", function),
     };
 
@@ -1767,7 +1767,7 @@ fn tag_from_bit_size(bit_size: BitSize) -> AvmTypeTag {
     }
 }
 
-/// #[oracle(avmOpcodeSuccessCopy)]
+/// #[oracle(aztec_avm_successCopy)]
 /// unconstrained fn success_copy_opcode() -> bool {}
 fn handle_success_copy(
     avm_instrs: &mut Vec<AvmInstruction>,

--- a/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
@@ -312,8 +312,9 @@ mod test {
             array.push(5);
             array.push(6);
 
-            // We test that the utilityCopyCapsule was never called, which is the expensive operation we want to avoid.
-            let mock = std::test::OracleMock::mock("utilityCopyCapsule");
+            // We test that the aztec_utl_copyCapsule was never called, which is the expensive operation we want to
+            // avoid.
+            let mock = std::test::OracleMock::mock("aztec_utl_copyCapsule");
 
             array.for_each(|index, _| { array.remove(index); });
 

--- a/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/returns_hash.nr
@@ -1,8 +1,9 @@
 use crate::{hash::hash_args, oracle::execution_cache};
 use crate::protocol::traits::Deserialize;
 
-/// A hash that represents a private contract function call's return value. Call `get_preimage` to get the underlying
-/// value.
+/// The hash of a private contract function call's return value.
+///
+/// Use [`ReturnsHash::get_preimage`] to get the underlying value.
 ///
 /// The kernels don't process the actual return values but instead their hashes, so it is up to contracts to populate
 /// oracles with the preimages of these hashes on return to make them available to their callers.
@@ -81,17 +82,7 @@ mod test {
 
         let hash = hash_args(serialized);
 
-        let _ = OracleMock::mock("privateLoadFromExecutionCache").returns(bad_serialized);
+        let _ = OracleMock::mock("aztec_prv_loadFromExecutionCache").returns(bad_serialized);
         assert_eq(ReturnsHash::new(hash).get_preimage(), value);
     }
-
-    // This test passes due to a Noir bug. #[test(should_fail_with="Preimage mismatch")] unconstrained fn
-    // rejects_bad_empty_preimage() {
-    //     let value = (); let serialized = [];
-
-    //     let hash = hash_args(serialized);
-
-    //     let _ = OracleMock::mock("privateLoadFromExecutionCache").returns([1]);
-    // assert_eq(ReturnsHash::new(hash).get_preimage(), value);
-    // }
 }

--- a/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/getters/mod.nr
@@ -71,7 +71,7 @@ mod test {
         // partial address
         random_keys_and_partial_address[12] = 0x236703e2cb00a182e024e98e9f759231b556d25ff19f98896cebb69e9e678cc9;
 
-        let _ = OracleMock::mock("utilityTryGetPublicKeysAndPartialAddress").returns(Option::some(
+        let _ = OracleMock::mock("aztec_utl_tryGetPublicKeysAndPartialAddress").returns(Option::some(
             random_keys_and_partial_address,
         ));
         let _ = get_public_keys(account);

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -483,12 +483,12 @@ mod test {
 
             // Mock random values for deterministic test
             let eph_sk = 0x1358d15019d4639393d62b97e1588c095957ce74a1c32d6ec7d62fe6705d9538;
-            let _ = OracleMock::mock("utilityGetRandomField").returns(eph_sk).times(1);
+            let _ = OracleMock::mock("aztec_utl_getRandomField").returns(eph_sk).times(1);
 
             let randomness = 0x0101010101010101010101010101010101010101010101010101010101010101;
-            let _ = OracleMock::mock("utilityGetRandomField").returns(randomness).times(1000000);
+            let _ = OracleMock::mock("aztec_utl_getRandomField").returns(randomness).times(1000000);
 
-            let _ = OracleMock::mock("privateGetNextAppTagAsSender").returns(42);
+            let _ = OracleMock::mock("aztec_prv_getNextAppTagAsSender").returns(42);
 
             // Encrypt the message
             let encrypted_message = BoundedVec::from_array(AES128::encrypt(plaintext, recipient));
@@ -499,7 +499,7 @@ mod test {
                 recipient.to_address_point().unwrap().inner,
             );
 
-            let _ = OracleMock::mock("utilityGetSharedSecret").returns(shared_secret);
+            let _ = OracleMock::mock("aztec_utl_getSharedSecret").returns(shared_secret);
 
             // Decrypt the message
             let decrypted = AES128::decrypt(encrypted_message, recipient).unwrap();

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/utils.nr
@@ -34,9 +34,9 @@ mod test {
 
         let expected_tag = 42;
 
-        // Mock the tagging oracles - note privateGetSenderForTags returns none
-        let _ = OracleMock::mock("privateGetSenderForTags").returns(Option::<AztecAddress>::none());
-        let _ = OracleMock::mock("privateGetNextAppTagAsSender").returns(expected_tag);
+        // Mock the tagging oracles - note aztec_prv_getSenderForTags returns none
+        let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::<AztecAddress>::none());
+        let _ = OracleMock::mock("aztec_prv_getNextAppTagAsSender").returns(expected_tag);
 
         let log_without_tag = [1, 2, 3];
         let _ = prefix_with_tag(log_without_tag, recipient);
@@ -50,8 +50,8 @@ mod test {
         let expected_tag = 42;
 
         // Mock the tagging oracles
-        let _ = OracleMock::mock("privateGetSenderForTags").returns(Option::some(sender));
-        let _ = OracleMock::mock("privateGetNextAppTagAsSender").returns(expected_tag);
+        let _ = OracleMock::mock("aztec_prv_getSenderForTags").returns(Option::some(sender));
+        let _ = OracleMock::mock("aztec_prv_getNextAppTagAsSender").returns(expected_tag);
 
         let log_without_tag = [1, 2, 3];
         let log_with_tag = prefix_with_tag(log_without_tag, recipient);

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
@@ -2,7 +2,7 @@ use crate::{event::EventSelector, messages::logs::event::MAX_EVENT_SERIALIZED_LE
 use crate::protocol::{address::AztecAddress, traits::Serialize};
 
 /// Intermediate struct used to perform batch event validation by PXE. The
-/// `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in a
+/// `aztec_utl_validateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in a
 /// `CapsuleArray` at the given `base_slot`.
 #[derive(Serialize)]
 pub(crate) struct EventValidationRequest {

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/note_validation_request.nr
@@ -2,7 +2,7 @@ use crate::messages::logs::note::MAX_NOTE_PACKED_LEN;
 use crate::protocol::{address::AztecAddress, traits::Serialize};
 
 /// Intermediate struct used to perform batch note validation by PXE. The
-/// `utilityValidateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in a
+/// `aztec_utl_validateAndStoreEnqueuedNotesAndEvents` oracle expects for values of this type to be stored in a
 /// `CapsuleArray`.
 #[derive(Serialize)]
 pub(crate) struct NoteValidationRequest {

--- a/noir-projects/aztec-nr/aztec/src/oracle/aes128_decrypt.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/aes128_decrypt.nr
@@ -8,7 +8,7 @@
 /// Note that we accept ciphertext as a BoundedVec, not as an array. This is because this function is typically used
 /// when processing logs and at that point we don't have a comptime information about the length of the ciphertext as
 /// the log is not specific to any individual note.
-#[oracle(utilityAes128Decrypt)]
+#[oracle(aztec_utl_aes128Decrypt)]
 pub unconstrained fn aes128_decrypt_oracle<let N: u32>(
     ciphertext: BoundedVec<u8, N>,
     iv: [u8; 16],

--- a/noir-projects/aztec-nr/aztec/src/oracle/auth_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/auth_witness.nr
@@ -1,4 +1,4 @@
-#[oracle(utilityGetAuthWitness)]
+#[oracle(aztec_utl_getAuthWitness)]
 unconstrained fn get_auth_witness_oracle<let N: u32>(_message_hash: Field) -> [Field; N] {}
 
 /// Oracle wrapper to fetch an `auth_witness` for a given `message_hash` from the PXE.

--- a/noir-projects/aztec-nr/aztec/src/oracle/avm.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/avm.nr
@@ -118,82 +118,82 @@ pub unconstrained fn storage_write(storage_slot: Field, value: Field) {
     storage_write_opcode(storage_slot, value);
 }
 
-#[oracle(avmOpcodeAddress)]
+#[oracle(aztec_avm_address)]
 unconstrained fn address_opcode() -> AztecAddress {}
 
-#[oracle(avmOpcodeSender)]
+#[oracle(aztec_avm_sender)]
 unconstrained fn sender_opcode() -> AztecAddress {}
 
-#[oracle(avmOpcodeTransactionFee)]
+#[oracle(aztec_avm_transactionFee)]
 unconstrained fn transaction_fee_opcode() -> Field {}
 
-#[oracle(avmOpcodeChainId)]
+#[oracle(aztec_avm_chainId)]
 unconstrained fn chain_id_opcode() -> Field {}
 
-#[oracle(avmOpcodeVersion)]
+#[oracle(aztec_avm_version)]
 unconstrained fn version_opcode() -> Field {}
 
-#[oracle(avmOpcodeBlockNumber)]
+#[oracle(aztec_avm_blockNumber)]
 unconstrained fn block_number_opcode() -> u32 {}
 
-#[oracle(avmOpcodeTimestamp)]
+#[oracle(aztec_avm_timestamp)]
 unconstrained fn timestamp_opcode() -> u64 {}
 
-#[oracle(avmOpcodeMinFeePerL2Gas)]
+#[oracle(aztec_avm_minFeePerL2Gas)]
 unconstrained fn min_fee_per_l2_gas_opcode() -> u128 {}
 
-#[oracle(avmOpcodeMinFeePerDaGas)]
+#[oracle(aztec_avm_minFeePerDaGas)]
 unconstrained fn min_fee_per_da_gas_opcode() -> u128 {}
 
-#[oracle(avmOpcodeL2GasLeft)]
+#[oracle(aztec_avm_l2GasLeft)]
 unconstrained fn l2_gas_left_opcode() -> u32 {}
 
-#[oracle(avmOpcodeDaGasLeft)]
+#[oracle(aztec_avm_daGasLeft)]
 unconstrained fn da_gas_left_opcode() -> u32 {}
 
-#[oracle(avmOpcodeIsStaticCall)]
+#[oracle(aztec_avm_isStaticCall)]
 unconstrained fn is_static_call_opcode() -> u1 {}
 
-#[oracle(avmOpcodeNoteHashExists)]
+#[oracle(aztec_avm_noteHashExists)]
 unconstrained fn note_hash_exists_opcode(note_hash: Field, leaf_index: u64) -> u1 {}
 
-#[oracle(avmOpcodeEmitNoteHash)]
+#[oracle(aztec_avm_emitNoteHash)]
 unconstrained fn emit_note_hash_opcode(note_hash: Field) {}
 
-#[oracle(avmOpcodeNullifierExists)]
+#[oracle(aztec_avm_nullifierExists)]
 unconstrained fn nullifier_exists_opcode(siloed_nullifier: Field) -> u1 {}
 
-#[oracle(avmOpcodeEmitNullifier)]
+#[oracle(aztec_avm_emitNullifier)]
 unconstrained fn emit_nullifier_opcode(nullifier: Field) {}
 
-#[oracle(avmOpcodeEmitPublicLog)]
+#[oracle(aztec_avm_emitPublicLog)]
 unconstrained fn emit_public_log_opcode(message: [Field]) {}
 
-#[oracle(avmOpcodeL1ToL2MsgExists)]
+#[oracle(aztec_avm_l1ToL2MsgExists)]
 unconstrained fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: u64) -> u1 {}
 
-#[oracle(avmOpcodeSendL2ToL1Msg)]
+#[oracle(aztec_avm_sendL2ToL1Msg)]
 unconstrained fn send_l2_to_l1_msg_opcode(recipient: EthAddress, content: Field) {}
 
-#[oracle(avmOpcodeCalldataCopy)]
+#[oracle(aztec_avm_calldataCopy)]
 unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {}
 
-#[oracle(avmOpcodeReturndataSize)]
+#[oracle(aztec_avm_returndataSize)]
 unconstrained fn returndata_size_opcode() -> u32 {}
 
-#[oracle(avmOpcodeReturndataCopy)]
+#[oracle(aztec_avm_returndataCopy)]
 unconstrained fn returndata_copy_opcode(rdoffset: u32, copy_size: u32) -> [Field] {}
 
-#[oracle(avmOpcodeReturn)]
+#[oracle(aztec_avm_return)]
 unconstrained fn return_opcode(returndata: [Field]) {}
 
-#[oracle(avmOpcodeRevert)]
+#[oracle(aztec_avm_revert)]
 unconstrained fn revert_opcode(revertdata: [Field]) {}
 
 // While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
 // level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
 // that route.
-#[oracle(avmOpcodeCall)]
+#[oracle(aztec_avm_call)]
 unconstrained fn call_opcode<let N: u32>(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
@@ -205,7 +205,7 @@ unconstrained fn call_opcode<let N: u32>(
 // While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
 // level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
 // that route.
-#[oracle(avmOpcodeStaticCall)]
+#[oracle(aztec_avm_staticCall)]
 unconstrained fn call_static_opcode<let N: u32>(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
@@ -214,11 +214,11 @@ unconstrained fn call_static_opcode<let N: u32>(
     args: [Field; N],
 ) {}
 
-#[oracle(avmOpcodeSuccessCopy)]
+#[oracle(aztec_avm_successCopy)]
 unconstrained fn success_copy_opcode() -> bool {}
 
-#[oracle(avmOpcodeStorageRead)]
+#[oracle(aztec_avm_storageRead)]
 unconstrained fn storage_read_opcode(storage_slot: Field, contract_address: Field) -> Field {}
 
-#[oracle(avmOpcodeStorageWrite)]
+#[oracle(aztec_avm_storageWrite)]
 unconstrained fn storage_write_opcode(storage_slot: Field, value: Field) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
@@ -2,7 +2,7 @@ use crate::protocol::{abis::block_header::BlockHeader, merkle_tree::root::root_f
 
 use crate::{context::PrivateContext, oracle::get_membership_witness::get_block_hash_membership_witness};
 
-#[oracle(utilityGetBlockHeader)]
+#[oracle(aztec_utl_getBlockHeader)]
 unconstrained fn get_block_header_at_oracle(_block_number: u32) -> BlockHeader {}
 
 unconstrained fn get_block_header_at_internal(block_number: u32) -> BlockHeader {

--- a/noir-projects/aztec-nr/aztec/src/oracle/call_private_function.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/call_private_function.nr
@@ -1,6 +1,6 @@
 use crate::protocol::{abis::function_selector::FunctionSelector, address::AztecAddress, utils::reader::Reader};
 
-#[oracle(privateCallPrivateFunction)]
+#[oracle(aztec_prv_callPrivateFunction)]
 unconstrained fn call_private_function_oracle(
     _contract_address: AztecAddress,
     _function_selector: FunctionSelector,

--- a/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/capsules.nr
@@ -33,7 +33,7 @@ pub unconstrained fn copy(contract_address: AztecAddress, src_slot: Field, dst_s
     copy_oracle(contract_address, src_slot, dst_slot, num_entries);
 }
 
-#[oracle(utilityStoreCapsule)]
+#[oracle(aztec_utl_storeCapsule)]
 unconstrained fn store_oracle<let N: u32>(contract_address: AztecAddress, slot: Field, values: [Field; N]) {}
 
 /// We need to pass in `array_len` (the value of N) as a parameter to tell the oracle how many fields the response must
@@ -43,17 +43,17 @@ unconstrained fn store_oracle<let N: u32>(contract_address: AztecAddress, slot: 
 /// require for the oracle resolver to know the shape of T (e.g. if T were a struct of 3 u32 values then the expected
 /// response shape would be 3 single items, whereas it were a struct containing `u32, [Field;10], u32` then the
 /// expected shape would be single, array, single.). Instead, we return the serialization and deserialize in Noir.
-#[oracle(utilityLoadCapsule)]
+#[oracle(aztec_utl_loadCapsule)]
 unconstrained fn load_oracle<let N: u32>(
     contract_address: AztecAddress,
     slot: Field,
     array_len: u32,
 ) -> Option<[Field; N]> {}
 
-#[oracle(utilityDeleteCapsule)]
+#[oracle(aztec_utl_deleteCapsule)]
 unconstrained fn delete_oracle(contract_address: AztecAddress, slot: Field) {}
 
-#[oracle(utilityCopyCapsule)]
+#[oracle(aztec_utl_copyCapsule)]
 unconstrained fn copy_oracle(contract_address: AztecAddress, src_slot: Field, dst_slot: Field, num_entries: u32) {}
 
 mod test {

--- a/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/enqueue_public_function_call.nr
@@ -1,6 +1,6 @@
 use crate::protocol::address::AztecAddress;
 
-#[oracle(privateNotifyEnqueuedPublicFunctionCall)]
+#[oracle(aztec_prv_notifyEnqueuedPublicFunctionCall)]
 unconstrained fn notify_enqueued_public_function_call_oracle(
     _contract_address: AztecAddress,
     _calldata_hash: Field,
@@ -40,7 +40,7 @@ pub fn notify_enqueued_public_function_call(
     }
 }
 
-#[oracle(privateNotifySetPublicTeardownFunctionCall)]
+#[oracle(aztec_prv_notifySetPublicTeardownFunctionCall)]
 unconstrained fn notify_set_public_teardown_function_call_oracle(
     _contract_address: AztecAddress,
     _calldata_hash: Field,
@@ -90,12 +90,12 @@ pub unconstrained fn notify_set_min_revertible_side_effect_counter_oracle_wrappe
     notify_set_min_revertible_side_effect_counter_oracle(counter);
 }
 
-#[oracle(privateNotifySetMinRevertibleSideEffectCounter)]
+#[oracle(aztec_prv_notifySetMinRevertibleSideEffectCounter)]
 unconstrained fn notify_set_min_revertible_side_effect_counter_oracle(_counter: u32) {}
 
 pub unconstrained fn is_side_effect_counter_revertible_oracle_wrapper(counter: u32) -> bool {
     is_side_effect_counter_revertible_oracle(counter)
 }
 
-#[oracle(privateIsSideEffectCounterRevertible)]
+#[oracle(aztec_prv_isSideEffectCounterRevertible)]
 unconstrained fn is_side_effect_counter_revertible_oracle(counter: u32) -> bool {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
@@ -1,6 +1,6 @@
 use crate::context::UtilityContext;
 
-#[oracle(utilityGetUtilityContext)]
+#[oracle(aztec_utl_getUtilityContext)]
 unconstrained fn get_utility_context_oracle() -> UtilityContext {}
 
 /// Returns a utility context built from the global variables of anchor block and the contract address of the function

--- a/noir-projects/aztec-nr/aztec/src/oracle/execution_cache.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/execution_cache.nr
@@ -13,8 +13,8 @@ pub unconstrained fn load<let N: u32>(hash: Field) -> [Field; N] {
     load_from_execution_cache_oracle(hash)
 }
 
-#[oracle(privateStoreInExecutionCache)]
+#[oracle(aztec_prv_storeInExecutionCache)]
 unconstrained fn store_in_execution_cache_oracle<let N: u32>(_values: [Field; N], _hash: Field) {}
 
-#[oracle(privateLoadFromExecutionCache)]
+#[oracle(aztec_prv_loadFromExecutionCache)]
 unconstrained fn load_from_execution_cache_oracle<let N: u32>(_hash: Field) -> [Field; N] {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_contract_instance.nr
@@ -3,7 +3,7 @@ use crate::protocol::{
 };
 
 // NOTE: this is for use in private only
-#[oracle(utilityGetContractInstance)]
+#[oracle(aztec_utl_getContractInstance)]
 unconstrained fn get_contract_instance_oracle(_address: AztecAddress) -> ContractInstance {}
 
 // NOTE: this is for use in private only
@@ -27,11 +27,11 @@ struct GetContractInstanceResult {
 }
 
 // These oracles each return a ContractInstance member plus a boolean indicating whether the instance was found.
-#[oracle(avmOpcodeGetContractInstanceDeployer)]
+#[oracle(aztec_avm_getContractInstanceDeployer)]
 unconstrained fn get_contract_instance_deployer_oracle_avm(_address: AztecAddress) -> [GetContractInstanceResult; 1] {}
-#[oracle(avmOpcodeGetContractInstanceClassId)]
+#[oracle(aztec_avm_getContractInstanceClassId)]
 unconstrained fn get_contract_instance_class_id_oracle_avm(_address: AztecAddress) -> [GetContractInstanceResult; 1] {}
-#[oracle(avmOpcodeGetContractInstanceInitializationHash)]
+#[oracle(aztec_avm_getContractInstanceInitializationHash)]
 unconstrained fn get_contract_instance_initialization_hash_oracle_avm(
     _address: AztecAddress,
 ) -> [GetContractInstanceResult; 1] {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_l1_to_l2_membership_witness.nr
@@ -11,7 +11,7 @@ pub unconstrained fn get_l1_to_l2_membership_witness(
 }
 
 // Obtains membership witness (index and sibling path) for a message in the L1 to L2 message tree.
-#[oracle(utilityGetL1ToL2MembershipWitness)]
+#[oracle(aztec_utl_getL1ToL2MembershipWitness)]
 unconstrained fn get_l1_to_l2_membership_witness_oracle(
     _contract_address: AztecAddress,
     _message_hash: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -17,13 +17,13 @@ pub struct MembershipWitness<let N: u32, let M: u32> {
     pub path: [Field; N],
 }
 
-#[oracle(utilityGetNoteHashMembershipWitness)]
+#[oracle(aztec_utl_getNoteHashMembershipWitness)]
 unconstrained fn get_note_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     note_hash: Field,
 ) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {}
 
-#[oracle(utilityGetBlockHashMembershipWitness)]
+#[oracle(aztec_utl_getBlockHashMembershipWitness)]
 unconstrained fn get_block_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     block_hash: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
@@ -11,7 +11,7 @@ pub struct NullifierMembershipWitness {
     pub path: [Field; NULLIFIER_TREE_HEIGHT],
 }
 
-#[oracle(utilityGetLowNullifierMembershipWitness)]
+#[oracle(aztec_utl_getLowNullifierMembershipWitness)]
 unconstrained fn get_low_nullifier_membership_witness_oracle(
     _block_hash: Field,
     _nullifier: Field,
@@ -27,7 +27,7 @@ pub unconstrained fn get_low_nullifier_membership_witness(
     get_low_nullifier_membership_witness_oracle(block_hash, nullifier)
 }
 
-#[oracle(utilityGetNullifierMembershipWitness)]
+#[oracle(aztec_utl_getNullifierMembershipWitness)]
 unconstrained fn get_nullifier_membership_witness_oracle(
     _block_hash: Field,
     _nullifier: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_public_data_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_public_data_witness.nr
@@ -12,7 +12,7 @@ pub struct PublicDataWitness {
     pub path: [Field; PUBLIC_DATA_TREE_HEIGHT],
 }
 
-#[oracle(utilityGetPublicDataWitness)]
+#[oracle(aztec_utl_getPublicDataWitness)]
 unconstrained fn get_public_data_witness_oracle(
     _block_hash: Field,
     _public_data_tree_index: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/key_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/key_validation_request.nr
@@ -1,6 +1,6 @@
 use crate::protocol::abis::validation_requests::KeyValidationRequest;
 
-#[oracle(utilityGetKeyValidationRequest)]
+#[oracle(aztec_utl_getKeyValidationRequest)]
 unconstrained fn get_key_validation_request_oracle(_pk_m_hash: Field, _key_index: Field) -> KeyValidationRequest {}
 
 pub unconstrained fn get_key_validation_request(pk_m_hash: Field, key_index: Field) -> KeyValidationRequest {

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -8,7 +8,7 @@ pub unconstrained fn get_public_keys_and_partial_address(address: AztecAddress) 
     try_get_public_keys_and_partial_address(address).expect(f"Public keys not registered for account {address}")
 }
 
-#[oracle(utilityTryGetPublicKeysAndPartialAddress)]
+#[oracle(aztec_utl_tryGetPublicKeysAndPartialAddress)]
 unconstrained fn try_get_public_keys_and_partial_address_oracle(_address: AztecAddress) -> Option<[Field; 13]> {}
 
 pub unconstrained fn try_get_public_keys_and_partial_address(

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -10,7 +10,7 @@ pub unconstrained fn notify_created_contract_class_log<let N: u32>(
     notify_created_contract_class_log_private_oracle(contract_address, message, length, counter)
 }
 
-#[oracle(privateNotifyCreatedContractClassLog)]
+#[oracle(aztec_prv_notifyCreatedContractClassLog)]
 unconstrained fn notify_created_contract_class_log_private_oracle<let N: u32>(
     contract_address: AztecAddress,
     message: [Field; N],

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -6,7 +6,7 @@ pub unconstrained fn fetch_tagged_logs(pending_tagged_log_array_base_slot: Field
     fetch_tagged_logs_oracle(pending_tagged_log_array_base_slot);
 }
 
-#[oracle(utilityFetchTaggedLogs)]
+#[oracle(aztec_utl_fetchTaggedLogs)]
 unconstrained fn fetch_tagged_logs_oracle(pending_tagged_log_array_base_slot: Field) {}
 
 // This must be a single oracle and not one for notes and one for events because the entire point is to validate all
@@ -23,7 +23,7 @@ pub(crate) unconstrained fn validate_and_store_enqueued_notes_and_events(
     );
 }
 
-#[oracle(utilityValidateAndStoreEnqueuedNotesAndEvents)]
+#[oracle(aztec_utl_validateAndStoreEnqueuedNotesAndEvents)]
 unconstrained fn validate_and_store_enqueued_notes_and_events_oracle(
     contract_address: AztecAddress,
     note_validation_requests_array_base_slot: Field,
@@ -42,7 +42,7 @@ pub(crate) unconstrained fn bulk_retrieve_logs(
     );
 }
 
-#[oracle(utilityBulkRetrieveLogs)]
+#[oracle(aztec_utl_bulkRetrieveLogs)]
 unconstrained fn bulk_retrieve_logs_oracle(
     contract_address: AztecAddress,
     log_retrieval_requests_array_base_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -57,7 +57,7 @@ unconstrained fn notify_created_note_oracle_wrapper<let N: u32>(
     );
 }
 
-#[oracle(privateNotifyCreatedNote)]
+#[oracle(aztec_prv_notifyCreatedNote)]
 unconstrained fn notify_created_note_oracle<let N: u32>(
     _owner: AztecAddress,
     _storage_slot: Field,
@@ -72,10 +72,10 @@ unconstrained fn notify_nullified_note_oracle_wrapper(nullifier: Field, note_has
     notify_nullified_note_oracle(nullifier, note_hash, counter);
 }
 
-#[oracle(privateNotifyNullifiedNote)]
+#[oracle(aztec_prv_notifyNullifiedNote)]
 unconstrained fn notify_nullified_note_oracle(_nullifier: Field, _note_hash: Field, _counter: u32) {}
 
-#[oracle(utilityGetNotes)]
+#[oracle(aztec_utl_getNotes)]
 unconstrained fn get_notes_oracle<Note, let M: u32, let MaxNotes: u32>(
     _owner: Option<AztecAddress>,
     _storage_slot: Field,
@@ -189,7 +189,7 @@ pub unconstrained fn get_next_app_tag_as_sender(sender: AztecAddress, recipient:
     get_next_app_tag_as_sender_oracle(sender, recipient)
 }
 
-#[oracle(privateGetNextAppTagAsSender)]
+#[oracle(aztec_prv_getNextAppTagAsSender)]
 unconstrained fn get_next_app_tag_as_sender_oracle(_sender: AztecAddress, _recipient: AztecAddress) -> Field {}
 
 /// Gets the sender for tags.
@@ -204,7 +204,7 @@ pub unconstrained fn get_sender_for_tags() -> Option<AztecAddress> {
     get_sender_for_tags_oracle()
 }
 
-#[oracle(privateGetSenderForTags)]
+#[oracle(aztec_prv_getSenderForTags)]
 unconstrained fn get_sender_for_tags_oracle() -> Option<AztecAddress> {}
 
 /// Sets the sender for tags.
@@ -220,5 +220,5 @@ pub unconstrained fn set_sender_for_tags(sender_for_tags: AztecAddress) {
     set_sender_for_tags_oracle(sender_for_tags);
 }
 
-#[oracle(privateSetSenderForTags)]
+#[oracle(aztec_prv_setSenderForTags)]
 unconstrained fn set_sender_for_tags_oracle(_sender_for_tags: AztecAddress) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/nullifiers.nr
@@ -11,7 +11,7 @@ pub fn notify_created_nullifier(inner_nullifier: Field) {
     unsafe { notify_created_nullifier_oracle(inner_nullifier) };
 }
 
-#[oracle(privateNotifyCreatedNullifier)]
+#[oracle(aztec_prv_notifyCreatedNullifier)]
 unconstrained fn notify_created_nullifier_oracle(_inner_nullifier: Field) {}
 
 /// Returns true if the nullifier has been emitted in the same transaction, i.e. if [`notify_created_nullifier`] has
@@ -26,7 +26,7 @@ pub unconstrained fn is_nullifier_pending(inner_nullifier: Field, contract_addre
     is_nullifier_pending_oracle(inner_nullifier, contract_address)
 }
 
-#[oracle(privateIsNullifierPending)]
+#[oracle(aztec_prv_isNullifierPending)]
 unconstrained fn is_nullifier_pending_oracle(_inner_nullifier: Field, _contract_address: AztecAddress) -> bool {}
 
 /// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the
@@ -37,5 +37,5 @@ pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
     check_nullifier_exists_oracle(inner_nullifier)
 }
 
-#[oracle(utilityCheckNullifierExists)]
+#[oracle(aztec_utl_checkNullifierExists)]
 unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/offchain_effect.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/offchain_effect.nr
@@ -13,5 +13,5 @@ where
     emit_offchain_effect_oracle(data.serialize());
 }
 
-#[oracle(utilityEmitOffchainEffect)]
+#[oracle(aztec_utl_emitOffchainEffect)]
 unconstrained fn emit_offchain_effect_oracle<let N: u32>(data: [Field; N]) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/random.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/random.nr
@@ -6,5 +6,5 @@ pub unconstrained fn random() -> Field {
     rand_oracle()
 }
 
-#[oracle(utilityGetRandomField)]
+#[oracle(aztec_utl_getRandomField)]
 unconstrained fn rand_oracle() -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/shared_secret.nr
@@ -1,7 +1,7 @@
 use crate::protocol::{address::aztec_address::AztecAddress, point::Point};
 
 // TODO(#12656): return an app-siloed secret + document this
-#[oracle(utilityGetSharedSecret)]
+#[oracle(aztec_utl_getSharedSecret)]
 unconstrained fn get_shared_secret_oracle(address: AztecAddress, ephPk: Point) -> Point {}
 
 /// Returns an app-siloed shared secret between `address` and someone who knows the secret key behind an ephemeral

--- a/noir-projects/aztec-nr/aztec/src/oracle/storage.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/storage.nr
@@ -1,6 +1,6 @@
 use crate::protocol::{abis::block_header::BlockHeader, address::AztecAddress, traits::{Hash, Packable, ToField}};
 
-#[oracle(utilityStorageRead)]
+#[oracle(aztec_utl_storageRead)]
 unconstrained fn storage_read_oracle<let N: u32>(
     block_hash: Field,
     address: Field,

--- a/noir-projects/aztec-nr/aztec/src/oracle/version.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/version.nr
@@ -2,9 +2,10 @@
 /// to version the oracle interface to ensure that developers get a reasonable error message if they use incompatible
 /// versions of Aztec.nr and PXE. The TypeScript counterpart is in `oracle_version.ts`.
 ///
-/// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
+/// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is
+/// called
 /// and if the oracle version is incompatible an error is thrown.
-pub global ORACLE_VERSION: Field = 12;
+pub global ORACLE_VERSION: Field = 13;
 
 /// Asserts that the version of the oracle is compatible with the version expected by the contract.
 pub fn assert_compatible_oracle_version() {
@@ -19,7 +20,7 @@ unconstrained fn assert_compatible_oracle_version_wrapper() {
     assert_compatible_oracle_version_oracle(ORACLE_VERSION);
 }
 
-#[oracle(utilityAssertCompatibleOracleVersion)]
+#[oracle(aztec_utl_assertCompatibleOracleVersion)]
 unconstrained fn assert_compatible_oracle_version_oracle(version: Field) {}
 
 mod test {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/misc.nr
@@ -39,7 +39,7 @@ unconstrained fn private_public_and_utility_context_share_default_chain_id() {
 
 #[test]
 unconstrained fn oracle_version_is_checked_upon_env_creation() {
-    let mock = OracleMock::mock("utilityAssertCompatibleOracleVersion");
+    let mock = OracleMock::mock("aztec_utl_assertCompatibleOracleVersion");
 
     let _env = TestEnvironment::new();
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -63,19 +63,19 @@ pub unconstrained fn execute_utility_function<let M: u32, let N: u32>(
     execute_utility_function_oracle(contract_address, function_selector, args)
 }
 
-#[oracle(txeGetNextBlockNumber)]
+#[oracle(aztec_txe_getNextBlockNumber)]
 pub unconstrained fn get_next_block_number() -> u32 {}
 
-#[oracle(txeGetNextBlockTimestamp)]
+#[oracle(aztec_txe_getNextBlockTimestamp)]
 pub unconstrained fn get_next_block_timestamp() -> u64 {}
 
-#[oracle(txeGetLastBlockTimestamp)]
+#[oracle(aztec_txe_getLastBlockTimestamp)]
 pub unconstrained fn get_last_block_timestamp() -> u64 {}
 
-#[oracle(txeGetLastTxEffects)]
+#[oracle(aztec_txe_getLastTxEffects)]
 pub unconstrained fn get_last_tx_effects() -> (Field, BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>, BoundedVec<Field, MAX_NULLIFIERS_PER_TX>) {}
 
-#[oracle(txeGetDefaultAddress)]
+#[oracle(aztec_txe_getDefaultAddress)]
 pub unconstrained fn get_default_address() -> AztecAddress {}
 
 // experimental
@@ -97,20 +97,20 @@ pub(crate) unconstrained fn get_private_events(
     events
 }
 
-#[oracle(txeGetPrivateEvents)]
+#[oracle(aztec_txe_getPrivateEvents)]
 unconstrained fn get_private_events_oracle(
     selector: EventSelector,
     contract_address: AztecAddress,
     scope: AztecAddress,
     ) -> ([[Field; MAX_EVENT_SERIALIZATION_LENGTH]; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], [u32; MAX_PRIVATE_EVENTS_PER_TXE_QUERY], u32) {}
 
-#[oracle(txeAdvanceBlocksBy)]
+#[oracle(aztec_txe_advanceBlocksBy)]
 pub unconstrained fn advance_blocks_by(blocks: u32) {}
 
-#[oracle(txeAdvanceTimestampBy)]
+#[oracle(aztec_txe_advanceTimestampBy)]
 pub unconstrained fn advance_timestamp_by(duration: u64) {}
 
-#[oracle(txeDeploy)]
+#[oracle(aztec_txe_deploy)]
 pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(
     path: str<N>,
     initializer: str<P>,
@@ -118,16 +118,16 @@ pub unconstrained fn deploy_oracle<let N: u32, let P: u32>(
     secret: Field,
 ) -> [Field; CONTRACT_INSTANCE_LENGTH] {}
 
-#[oracle(txeCreateAccount)]
+#[oracle(aztec_txe_createAccount)]
 pub unconstrained fn create_account(secret: Field) -> TestAccount {}
 
-#[oracle(txeAddAccount)]
+#[oracle(aztec_txe_addAccount)]
 pub unconstrained fn add_account(secret: Field) -> TestAccount {}
 
-#[oracle(txeAddAuthWitness)]
+#[oracle(aztec_txe_addAuthWitness)]
 pub unconstrained fn add_authwit(address: AztecAddress, message_hash: Field) {}
 
-#[oracle(txePrivateCallNewFlow)]
+#[oracle(aztec_txe_privateCallNewFlow)]
 unconstrained fn private_call_new_flow_oracle<let M: u32, let N: u32>(
     _from: AztecAddress,
     _contract_address: AztecAddress,
@@ -137,7 +137,7 @@ unconstrained fn private_call_new_flow_oracle<let M: u32, let N: u32>(
     _is_static_call: bool,
 ) -> [Field; N] {}
 
-#[oracle(txePublicCallNewFlow)]
+#[oracle(aztec_txe_publicCallNewFlow)]
 unconstrained fn public_call_new_flow_oracle<let M: u32, let N: u32>(
     from: AztecAddress,
     contract_address: AztecAddress,
@@ -145,24 +145,24 @@ unconstrained fn public_call_new_flow_oracle<let M: u32, let N: u32>(
     is_static_call: bool,
 ) -> [Field; N] {}
 
-#[oracle(txeExecuteUtilityFunction)]
+#[oracle(aztec_txe_executeUtilityFunction)]
 unconstrained fn execute_utility_function_oracle<let M: u32, let N: u32>(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args: [Field; M],
 ) -> [Field; N] {}
 
-#[oracle(txeSetTopLevelTXEContext)]
+#[oracle(aztec_txe_setTopLevelTXEContext)]
 pub unconstrained fn set_top_level_txe_context() {}
 
-#[oracle(txeSetPrivateTXEContext)]
+#[oracle(aztec_txe_setPrivateTXEContext)]
 pub unconstrained fn set_private_txe_context(
     contract_address: Option<AztecAddress>,
     anchor_block_number: Option<u32>,
 ) -> PrivateContextInputs {}
 
-#[oracle(txeSetPublicTXEContext)]
+#[oracle(aztec_txe_setPublicTXEContext)]
 pub unconstrained fn set_public_txe_context(contract_address: Option<AztecAddress>) {}
 
-#[oracle(txeSetUtilityTXEContext)]
+#[oracle(aztec_txe_setUtilityTXEContext)]
 pub unconstrained fn set_utility_txe_context(contract_address: Option<AztecAddress>) {}

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -173,7 +173,7 @@ mod test {
 
             // Mock the oracle to return a non-zero hint/packed value
             let value_packed = MockStruct { a: 1, b: 1 }.pack();
-            let _ = OracleMock::mock("utilityStorageRead")
+            let _ = OracleMock::mock("aztec_utl_storageRead")
                 .with_params((block_header.hash(), address.to_field(), STORAGE_SLOT, value_packed.len()))
                 .returns(value_packed)
                 .times(1);

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/storage.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/history/storage.nr
@@ -17,7 +17,7 @@ pub struct PublicDataWitness {
     pub path: [Field; PUBLIC_DATA_TREE_HEIGHT],
 }
 
-#[oracle(utilityGetPublicDataWitness)]
+#[oracle(aztec_utl_getPublicDataWitness)]
 unconstrained fn get_public_data_witness_oracle(
     _block_hash: Field,
     _public_data_tree_index: Field,

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/avm.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/avm.nr
@@ -118,82 +118,82 @@ pub unconstrained fn storage_write(storage_slot: Field, value: Field) {
     storage_write_opcode(storage_slot, value);
 }
 
-#[oracle(avmOpcodeAddress)]
+#[oracle(aztec_avm_address)]
 unconstrained fn address_opcode() -> AztecAddress {}
 
-#[oracle(avmOpcodeSender)]
+#[oracle(aztec_avm_sender)]
 unconstrained fn sender_opcode() -> AztecAddress {}
 
-#[oracle(avmOpcodeTransactionFee)]
+#[oracle(aztec_avm_transactionFee)]
 unconstrained fn transaction_fee_opcode() -> Field {}
 
-#[oracle(avmOpcodeChainId)]
+#[oracle(aztec_avm_chainId)]
 unconstrained fn chain_id_opcode() -> Field {}
 
-#[oracle(avmOpcodeVersion)]
+#[oracle(aztec_avm_version)]
 unconstrained fn version_opcode() -> Field {}
 
-#[oracle(avmOpcodeBlockNumber)]
+#[oracle(aztec_avm_blockNumber)]
 unconstrained fn block_number_opcode() -> u32 {}
 
-#[oracle(avmOpcodeTimestamp)]
+#[oracle(aztec_avm_timestamp)]
 unconstrained fn timestamp_opcode() -> u64 {}
 
-#[oracle(avmOpcodeMinFeePerL2Gas)]
+#[oracle(aztec_avm_minFeePerL2Gas)]
 unconstrained fn min_fee_per_l2_gas_opcode() -> u128 {}
 
-#[oracle(avmOpcodeMinFeePerDaGas)]
+#[oracle(aztec_avm_minFeePerDaGas)]
 unconstrained fn min_fee_per_da_gas_opcode() -> u128 {}
 
-#[oracle(avmOpcodeL2GasLeft)]
+#[oracle(aztec_avm_l2GasLeft)]
 unconstrained fn l2_gas_left_opcode() -> u32 {}
 
-#[oracle(avmOpcodeDaGasLeft)]
+#[oracle(aztec_avm_daGasLeft)]
 unconstrained fn da_gas_left_opcode() -> u32 {}
 
-#[oracle(avmOpcodeIsStaticCall)]
+#[oracle(aztec_avm_isStaticCall)]
 unconstrained fn is_static_call_opcode() -> u1 {}
 
-#[oracle(avmOpcodeNoteHashExists)]
+#[oracle(aztec_avm_noteHashExists)]
 unconstrained fn note_hash_exists_opcode(note_hash: Field, leaf_index: u64) -> u1 {}
 
-#[oracle(avmOpcodeEmitNoteHash)]
+#[oracle(aztec_avm_emitNoteHash)]
 unconstrained fn emit_note_hash_opcode(note_hash: Field) {}
 
-#[oracle(avmOpcodeNullifierExists)]
+#[oracle(aztec_avm_nullifierExists)]
 unconstrained fn nullifier_exists_opcode(siloed_nullifier: Field) -> u1 {}
 
-#[oracle(avmOpcodeEmitNullifier)]
+#[oracle(aztec_avm_emitNullifier)]
 unconstrained fn emit_nullifier_opcode(nullifier: Field) {}
 
-#[oracle(avmOpcodeEmitPublicLog)]
+#[oracle(aztec_avm_emitPublicLog)]
 unconstrained fn emit_public_log_opcode(message: [Field]) {}
 
-#[oracle(avmOpcodeL1ToL2MsgExists)]
+#[oracle(aztec_avm_l1ToL2MsgExists)]
 unconstrained fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: u64) -> u1 {}
 
-#[oracle(avmOpcodeSendL2ToL1Msg)]
+#[oracle(aztec_avm_sendL2ToL1Msg)]
 unconstrained fn send_l2_to_l1_msg_opcode(recipient: EthAddress, content: Field) {}
 
-#[oracle(avmOpcodeCalldataCopy)]
+#[oracle(aztec_avm_calldataCopy)]
 unconstrained fn calldata_copy_opcode<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {}
 
-#[oracle(avmOpcodeReturndataSize)]
+#[oracle(aztec_avm_returndataSize)]
 unconstrained fn returndata_size_opcode() -> u32 {}
 
-#[oracle(avmOpcodeReturndataCopy)]
+#[oracle(aztec_avm_returndataCopy)]
 unconstrained fn returndata_copy_opcode(rdoffset: u32, copy_size: u32) -> [Field] {}
 
-#[oracle(avmOpcodeReturn)]
+#[oracle(aztec_avm_return)]
 unconstrained fn return_opcode(returndata: [Field]) {}
 
-#[oracle(avmOpcodeRevert)]
+#[oracle(aztec_avm_revert)]
 unconstrained fn revert_opcode(revertdata: [Field]) {}
 
 // While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
 // level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
 // that route.
-#[oracle(avmOpcodeCall)]
+#[oracle(aztec_avm_call)]
 unconstrained fn call_opcode<let N: u32>(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
@@ -205,7 +205,7 @@ unconstrained fn call_opcode<let N: u32>(
 // While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
 // level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take
 // that route.
-#[oracle(avmOpcodeStaticCall)]
+#[oracle(aztec_avm_staticCall)]
 unconstrained fn call_static_opcode<let N: u32>(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
@@ -214,11 +214,11 @@ unconstrained fn call_static_opcode<let N: u32>(
     args: [Field; N],
 ) {}
 
-#[oracle(avmOpcodeSuccessCopy)]
+#[oracle(aztec_avm_successCopy)]
 unconstrained fn success_copy_opcode() -> bool {}
 
-#[oracle(avmOpcodeStorageRead)]
+#[oracle(aztec_avm_storageRead)]
 unconstrained fn storage_read_opcode(storage_slot: Field, contract_address: Field) -> Field {}
 
-#[oracle(avmOpcodeStorageWrite)]
+#[oracle(aztec_avm_storageWrite)]
 unconstrained fn storage_write_opcode(storage_slot: Field, value: Field) {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/call_private_function.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/call_private_function.nr
@@ -2,7 +2,7 @@ use crate::protocol::{
     abis::function_selector::FunctionSelector, address::AztecAddress, utils::reader::Reader,
 };
 
-#[oracle(privateCallPrivateFunction)]
+#[oracle(aztec_prv_callPrivateFunction)]
 unconstrained fn call_private_function_oracle(
     _contract_address: AztecAddress,
     _function_selector: FunctionSelector,

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/capsules.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/capsules.nr
@@ -38,7 +38,7 @@ pub unconstrained fn copy(
     copy_oracle(contract_address, src_slot, dst_slot, num_entries);
 }
 
-#[oracle(utilityStoreCapsule)]
+#[oracle(aztec_utl_storeCapsule)]
 unconstrained fn store_oracle<let N: u32>(
     contract_address: AztecAddress,
     slot: Field,
@@ -52,17 +52,17 @@ unconstrained fn store_oracle<let N: u32>(
 /// require for the oracle resolver to know the shape of T (e.g. if T were a struct of 3 u32 values then the expected
 /// response shape would be 3 single items, whereas it were a struct containing `u32, [Field;10], u32` then the
 /// expected shape would be single, array, single.). Instead, we return the serialization and deserialize in Noir.
-#[oracle(utilityLoadCapsule)]
+#[oracle(aztec_utl_loadCapsule)]
 unconstrained fn load_oracle<let N: u32>(
     contract_address: AztecAddress,
     slot: Field,
     array_len: u32,
 ) -> Option<[Field; N]> {}
 
-#[oracle(utilityDeleteCapsule)]
+#[oracle(aztec_utl_deleteCapsule)]
 unconstrained fn delete_oracle(contract_address: AztecAddress, slot: Field) {}
 
-#[oracle(utilityCopyCapsule)]
+#[oracle(aztec_utl_copyCapsule)]
 unconstrained fn copy_oracle(
     contract_address: AztecAddress,
     src_slot: Field,

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/enqueue_public_function_call.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/enqueue_public_function_call.nr
@@ -1,6 +1,6 @@
 use crate::protocol::address::AztecAddress;
 
-#[oracle(privateNotifyEnqueuedPublicFunctionCall)]
+#[oracle(aztec_prv_notifyEnqueuedPublicFunctionCall)]
 unconstrained fn notify_enqueued_public_function_call_oracle(
     _contract_address: AztecAddress,
     _calldata_hash: Field,
@@ -40,7 +40,7 @@ pub fn notify_enqueued_public_function_call(
     }
 }
 
-#[oracle(privateNotifySetPublicTeardownFunctionCall)]
+#[oracle(aztec_prv_notifySetPublicTeardownFunctionCall)]
 unconstrained fn notify_set_public_teardown_function_call_oracle(
     _contract_address: AztecAddress,
     _calldata_hash: Field,
@@ -90,12 +90,12 @@ pub unconstrained fn notify_set_min_revertible_side_effect_counter_oracle_wrappe
     notify_set_min_revertible_side_effect_counter_oracle(counter);
 }
 
-#[oracle(privateNotifySetMinRevertibleSideEffectCounter)]
+#[oracle(aztec_prv_notifySetMinRevertibleSideEffectCounter)]
 unconstrained fn notify_set_min_revertible_side_effect_counter_oracle(_counter: u32) {}
 
 pub unconstrained fn is_side_effect_counter_revertible_oracle_wrapper(counter: u32) -> bool {
     is_side_effect_counter_revertible_oracle(counter)
 }
 
-#[oracle(privateIsSideEffectCounterRevertible)]
+#[oracle(aztec_prv_isSideEffectCounterRevertible)]
 unconstrained fn is_side_effect_counter_revertible_oracle(counter: u32) -> bool {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution.nr
@@ -1,6 +1,6 @@
 use crate::context::UtilityContext;
 
-#[oracle(utilityGetUtilityContext)]
+#[oracle(aztec_utl_getUtilityContext)]
 unconstrained fn get_utility_context_oracle() -> UtilityContext {}
 
 /// Returns a utility context built from the global variables of anchor block and the contract address of the function

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution_cache.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/execution_cache.nr
@@ -16,8 +16,8 @@ pub unconstrained fn load<let N: u32>(hash: Field) -> [Field; N] {
     load_from_execution_cache_oracle(hash)
 }
 
-#[oracle(privateStoreInExecutionCache)]
+#[oracle(aztec_prv_storeInExecutionCache)]
 unconstrained fn store_in_execution_cache_oracle<let N: u32>(_values: [Field; N], _hash: Field) {}
 
-#[oracle(privateLoadFromExecutionCache)]
+#[oracle(aztec_prv_loadFromExecutionCache)]
 unconstrained fn load_from_execution_cache_oracle<let N: u32>(_hash: Field) -> [Field; N] {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/get_l1_to_l2_membership_witness.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/get_l1_to_l2_membership_witness.nr
@@ -11,7 +11,7 @@ pub unconstrained fn get_l1_to_l2_membership_witness(
 }
 
 // Obtains membership witness (index and sibling path) for a message in the L1 to L2 message tree.
-#[oracle(utilityGetL1ToL2MembershipWitness)]
+#[oracle(aztec_utl_getL1ToL2MembershipWitness)]
 unconstrained fn get_l1_to_l2_membership_witness_oracle(
     _contract_address: AztecAddress,
     _message_hash: Field,

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/logs.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/logs.nr
@@ -10,7 +10,7 @@ pub unconstrained fn notify_created_contract_class_log<let N: u32>(
     notify_created_contract_class_log_private_oracle(contract_address, message, length, counter)
 }
 
-#[oracle(privateNotifyCreatedContractClassLog)]
+#[oracle(aztec_prv_notifyCreatedContractClassLog)]
 unconstrained fn notify_created_contract_class_log_private_oracle<let N: u32>(
     contract_address: AztecAddress,
     message: [Field; N],

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/nullifiers.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/nullifiers.nr
@@ -11,7 +11,7 @@ pub fn notify_created_nullifier(inner_nullifier: Field) {
     unsafe { notify_created_nullifier_oracle(inner_nullifier) };
 }
 
-#[oracle(privateNotifyCreatedNullifier)]
+#[oracle(aztec_prv_notifyCreatedNullifier)]
 unconstrained fn notify_created_nullifier_oracle(_inner_nullifier: Field) {}
 
 /// Returns true if the nullifier has been emitted in the same transaction, i.e. if [notify_created_nullifier] has been
@@ -28,7 +28,7 @@ pub unconstrained fn is_nullifier_pending(
     is_nullifier_pending_oracle(inner_nullifier, contract_address)
 }
 
-#[oracle(privateIsNullifierPending)]
+#[oracle(aztec_prv_isNullifierPending)]
 unconstrained fn is_nullifier_pending_oracle(
     _inner_nullifier: Field,
     _contract_address: AztecAddress,
@@ -42,5 +42,5 @@ pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
     check_nullifier_exists_oracle(inner_nullifier)
 }
 
-#[oracle(utilityCheckNullifierExists)]
+#[oracle(aztec_utl_checkNullifierExists)]
 unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}

--- a/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/storage.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/aztec_sublib/src/oracle/storage.nr
@@ -4,7 +4,7 @@ use crate::protocol::{
     traits::{Hash, Packable, ToField},
 };
 
-#[oracle(utilityStorageRead)]
+#[oracle(aztec_utl_storageRead)]
 unconstrained fn storage_read_oracle<let N: u32>(
     block_hash: Field,
     address: Field,

--- a/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/fake_avm_oracle.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/fake_avm_oracle.nr
@@ -32,7 +32,7 @@ pub unconstrained fn revert(revertdata: [Field]) {
 // While the length parameter might seem unnecessary given that we have N we keep it around because at the AVM bytecode
 // level, we want to support non-comptime-known lengths for such opcodes, even if Noir code will not generally take that
 // route.
-#[oracle(avmOpcodeCall)]
+#[oracle(aztec_avm_call)]
 unconstrained fn call_opcode<let N: u32>(
     l2_gas_allocation: u32,
     da_gas_allocation: u32,
@@ -41,17 +41,17 @@ unconstrained fn call_opcode<let N: u32>(
     args: [Field; N],
 ) {}
 
-#[oracle(avmOpcodeSuccessCopy)]
+#[oracle(aztec_avm_successCopy)]
 unconstrained fn success_copy_opcode() -> bool {}
 
-#[oracle(avmOpcodeReturndataSize)]
+#[oracle(aztec_avm_returndataSize)]
 unconstrained fn returndata_size_opcode() -> u32 {}
 
-#[oracle(avmOpcodeReturndataCopy)]
+#[oracle(aztec_avm_returndataCopy)]
 unconstrained fn returndata_copy_opcode(rdoffset: u32, copy_size: u32) -> [Field] {}
 
-#[oracle(avmOpcodeReturn)]
+#[oracle(aztec_avm_return)]
 unconstrained fn return_opcode(returndata: [Field]) {}
 
-#[oracle(avmOpcodeRevert)]
+#[oracle(aztec_avm_revert)]
 unconstrained fn revert_opcode(revertdata: [Field]) {}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/logging.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/logging.nr
@@ -83,7 +83,7 @@ unconstrained fn log_oracle_wrapper<let M: u32, let N: u32>(
     log_oracle(log_level, msg, N, args);
 }
 
-#[oracle(utilityLog)]
+#[oracle(aztec_utl_log)]
 unconstrained fn log_oracle<let M: u32, let N: u32>(
     log_level: u8,
     msg: str<M>,

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -277,7 +277,7 @@ export class ContractFunctionSimulator {
       );
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await privateExecutionOracle.privateLoadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.loadFromExecutionCache(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/interfaces.ts
@@ -52,9 +52,9 @@ export interface NoteData {
 export interface IMiscOracle {
   isMisc: true;
 
-  utilityGetRandomField(): Fr;
-  utilityAssertCompatibleOracleVersion(version: number): void;
-  utilityLog(level: number, message: string, fields: Fr[]): Promise<void>;
+  getRandomField(): Fr;
+  assertCompatibleOracleVersion(version: number): void;
+  log(level: number, message: string, fields: Fr[]): Promise<void>;
 }
 
 /**
@@ -64,30 +64,30 @@ export interface IMiscOracle {
 export interface IUtilityExecutionOracle {
   isUtility: true;
 
-  utilityGetUtilityContext(): UtilityContext;
-  utilityGetKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest>;
-  utilityGetContractInstance(address: AztecAddress): Promise<ContractInstance>;
-  utilityGetNoteHashMembershipWitness(
+  getUtilityContext(): UtilityContext;
+  getKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest>;
+  getContractInstance(address: AztecAddress): Promise<ContractInstance>;
+  getNoteHashMembershipWitness(
     anchorBlockHash: BlockHash,
     noteHash: Fr,
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined>;
-  utilityGetBlockHashMembershipWitness(
+  getBlockHashMembershipWitness(
     anchorBlockHash: BlockHash,
     blockHash: BlockHash,
   ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined>;
-  utilityGetNullifierMembershipWitness(
+  getNullifierMembershipWitness(
     anchorBlockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
-  utilityGetPublicDataWitness(anchorBlockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined>;
-  utilityGetLowNullifierMembershipWitness(
+  getPublicDataWitness(anchorBlockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined>;
+  getLowNullifierMembershipWitness(
     anchorBlockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined>;
-  utilityGetBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined>;
-  utilityTryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined>;
-  utilityGetAuthWitness(messageHash: Fr): Promise<Fr[] | undefined>;
-  utilityGetNotes(
+  getBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined>;
+  tryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined>;
+  getAuthWitness(messageHash: Fr): Promise<Fr[] | undefined>;
+  getNotes(
     owner: AztecAddress | undefined,
     storageSlot: Fr,
     numSelects: number,
@@ -104,35 +104,35 @@ export interface IUtilityExecutionOracle {
     offset: number,
     status: NoteStatus,
   ): Promise<NoteData[]>;
-  utilityCheckNullifierExists(innerNullifier: Fr): Promise<boolean>;
-  utilityGetL1ToL2MembershipWitness(
+  checkNullifierExists(innerNullifier: Fr): Promise<boolean>;
+  getL1ToL2MembershipWitness(
     contractAddress: AztecAddress,
     messageHash: Fr,
     secret: Fr,
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
-  utilityStorageRead(
+  storageRead(
     anchorBlockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
     numberOfElements: number,
   ): Promise<Fr[]>;
-  utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr): Promise<void>;
-  utilityValidateAndStoreEnqueuedNotesAndEvents(
+  fetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr): Promise<void>;
+  validateAndStoreEnqueuedNotesAndEvents(
     contractAddress: AztecAddress,
     noteValidationRequestsArrayBaseSlot: Fr,
     eventValidationRequestsArrayBaseSlot: Fr,
   ): Promise<void>;
-  utilityBulkRetrieveLogs(
+  bulkRetrieveLogs(
     contractAddress: AztecAddress,
     logRetrievalRequestsArrayBaseSlot: Fr,
     logRetrievalResponsesArrayBaseSlot: Fr,
   ): Promise<void>;
-  utilityStoreCapsule(contractAddress: AztecAddress, key: Fr, capsule: Fr[]): Promise<void>;
-  utilityLoadCapsule(contractAddress: AztecAddress, key: Fr): Promise<Fr[] | null>;
-  utilityDeleteCapsule(contractAddress: AztecAddress, key: Fr): Promise<void>;
-  utilityCopyCapsule(contractAddress: AztecAddress, srcKey: Fr, dstKey: Fr, numEntries: number): Promise<void>;
-  utilityAes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
-  utilityGetSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point>;
+  storeCapsule(contractAddress: AztecAddress, key: Fr, capsule: Fr[]): Promise<void>;
+  loadCapsule(contractAddress: AztecAddress, key: Fr): Promise<Fr[] | null>;
+  deleteCapsule(contractAddress: AztecAddress, key: Fr): Promise<void>;
+  copyCapsule(contractAddress: AztecAddress, srcKey: Fr, dstKey: Fr, numEntries: number): Promise<void>;
+  aes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer>;
+  getSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point>;
 }
 
 /**
@@ -142,9 +142,9 @@ export interface IUtilityExecutionOracle {
 export interface IPrivateExecutionOracle {
   isPrivate: true;
 
-  privateStoreInExecutionCache(values: Fr[], hash: Fr): void;
-  privateLoadFromExecutionCache(hash: Fr): Promise<Fr[]>;
-  privateNotifyCreatedNote(
+  storeInExecutionCache(values: Fr[], hash: Fr): void;
+  loadFromExecutionCache(hash: Fr): Promise<Fr[]>;
+  notifyCreatedNote(
     owner: AztecAddress,
     storageSlot: Fr,
     randomness: Fr,
@@ -153,33 +153,33 @@ export interface IPrivateExecutionOracle {
     noteHash: Fr,
     counter: number,
   ): void;
-  privateNotifyNullifiedNote(innerNullifier: Fr, noteHash: Fr, counter: number): Promise<void>;
-  privateNotifyCreatedNullifier(innerNullifier: Fr): Promise<void>;
-  privateIsNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean>;
-  privateNotifyCreatedContractClassLog(log: ContractClassLog, counter: number): void;
-  privateCallPrivateFunction(
+  notifyNullifiedNote(innerNullifier: Fr, noteHash: Fr, counter: number): Promise<void>;
+  notifyCreatedNullifier(innerNullifier: Fr): Promise<void>;
+  isNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean>;
+  notifyCreatedContractClassLog(log: ContractClassLog, counter: number): void;
+  callPrivateFunction(
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
     argsHash: Fr,
     sideEffectCounter: number,
     isStaticCall: boolean,
   ): Promise<{ endSideEffectCounter: Fr; returnsHash: Fr }>;
-  privateNotifyEnqueuedPublicFunctionCall(
+  notifyEnqueuedPublicFunctionCall(
     targetContractAddress: AztecAddress,
     calldataHash: Fr,
     sideEffectCounter: number,
     isStaticCall: boolean,
   ): Promise<void>;
-  privateNotifySetPublicTeardownFunctionCall(
+  notifySetPublicTeardownFunctionCall(
     targetContractAddress: AztecAddress,
     calldataHash: Fr,
     sideEffectCounter: number,
     isStaticCall: boolean,
   ): Promise<void>;
-  privateNotifySetMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter: number): Promise<void>;
-  privateIsSideEffectCounterRevertible(sideEffectCounter: number): Promise<boolean>;
-  privateGetSenderForTags(): Promise<AztecAddress | undefined>;
-  privateSetSenderForTags(senderForTags: AztecAddress): Promise<void>;
-  privateGetNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag>;
-  utilityEmitOffchainEffect(data: Fr[]): Promise<void>;
+  notifySetMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter: number): Promise<void>;
+  isSideEffectCounterRevertible(sideEffectCounter: number): Promise<boolean>;
+  getSenderForTags(): Promise<AztecAddress | undefined>;
+  setSenderForTags(senderForTags: AztecAddress): Promise<void>;
+  getNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag>;
+  emitOffchainEffect(data: Fr[]): Promise<void>;
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -69,12 +69,12 @@ export class Oracle {
       name => !excludedProps.includes(name as (typeof excludedProps)[number]),
     );
 
-    // Validate oracle names - these must be prefixed with either "private" or "utility" to indicate their scope
+    // Validate oracle names - these must be prefixed with either "aztec_prv_" or "aztec_utl_" to indicate their scope
     // and must correspond to a function on the Oracle class.
     oracleNames.forEach(name => {
-      if (!name.startsWith('private') && !name.startsWith('utility')) {
+      if (!name.startsWith('aztec_prv_') && !name.startsWith('aztec_utl_')) {
         throw new Error(
-          `Oracle function "${name}" must be prefixed with either "private" or "utility" to indicate its scope`,
+          `Oracle function "${name}" must be prefixed with either "aztec_prv_" or "aztec_utl_" to indicate its scope`,
         );
       }
 
@@ -92,41 +92,46 @@ export class Oracle {
     }, {} as ACIRCallback);
   }
 
-  utilityAssertCompatibleOracleVersion([version]: ACVMField[]) {
-    this.handlerAsMisc().utilityAssertCompatibleOracleVersion(Fr.fromString(version).toNumber());
+  // eslint-disable-next-line camelcase
+  aztec_utl_assertCompatibleOracleVersion([version]: ACVMField[]) {
+    this.handlerAsMisc().assertCompatibleOracleVersion(Fr.fromString(version).toNumber());
     return Promise.resolve([]);
   }
 
-  utilityGetRandomField(): Promise<ACVMField[]> {
-    const val = this.handlerAsMisc().utilityGetRandomField();
+  // eslint-disable-next-line camelcase
+  aztec_utl_getRandomField(): Promise<ACVMField[]> {
+    const val = this.handlerAsMisc().getRandomField();
     return Promise.resolve([toACVMField(val)]);
   }
 
-  privateStoreInExecutionCache(values: ACVMField[], [hash]: ACVMField[]): Promise<ACVMField[]> {
-    this.handlerAsPrivate().privateStoreInExecutionCache(values.map(Fr.fromString), Fr.fromString(hash));
+  // eslint-disable-next-line camelcase
+  aztec_prv_storeInExecutionCache(values: ACVMField[], [hash]: ACVMField[]): Promise<ACVMField[]> {
+    this.handlerAsPrivate().storeInExecutionCache(values.map(Fr.fromString), Fr.fromString(hash));
     return Promise.resolve([]);
   }
 
-  async privateLoadFromExecutionCache([returnsHash]: ACVMField[]): Promise<ACVMField[][]> {
-    const values = await this.handlerAsPrivate().privateLoadFromExecutionCache(Fr.fromString(returnsHash));
+  // eslint-disable-next-line camelcase
+  async aztec_prv_loadFromExecutionCache([returnsHash]: ACVMField[]): Promise<ACVMField[][]> {
+    const values = await this.handlerAsPrivate().loadFromExecutionCache(Fr.fromString(returnsHash));
     return [values.map(toACVMField)];
   }
 
-  utilityGetUtilityContext(): Promise<(ACVMField | ACVMField[])[]> {
-    const context = this.handlerAsUtility().utilityGetUtilityContext();
+  // eslint-disable-next-line camelcase
+  aztec_utl_getUtilityContext(): Promise<(ACVMField | ACVMField[])[]> {
+    const context = this.handlerAsUtility().getUtilityContext();
     return Promise.resolve(context.toNoirRepresentation());
   }
 
-  async utilityGetKeyValidationRequest([pkMHash]: ACVMField[]): Promise<ACVMField[]> {
-    const keyValidationRequest = await this.handlerAsUtility().utilityGetKeyValidationRequest(Fr.fromString(pkMHash));
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getKeyValidationRequest([pkMHash]: ACVMField[]): Promise<ACVMField[]> {
+    const keyValidationRequest = await this.handlerAsUtility().getKeyValidationRequest(Fr.fromString(pkMHash));
 
     return keyValidationRequest.toFields().map(toACVMField);
   }
 
-  async utilityGetContractInstance([address]: ACVMField[]): Promise<ACVMField[]> {
-    const instance = await this.handlerAsUtility().utilityGetContractInstance(
-      AztecAddress.fromField(Fr.fromString(address)),
-    );
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getContractInstance([address]: ACVMField[]): Promise<ACVMField[]> {
+    const instance = await this.handlerAsUtility().getContractInstance(AztecAddress.fromField(Fr.fromString(address)));
 
     return [
       instance.salt,
@@ -137,17 +142,15 @@ export class Oracle {
     ].map(toACVMField);
   }
 
-  async utilityGetNoteHashMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNoteHashMembershipWitness(
     [anchorBlockHash]: ACVMField[],
     [noteHash]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAnchorBlockHash = BlockHash.fromString(anchorBlockHash);
     const parsedNoteHash = Fr.fromString(noteHash);
 
-    const witness = await this.handlerAsUtility().utilityGetNoteHashMembershipWitness(
-      parsedAnchorBlockHash,
-      parsedNoteHash,
-    );
+    const witness = await this.handlerAsUtility().getNoteHashMembershipWitness(parsedAnchorBlockHash, parsedNoteHash);
     if (!witness) {
       throw new Error(
         `Note hash ${noteHash} not found in the note hash tree at anchor block hash ${parsedAnchorBlockHash.toString()}.`,
@@ -156,17 +159,15 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  async utilityGetBlockHashMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getBlockHashMembershipWitness(
     [anchorBlockHash]: ACVMField[],
     [blockHash]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAnchorBlockHash = BlockHash.fromString(anchorBlockHash);
     const parsedBlockHash = BlockHash.fromString(blockHash);
 
-    const witness = await this.handlerAsUtility().utilityGetBlockHashMembershipWitness(
-      parsedAnchorBlockHash,
-      parsedBlockHash,
-    );
+    const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(parsedAnchorBlockHash, parsedBlockHash);
     if (!witness) {
       throw new Error(
         `Block hash ${parsedBlockHash.toString()} not found in the archive tree at anchor block ${parsedAnchorBlockHash.toString()}.`,
@@ -175,17 +176,15 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  async utilityGetNullifierMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNullifierMembershipWitness(
     [blockHash]: ACVMField[],
     [nullifier]: ACVMField[], // nullifier, we try to find the witness for (to prove inclusion)
   ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedNullifier = Fr.fromString(nullifier);
 
-    const witness = await this.handlerAsUtility().utilityGetNullifierMembershipWitness(
-      parsedBlockHash,
-      parsedNullifier,
-    );
+    const witness = await this.handlerAsUtility().getNullifierMembershipWitness(parsedBlockHash, parsedNullifier);
     if (!witness) {
       throw new Error(
         `Nullifier witness not found for nullifier ${parsedNullifier} at block hash ${parsedBlockHash.toString()}.`,
@@ -194,17 +193,15 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  async utilityGetLowNullifierMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getLowNullifierMembershipWitness(
     [blockHash]: ACVMField[],
     [nullifier]: ACVMField[], // nullifier, we try to find the low nullifier witness for (to prove non-inclusion)
   ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedNullifier = Fr.fromString(nullifier);
 
-    const witness = await this.handlerAsUtility().utilityGetLowNullifierMembershipWitness(
-      parsedBlockHash,
-      parsedNullifier,
-    );
+    const witness = await this.handlerAsUtility().getLowNullifierMembershipWitness(parsedBlockHash, parsedNullifier);
     if (!witness) {
       throw new Error(
         `Low nullifier witness not found for nullifier ${parsedNullifier} at block hash ${parsedBlockHash.toString()}.`,
@@ -213,14 +210,15 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  async utilityGetPublicDataWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getPublicDataWitness(
     [blockHash]: ACVMField[],
     [leafSlot]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
     const parsedBlockHash = BlockHash.fromString(blockHash);
     const parsedLeafSlot = Fr.fromString(leafSlot);
 
-    const witness = await this.handlerAsUtility().utilityGetPublicDataWitness(parsedBlockHash, parsedLeafSlot);
+    const witness = await this.handlerAsUtility().getPublicDataWitness(parsedBlockHash, parsedLeafSlot);
     if (!witness) {
       throw new Error(
         `Public data witness not found for slot ${parsedLeafSlot} at block hash ${parsedBlockHash.toString()}.`,
@@ -229,28 +227,31 @@ export class Oracle {
     return witness.toNoirRepresentation();
   }
 
-  async utilityGetBlockHeader([blockNumber]: ACVMField[]): Promise<ACVMField[]> {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getBlockHeader([blockNumber]: ACVMField[]): Promise<ACVMField[]> {
     const parsedBlockNumber = Fr.fromString(blockNumber).toNumber();
 
-    const header = await this.handlerAsUtility().utilityGetBlockHeader(BlockNumber(parsedBlockNumber));
+    const header = await this.handlerAsUtility().getBlockHeader(BlockNumber(parsedBlockNumber));
     if (!header) {
       throw new Error(`Block header not found for block ${parsedBlockNumber}.`);
     }
     return header.toFields().map(toACVMField);
   }
 
-  async utilityGetAuthWitness([messageHash]: ACVMField[]): Promise<ACVMField[][]> {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getAuthWitness([messageHash]: ACVMField[]): Promise<ACVMField[][]> {
     const messageHashField = Fr.fromString(messageHash);
-    const witness = await this.handlerAsUtility().utilityGetAuthWitness(messageHashField);
+    const witness = await this.handlerAsUtility().getAuthWitness(messageHashField);
     if (!witness) {
       throw new Error(`Unknown auth witness for message hash ${messageHashField}`);
     }
     return [witness.map(toACVMField)];
   }
 
-  async utilityTryGetPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<(ACVMField | ACVMField[])[]> {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_tryGetPublicKeysAndPartialAddress([address]: ACVMField[]): Promise<(ACVMField | ACVMField[])[]> {
     const parsedAddress = AztecAddress.fromField(Fr.fromString(address));
-    const result = await this.handlerAsUtility().utilityTryGetPublicKeysAndPartialAddress(parsedAddress);
+    const result = await this.handlerAsUtility().tryGetPublicKeysAndPartialAddress(parsedAddress);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -263,7 +264,8 @@ export class Oracle {
     }
   }
 
-  async utilityGetNotes(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNotes(
     [ownerSome]: ACVMField[],
     [ownerValue]: ACVMField[],
     [storageSlot]: ACVMField[],
@@ -285,7 +287,7 @@ export class Oracle {
   ): Promise<(ACVMField | ACVMField[])[]> {
     // Parse Option<AztecAddress>: ownerSome is 0 for None, 1 for Some
     const owner = Fr.fromString(ownerSome).toNumber() === 1 ? AztecAddress.fromString(ownerValue) : undefined;
-    const noteDatas = await this.handlerAsUtility().utilityGetNotes(
+    const noteDatas = await this.handlerAsUtility().getNotes(
       owner,
       Fr.fromString(storageSlot),
       +numSelects,
@@ -324,7 +326,8 @@ export class Oracle {
     return arrayOfArraysToBoundedVecOfArrays(returnDataAsArrayOfACVMFieldArrays, +maxNotes, +packedHintedNoteLength);
   }
 
-  privateNotifyCreatedNote(
+  // eslint-disable-next-line camelcase
+  aztec_prv_notifyCreatedNote(
     [owner]: ACVMField[],
     [storageSlot]: ACVMField[],
     [randomness]: ACVMField[],
@@ -333,7 +336,7 @@ export class Oracle {
     [noteHash]: ACVMField[],
     [counter]: ACVMField[],
   ): Promise<ACVMField[]> {
-    this.handlerAsPrivate().privateNotifyCreatedNote(
+    this.handlerAsPrivate().notifyCreatedNote(
       AztecAddress.fromString(owner),
       Fr.fromString(storageSlot),
       Fr.fromString(randomness),
@@ -345,43 +348,47 @@ export class Oracle {
     return Promise.resolve([]);
   }
 
-  async privateNotifyNullifiedNote(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifyNullifiedNote(
     [innerNullifier]: ACVMField[],
     [noteHash]: ACVMField[],
     [counter]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().privateNotifyNullifiedNote(
-      Fr.fromString(innerNullifier),
-      Fr.fromString(noteHash),
-      +counter,
-    );
+    await this.handlerAsPrivate().notifyNullifiedNote(Fr.fromString(innerNullifier), Fr.fromString(noteHash), +counter);
     return [];
   }
 
-  async privateNotifyCreatedNullifier([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().privateNotifyCreatedNullifier(Fr.fromString(innerNullifier));
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifyCreatedNullifier([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
+    await this.handlerAsPrivate().notifyCreatedNullifier(Fr.fromString(innerNullifier));
     return [];
   }
 
-  async privateIsNullifierPending([innerNullifier]: ACVMField[], [contractAddress]: ACVMField[]): Promise<ACVMField[]> {
-    const isPending = await this.handlerAsPrivate().privateIsNullifierPending(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_isNullifierPending(
+    [innerNullifier]: ACVMField[],
+    [contractAddress]: ACVMField[],
+  ): Promise<ACVMField[]> {
+    const isPending = await this.handlerAsPrivate().isNullifierPending(
       Fr.fromString(innerNullifier),
       AztecAddress.fromString(contractAddress),
     );
     return [toACVMField(isPending)];
   }
 
-  async utilityCheckNullifierExists([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
-    const exists = await this.handlerAsUtility().utilityCheckNullifierExists(Fr.fromString(innerNullifier));
+  // eslint-disable-next-line camelcase
+  async aztec_utl_checkNullifierExists([innerNullifier]: ACVMField[]): Promise<ACVMField[]> {
+    const exists = await this.handlerAsUtility().checkNullifierExists(Fr.fromString(innerNullifier));
     return [toACVMField(exists)];
   }
 
-  async utilityGetL1ToL2MembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getL1ToL2MembershipWitness(
     [contractAddress]: ACVMField[],
     [messageHash]: ACVMField[],
     [secret]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const message = await this.handlerAsUtility().utilityGetL1ToL2MembershipWitness(
+    const message = await this.handlerAsUtility().getL1ToL2MembershipWitness(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(messageHash),
       Fr.fromString(secret),
@@ -389,13 +396,14 @@ export class Oracle {
     return message.toNoirRepresentation();
   }
 
-  async utilityStorageRead(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_storageRead(
     [blockHash]: ACVMField[],
     [contractAddress]: ACVMField[],
     [startStorageSlot]: ACVMField[],
     [numberOfElements]: ACVMField[],
   ): Promise<ACVMField[][]> {
-    const values = await this.handlerAsUtility().utilityStorageRead(
+    const values = await this.handlerAsUtility().storageRead(
       BlockHash.fromString(blockHash),
       new AztecAddress(Fr.fromString(contractAddress)),
       Fr.fromString(startStorageSlot),
@@ -404,7 +412,8 @@ export class Oracle {
     return [values.map(toACVMField)];
   }
 
-  privateNotifyCreatedContractClassLog(
+  // eslint-disable-next-line camelcase
+  aztec_prv_notifyCreatedContractClassLog(
     [contractAddress]: ACVMField[],
     message: ACVMField[],
     [length]: ACVMField[],
@@ -413,11 +422,12 @@ export class Oracle {
     const logFields = new ContractClassLogFields(message.map(Fr.fromString));
     const log = new ContractClassLog(new AztecAddress(Fr.fromString(contractAddress)), logFields, +length);
 
-    this.handlerAsPrivate().privateNotifyCreatedContractClassLog(log, +counter);
+    this.handlerAsPrivate().notifyCreatedContractClassLog(log, +counter);
     return Promise.resolve([]);
   }
 
-  async utilityLog(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_log(
     level: ACVMField[],
     message: ACVMField[],
     _ignoredFieldsSize: ACVMField[],
@@ -426,20 +436,21 @@ export class Oracle {
     const levelFr = Fr.fromString(level[0]);
     const messageStr = message.map(acvmField => String.fromCharCode(Fr.fromString(acvmField).toNumber())).join('');
     const fieldsFr = fields.map(Fr.fromString);
-    await this.handlerAsMisc().utilityLog(levelFr.toNumber(), messageStr, fieldsFr);
+    await this.handlerAsMisc().log(levelFr.toNumber(), messageStr, fieldsFr);
     return [];
   }
 
   // This function's name is directly hardcoded in `circuit_recorder.ts`. Don't forget to update it there if you
   // change the name here.
-  async privateCallPrivateFunction(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_callPrivateFunction(
     [contractAddress]: ACVMField[],
     [functionSelector]: ACVMField[],
     [argsHash]: ACVMField[],
     [sideEffectCounter]: ACVMField[],
     [isStaticCall]: ACVMField[],
   ): Promise<ACVMField[][]> {
-    const { endSideEffectCounter, returnsHash } = await this.handlerAsPrivate().privateCallPrivateFunction(
+    const { endSideEffectCounter, returnsHash } = await this.handlerAsPrivate().callPrivateFunction(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       FunctionSelector.fromField(Fr.fromString(functionSelector)),
       Fr.fromString(argsHash),
@@ -449,13 +460,14 @@ export class Oracle {
     return [[endSideEffectCounter, returnsHash].map(toACVMField)];
   }
 
-  async privateNotifyEnqueuedPublicFunctionCall(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifyEnqueuedPublicFunctionCall(
     [contractAddress]: ACVMField[],
     [calldataHash]: ACVMField[],
     [sideEffectCounter]: ACVMField[],
     [isStaticCall]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().privateNotifyEnqueuedPublicFunctionCall(
+    await this.handlerAsPrivate().notifyEnqueuedPublicFunctionCall(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(calldataHash),
       Fr.fromString(sideEffectCounter).toNumber(),
@@ -464,13 +476,14 @@ export class Oracle {
     return [];
   }
 
-  async privateNotifySetPublicTeardownFunctionCall(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifySetPublicTeardownFunctionCall(
     [contractAddress]: ACVMField[],
     [calldataHash]: ACVMField[],
     [sideEffectCounter]: ACVMField[],
     [isStaticCall]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().privateNotifySetPublicTeardownFunctionCall(
+    await this.handlerAsPrivate().notifySetPublicTeardownFunctionCall(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(calldataHash),
       Fr.fromString(sideEffectCounter).toNumber(),
@@ -479,41 +492,46 @@ export class Oracle {
     return [];
   }
 
-  async privateNotifySetMinRevertibleSideEffectCounter([minRevertibleSideEffectCounter]: ACVMField[]): Promise<
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifySetMinRevertibleSideEffectCounter([minRevertibleSideEffectCounter]: ACVMField[]): Promise<
     ACVMField[]
   > {
-    await this.handlerAsPrivate().privateNotifySetMinRevertibleSideEffectCounter(
+    await this.handlerAsPrivate().notifySetMinRevertibleSideEffectCounter(
       Fr.fromString(minRevertibleSideEffectCounter).toNumber(),
     );
     return Promise.resolve([]);
   }
 
-  async privateIsSideEffectCounterRevertible([sideEffectCounter]: ACVMField[]): Promise<ACVMField[]> {
-    const isRevertible = await this.handlerAsPrivate().privateIsSideEffectCounterRevertible(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_isSideEffectCounterRevertible([sideEffectCounter]: ACVMField[]): Promise<ACVMField[]> {
+    const isRevertible = await this.handlerAsPrivate().isSideEffectCounterRevertible(
       Fr.fromString(sideEffectCounter).toNumber(),
     );
     return Promise.resolve([toACVMField(isRevertible)]);
   }
 
-  async privateGetNextAppTagAsSender([sender]: ACVMField[], [recipient]: ACVMField[]): Promise<ACVMField[]> {
-    const tag = await this.handlerAsPrivate().privateGetNextAppTagAsSender(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_getNextAppTagAsSender([sender]: ACVMField[], [recipient]: ACVMField[]): Promise<ACVMField[]> {
+    const tag = await this.handlerAsPrivate().getNextAppTagAsSender(
       AztecAddress.fromString(sender),
       AztecAddress.fromString(recipient),
     );
     return [toACVMField(tag.value)];
   }
 
-  async utilityFetchTaggedLogs([pendingTaggedLogArrayBaseSlot]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityFetchTaggedLogs(Fr.fromString(pendingTaggedLogArrayBaseSlot));
+  // eslint-disable-next-line camelcase
+  async aztec_utl_fetchTaggedLogs([pendingTaggedLogArrayBaseSlot]: ACVMField[]): Promise<ACVMField[]> {
+    await this.handlerAsUtility().fetchTaggedLogs(Fr.fromString(pendingTaggedLogArrayBaseSlot));
     return [];
   }
 
-  async utilityValidateAndStoreEnqueuedNotesAndEvents(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_validateAndStoreEnqueuedNotesAndEvents(
     [contractAddress]: ACVMField[],
     [noteValidationRequestsArrayBaseSlot]: ACVMField[],
     [eventValidationRequestsArrayBaseSlot]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityValidateAndStoreEnqueuedNotesAndEvents(
+    await this.handlerAsUtility().validateAndStoreEnqueuedNotesAndEvents(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(noteValidationRequestsArrayBaseSlot),
       Fr.fromString(eventValidationRequestsArrayBaseSlot),
@@ -522,12 +540,13 @@ export class Oracle {
     return [];
   }
 
-  async utilityBulkRetrieveLogs(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_bulkRetrieveLogs(
     [contractAddress]: ACVMField[],
     [logRetrievalRequestsArrayBaseSlot]: ACVMField[],
     [logRetrievalResponsesArrayBaseSlot]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityBulkRetrieveLogs(
+    await this.handlerAsUtility().bulkRetrieveLogs(
       AztecAddress.fromString(contractAddress),
       Fr.fromString(logRetrievalRequestsArrayBaseSlot),
       Fr.fromString(logRetrievalResponsesArrayBaseSlot),
@@ -535,12 +554,13 @@ export class Oracle {
     return [];
   }
 
-  async utilityStoreCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_storeCapsule(
     [contractAddress]: ACVMField[],
     [slot]: ACVMField[],
     capsule: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityStoreCapsule(
+    await this.handlerAsUtility().storeCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(slot),
       capsule.map(Fr.fromString),
@@ -548,12 +568,13 @@ export class Oracle {
     return [];
   }
 
-  async utilityLoadCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_loadCapsule(
     [contractAddress]: ACVMField[],
     [slot]: ACVMField[],
     [tSize]: ACVMField[],
   ): Promise<(ACVMField | ACVMField[])[]> {
-    const values = await this.handlerAsUtility().utilityLoadCapsule(
+    const values = await this.handlerAsUtility().loadCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(slot),
     );
@@ -569,21 +590,23 @@ export class Oracle {
     }
   }
 
-  async utilityDeleteCapsule([contractAddress]: ACVMField[], [slot]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityDeleteCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_deleteCapsule([contractAddress]: ACVMField[], [slot]: ACVMField[]): Promise<ACVMField[]> {
+    await this.handlerAsUtility().deleteCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(slot),
     );
     return [];
   }
 
-  async utilityCopyCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_copyCapsule(
     [contractAddress]: ACVMField[],
     [srcSlot]: ACVMField[],
     [dstSlot]: ACVMField[],
     [numEntries]: ACVMField[],
   ): Promise<ACVMField[]> {
-    await this.handlerAsUtility().utilityCopyCapsule(
+    await this.handlerAsUtility().copyCapsule(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
       Fr.fromString(srcSlot),
       Fr.fromString(dstSlot),
@@ -592,7 +615,8 @@ export class Oracle {
     return [];
   }
 
-  async utilityAes128Decrypt(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_aes128Decrypt(
     ciphertextBVecStorage: ACVMField[],
     [ciphertextLength]: ACVMField[],
     iv: ACVMField[],
@@ -602,36 +626,40 @@ export class Oracle {
     const ivBuffer = fromUintArray(iv, 8);
     const symKeyBuffer = fromUintArray(symKey, 8);
 
-    const plaintext = await this.handlerAsUtility().utilityAes128Decrypt(ciphertext, ivBuffer, symKeyBuffer);
+    const plaintext = await this.handlerAsUtility().aes128Decrypt(ciphertext, ivBuffer, symKeyBuffer);
     return bufferToBoundedVec(plaintext, ciphertextBVecStorage.length);
   }
 
-  async utilityGetSharedSecret(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getSharedSecret(
     [address]: ACVMField[],
     [ephPKField0]: ACVMField[],
     [ephPKField1]: ACVMField[],
     [ephPKField2]: ACVMField[],
   ): Promise<ACVMField[]> {
-    const secret = await this.handlerAsUtility().utilityGetSharedSecret(
+    const secret = await this.handlerAsUtility().getSharedSecret(
       AztecAddress.fromField(Fr.fromString(address)),
       Point.fromFields([ephPKField0, ephPKField1, ephPKField2].map(Fr.fromString)),
     );
     return secret.toFields().map(toACVMField);
   }
 
-  async utilityEmitOffchainEffect(data: ACVMField[]) {
-    await this.handlerAsPrivate().utilityEmitOffchainEffect(data.map(Fr.fromString));
+  // eslint-disable-next-line camelcase
+  async aztec_utl_emitOffchainEffect(data: ACVMField[]) {
+    await this.handlerAsPrivate().emitOffchainEffect(data.map(Fr.fromString));
     return [];
   }
 
-  async privateGetSenderForTags(): Promise<ACVMField[]> {
-    const sender = await this.handlerAsPrivate().privateGetSenderForTags();
+  // eslint-disable-next-line camelcase
+  async aztec_prv_getSenderForTags(): Promise<ACVMField[]> {
+    const sender = await this.handlerAsPrivate().getSenderForTags();
     // Return [1, address] for Some(address), [0, 0] for None
     return sender ? [toACVMField(1n), toACVMField(sender)] : [toACVMField(0n), toACVMField(0n)];
   }
 
-  async privateSetSenderForTags([senderForTags]: ACVMField[]): Promise<ACVMField[]> {
-    await this.handlerAsPrivate().privateSetSenderForTags(AztecAddress.fromField(Fr.fromString(senderForTags)));
+  // eslint-disable-next-line camelcase
+  async aztec_prv_setSenderForTags([senderForTags]: ACVMField[]): Promise<ACVMField[]> {
+    await this.handlerAsPrivate().setSenderForTags(AztecAddress.fromField(Fr.fromString(senderForTags)));
     return [];
   }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle_version_is_checked.test.ts
@@ -41,8 +41,8 @@ describe('Oracle Version Check test suite', () => {
   let acirSimulator: ContractFunctionSimulator;
   let contractAddress: AztecAddress;
   let anchorBlockHeader: BlockHeader;
-  let utilityAssertCompatibleOracleVersionSpy: jest.SpiedFunction<
-    typeof UtilityExecutionOracle.prototype.utilityAssertCompatibleOracleVersion
+  let assertCompatibleOracleVersionSpy: jest.SpiedFunction<
+    typeof UtilityExecutionOracle.prototype.assertCompatibleOracleVersion
   >;
 
   beforeEach(async () => {
@@ -57,11 +57,8 @@ describe('Oracle Version Check test suite', () => {
     capsuleStore = mock<CapsuleStore>();
     privateEventStore = mock<PrivateEventStore>();
     contractSyncService = mock<ContractSyncService>();
-    utilityAssertCompatibleOracleVersionSpy = jest.spyOn(
-      UtilityExecutionOracle.prototype,
-      'utilityAssertCompatibleOracleVersion',
-    );
-    utilityAssertCompatibleOracleVersionSpy.mockClear();
+    assertCompatibleOracleVersionSpy = jest.spyOn(UtilityExecutionOracle.prototype, 'assertCompatibleOracleVersion');
+    assertCompatibleOracleVersionSpy.mockClear();
 
     aztecNode.getPublicStorageAt.mockResolvedValue(Fr.ZERO);
     anchorBlockHeader = BlockHeader.random();
@@ -107,7 +104,7 @@ describe('Oracle Version Check test suite', () => {
   });
 
   describe('private function execution', () => {
-    it('should call utilityAssertCompatibleOracleVersion oracle when private function is called', async () => {
+    it('should call assertCompatibleOracleVersion oracle when private function is called', async () => {
       // Load the artifact of the OracleVersionCheck::private_function contract function and set up the relevant oracle handler
       const privateFunctionArtifact = {
         ...OracleVersionCheckContractArtifact.functions.find(f => f.name === 'private_function')!,
@@ -149,12 +146,12 @@ describe('Oracle Version Check test suite', () => {
         scopes: 'ALL_SCOPES',
       });
 
-      expect(utilityAssertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
+      expect(assertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
     }, 30_000);
   });
 
   describe('utility function execution', () => {
-    it('should call utilityAssertCompatibleOracleVersion oracle when utility function is called', async () => {
+    it('should call assertCompatibleOracleVersion oracle when utility function is called', async () => {
       // Load the artifact of the OracleVersionCheck::utility_function contract function and set up the relevant oracle
       // handler
       const utilityFunctionArtifact = {
@@ -178,7 +175,7 @@ describe('Oracle Version Check test suite', () => {
       // Call the utility function
       await acirSimulator.runUtility(execRequest, [], anchorBlockHeader, [], 'test');
 
-      expect(utilityAssertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
+      expect(assertCompatibleOracleVersionSpy).toHaveBeenCalledTimes(1);
     }, 30_000);
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -76,7 +76,7 @@ export async function executePrivateFunction(
 
   const contractClassLogs = privateExecutionOracle.getContractClassLogs();
 
-  const rawReturnValues = await privateExecutionOracle.privateLoadFromExecutionCache(publicInputs.returnsHash);
+  const rawReturnValues = await privateExecutionOracle.loadFromExecutionCache(publicInputs.returnsHash);
 
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -189,7 +189,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * The value persists through nested calls, meaning all calls down the stack will use the same
    * 'senderForTags' value (unless it is replaced).
    */
-  public privateGetSenderForTags(): Promise<AztecAddress | undefined> {
+  public getSenderForTags(): Promise<AztecAddress | undefined> {
     return Promise.resolve(this.senderForTags);
   }
 
@@ -204,7 +204,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * through nested calls, meaning all calls down the stack will use the same 'senderForTags'
    * value (unless it is replaced by another call to this setter).
    */
-  public privateSetSenderForTags(senderForTags: AztecAddress): Promise<void> {
+  public setSenderForTags(senderForTags: AztecAddress): Promise<void> {
     this.senderForTags = senderForTags;
     return Promise.resolve();
   }
@@ -215,7 +215,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param recipient - The address receiving the log
    * @returns An app tag to be used in a log.
    */
-  public async privateGetNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag> {
+  public async getNextAppTagAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<Tag> {
     const extendedSecret = await this.#calculateExtendedDirectionalAppTaggingSecret(
       this.contractAddress,
       sender,
@@ -223,7 +223,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     );
 
     const index = await this.#getIndexToUseForSecret(extendedSecret);
-    this.log.debug(
+    this.logger.debug(
       `Incrementing tagging index for sender: ${sender}, recipient: ${recipient}, contract: ${this.contractAddress} to ${index}`,
     );
     this.taggingIndexCache.setLastUsedIndex(extendedSecret, index);
@@ -277,7 +277,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param values - Values to store.
    * @returns The hash of the values.
    */
-  public privateStoreInExecutionCache(values: Fr[], hash: Fr) {
+  public storeInExecutionCache(values: Fr[], hash: Fr) {
     return this.executionCache.store(values, hash);
   }
 
@@ -286,7 +286,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param hash - Hash of the values.
    * @returns The values.
    */
-  public privateLoadFromExecutionCache(hash: Fr): Promise<Fr[]> {
+  public loadFromExecutionCache(hash: Fr): Promise<Fr[]> {
     const preimage = this.executionCache.getPreimage(hash);
     if (!preimage) {
       throw new Error(`Preimage for hash ${hash.toString()} not found in cache`);
@@ -294,12 +294,12 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return Promise.resolve(preimage);
   }
 
-  override async utilityCheckNullifierExists(innerNullifier: Fr): Promise<boolean> {
+  override async checkNullifierExists(innerNullifier: Fr): Promise<boolean> {
     // This oracle must be overridden because while utility execution can only meaningfully check if a nullifier exists
     // in the synched block, during private execution there's also the possibility of it being pending, i.e. created
     // in the current transaction.
 
-    this.log.debug(`Checking existence of inner nullifier ${innerNullifier}`, {
+    this.logger.debug(`Checking existence of inner nullifier ${innerNullifier}`, {
       contractAddress: this.contractAddress,
     });
 
@@ -307,7 +307,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
 
     return (
       this.noteCache.getNullifiers(this.contractAddress).has(nullifier) ||
-      (await super.utilityCheckNullifierExists(innerNullifier))
+      (await super.checkNullifierExists(innerNullifier))
     );
   }
 
@@ -332,7 +332,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param status - The status of notes to fetch.
    * @returns Array of note data.
    */
-  public override async utilityGetNotes(
+  public override async getNotes(
     owner: AztecAddress | undefined,
     storageSlot: Fr,
     numSelects: number,
@@ -378,7 +378,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       offset,
     });
 
-    this.log.debug(
+    this.logger.debug(
       `Returning ${notes.length} notes for ${this.callContext.contractAddress} at ${storageSlot}: ${notes
         .map(n => `${n.noteNonce.toString()}:[${n.note.items.map(i => i.toString()).join(',')}]`)
         .join(', ')}`,
@@ -398,7 +398,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param noteHash - A hash of the new note.
    * @returns
    */
-  public privateNotifyCreatedNote(
+  public notifyCreatedNote(
     owner: AztecAddress,
     storageSlot: Fr,
     randomness: Fr,
@@ -407,7 +407,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     noteHash: Fr,
     counter: number,
   ) {
-    this.log.debug(`Notified of new note with inner hash ${noteHash}`, {
+    this.logger.debug(`Notified of new note with inner hash ${noteHash}`, {
       contractAddress: this.callContext.contractAddress,
       storageSlot,
       randomness,
@@ -439,7 +439,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param innerNullifier - The pending nullifier to add in the list (not yet siloed by contract address).
    * @param noteHash - A hash of the new note.
    */
-  public async privateNotifyNullifiedNote(innerNullifier: Fr, noteHash: Fr, counter: number) {
+  public async notifyNullifiedNote(innerNullifier: Fr, noteHash: Fr, counter: number) {
     const nullifiedNoteHashCounter = await this.noteCache.nullifyNote(
       this.callContext.contractAddress,
       innerNullifier,
@@ -456,19 +456,19 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param innerNullifier - The pending nullifier to add in the list (not yet siloed by contract address).
    * @param noteHash - A hash of the new note.
    */
-  public privateNotifyCreatedNullifier(innerNullifier: Fr) {
-    this.log.debug(`Notified of new inner nullifier ${innerNullifier}`, { contractAddress: this.contractAddress });
+  public notifyCreatedNullifier(innerNullifier: Fr) {
+    this.logger.debug(`Notified of new inner nullifier ${innerNullifier}`, { contractAddress: this.contractAddress });
     return this.noteCache.nullifierCreated(this.callContext.contractAddress, innerNullifier);
   }
 
   /**
-   * Check if a nullifier has been emitted in the same transaction, i.e. if privateNotifyCreatedNullifier has been
+   * Check if a nullifier has been emitted in the same transaction, i.e. if notifyCreatedNullifier has been
    * called for this inner nullifier from the contract with the specified address.
    * @param innerNullifier - The inner nullifier to check.
    * @param contractAddress - Address of the contract that emitted the nullifier.
    * @returns A boolean indicating whether the nullifier is pending or not.
    */
-  public async privateIsNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean> {
+  public async isNullifierPending(innerNullifier: Fr, contractAddress: AztecAddress): Promise<boolean> {
     const siloedNullifier = await siloNullifier(contractAddress, innerNullifier);
     const isNullifierPending = this.noteCache.getNullifiers(contractAddress).has(siloedNullifier.toBigInt());
     return Promise.resolve(isNullifierPending);
@@ -481,10 +481,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param log - The contract class log to be emitted.
    * @param counter - The contract class log's counter.
    */
-  public privateNotifyCreatedContractClassLog(log: ContractClassLog, counter: number) {
+  public notifyCreatedContractClassLog(log: ContractClassLog, counter: number) {
     this.contractClassLogs.push(new CountedContractClassLog(log, counter));
     const text = log.toBuffer().toString('hex');
-    this.log.verbose(
+    this.logger.verbose(
       `Emitted log from ContractClassRegistry: "${text.length > 100 ? text.slice(0, 100) + '...' : text}"`,
     );
   }
@@ -510,7 +510,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param isStaticCall - Whether the call is a static call.
    * @returns The execution result.
    */
-  async privateCallPrivateFunction(
+  async callPrivateFunction(
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
     argsHash: Fr,
@@ -524,7 +524,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     }
 
     const simulatorSetupTimer = new Timer();
-    this.log.debug(
+    this.logger.debug(
       `Calling private function ${targetContractAddress}:${functionSelector} from ${this.callContext.contractAddress}`,
     );
 
@@ -573,7 +573,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
       jobId: this.jobId,
       totalPublicCalldataCount: this.totalPublicCalldataCount,
       sideEffectCounter,
-      log: this.log,
+      log: this.logger,
       scopes: this.scopes,
       senderForTags: this.senderForTags,
       simulator: this.simulator!,
@@ -627,7 +627,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param sideEffectCounter - The side effect counter at the start of the call.
    * @param isStaticCall - Whether the call is a static call.
    */
-  public privateNotifyEnqueuedPublicFunctionCall(
+  public notifyEnqueuedPublicFunctionCall(
     _targetContractAddress: AztecAddress,
     calldataHash: Fr,
     _sideEffectCounter: number,
@@ -644,7 +644,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
    * @param sideEffectCounter - The side effect counter at the start of the call.
    * @param isStaticCall - Whether the call is a static call.
    */
-  public privateNotifySetPublicTeardownFunctionCall(
+  public notifySetPublicTeardownFunctionCall(
     _targetContractAddress: AztecAddress,
     calldataHash: Fr,
     _sideEffectCounter: number,
@@ -654,11 +654,11 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return Promise.resolve();
   }
 
-  public privateNotifySetMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter: number): Promise<void> {
+  public notifySetMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter: number): Promise<void> {
     return this.noteCache.setMinRevertibleSideEffectCounter(minRevertibleSideEffectCounter);
   }
 
-  public privateIsSideEffectCounterRevertible(sideEffectCounter: number): Promise<boolean> {
+  public isSideEffectCounterRevertible(sideEffectCounter: number): Promise<boolean> {
     return Promise.resolve(this.noteCache.isSideEffectCounterRevertible(sideEffectCounter));
   }
 
@@ -686,7 +686,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle implements IP
     return this.contractStore.getDebugFunctionName(this.contractAddress, this.callContext.functionSelector);
   }
 
-  public utilityEmitOffchainEffect(data: Fr[]): Promise<void> {
+  public emitOffchainEffect(data: Fr[]): Promise<void> {
     this.offchainEffects.push({ data });
     return Promise.resolve();
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -226,7 +226,7 @@ describe('Utility Execution test suite', () => {
 
     describe('Respects synced block number', () => {
       it('throws when getting block for future block number', async () => {
-        await expect(utilityExecutionOracle.utilityGetBlockHeader(BlockNumber(syncedBlockNumber + 1))).rejects.toThrow(
+        await expect(utilityExecutionOracle.getBlockHeader(BlockNumber(syncedBlockNumber + 1))).rejects.toThrow(
           `Block number ${syncedBlockNumber + 1} is higher than current block ${syncedBlockNumber}`,
         );
       });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -86,7 +86,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   protected readonly capsuleStore: CapsuleStore;
   protected readonly privateEventStore: PrivateEventStore;
   protected readonly jobId: string;
-  protected log: ReturnType<typeof createLogger>;
+  protected logger: ReturnType<typeof createLogger>;
   protected readonly scopes: AccessScopes;
 
   constructor(args: UtilityExecutionOracleArgs) {
@@ -104,21 +104,21 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     this.capsuleStore = args.capsuleStore;
     this.privateEventStore = args.privateEventStore;
     this.jobId = args.jobId;
-    this.log = args.log ?? createLogger('simulator:client_view_context');
+    this.logger = args.log ?? createLogger('simulator:client_view_context');
     this.scopes = args.scopes;
   }
 
-  public utilityAssertCompatibleOracleVersion(version: number): void {
+  public assertCompatibleOracleVersion(version: number): void {
     if (version !== ORACLE_VERSION) {
       throw new Error(`Incompatible oracle version. Expected version ${ORACLE_VERSION}, got ${version}.`);
     }
   }
 
-  public utilityGetRandomField(): Fr {
+  public getRandomField(): Fr {
     return Fr.random();
   }
 
-  public utilityGetUtilityContext(): UtilityContext {
+  public getUtilityContext(): UtilityContext {
     return new UtilityContext(this.anchorBlockHeader, this.contractAddress);
   }
 
@@ -129,7 +129,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @throws If the keys are not registered in the key store.
    * @throws If scopes are defined and the account is not in the scopes.
    */
-  public async utilityGetKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest> {
+  public async getKeyValidationRequest(pkMHash: Fr): Promise<KeyValidationRequest> {
     // If scopes are defined, check that the key belongs to an account in the scopes.
     if (this.scopes !== 'ALL_SCOPES' && this.scopes.length > 0) {
       let hasAccess = false;
@@ -152,7 +152,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param noteHash - The note hash to find in the note hash tree.
    * @returns The membership witness containing the leaf index and sibling path
    */
-  public utilityGetNoteHashMembershipWitness(
+  public getNoteHashMembershipWitness(
     anchorBlockHash: BlockHash,
     noteHash: Fr,
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
@@ -170,7 +170,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param blockHash - The block hash to find in the archive tree.
    * @returns The membership witness containing the leaf index and sibling path
    */
-  public utilityGetBlockHashMembershipWitness(
+  public getBlockHashMembershipWitness(
     anchorBlockHash: BlockHash,
     blockHash: BlockHash,
   ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined> {
@@ -183,7 +183,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param nullifier - Nullifier we try to find witness for.
    * @returns The nullifier membership witness (if found).
    */
-  public utilityGetNullifierMembershipWitness(
+  public getNullifierMembershipWitness(
     blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
@@ -199,7 +199,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * list structure" of leaves and proving that a lower nullifier is pointing to a bigger next value than the nullifier
    * we are trying to prove non-inclusion for.
    */
-  public utilityGetLowNullifierMembershipWitness(
+  public getLowNullifierMembershipWitness(
     blockHash: BlockHash,
     nullifier: Fr,
   ): Promise<NullifierMembershipWitness | undefined> {
@@ -212,7 +212,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param leafSlot - The slot of the public data tree to get the witness for.
    * @returns - The witness
    */
-  public utilityGetPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
+  public getPublicDataWitness(blockHash: BlockHash, leafSlot: Fr): Promise<PublicDataWitness | undefined> {
     return this.aztecNode.getPublicDataWitness(blockHash, leafSlot);
   }
 
@@ -221,7 +221,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param blockNumber - The number of a block of which to get the block header.
    * @returns Block extracted from a block with block number `blockNumber`.
    */
-  public async utilityGetBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined> {
+  public async getBlockHeader(blockNumber: BlockNumber): Promise<BlockHeader | undefined> {
     const anchorBlockNumber = this.anchorBlockHeader.getBlockNumber();
     if (blockNumber > anchorBlockNumber) {
       throw new Error(`Block number ${blockNumber} is higher than current block ${anchorBlockNumber}`);
@@ -236,7 +236,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param account - The account address.
    * @returns A complete address associated with the input address, or `undefined` if not registered.
    */
-  public utilityTryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined> {
+  public tryGetPublicKeysAndPartialAddress(account: AztecAddress): Promise<CompleteAddress | undefined> {
     return this.addressStore.getCompleteAddress(account);
   }
 
@@ -256,11 +256,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param address - Address.
    * @returns A contract instance.
    */
-  public utilityGetContractInstance(address: AztecAddress): Promise<ContractInstance> {
-    return this.getContractInstance(address);
-  }
-
-  protected async getContractInstance(address: AztecAddress): Promise<ContractInstance> {
+  public async getContractInstance(address: AztecAddress): Promise<ContractInstance> {
     const instance = await this.contractStore.getContractInstance(address);
     if (!instance) {
       throw new Error(`No contract instance found for address ${address.toString()}`);
@@ -274,7 +270,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param messageHash - Hash of the message to authenticate.
    * @returns Authentication witness for the requested message hash.
    */
-  public utilityGetAuthWitness(messageHash: Fr): Promise<Fr[] | undefined> {
+  public getAuthWitness(messageHash: Fr): Promise<Fr[] | undefined> {
     return Promise.resolve(this.authWitnesses.find(w => w.requestHash.equals(messageHash))?.witness);
   }
 
@@ -300,7 +296,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param status - The status of notes to fetch.
    * @returns Array of note data.
    */
-  public async utilityGetNotes(
+  public async getNotes(
     owner: AztecAddress | undefined,
     storageSlot: Fr,
     numSelects: number,
@@ -340,7 +336,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param innerNullifier - The inner nullifier.
    * @returns A boolean indicating whether the nullifier exists in the tree or not.
    */
-  public async utilityCheckNullifierExists(innerNullifier: Fr) {
+  public async checkNullifierExists(innerNullifier: Fr) {
     const [nullifier, anchorBlockHash] = await Promise.all([
       siloNullifier(this.contractAddress, innerNullifier!),
       this.anchorBlockHeader.hash(),
@@ -359,7 +355,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @dev Contract address and secret are only used to compute the nullifier to get non-nullified messages
    * @returns The l1 to l2 membership witness (index of message in the tree and sibling path).
    */
-  public async utilityGetL1ToL2MembershipWitness(contractAddress: AztecAddress, messageHash: Fr, secret: Fr) {
+  public async getL1ToL2MembershipWitness(contractAddress: AztecAddress, messageHash: Fr, secret: Fr) {
     const [messageIndex, siblingPath] = await getNonNullifiedL1ToL2MessageWitness(
       this.aztecNode,
       contractAddress,
@@ -377,7 +373,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param startStorageSlot - The starting storage slot.
    * @param numberOfElements - Number of elements to read from the starting storage slot.
    */
-  public async utilityStorageRead(
+  public async storageRead(
     blockHash: BlockHash,
     contractAddress: AztecAddress,
     startStorageSlot: Fr,
@@ -391,7 +387,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       slots.map(storageSlot => this.aztecNode.getPublicStorageAt(blockHash, contractAddress, storageSlot)),
     );
 
-    this.log.debug(
+    this.logger.debug(
       `Oracle storage read: slots=[${slots.map(slot => slot.toString()).join(', ')}] address=${contractAddress.toString()} values=[${values.join(', ')}]`,
     );
 
@@ -414,7 +410,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return this.contractLogger;
   }
 
-  public async utilityLog(level: number, message: string, fields: Fr[]): Promise<void> {
+  public async log(level: number, message: string, fields: Fr[]): Promise<void> {
     if (!LogLevels[level]) {
       throw new Error(`Invalid log level: ${level}`);
     }
@@ -422,7 +418,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     logContractMessage(logger, LogLevels[level], message, fields);
   }
 
-  public async utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {
+  public async fetchTaggedLogs(pendingTaggedLogArrayBaseSlot: Fr) {
     const logService = new LogService(
       this.aztecNode,
       this.anchorBlockHeader,
@@ -432,7 +428,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.senderAddressBookStore,
       this.addressStore,
       this.jobId,
-      this.log.getBindings(),
+      this.logger.getBindings(),
     );
 
     await logService.fetchTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
@@ -448,7 +444,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param noteValidationRequestsArrayBaseSlot - The base slot of capsule array containing note validation requests.
    * @param eventValidationRequestsArrayBaseSlot - The base slot of capsule array containing event validation requests.
    */
-  public async utilityValidateAndStoreEnqueuedNotesAndEvents(
+  public async validateAndStoreEnqueuedNotesAndEvents(
     contractAddress: AztecAddress,
     noteValidationRequestsArrayBaseSlot: Fr,
     eventValidationRequestsArrayBaseSlot: Fr,
@@ -504,7 +500,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     await this.capsuleStore.setCapsuleArray(contractAddress, eventValidationRequestsArrayBaseSlot, [], this.jobId);
   }
 
-  public async utilityBulkRetrieveLogs(
+  public async bulkRetrieveLogs(
     contractAddress: AztecAddress,
     logRetrievalRequestsArrayBaseSlot: Fr,
     logRetrievalResponsesArrayBaseSlot: Fr,
@@ -529,7 +525,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
       this.senderAddressBookStore,
       this.addressStore,
       this.jobId,
-      this.log.getBindings(),
+      this.logger.getBindings(),
     );
 
     const maybeLogRetrievalResponses = await logService.bulkRetrieveLogs(logRetrievalRequests);
@@ -546,7 +542,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-  public utilityStoreCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[]): Promise<void> {
+  public storeCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[]): Promise<void> {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
@@ -555,7 +551,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return Promise.resolve();
   }
 
-  public async utilityLoadCapsule(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null> {
+  public async loadCapsule(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null> {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
@@ -567,7 +563,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     );
   }
 
-  public utilityDeleteCapsule(contractAddress: AztecAddress, slot: Fr): Promise<void> {
+  public deleteCapsule(contractAddress: AztecAddress, slot: Fr): Promise<void> {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
@@ -576,12 +572,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
     return Promise.resolve();
   }
 
-  public utilityCopyCapsule(
-    contractAddress: AztecAddress,
-    srcSlot: Fr,
-    dstSlot: Fr,
-    numEntries: number,
-  ): Promise<void> {
+  public copyCapsule(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void> {
     if (!contractAddress.equals(this.contractAddress)) {
       // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
       throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
@@ -590,7 +581,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
   }
 
   // TODO(#11849): consider replacing this oracle with a pure Noir implementation of aes decryption.
-  public utilityAes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer> {
+  public aes128Decrypt(ciphertext: Buffer, iv: Buffer, symKey: Buffer): Promise<Buffer> {
     const aes128 = new Aes128();
     return aes128.decryptBufferCBC(ciphertext, iv, symKey);
   }
@@ -601,11 +592,7 @@ export class UtilityExecutionOracle implements IMiscOracle, IUtilityExecutionOra
    * @param ephPk - The ephemeral public key to get the secret for.
    * @returns The secret for the given address.
    */
-  public utilityGetSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
-    return this.getSharedSecret(address, ephPk);
-  }
-
-  protected async getSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
+  public async getSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
     // TODO(#12656): return an app-siloed secret
     const recipientCompleteAddress = await this.getCompleteAddressOrFail(address);
     const ivskM = await this.keyStore.getMasterSecretKey(

--- a/yarn-project/pxe/src/oracle_version.ts
+++ b/yarn-project/pxe/src/oracle_version.ts
@@ -2,11 +2,11 @@
 /// to version the oracle interface to ensure that developers get a reasonable error message if they use incompatible
 /// versions of Aztec.nr and PXE. The Noir counterpart is in `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
 ///
-/// @dev Whenever a contract function or Noir test is run, the `utilityAssertCompatibleOracleVersion` oracle is called
+/// @dev Whenever a contract function or Noir test is run, the `aztec_utl_assertCompatibleOracleVersion` oracle is called
 /// and if the oracle version is incompatible an error is thrown.
-export const ORACLE_VERSION = 12;
+export const ORACLE_VERSION = 13;
 
 /// This hash is computed as by hashing the Oracle interface and it is used to detect when the Oracle interface changes,
 /// which in turn implies that you need to update the ORACLE_VERSION constant in this file and in
 /// `noir-projects/aztec-nr/aztec/src/oracle/version.nr`.
-export const ORACLE_INTERFACE_HASH = '666a8a7fc697f72b29dbf0ae7464db269cf5afa019acac8861f814543147dbb4';
+export const ORACLE_INTERFACE_HASH = '9fb918682455c164ce8dd3acb71c751e2b9b2fc48913604069c9ea885fa378ca';

--- a/yarn-project/simulator/src/private/circuit_recording/circuit_recorder.ts
+++ b/yarn-project/simulator/src/private/circuit_recording/circuit_recorder.ts
@@ -161,11 +161,11 @@ export class CircuitRecorder {
         throw new Error(`Oracle method ${name} not found when setting up recording callback`);
       }
 
-      const isExternalCall = (name as keyof ACIRCallback) === 'privateCallPrivateFunction';
+      const isExternalCall = (name as keyof ACIRCallback) === 'aztec_prv_callPrivateFunction';
 
       recordingCallback[name as keyof ACIRCallback] = (...args: ForeignCallInput[]): ReturnType<typeof fn> => {
         const timer = new Timer();
-        // If we're entering another circuit via `privateCallPrivateFunction`, we increase the stack depth and set the
+        // If we're entering another circuit via `aztec_prv_callPrivateFunction`, we increase the stack depth and set the
         // newCircuit variable to ensure we are creating a new recording object.
         if (isExternalCall) {
           this.stackDepth++;

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -247,11 +247,11 @@ class TXEDispatcher {
     }
 
     switch (functionName) {
-      case 'txeDeploy': {
+      case 'aztec_txe_deploy': {
         await this.#processDeployInputs(callData);
         break;
       }
-      case 'txeAddAccount': {
+      case 'aztec_txe_addAccount': {
         await this.#processAddAccountInputs(callData);
         break;
       }

--- a/yarn-project/txe/src/oracle/interfaces.ts
+++ b/yarn-project/txe/src/oracle/interfaces.ts
@@ -24,18 +24,18 @@ import type { UInt64 } from '@aztec/stdlib/types';
 export interface IAvmExecutionOracle {
   isAvm: true;
 
-  avmOpcodeAddress(): Promise<AztecAddress>;
-  avmOpcodeSender(): Promise<AztecAddress>;
-  avmOpcodeBlockNumber(): Promise<BlockNumber>;
-  avmOpcodeTimestamp(): Promise<bigint>;
-  avmOpcodeIsStaticCall(): Promise<boolean>;
-  avmOpcodeChainId(): Promise<Fr>;
-  avmOpcodeVersion(): Promise<Fr>;
-  avmOpcodeEmitNullifier(nullifier: Fr): Promise<void>;
-  avmOpcodeEmitNoteHash(noteHash: Fr): Promise<void>;
-  avmOpcodeNullifierExists(siloedNullifier: Fr): Promise<boolean>;
-  avmOpcodeStorageWrite(slot: Fr, value: Fr): Promise<void>;
-  avmOpcodeStorageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr>;
+  address(): Promise<AztecAddress>;
+  sender(): Promise<AztecAddress>;
+  blockNumber(): Promise<BlockNumber>;
+  timestamp(): Promise<bigint>;
+  isStaticCall(): Promise<boolean>;
+  chainId(): Promise<Fr>;
+  version(): Promise<Fr>;
+  emitNullifier(nullifier: Fr): Promise<void>;
+  emitNoteHash(noteHash: Fr): Promise<void>;
+  nullifierExists(siloedNullifier: Fr): Promise<boolean>;
+  storageWrite(slot: Fr, value: Fr): Promise<void>;
+  storageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr>;
 }
 
 /**
@@ -44,27 +44,23 @@ export interface IAvmExecutionOracle {
 export interface ITxeExecutionOracle {
   isTxe: true;
 
-  txeGetDefaultAddress(): AztecAddress;
-  txeGetNextBlockNumber(): Promise<BlockNumber>;
-  txeGetNextBlockTimestamp(): Promise<UInt64>;
-  txeAdvanceBlocksBy(blocks: number): Promise<void>;
-  txeAdvanceTimestampBy(duration: UInt64): void;
-  txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: Fr): Promise<void>;
-  txeCreateAccount(secret: Fr): Promise<CompleteAddress>;
-  txeAddAccount(
-    artifact: ContractArtifact,
-    instance: ContractInstanceWithAddress,
-    secret: Fr,
-  ): Promise<CompleteAddress>;
-  txeAddAuthWitness(address: AztecAddress, messageHash: Fr): Promise<void>;
-  txeGetLastBlockTimestamp(): Promise<bigint>;
-  txeGetLastTxEffects(): Promise<{
+  getDefaultAddress(): AztecAddress;
+  getNextBlockNumber(): Promise<BlockNumber>;
+  getNextBlockTimestamp(): Promise<UInt64>;
+  advanceBlocksBy(blocks: number): Promise<void>;
+  advanceTimestampBy(duration: UInt64): void;
+  deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: Fr): Promise<void>;
+  createAccount(secret: Fr): Promise<CompleteAddress>;
+  addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr): Promise<CompleteAddress>;
+  addAuthWitness(address: AztecAddress, messageHash: Fr): Promise<void>;
+  getLastBlockTimestamp(): Promise<bigint>;
+  getLastTxEffects(): Promise<{
     txHash: TxHash;
     noteHashes: Fr[];
     nullifiers: Fr[];
   }>;
-  txeGetPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
-  txePrivateCallNewFlow(
+  getPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress): Promise<Fr[][]>;
+  privateCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
@@ -73,13 +69,13 @@ export interface ITxeExecutionOracle {
     isStaticCall: boolean,
     jobId: string,
   ): Promise<Fr[]>;
-  txeExecuteUtilityFunction(
+  executeUtilityFunction(
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
     args: Fr[],
     jobId: string,
   ): Promise<Fr[]>;
-  txePublicCallNewFlow(
+  publicCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress,
     calldata: Fr[],

--- a/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_public_context.ts
@@ -39,46 +39,46 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
     });
   }
 
-  avmOpcodeAddress(): Promise<AztecAddress> {
+  address(): Promise<AztecAddress> {
     return Promise.resolve(this.contractAddress);
   }
 
-  avmOpcodeSender(): Promise<AztecAddress> {
+  sender(): Promise<AztecAddress> {
     return Promise.resolve(AztecAddress.ZERO); // todo: change?
   }
 
-  avmOpcodeBlockNumber(): Promise<BlockNumber> {
+  blockNumber(): Promise<BlockNumber> {
     return Promise.resolve(this.globalVariables.blockNumber);
   }
 
-  avmOpcodeTimestamp(): Promise<bigint> {
+  timestamp(): Promise<bigint> {
     return Promise.resolve(this.globalVariables.timestamp);
   }
 
-  avmOpcodeIsStaticCall(): Promise<boolean> {
+  isStaticCall(): Promise<boolean> {
     return Promise.resolve(false);
   }
 
-  avmOpcodeChainId(): Promise<Fr> {
+  chainId(): Promise<Fr> {
     return Promise.resolve(this.globalVariables.chainId);
   }
 
-  avmOpcodeVersion(): Promise<Fr> {
+  version(): Promise<Fr> {
     return Promise.resolve(this.globalVariables.version);
   }
 
-  async avmOpcodeEmitNullifier(nullifier: Fr) {
+  async emitNullifier(nullifier: Fr) {
     const siloedNullifier = await siloNullifier(this.contractAddress, nullifier);
     this.transientSiloedNullifiers.push(siloedNullifier);
   }
 
-  async avmOpcodeEmitNoteHash(noteHash: Fr) {
+  async emitNoteHash(noteHash: Fr) {
     const siloedNoteHash = await siloNoteHash(this.contractAddress, noteHash);
     // TODO: make the note hash unique - they are only siloed right now
     this.transientUniqueNoteHashes.push(siloedNoteHash);
   }
 
-  async avmOpcodeNullifierExists(siloedNullifier: Fr): Promise<boolean> {
+  async nullifierExists(siloedNullifier: Fr): Promise<boolean> {
     const treeIndex = (
       await this.forkedWorldTrees.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, [siloedNullifier.toBuffer()])
     )[0];
@@ -87,7 +87,7 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
     return treeIndex !== undefined || transientIndex !== undefined;
   }
 
-  async avmOpcodeStorageWrite(slot: Fr, value: Fr) {
+  async storageWrite(slot: Fr, value: Fr) {
     this.logger.debug('AVM storage write', { slot, value });
 
     const dataWrite = new PublicDataWrite(await computePublicDataTreeLeafSlot(this.contractAddress, slot), value);
@@ -99,7 +99,7 @@ export class TXEOraclePublicContext implements IAvmExecutionOracle {
     ]);
   }
 
-  async avmOpcodeStorageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr> {
+  async storageRead(slot: Fr, contractAddress: AztecAddress): Promise<Fr> {
     const leafSlot = await computePublicDataTreeLeafSlot(contractAddress, slot);
 
     const lowLeafResult = await this.forkedWorldTrees.getPreviousValueIndex(

--- a/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle_top_level_context.ts
@@ -116,7 +116,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     this.logger.debug('Entering Top Level Context');
   }
 
-  utilityAssertCompatibleOracleVersion(version: number): void {
+  assertCompatibleOracleVersion(version: number): void {
     if (version !== ORACLE_VERSION) {
       throw new Error(
         `Incompatible oracle version. TXE is using version '${ORACLE_VERSION}', but got a request for '${version}'.`,
@@ -126,12 +126,12 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
   // This is typically only invoked in private contexts, but it is convenient to also have it in top-level for testing
   // setup.
-  utilityGetRandomField(): Fr {
+  getRandomField(): Fr {
     return Fr.random();
   }
 
   // We instruct users to debug contracts via this oracle, so it makes sense that they'd expect it to also work in tests
-  utilityLog(level: number, message: string, fields: Fr[]): Promise<void> {
+  log(level: number, message: string, fields: Fr[]): Promise<void> {
     if (!LogLevels[level]) {
       throw new Error(`Invalid log level: ${level}`);
     }
@@ -141,23 +141,23 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return Promise.resolve();
   }
 
-  txeGetDefaultAddress(): AztecAddress {
+  getDefaultAddress(): AztecAddress {
     return DEFAULT_ADDRESS;
   }
 
-  async txeGetNextBlockNumber(): Promise<BlockNumber> {
+  async getNextBlockNumber(): Promise<BlockNumber> {
     return BlockNumber((await this.getLastBlockNumber()) + 1);
   }
 
-  txeGetNextBlockTimestamp(): Promise<bigint> {
+  getNextBlockTimestamp(): Promise<bigint> {
     return Promise.resolve(this.nextBlockTimestamp);
   }
 
-  async txeGetLastBlockTimestamp() {
+  async getLastBlockTimestamp() {
     return (await this.stateMachine.node.getBlockHeader('latest'))!.globalVariables.timestamp;
   }
 
-  async txeGetLastTxEffects() {
+  async getLastTxEffects() {
     const latestBlockNumber = await this.stateMachine.archiver.getBlockNumber();
     const block = await this.stateMachine.archiver.getBlock(latestBlockNumber);
 
@@ -173,7 +173,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
 
   async syncContractNonOracleMethod(contractAddress: AztecAddress, scope: AztecAddress, jobId: string) {
     if (contractAddress.equals(DEFAULT_ADDRESS)) {
-      this.logger.debug(`Skipping sync in txeGetPrivateEvents because the events correspond to the default address.`);
+      this.logger.debug(`Skipping sync in getPrivateEvents because the events correspond to the default address.`);
       return;
     }
 
@@ -190,7 +190,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     );
   }
 
-  async txeGetPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress) {
+  async getPrivateEvents(selector: EventSelector, contractAddress: AztecAddress, scope: AztecAddress) {
     return (
       await this.privateEventStore.getPrivateEvents(selector, {
         contractAddress,
@@ -201,7 +201,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     ).map(e => e.packedEvent);
   }
 
-  async txeAdvanceBlocksBy(blocks: number) {
+  async advanceBlocksBy(blocks: number) {
     this.logger.debug(`time traveling ${blocks} blocks`);
 
     for (let i = 0; i < blocks; i++) {
@@ -209,12 +209,12 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
-  txeAdvanceTimestampBy(duration: UInt64) {
+  advanceTimestampBy(duration: UInt64) {
     this.logger.debug(`time traveling ${duration} seconds`);
     this.nextBlockTimestamp += duration;
   }
 
-  async txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {
+  async deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {
     // Emit deployment nullifier
     await this.mineBlock({
       nullifiers: [
@@ -226,7 +226,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     });
 
     if (!secret.equals(Fr.ZERO)) {
-      await this.txeAddAccount(artifact, instance, secret);
+      await this.addAccount(artifact, instance, secret);
     } else {
       await this.contractStore.addContractInstance(instance);
       await this.contractStore.addContractArtifact(artifact);
@@ -234,7 +234,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     }
   }
 
-  async txeAddAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {
+  async addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: Fr) {
     const partialAddress = await computePartialAddress(instance);
 
     this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
@@ -249,7 +249,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return completeAddress;
   }
 
-  async txeCreateAccount(secret: Fr) {
+  async createAccount(secret: Fr) {
     // This is a foot gun !
     const completeAddress = await this.keyStore.addAccount(secret, secret);
     await this.accountStore.setAccount(completeAddress.address, completeAddress);
@@ -259,7 +259,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return completeAddress;
   }
 
-  async txeAddAuthWitness(address: AztecAddress, messageHash: Fr) {
+  async addAuthWitness(address: AztecAddress, messageHash: Fr) {
     const account = await this.accountStore.getAccount(address);
     const privateKey = await this.keyStore.getMasterSecretKey(account.publicKeys.masterIncomingViewingPublicKey);
 
@@ -272,7 +272,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
   }
 
   async mineBlock(options: { nullifiers?: Fr[] } = {}) {
-    const blockNumber = await this.txeGetNextBlockNumber();
+    const blockNumber = await this.getNextBlockNumber();
 
     const txEffect = TxEffect.empty();
     txEffect.nullifiers = [getSingleTxBlockRequestHash(blockNumber), ...(options.nullifiers ?? [])];
@@ -296,7 +296,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     await this.stateMachine.handleL2Block(block);
   }
 
-  async txePrivateCallNewFlow(
+  async privateCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress = AztecAddress.zero(),
     functionSelector: FunctionSelector = FunctionSelector.empty(),
@@ -336,7 +336,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       effectiveScopes,
     );
 
-    const blockNumber = await this.txeGetNextBlockNumber();
+    const blockNumber = await this.getNextBlockNumber();
 
     const callContext = new CallContext(from, targetContractAddress, functionSelector, isStaticCall);
 
@@ -409,7 +409,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       );
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await privateExecutionOracle.privateLoadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.loadFromExecutionCache(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );
@@ -523,7 +523,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return executionResult.returnValues ?? [];
   }
 
-  async txePublicCallNewFlow(
+  async publicCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress,
     calldata: Fr[],
@@ -533,7 +533,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
       `Executing public function ${await this.contractStore.getDebugFunctionName(targetContractAddress, FunctionSelector.fromField(calldata[0]))}@${targetContractAddress} isStaticCall=${isStaticCall}`,
     );
 
-    const blockNumber = await this.txeGetNextBlockNumber();
+    const blockNumber = await this.getNextBlockNumber();
 
     const gasLimits = new Gas(DEFAULT_DA_GAS_LIMIT, DEFAULT_L2_GAS_LIMIT);
 
@@ -678,7 +678,7 @@ export class TXEOracleTopLevelContext implements IMiscOracle, ITxeExecutionOracl
     return returnValues ?? [];
   }
 
-  async txeExecuteUtilityFunction(
+  async executeUtilityFunction(
     targetContractAddress: AztecAddress,
     functionSelector: FunctionSelector,
     args: Fr[],

--- a/yarn-project/txe/src/rpc_translator.ts
+++ b/yarn-project/txe/src/rpc_translator.ts
@@ -104,13 +104,15 @@ export class RPCTranslator {
 
   // TXE session state transition functions - these get handled by the state handler
 
-  async txeSetTopLevelTXEContext() {
+  // eslint-disable-next-line camelcase
+  async aztec_txe_setTopLevelTXEContext() {
     await this.stateHandler.enterTopLevelState();
 
     return toForeignCallResult([]);
   }
 
-  async txeSetPrivateTXEContext(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_setPrivateTXEContext(
     foreignContractAddressIsSome: ForeignCallSingle,
     foreignContractAddressValue: ForeignCallSingle,
     foreignAnchorBlockNumberIsSome: ForeignCallSingle,
@@ -129,7 +131,8 @@ export class RPCTranslator {
     return toForeignCallResult(privateContextInputs.toFields().map(toSingle));
   }
 
-  async txeSetPublicTXEContext(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_setPublicTXEContext(
     foreignContractAddressIsSome: ForeignCallSingle,
     foreignContractAddressValue: ForeignCallSingle,
   ) {
@@ -142,7 +145,8 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
-  async txeSetUtilityTXEContext(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_setUtilityTXEContext(
     foreignContractAddressIsSome: ForeignCallSingle,
     foreignContractAddressValue: ForeignCallSingle,
   ) {
@@ -159,44 +163,54 @@ export class RPCTranslator {
 
   // TXE-specific oracles
 
-  txeGetDefaultAddress() {
-    const defaultAddress = this.handlerAsTxe().txeGetDefaultAddress();
+  // eslint-disable-next-line camelcase
+  aztec_txe_getDefaultAddress() {
+    const defaultAddress = this.handlerAsTxe().getDefaultAddress();
 
     return toForeignCallResult([toSingle(defaultAddress)]);
   }
 
-  async txeGetNextBlockNumber() {
-    const nextBlockNumber = await this.handlerAsTxe().txeGetNextBlockNumber();
+  // eslint-disable-next-line camelcase
+  async aztec_txe_getNextBlockNumber() {
+    const nextBlockNumber = await this.handlerAsTxe().getNextBlockNumber();
 
     return toForeignCallResult([toSingle(nextBlockNumber)]);
   }
 
-  async txeGetNextBlockTimestamp() {
-    const nextBlockTimestamp = await this.handlerAsTxe().txeGetNextBlockTimestamp();
+  // eslint-disable-next-line camelcase
+  async aztec_txe_getNextBlockTimestamp() {
+    const nextBlockTimestamp = await this.handlerAsTxe().getNextBlockTimestamp();
 
     return toForeignCallResult([toSingle(nextBlockTimestamp)]);
   }
 
-  async txeAdvanceBlocksBy(foreignBlocks: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_txe_advanceBlocksBy(foreignBlocks: ForeignCallSingle) {
     const blocks = fromSingle(foreignBlocks).toNumber();
 
-    await this.handlerAsTxe().txeAdvanceBlocksBy(blocks);
+    await this.handlerAsTxe().advanceBlocksBy(blocks);
 
     return toForeignCallResult([]);
   }
 
-  txeAdvanceTimestampBy(foreignDuration: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  aztec_txe_advanceTimestampBy(foreignDuration: ForeignCallSingle) {
     const duration = fromSingle(foreignDuration).toBigInt();
 
-    this.handlerAsTxe().txeAdvanceTimestampBy(duration);
+    this.handlerAsTxe().advanceTimestampBy(duration);
 
     return toForeignCallResult([]);
   }
 
-  async txeDeploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, foreignSecret: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_txe_deploy(
+    artifact: ContractArtifact,
+    instance: ContractInstanceWithAddress,
+    foreignSecret: ForeignCallSingle,
+  ) {
     const secret = fromSingle(foreignSecret);
 
-    await this.handlerAsTxe().txeDeploy(artifact, instance, secret);
+    await this.handlerAsTxe().deploy(artifact, instance, secret);
 
     return toForeignCallResult([
       toArray([
@@ -209,10 +223,11 @@ export class RPCTranslator {
     ]);
   }
 
-  async txeCreateAccount(foreignSecret: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_txe_createAccount(foreignSecret: ForeignCallSingle) {
     const secret = fromSingle(foreignSecret);
 
-    const completeAddress = await this.handlerAsTxe().txeCreateAccount(secret);
+    const completeAddress = await this.handlerAsTxe().createAccount(secret);
 
     return toForeignCallResult([
       toSingle(completeAddress.address),
@@ -220,14 +235,15 @@ export class RPCTranslator {
     ]);
   }
 
-  async txeAddAccount(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_addAccount(
     artifact: ContractArtifact,
     instance: ContractInstanceWithAddress,
     foreignSecret: ForeignCallSingle,
   ) {
     const secret = fromSingle(foreignSecret);
 
-    const completeAddress = await this.handlerAsTxe().txeAddAccount(artifact, instance, secret);
+    const completeAddress = await this.handlerAsTxe().addAccount(artifact, instance, secret);
 
     return toForeignCallResult([
       toSingle(completeAddress.address),
@@ -235,39 +251,44 @@ export class RPCTranslator {
     ]);
   }
 
-  async txeAddAuthWitness(foreignAddress: ForeignCallSingle, foreignMessageHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_txe_addAuthWitness(foreignAddress: ForeignCallSingle, foreignMessageHash: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
     const messageHash = fromSingle(foreignMessageHash);
 
-    await this.handlerAsTxe().txeAddAuthWitness(address, messageHash);
+    await this.handlerAsTxe().addAuthWitness(address, messageHash);
 
     return toForeignCallResult([]);
   }
 
   // PXE oracles
 
-  utilityAssertCompatibleOracleVersion(foreignVersion: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  aztec_utl_assertCompatibleOracleVersion(foreignVersion: ForeignCallSingle) {
     const version = fromSingle(foreignVersion).toNumber();
 
-    this.handlerAsMisc().utilityAssertCompatibleOracleVersion(version);
+    this.handlerAsMisc().assertCompatibleOracleVersion(version);
 
     return toForeignCallResult([]);
   }
 
-  utilityGetRandomField() {
-    const randomField = this.handlerAsMisc().utilityGetRandomField();
+  // eslint-disable-next-line camelcase
+  aztec_utl_getRandomField() {
+    const randomField = this.handlerAsMisc().getRandomField();
 
     return toForeignCallResult([toSingle(randomField)]);
   }
 
-  async txeGetLastBlockTimestamp() {
-    const timestamp = await this.handlerAsTxe().txeGetLastBlockTimestamp();
+  // eslint-disable-next-line camelcase
+  async aztec_txe_getLastBlockTimestamp() {
+    const timestamp = await this.handlerAsTxe().getLastBlockTimestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
-  async txeGetLastTxEffects() {
-    const { txHash, noteHashes, nullifiers } = await this.handlerAsTxe().txeGetLastTxEffects();
+  // eslint-disable-next-line camelcase
+  async aztec_txe_getLastTxEffects() {
+    const { txHash, noteHashes, nullifiers } = await this.handlerAsTxe().getLastTxEffects();
 
     return toForeignCallResult([
       toSingle(txHash.hash),
@@ -276,7 +297,8 @@ export class RPCTranslator {
     ]);
   }
 
-  async txeGetPrivateEvents(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_getPrivateEvents(
     foreignSelector: ForeignCallSingle,
     foreignContractAddress: ForeignCallSingle,
     foreignScope: ForeignCallSingle,
@@ -292,7 +314,7 @@ export class RPCTranslator {
       await this.stateHandler.cycleJob();
     }
 
-    const events = await this.handlerAsTxe().txeGetPrivateEvents(selector, contractAddress, scope);
+    const events = await this.handlerAsTxe().getPrivateEvents(selector, contractAddress, scope);
 
     if (events.length > MAX_PRIVATE_EVENTS_PER_TXE_QUERY) {
       throw new Error(`Array of length ${events.length} larger than maxLen ${MAX_PRIVATE_EVENTS_PER_TXE_QUERY}`);
@@ -316,26 +338,29 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(rawArrayStorage), toArray(eventLengths), toSingle(queryLength)]);
   }
 
-  privateStoreInExecutionCache(foreignValues: ForeignCallArray, foreignHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  aztec_prv_storeInExecutionCache(foreignValues: ForeignCallArray, foreignHash: ForeignCallSingle) {
     const values = fromArray(foreignValues);
     const hash = fromSingle(foreignHash);
 
-    this.handlerAsPrivate().privateStoreInExecutionCache(values, hash);
+    this.handlerAsPrivate().storeInExecutionCache(values, hash);
 
     return toForeignCallResult([]);
   }
 
-  async privateLoadFromExecutionCache(foreignHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_prv_loadFromExecutionCache(foreignHash: ForeignCallSingle) {
     const hash = fromSingle(foreignHash);
 
-    const returns = await this.handlerAsPrivate().privateLoadFromExecutionCache(hash);
+    const returns = await this.handlerAsPrivate().loadFromExecutionCache(hash);
 
     return toForeignCallResult([toArray(returns)]);
   }
 
   // When the argument is a slice, noir automatically adds a length field to oracle call.
   // When the argument is an array, we add the field length manually to the signature.
-  async utilityLog(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_log(
     foreignLevel: ForeignCallSingle,
     foreignMessage: ForeignCallArray,
     _foreignLength: ForeignCallSingle,
@@ -347,12 +372,13 @@ export class RPCTranslator {
       .join('');
     const fields = fromArray(foreignFields);
 
-    await this.handlerAsMisc().utilityLog(level, message, fields);
+    await this.handlerAsMisc().log(level, message, fields);
 
     return toForeignCallResult([]);
   }
 
-  async utilityStorageRead(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_storageRead(
     foreignBlockHash: ForeignCallSingle,
     foreignContractAddress: ForeignCallSingle,
     foreignStartStorageSlot: ForeignCallSingle,
@@ -363,7 +389,7 @@ export class RPCTranslator {
     const startStorageSlot = fromSingle(foreignStartStorageSlot);
     const numberOfElements = fromSingle(foreignNumberOfElements).toNumber();
 
-    const values = await this.handlerAsUtility().utilityStorageRead(
+    const values = await this.handlerAsUtility().storageRead(
       blockHash,
       contractAddress,
       startStorageSlot,
@@ -373,11 +399,12 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(values)]);
   }
 
-  async utilityGetPublicDataWitness(foreignBlockHash: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getPublicDataWitness(foreignBlockHash: ForeignCallSingle, foreignLeafSlot: ForeignCallSingle) {
     const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const leafSlot = fromSingle(foreignLeafSlot);
 
-    const witness = await this.handlerAsUtility().utilityGetPublicDataWitness(blockHash, leafSlot);
+    const witness = await this.handlerAsUtility().getPublicDataWitness(blockHash, leafSlot);
 
     if (!witness) {
       throw new Error(`Public data witness not found for slot ${leafSlot} at block ${blockHash.toString()}.`);
@@ -385,7 +412,8 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityGetNotes(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNotes(
     foreignOwnerIsSome: ForeignCallSingle,
     foreignOwnerValue: ForeignCallSingle,
     foreignStorageSlot: ForeignCallSingle,
@@ -426,7 +454,7 @@ export class RPCTranslator {
     const maxNotes = fromSingle(foreignMaxNotes).toNumber();
     const packedHintedNoteLength = fromSingle(foreignPackedHintedNoteLength).toNumber();
 
-    const noteDatas = await this.handlerAsUtility().utilityGetNotes(
+    const noteDatas = await this.handlerAsUtility().getNotes(
       owner,
       storageSlot,
       numSelects,
@@ -467,7 +495,8 @@ export class RPCTranslator {
     );
   }
 
-  privateNotifyCreatedNote(
+  // eslint-disable-next-line camelcase
+  aztec_prv_notifyCreatedNote(
     foreignOwner: ForeignCallSingle,
     foreignStorageSlot: ForeignCallSingle,
     foreignRandomness: ForeignCallSingle,
@@ -484,20 +513,13 @@ export class RPCTranslator {
     const noteHash = fromSingle(foreignNoteHash);
     const counter = fromSingle(foreignCounter).toNumber();
 
-    this.handlerAsPrivate().privateNotifyCreatedNote(
-      owner,
-      storageSlot,
-      randomness,
-      noteTypeId,
-      note,
-      noteHash,
-      counter,
-    );
+    this.handlerAsPrivate().notifyCreatedNote(owner, storageSlot, randomness, noteTypeId, note, noteHash, counter);
 
     return toForeignCallResult([]);
   }
 
-  async privateNotifyNullifiedNote(
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifyNullifiedNote(
     foreignInnerNullifier: ForeignCallSingle,
     foreignNoteHash: ForeignCallSingle,
     foreignCounter: ForeignCallSingle,
@@ -506,40 +528,47 @@ export class RPCTranslator {
     const noteHash = fromSingle(foreignNoteHash);
     const counter = fromSingle(foreignCounter).toNumber();
 
-    await this.handlerAsPrivate().privateNotifyNullifiedNote(innerNullifier, noteHash, counter);
+    await this.handlerAsPrivate().notifyNullifiedNote(innerNullifier, noteHash, counter);
 
     return toForeignCallResult([]);
   }
 
-  async privateNotifyCreatedNullifier(foreignInnerNullifier: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_prv_notifyCreatedNullifier(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    await this.handlerAsPrivate().privateNotifyCreatedNullifier(innerNullifier);
+    await this.handlerAsPrivate().notifyCreatedNullifier(innerNullifier);
 
     return toForeignCallResult([]);
   }
 
-  async privateIsNullifierPending(foreignInnerNullifier: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_prv_isNullifierPending(
+    foreignInnerNullifier: ForeignCallSingle,
+    foreignContractAddress: ForeignCallSingle,
+  ) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
     const contractAddress = addressFromSingle(foreignContractAddress);
 
-    const isPending = await this.handlerAsPrivate().privateIsNullifierPending(innerNullifier, contractAddress);
+    const isPending = await this.handlerAsPrivate().isNullifierPending(innerNullifier, contractAddress);
 
     return toForeignCallResult([toSingle(new Fr(isPending))]);
   }
 
-  async utilityCheckNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_checkNullifierExists(foreignInnerNullifier: ForeignCallSingle) {
     const innerNullifier = fromSingle(foreignInnerNullifier);
 
-    const exists = await this.handlerAsUtility().utilityCheckNullifierExists(innerNullifier);
+    const exists = await this.handlerAsUtility().checkNullifierExists(innerNullifier);
 
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
 
-  async utilityGetContractInstance(foreignAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getContractInstance(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.handlerAsUtility().utilityGetContractInstance(address);
+    const instance = await this.handlerAsUtility().getContractInstance(address);
 
     return toForeignCallResult(
       [
@@ -552,10 +581,11 @@ export class RPCTranslator {
     );
   }
 
-  async utilityTryGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_tryGetPublicKeysAndPartialAddress(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const result = await this.handlerAsUtility().utilityTryGetPublicKeysAndPartialAddress(address);
+    const result = await this.handlerAsUtility().tryGetPublicKeysAndPartialAddress(address);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -571,15 +601,17 @@ export class RPCTranslator {
     }
   }
 
-  async utilityGetKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getKeyValidationRequest(foreignPkMHash: ForeignCallSingle) {
     const pkMHash = fromSingle(foreignPkMHash);
 
-    const keyValidationRequest = await this.handlerAsUtility().utilityGetKeyValidationRequest(pkMHash);
+    const keyValidationRequest = await this.handlerAsUtility().getKeyValidationRequest(pkMHash);
 
     return toForeignCallResult(keyValidationRequest.toFields().map(toSingle));
   }
 
-  privateCallPrivateFunction(
+  // eslint-disable-next-line camelcase
+  aztec_prv_callPrivateFunction(
     _foreignTargetContractAddress: ForeignCallSingle,
     _foreignFunctionSelector: ForeignCallSingle,
     _foreignArgsHash: ForeignCallSingle,
@@ -591,11 +623,15 @@ export class RPCTranslator {
     );
   }
 
-  async utilityGetNullifierMembershipWitness(foreignBlockHash: ForeignCallSingle, foreignNullifier: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNullifierMembershipWitness(
+    foreignBlockHash: ForeignCallSingle,
+    foreignNullifier: ForeignCallSingle,
+  ) {
     const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const nullifier = fromSingle(foreignNullifier);
 
-    const witness = await this.handlerAsUtility().utilityGetNullifierMembershipWitness(blockHash, nullifier);
+    const witness = await this.handlerAsUtility().getNullifierMembershipWitness(blockHash, nullifier);
 
     if (!witness) {
       throw new Error(`Nullifier membership witness not found at block ${blockHash}.`);
@@ -603,10 +639,11 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityGetAuthWitness(foreignMessageHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getAuthWitness(foreignMessageHash: ForeignCallSingle) {
     const messageHash = fromSingle(foreignMessageHash);
 
-    const authWitness = await this.handlerAsUtility().utilityGetAuthWitness(messageHash);
+    const authWitness = await this.handlerAsUtility().getAuthWitness(messageHash);
 
     if (!authWitness) {
       throw new Error(`Auth witness not found for message hash ${messageHash}.`);
@@ -614,7 +651,8 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(authWitness)]);
   }
 
-  public privateNotifyEnqueuedPublicFunctionCall(
+  // eslint-disable-next-line camelcase
+  public aztec_prv_notifyEnqueuedPublicFunctionCall(
     _foreignTargetContractAddress: ForeignCallSingle,
     _foreignCalldataHash: ForeignCallSingle,
     _foreignSideEffectCounter: ForeignCallSingle,
@@ -623,7 +661,8 @@ export class RPCTranslator {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
-  public privateNotifySetPublicTeardownFunctionCall(
+  // eslint-disable-next-line camelcase
+  public aztec_prv_notifySetPublicTeardownFunctionCall(
     _foreignTargetContractAddress: ForeignCallSingle,
     _foreignCalldataHash: ForeignCallSingle,
     _foreignSideEffectCounter: ForeignCallSingle,
@@ -632,26 +671,30 @@ export class RPCTranslator {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
-  public privateNotifySetMinRevertibleSideEffectCounter(_foreignMinRevertibleSideEffectCounter: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  public aztec_prv_notifySetMinRevertibleSideEffectCounter(_foreignMinRevertibleSideEffectCounter: ForeignCallSingle) {
     throw new Error('Enqueueing public calls is not supported in TestEnvironment::private_context');
   }
 
-  public async privateIsSideEffectCounterRevertible(foreignSideEffectCounter: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  public async aztec_prv_isSideEffectCounterRevertible(foreignSideEffectCounter: ForeignCallSingle) {
     const sideEffectCounter = fromSingle(foreignSideEffectCounter).toNumber();
-    const isRevertible = await this.handlerAsPrivate().privateIsSideEffectCounterRevertible(sideEffectCounter);
+    const isRevertible = await this.handlerAsPrivate().isSideEffectCounterRevertible(sideEffectCounter);
     return toForeignCallResult([toSingle(new Fr(isRevertible))]);
   }
 
-  utilityGetUtilityContext() {
-    const context = this.handlerAsUtility().utilityGetUtilityContext();
+  // eslint-disable-next-line camelcase
+  aztec_utl_getUtilityContext() {
+    const context = this.handlerAsUtility().getUtilityContext();
 
     return toForeignCallResult(context.toNoirRepresentation());
   }
 
-  async utilityGetBlockHeader(foreignBlockNumber: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getBlockHeader(foreignBlockNumber: ForeignCallSingle) {
     const blockNumber = BlockNumber(fromSingle(foreignBlockNumber).toNumber());
 
-    const header = await this.handlerAsUtility().utilityGetBlockHeader(blockNumber);
+    const header = await this.handlerAsUtility().getBlockHeader(blockNumber);
 
     if (!header) {
       throw new Error(`Block header not found for block ${blockNumber}.`);
@@ -659,14 +702,15 @@ export class RPCTranslator {
     return toForeignCallResult(header.toFields().map(toSingle));
   }
 
-  async utilityGetNoteHashMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getNoteHashMembershipWitness(
     foreignAnchorBlockHash: ForeignCallSingle,
     foreignNoteHash: ForeignCallSingle,
   ) {
     const blockHash = new BlockHash(fromSingle(foreignAnchorBlockHash));
     const noteHash = fromSingle(foreignNoteHash);
 
-    const witness = await this.handlerAsUtility().utilityGetNoteHashMembershipWitness(blockHash, noteHash);
+    const witness = await this.handlerAsUtility().getNoteHashMembershipWitness(blockHash, noteHash);
 
     if (!witness) {
       throw new Error(`Note hash ${noteHash} not found in the note hash tree at block ${blockHash.toString()}.`);
@@ -674,14 +718,15 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityGetBlockHashMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getBlockHashMembershipWitness(
     foreignAnchorBlockHash: ForeignCallSingle,
     foreignBlockHash: ForeignCallSingle,
   ) {
     const anchorBlockHash = new BlockHash(fromSingle(foreignAnchorBlockHash));
     const blockHash = new BlockHash(fromSingle(foreignBlockHash));
 
-    const witness = await this.handlerAsUtility().utilityGetBlockHashMembershipWitness(anchorBlockHash, blockHash);
+    const witness = await this.handlerAsUtility().getBlockHashMembershipWitness(anchorBlockHash, blockHash);
 
     if (!witness) {
       throw new Error(
@@ -691,14 +736,15 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityGetLowNullifierMembershipWitness(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getLowNullifierMembershipWitness(
     foreignBlockHash: ForeignCallSingle,
     foreignNullifier: ForeignCallSingle,
   ) {
     const blockHash = new BlockHash(fromSingle(foreignBlockHash));
     const nullifier = fromSingle(foreignNullifier);
 
-    const witness = await this.handlerAsUtility().utilityGetLowNullifierMembershipWitness(blockHash, nullifier);
+    const witness = await this.handlerAsUtility().getLowNullifierMembershipWitness(blockHash, nullifier);
 
     if (!witness) {
       throw new Error(`Low nullifier witness not found for nullifier ${nullifier} at block ${blockHash}.`);
@@ -706,15 +752,17 @@ export class RPCTranslator {
     return toForeignCallResult(witness.toNoirRepresentation());
   }
 
-  async utilityFetchTaggedLogs(foreignPendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_fetchTaggedLogs(foreignPendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
     const pendingTaggedLogArrayBaseSlot = fromSingle(foreignPendingTaggedLogArrayBaseSlot);
 
-    await this.handlerAsUtility().utilityFetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
+    await this.handlerAsUtility().fetchTaggedLogs(pendingTaggedLogArrayBaseSlot);
 
     return toForeignCallResult([]);
   }
 
-  public async utilityValidateAndStoreEnqueuedNotesAndEvents(
+  // eslint-disable-next-line camelcase
+  public async aztec_utl_validateAndStoreEnqueuedNotesAndEvents(
     foreignContractAddress: ForeignCallSingle,
     foreignNoteValidationRequestsArrayBaseSlot: ForeignCallSingle,
     foreignEventValidationRequestsArrayBaseSlot: ForeignCallSingle,
@@ -723,7 +771,7 @@ export class RPCTranslator {
     const noteValidationRequestsArrayBaseSlot = fromSingle(foreignNoteValidationRequestsArrayBaseSlot);
     const eventValidationRequestsArrayBaseSlot = fromSingle(foreignEventValidationRequestsArrayBaseSlot);
 
-    await this.handlerAsUtility().utilityValidateAndStoreEnqueuedNotesAndEvents(
+    await this.handlerAsUtility().validateAndStoreEnqueuedNotesAndEvents(
       contractAddress,
       noteValidationRequestsArrayBaseSlot,
       eventValidationRequestsArrayBaseSlot,
@@ -732,7 +780,8 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
-  public async utilityBulkRetrieveLogs(
+  // eslint-disable-next-line camelcase
+  public async aztec_utl_bulkRetrieveLogs(
     foreignContractAddress: ForeignCallSingle,
     foreignLogRetrievalRequestsArrayBaseSlot: ForeignCallSingle,
     foreignLogRetrievalResponsesArrayBaseSlot: ForeignCallSingle,
@@ -741,7 +790,7 @@ export class RPCTranslator {
     const logRetrievalRequestsArrayBaseSlot = fromSingle(foreignLogRetrievalRequestsArrayBaseSlot);
     const logRetrievalResponsesArrayBaseSlot = fromSingle(foreignLogRetrievalResponsesArrayBaseSlot);
 
-    await this.handlerAsUtility().utilityBulkRetrieveLogs(
+    await this.handlerAsUtility().bulkRetrieveLogs(
       contractAddress,
       logRetrievalRequestsArrayBaseSlot,
       logRetrievalResponsesArrayBaseSlot,
@@ -750,7 +799,8 @@ export class RPCTranslator {
     return toForeignCallResult([]);
   }
 
-  async utilityStoreCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_storeCapsule(
     foreignContractAddress: ForeignCallSingle,
     foreignSlot: ForeignCallSingle,
     foreignCapsule: ForeignCallArray,
@@ -759,12 +809,13 @@ export class RPCTranslator {
     const slot = fromSingle(foreignSlot);
     const capsule = fromArray(foreignCapsule);
 
-    await this.handlerAsUtility().utilityStoreCapsule(contractAddress, slot, capsule);
+    await this.handlerAsUtility().storeCapsule(contractAddress, slot, capsule);
 
     return toForeignCallResult([]);
   }
 
-  async utilityLoadCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_loadCapsule(
     foreignContractAddress: ForeignCallSingle,
     foreignSlot: ForeignCallSingle,
     foreignTSize: ForeignCallSingle,
@@ -773,7 +824,7 @@ export class RPCTranslator {
     const slot = fromSingle(foreignSlot);
     const tSize = fromSingle(foreignTSize).toNumber();
 
-    const values = await this.handlerAsUtility().utilityLoadCapsule(contractAddress, slot);
+    const values = await this.handlerAsUtility().loadCapsule(contractAddress, slot);
 
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
@@ -786,16 +837,18 @@ export class RPCTranslator {
     }
   }
 
-  async utilityDeleteCapsule(foreignContractAddress: ForeignCallSingle, foreignSlot: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_utl_deleteCapsule(foreignContractAddress: ForeignCallSingle, foreignSlot: ForeignCallSingle) {
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
     const slot = fromSingle(foreignSlot);
 
-    await this.handlerAsUtility().utilityDeleteCapsule(contractAddress, slot);
+    await this.handlerAsUtility().deleteCapsule(contractAddress, slot);
 
     return toForeignCallResult([]);
   }
 
-  async utilityCopyCapsule(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_copyCapsule(
     foreignContractAddress: ForeignCallSingle,
     foreignSrcSlot: ForeignCallSingle,
     foreignDstSlot: ForeignCallSingle,
@@ -806,7 +859,7 @@ export class RPCTranslator {
     const dstSlot = fromSingle(foreignDstSlot);
     const numEntries = fromSingle(foreignNumEntries).toNumber();
 
-    await this.handlerAsUtility().utilityCopyCapsule(contractAddress, srcSlot, dstSlot, numEntries);
+    await this.handlerAsUtility().copyCapsule(contractAddress, srcSlot, dstSlot, numEntries);
 
     return toForeignCallResult([]);
   }
@@ -815,7 +868,8 @@ export class RPCTranslator {
   // The compiler didn't throw an error, so it took me a while to learn of the existence of this file, and that I need
   // to implement this function here. Isn't there a way to programmatically identify that this is missing, given the
   // existence of a txe_oracle method?
-  async utilityAes128Decrypt(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_aes128Decrypt(
     foreignCiphertextBVecStorage: ForeignCallArray,
     foreignCiphertextLength: ForeignCallSingle,
     foreignIv: ForeignCallArray,
@@ -825,14 +879,15 @@ export class RPCTranslator {
     const iv = fromUintArray(foreignIv, 8);
     const symKey = fromUintArray(foreignSymKey, 8);
 
-    const plaintextBuffer = await this.handlerAsUtility().utilityAes128Decrypt(ciphertext, iv, symKey);
+    const plaintextBuffer = await this.handlerAsUtility().aes128Decrypt(ciphertext, iv, symKey);
 
     return toForeignCallResult(
       arrayToBoundedVec(bufferToU8Array(plaintextBuffer), foreignCiphertextBVecStorage.length),
     );
   }
 
-  async utilityGetSharedSecret(
+  // eslint-disable-next-line camelcase
+  async aztec_utl_getSharedSecret(
     foreignAddress: ForeignCallSingle,
     foreignEphPKField0: ForeignCallSingle,
     foreignEphPKField1: ForeignCallSingle,
@@ -845,44 +900,49 @@ export class RPCTranslator {
       fromSingle(foreignEphPKField2),
     ]);
 
-    const secret = await this.handlerAsUtility().utilityGetSharedSecret(address, ephPK);
+    const secret = await this.handlerAsUtility().getSharedSecret(address, ephPK);
 
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
-  emitOffchainEffect(_foreignData: ForeignCallArray) {
+  // eslint-disable-next-line camelcase
+  aztec_utl_emitOffchainEffect(_foreignData: ForeignCallArray) {
     throw new Error('Offchain effects are not yet supported in the TestEnvironment');
   }
 
   // AVM opcodes
 
-  avmOpcodeEmitPublicLog(_foreignMessage: ForeignCallArray) {
+  // eslint-disable-next-line camelcase
+  aztec_avm_emitPublicLog(_foreignMessage: ForeignCallArray) {
     // TODO(#8811): Implement
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeStorageRead(foreignSlot: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_storageRead(foreignSlot: ForeignCallSingle, foreignContractAddress: ForeignCallSingle) {
     const slot = fromSingle(foreignSlot);
     const contractAddress = AztecAddress.fromField(fromSingle(foreignContractAddress));
 
-    const value = (await this.handlerAsAvm().avmOpcodeStorageRead(slot, contractAddress)).value;
+    const value = (await this.handlerAsAvm().storageRead(slot, contractAddress)).value;
 
     return toForeignCallResult([toSingle(new Fr(value))]);
   }
 
-  async avmOpcodeStorageWrite(foreignSlot: ForeignCallSingle, foreignValue: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_storageWrite(foreignSlot: ForeignCallSingle, foreignValue: ForeignCallSingle) {
     const slot = fromSingle(foreignSlot);
     const value = fromSingle(foreignValue);
 
-    await this.handlerAsAvm().avmOpcodeStorageWrite(slot, value);
+    await this.handlerAsAvm().storageWrite(slot, value);
 
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeGetContractInstanceDeployer(foreignAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_getContractInstanceDeployer(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.handlerAsUtility().utilityGetContractInstance(address);
+    const instance = await this.handlerAsUtility().getContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.deployer),
@@ -891,10 +951,11 @@ export class RPCTranslator {
     ]);
   }
 
-  async avmOpcodeGetContractInstanceClassId(foreignAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_getContractInstanceClassId(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.handlerAsUtility().utilityGetContractInstance(address);
+    const instance = await this.handlerAsUtility().getContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.currentContractClassId),
@@ -903,10 +964,11 @@ export class RPCTranslator {
     ]);
   }
 
-  async avmOpcodeGetContractInstanceInitializationHash(foreignAddress: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_getContractInstanceInitializationHash(foreignAddress: ForeignCallSingle) {
     const address = addressFromSingle(foreignAddress);
 
-    const instance = await this.handlerAsUtility().utilityGetContractInstance(address);
+    const instance = await this.handlerAsUtility().getContractInstance(address);
 
     return toForeignCallResult([
       toSingle(instance.initializationHash),
@@ -915,85 +977,98 @@ export class RPCTranslator {
     ]);
   }
 
-  async avmOpcodeSender() {
-    const sender = await this.handlerAsAvm().avmOpcodeSender();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_sender() {
+    const sender = await this.handlerAsAvm().sender();
 
     return toForeignCallResult([toSingle(sender)]);
   }
 
-  async avmOpcodeEmitNullifier(foreignNullifier: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_emitNullifier(foreignNullifier: ForeignCallSingle) {
     const nullifier = fromSingle(foreignNullifier);
 
-    await this.handlerAsAvm().avmOpcodeEmitNullifier(nullifier);
+    await this.handlerAsAvm().emitNullifier(nullifier);
 
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeEmitNoteHash(foreignNoteHash: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_emitNoteHash(foreignNoteHash: ForeignCallSingle) {
     const noteHash = fromSingle(foreignNoteHash);
 
-    await this.handlerAsAvm().avmOpcodeEmitNoteHash(noteHash);
+    await this.handlerAsAvm().emitNoteHash(noteHash);
 
     return toForeignCallResult([]);
   }
 
-  async avmOpcodeNullifierExists(foreignSiloedNullifier: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_avm_nullifierExists(foreignSiloedNullifier: ForeignCallSingle) {
     const siloedNullifier = fromSingle(foreignSiloedNullifier);
 
-    const exists = await this.handlerAsAvm().avmOpcodeNullifierExists(siloedNullifier);
+    const exists = await this.handlerAsAvm().nullifierExists(siloedNullifier);
 
     return toForeignCallResult([toSingle(new Fr(exists))]);
   }
 
-  async avmOpcodeAddress() {
-    const contractAddress = await this.handlerAsAvm().avmOpcodeAddress();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_address() {
+    const contractAddress = await this.handlerAsAvm().address();
 
     return toForeignCallResult([toSingle(contractAddress.toField())]);
   }
 
-  async avmOpcodeBlockNumber() {
-    const blockNumber = await this.handlerAsAvm().avmOpcodeBlockNumber();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_blockNumber() {
+    const blockNumber = await this.handlerAsAvm().blockNumber();
 
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
-  async avmOpcodeTimestamp() {
-    const timestamp = await this.handlerAsAvm().avmOpcodeTimestamp();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_timestamp() {
+    const timestamp = await this.handlerAsAvm().timestamp();
 
     return toForeignCallResult([toSingle(new Fr(timestamp))]);
   }
 
-  async avmOpcodeIsStaticCall() {
-    const isStaticCall = await this.handlerAsAvm().avmOpcodeIsStaticCall();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_isStaticCall() {
+    const isStaticCall = await this.handlerAsAvm().isStaticCall();
 
     return toForeignCallResult([toSingle(new Fr(isStaticCall ? 1 : 0))]);
   }
 
-  async avmOpcodeChainId() {
-    const chainId = await this.handlerAsAvm().avmOpcodeChainId();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_chainId() {
+    const chainId = await this.handlerAsAvm().chainId();
 
     return toForeignCallResult([toSingle(chainId)]);
   }
 
-  async avmOpcodeVersion() {
-    const version = await this.handlerAsAvm().avmOpcodeVersion();
+  // eslint-disable-next-line camelcase
+  async aztec_avm_version() {
+    const version = await this.handlerAsAvm().version();
 
     return toForeignCallResult([toSingle(version)]);
   }
 
-  avmOpcodeReturndataSize() {
+  // eslint-disable-next-line camelcase
+  aztec_avm_returndataSize() {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
     );
   }
 
-  avmOpcodeReturndataCopy(_foreignRdOffset: ForeignCallSingle, _foreignCopySize: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  aztec_avm_returndataCopy(_foreignRdOffset: ForeignCallSingle, _foreignCopySize: ForeignCallSingle) {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
     );
   }
 
-  avmOpcodeCall(
+  // eslint-disable-next-line camelcase
+  aztec_avm_call(
     _foreignL2Gas: ForeignCallSingle,
     _foreignDaGas: ForeignCallSingle,
     _foreignAddress: ForeignCallSingle,
@@ -1005,7 +1080,8 @@ export class RPCTranslator {
     );
   }
 
-  avmOpcodeStaticCall(
+  // eslint-disable-next-line camelcase
+  aztec_avm_staticCall(
     _foreignL2Gas: ForeignCallSingle,
     _foreignDaGas: ForeignCallSingle,
     _foreignAddress: ForeignCallSingle,
@@ -1017,13 +1093,15 @@ export class RPCTranslator {
     );
   }
 
-  avmOpcodeSuccessCopy() {
+  // eslint-disable-next-line camelcase
+  aztec_avm_successCopy() {
     throw new Error(
       'Contract calls are forbidden inside a `TestEnvironment::public_context`, use `public_call` instead',
     );
   }
 
-  async txePrivateCallNewFlow(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_privateCallNewFlow(
     foreignFrom: ForeignCallSingle,
     foreignTargetContractAddress: ForeignCallSingle,
     foreignFunctionSelector: ForeignCallSingle,
@@ -1038,7 +1116,7 @@ export class RPCTranslator {
     const argsHash = fromSingle(foreignArgsHash);
     const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
 
-    const returnValues = await this.handlerAsTxe().txePrivateCallNewFlow(
+    const returnValues = await this.handlerAsTxe().privateCallNewFlow(
       from,
       targetContractAddress,
       functionSelector,
@@ -1053,7 +1131,8 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(returnValues)]);
   }
 
-  async txeExecuteUtilityFunction(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_executeUtilityFunction(
     foreignTargetContractAddress: ForeignCallSingle,
     foreignFunctionSelector: ForeignCallSingle,
     foreignArgs: ForeignCallArray,
@@ -1062,7 +1141,7 @@ export class RPCTranslator {
     const functionSelector = FunctionSelector.fromField(fromSingle(foreignFunctionSelector));
     const args = fromArray(foreignArgs);
 
-    const returnValues = await this.handlerAsTxe().txeExecuteUtilityFunction(
+    const returnValues = await this.handlerAsTxe().executeUtilityFunction(
       targetContractAddress,
       functionSelector,
       args,
@@ -1074,7 +1153,8 @@ export class RPCTranslator {
     return toForeignCallResult([toArray(returnValues)]);
   }
 
-  async txePublicCallNewFlow(
+  // eslint-disable-next-line camelcase
+  async aztec_txe_publicCallNewFlow(
     foreignFrom: ForeignCallSingle,
     foreignAddress: ForeignCallSingle,
     foreignCalldata: ForeignCallArray,
@@ -1085,15 +1165,16 @@ export class RPCTranslator {
     const calldata = fromArray(foreignCalldata);
     const isStaticCall = fromSingle(foreignIsStaticCall).toBool();
 
-    const returnValues = await this.handlerAsTxe().txePublicCallNewFlow(from, address, calldata, isStaticCall);
+    const returnValues = await this.handlerAsTxe().publicCallNewFlow(from, address, calldata, isStaticCall);
 
     // TODO(F-335): Avoid doing the following call here.
     await this.stateHandler.cycleJob();
     return toForeignCallResult([toArray(returnValues)]);
   }
 
-  async privateGetSenderForTags() {
-    const sender = await this.handlerAsPrivate().privateGetSenderForTags();
+  // eslint-disable-next-line camelcase
+  async aztec_prv_getSenderForTags() {
+    const sender = await this.handlerAsPrivate().getSenderForTags();
 
     // Return a Noir Option struct with `some` and `value` fields
     if (sender === undefined) {
@@ -1105,19 +1186,21 @@ export class RPCTranslator {
     }
   }
 
-  async privateSetSenderForTags(foreignSenderForTags: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_prv_setSenderForTags(foreignSenderForTags: ForeignCallSingle) {
     const senderForTags = AztecAddress.fromField(fromSingle(foreignSenderForTags));
 
-    await this.handlerAsPrivate().privateSetSenderForTags(senderForTags);
+    await this.handlerAsPrivate().setSenderForTags(senderForTags);
 
     return toForeignCallResult([]);
   }
 
-  async privateGetNextAppTagAsSender(foreignSender: ForeignCallSingle, foreignRecipient: ForeignCallSingle) {
+  // eslint-disable-next-line camelcase
+  async aztec_prv_getNextAppTagAsSender(foreignSender: ForeignCallSingle, foreignRecipient: ForeignCallSingle) {
     const sender = AztecAddress.fromField(fromSingle(foreignSender));
     const recipient = AztecAddress.fromField(fromSingle(foreignRecipient));
 
-    const nextAppTag = await this.handlerAsPrivate().privateGetNextAppTagAsSender(sender, recipient);
+    const nextAppTag = await this.handlerAsPrivate().getNextAppTagAsSender(sender, recipient);
 
     return toForeignCallResult([toSingle(nextAppTag.value)]);
   }

--- a/yarn-project/txe/src/txe_session.ts
+++ b/yarn-project/txe/src/txe_session.ts
@@ -202,7 +202,7 @@ export class TXESession implements TXESessionStateHandler {
       chainId,
       new Map(),
     );
-    await topLevelOracleHandler.txeAdvanceBlocksBy(1);
+    await topLevelOracleHandler.advanceBlocksBy(1);
 
     return new TXESession(
       createLogger('txe:session'),
@@ -452,8 +452,8 @@ export class TXESession implements TXESessionStateHandler {
 
     // Note that while all public and private contexts do is build a single block that we then process when exiting
     // those, the top level context performs a large number of actions not captured in the following 'close' call. Among
-    // others, it will create empty blocks (via `txeAdvanceBlocksBy` and `deploy`), create blocks with transactions via
-    // `txePrivateCallNewFlow` and `txePublicCallNewFlow`, add accounts to PXE via `txeAddAccount`, etc. This is a
+    // others, it will create empty blocks (via `advanceBlocksBy` and `deploy`), create blocks with transactions via
+    // `privateCallNewFlow` and `publicCallNewFlow`, add accounts to PXE via `addAccount`, etc. This is a
     // slight inconsistency in the working model of this class, but is not too bad.
     // TODO: it's quite unfortunate that we need to capture the authwits created to later pass them again when the top
     // level context is re-created. This is because authwits create a temporary utility context that'd otherwise reset


### PR DESCRIPTION
This adds the `aztec` namespace prefix to all oracles. We need this for https://github.com/noir-lang/noir/issues/10105, so that we can get proper error messages on `nargo` that link to aztec docs.

It also shortens the current prefixes:
- `utility` → `utl`
- `private` → `prv`
- `avmOpcode` → `avm`
- `txe` unchanged

The prefixes only exist as the actual oracle name in the nr <> ts communication layer, they are not present in the nr code nor ts code. I actually removed the current prefixes from oracle handler fn (e.g. `utilityGetBlockNumber` becomes `getBlockNumber`) to reduce verbosity and repetitiveness, given that those functions already exist in interfaces that scope the oracles that correspond to that execution mode.