### PR TITLE
feat: additional validation in public setup allowlist (onlySelf + null msg sender)

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/allowed_public_setup.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/allowed_public_setup.ts
@@ -22,6 +22,7 @@ export async function getDefaultAllowedSetupFunctions(): Promise<AllowedElement[
       {
         address: ProtocolContractAddress.AuthRegistry,
         selector: setAuthorizedInternalSelector,
+        onlySelf: true,
       },
       // AuthRegistry: needed for authwit support via public path (PublicFeePaymentMethod calls set_authorized directly)
       {
@@ -32,11 +33,13 @@ export async function getDefaultAllowedSetupFunctions(): Promise<AllowedElement[
       {
         address: ProtocolContractAddress.FeeJuice,
         selector: increaseBalanceSelector,
+        onlySelf: true,
       },
       // Token: needed for private transfers via FPC (transfer_to_public enqueues this)
       {
         classId: tokenClassId,
         selector: increaseBalanceSelector,
+        onlySelf: true,
       },
       // Token: needed for public transfers via FPC (fee_entrypoint_public enqueues this)
       {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/allowed_public_setup.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/allowed_public_setup.ts
@@ -23,11 +23,13 @@ export async function getDefaultAllowedSetupFunctions(): Promise<AllowedElement[
         address: ProtocolContractAddress.AuthRegistry,
         selector: setAuthorizedInternalSelector,
         onlySelf: true,
+        rejectNullMsgSender: true,
       },
       // AuthRegistry: needed for authwit support via public path (PublicFeePaymentMethod calls set_authorized directly)
       {
         address: ProtocolContractAddress.AuthRegistry,
         selector: setAuthorizedSelector,
+        rejectNullMsgSender: true,
       },
       // FeeJuice: needed for claiming on the same tx as a spend (claim_and_end_setup enqueues this)
       {

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.test.ts
@@ -1,11 +1,13 @@
+import { NULL_MSG_SENDER_CONTRACT_ADDRESS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
-import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { makeAztecAddress, makeSelector, mockTx } from '@aztec/stdlib/testing';
 import {
   TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED,
   TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT,
+  TX_ERROR_SETUP_NULL_MSG_SENDER,
   TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER,
   type Tx,
 } from '@aztec/stdlib/tx';
@@ -248,7 +250,7 @@ describe('PhasesTxValidator', () => {
       await patchNonRevertibleFn(tx, 0, {
         address: allowedOnlySelfContract,
         selector: allowedOnlySelfSelector,
-        msgSender: makeAztecAddress(),
+        msgSender: makeAztecAddress(999),
       });
 
       await expectInvalid(tx, TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER);
@@ -309,6 +311,70 @@ describe('PhasesTxValidator', () => {
         address: allowedContract,
         selector: allowedSetupSelector1,
         msgSender: makeAztecAddress(),
+      });
+
+      await expectValid(tx);
+    });
+  });
+
+  describe('rejectNullMsgSender validation', () => {
+    const nullMsgSender = AztecAddress.fromBigInt(NULL_MSG_SENDER_CONTRACT_ADDRESS);
+    let rejectNullContract: AztecAddress;
+    let rejectNullSelector: FunctionSelector;
+    let noRejectNullContract: AztecAddress;
+    let noRejectNullSelector: FunctionSelector;
+
+    beforeEach(() => {
+      rejectNullContract = makeAztecAddress(50);
+      rejectNullSelector = makeSelector(50);
+      noRejectNullContract = makeAztecAddress(51);
+      noRejectNullSelector = makeSelector(51);
+
+      txValidator = new PhasesTxValidator(
+        contractDataSource,
+        [
+          {
+            address: rejectNullContract,
+            selector: rejectNullSelector,
+            rejectNullMsgSender: true,
+          },
+          {
+            address: noRejectNullContract,
+            selector: noRejectNullSelector,
+          },
+        ],
+        timestamp,
+      );
+    });
+
+    it('rejects when msgSender is NULL_MSG_SENDER_CONTRACT_ADDRESS', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: rejectNullContract,
+        selector: rejectNullSelector,
+        msgSender: nullMsgSender,
+      });
+
+      await expectInvalid(tx, TX_ERROR_SETUP_NULL_MSG_SENDER);
+    });
+
+    it('allows when msgSender is a normal address', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: rejectNullContract,
+        selector: rejectNullSelector,
+        msgSender: makeAztecAddress(100),
+      });
+
+      await expectValid(tx);
+    });
+
+    it('allows null msgSender on entries without the flag', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: noRejectNullContract,
+        selector: noRejectNullSelector,
+        msgSender: nullMsgSender,
       });
 
       await expectValid(tx);

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.test.ts
@@ -6,6 +6,7 @@ import { makeAztecAddress, makeSelector, mockTx } from '@aztec/stdlib/testing';
 import {
   TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED,
   TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT,
+  TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER,
   type Tx,
 } from '@aztec/stdlib/tx';
 
@@ -197,5 +198,120 @@ describe('PhasesTxValidator', () => {
     await expectValid(tx);
 
     expect(contractDataSource.getContract).not.toHaveBeenCalled();
+  });
+
+  describe('onlySelf validation', () => {
+    let allowedOnlySelfSelector: FunctionSelector;
+    let allowedOnlySelfContract: AztecAddress;
+    let allowedOnlySelfClass: Fr;
+
+    beforeEach(() => {
+      allowedOnlySelfSelector = makeSelector(10);
+      allowedOnlySelfContract = makeAztecAddress();
+      allowedOnlySelfClass = Fr.random();
+
+      txValidator = new PhasesTxValidator(
+        contractDataSource,
+        [
+          {
+            address: allowedOnlySelfContract,
+            selector: allowedOnlySelfSelector,
+            onlySelf: true,
+          },
+          {
+            classId: allowedOnlySelfClass,
+            selector: allowedOnlySelfSelector,
+            onlySelf: true,
+          },
+          {
+            address: allowedContract,
+            selector: allowedSetupSelector1,
+          },
+        ],
+        timestamp,
+      );
+    });
+
+    it('allows onlySelf address entry when msgSender equals contractAddress', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: allowedOnlySelfContract,
+        selector: allowedOnlySelfSelector,
+        msgSender: allowedOnlySelfContract,
+      });
+
+      await expectValid(tx);
+    });
+
+    it('rejects onlySelf address entry when msgSender differs from contractAddress', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: allowedOnlySelfContract,
+        selector: allowedOnlySelfSelector,
+        msgSender: makeAztecAddress(),
+      });
+
+      await expectInvalid(tx, TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER);
+    });
+
+    it('allows onlySelf class entry when msgSender equals contractAddress', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      const address = await patchNonRevertibleFn(tx, 0, {
+        selector: allowedOnlySelfSelector,
+        msgSender: undefined, // will be patched below
+      });
+
+      // Patch msgSender to equal contractAddress
+      tx.data.forPublic!.nonRevertibleAccumulatedData.publicCallRequests[0].msgSender = address;
+
+      contractDataSource.getContract.mockImplementationOnce((contractAddress, atTimestamp) => {
+        if (timestamp !== atTimestamp) {
+          throw new Error('Unexpected timestamp');
+        }
+        if (address.equals(contractAddress)) {
+          return Promise.resolve({
+            currentContractClassId: allowedOnlySelfClass,
+            originalContractClassId: Fr.random(),
+          } as any);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await expectValid(tx);
+    });
+
+    it('rejects onlySelf class entry when msgSender differs from contractAddress', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      const address = await patchNonRevertibleFn(tx, 0, {
+        selector: allowedOnlySelfSelector,
+        msgSender: makeAztecAddress(),
+      });
+
+      contractDataSource.getContract.mockImplementationOnce((contractAddress, atTimestamp) => {
+        if (timestamp !== atTimestamp) {
+          throw new Error('Unexpected timestamp');
+        }
+        if (address.equals(contractAddress)) {
+          return Promise.resolve({
+            currentContractClassId: allowedOnlySelfClass,
+            originalContractClassId: Fr.random(),
+          } as any);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await expectInvalid(tx, TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER);
+    });
+
+    it('allows non-onlySelf entry with different msgSender', async () => {
+      const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
+      await patchNonRevertibleFn(tx, 0, {
+        address: allowedContract,
+        selector: allowedSetupSelector1,
+        msgSender: makeAztecAddress(),
+      });
+
+      await expectValid(tx);
+    });
   });
 });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
@@ -7,6 +7,7 @@ import {
   TX_ERROR_DURING_VALIDATION,
   TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED,
   TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT,
+  TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER,
   Tx,
   TxExecutionPhase,
   type TxValidationResult,
@@ -84,6 +85,9 @@ export class PhasesTxValidator implements TxValidator<Tx> {
     for (const entry of allowList) {
       if ('address' in entry) {
         if (contractAddress.equals(entry.address) && entry.selector.equals(functionSelector)) {
+          if (entry.onlySelf && !publicCall.request.msgSender.equals(contractAddress)) {
+            return TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER;
+          }
           return undefined;
         }
       }
@@ -105,6 +109,9 @@ export class PhasesTxValidator implements TxValidator<Tx> {
       }
 
       if (contractClassId.value === entry.classId.toString() && entry.selector.equals(functionSelector)) {
+        if (entry.onlySelf && !publicCall.request.msgSender.equals(contractAddress)) {
+          return TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER;
+        }
         return undefined;
       }
     }

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
@@ -1,5 +1,7 @@
+import { NULL_MSG_SENDER_CONTRACT_ADDRESS } from '@aztec/constants';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { PublicContractsDB, getCallRequestsWithCalldataByPhase } from '@aztec/simulator/server';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import type { AllowedElement } from '@aztec/stdlib/interfaces/server';
 import {
@@ -7,6 +9,7 @@ import {
   TX_ERROR_DURING_VALIDATION,
   TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED,
   TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT,
+  TX_ERROR_SETUP_NULL_MSG_SENDER,
   TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER,
   Tx,
   TxExecutionPhase,
@@ -88,6 +91,12 @@ export class PhasesTxValidator implements TxValidator<Tx> {
           if (entry.onlySelf && !publicCall.request.msgSender.equals(contractAddress)) {
             return TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER;
           }
+          if (
+            entry.rejectNullMsgSender &&
+            publicCall.request.msgSender.equals(AztecAddress.fromBigInt(NULL_MSG_SENDER_CONTRACT_ADDRESS))
+          ) {
+            return TX_ERROR_SETUP_NULL_MSG_SENDER;
+          }
           return undefined;
         }
       }
@@ -111,6 +120,12 @@ export class PhasesTxValidator implements TxValidator<Tx> {
       if (contractClassId.value === entry.classId.toString() && entry.selector.equals(functionSelector)) {
         if (entry.onlySelf && !publicCall.request.msgSender.equals(contractAddress)) {
           return TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER;
+        }
+        if (
+          entry.rejectNullMsgSender &&
+          publicCall.request.msgSender.equals(AztecAddress.fromBigInt(NULL_MSG_SENDER_CONTRACT_ADDRESS))
+        ) {
+          return TX_ERROR_SETUP_NULL_MSG_SENDER;
         }
         return undefined;
       }

--- a/yarn-project/stdlib/src/interfaces/allowed_element.ts
+++ b/yarn-project/stdlib/src/interfaces/allowed_element.ts
@@ -6,14 +6,34 @@ import type { FunctionSelector } from '../abi/function_selector.js';
 import type { AztecAddress } from '../aztec-address/index.js';
 import { schemas, zodFor } from '../schemas/index.js';
 
-type AllowedInstanceFunction = { address: AztecAddress; selector: FunctionSelector; onlySelf?: boolean };
-type AllowedClassFunction = { classId: Fr; selector: FunctionSelector; onlySelf?: boolean };
+type AllowedInstanceFunction = {
+  address: AztecAddress;
+  selector: FunctionSelector;
+  onlySelf?: boolean;
+  rejectNullMsgSender?: boolean;
+};
+type AllowedClassFunction = {
+  classId: Fr;
+  selector: FunctionSelector;
+  onlySelf?: boolean;
+  rejectNullMsgSender?: boolean;
+};
 
 export type AllowedElement = AllowedInstanceFunction | AllowedClassFunction;
 
 export const AllowedElementSchema = zodFor<AllowedElement>()(
   z.union([
-    z.object({ address: schemas.AztecAddress, selector: schemas.FunctionSelector, onlySelf: z.boolean().optional() }),
-    z.object({ classId: schemas.Fr, selector: schemas.FunctionSelector, onlySelf: z.boolean().optional() }),
+    z.object({
+      address: schemas.AztecAddress,
+      selector: schemas.FunctionSelector,
+      onlySelf: z.boolean().optional(),
+      rejectNullMsgSender: z.boolean().optional(),
+    }),
+    z.object({
+      classId: schemas.Fr,
+      selector: schemas.FunctionSelector,
+      onlySelf: z.boolean().optional(),
+      rejectNullMsgSender: z.boolean().optional(),
+    }),
   ]),
 );

--- a/yarn-project/stdlib/src/interfaces/allowed_element.ts
+++ b/yarn-project/stdlib/src/interfaces/allowed_element.ts
@@ -6,14 +6,14 @@ import type { FunctionSelector } from '../abi/function_selector.js';
 import type { AztecAddress } from '../aztec-address/index.js';
 import { schemas, zodFor } from '../schemas/index.js';
 
-type AllowedInstanceFunction = { address: AztecAddress; selector: FunctionSelector };
-type AllowedClassFunction = { classId: Fr; selector: FunctionSelector };
+type AllowedInstanceFunction = { address: AztecAddress; selector: FunctionSelector; onlySelf?: boolean };
+type AllowedClassFunction = { classId: Fr; selector: FunctionSelector; onlySelf?: boolean };
 
 export type AllowedElement = AllowedInstanceFunction | AllowedClassFunction;
 
 export const AllowedElementSchema = zodFor<AllowedElement>()(
   z.union([
-    z.object({ address: schemas.AztecAddress, selector: schemas.FunctionSelector }),
-    z.object({ classId: schemas.Fr, selector: schemas.FunctionSelector }),
+    z.object({ address: schemas.AztecAddress, selector: schemas.FunctionSelector, onlySelf: z.boolean().optional() }),
+    z.object({ classId: schemas.Fr, selector: schemas.FunctionSelector, onlySelf: z.boolean().optional() }),
   ]),
 );

--- a/yarn-project/stdlib/src/tx/validator/error_texts.ts
+++ b/yarn-project/stdlib/src/tx/validator/error_texts.ts
@@ -7,6 +7,7 @@ export const TX_ERROR_GAS_LIMIT_TOO_HIGH = 'Gas limit is higher than the amount 
 // Phases
 export const TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED = 'Setup function not on allow list';
 export const TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT = 'Setup function targets unknown contract';
+export const TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER = 'Setup only_self function called with incorrect msg_sender';
 
 // Nullifiers
 export const TX_ERROR_DUPLICATE_NULLIFIER_IN_TX = 'Duplicate nullifier in tx';

--- a/yarn-project/stdlib/src/tx/validator/error_texts.ts
+++ b/yarn-project/stdlib/src/tx/validator/error_texts.ts
@@ -8,6 +8,7 @@ export const TX_ERROR_GAS_LIMIT_TOO_HIGH = 'Gas limit is higher than the amount 
 export const TX_ERROR_SETUP_FUNCTION_NOT_ALLOWED = 'Setup function not on allow list';
 export const TX_ERROR_SETUP_FUNCTION_UNKNOWN_CONTRACT = 'Setup function targets unknown contract';
 export const TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER = 'Setup only_self function called with incorrect msg_sender';
+export const TX_ERROR_SETUP_NULL_MSG_SENDER = 'Setup function called with null msg sender';
 
 // Nullifiers
 export const TX_ERROR_DUPLICATE_NULLIFIER_IN_TX = 'Duplicate nullifier in tx';


### PR DESCRIPTION
## Summary

Adds two new protocol-level validations to the `PhasesTxValidator` for setup-phase public calls, providing defense-in-depth beyond contract bytecode assertions:

- **`onlySelf` validation (A-619)**: Setup functions flagged as `onlySelf` (internal functions like `_set_authorized`, `_increase_public_balance`) are rejected if `msgSender != contractAddress`. This enforces at the sequencer/P2P level that only the contract itself can enqueue calls to its internal functions.

- **`rejectNullMsgSender` validation (A-618)**: AuthRegistry's `set_authorized` and `_set_authorized` entries are rejected if `msgSender` is `NULL_MSG_SENDER_CONTRACT_ADDRESS` (the `-1` / max Field sentinel). This prevents malicious transactions from storing authwit approvals under the null sender address, which could be exploited via `consume`.

Both flags are opt-in on `AllowedElement` entries, so only explicitly annotated functions are affected.

## Changes

- **`stdlib/src/interfaces/allowed_element.ts`**: Added `onlySelf` and `rejectNullMsgSender` optional boolean fields to `AllowedElement` types and Zod schema.
- **`stdlib/src/tx/validator/error_texts.ts`**: Added `TX_ERROR_SETUP_ONLY_SELF_WRONG_SENDER` and `TX_ERROR_SETUP_NULL_MSG_SENDER` error constants.
- **`p2p/.../phases_validator.ts`**: Added checks for both flags in both address-based and class-based allow list matching branches.
- **`p2p/.../allowed_public_setup.ts`**: Annotated AuthRegistry entries with `rejectNullMsgSender: true`, and `_set_authorized`/`_increase_public_balance`/Token `_increase_public_balance` with `onlySelf: true`.
- **`p2p/.../phases_validator.test.ts`**: Added two new test describe blocks (`onlySelf validation` with 5 tests, `rejectNullMsgSender validation` with 3 tests) covering both address-based and class-based entries.

Fixes A-618
Fixes A-619
