### PR TITLE
chore: update commit hash in scope docs for bool/bytearray and field

### DIFF
--- a/barretenberg/cpp/scripts/audit/audit_scopes/bool_byte_array_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/bool_byte_array_audit_scope.md
@@ -1,7 +1,7 @@
 # External Audit Scope: bool and byte_array
 
 Repository: https://github.com/AztecProtocol/aztec-packages
-Commit hash: `b463d7c1c52fec2f4e39acfd21219464b00a39d8` ([link](https://github.com/AztecProtocol/aztec-packages/tree/b463d7c1c52fec2f4e39acfd21219464b00a39d8))
+Commit hash: `940351a2d7cb027bc9ce6844dfc1158fbc684333` ([link](https://github.com/AztecProtocol/aztec-packages/commit/940351a2d7cb027bc9ce6844dfc1158fbc684333))
 
 ## Files to Audit
 Note: Paths relative to `aztec-packages/barretenberg/cpp/src/barretenberg`

--- a/barretenberg/cpp/scripts/audit/audit_scopes/field_audit_scope.md
+++ b/barretenberg/cpp/scripts/audit/audit_scopes/field_audit_scope.md
@@ -1,7 +1,7 @@
 # External Audit Scope: field
 
 Repository: https://github.com/AztecProtocol/aztec-packages
-Commit hash: `458fb330efa8c470567ab4b84a8a92a58b00586a` ([link](https://github.com/AztecProtocol/aztec-packages/tree/458fb330efa8c470567ab4b84a8a92a58b00586a))
+Commit hash: `940351a2d7cb027bc9ce6844dfc1158fbc684333` ([link](https://github.com/AztecProtocol/aztec-packages/commit/940351a2d7cb027bc9ce6844dfc1158fbc684333))
 
 ## Files to Audit
 Note: Paths relative to `aztec-packages/barretenberg/cpp/src/barretenberg`


### PR DESCRIPTION
Update bool/byte_array + field audit scope docs with most recent hash on next.