### PR TITLE
chore: merkle tree audit 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.hpp
@@ -42,6 +42,8 @@
 
 namespace bb::crypto::merkle_tree {
 
+template <typename Store, typename HashingPolicy> struct ContentAddressedIndexedTreeTestAccess;
+
 /**
  * @brief Implements a parallelized batch insertion indexed tree
  * Accepts template argument of the type of store backing the tree, the type of store containing the leaves and the
@@ -50,6 +52,7 @@ namespace bb::crypto::merkle_tree {
  */
 template <typename Store, typename HashingPolicy>
 class ContentAddressedIndexedTree : public ContentAddressedAppendOnlyTree<Store, HashingPolicy> {
+
   public:
     using StoreType = Store;
 
@@ -162,6 +165,8 @@ class ContentAddressedIndexedTree : public ContentAddressedAppendOnlyTree<Store,
     using ContentAddressedAppendOnlyTree<Store, HashingPolicy>::get_sibling_path;
 
   private:
+    template <typename S, typename H> friend struct ContentAddressedIndexedTreeTestAccess;
+
     using typename ContentAddressedAppendOnlyTree<Store, HashingPolicy>::AppendCompletionCallback;
     using ReadTransaction = typename Store::ReadTransaction;
     using ReadTransactionPtr = typename Store::ReadTransactionPtr;
@@ -872,16 +877,29 @@ void ContentAddressedIndexedTree<Store, HashingPolicy>::perform_updates_without_
             }
 
             if (opCount->count.fetch_sub(1) == 1) {
+
+                TypedResponse<UpdatesCompletionResponse> response;
+                if (!status->success) {
+                    response.success = false;
+                    response.message = status->message;
+                    completion(response);
+                    return;
+                }
+
                 std::vector<std::pair<index_t, fr>> hashes_at_level;
                 for (size_t i = 0; i < opCount->roots.size(); i++) {
                     if (opCount->roots[i].first) {
                         hashes_at_level.push_back(std::make_pair(i, opCount->roots[i].second));
                     }
                 }
-                sparse_batch_update(hashes_at_level, rootLevel);
+                try {
+                    sparse_batch_update(hashes_at_level, rootLevel);
+                    response.success = true;
+                } catch (std::exception& e) {
+                    response.success = false;
+                    response.message = e.what();
+                }
 
-                TypedResponse<UpdatesCompletionResponse> response;
-                response.success = true;
                 completion(response);
             }
         };

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/indexed_tree/content_addressed_indexed_tree.test.cpp
@@ -23,6 +23,23 @@
 #include <stdexcept>
 #include <vector>
 
+namespace bb::crypto::merkle_tree {
+template <typename Store, typename HashingPolicy> struct ContentAddressedIndexedTreeTestAccess {
+    using Tree = ContentAddressedIndexedTree<Store, HashingPolicy>;
+    using LeafUpdate = typename Tree::LeafUpdate;
+    using UpdatesCompletionResponse = typename Tree::UpdatesCompletionResponse;
+    using UpdatesCompletionCallback = typename Tree::UpdatesCompletionCallback;
+
+    static void perform_updates_without_witness(Tree& tree,
+                                                const index_t& highest_index,
+                                                std::shared_ptr<std::vector<LeafUpdate>> updates,
+                                                const UpdatesCompletionCallback& completion)
+    {
+        tree.perform_updates_without_witness(highest_index, std::move(updates), completion);
+    }
+};
+} // namespace bb::crypto::merkle_tree
+
 using namespace bb;
 using namespace bb::crypto::merkle_tree;
 
@@ -3228,4 +3245,78 @@ TEST_F(PersistedContentAddressedIndexedTreeTest, nullifiers_can_be_inserted_afte
         current_size += size_to_insert;
         check_size(forkTree, current_size);
     }
+}
+
+// Configured to throw an exception when put_cached_node_by_index is called, to simulate a failure in the thread during
+// a path update.
+class ThrowingNullifierStore : public ContentAddressedCachedTreeStore<NullifierLeafValue> {
+  public:
+    using Base = ContentAddressedCachedTreeStore<NullifierLeafValue>;
+    using Base::Base;
+
+    std::atomic<bool> throw_on_put_cached_node_by_index{ false };
+    std::atomic<uint64_t> num_put_cached_node_calls{ 0 };
+
+    void put_cached_node_by_index(uint32_t level, index_t index, const fr& value)
+    {
+        if (throw_on_put_cached_node_by_index.load()) {
+            num_put_cached_node_calls.fetch_add(1);
+            throw std::runtime_error("injected failure from put_cached_node_by_index");
+        }
+        Base::put_cached_node_by_index(level, index, value);
+    }
+};
+
+using ThrowingTreeType = ContentAddressedIndexedTree<ThrowingNullifierStore, Poseidon2HashPolicy>;
+using TestAccess = ContentAddressedIndexedTreeTestAccess<ThrowingNullifierStore, Poseidon2HashPolicy>;
+
+// The test checks that the perform_updates_without_witness callback has success=false
+// and an error message, and that at least one call to put_cached_node_by_index was made (to ensure the failure was
+// injected at the right place). This tests that the tree correctly handles exceptions thrown from the thread.
+TEST_F(PersistedContentAddressedIndexedTreeTest, perform_updates_without_witness_when_thread_fails)
+{
+    constexpr size_t depth = 6;
+    constexpr index_t initial_size = 2;
+
+    std::string name = random_string();
+    LMDBTreeStore::SharedPtr db = std::make_shared<LMDBTreeStore>(_directory, name, _mapSize, _maxReaders);
+    auto store = std::make_unique<ThrowingNullifierStore>(name, depth, db);
+    auto* raw_store = store.get();
+
+    ThreadPoolPtr workers = make_thread_pool(4);
+    ThrowingTreeType tree(std::move(store), workers, initial_size);
+
+    auto updates = std::make_shared<std::vector<typename TestAccess::LeafUpdate>>();
+    updates->push_back(typename TestAccess::LeafUpdate{
+        .leaf_index = 1,
+        .updated_leaf = IndexedLeaf<NullifierLeafValue>(NullifierLeafValue(fr(123)), 0, fr(0)),
+        .original_leaf = IndexedLeaf<NullifierLeafValue>::empty(),
+    });
+
+    // Configure to throw an exception when put_cached_node_by_index is called, to simulate a failure in the thread
+    // during a path update.
+    raw_store->throw_on_put_cached_node_by_index = true;
+
+    Signal signal;
+    bool callback_success = false;
+    std::string callback_message;
+
+    TestAccess::perform_updates_without_witness(
+        tree,
+        /*highest_index=*/1,
+        updates,
+        [&](const TypedResponse<typename TestAccess::UpdatesCompletionResponse>& response) {
+            callback_success = response.success;
+            callback_message = response.message;
+            signal.signal_level();
+        });
+
+    signal.wait_for_level();
+
+    // At least one call to put_cached_node_by_index should have been made
+    EXPECT_GT(raw_store->num_put_cached_node_calls.load(), 0);
+
+    // The callback should indicate failure and contain an error message
+    EXPECT_FALSE(callback_success);
+    EXPECT_FALSE(callback_message.empty());
 }

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/nullifier_tree/nullifier_memory_tree.hpp
@@ -144,6 +144,9 @@ template <typename HashingPolicy> fr_sibling_path NullifierMemoryTree<HashingPol
     if (value == 0) {
         auto zero_leaf = WrappedNullifierLeaf<HashingPolicy>::zero();
         hash_path = get_sibling_path(leaves_.size() - 1);
+        if (leaves_.size() >= total_size_) {
+            throw std::runtime_error("NullifierMemoryTree is full");
+        }
         leaves_.push_back(zero_leaf);
         update_element(leaves_.size() - 1, zero_leaf.hash());
         return hash_path;
@@ -164,6 +167,10 @@ template <typename HashingPolicy> fr_sibling_path NullifierMemoryTree<HashingPol
         current_leaf.nextValue = value;
 
         leaves_[current].set(current_leaf);
+
+        if (leaves_.size() >= total_size_) {
+            throw std::runtime_error("NullifierMemoryTree is full");
+        }
 
         // Insert the new leaf with (nextIndex, nextValue) of the current leaf
         leaves_.push_back(new_leaf);

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/nullifier_tree/nullifier_memory_tree.test.cpp
@@ -394,3 +394,18 @@ TEST(crypto_nullifier_tree, test_nullifier_tree)
     auto hash_path = tree.get_hash_path(index);
     EXPECT_TRUE(check_hash_path(tree.root(), hash_path, leaves[index].unwrap(), index));
 }
+
+TEST(crypto_nullifier_tree, nullifier_memory_tree_rejects_overfill)
+{
+    // depth = 1 => capacity = 2 leaves
+    // default initial_size = 2, so the tree starts full
+    NullifierMemoryTree<HashPolicy> tree(/*depth=*/1);
+
+    ASSERT_EQ(tree.get_leaves().size(), 2);
+
+    // Any further insertion should be rejected deterministically
+    EXPECT_THROW(tree.update_element(fr(42)), std::runtime_error);
+
+    // State should remain unchanged
+    EXPECT_EQ(tree.get_leaves().size(), 2);
+}

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
@@ -271,7 +271,9 @@ void execute_and_report(const std::function<void(TypedResponse<ResponseType>&)>&
     }
     try {
         on_completion(response);
-    } catch (std::exception&) {
+    } catch (std::exception& e) {
+        std::cerr << "Completion callback threw: " << e.what() << std::endl;
+        std::abort();
     }
 }
 
@@ -287,7 +289,9 @@ inline void execute_and_report(const std::function<void()>& f, const std::functi
     }
     try {
         on_completion(response);
-    } catch (std::exception&) {
+    } catch (std::exception& e) {
+        std::cerr << "Completion callback threw: " << e.what() << std::endl;
+        std::abort();
     }
 }
 } // namespace bb::crypto::merkle_tree


### PR DESCRIPTION
Addresses the following in the merkle tree module:
- thread failures in `perform_updates_without_witness` were not propagated, making the update path to report success even when threads failed
- `NullifierMemoryTree` did not enforce its leaf capacity bound and allowed inserts beyond the maximum tree size
- Add tests to validate the above two
- `execute_and_report` does not report exceptions thrown by completion callbacks, which could hide failures and potentially lead to hangs 
  - update `execute_and_report` to log the error and abort the process