### PR TITLE
feat: asserts that aztec dep version matches cli

### DIFF
--- a/docs/docs-developers/docs/aztec-nr/framework-description/dependencies.md
+++ b/docs/docs-developers/docs/aztec-nr/framework-description/dependencies.md
@@ -18,25 +18,17 @@ aztec = { git="https://github.com/AztecProtocol/aztec-nr/", tag="#include_aztec_
 ### Aztec (required)
 
 ```toml
-aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/aztec" }
+aztec = { git="https://github.com/AztecProtocol/aztec-nr/", tag="#include_aztec_version", directory="aztec" }
 ```
 
 The core Aztec library required for every Aztec.nr smart contract.
-
-### Protocol Types
-
-```toml
-protocol = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/noir-protocol-circuits/crates/types"}
-```
-
-Contains types used in the Aztec protocol (addresses, constants, hashes, etc.).
 
 ## Note Types
 
 ### Address Note
 
 ```toml
-address_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/address-note" }
+address_note = { git="https://github.com/AztecProtocol/aztec-nr/", tag="#include_aztec_version", directory="address-note" }
 ```
 
 Provides `AddressNote`, a note type for storing `AztecAddress` values.
@@ -76,3 +68,24 @@ compressed_string = { git="https://github.com/AztecProtocol/aztec-nr/", tag="#in
 ```
 
 Provides `CompressedString` and `FieldCompressedString` utilities for working with compressed string data.
+
+## Updating your aztec dependencies
+
+When `aztec compile` warns that your aztec dependency tag does not match the CLI version, update
+the `tag` field in every Aztec.nr entry in your `Nargo.toml` to match the CLI version you are
+running.
+
+For example, if your CLI is `v#include_aztec_version`, change:
+
+```toml
+aztec = { git="https://github.com/AztecProtocol/aztec-nr/", tag="v<old-version>", directory="aztec" }
+```
+
+to:
+
+```toml
+aztec = { git="https://github.com/AztecProtocol/aztec-nr/", tag="v#include_aztec_version", directory="aztec" }
+```
+
+Repeat for every other Aztec.nr dependency in your `Nargo.toml` (e.g. `address_note`,
+`balance_set`, etc.). You can check your current CLI version with `aztec --version`.

--- a/docs/docs-words.txt
+++ b/docs/docs-words.txt
@@ -366,6 +366,7 @@ valuenote
 vecs
 versionˮ
 viewability
+vnext
 visualisation
 visualise
 visualised

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -805,3 +805,8 @@
     # PXE: incompatible oracle version between contract and PXE
     from = "/errors/8"
     to = "/developers/docs/foundational-topics/pxe"
+
+[[redirects]]
+    # CLI: aztec dep version in Nargo.toml does not match the CLI version
+    from = "/errors/9"
+    to = "/developers/docs/aztec-nr/framework-description/dependencies#updating-your-aztec-dependencies"

--- a/yarn-project/aztec/src/cli/cmds/compile.ts
+++ b/yarn-project/aztec/src/cli/cmds/compile.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { readArtifactFiles } from './utils/artifacts.js';
 import { needsRecompile } from './utils/needs_recompile.js';
 import { run } from './utils/spawn.js';
+import { warnIfAztecVersionMismatch } from './utils/warn_if_aztec_version_mismatch.js';
 
 /** Returns paths to contract artifacts in the target directory. */
 async function collectContractArtifacts(): Promise<string[]> {
@@ -139,6 +140,8 @@ async function checkNoTestsInContracts(nargo: string, log: LogFn): Promise<void>
 
 /** Compiles Aztec Noir contracts and postprocesses artifacts. */
 async function compileAztecContract(nargoArgs: string[], log: LogFn): Promise<void> {
+  await warnIfAztecVersionMismatch(log);
+
   if (!(await needsRecompile())) {
     log('No source changes detected, skipping compilation.');
     return;

--- a/yarn-project/aztec/src/cli/cmds/utils/collect_crate_dirs.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/collect_crate_dirs.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+import { collectCrateDirs, nargoGitDepPath } from './collect_crate_dirs.js';
+import { run } from './spawn.js';
+
+/** Create a directory (recursively). */
+async function mkdirp(dir: string) {
+  await mkdir(dir, { recursive: true });
+}
+
+/** Create a directory with a minimal `[package]` Nargo.toml inside it. */
+async function makePackage(dir: string, name: string, type = 'lib', deps?: Record<string, string>): Promise<void> {
+  await mkdirp(dir);
+  let toml = `[package]\nname = "${name}"\ntype = "${type}"\n`;
+  if (deps) {
+    toml += `\n[dependencies]\n`;
+    for (const [depName, depValue] of Object.entries(deps)) {
+      toml += `${depName} = ${depValue}\n`;
+    }
+  }
+  await writeFile(join(dir, 'Nargo.toml'), toml);
+}
+
+/**
+ * Creates a local git repository with a Nargo.toml committed and tagged. Returns the repo path,
+ * which can be used as a `file://` git URL in tests.
+ */
+async function makeGitRepo(dir: string, tag: string, pkgName: string): Promise<void> {
+  await makePackage(dir, pkgName);
+  await run('git', ['-C', dir, 'init']);
+  await run('git', ['-C', dir, 'config', 'user.email', 'test@test.com']);
+  await run('git', ['-C', dir, 'config', 'user.name', 'Test']);
+  await run('git', ['-C', dir, 'add', '.']);
+  await run('git', ['-C', dir, 'commit', '-m', 'init', '--no-gpg-sign']);
+  await run('git', ['-C', dir, 'tag', tag]);
+}
+
+describe('collectCrateDirs', () => {
+  let tempDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `collect-crate-dirs-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdirp(tempDir);
+    // Redirect $HOME so nargoGitDepPath writes into our temp tree instead of the real ~/.nargo
+    originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Path / workspace traversal ───────────────────────────────────────────
+
+  it('returns only the start crate when there are no dependencies', async () => {
+    const projectDir = join(tempDir, 'project');
+    await makePackage(projectDir, 'project', 'contract');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toEqual([resolve(projectDir)]);
+  });
+
+  it('follows path-based dependencies', async () => {
+    const projectDir = join(tempDir, 'project');
+    const libDir = join(tempDir, 'lib');
+
+    await makePackage(projectDir, 'project', 'contract', { lib: '{ path = "../lib" }' });
+    await makePackage(libDir, 'lib');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContain(resolve(projectDir));
+    expect(result).toContain(resolve(libDir));
+  });
+
+  it('visits all members of a workspace root', async () => {
+    const workspaceDir = join(tempDir, 'workspace');
+    const crateA = join(workspaceDir, 'a');
+    const crateB = join(workspaceDir, 'b');
+
+    await mkdirp(workspaceDir);
+    await writeFile(join(workspaceDir, 'Nargo.toml'), `[workspace]\nmembers = ["a", "b"]\n`);
+    await makePackage(crateA, 'a', 'contract');
+    await makePackage(crateB, 'b', 'lib');
+
+    const result = await collectCrateDirs(workspaceDir);
+
+    expect(result).toHaveLength(3);
+    expect(result).toContain(resolve(workspaceDir));
+    expect(result).toContain(resolve(crateA));
+    expect(result).toContain(resolve(crateB));
+  });
+
+  it('visits a shared dependency only once', async () => {
+    const projectDir = join(tempDir, 'project');
+    const crateA = join(tempDir, 'a');
+    const crateB = join(tempDir, 'b');
+    const shared = join(tempDir, 'shared');
+
+    await makePackage(projectDir, 'project', 'contract', { a: '{ path = "../a" }', b: '{ path = "../b" }' });
+    await makePackage(crateA, 'a', 'lib', { shared: '{ path = "../shared" }' });
+    await makePackage(crateB, 'b', 'lib', { shared: '{ path = "../shared" }' });
+    await makePackage(shared, 'shared');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toHaveLength(4); // project, a, b, shared
+    expect(result.filter(d => d === resolve(shared))).toHaveLength(1);
+  });
+
+  it('does not infinite-loop on circular path dependencies', async () => {
+    const crateA = join(tempDir, 'a');
+    const crateB = join(tempDir, 'b');
+
+    await makePackage(crateA, 'a', 'lib', { b: '{ path = "../b" }' });
+    await makePackage(crateB, 'b', 'lib', { a: '{ path = "../a" }' });
+
+    const result = await collectCrateDirs(crateA);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContain(resolve(crateA));
+    expect(result).toContain(resolve(crateB));
+  });
+
+  it('throws when Nargo.toml is missing from the start directory', async () => {
+    const projectDir = join(tempDir, 'project');
+    await mkdirp(projectDir); // directory exists but no Nargo.toml
+
+    await expect(collectCrateDirs(projectDir)).rejects.toThrow('Nargo.toml not found');
+  });
+
+  it('throws when a path dependency resolves to a file instead of a directory', async () => {
+    const projectDir = join(tempDir, 'project');
+    await writeFile(join(tempDir, 'not_a_dir'), 'I am a file');
+    await makePackage(projectDir, 'project', 'contract', { bad: '{ path = "../not_a_dir" }' });
+
+    await expect(collectCrateDirs(projectDir)).rejects.toThrow('not a directory');
+  });
+
+  // ── skipGitDeps ──────────────────────────────────────────────────────────
+
+  it('ignores git-based dependencies when skipGitDeps is true', async () => {
+    const projectDir = join(tempDir, 'project');
+    await makePackage(projectDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-packages", tag = "v1.0" }',
+    });
+
+    // Should return only the project dir without attempting to resolve or clone the git dep
+    const result = await collectCrateDirs(projectDir, { skipGitDeps: true });
+
+    expect(result).toEqual([resolve(projectDir)]);
+  });
+
+  // ── Git deps — already cached ($HOME redirected, no real clone) ──────────
+
+  it('includes a cached git dependency without cloning', async () => {
+    const projectDir = join(tempDir, 'project');
+    // Pre-create the nargo cache entry that nargoGitDepPath would compute — simulates nargo having
+    // already fetched this dep (existsSync check passes so no clone is attempted).
+    const cacheDir = nargoGitDepPath('https://github.com/AztecProtocol/aztec-packages', 'v1.0');
+    await makePackage(projectDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-packages", tag = "v1.0" }',
+    });
+    await makePackage(cacheDir, 'aztec-packages');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toContain(resolve(cacheDir));
+  });
+
+  it('visits the subdirectory crate when the git dep has a directory field', async () => {
+    // Models the real aztec-nr pattern:
+    //   aztec = { git = "…/aztec-packages", tag = "v0.82.0", directory = "noir-projects/aztec-nr/aztec" }
+    // nargo clones the whole repo to the cache root; only the subdir is the actual crate.
+    const projectDir = join(tempDir, 'project');
+    const cacheRoot = nargoGitDepPath('https://github.com/AztecProtocol/aztec-packages', 'v0.82.0');
+    const crateDir = join(cacheRoot, 'noir-projects', 'aztec-nr', 'aztec');
+
+    await makePackage(projectDir, 'project', 'contract', {
+      aztec:
+        '{ git = "https://github.com/AztecProtocol/aztec-packages", tag = "v0.82.0", directory = "noir-projects/aztec-nr/aztec" }',
+    });
+    // makePackage(crateDir) creates all parents including cacheRoot via mkdirp
+    await makePackage(crateDir, 'aztec');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toContain(resolve(crateDir));
+    // The cache root itself is never visited as a crate (only the subdir is)
+    expect(result).not.toContain(resolve(cacheRoot));
+  });
+
+  it('follows path deps declared inside a cached git dependency', async () => {
+    // This test scenario could occur as the git based dep could point to a path based dep in the repository that got
+    // cloned.
+
+    const projectDir = join(tempDir, 'project');
+    const cacheDir = nargoGitDepPath('https://github.com/SomeOrg/some-repo', 'v2.0');
+    const transitiveDep = join(cacheDir, 'lib');
+
+    await makePackage(projectDir, 'project', 'contract', {
+      some_dep: '{ git = "https://github.com/SomeOrg/some-repo", tag = "v2.0" }', // eslint-disable-line camelcase
+    });
+    // Cached dep itself has a path dependency
+    await makePackage(cacheDir, 'some_dep', 'lib', { lib: '{ path = "lib" }' });
+    await makePackage(transitiveDep, 'lib');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toContain(resolve(cacheDir));
+    expect(result).toContain(resolve(transitiveDep));
+  });
+
+  // ── Git deps — fetch behavior (real local git repos) ───────────────────
+
+  it('clones a git dependency when it is not in the cache', async () => {
+    // Create a real local git repo tagged "v2.0" to serve as the remote.
+    // This exercises the actual clone path without any network access.
+    const repoDir = join(tempDir, 'upstream-repo');
+    await makeGitRepo(repoDir, 'v2.0', 'my-dep');
+
+    const projectDir = join(tempDir, 'project');
+    await makePackage(projectDir, 'project', 'contract', {
+      my_dep: `{ git = "file://${repoDir}", tag = "v2.0" }`, // eslint-disable-line camelcase
+    });
+
+    const expectedCachePath = nargoGitDepPath(`file://${repoDir}`, 'v2.0');
+
+    const result = await collectCrateDirs(projectDir);
+
+    expect(result).toContain(resolve(expectedCachePath));
+  });
+
+  it('throws a helpful error when the git clone fails', async () => {
+    const projectDir = join(tempDir, 'project');
+    await makePackage(projectDir, 'project', 'contract', {
+      bad: '{ git = "file:///nonexistent/repo/that/does/not/exist", tag = "v1.0" }',
+    });
+
+    const err: Error = await collectCrateDirs(projectDir).catch(e => e);
+    expect(err.message).toContain('Failed to fetch git dependency');
+    expect(err.message).toContain('nargo check');
+  });
+});

--- a/yarn-project/aztec/src/cli/cmds/utils/collect_crate_dirs.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/collect_crate_dirs.ts
@@ -1,0 +1,118 @@
+import TOML from '@iarna/toml';
+import { existsSync } from 'fs';
+import { mkdir, readFile, stat } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import { run } from './spawn.js';
+
+/**
+ * Recursively collects crate directories starting from startCrateDir by following dependencies declared in Nargo.toml
+ * files.
+ *
+ * When `skipGitDeps` is false (default), git-based deps are followed and fetched into the nargo cache
+ * (`$HOME/nargo/<domain>/<repo-path>/<tag>`) if not already present.
+ *
+ * When `skipGitDeps` is true, git-based deps are ignored entirely.
+ */
+export async function collectCrateDirs(startCrateDir: string, opts?: { skipGitDeps?: boolean }): Promise<string[]> {
+  const { skipGitDeps = false } = opts ?? {};
+  const visited = new Set<string>();
+
+  async function visit(crateDir: string): Promise<void> {
+    const absDir = resolve(crateDir);
+    if (visited.has(absDir)) {
+      return;
+    }
+    visited.add(absDir);
+
+    const tomlPath = join(absDir, 'Nargo.toml');
+    const content = await readFile(tomlPath, 'utf-8').catch(() => {
+      throw new Error(`Incorrectly defined dependency. Nargo.toml not found in ${absDir}`);
+    });
+
+    const parsed = TOML.parse(content) as Record<string, any>;
+    const members = (parsed.workspace as Record<string, any>)?.members as string[] | undefined;
+
+    // A Nargo.toml is either a workspace root (has workspace.members) or a single crate (has dependencies).
+    if (Array.isArray(members)) {
+      // The crate is a workspace root and has members defined so we visit the members
+      for (const member of members) {
+        await visit(resolve(absDir, member));
+      }
+    } else {
+      // Single crate — follow its deps
+      const deps = (parsed.dependencies as Record<string, any>) ?? {};
+      for (const dep of Object.values(deps)) {
+        if (!dep || typeof dep !== 'object') {
+          continue;
+        }
+        if (typeof dep.path === 'string') {
+          // Dependency contains "path" hence it's a local dependency. We just check it's a real directory and then we
+          // recursively search through it
+          const depPath = resolve(absDir, dep.path);
+          const s = await stat(depPath);
+          if (!s.isDirectory()) {
+            throw new Error(
+              `Dependency path "${dep.path}" in ${tomlPath} resolves to ${depPath} which is not a directory`,
+            );
+          }
+          await visit(depPath);
+        } else if (!skipGitDeps && typeof dep.git === 'string' && typeof dep.tag === 'string') {
+          // Dependency contains "git" hence it's a git dependency. We ensure it has been fetched and fetch it if
+          // it's not the case and then we recursively search through it.
+          await fetchAndVisit(dep.git, dep.tag, dep.directory);
+        }
+      }
+    }
+  }
+
+  async function fetchAndVisit(gitUrl: string, tag: string, directory?: string): Promise<void> {
+    // `directory` is set when the dep lives in a subdirectory of a repository, e.g.:
+    //   aztec = { git = "https://github.com/AztecProtocol/aztec-packages", tag = "v0.82.0",
+    //             directory = "noir-projects/aztec-nr/aztec" }
+    // In that case nargo clones the whole repo and the crate root is <cachePath>/<directory>.
+    const cachePath = nargoGitDepPath(gitUrl, tag);
+    const crateDir = directory ? join(cachePath, directory) : cachePath;
+    await ensureGitDepCached(gitUrl, tag, cachePath);
+    await visit(crateDir);
+  }
+
+  await visit(startCrateDir);
+  return [...visited];
+}
+
+/**
+ * Computes the local nargo cache path for a git dependency, mirroring nargo's own `git_dep_location` function.
+ * Path format: `$HOME/nargo/<domain>/<repo-path>/<tag>`
+ * e.g. `~/nargo/github.com/AztecProtocol/aztec-packages/v0.82.0`
+ *
+ * Source: noir/noir-repo/tooling/nargo_toml/src/git.rs
+ */
+export function nargoGitDepPath(gitUrl: string, tag: string): string {
+  const url = new URL(gitUrl);
+  const domain = url.hostname;
+  const repoPath = url.pathname.replace(/^\//, '');
+  return join(process.env.HOME ?? homedir(), 'nargo', domain, repoPath, tag);
+}
+
+/**
+ * Ensures a git dep is present in the nargo cache, cloning it if it isn't. Mirrors nargo's `clone_git_repo`.
+ * If cloning fails (e.g. no network), throws with a message suggesting `nargo check` to prime the cache.
+ *
+ * Source: noir/noir-repo/tooling/nargo_toml/src/git.rs
+ */
+async function ensureGitDepCached(gitUrl: string, tag: string, cachePath: string): Promise<void> {
+  if (existsSync(cachePath)) {
+    return;
+  }
+  await mkdir(dirname(cachePath), { recursive: true });
+  try {
+    await run('git', ['-c', 'advice.detachedHead=false', 'clone', '--depth', '1', '--branch', tag, gitUrl, cachePath]);
+  } catch (err: any) {
+    throw new Error(
+      `Failed to fetch git dependency ${gitUrl}@${tag}: ${err?.message ?? err}.\n` +
+        `Try running \`nargo check\` first to prime the dependency cache.`,
+    );
+  }
+}

--- a/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/needs_recompile.ts
@@ -1,6 +1,7 @@
-import TOML from '@iarna/toml';
-import { readFile, readdir, stat } from 'fs/promises';
-import { join, resolve } from 'path';
+import { readdir, stat } from 'fs/promises';
+import { join } from 'path';
+
+import { collectCrateDirs } from './collect_crate_dirs.js';
 
 /**
  * Returns true if recompilation is needed: either no artifacts exist in target/ or any .nr or Nargo.toml source file
@@ -16,7 +17,10 @@ export async function needsRecompile(): Promise<boolean> {
     return true;
   }
 
-  const crateDirs = await collectCrateDirs('.');
+  // Git deps are pinned to a specific tag in Nargo.toml and nargo always fetches an exact tag, so their contents never
+  // change without Nargo.toml itself changing — and Nargo.toml is already tracked as a source file. Hence we can
+  // safely ignore checking source files of git deps.
+  const crateDirs = await collectCrateDirs('.', { skipGitDeps: true });
   return hasNewerSourceFile(crateDirs, oldestArtifactMs);
 }
 
@@ -47,63 +51,6 @@ async function getOldestArtifactModificationTime(targetDir: string): Promise<num
     }
   }
   return oldest;
-}
-
-/**
- * Recursively collects crate directories starting from startCrateDir by following path-based dependencies declared in
- * Nargo.toml files. Git-based deps are ignored (they only change when Nargo.toml itself is modified since the deps are
- * tagged).
- */
-async function collectCrateDirs(startCrateDir: string): Promise<string[]> {
-  // We have a set of visited dirs we check against when entering a new dir because we could stumble upon a directory
-  // multiple times in case multiple deps shared a dep (e.g. dep A and dep B both sharing dep C).
-  const visited = new Set<string>();
-
-  async function visit(crateDir: string): Promise<void> {
-    const absDir = resolve(crateDir);
-    if (visited.has(absDir)) {
-      return;
-    }
-    visited.add(absDir);
-
-    // Every dep is its own crate and every crate needs to have Nargo.toml defined in the root so we try to load it and
-    // error out if it's not the case.
-    const tomlPath = join(absDir, 'Nargo.toml');
-    const content = await readFile(tomlPath, 'utf-8').catch(() => {
-      throw new Error(`Incorrectly defined dependency. Nargo.toml not found in ${absDir}`);
-    });
-
-    const parsed = TOML.parse(content) as Record<string, any>;
-
-    const members = (parsed.workspace as Record<string, any>)?.members as string[] | undefined;
-
-    // A Nargo.toml is either a workspace root (has workspace.members) or a single crate (has dependencies).
-    if (Array.isArray(members)) {
-      // The crate is a workspace root and has members defined so we visit the members
-      for (const member of members) {
-        const memberPath = resolve(absDir, member);
-        await visit(memberPath);
-      }
-    } else {
-      // The crate is not a workspace root so we check for dependencies
-      const deps = (parsed.dependencies as Record<string, any>) ?? {};
-      for (const dep of Object.values(deps)) {
-        if (dep && typeof dep === 'object' && typeof dep.path === 'string') {
-          const depPath = resolve(absDir, dep.path);
-          const s = await stat(depPath);
-          if (!s.isDirectory()) {
-            throw new Error(
-              `Dependency path "${dep.path}" in ${tomlPath} resolves to ${depPath} which is not a directory`,
-            );
-          }
-          await visit(depPath);
-        }
-      }
-    }
-  }
-
-  await visit(startCrateDir);
-  return [...visited];
 }
 
 /**

--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { warnIfAztecVersionMismatch } from './warn_if_aztec_version_mismatch.js';
+
+/** Create a directory (recursively). */
+async function mkdirp(dir: string) {
+  await mkdir(dir, { recursive: true });
+}
+
+/** Create a directory with a minimal `[package]` Nargo.toml inside it. */
+async function makePackage(dir: string, name: string, type = 'lib', deps?: Record<string, string>): Promise<void> {
+  await mkdirp(dir);
+  let toml = `[package]\nname = "${name}"\ntype = "${type}"\n`;
+  if (deps) {
+    toml += `\n[dependencies]\n`;
+    for (const [depName, depValue] of Object.entries(deps)) {
+      toml += `${depName} = ${depValue}\n`;
+    }
+  }
+  await writeFile(join(dir, 'Nargo.toml'), toml);
+}
+
+describe('warnIfAztecVersionMismatch', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let logMessages: string[];
+  const log = (msg: string) => {
+    logMessages.push(msg);
+  };
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tempDir = join(tmpdir(), `version-match-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdirp(tempDir);
+    process.chdir(tempDir);
+    logMessages = [];
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('does not warn when the aztec dependency tag matches the CLI version', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v1.0.0", directory = "aztec" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
+  });
+
+  it('warns when the aztec dependency tag does not match the CLI version', async () => {
+    await makePackage(tempDir, 'project', 'contract', {
+      aztec: '{ git = "https://github.com/AztecProtocol/aztec-nr", tag = "v0.99.0", directory = "aztec" }',
+    });
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain('WARNING');
+    expect(logMessages[0]).toContain('v0.99.0');
+    expect(logMessages[0]).toContain('v1.0.0');
+  });
+
+  it('warns when the CLI version is not available', async () => {
+    await makePackage(tempDir, 'project', 'contract');
+
+    await warnIfAztecVersionMismatch(log, '');
+
+    expect(logMessages).toHaveLength(1);
+    expect(logMessages[0]).toContain('CLI version not found');
+  });
+
+  it('does not warn when the project has no aztec dependency', async () => {
+    const libDir = join(tempDir, 'lib');
+    await makePackage(tempDir, 'project', 'contract', {
+      some_other_lib: '{ path = "lib" }', // eslint-disable-line camelcase
+    });
+    await makePackage(libDir, 'lib');
+
+    await warnIfAztecVersionMismatch(log, '1.0.0');
+
+    expect(logMessages.filter(m => m.includes('WARNING'))).toHaveLength(0);
+  });
+});

--- a/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
+++ b/yarn-project/aztec/src/cli/cmds/utils/warn_if_aztec_version_mismatch.ts
@@ -1,0 +1,54 @@
+import type { LogFn } from '@aztec/foundation/log';
+import { getPackageVersion } from '@aztec/stdlib/update-checker';
+
+import TOML from '@iarna/toml';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import { collectCrateDirs } from './collect_crate_dirs.js';
+
+/** Warns if the `aztec` dependency tag in any crate's Nargo.toml doesn't match the CLI version. */
+export async function warnIfAztecVersionMismatch(log: LogFn, cliVersion?: string): Promise<void> {
+  const version = cliVersion ?? getPackageVersion();
+  if (!version) {
+    log(`WARNING: aztec CLI version not found. Skipping dependency compatibility check.`);
+    return;
+  }
+
+  const expectedTag = `v${version}`;
+  const mismatches: { file: string; tag: string }[] = [];
+
+  const crateDirs = await collectCrateDirs('.', { skipGitDeps: true });
+
+  for (const dir of crateDirs) {
+    const tomlPath = join(dir, 'Nargo.toml');
+    let content: string;
+    try {
+      content = await readFile(tomlPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const parsed = TOML.parse(content) as Record<string, any>;
+    const aztecDep = (parsed.dependencies as Record<string, any>)?.aztec;
+    if (!aztecDep || typeof aztecDep !== 'object' || typeof aztecDep.tag !== 'string') {
+      // If a dep called "aztec" doesn't exist or it does not get parsed to an object or it doesn't have a tag defined
+      // we skip the check.
+      continue;
+    }
+
+    if (aztecDep.tag !== expectedTag) {
+      mismatches.push({ file: tomlPath, tag: aztecDep.tag });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    const details = mismatches.map(m => `  ${m.file} (${m.tag})`).join('\n');
+    log(
+      `WARNING: Aztec dependency version mismatch detected.\n` +
+        `The following crates have an aztec dependency that does not match the CLI version (${expectedTag}):\n` +
+        `${details}\n\n` +
+        `See https://docs.aztec.network/errors/9 for how to update your dependencies.`,
+    );
+  }
+}


### PR DESCRIPTION
In this PR I add a check that makes `aztec compile` throw an error in case the compile crate or any of its dependencies do not match the version of the `aztec` command. We are currently just checking for version equality instead of doing a more sophisticated semver checks as we are not tracking the versions reliably now. Proper semver checks are likely to be introduced in the future when we track `Aztec.nr` versioning separately from `aztec-packages`.

Since I need to check versions not only of local path based dependencies but also of the remote git based deps the approach I use here is that I check if the dep is in the relevant nargo dir, if not I fetch it there, and then I perform the check on that dep there. This means that I re-implement some `nargo` functionality here.

Closes https://linear.app/aztec-labs/issue/F-288/make-aztec-compile-warn-of-oldincompatible-aztec-deps-from-nargotoml