### PR TITLE
fix: (A-591) aztecProofSubmissionEpochs incorrectly named as aztecProofSubmissionWindow

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -213,7 +213,7 @@ describe('e2e_p2p_network', () => {
         return provenBlock > 0;
       },
       'proven block',
-      SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES.aztecProofSubmissionWindow * AZTEC_EPOCH_DURATION * AZTEC_SLOT_DURATION,
+      SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES.aztecProofSubmissionEpochs * AZTEC_EPOCH_DURATION * AZTEC_SLOT_DURATION,
     );
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -59,7 +59,7 @@ export const WAIT_FOR_TX_TIMEOUT = l1ContractsConfig.aztecSlotDuration * 3;
 export const SHORTENED_BLOCK_TIME_CONFIG_NO_PRUNES = {
   aztecSlotDuration: 12,
   ethereumSlotDuration: 4,
-  aztecProofSubmissionWindow: 640,
+  aztecProofSubmissionEpochs: 640,
 };
 
 export class P2PNetworkTest {


### PR DESCRIPTION
- Incorrect config property was silently dropped due to as AztecNodeConfig cast.
- Fixes other tests (e.g. gossip) reliant on this config setup.