### PR TITLE
fix: link libc++ instead of libstdc++ for Rust FFI on Linux

### DIFF
--- a/barretenberg/rust/barretenberg-rs/build.rs
+++ b/barretenberg/rust/barretenberg-rs/build.rs
@@ -10,13 +10,9 @@ fn main() {
         // libbb-external.a contains everything needed: barretenberg + env + vm2_stub
         println!("cargo:rustc-link-lib=static=bb-external");
 
-        // Link C++ standard library (different name on macOS/iOS vs Linux)
-        let target = std::env::var("TARGET").unwrap();
-        if target.contains("apple") || target.contains("android") {
-            println!("cargo:rustc-link-lib=dylib=c++");
-        } else {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
-        }
+        // Link C++ standard library
+        // barretenberg is built with Clang/libc++ on all platforms
+        println!("cargo:rustc-link-lib=dylib=c++");
     }
 }
 


### PR DESCRIPTION
## Summary
- Rust build script was linking `libstdc++` on Linux, but barretenberg is built with Clang/libc++ (`std::__1::` ABI)
- This caused undefined reference errors at link time for `cargo test --release --features ffi`
- Fix: link `libc++` on all platforms since barretenberg uses Clang/libc++ everywhere