### PR TITLE
chore: add stable error link for direct function invocation

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/debugging.md
+++ b/docs/docs-developers/docs/aztec-nr/debugging.md
@@ -94,6 +94,7 @@ LOG_LEVEL="info;debug:simulator:client_execution_context;debug:simulator:client_
 | `Public state writes only supported in public functions` | Move state writes to public functions                                                                                                                           |
 | `Unknown contract 0x0`                                   | Call `wallet.registerContract(...)` to register contract                                                                                                        |
 | `No public key registered for address`                   | Call `wallet.registerSender(...)`                                                                                                                               |
+| `Direct invocation of ... functions is not supported`    | Use `self.call()`, `self.view()`, or `self.enqueue()` to [call contract functions](framework-description/calling_contracts.md) |
 | `Failed to solve brillig function`                       | Check function parameters and note validity                                                                                                                     |
 
 ### Circuit Errors

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -791,3 +791,8 @@
     from = "/errors/5"
     to = "/aztec-nr-api/nightly/noir_aztec/macros/events/fn.event.html"
 
+[[redirects]]
+    # Aztec-nr: direct invocation of contract functions is not supported
+    from = "/errors/6"
+    to = "/developers/docs/aztec-nr/framework-description/calling_contracts"
+

--- a/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/internals_functions_generation/mod.nr
@@ -23,9 +23,8 @@ comptime fn make_functions_uncallable<let N: u32>(functions: [FunctionDefinition
         let name = function.name();
         // The body of the function will contain a static_assert(false, ...) to prevent the function from being called
         // directly and a std::mem::zeroed() to make the compilation fail on the static_assert and not on a missing
-        // return value. TODO(benesjan): Add a link to the documentation for instructions on the proper invocation of
-        // functions.
-        let error_message = f"{error_message_template}{name}. See documentation for instructions on the proper invocation of functions.";
+        // return value.
+        let error_message = f"{error_message_template}{name}. See https://docs.aztec.network/errors/6";
         let body = f"{{ std::static_assert(false, \"{error_message}\"); std::mem::zeroed() }}".quoted_contents();
         let body_expr = body.as_expr().expect(f"Body is not an expression: {body}");
 

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_private_external_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_private_external_fn_call/expected_error
@@ -1,1 +1,1 @@
-Direct invocation of private functions is not supported. You attempted to call arbitrary_external_function. See documentation for instructions on the proper invocation of functions.
+Direct invocation of private functions is not supported. You attempted to call arbitrary_external_function. See https://docs.aztec.network/errors/6

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_private_internal_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_private_internal_fn_call/expected_error
@@ -1,1 +1,1 @@
-Direct invocation of private internal functions is not supported. You attempted to call arbitrary_private_function. See documentation for instructions on the proper invocation of functions.
+Direct invocation of private internal functions is not supported. You attempted to call arbitrary_private_function. See https://docs.aztec.network/errors/6

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_public_external_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_public_external_fn_call/expected_error
@@ -1,1 +1,1 @@
-Direct invocation of public functions is not supported. You attempted to call arbitrary_external_function. See documentation for instructions on the proper invocation of functions.
+Direct invocation of public functions is not supported. You attempted to call arbitrary_external_function. See https://docs.aztec.network/errors/6

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_public_internal_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_public_internal_fn_call/expected_error
@@ -1,1 +1,1 @@
-Direct invocation of public internal functions is not supported. You attempted to call arbitrary_public_function. See documentation for instructions on the proper invocation of functions.
+Direct invocation of public internal functions is not supported. You attempted to call arbitrary_public_function. See https://docs.aztec.network/errors/6

--- a/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_utility_external_fn_call/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/panic_on_direct_utility_external_fn_call/expected_error
@@ -1,1 +1,1 @@
-Calling utility functions directly from within the contract is not supported. You attempted to call arbitrary_external_function. See documentation for instructions on the proper invocation of functions.
+Calling utility functions directly from within the contract is not supported. You attempted to call arbitrary_external_function. See https://docs.aztec.network/errors/6


### PR DESCRIPTION
This was an old TODO of mine I had opened at a time when we didn't have the stable error links set up so made sense to tackle it now that we have them.

## AI Summary
- Adds `https://docs.aztec.network/errors/6` to the compile-time error message shown when developers directly call contract functions (private, public, utility, or internal)
- The `/errors/6` redirect points to the existing `calling_contracts` docs page which documents `self.call()`, `self.view()`, and `self.enqueue()`
- Adds the error to the debugging troubleshooting table in `debugging.md`