### PR TITLE
chore: deflake duplicate attestations and proposals slash tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_attestation_slash.test.ts
@@ -16,7 +16,7 @@ import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { ATTESTER_PRIVATE_KEYS_START_INDEX, createNode } from '../fixtures/setup_p2p_test.js';
 import { getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { P2PNetworkTest } from './p2p_network.js';
-import { awaitCommitteeExists, awaitEpochWithProposer, awaitOffenseDetected } from './shared.js';
+import { advanceToEpochBeforeProposer, awaitCommitteeExists, awaitOffenseDetected } from './shared.js';
 
 const TEST_TIMEOUT = 600_000; // 10 minutes
 
@@ -211,18 +211,23 @@ describe('e2e_p2p_duplicate_attestation_slash', () => {
     ]);
     await awaitCommitteeExists({ rollup, logger: t.logger });
 
-    // Advance to an epoch where the malicious proposer is selected
+    // Find an epoch where the malicious proposer is selected, stopping one epoch before
+    // so we have time to start sequencers before the target epoch arrives
     const epochCache = (honestNode1 as TestAztecNodeService).epochCache;
-    await awaitEpochWithProposer({
+    const { targetEpoch } = await advanceToEpochBeforeProposer({
       epochCache,
       cheatCodes: t.ctx.cheatCodes.rollup,
       targetProposer: maliciousProposerAddress,
       logger: t.logger,
     });
 
-    // Start all sequencers simultaneously
+    // Start all sequencers while still one epoch before the target
     t.logger.warn('Starting all sequencers');
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+
+    // Now warp to the target epoch — sequencers are already running
+    t.logger.warn(`Advancing to target epoch ${targetEpoch}`);
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(targetEpoch);
 
     // Wait for offenses to be detected
     // We expect BOTH duplicate proposal AND duplicate attestation offenses

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -231,15 +231,17 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
 
     t.logger.warn(`Collected offenses`, { offenses });
 
-    // Verify the offense is correct
-    expect(offenses.length).toBeGreaterThan(0);
-    for (const offense of offenses) {
-      expect(offense.offenseType).toEqual(OffenseType.DUPLICATE_PROPOSAL);
+    // Filter to only DUPLICATE_PROPOSAL offenses. The two malicious nodes sharing the same key
+    // will also each self-attest to their own (different) checkpoint proposals, which causes honest
+    // nodes to detect a DUPLICATE_ATTESTATION as well. We only care about proposals here.
+    const proposalOffenses = offenses.filter(o => o.offenseType === OffenseType.DUPLICATE_PROPOSAL);
+    expect(proposalOffenses.length).toBeGreaterThan(0);
+    for (const offense of proposalOffenses) {
       expect(offense.validator.toString()).toEqual(maliciousValidatorAddress.toString());
     }
 
     // Verify that for each offense, the proposer for that slot is the malicious validator
-    for (const offense of offenses) {
+    for (const offense of proposalOffenses) {
       const offenseSlot = SlotNumber(Number(offense.epochOrSlot));
       const proposerForSlot = await epochCache.getProposerAttesterAddressInSlot(offenseSlot);
       t.logger.info(`Offense slot ${offenseSlot}: proposer is ${proposerForSlot?.toString()}`);

--- a/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/duplicate_proposal_slash.test.ts
@@ -16,7 +16,7 @@ import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { ATTESTER_PRIVATE_KEYS_START_INDEX, createNode } from '../fixtures/setup_p2p_test.js';
 import { getPrivateKeyFromIndex } from '../fixtures/utils.js';
 import { P2PNetworkTest } from './p2p_network.js';
-import { awaitCommitteeExists, awaitEpochWithProposer, awaitOffenseDetected } from './shared.js';
+import { advanceToEpochBeforeProposer, awaitCommitteeExists, awaitOffenseDetected } from './shared.js';
 
 const TEST_TIMEOUT = 600_000; // 10 minutes
 
@@ -199,18 +199,23 @@ describe('e2e_p2p_duplicate_proposal_slash', () => {
     ]);
     await awaitCommitteeExists({ rollup, logger: t.logger });
 
-    // Advance to an epoch where the malicious proposer is selected
+    // Find an epoch where the malicious proposer is selected, stopping one epoch before
+    // so we have time to start sequencers before the target epoch arrives
     const epochCache = (honestNode1 as TestAztecNodeService).epochCache;
-    await awaitEpochWithProposer({
+    const { targetEpoch } = await advanceToEpochBeforeProposer({
       epochCache,
       cheatCodes: t.ctx.cheatCodes.rollup,
       targetProposer: maliciousValidatorAddress,
       logger: t.logger,
     });
 
-    // Start all sequencers simultaneously
+    // Start all sequencers while still one epoch before the target
     t.logger.warn('Starting all sequencers');
     await Promise.all(nodes.map(n => n.getSequencer()!.start()));
+
+    // Now warp to the target epoch — sequencers are already running
+    t.logger.warn(`Advancing to target epoch ${targetEpoch}`);
+    await t.ctx.cheatCodes.rollup.advanceToEpoch(targetEpoch);
 
     // Wait for offense to be detected
     // The honest nodes should detect the duplicate proposal from the malicious validator

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -152,11 +152,14 @@ export async function awaitCommitteeExists({
 }
 
 /**
- * Advance epochs until we find one where the target proposer is selected for at least one slot.
- * With N validators and M slots per epoch, a specific proposer may not be selected in any given epoch.
- * For example, with 4 validators and 2 slots/epoch, there is about a 44% chance per epoch.
+ * Advance epochs until we find one where the target proposer is selected for at least one slot,
+ * then stop one epoch before it. This leaves time for the caller to start sequencers before
+ * warping to the target epoch, avoiding the race where the target epoch passes before sequencers
+ * are ready.
+ *
+ * Returns the target epoch number so the caller can warp to it after starting sequencers.
  */
-export async function awaitEpochWithProposer({
+export async function advanceToEpochBeforeProposer({
   epochCache,
   cheatCodes,
   targetProposer,
@@ -168,25 +171,32 @@ export async function awaitEpochWithProposer({
   targetProposer: EthAddress;
   logger: Logger;
   maxAttempts?: number;
-}): Promise<void> {
+}): Promise<{ targetEpoch: EpochNumber }> {
   const { epochDuration } = await cheatCodes.getConfig();
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const currentEpoch = await cheatCodes.getEpoch();
-    const startSlot = Number(currentEpoch) * Number(epochDuration);
+    // Check the NEXT epoch's slots so we stay one epoch before the target,
+    // giving the caller time to start sequencers before the target epoch arrives.
+    const nextEpoch = Number(currentEpoch) + 1;
+    const startSlot = nextEpoch * Number(epochDuration);
     const endSlot = startSlot + Number(epochDuration);
 
-    logger.info(`Checking epoch ${currentEpoch} (slots ${startSlot}-${endSlot - 1}) for proposer ${targetProposer}`);
+    logger.info(
+      `Checking next epoch ${nextEpoch} (slots ${startSlot}-${endSlot - 1}) for proposer ${targetProposer} (current epoch: ${currentEpoch})`,
+    );
 
     for (let s = startSlot; s < endSlot; s++) {
       const proposer = await epochCache.getProposerAttesterAddressInSlot(SlotNumber(s));
       if (proposer && proposer.equals(targetProposer)) {
-        logger.warn(`Found target proposer ${targetProposer} in slot ${s} of epoch ${currentEpoch}`);
-        return;
+        logger.warn(
+          `Found target proposer ${targetProposer} in slot ${s} of epoch ${nextEpoch}. Staying at epoch ${currentEpoch} to allow sequencer startup.`,
+        );
+        return { targetEpoch: EpochNumber(nextEpoch) };
       }
     }
 
-    logger.info(`Target proposer not found in epoch ${currentEpoch}, advancing to next epoch`);
+    logger.info(`Target proposer not found in epoch ${nextEpoch}, advancing to next epoch`);
     await cheatCodes.advanceToNextEpoch();
   }
 


### PR DESCRIPTION
## Summary

Fixes a race condition in the `duplicate_attestation_slash` and `duplicate_proposal_slash` e2e tests that caused intermittent timeouts waiting for slashing offenses to be detected.

## Root Cause

Investigated CI failure [2abee794200ae6a7](http://ci.aztec-labs.com/2abee794200ae6a7) (commit `f71c235a670d`, merge queue for PR #20555). This run **did include** the fix from #20990, yet the `duplicate_attestation_slash` test still failed with a timeout after ~478 seconds.

The failure sequence from the logs:
1. `awaitEpochWithProposer` found the malicious proposer at **slot 14** (epoch 7)
2. The function returned, having warped L1 time to the start of epoch 7
3. Sequencers were then started (`await Promise.all(nodes.map(n => n.getSequencer()!.start()))`)
4. By the time sequencers were ready to build blocks, L1 time had advanced past epoch 7 into **epoch 8** (first block built at slot 16)
5. The malicious proposer was never selected in epoch 8+, so no duplicate proposals/attestations were created
6. The slasher had nothing to detect, and the test timed out

The core issue: `awaitEpochWithProposer` warped to the target epoch and returned, but starting sequencers takes real time. With only 2 slots per epoch (48s total), the epoch passed before sequencers could act.

## Fix

Renamed `awaitEpochWithProposer` to `advanceToEpochBeforeProposer` and changed the approach to a two-phase pattern:

1. **Find phase**: The function now checks the **next** epoch's slots (N+1) instead of the current epoch's (N). When the target proposer is found, it returns `{ targetEpoch }` while staying at epoch N -- one full epoch before the target.

2. **Start + warp phase** (in the test): After the function returns, sequencers are started while still one epoch before the target. Only then does the test warp to the target epoch via `advanceToEpoch(targetEpoch)`.

This eliminates the race because sequencers are already running when the target epoch begins.

The function can safely query future epoch slots because `epochCache.getProposerAttesterAddressInSlot` works for any slot within the `lagInEpochsForValidatorSet` window (typically 2 epochs ahead), and we only look 1 epoch ahead.

## Changes

- **`shared.ts`**: Renamed `awaitEpochWithProposer` -> `advanceToEpochBeforeProposer`. Now checks next epoch's slots and returns `{ targetEpoch: EpochNumber }` instead of `void`.
- **`duplicate_attestation_slash.test.ts`**: Updated to start sequencers before warping to target epoch.
- **`duplicate_proposal_slash.test.ts`**: Same change. Also filtered offense assertions to only check `DUPLICATE_PROPOSAL` offenses, since the two malicious nodes sharing the same key each self-attest to their own (different) checkpoint proposals, causing honest nodes to also detect a `DUPLICATE_ATTESTATION` offense.

Fixes A-632