### PR TITLE
docs: clarifying Noir fields vs struct fields in event metadata

### DIFF
--- a/yarn-project/stdlib/src/abi/event_metadata_definition.ts
+++ b/yarn-project/stdlib/src/abi/event_metadata_definition.ts
@@ -1,8 +1,10 @@
 import type { AbiType } from './abi.js';
 import type { EventSelector } from './event_selector.js';
 
+/** Metadata for a contract event, used to decode emitted event logs back into structured data. */
 export type EventMetadataDefinition = {
   eventSelector: EventSelector;
   abiType: AbiType;
+  /** Names of the event's struct members (not serialized Noir Field elements). */
   fieldNames: string[];
 };

--- a/yarn-project/stdlib/src/logs/public_log.ts
+++ b/yarn-project/stdlib/src/logs/public_log.ts
@@ -120,8 +120,8 @@ export class FlatPublicLogs {
 
 export class PublicLog {
   constructor(
-    public contractAddress: AztecAddress,
-    public fields: Fr[],
+    public readonly contractAddress: AztecAddress,
+    public readonly fields: Fr[],
   ) {}
 
   static from(fields: FieldsOf<PublicLog>) {
@@ -146,7 +146,9 @@ export class PublicLog {
     return this.fields.length + PUBLIC_LOG_HEADER_LENGTH;
   }
 
+  /** Returns the serialized log (field as in noir field and not a struct field). */
   getEmittedFields() {
+    // We slice from 0 to return a shallow copy.
     return this.fields.slice(0);
   }
 


### PR DESCRIPTION
Just a smol docs PR tackling confusion between noir fields and struct members.

In a process of finishing https://github.com/AztecProtocol/aztec-packages/issues/20332#issuecomment-3896840553