### PR TITLE
feat: check event commitment nullifier existence on Noir side

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -1,5 +1,6 @@
 use crate::{
     event::event_interface::compute_private_serialized_event_commitment,
+    logging::aztecnr_warn_log_format,
     messages::{
         encoding::MAX_MESSAGE_CONTENT_LEN, logs::event::decode_private_event_message,
         processing::enqueue_event_for_validation,
@@ -20,15 +21,21 @@ pub(crate) unconstrained fn process_private_event_msg(
     let event_commitment =
         compute_private_serialized_event_commitment(serialized_event, randomness, event_type_id.to_field());
 
-    assert(check_nullifier_exists(event_commitment), "Event commitment is not present in the nullifier tree");
-
-    enqueue_event_for_validation(
-        contract_address,
-        event_type_id,
-        randomness,
-        serialized_event,
-        event_commitment,
-        tx_hash,
-        recipient,
-    );
+    if check_nullifier_exists(event_commitment) {
+        enqueue_event_for_validation(
+            contract_address,
+            event_type_id,
+            randomness,
+            serialized_event,
+            event_commitment,
+            tx_hash,
+            recipient,
+        );
+    } else {
+        aztecnr_warn_log_format!(
+            "Event commitment is not present in the nullifier tree for tx {0}, ignoring",
+        )(
+            [tx_hash],
+        );
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -33,9 +33,9 @@ pub(crate) unconstrained fn process_private_event_msg(
         );
     } else {
         aztecnr_warn_log_format!(
-            "Event commitment is not present in the nullifier tree for tx {0}, ignoring",
+            "Discarding private event message from tx {0}: event commitment {1} not found in the nullifier tree",
         )(
-            [tx_hash],
+            [tx_hash, event_commitment],
         );
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -4,6 +4,7 @@ use crate::{
         encoding::MAX_MESSAGE_CONTENT_LEN, logs::event::decode_private_event_message,
         processing::enqueue_event_for_validation,
     },
+    oracle::nullifiers::check_nullifier_exists,
 };
 use crate::protocol::{address::AztecAddress, traits::ToField};
 
@@ -18,6 +19,8 @@ pub(crate) unconstrained fn process_private_event_msg(
 
     let event_commitment =
         compute_private_serialized_event_commitment(serialized_event, randomness, event_type_id.to_field());
+
+    assert(check_nullifier_exists(event_commitment), "Event commitment is not present in the nullifier tree");
 
     enqueue_event_for_validation(
         contract_address,


### PR DESCRIPTION
Implemented this PR as a reaction to [this comment](https://github.com/AztecProtocol/aztec-packages/pull/21093#discussion_r2885741306). Makes sense to have the check in Noir for events as well as it's a good software design to handle invalid data as soon as possible in the data processing pipeline. It will also make the behavior the same between note and events since in the case of notes we have already performed this validation in Noir when brute forcing nonces.

## Summary

- Adds a `check_nullifier_exists` call in `process_private_event_msg` (Noir) to verify the event commitment exists in the nullifier tree before enqueuing it for validation
- This mirrors the existing TypeScript-side check in `event_service.ts` that verifies the siloed event commitment is present in the tx's nullifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)