### PR TITLE
refactor: deduplicate MembershipWitness struct

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/history/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note.nr
@@ -36,7 +36,7 @@ where
     // don't even care _where_ in the tree it is stored. This is because entries in the note hash tree are unique.
     assert_eq(
         block_header.state.partial.note_hash_tree.root,
-        root_from_sibling_path(unique_note_hash, witness.index, witness.path),
+        root_from_sibling_path(unique_note_hash, witness.leaf_index, witness.sibling_path),
         "Proving note inclusion failed",
     );
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
@@ -61,7 +61,7 @@ fn constrain_get_block_header_at_internal(
     // 3) Check that the block is in the archive (i.e. the witness is valid)
     assert_eq(
         anchor_block_header.last_archive.root,
-        root_from_sibling_path(block_hash, witness.index, witness.path),
+        root_from_sibling_path(block_hash, witness.leaf_index, witness.sibling_path),
         "Proving membership of a block in archive failed",
     );
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_membership_witness.nr
@@ -1,33 +1,21 @@
 use crate::protocol::{
     abis::block_header::BlockHeader,
     constants::{ARCHIVE_HEIGHT, NOTE_HASH_TREE_HEIGHT},
-    traits::{Deserialize, Hash, Serialize},
+    merkle_tree::MembershipWitness,
+    traits::Hash,
 };
-
-// Note: We have M here because we need to somehow set it when calling get_membership_witness function and one way to
-// do it is to set M here and then set type of the return param, e.g.:
-//
-// `let witness: MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> = get_membership_witness(...);`
-//
-// Another way to do it would be to add "type_hint: [Field; T]" as argument to `get_membership_witness` but that's a
-// bit too boilerplatey for my taste.
-#[derive(Deserialize, Eq, Serialize)]
-pub struct MembershipWitness<let N: u32, let M: u32> {
-    pub index: Field,
-    pub path: [Field; N],
-}
 
 #[oracle(aztec_utl_getNoteHashMembershipWitness)]
 unconstrained fn get_note_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     note_hash: Field,
-) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {}
+) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT> {}
 
 #[oracle(aztec_utl_getBlockHashMembershipWitness)]
 unconstrained fn get_block_hash_membership_witness_oracle(
     anchor_block_hash: Field,
     block_hash: Field,
-) -> MembershipWitness<ARCHIVE_HEIGHT, ARCHIVE_HEIGHT + 1> {}
+) -> MembershipWitness<ARCHIVE_HEIGHT> {}
 
 // Note: get_nullifier_membership_witness function is implemented in get_nullifier_membership_witness.nr
 
@@ -36,7 +24,7 @@ unconstrained fn get_block_hash_membership_witness_oracle(
 pub unconstrained fn get_note_hash_membership_witness(
     anchor_block_header: BlockHeader,
     note_hash: Field,
-) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT, NOTE_HASH_TREE_HEIGHT + 1> {
+) -> MembershipWitness<NOTE_HASH_TREE_HEIGHT> {
     let anchor_block_hash = anchor_block_header.hash();
     get_note_hash_membership_witness_oracle(anchor_block_hash, note_hash)
 }
@@ -48,7 +36,7 @@ pub unconstrained fn get_note_hash_membership_witness(
 pub unconstrained fn get_block_hash_membership_witness(
     anchor_block_header: BlockHeader,
     block_hash: Field,
-) -> MembershipWitness<ARCHIVE_HEIGHT, ARCHIVE_HEIGHT + 1> {
+) -> MembershipWitness<ARCHIVE_HEIGHT> {
     let anchor_block_hash = anchor_block_header.hash();
     get_block_hash_membership_witness_oracle(anchor_block_hash, block_hash)
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/get_nullifier_membership_witness.nr
@@ -17,8 +17,12 @@ unconstrained fn get_low_nullifier_membership_witness_oracle(
     _nullifier: Field,
 ) -> NullifierMembershipWitness {}
 
-// Nullifier here refers to the nullifier we are looking to get non-inclusion proof for (by proving that a lower
-// nullifier's next_value is bigger than the nullifier)
+/// Returns a membership witness for the low nullifier of `nullifier` in the nullifier tree whose root is defined in
+/// `block_header`.
+///
+/// The low nullifier is the leaf with the largest value that is still smaller than `nullifier`. This is used to prove
+/// non-inclusion: if the low nullifier's `next_value` is greater than `nullifier`, then `nullifier` is not in the
+/// tree.
 pub unconstrained fn get_low_nullifier_membership_witness(
     block_header: BlockHeader,
     nullifier: Field,
@@ -33,8 +37,9 @@ unconstrained fn get_nullifier_membership_witness_oracle(
     _nullifier: Field,
 ) -> NullifierMembershipWitness {}
 
-// Nullifier here refers to the nullifier we are looking to get non-inclusion proof for (by proving that a lower
-// nullifier's next_value is bigger than the nullifier)
+/// Returns a membership witness for `nullifier` in the nullifier tree whose root is defined in `block_header`.
+///
+/// This is used to prove that a nullifier exists in the tree (inclusion proof).
 pub unconstrained fn get_nullifier_membership_witness(
     block_header: BlockHeader,
     nullifier: Field,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
@@ -4,10 +4,10 @@ use crate::{
         leaf_preimage::IndexedTreeLeafPreimage,
         root::{root_from_sibling_path, root_from_sibling_path_with_hasher},
     },
-    traits::Empty,
+    traits::{Deserialize, Empty, Serialize},
 };
 
-#[derive(Eq)]
+#[derive(Deserialize, Eq, Serialize)]
 pub struct MembershipWitness<let N: u32> {
     pub leaf_index: Field,
     pub sibling_path: [Field; N],


### PR DESCRIPTION
We had a superfluous generic param `M` defined on `MembershipWitness` type that was there probably because of some old Noir issue. Dropping it now resulted in the code normally compiling. Given that we already had `MembershipWitness` defined in protocol types I dropped the Aztec.nr version and use just the one from types.

Tackling this now as I am going through the oracles cleanup that is tracked by [this issue](https://linear.app/aztec-labs/issue/F-348/review-current-status-of-oracles).

## AI Summary
- Remove the duplicate `MembershipWitness<N, M>` struct from `aztec-nr/oracle/get_membership_witness.nr` and reuse the canonical `MembershipWitness<N>` from `noir-protocol-circuits/types/merkle_tree/membership`
- Drop the unnecessary `M` generic parameter (was a workaround for a Noir limitation that no longer exists)
- Add `Deserialize`/`Serialize` derives to the protocol-circuits `MembershipWitness` so it works with oracle deserialization
- Improve doc comments on nullifier membership witness functions