### PR TITLE
fix: sanitize GITHUB_ACTOR in EC2 tags to handle bot users

### DIFF
--- a/ci3/aws_request_instance_type
+++ b/ci3/aws_request_instance_type
@@ -112,7 +112,7 @@ fi
 echo "Instance id: $iid"
 
 tags="Key=Name,Value=$name Key=Group,Value=build-instance"
-[ -n "${GITHUB_ACTOR:-}" ] && tags+=" Key=GithubActor,Value=$GITHUB_ACTOR"
+[ -n "${GITHUB_ACTOR:-}" ] && tags+=" Key=GithubActor,Value=${GITHUB_ACTOR//[\[\]]/}"
 [ -n "${CI_MODE:-}" ] && tags+=" Key=CICommand,Value=$CI_MODE"
 [ -n "${CI_DASHBOARD:-}" ] && tags+=" Key=Dashboard,Value=$CI_DASHBOARD"
 if [ "${UNSAFE_AWS_KEEP_ALIVE:-0}" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- Strip `[` and `]` from `GITHUB_ACTOR` before using it as an AWS EC2 tag value
- Bot actors like `aztec-bot[bot]` contain square brackets which are invalid in AWS tag values, causing `aws ec2 create-tags` to fail

## Test plan
- [ ] CI passes (triggered by a non-bot actor)
- [ ] Verify bot-triggered runs (e.g. from `aztec-bot[bot]`) no longer fail on `create-tags`