### PR TITLE
fix: restore SSH key for Redis tunnel in SSM mode

### DIFF
--- a/.github/ci3.sh
+++ b/.github/ci3.sh
@@ -31,10 +31,9 @@ function setup_environment {
     echo "INSTANCE_POSTFIX=$INSTANCE_POSTFIX" >> $GITHUB_ENV
     echo "Instance postfix set to: $INSTANCE_POSTFIX"
   fi
-  # Setup SSH key for connecting to EC2 instances
-  # Note: The key is used to SSH into instances but is only copied INTO instances when CI_USE_BUILD_INSTANCE_KEY=1 (internal CI only)
-  # SSH key is only needed when using the SSH bootstrap path.
-  if [ "${CI_USE_SSH:-0}" -eq 1 ] && [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
+  # Setup SSH key — needed for the Redis tunnel (denoise logs) even in SSM mode,
+  # and for direct SSH bootstrap when CI_USE_SSH=1.
+  if [ -n "${BUILD_INSTANCE_SSH_KEY:-}" ]; then
     mkdir -p ~/.ssh
     echo "${BUILD_INSTANCE_SSH_KEY}" | base64 --decode > ~/.ssh/build_instance_key
     chmod 600 ~/.ssh/build_instance_key


### PR DESCRIPTION
## Summary
- The SSH key in `ci3.sh` was only written when `CI_USE_SSH=1`, but `source_redis` needs `~/.ssh/build_instance_key` to open the SSH tunnel to ElastiCache from the GH Actions runner.
- Without it, `denoise` running on the runner can't write its logs to Redis, causing "Key not found" when clicking parent log links in the CI dashboard.
- Fix: always write the SSH key when `BUILD_INSTANCE_SSH_KEY` is available, regardless of bootstrap mode.

## Test plan
- [ ] Run a CI job in SSM mode and verify parent log links resolve in the dashboard