### PR TITLE
fix(txpool): weight priority fee by gas limits

### DIFF
--- a/yarn-project/p2p/src/mem_pools/tx_pool/priority.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/priority.ts
@@ -5,19 +5,17 @@ import type { Tx } from '@aztec/stdlib/tx';
 /**
  * Returns a string representing the priority of a tx.
  * Txs with a higher priority value are returned first when retrieving pending tx hashes.
- * We currently use the sum of the priority fees for the tx for this value, represented as hex.
+ * Priority is the estimated total tip: capped per-gas priority fees multiplied by gas limits.
  */
 export function getPendingTxPriority(tx: Tx): string {
   return Buffer32.fromBigInt(getTxPriorityFee(tx)).toString();
 }
 
-/**
- * Returns the priority of a tx based on the priority fees, capped by the max fees per gas.
- */
+/** Returns the estimated total priority fee (tip) for a tx, weighted by gas limits. */
 export function getTxPriorityFee(tx: Tx): bigint {
-  const { maxPriorityFeesPerGas: priorityFees, maxFeesPerGas } = tx.getGasSettings();
-  const totalFees =
-    minBigint(maxFeesPerGas.feePerDaGas, priorityFees.feePerDaGas) +
-    minBigint(maxFeesPerGas.feePerL2Gas, priorityFees.feePerL2Gas);
-  return totalFees;
+  const { maxPriorityFeesPerGas: priorityFees, maxFeesPerGas, gasLimits } = tx.getGasSettings();
+  return (
+    minBigint(maxFeesPerGas.feePerDaGas, priorityFees.feePerDaGas) * BigInt(gasLimits.daGas) +
+    minBigint(maxFeesPerGas.feePerL2Gas, priorityFees.feePerL2Gas) * BigInt(gasLimits.l2Gas)
+  );
 }

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.compat.test.ts
@@ -12,7 +12,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
 import { RevertCode } from '@aztec/stdlib/avm';
 import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
-import { GasFees } from '@aztec/stdlib/gas';
+import { Gas, GasFees } from '@aztec/stdlib/gas';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { mockTx } from '@aztec/stdlib/testing';
 import {
@@ -97,7 +97,11 @@ describe('TxPoolV2 Compatibility Tests', () => {
   });
 
   const mockFixedSizeTx = async (maxPriorityFeesPerGas?: GasFees) => {
-    const tx = await mockTx(nextTxSeed++, { maxPriorityFeesPerGas, maxFeesPerGas: maxPriorityFeesPerGas });
+    const tx = await mockTx(nextTxSeed++, {
+      maxPriorityFeesPerGas,
+      maxFeesPerGas: maxPriorityFeesPerGas,
+      gasLimits: new Gas(1, 1),
+    });
     jest.spyOn(tx, 'getSize').mockReturnValue(mockFixedTxSize);
     return tx;
   };
@@ -275,6 +279,7 @@ describe('TxPoolV2 Compatibility Tests', () => {
         const gs = unfreeze(tx.data.constants.txContext.gasSettings);
         gs.maxPriorityFeesPerGas = new GasFees(fee, fee);
         gs.maxFeesPerGas = new GasFees(fee, fee);
+        gs.gasLimits = new Gas(1, 1);
         return tx;
       };
 
@@ -374,42 +379,42 @@ describe('TxPoolV2 Compatibility Tests', () => {
     );
     await pool.start();
 
-    const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) });
-    const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
-    const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) });
+    const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1), gasLimits: new Gas(1, 1) });
+    const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2), gasLimits: new Gas(1, 1) });
+    const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx1, tx2, tx3]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx3.getTxHash(), tx2.getTxHash(), tx1.getTxHash()]);
 
     // once the tx pool count limit is reached, the lowest priority txs (tx1, tx2) should be evicted
-    const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4) });
-    const tx5 = await mockTx(5, { maxPriorityFeesPerGas: new GasFees(5, 5) });
+    const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4), gasLimits: new Gas(1, 1) });
+    const tx5 = await mockTx(5, { maxPriorityFeesPerGas: new GasFees(5, 5), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx4, tx5]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx3.getTxHash()]);
 
     // if another low priority tx is added after the tx pool count limit is reached, it should be evicted
-    const tx6 = await mockTx(6, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    const tx6 = await mockTx(6, { maxPriorityFeesPerGas: new GasFees(1, 1), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx6]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx3.getTxHash()]);
 
     // if a tx is deleted via handleFailedExecution, any txs can be added until the limit is reached
     await pool.handleFailedExecution([tx3.getTxHash()]);
-    const tx7 = await mockTx(7, { maxPriorityFeesPerGas: new GasFees(2, 2) });
+    const tx7 = await mockTx(7, { maxPriorityFeesPerGas: new GasFees(2, 2), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx7]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx4.getTxHash(), tx7.getTxHash()]);
 
     // if a tx is mined, any txs can be added until the limit is reached
     await pool.handleMinedBlock(makeBlock([tx4], block1Header));
-    const tx8 = await mockTx(8, { maxPriorityFeesPerGas: new GasFees(3, 3) });
+    const tx8 = await mockTx(8, { maxPriorityFeesPerGas: new GasFees(3, 3), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx8]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx8.getTxHash(), tx7.getTxHash()]);
 
     // verify that the tx pool count limit is respected after mining and deletions
-    const tx9 = await mockTx(9, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+    const tx9 = await mockTx(9, { maxPriorityFeesPerGas: new GasFees(1, 1), gasLimits: new Gas(1, 1) });
     await pool.addPendingTxs([tx9]);
     await checkPendingTxConsistency();
     expect(await pool.getPendingTxHashes()).toEqual([tx5.getTxHash(), tx8.getTxHash(), tx7.getTxHash()]);
@@ -645,10 +650,10 @@ describe('TxPoolV2 Compatibility Tests', () => {
       );
       await pool.start();
 
-      const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1) });
-      const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
-      const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) });
-      const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4) });
+      const tx1 = await mockTx(1, { maxPriorityFeesPerGas: new GasFees(1, 1), gasLimits: new Gas(1, 1) });
+      const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2), gasLimits: new Gas(1, 1) });
+      const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3), gasLimits: new Gas(1, 1) });
+      const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4), gasLimits: new Gas(1, 1) });
       await pool.addPendingTxs([tx3, tx1, tx4, tx2]);
 
       const res1 = await pool.getLowestPriorityPending(1);
@@ -662,7 +667,7 @@ describe('TxPoolV2 Compatibility Tests', () => {
     });
 
     it('respects zero limit', async () => {
-      const tx1 = await mockTx(10, { maxPriorityFeesPerGas: new GasFees(1, 1) });
+      const tx1 = await mockTx(10, { maxPriorityFeesPerGas: new GasFees(1, 1), gasLimits: new Gas(1, 1) });
       await pool.addPendingTxs([tx1]);
 
       expect(await pool.getLowestPriorityPending(0)).toEqual([]);
@@ -684,6 +689,7 @@ describe('TxPoolV2 Compatibility Tests', () => {
       mockTx(seed, {
         maxPriorityFeesPerGas: new GasFees(fee, fee),
         maxFeesPerGas: new GasFees(fee, fee),
+        gasLimits: new Gas(1, 1),
         numberOfNonRevertiblePublicCallRequests: 1,
       });
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2.test.ts
@@ -153,7 +153,11 @@ describe('TxPoolV2', () => {
   });
 
   const mockTxWithFee = (seed: number, fee: number) =>
-    mockTx(seed, { maxPriorityFeesPerGas: new GasFees(fee, fee), maxFeesPerGas: new GasFees(fee, fee) });
+    mockTx(seed, {
+      maxPriorityFeesPerGas: new GasFees(fee, fee),
+      maxFeesPerGas: new GasFees(fee, fee),
+      gasLimits: new Gas(1, 1),
+    });
 
   // Helper functions for string-based TxHash comparisons
   const toStrings = (hashes: TxHash[]) => hashes.map(h => h.toString());
@@ -163,6 +167,7 @@ describe('TxPoolV2', () => {
     mockTx(seed, {
       maxPriorityFeesPerGas: new GasFees(fee, fee),
       maxFeesPerGas: new GasFees(fee, fee),
+      gasLimits: new Gas(1, 1),
       numberOfNonRevertiblePublicCallRequests: 1,
     });
 

--- a/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool_v2/tx_pool_v2_bench.test.ts
@@ -5,7 +5,7 @@ import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { RevertCode } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Body, L2Block, type L2BlockId, type L2BlockSource } from '@aztec/stdlib/block';
-import { GasFees } from '@aztec/stdlib/gas';
+import { Gas, GasFees } from '@aztec/stdlib/gas';
 import type { MerkleTreeReadOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { mockTx } from '@aztec/stdlib/testing';
 import {
@@ -78,6 +78,8 @@ describe('TxPoolV2: benchmarks', () => {
         await mockTx((startSeed + i) * 100, {
           numberOfNonRevertiblePublicCallRequests: 1,
           maxPriorityFeesPerGas: new GasFees(priorityFee, priorityFee),
+          maxFeesPerGas: new GasFees(priorityFee, priorityFee),
+          gasLimits: new Gas(1, 1),
           feePayer,
         }),
       );


### PR DESCRIPTION
## Summary

- Multiplies capped per-gas priority fees by gas limits to estimate total tip, so txs consuming more gas are correctly ranked higher than txs with the same per-gas rate but lower gas usage
- Updates test helpers to pass explicit `gasLimits: new Gas(1, 1)` and `maxFeesPerGas` so tests control priority values without interference from default gas limits

Priority formula: `min(maxFee_DA, priorityFee_DA) * gasLimit_DA + min(maxFee_L2, priorityFee_L2) * gasLimit_L2`

**Open question:** a malicious user could game this by setting an inflated gas limit they know their tx won't reach, getting higher pool priority. Ethereum doesn't weight by gas limits in mempool ordering (just priority fee per gas). However, the user still has to have balance to cover `gasLimits * maxFeesPerGas`, which limits the attack surface. Worth discussing if this is the right approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)