### PR TITLE
fix: add barretenberg-rs and iOS/Android targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ avm-transpiler-cross: avm-transpiler-cross-amd64-macos avm-transpiler-cross-arm6
 #==============================================================================
 
 # Barretenberg - Aggregate target for all barretenberg sub-projects.
-barretenberg: bb-cpp bb-ts bb-acir bb-docs bb-sol bb-bbup bb-crs
+barretenberg: bb-cpp bb-ts bb-rs bb-acir bb-docs bb-sol bb-bbup bb-crs
 
 # BB C++ - Main aggregate target.
 bb-cpp: bb-cpp-native bb-cpp-wasm bb-cpp-wasm-threads
@@ -148,7 +148,31 @@ bb-cpp-cross-amd64-macos: bb-cpp-cross-amd64-macos-objects avm-transpiler-cross-
 bb-cpp-cross-arm64-macos: bb-cpp-cross-arm64-macos-objects avm-transpiler-cross-arm64-macos
 	$(call build,$@,barretenberg/cpp,build_cross arm64-macos)
 
-bb-cpp-cross: bb-cpp-cross-arm64-linux bb-cpp-cross-amd64-macos bb-cpp-cross-arm64-macos
+bb-cpp-cross: bb-cpp-cross-arm64-linux bb-cpp-cross-amd64-macos bb-cpp-cross-arm64-macos bb-cpp-cross-arm64-ios bb-cpp-cross-arm64-ios-sim bb-cpp-cross-arm64-android bb-cpp-cross-x86_64-android
+
+# iOS SDK download (shared by all iOS cross-compile targets)
+bb-cpp-ios-sdk:
+	$(call run_command,$@,$(ROOT)/barretenberg/cpp,bash scripts/download-ios-sdk.sh)
+
+# Android sysroot download (shared by all Android cross-compile targets)
+bb-cpp-android-sysroot:
+	$(call run_command,$@,$(ROOT)/barretenberg/cpp,bash scripts/download-android-sysroot.sh)
+
+# Cross-compile for ARM64 iOS (release only, static lib only)
+bb-cpp-cross-arm64-ios: bb-cpp-ios-sdk
+	$(call build,$@,barretenberg/cpp,build_ios zig-arm64-ios)
+
+# Cross-compile for ARM64 iOS Simulator (release only, static lib only)
+bb-cpp-cross-arm64-ios-sim: bb-cpp-ios-sdk
+	$(call build,$@,barretenberg/cpp,build_ios zig-arm64-ios-sim)
+
+# Cross-compile for ARM64 Android (release only, static lib only)
+bb-cpp-cross-arm64-android: bb-cpp-android-sysroot
+	$(call build,$@,barretenberg/cpp,build_android zig-arm64-android)
+
+# Cross-compile for x86_64 Android (release only, static lib only)
+bb-cpp-cross-x86_64-android: bb-cpp-android-sysroot
+	$(call build,$@,barretenberg/cpp,build_android zig-x86_64-android)
 
 # GCC syntax check (CI only, non-release)
 bb-cpp-gcc:
@@ -178,6 +202,10 @@ bb-ts: bb-cpp-wasm bb-cpp-wasm-threads bb-cpp-native
 # Copies the cross-compiles into bb.js.
 bb-ts-cross-copy: bb-ts bb-cpp-cross
 	$(call build,$@,barretenberg/ts,cross_copy)
+
+# BB Rust - barretenberg-rs FFI crate
+bb-rs: bb-ts bb-cpp-native
+	$(call build,$@,barretenberg/rust)
 
 # BB ACIR Tests - ACIR compatibility tests
 bb-acir: noir bb-cpp-native bb-ts
@@ -222,7 +250,10 @@ bb-docs-tests: bb-docs
 bb-bbup-tests: bb-bbup
 	$(call test,$@,barretenberg/bbup)
 
-bb-tests: bb-cpp-native-tests bb-acir-tests bb-ts-tests bb-sol-tests bb-bbup-tests bb-docs-tests
+bb-rs-tests: bb-rs
+	$(call test,$@,barretenberg/rust)
+
+bb-tests: bb-cpp-native-tests bb-acir-tests bb-ts-tests bb-sol-tests bb-bbup-tests bb-docs-tests bb-rs-tests
 
 bb-full-tests: bb-cpp-wasm-threads-tests bb-cpp-asan-tests bb-cpp-smt-tests
 


### PR DESCRIPTION
Adds `bb-rs` and `bb-rs-tests` targets to the root Makefile so the Rust FFI crate is built and link-tested as part of `fast` and `full` CI (not only `ci-barretenberg-full`).

Also adds iOS and Android cross-compile targets (`bb-cpp-cross-arm64-ios`, `bb-cpp-cross-arm64-ios-sim`, `bb-cpp-cross-arm64-android`, `bb-cpp-cross-x86_64-android`) to the Makefile, wired into `bb-cpp-cross` so they get built during `release`. These were previously only built via the legacy `build_with_makefile` path in bootstrap.sh.

This would have caught the libc++/libstdc++ mismatch (fixed in #21203) that was introduced when the Zig preset became the default.