### PR TITLE
fix: silently drop invalid private messages instead of crashing PXE sync

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -46,6 +46,7 @@ members = [
     "contracts/test/event_only_contract",
     "contracts/test/import_test_contract",
     "contracts/test/invalid_account_contract",
+    "contracts/test/invalid_message_contract",
     "contracts/test/no_constructor_contract",
     "contracts/test/note_getter_contract",
     "contracts/test/offchain_effect_contract",

--- a/noir-projects/noir-contracts/contracts/test/invalid_message_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/invalid_message_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "invalid_message_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/invalid_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/invalid_message_contract/src/main.nr
@@ -1,0 +1,33 @@
+use aztec::macros::aztec;
+
+/// Emits invalid private messages that the recipient's PXE should handle gracefully (e.g. by silently dropping them)
+/// rather than crashing the sync.
+#[aztec]
+contract InvalidMessage {
+    use aztec::macros::functions::external;
+    use aztec::messages::encoding::encode_message;
+    use aztec::messages::message_delivery::{do_private_message_delivery, MessageDelivery};
+    use aztec::messages::msg_type::PRIVATE_EVENT_MSG_TYPE_ID;
+    use aztec::protocol::address::AztecAddress;
+
+    /// Emits a properly encrypted event message with no matching commitment nullifier in the tx.
+    #[external("private")]
+    fn emit_fake_event_message(recipient: AztecAddress) {
+        let bogus_event_type_id: u64 = 0xDEAD;
+        let randomness: Field = 42;
+        let msg_content = [randomness, 1, 2];
+
+        let msg = encode_message(PRIVATE_EVENT_MSG_TYPE_ID, bogus_event_type_id, msg_content);
+        do_private_message_delivery(
+            self.context,
+            || msg,
+            Option::none(),
+            recipient,
+            MessageDelivery.ONCHAIN_UNCONSTRAINED,
+        );
+    }
+
+    /// No-op private function used to trigger a contract sync in PXE without side effects.
+    #[external("private")]
+    fn noop() {}
+}

--- a/yarn-project/end-to-end/src/e2e_invalid_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_invalid_message.test.ts
@@ -8,9 +8,9 @@ import { ensureAccountContractsPublished, setup } from './fixtures/utils.js';
 
 const TIMEOUT = 120_000;
 
-/// Tests that PXE gracefully handles invalid private messages (messages whose content does not match any commitment or
-/// note hash in the tx). A malicious or buggy contract can emit such messages because message content is unconstrained.
-/// The recipient's PXE should silently drop them instead of crashing.
+// Tests that PXE gracefully handles invalid private messages (messages whose content does not match any commitment or
+// note hash in the tx). A malicious or buggy contract can emit such messages because message content is unconstrained.
+// The recipient's PXE should silently drop them instead of crashing.
 describe('e2e_invalid_message', () => {
   jest.setTimeout(TIMEOUT);
 
@@ -35,8 +35,8 @@ describe('e2e_invalid_message', () => {
     // Emit an invalid event message: properly encrypted but with no commitment nullifier in the tx.
     await contract.methods.emit_fake_event_message(account).send({ from: account });
 
-    // Contract sync is lazy: it only runs when you interact with a contract. We call noop() to force PXE to sync
-    // the contract, which discovers and processes the invalid event message from the previous block.
+    // Contract sync is lazy: it only runs when you interact with a contract. We call noop() to force PXE to sync the
+    // contract, which discovers and processes the invalid event message from the previous block.
     await contract.methods.noop().simulate({ from: account });
   });
 });

--- a/yarn-project/end-to-end/src/e2e_invalid_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_invalid_message.test.ts
@@ -1,0 +1,42 @@
+import type { AztecAddress } from '@aztec/aztec.js/addresses';
+import type { Wallet } from '@aztec/aztec.js/wallet';
+import { InvalidMessageContract } from '@aztec/noir-test-contracts.js/InvalidMessage';
+
+import { jest } from '@jest/globals';
+
+import { ensureAccountContractsPublished, setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+/// Tests that PXE gracefully handles invalid private messages (messages whose content does not match any commitment or
+/// note hash in the tx). A malicious or buggy contract can emit such messages because message content is unconstrained.
+/// The recipient's PXE should silently drop them instead of crashing.
+describe('e2e_invalid_message', () => {
+  jest.setTimeout(TIMEOUT);
+
+  let wallet: Wallet;
+  let account: AztecAddress;
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({
+      teardown,
+      wallet,
+      accounts: [account],
+    } = await setup(1));
+    await ensureAccountContractsPublished(wallet, [account]);
+  });
+
+  afterAll(() => teardown());
+
+  it('should gracefully handle a fake event message with no commitment in tx', async () => {
+    const { contract } = await InvalidMessageContract.deploy(wallet).send({ from: account });
+
+    // Emit an invalid event message: properly encrypted but with no commitment nullifier in the tx.
+    await contract.methods.emit_fake_event_message(account).send({ from: account });
+
+    // Contract sync is lazy: it only runs when you interact with a contract. We call noop() to force PXE to sync
+    // the contract, which discovers and processes the invalid event message from the previous block.
+    await contract.methods.noop().simulate({ from: account });
+  });
+});

--- a/yarn-project/pxe/src/events/event_service.test.ts
+++ b/yarn-project/pxe/src/events/event_service.test.ts
@@ -106,10 +106,17 @@ describe('validateAndStoreEvent', () => {
     await expect(runStoreEvent).rejects.toThrow(/Could not find tx effect for tx hash .* as of block number/);
   });
 
-  it('should throw if event commitment is not in the tx effects', async () => {
-    await expect(runStoreEvent({ eventCommitment: Fr.random() })).rejects.toThrow(
-      /Event commitment .* is not present in tx/,
-    );
+  it('should silently drop event not present in the tx', async () => {
+    await runStoreEvent({ eventCommitment: Fr.random() });
+
+    // Verify no event was stored
+    const result = await privateEventStore.getPrivateEvents(eventSelector, {
+      contractAddress,
+      fromBlock: blockNumber,
+      toBlock: blockNumber + 1,
+      scopes: [recipient],
+    });
+    expect(result).toHaveLength(0);
   });
 
   it('should store event for later retrieval', async () => {

--- a/yarn-project/pxe/src/events/event_service.ts
+++ b/yarn-project/pxe/src/events/event_service.ts
@@ -1,4 +1,5 @@
 import type { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
 import type { EventSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { siloNullifier } from '@aztec/stdlib/hash';
@@ -8,6 +9,8 @@ import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
 import { PrivateEventStore } from '../storage/private_event_store/private_event_store.js';
 
 export class EventService {
+  private readonly log = createLogger('pxe:event-service');
+
   constructor(
     private readonly anchorBlockHeader: BlockHeader,
     private readonly aztecNode: AztecNode,
@@ -46,9 +49,10 @@ export class EventService {
     // Find the index of the event commitment in the nullifiers array to determine event ordering within the tx
     const eventIndexInTx = txEffect.data.nullifiers.findIndex(n => n.equals(siloedEventCommitment));
     if (eventIndexInTx === -1) {
-      throw new Error(
-        `Event commitment ${eventCommitment} (siloed as ${siloedEventCommitment}) is not present in tx ${txHash}`,
+      this.log.warn(
+        `Event commitment ${eventCommitment} (siloed as ${siloedEventCommitment}) is not present in tx ${txHash}, dropping`,
       );
+      return;
     }
 
     return this.privateEventStore.storePrivateEventLog(

--- a/yarn-project/pxe/src/notes/note_service.test.ts
+++ b/yarn-project/pxe/src/notes/note_service.test.ts
@@ -307,21 +307,23 @@ describe('NoteService', () => {
       ).rejects.toThrow(/Could not find tx effect/);
     });
 
-    it('should throw if note was not emitted in the tx', async () => {
-      await expect(
-        noteService.validateAndStoreNote(
-          contractAddress,
-          owner,
-          storageSlot,
-          randomness,
-          noteNonce,
-          content,
-          Fr.random(), // note hash
-          nullifier,
-          txHash,
-          recipient.address,
-        ),
-      ).rejects.toThrow(/is not present in tx/);
+    it('should silently drop note not emitted in the tx', async () => {
+      await noteService.validateAndStoreNote(
+        contractAddress,
+        owner,
+        storageSlot,
+        randomness,
+        noteNonce,
+        content,
+        Fr.random(), // note hash that doesn't match any note in the tx
+        nullifier,
+        txHash,
+        recipient.address,
+      );
+
+      // Verify no note was stored
+      const notes = await noteStore.getNotes({ contractAddress, scopes: [recipient.address] }, 'test');
+      expect(notes).toHaveLength(0);
     });
 
     it('should throw if tx was mined after synced block number', async () => {

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -166,10 +166,10 @@ export class NoteService {
     }
 
     // Find the index of the note hash in the noteHashes array to determine note ordering within the tx.
-    // aztec-nr's nonce discovery already filters out note messages whose computed hash doesn't match any note hash
-    // in the tx, but we still check here to avoid storing notes that somehow bypassed that filter.
     const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
     if (noteIndexInTx === -1) {
+      // aztec-nr's nonce discovery already filters out note messages whose computed hash doesn't match any note hash
+      // in the tx, but we still check here to avoid storing notes that somehow bypassed that filter.
       this.log.warn(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}, dropping`);
       return;
     }

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -1,4 +1,5 @@
 import { Fr } from '@aztec/foundation/curves/bn254';
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { DataInBlock } from '@aztec/stdlib/block';
 import { computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
@@ -11,6 +12,8 @@ import type { AccessScopes } from '../access_scopes.js';
 import type { NoteStore } from '../storage/note_store/note_store.js';
 
 export class NoteService {
+  private readonly log = createLogger('pxe:note-service');
+
   constructor(
     private readonly noteStore: NoteStore,
     private readonly aztecNode: AztecNode,
@@ -162,10 +165,13 @@ export class NoteService {
       throw new Error(`Could not find tx effect for tx hash ${txHash} as of block number ${anchorBlockNumber}`);
     }
 
-    // Find the index of the note hash in the noteHashes array to determine note ordering within the tx
+    // Find the index of the note hash in the noteHashes array to determine note ordering within the tx.
+    // aztec-nr's nonce discovery already filters out note messages whose computed hash doesn't match any note hash
+    // in the tx, but we still check here to avoid storing notes that somehow bypassed that filter.
     const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
     if (noteIndexInTx === -1) {
-      throw new Error(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}`);
+      this.log.warn(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}, dropping`);
+      return;
     }
 
     const noteDao = new NoteDao(

--- a/yarn-project/pxe/src/notes/note_service.ts
+++ b/yarn-project/pxe/src/notes/note_service.ts
@@ -168,9 +168,9 @@ export class NoteService {
     // Find the index of the note hash in the noteHashes array to determine note ordering within the tx.
     const noteIndexInTx = txEffect.data.noteHashes.findIndex(nh => nh.equals(uniqueNoteHash));
     if (noteIndexInTx === -1) {
-      // aztec-nr's nonce discovery already filters out note messages whose computed hash doesn't match any note hash
-      // in the tx, but we still check here to avoid storing notes that somehow bypassed that filter.
-      this.log.warn(`Note hash ${noteHash} (uniqued as ${uniqueNoteHash}) is not present in tx ${txHash}, dropping`);
+      // aztec-nr's nonce discovery already filters out note messages whose computed hash doesn't match any note hash in
+      // the tx, but we still check here to avoid storing notes that somehow bypassed that filter.
+      this.log.warn(`Note hash ${noteHash} (unique: ${uniqueNoteHash}) is not present in tx ${txHash}, dropping`);
       return;
     }
 


### PR DESCRIPTION
## Summary

We need to be careful when handling messages and, in this particular task, we looked into event and note messages. Contracts can create invalid messages that don't have a matching note/event, so we need to make sure we can handle them gracefully. Notes already apply a filter with `nonce_discovery`, but events don't. We were able to build an E2E test to trigger a scenario for events that crashed PXE's sync

Now, on both the notes and event service, we will gracefully handle an invalid notes instead of throwing an error

Fixes F-343
Fixes F-361