### PR TITLE
fix: SSM CI jobs showing inactive on dashboard despite passing

### DIFF
--- a/ci3/bootstrap_ssm
+++ b/ci3/bootstrap_ssm
@@ -208,19 +208,19 @@ function run {
   if semver check "\$REF_NAME"; then
     echo "Performing a release because \$REF_NAME is a semver."
   fi
-  mpstat 2 > >(cache_log cpufile) &
-  cpu_pid=\$!
-  vmstat -w -S M 2 > >(add_timestamps | cache_log memfile) &
-  mem_pid=\$!
-  bash -c "while true; do pstree -ag; echo; echo; sleep 10; done" 2>&1 > >(add_timestamps | cache_log processes) &
-  pstree_pid=\$!
+  # Background monitors. cache_log and add_timestamps both close inherited pipeline
+  # fds internally, so these long-running processes won't block the outer pipeline.
+  mpstat 2 2>&1 | cache_log cpufile &
+  vmstat -w -S M 2 2>&1 | add_timestamps | cache_log memfile &
+  bash -c "while true; do pstree -agl; echo; echo; sleep 10; done" 2>&1 | add_timestamps | cache_log processes &
+
   set +e
   set -x
   $cmd
   local code=\${PIPESTATUS[0]}
-  set +x
-  sudo dmesg 2>&1 | cache_log "dmesg"
-  kill "\$cpu_pid" "\$mem_pid" "\$pstree_pid" &>/dev/null || true
+
+  sudo dmesg 2>&1 | cache_log 'dmesg'
+
   return \$code
 }
 export -f run

--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -9,7 +9,7 @@ if [ -z "${RUN_ID:-}" ]; then
   exit
 fi
 
-if [ -z "$CI_DASHBOARD:-}" ]; then
+if [ -z "${CI_DASHBOARD:-}" ]; then
   # This path is deprecated. Set CI_DASHBOARD explicitly in ci.sh.
   # CI runs are grouped by:
   # - The 'release' group if tagged with a semver.


### PR DESCRIPTION
## Summary

Merge-queue CI jobs (a1-fast, x1-full) show as grey/INACTIVE on the dashboard even though they pass. The jobs complete successfully (denoise prints "done"), but their Redis entries never transition from RUNNING to PASSED — so once the heartbeat expires, the dashboard marks them INACTIVE.

### Process substitution fd leak in bootstrap_ssm

The `run` function in `bootstrap_ssm` used process substitutions (`> >(cache_log ...)`) for background monitors (mpstat, vmstat, pstree). This left their stderr (fd 2) pointing at the outer pipeline (`run 2>&1 | add_timestamps | cache_log`). When the CI command finished, the pipeline couldn't close because those fds were still held open, delaying or preventing `log_ci_run PASSED` from executing.

**Fix:** Switch to the pipe pattern used by `bootstrap_ec2` (`2>&1 | cache_log ...`), which redirects stderr into the internal pipe instead of inheriting the outer pipeline's fd. Also removes the explicit `kill` of background PIDs since the pipe pattern handles cleanup naturally (matching ec2 behavior).

### Syntax bug in log_ci_run

The CI_DASHBOARD check on line 12 used `"$CI_DASHBOARD:-}"` instead of `"${CI_DASHBOARD:-}"` (missing opening brace). This meant the `-z` test was checking `$CI_DASHBOARD` concatenated with literal `:-}` instead of using bash default-value syntax.

## Test plan

- [ ] Merge-queue runs should show green (PASSED) instead of grey (INACTIVE) on the dashboard
- [ ] PR/local CI runs should be unaffected