### PR TITLE
fix(docs): clarify nullifier hiding key naming and add SDK access reference

### DIFF
--- a/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/aztec-nr/framework-description/custom_notes.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/aztec-nr/framework-description/custom_notes.md
@@ -174,6 +174,7 @@ With `#[custom_note]`, you must implement the `NoteHash` trait yourself:
 ```rust
 use aztec::{
     context::PrivateContext,
+    keys::getters::{get_nhk_app, get_public_keys, try_get_public_keys},
     macros::notes::custom_note,
     note::note_interface::NoteHash,
     protocol::{
@@ -211,7 +212,7 @@ impl NoteHash for CustomHashNote {
         note_hash_for_nullification: Field,
     ) -> Field {
         // Standard nullifier using owner's nullifier hiding key
-        let owner_npk_m = aztec::keys::getters::get_public_keys(owner).npk_m;
+        let owner_npk_m = get_public_keys(owner).npk_m;
         let secret = context.request_nhk_app(owner_npk_m.hash());
         poseidon2_hash_with_separator(
             [note_hash_for_nullification, secret],
@@ -223,16 +224,21 @@ impl NoteHash for CustomHashNote {
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
-        let owner_npk_m = aztec::keys::getters::get_public_keys(owner).npk_m;
-        let secret = aztec::keys::getters::get_nhk_app(owner_npk_m.hash());
-        poseidon2_hash_with_separator(
-            [note_hash_for_nullification, secret],
-            DOM_SEP__NOTE_NULLIFIER,
-        )
+    ) -> Option<Field> {
+        try_get_public_keys(owner).map(|public_keys| {
+            let secret = get_nhk_app(public_keys.npk_m.hash());
+            poseidon2_hash_with_separator(
+                [note_hash_for_nullification, secret],
+                DOM_SEP__NOTE_NULLIFIER,
+            )
+        })
     }
 }
 ```
+
+:::tip Naming note
+The secret returned by `request_nhk_app` is the **nullifier hiding key** (abbreviated `nhk`). Older docs and code comments may call it the "nullifier secret key" (`nsk`) — these refer to the same key. Always use `request_nhk_app()` rather than computing this key yourself.
+:::
 
 ## Viewing notes (unconstrained)
 

--- a/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/foundational-topics/accounts/keys.md
+++ b/docs/developer_versioned_docs/version-v4.0.0-devnet.2-patch.1/docs/foundational-topics/accounts/keys.md
@@ -59,6 +59,27 @@ This last point could be confusing for most developers: how could a protocol ver
 
 :::
 
+#### Accessing nullifier keys in code
+
+The nullifier hiding key (`nhk`) — sometimes referred to in older documentation as the "nullifier secret key" (`nsk`) — is the secret scalar used to compute nullifiers. You should **never** derive or construct this key manually. Use the framework-provided functions:
+
+| Context | Function | Import / Access |
+|---------|----------|----------------|
+| Private (constrained) | `context.request_nhk_app(owner_npk_m_hash)` | Called on `&mut PrivateContext` |
+| Unconstrained | `get_nhk_app(owner_npk_m_hash)` | `use aztec::keys::getters::get_nhk_app` |
+| TypeScript (master key) | `deriveMasterNullifierHidingKey(secretKey)` | `import { deriveMasterNullifierHidingKey } from '@aztec/aztec.js/keys'` |
+| TypeScript (app-siloed) | `computeAppNullifierHidingKey(nhkM, app)` | `import { computeAppNullifierHidingKey } from '@aztec/aztec.js/keys'` |
+
+To get the owner's master nullifier public key hash (needed as input):
+
+```rust
+let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+```
+
+:::warning
+Do not compute nullifier keys by hand or derive custom blinding factors. The protocol kernel validates that `nhk_app` derives correctly from the master key — a hand-rolled value will fail verification.
+:::
+
 ### Incoming Viewing Keys
 
 **Purpose**: Receiving and decrypting private notes

--- a/docs/docs-developers/ai_tooling.md
+++ b/docs/docs-developers/ai_tooling.md
@@ -29,9 +29,17 @@ This is an Aztec smart contract project. Always use the `aztec` CLI wrapper inst
 - **Compile**: `aztec compile` (NOT `nargo compile`). Using `nargo compile` alone produces incomplete artifacts.
 - **Test**: `aztec test` (NOT `nargo test`).
 - **Other nargo commands** like `nargo fmt` and `nargo doc` are fine to use directly.
+
+## Hashing: Default to Poseidon2
+
+When writing Aztec.nr contract code that requires hashing, **always use Poseidon2** unless a specific protocol or interoperability requirement calls for a different hash.
+
+- **Default**: `use aztec::protocol::hash::poseidon2_hash;`
+- **Do NOT** default to Pedersen (`pedersen_hash`). Pedersen is available but Poseidon2 is cheaper in circuits and is the standard across Aztec.
+- If you are unsure which hash to use, use Poseidon2.
 ```
 
-This prevents the most common AI mistake: using `nargo compile` and `nargo test` instead of their Aztec wrappers.
+This prevents the two most common AI mistakes: using `nargo compile`/`nargo test` instead of their Aztec wrappers, and defaulting to Pedersen hashes instead of Poseidon2.
 
 ### Why this matters
 

--- a/docs/docs-developers/docs/aztec-nr/framework-description/custom_notes.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/custom_notes.md
@@ -124,6 +124,7 @@ With `#[custom_note]`, you must implement the `NoteHash` trait yourself:
 ```rust
 use aztec::{
     context::PrivateContext,
+    keys::getters::{get_nhk_app, get_public_keys, try_get_public_keys},
     macros::notes::custom_note,
     note::note_interface::NoteHash,
     protocol::{
@@ -161,7 +162,7 @@ impl NoteHash for CustomHashNote {
         note_hash_for_nullification: Field,
     ) -> Field {
         // Standard nullifier using owner's nullifier hiding key
-        let owner_npk_m = aztec::keys::getters::get_public_keys(owner).npk_m;
+        let owner_npk_m = get_public_keys(owner).npk_m;
         let secret = context.request_nhk_app(owner_npk_m.hash());
         poseidon2_hash_with_separator(
             [note_hash_for_nullification, secret],
@@ -173,16 +174,21 @@ impl NoteHash for CustomHashNote {
         self,
         owner: AztecAddress,
         note_hash_for_nullification: Field,
-    ) -> Field {
-        let owner_npk_m = aztec::keys::getters::get_public_keys(owner).npk_m;
-        let secret = aztec::keys::getters::get_nhk_app(owner_npk_m.hash());
-        poseidon2_hash_with_separator(
-            [note_hash_for_nullification, secret],
-            DOM_SEP__NOTE_NULLIFIER,
-        )
+    ) -> Option<Field> {
+        try_get_public_keys(owner).map(|public_keys| {
+            let secret = get_nhk_app(public_keys.npk_m.hash());
+            poseidon2_hash_with_separator(
+                [note_hash_for_nullification, secret],
+                DOM_SEP__NOTE_NULLIFIER,
+            )
+        })
     }
 }
 ```
+
+:::tip Naming note
+The secret returned by `request_nhk_app` is the **nullifier hiding key** (abbreviated `nhk`). Older docs and code comments may call it the "nullifier secret key" (`nsk`) — these refer to the same key. Always use `request_nhk_app()` rather than computing this key yourself.
+:::
 
 ## Viewing notes (unconstrained)
 

--- a/docs/docs-developers/docs/foundational-topics/accounts/keys.md
+++ b/docs/docs-developers/docs/foundational-topics/accounts/keys.md
@@ -56,6 +56,27 @@ This last point could be confusing for most developers: how could a protocol ver
 
 :::
 
+#### Accessing nullifier keys in code
+
+The nullifier hiding key (`nhk`) — sometimes referred to in older documentation as the "nullifier secret key" (`nsk`) — is the secret scalar used to compute nullifiers. You should **never** derive or construct this key manually. Use the framework-provided functions:
+
+| Context | Function | Import / Access |
+|---------|----------|----------------|
+| Private (constrained) | `context.request_nhk_app(owner_npk_m_hash)` | Called on `&mut PrivateContext` |
+| Unconstrained | `get_nhk_app(owner_npk_m_hash)` | `use aztec::keys::getters::get_nhk_app` |
+| TypeScript (master key) | `deriveMasterNullifierHidingKey(secretKey)` | `import { deriveMasterNullifierHidingKey } from '@aztec/aztec.js/keys'` |
+| TypeScript (app-siloed) | `computeAppNullifierHidingKey(nhkM, app)` | `import { computeAppNullifierHidingKey } from '@aztec/aztec.js/keys'` |
+
+To get the owner's master nullifier public key hash (needed as input):
+
+```rust
+let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
+```
+
+:::warning
+Do not compute nullifier keys by hand or derive custom blinding factors. The protocol kernel validates that `nhk_app` derives correctly from the master key — a hand-rolled value will fail verification.
+:::
+
 ### Incoming Viewing Keys
 
 **Purpose**: Receiving and decrypting private notes

--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -727,10 +727,10 @@ impl PrivateContext {
         self.request_sk_app(npk_m_hash, NULLIFIER_INDEX)
     }
 
-    /// Requests the app-siloed nullifier secret key (nsk_app) for the given (hashed) master nullifier public key
-    /// (npk_m), from the user's PXE.
+    /// Requests the app-siloed outgoing viewing secret key (ovsk_app) for the given (hashed) master outgoing
+    /// viewing public key (ovpk_m), from the user's PXE.
     ///
-    /// See `request_nsk_app` and `request_sk_app` for more info.
+    /// See `request_nhk_app` and `request_sk_app` for more info.
     ///
     /// The intention of the "outgoing" keypair is to provide a second secret key for all of a user's outgoing activity
     /// (i.e. for notes that a user creates, as opposed to notes that a user receives from others). The separation of


### PR DESCRIPTION
## Summary

- **keys.md**: Add "Accessing nullifier keys in code" subsection with SDK reference table showing how to access nhk in Noir (private/unconstrained) and TypeScript, plus a warning against hand-rolling nullifier keys
- **private_context.nr**: Fix stale docstring on `request_ovsk_app` that incorrectly said "nullifier secret key (nsk_app)" instead of "outgoing viewing secret key (ovsk_app)", and referenced non-existent `request_nsk_app`
- **custom_notes.md**: Fix `#[custom_note]` example to match current `NoteHash` trait signatures (`Option<Field>` return type, `try_get_public_keys` pattern), and add naming tip about nhk vs nsk terminology

## Test plan

- [ ] Verify keys.md renders correctly with the new table (yarn start in docs/)
- [ ] Confirm `grep -r "nsk" noir-projects/aztec-nr/aztec/src/context/private_context.nr` returns zero hits
- [ ] Docstring changes are comment-only so compilation is unaffected