### PR TITLE
fix(pxe): correct contract class log DA gas metering from +2 to +1

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -809,9 +809,9 @@ function meterGasUsed(data: PrivateToRollupAccumulatedData | PrivateToPublicAccu
   meteredL2Gas += numPrivatelogs * L2_GAS_PER_PRIVATE_LOG;
 
   const numContractClassLogs = arrayNonEmptyLength(data.contractClassLogsHashes, log => log.isEmpty());
-  // Every contract class log emits its length and contract address as additional fields
+  // Every contract class log emits its contract address as an additional field
   meteredDAFields += data.contractClassLogsHashes.reduce(
-    (acc, log) => (!log.isEmpty() ? acc + log.logHash.length + 2 : acc),
+    (acc, log) => (!log.isEmpty() ? acc + log.logHash.length + 1 : acc),
     0,
   );
   meteredL2Gas += numContractClassLogs * L2_GAS_PER_CONTRACT_CLASS_LOG;


### PR DESCRIPTION
## Summary

- Fixes contract class log DA gas metering in the PXE contract function simulator
- Changed `+ 2` to `+ 1` for the additional fields per contract class log, matching the circuits (gas_meter.nr, tx_blob_data.nr, sponge_blob.nr) and the TS blob encoder which all use `+ 1`
- Contract class logs only emit the contract address as an extra field (unlike private logs which also emit a length field), so the old `+ 2` was overcharging by 1 DA field (32 DA gas) per log

Fixes F-377

## Test plan

- Existing tests pass — this is a gas metering correction, not a logic change
- Contract class log blob encoding is unchanged; only the gas estimation in the PXE was wrong


🤖 Generated with [Claude Code](https://claude.com/claude-code)