### PR TITLE
fix(log): do not log validation error if unregistered handler

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -237,11 +237,11 @@ export class LibP2PService extends WithTracer implements P2PService {
     this.gossipSubEventHandler = this.handleGossipSubEvent.bind(this);
 
     this.blockReceivedCallback = async (block: BlockProposal): Promise<boolean> => {
-      this.logger.debug(
-        `Handler not yet registered: Block received callback not set. Received block for slot ${block.slotNumber} from peer.`,
+      this.logger.warn(
+        `Handler for block received not yet registered on P2P service. Received block ${block.blockNumber} for slot ${block.slotNumber} from peer.`,
         { p2pMessageIdentifier: await block.p2pMessageLoggingIdentifier() },
       );
-      return false;
+      return true;
     };
 
     this.checkpointReceivedCallback = (


### PR DESCRIPTION
If we didn't register a block proposal handler on libp2p service, we'd log that validation had failed. This commit increases the log level for an unregistered handler, which should not happen, and supresses the validation failed error in that case.
