### PR TITLE
fix: use native sha256 to speed up proving job id generation

### DIFF
--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
@@ -5,7 +5,6 @@ import type {
   RECURSIVE_PROOF_LENGTH,
 } from '@aztec/constants';
 import { EpochNumber } from '@aztec/foundation/branded-types';
-import { sha256 } from '@aztec/foundation/crypto/sha256';
 import { type Logger, type LoggerBindings, createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { truncate } from '@aztec/foundation/string';
@@ -45,6 +44,8 @@ import type {
   TxMergeRollupPrivateInputs,
   TxRollupPublicInputs,
 } from '@aztec/stdlib/rollup';
+
+import { createHash } from 'node:crypto';
 
 import { InlineProofStore, type ProofStore } from './proof_store/index.js';
 
@@ -659,8 +660,12 @@ export class BrokerCircuitProverFacade implements ServerCircuitProver {
     );
   }
 
-  private generateId(type: ProvingRequestType, inputs: { toBuffer(): Buffer }, epochNumber = EpochNumber.ZERO) {
-    const inputsHash = sha256(inputs.toBuffer());
-    return makeProvingJobId(epochNumber, type, inputsHash.toString('hex'));
+  private generateId(
+    type: ProvingRequestType,
+    inputs: { toBuffer(): Buffer },
+    epochNumber = EpochNumber.ZERO,
+  ): ProvingJobId {
+    const inputsHash = createHash('sha256').update(inputs.toBuffer()).digest('hex');
+    return makeProvingJobId(epochNumber, type, inputsHash);
   }
 }


### PR DESCRIPTION
In #20846 we showed the hash.js's sha256 implementation is very slow on large buffers and we know we're pushing hundreds of KB to megabytes to the broker every seconds, this would speed up proving job ID generation a lot.

I have not used the async variant through `crypto.subtle` because ID generation is synchronous. The sync API is much faster than the async but won't be capable of as high throughput.