### PR TITLE
chore: migrate all CI workflows from static AWS keys to OIDC

### DIFF
--- a/.github/workflows/avm-circuit-inputs.yml
+++ b/.github/workflows/avm-circuit-inputs.yml
@@ -16,11 +16,21 @@ concurrency:
 jobs:
   collect-avm-circuit-inputs:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
 
       - name: Compute tarball name
         id: compute-hash
@@ -34,8 +44,6 @@ jobs:
 
       - name: Collect AVM Circuit Inputs
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
         run: |
           set -eu
@@ -48,9 +56,6 @@ jobs:
           ./ci.sh avm-inputs-collection
 
       - name: Download and attach inputs as artifact
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           set -eu
           TARBALL_NAME="${{ steps.compute-hash.outputs.tarball_name }}"
@@ -67,16 +72,24 @@ jobs:
   avm-check-circuit:
     needs: collect-avm-circuit-inputs
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Run AVM Check-Circuit
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
         run: |
           set -eu

--- a/.github/workflows/barretenberg-nightly-debug-build.yml
+++ b/.github/workflows/barretenberg-nightly-debug-build.yml
@@ -12,17 +12,26 @@ concurrency:
 jobs:
   debug-build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: next
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 9000 # 2h30m — covers 120min job timeout + buffer
+
       - name: Run debug build
         timeout-minutes: 120
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -63,12 +63,11 @@ jobs:
           persist-credentials: true   # Required for bootstrap_ssm's git fetch
 
       - name: Configure AWS credentials (OIDC)
-        if: vars.CI_USE_SSH != '1' || contains(github.event.pull_request.labels.*.name, 'ci-ssm')
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
-          role-session-name: ci3-${{ github.run_id }}
+          role-session-name: gha-${{ github.run_id }}
 
       - name: Determine CI Mode
         env:
@@ -81,9 +80,6 @@ jobs:
       - name: Run
         env:
           CI_USE_SSH: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && '1' || '0' }}
-          # Only override AWS creds for SSH mode; omit for SSM so OIDC credentials pass through.
-          AWS_ACCESS_KEY_ID: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && secrets.AWS_ACCESS_KEY_ID || env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ (vars.CI_USE_SSH == '1' && !contains(github.event.pull_request.labels.*.name, 'ci-ssm')) && secrets.AWS_SECRET_ACCESS_KEY || env.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -190,11 +186,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
-          role-session-name: ci3-network-scenario-${{ github.run_id }}
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 22800 # 6h20m — covers 350min step timeout + buffer
 
       - name: Run Network Scenarios
         timeout-minutes: 350
@@ -283,6 +280,9 @@ jobs:
   ci-network-bench:
     name: ${{ matrix.bench_type }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -312,11 +312,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 19800 # 5h30m — covers 300min max matrix timeout + buffer
+
       - name: Run Network Benchmarks
         timeout-minutes: ${{ matrix.timeout }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -337,8 +343,6 @@ jobs:
       - name: Cleanup network resources
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -348,9 +352,6 @@ jobs:
 
       - name: Download benchmarks
         if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           if ./ci.sh ${{ matrix.download_cmd }}; then
             echo "ENABLE_DEPLOY_BENCH=1" >> $GITHUB_ENV
@@ -395,11 +396,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
-          role-session-name: ci3-network-kind-${{ github.run_id }}
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 12600 # 3h30m — covers 180min job timeout + buffer
 
       - name: Run KIND Test
         env:

--- a/.github/workflows/create-rollup-upgrade-payload.yml
+++ b/.github/workflows/create-rollup-upgrade-payload.yml
@@ -29,6 +29,9 @@ on:
 jobs:
   deploy-rollup:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     steps:
@@ -47,10 +50,15 @@ jobs:
           printf '%s' "$GCP_SA_KEY" > "$GOOGLE_APPLICATION_CREDENTIALS"
           jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Deploy rollup upgrade via EC2
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/deploy-fisherman-network.yaml
+++ b/.github/workflows/deploy-fisherman-network.yaml
@@ -38,6 +38,9 @@ concurrency:
 jobs:
   deploy-fisherman:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     steps:
@@ -129,10 +132,15 @@ jobs:
             echo "LABS_INFRA_MNEMONIC_SECRET_NAME=mainnet-labs-ignition-fisherman-mnemonic" >> $GITHUB_ENV
           fi
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Deploy fisherman network
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -75,6 +75,9 @@ concurrency:
 jobs:
   deploy-network:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-key.json
     outputs:
@@ -158,11 +161,16 @@ jobs:
             chmod 600 ~/.ssh/build_instance_key
           fi
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Deploy network
         id: deploy-network
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/deploy-next-net.yml
+++ b/.github/workflows/deploy-next-net.yml
@@ -18,6 +18,11 @@ concurrency:
   group: deploy-next-net-${{ inputs.image_tag || 'nightly' }}
   cancel-in-progress: true
 
+# Required so the called deploy-network workflow can request an OIDC token for AWS.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   get-image-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging-network.yml
+++ b/.github/workflows/deploy-staging-network.yml
@@ -39,6 +39,11 @@ concurrency:
   group: deploy-staging-network-${{ inputs.network }}-${{ inputs.semver }}-${{ github.ref || github.ref_name }}
   cancel-in-progress: true
 
+# Required so the called deploy-network workflow can request an OIDC token for AWS.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy-network:
     uses: ./.github/workflows/deploy-network.yml

--- a/.github/workflows/deploy-staging-networks.yml
+++ b/.github/workflows/deploy-staging-networks.yml
@@ -18,6 +18,11 @@ concurrency:
   group: deploy-staging-networks-${{ (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha) || (github.event_name == 'workflow_dispatch' && inputs.semver) || github.sha }}
   cancel-in-progress: true
 
+# Required so called workflows (deploy-network, deploy-fisherman-network) can request OIDC tokens for AWS.
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   determine-semver:
     if: |

--- a/.github/workflows/devnet-deploys.yml
+++ b/.github/workflows/devnet-deploys.yml
@@ -12,6 +12,11 @@ concurrency:
   group: devnet-deploys-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Required so the called deploy-network workflow can request an OIDC token for AWS.
+permissions:
+  id-token: write
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-typesense.yml
+++ b/.github/workflows/docs-typesense.yml
@@ -14,9 +14,10 @@ on:
 jobs:
   docs-scraper:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/nightly-spartan-bench.yml
+++ b/.github/workflows/nightly-spartan-bench.yml
@@ -17,11 +17,22 @@ concurrency:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: next
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 16200 # 4h30m — covers 240min job timeout + buffer
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -49,8 +60,6 @@ jobs:
       - name: Run benchmarks
         timeout-minutes: 240
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -66,8 +75,6 @@ jobs:
       - name: Cleanup network resources
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -77,9 +84,6 @@ jobs:
 
       - name: Download benchmarks
         if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           if ./ci.sh gh-spartan-bench; then
             echo "ENABLE_DEPLOY_BENCH=1" >> $GITHUB_ENV
@@ -122,11 +126,22 @@ jobs:
 
   proving-benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: next
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 12600 # 3h30m — covers 180min job timeout + buffer
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -154,8 +169,6 @@ jobs:
       - name: Run proving benchmarks
         timeout-minutes: 180
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -170,8 +183,6 @@ jobs:
       - name: Cleanup network resources
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -181,9 +192,6 @@ jobs:
 
       - name: Download benchmarks
         if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           if ./ci.sh gh-spartan-proving-bench; then
             echo "ENABLE_DEPLOY_BENCH=1" >> $GITHUB_ENV

--- a/.github/workflows/private-fork-release.yml
+++ b/.github/workflows/private-fork-release.yml
@@ -4,6 +4,9 @@
 # The tag and release are created via the Releases API (not git push) so they
 # don't trigger ci3.yml. The API creates the tag as a side-effect of the release,
 # avoiding the tag protection ruleset that blocks GITHUB_TOKEN git pushes.
+#
+# TODO: This workflow needs a dedicated OIDC role (e.g. AWS_OIDC_ROLE_ARN_PRIVATE_FORK)
+# because it checks out code from aztec-packages-private.
 name: Release (Fork)
 on:
   workflow_dispatch:
@@ -19,6 +22,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: master
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -53,6 +59,13 @@ jobs:
             echo "Created release ${{ inputs.tag }}"
           fi
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN_PRIVATE_FORK }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Release
         env:
           CI: "1"
@@ -60,8 +73,6 @@ jobs:
           REF_NAME: ${{ inputs.tag }}
           RUN_ID: ${{ github.run_id }}
           SOURCE_REPOSITORY: AztecProtocol/aztec-packages-private
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -27,6 +27,7 @@ on:
           - low
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 
@@ -41,10 +42,15 @@ jobs:
           ref: next
           token: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+
       - name: Run
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_TOKEN }}

--- a/.github/workflows/test-network-scenarios.yml
+++ b/.github/workflows/test-network-scenarios.yml
@@ -32,6 +32,9 @@ concurrency:
 jobs:
   deploy-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -40,11 +43,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 22800 # 6h20m — covers 350min job timeout + buffer
+
       - name: Run Network Scenarios
         timeout-minutes: 350
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -61,8 +70,6 @@ jobs:
       - name: Cleanup network resources
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/weekly-proving-bench.yml
+++ b/.github/workflows/weekly-proving-bench.yml
@@ -17,11 +17,22 @@ concurrency:
 jobs:
   real-proving-benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: next
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+          role-session-name: gha-${{ github.run_id }}
+          role-duration-seconds: 12600 # 3h30m — covers 180min job timeout + buffer
 
       - name: Determine nightly tag
         id: nightly-tag
@@ -49,8 +60,6 @@ jobs:
       - name: Run real proving benchmarks
         timeout-minutes: 180
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -65,8 +74,6 @@ jobs:
       - name: Cleanup network resources
         if: always()
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -76,9 +83,6 @@ jobs:
 
       - name: Download benchmarks
         if: always()
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           if ./ci.sh gh-spartan-proving-bench; then
             echo "ENABLE_DEPLOY_BENCH=1" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Remove all `secrets.AWS_ACCESS_KEY_ID` / `secrets.AWS_SECRET_ACCESS_KEY` usage from CI workflows
- Add `aws-actions/configure-aws-credentials` OIDC step to every job that needs AWS access
- Add `permissions: id-token: write` to all jobs (and caller workflows for reusable workflows)
- Pin `configure-aws-credentials` to `v6.0.0` (`8df5847`) with `role-duration-seconds` set for long-running jobs
- Use a dedicated `AWS_OIDC_ROLE_ARN_PRIVATE_FORK` for the private fork release workflow

Fixes the Post-Actions `cache_upload` skipping with "no aws credentials found" — the OIDC step was previously conditional on `CI_USE_SSH != '1'`, so when SSH mode was active, no credentials flowed to later steps.

## Test plan
- [x] CI passes on this PR (proves OIDC works for the main `ci` job)
- [x] Verify `cache_upload` in Post-Actions no longer skips
- [ ] Nightly/weekly workflows will validate on next scheduled run