### PR TITLE
fix: use actual data extent for CommitmentKey in HypernovaDeciderProver

### DIFF
--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_prover.cpp
@@ -11,17 +11,19 @@ HonkProof HypernovaDeciderProver::construct_proof(Accumulator& accumulator)
 {
     vinfo("HypernovaFoldingDecider: prove PCS...");
 
-    size_t actual_size = accumulator.dyadic_size;
-    CommitmentKey ck(actual_size);
+    size_t dyadic_size = accumulator.dyadic_size;
+    size_t actual_data_size =
+        std::max(accumulator.non_shifted_polynomial.end_index(), accumulator.shifted_polynomial.end_index());
+    CommitmentKey ck(actual_data_size);
 
     // Open the commitments with Shplemini
-    PolynomialBatcher polynomial_batcher(actual_size);
+    PolynomialBatcher polynomial_batcher(dyadic_size, actual_data_size);
     polynomial_batcher.set_unshifted(RefVector(accumulator.non_shifted_polynomial));
     polynomial_batcher.set_to_be_shifted_by_one(RefVector(accumulator.shifted_polynomial));
 
     OpeningClaim prover_opening_claim;
     prover_opening_claim =
-        ShpleminiProver::prove(actual_size, polynomial_batcher, accumulator.challenge, ck, transcript);
+        ShpleminiProver::prove(dyadic_size, polynomial_batcher, accumulator.challenge, ck, transcript);
 
     vinfo("HypernovaFoldingDecider: executed multivariate-to-univariate reduction");
 

--- a/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/hypernova/hypernova_decider_prover.cpp
@@ -11,7 +11,7 @@ HonkProof HypernovaDeciderProver::construct_proof(Accumulator& accumulator)
 {
     vinfo("HypernovaFoldingDecider: prove PCS...");
 
-    size_t actual_size = accumulator.non_shifted_polynomial.virtual_size();
+    size_t actual_size = accumulator.dyadic_size;
     CommitmentKey ck(actual_size);
 
     // Open the commitments with Shplemini


### PR DESCRIPTION
## Summary
- After #21179 optimized `compute_new_claim()` to move polynomials instead of copying, `virtual_size()` on accumulator polynomials no longer reliably equals the accumulator's dyadic size.
- `HypernovaDeciderProver::construct_proof` used `virtual_size()` to create a `CommitmentKey`, which could request 2^21 CRS points — exceeding the WASM default of 2^20.
- Fix: use `end_index()` to compute the tightest CRS size for the `CommitmentKey`, while passing `dyadic_size` to `PolynomialBatcher` and `ShpleminiProver` which need the multilinear domain size.

## Test plan
- [x] `hypernova_tests` pass (9/9)
- [x] `chonk_tests` pass (25/25)
- [ ] CI chonk integration tests