### PR TITLE
chore(docs): print prominent error summary at bottom of docs bootstrap logs

### DIFF
--- a/docs/examples/bootstrap.sh
+++ b/docs/examples/bootstrap.sh
@@ -214,6 +214,28 @@ case "$cmd" in
 
     if [[ ${#FAILED_STEPS[@]} -gt 0 ]]; then
       send_failure_slack_message
+
+      # Print a prominent error summary at the bottom of the log
+      echo ""
+      echo "============================================================"
+      echo "  DOCS EXAMPLES FAILURE SUMMARY"
+      echo "============================================================"
+      for i in "${!FAILED_STEPS[@]}"; do
+        echo ""
+        echo "--- FAILED: ${FAILED_STEPS[$i]} ---"
+        # Extract lines containing 'error' or 'ERROR' for a concise summary
+        error_lines=$(echo "${FAILED_OUTPUTS[$i]}" | grep -i 'error' || true)
+        if [[ -n "$error_lines" ]]; then
+          echo "$error_lines"
+        else
+          # If no error lines found, show the last 20 lines of output
+          echo "${FAILED_OUTPUTS[$i]}" | tail -20
+        fi
+      done
+      echo ""
+      echo "============================================================"
+      echo ""
+
       # Block PRs on failure, but allow merge queue to proceed (may be transient infra issues)
       if [[ ! "$REF_NAME" =~ ^gh-readonly-queue/ ]]; then
         echo "ERROR: Docs examples validation failed. Failing the build."


### PR DESCRIPTION
## Summary

- When the docs examples bootstrap fails in CI, the actual error messages (e.g., TypeScript type errors) are buried hundreds of lines above the final `ERROR: Docs examples validation failed` message
- Adds a `DOCS EXAMPLES FAILURE SUMMARY` block at the very bottom of the log that extracts error lines from each failed step
- Falls back to showing the last 20 lines of output if no lines matching "error" are found

**Example output at the bottom of a failing CI log:**
```
============================================================
  DOCS EXAMPLES FAILURE SUMMARY
============================================================

--- FAILED: TypeScript validation ---
index.ts(294,39): error TS2488: Type 'GetPublicEventsResult<Transfer>' must have a '[Symbol.iterator]()' method that returns an iterator.
ERROR: Type checking failed for 'aztecjs_advanced'
ERROR: Some project(s) failed validation

============================================================

ERROR: Docs examples validation failed. Failing the build.
```

## Test plan
- [ ] Verify the error summary renders correctly by triggering a docs bootstrap failure