### PR TITLE
fix(p2p): report most severe failure in runValidations

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,5 +1,6 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
 import { BlockNumber, type SlotNumber } from '@aztec/foundation/branded-types';
+import { maxBy } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/curves/bn254';
 import { type Logger, createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -19,6 +20,7 @@ import {
   P2PMessage,
   type ValidationResult as P2PValidationResult,
   PeerErrorSeverity,
+  PeerErrorSeverityByHarshness,
   TopicType,
   createTopicString,
   getTopicsForConfig,
@@ -1662,8 +1664,10 @@ export class LibP2PService extends WithTracer implements P2PService {
 
     // A promise that resolves when all validations have been run
     const allValidations = await Promise.all(validationPromises);
-    const failed = allValidations.find(x => !x.isValid);
-    if (failed) {
+    const failures = allValidations.filter(x => !x.isValid);
+    if (failures.length > 0) {
+      // Pick the most severe failure (lowest tolerance = harshest penalty)
+      const failed = maxBy(failures, f => PeerErrorSeverityByHarshness.indexOf(f.severity))!;
       return {
         allPassed: false,
         failure: {

--- a/yarn-project/stdlib/src/p2p/peer_error.ts
+++ b/yarn-project/stdlib/src/p2p/peer_error.ts
@@ -15,3 +15,10 @@ export enum PeerErrorSeverity {
    */
   HighToleranceError = 'HighToleranceError',
 }
+
+/** Severities ordered from mildest to harshest. */
+export const PeerErrorSeverityByHarshness = [
+  PeerErrorSeverity.HighToleranceError,
+  PeerErrorSeverity.MidToleranceError,
+  PeerErrorSeverity.LowToleranceError,
+] as const;


### PR DESCRIPTION
When multiple validators fail, `runValidations` reported whichever failure appeared first in the Record by insertion order. Now it reports the one with the harshest penalty severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)