### PR TITLE
fix: hardcode default SSM security group and instance profile

### DIFF
--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -40,11 +40,9 @@ function setup_environment {
     chmod 600 ~/.ssh/build_instance_key
     echo "SSH key configured"
   fi
-  # Validate instance profile and security group for SSM mode.
+  # Log SSM mode settings (defaults are baked into aws_request_instance_type).
   if [ "${CI_USE_SSH:-0}" -eq 0 ]; then
-    : "${CI3_INSTANCE_PROFILE_NAME:?CI3_INSTANCE_PROFILE_NAME must be set for SSM mode}"
-    : "${CI3_SECURITY_GROUP_ID:?CI3_SECURITY_GROUP_ID must be set}"
-    echo "SSM mode: using instance profile $CI3_INSTANCE_PROFILE_NAME"
+    echo "SSM mode: instance profile ${CI3_INSTANCE_PROFILE_NAME:-ci3-build-instance-profile}, SG ${CI3_SECURITY_GROUP_ID:-sg-01fe61a1c1aaeb393}"
   fi
 }
 

--- a/ci3/aws_request_instance_type
+++ b/ci3/aws_request_instance_type
@@ -28,14 +28,14 @@ fi
 # IamInstanceProfile is only attached in SSM mode (no KEY_NAME = SSM).
 # In SSH mode, the build_instance IAM user lacks iam:PassRole for this role.
 iam_profile_json=""
-if [ -z "${KEY_NAME:-}" ] && [ -n "${CI3_INSTANCE_PROFILE_NAME:-}" ]; then
+if [ -z "${KEY_NAME:-}" ]; then
+  CI3_INSTANCE_PROFILE_NAME=${CI3_INSTANCE_PROFILE_NAME:-ci3-build-instance-profile}
   iam_profile_json="\"IamInstanceProfile\": { \"Name\": \"$CI3_INSTANCE_PROFILE_NAME\" },"
 fi
 
 # In SSM mode use the CI3 security group; in SSH mode use the original SG (allows port 22).
 if [ -z "${KEY_NAME:-}" ]; then
-  : "${CI3_SECURITY_GROUP_ID:?CI3_SECURITY_GROUP_ID must be set in SSM mode}"
-  sg_id="$CI3_SECURITY_GROUP_ID"
+  sg_id="${CI3_SECURITY_GROUP_ID:-sg-01fe61a1c1aaeb393}"
 else
   sg_id="sg-0ccd4e5df0dcca0c9"
 fi


### PR DESCRIPTION
## Summary
- Bakes default values for `CI3_SECURITY_GROUP_ID` (`sg-01fe61a1c1aaeb393`) and `CI3_INSTANCE_PROFILE_NAME` (`ci3-build-instance-profile`) into `ci3/aws_request_instance_type`.
- Removes the hard requirement for these env vars in `.github/ci3.sh`, so workflows other than `ci3.yml` (e.g. nightly benchmarks, network scenarios) can use SSM mode without explicitly passing these secrets.
- Values can still be overridden via env vars if needed.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify SSM-mode instances launch with correct security group and instance profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)