### PR TITLE
chore: add set -x to log_ci_run for debugging

### DIFF
--- a/ci3/log_ci_run
+++ b/ci3/log_ci_run
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 NO_CD=1 source $(git rev-parse --show-toplevel)/ci3/source
 
+set -x
+
 key=${1:?usage: log_ci_run <key> [status]}
 status=${2:-RUNNING}
 


### PR DESCRIPTION
## Summary
- Adds `set -x` to `log_ci_run` to trace all Redis operations
- Helps diagnose why some SSM multi-job runs stay as RUNNING/INACTIVE on the dashboard despite passing