### PR TITLE
chore: fix chonk_browser lint warning

### DIFF
--- a/yarn-project/ivc-integration/src/chonk_browser.test.ts
+++ b/yarn-project/ivc-integration/src/chonk_browser.test.ts
@@ -34,7 +34,7 @@ import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { createServer } from 'http';
 import { dirname, join } from 'path';
-import puppeteer, { Browser } from 'puppeteer';
+import { Browser, launch } from 'puppeteer';
 import { fileURLToPath } from 'url';
 
 const logger = createLogger('ivc-integration:test:browser');
@@ -89,7 +89,7 @@ describe('Chonk Integration - Browser with Puppeteer', () => {
       logger.info("Using Puppeteer's default Chrome");
     }
 
-    browser = await puppeteer.launch(launchOptions);
+    browser = await launch(launchOptions);
     logger.info('Browser launched');
   });
 


### PR DESCRIPTION
```
/mnt/user-data/sean/docs/aztec-packages/yarn-project/ivc-integration/src/chonk_browser.test.ts
  92:21  warning  Caution: `puppeteer` also has a named export `launch`. Check if you meant to write `import {launch} from 'puppeteer'` instead  import-x/no-named-as-default-member
```

fix this warning on yarn lint