### PR TITLE
fix: (A-635) e2e bot flake on nonce mismatch

### DIFF
--- a/yarn-project/aztec.js/src/ethereum/portal_manager.ts
+++ b/yarn-project/aztec.js/src/ethereum/portal_manager.ts
@@ -108,7 +108,9 @@ export class L1TokenManager {
     const mintAmount = await this.getMintAmount();
     this.logger.info(`Minting ${mintAmount} tokens for ${stringifyEthAddress(address, addressName)}`);
     // NOTE: the handler mints a fixed amount.
-    await this.handler.write.mint([address]);
+    await this.extendedClient.waitForTransactionReceipt({
+      hash: await this.handler.write.mint([address]),
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes a timing error where the mint function is called first without waiting for the tx receipt which causes the subsequent approve function to fail on nonce mismatch.